### PR TITLE
ui changes

### DIFF
--- a/apps/dashboard/src/components/ClawAgents/McpServerIcon.tsx
+++ b/apps/dashboard/src/components/ClawAgents/McpServerIcon.tsx
@@ -12,7 +12,9 @@ const MCP_ICON_BASE = '/assets/mcp';
 const MCP_SVG_ONLY = new Set(['gmail', 'google-drive', 'sequentialthinking', 'xyne-spaces']);
 const MCP_ICON_BG: Record<string, string> = { 'xyne-spaces': 'bg-transparent' };
 
-const SIZE: Record<'sm' | 'md' | 'lg', string> = {
+const SIZE: Record<'sm' | 'chip' | 'sm' | 'md' | 'lg', string> = {
+  sm: 'size-4 rounded p-0.5 text-[8px]',
+  chip: 'size-7 rounded-lg p-1.5 text-[10px]',
   sm: 'size-8 rounded-lg p-1 text-[10px]',
   md: 'size-10 rounded-lg p-1.5 text-xs',
   lg: 'size-12 rounded-xl p-2 text-sm',
@@ -32,8 +34,8 @@ export const McpServerIcon = ({
   server,
   size = 'md',
 }: {
-  server: McpServer;
-  size?: 'sm' | 'md' | 'lg';
+  server: Pick<McpServer, 'type' | 'name'>;
+  size?: 'sm' | 'chip' | 'sm' | 'md' | 'lg';
 }): ReactElement => {
   const [errored, setErrored] = useState(false);
   // `bg-card` (white), not `bg-muted` (grey), so brand logos sit on the same

--- a/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
@@ -192,7 +192,7 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
       }
       console.log(
         `[FlowRenderer] → sending ${action.type} actionId=${action.actionId} values=`,
-        stateRef.current.values,
+        redactFlowValuesForLog(stateRef.current.values),
       );
       try {
         const response = await flowActionService.execute({
@@ -331,6 +331,16 @@ function findFieldInComponents(components: FlowComponent[], name: string): FlowC
     }
   }
   return null;
+}
+
+function redactFlowValuesForLog(values: Record<string, unknown>): Record<string, unknown> {
+  const sensitive = /token|password|secret|key|credential|auth/i;
+  return Object.fromEntries(
+    Object.entries(values).map(([key, value]) => [
+      key,
+      sensitive.test(key) && value !== undefined && value !== '' ? '[redacted]' : value,
+    ]),
+  );
 }
 
 function validateRule(rule: ValidationRule, value: unknown): string | null {

--- a/apps/dashboard/src/components/flowUI/nodes/AgentCreationNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/AgentCreationNode.tsx
@@ -1,0 +1,347 @@
+import React, { useContext, useState } from 'react';
+import {
+  MaximizeFourArrow,
+  Spinner,
+  CheckTickSingle,
+  MultipleCrossCancelDefault,
+} from '@xyne/icons';
+import { useFlow } from '../FlowContext';
+import type { FlowComponent, AgentCreationProps } from '@xyne/shared';
+import { ArtifactPreview, InsideArtifactPreviewContext } from './ArtifactPreview';
+import { McpServerIcon } from '../../ClawAgents/McpServerIcon';
+import { useAgentProgress } from '../../../hooks/useAgentProgress';
+import { cn } from '../../../utils/classNames';
+
+interface AgentCreationNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+type AgentConnectLink = {
+  serverType: string;
+  displayName: string;
+  authUrl: string;
+};
+
+export const AgentCreationNode: React.FC<AgentCreationNodeProps> = ({ node }) => {
+  const props = node.props as AgentCreationProps | undefined;
+  const { executeAction, conversationId, messageId } = useFlow();
+  const insidePreview = useContext(InsideArtifactPreviewContext);
+  const [expanded, setExpanded] = useState(false);
+  const [pending, setPending] = useState<'approve' | 'decline' | null>(null);
+  const { agents } = useAgentProgress(conversationId || undefined);
+
+  if (!props) return null;
+
+  const agentRunning = agents.length > 0;
+
+  const isPending = props.phase === 'pending';
+  const isCreated = props.phase === 'created';
+
+  const submit = async (actionId: 'approve-write' | 'decline-write'): Promise<void> => {
+    if (pending !== null) return;
+    if (actionId === 'approve-write' && agentRunning) return;
+    setPending(actionId === 'approve-write' ? 'approve' : 'decline');
+    try {
+      await executeAction({ type: 'submit', actionId });
+      // On a decision, drop the expanded preview back to the thread view.
+      setExpanded(false);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const chip = isCreated ? (
+    <StatusChip label='Created' tone='created' />
+  ) : props.phase === 'rejected' ? (
+    <StatusChip label='Rejected' tone='rejected' />
+  ) : (
+    <StatusChip label='Review' tone='muted' />
+  );
+
+  const capabilityChips = (props.tools?.length || props.modelId) && (
+    <div className='flex flex-wrap items-center gap-1.5'>
+      {props.modelId && <MetaChip>{props.modelId}</MetaChip>}
+      {props.tools?.map(t => (
+        <ToolChip key={t} label={t} />
+      ))}
+    </div>
+  );
+
+  const connectLinks: AgentConnectLink[] = Array.isArray(props.connectLinks)
+    ? props.connectLinks
+    : [];
+  const setupLinks = connectLinks.length > 0 ? (
+    <div className='flex flex-col gap-2 rounded-lg border border-border bg-background/60 p-3'>
+      <p className='text-xs font-medium uppercase tracking-[0.4px] text-muted-foreground'>Connect accounts</p>
+      <div className='flex flex-wrap gap-2'>
+        {connectLinks.map(link => (
+          <a
+            key={link.serverType}
+            href={link.authUrl}
+            target='_blank'
+            rel='noopener noreferrer'
+            className={cn(
+              'inline-flex items-center rounded-lg border border-border bg-background px-2.5 py-1.5',
+              'text-sm font-medium leading-[1.2] text-foreground',
+              'hover:bg-foreground/[0.04]',
+            )}
+            data-track-category='AGENT_CREATION_ARTIFACT'
+            data-track-name='CONNECT_MCP'
+          >
+            Connect {link.displayName}
+          </a>
+        ))}
+      </div>
+    </div>
+  ) : null;
+
+  const footerContent = isPending ? (
+    <div className='flex flex-wrap items-center gap-2'>
+      <button
+        type='button'
+        onClick={() => void submit('approve-write')}
+        disabled={pending !== null || agentRunning}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='AGENT_CREATION_ARTIFACT'
+        data-track-name='CLICK_APPROVE'
+      >
+        {(pending === 'approve' || agentRunning) && <Spinner size={14} className='animate-spin' />}
+        {pending === 'approve' ? 'Creating…' : agentRunning ? 'Agent is working…' : 'Approve'}
+      </button>
+      <button
+        type='button'
+        onClick={() => void submit('decline-write')}
+        disabled={pending !== null}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-muted-foreground',
+          'hover:bg-foreground/[0.04] hover:text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='AGENT_CREATION_ARTIFACT'
+        data-track-name='CLICK_DECLINE'
+      >
+        {pending === 'decline' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'decline' ? 'Declining…' : 'Decline'}
+      </button>
+      {agentRunning && (
+        <span className='text-xs text-muted-foreground'>Approve once it finishes.</span>
+      )}
+    </div>
+  ) : isCreated ? (
+    <div className='flex items-center gap-2'>
+      <span className='flex size-4 items-center justify-center rounded-full bg-emerald-600'>
+        <CheckTickSingle size={12} strokeWidth={1.33} absoluteStrokeWidth className='text-white' />
+      </span>
+      <AuditLine
+        text={withDecisionTime(
+          props.decidedBy ? `Created by ${props.decidedBy}` : 'Finish setup (create + install its app) to start chatting.',
+          props.decidedAt,
+        )}
+      />
+    </div>
+  ) : (
+    <div className='flex items-center gap-2'>
+      <span className='flex size-4 items-center justify-center rounded-full bg-destructive'>
+        <MultipleCrossCancelDefault size={10} className='text-white' />
+      </span>
+      <AuditLine text={withDecisionTime(props.decidedBy ? `Declined by ${props.decidedBy}` : 'Declined', props.decidedAt)} />
+    </div>
+  );
+
+  return (
+    <CardShell style={node.style}>
+      <div className={cn('flex flex-col gap-3 p-4', props.phase === 'rejected' && 'opacity-70')}>
+        <div className='flex flex-col gap-[9px]'>
+          <Header
+            chip={chip}
+            onExpand={insidePreview ? undefined : (): void => setExpanded(true)}
+          />
+          <div className='flex flex-col gap-1.5'>
+            <div className='flex flex-wrap items-center gap-2'>
+              <p className='text-lg font-semibold leading-[1.2] text-foreground'>{props.name}</p>
+              <SlugPill slug={props.slug} />
+            </div>
+            {props.description && (
+              <p className='text-sm leading-[1.5] tracking-[-0.15px] text-foreground/80'>
+                {props.description}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {capabilityChips}
+        {setupLinks}
+
+        {props.note && isCreated && (
+          <p className='text-xs leading-[1.3] text-amber-600 dark:text-amber-400'>{props.note}</p>
+        )}
+      </div>
+
+      <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>{footerContent}</div>
+
+      <ArtifactPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        label='Agent'
+        messageId={messageId ?? ''}
+        title={props.name}
+        desc={props.description}
+        document={props.systemPrompt}
+        conversationId={conversationId ?? undefined}
+        footer={footerContent}
+        body={capabilityChips || setupLinks ? (
+          <div className='flex flex-col gap-3'>
+            {capabilityChips}
+            {setupLinks}
+          </div>
+        ) : undefined}
+        trackCategory='AGENT_CREATION_ARTIFACT'
+      />
+    </CardShell>
+  );
+};
+
+const CardShell: React.FC<{
+  children: React.ReactNode;
+  style?: React.CSSProperties | undefined;
+}> = ({ children, style }) => (
+  <div
+    className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+    style={style}
+  >
+    {children}
+  </div>
+);
+
+const Header: React.FC<{
+  chip?: React.ReactNode;
+  onExpand?: (() => void) | undefined;
+}> = ({ chip, onExpand }) => (
+  <div className='flex items-center justify-between'>
+    <div className='flex items-center gap-2'>
+      <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+        Agent
+      </span>
+      {chip}
+    </div>
+    {onExpand && (
+      <button
+        type='button'
+        onClick={onExpand}
+        aria-label='Expand agent details'
+        className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        data-track-category='AGENT_CREATION_ARTIFACT'
+        data-track-name='EXPAND_AGENT'
+      >
+        <MaximizeFourArrow size={16} className='shrink-0' />
+      </button>
+    )}
+  </div>
+);
+
+const SlugPill: React.FC<{ slug: string }> = ({ slug }) => (
+  <span className='rounded-md border border-border bg-background px-1.5 py-0.5 font-mono text-xs leading-[1.4] text-muted-foreground'>
+    @{slug}
+  </span>
+);
+
+const MetaChip: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <span className='rounded-md bg-foreground/[0.06] px-1.5 py-0.5 text-xs leading-[1.4] text-muted-foreground'>
+    {children}
+  </span>
+);
+
+const ToolChip: React.FC<{ label: string }> = ({ label }) => (
+  <span className='inline-flex h-9 max-w-full items-center gap-1.5 rounded-[10px] border border-emerald-500/25 bg-emerald-500/10 py-1 pl-1 pr-2 text-sm font-semibold leading-none text-foreground'>
+    <McpServerIcon server={serverFromToolLabel(label)} size='chip' />
+    <span className='truncate'>{label}</span>
+    <CheckTickSingle
+      size={16}
+      strokeWidth={1.33}
+      absoluteStrokeWidth
+      className='shrink-0 text-emerald-600 dark:text-emerald-400'
+    />
+  </span>
+);
+
+const TOOL_TYPE_ALIASES = new Map<string, string>([
+  ['google', 'google'],
+  ['gmail', 'gmail'],
+  ['mail', 'gmail'],
+  ['gdrive', 'google-drive'],
+  ['drive', 'google-drive'],
+  ['google-drive', 'google-drive'],
+  ['microsoft', 'microsoft'],
+  ['outlook', 'microsoft'],
+  ['office', 'microsoft'],
+  ['slack', 'slack'],
+  ['github', 'github'],
+  ['gitlab', 'gitlab'],
+  ['figma', 'figma'],
+  ['notion', 'notion'],
+  ['salesforce', 'salesforce'],
+  ['stripe', 'stripe'],
+  ['bitbucket', 'bitbucket'],
+]);
+
+const serverFromToolLabel = (label: string): { type: string; name: string } => {
+  const normalized = label.trim().toLowerCase().replace(/[_\s]+/g, '-');
+  return {
+    type: TOOL_TYPE_ALIASES.get(normalized) ?? normalized,
+    name: label,
+  };
+};
+
+const StatusChip: React.FC<{ label: string; tone: 'created' | 'muted' | 'rejected' }> = ({
+  label,
+  tone,
+}) => (
+  <span className='flex h-[18px] items-center'>
+    <span
+      className={cn(
+        'rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px]',
+        tone === 'muted' && 'bg-muted text-muted-foreground',
+        tone === 'rejected' && 'bg-destructive/10 text-destructive',
+        tone === 'created' && 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+      )}
+    >
+      {label}
+    </span>
+  </span>
+);
+
+const AuditLine: React.FC<{ text: string }> = ({ text }) => (
+  <span className='text-xs leading-[1.2] text-muted-foreground'>{text}</span>
+);
+
+const formatDecisionTime = (iso?: string): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const diffMs = Date.now() - d.getTime();
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  if (diffMs >= 0 && diffMs < ONE_DAY_MS) {
+    const mins = Math.floor(diffMs / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} ${mins === 1 ? 'min' : 'mins'} ago`;
+    const hrs = Math.floor(mins / 60);
+    return `${hrs} ${hrs === 1 ? 'hr' : 'hrs'} ago`;
+  }
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+const withDecisionTime = (label: string, iso?: string): string => {
+  const t = formatDecisionTime(iso);
+  return t ? `${label} · ${t}` : label;
+};

--- a/apps/dashboard/src/components/flowUI/nodes/ArtifactPreview.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ArtifactPreview.tsx
@@ -1,0 +1,210 @@
+import React, { useMemo, createContext } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { PreviewSplitDialog, PreviewThreadPanel } from '../../ui/PreviewSplitDialog';
+import { useParams } from 'react-router-dom';
+import { MultipleCrossCancelDefault } from '@xyne/icons';
+import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
+import { createMarkdownComponents } from '../../../utils/markdownComponents';
+import { usePlatform } from '../../../hooks/usePlatform';
+
+/** Prevent nested artifact cards in the thread panel from opening another preview. */
+export const InsideArtifactPreviewContext = createContext(false);
+
+export interface ArtifactPreviewProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  label: string;
+  messageId: string;
+  title: string;
+  desc?: string | undefined;
+  document?: string | undefined;
+  conversationId?: string | undefined;
+  footer?: React.ReactNode;
+  body?: React.ReactNode;
+  trackCategory?: string;
+  idPrefix?: string;
+}
+
+const PanelHeader: React.FC<{
+  label: string;
+  trackCategory: string;
+  onClose?: (() => void) | undefined;
+}> = ({ label, trackCategory, onClose }) => (
+  <div className='flex h-14 flex-shrink-0 items-center justify-between border-b border-border px-5'>
+    <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+      {label}
+    </span>
+    {onClose && (
+      <button
+        type='button'
+        onClick={onClose}
+        aria-label='Close'
+        className='rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        data-track-category={trackCategory}
+        data-track-name='CLOSE_ARTIFACT_PREVIEW'
+      >
+        <MultipleCrossCancelDefault size={18} />
+      </button>
+    )}
+  </div>
+);
+
+type AdmonitionKind = 'NOTE' | 'TIP' | 'IMPORTANT' | 'WARNING' | 'CAUTION';
+
+const ADMONITION_STYLES: Record<AdmonitionKind, { icon: string; box: string; label: string }> = {
+  NOTE: { icon: 'ℹ️', box: 'border-blue-500/40 bg-blue-500/10', label: 'text-blue-600 dark:text-blue-400' },
+  TIP: { icon: '💡', box: 'border-emerald-500/40 bg-emerald-500/10', label: 'text-emerald-600 dark:text-emerald-400' },
+  IMPORTANT: { icon: '❗', box: 'border-violet-500/40 bg-violet-500/10', label: 'text-violet-600 dark:text-violet-400' },
+  WARNING: { icon: '⚠️', box: 'border-amber-500/40 bg-amber-500/10', label: 'text-amber-600 dark:text-amber-400' },
+  CAUTION: { icon: '🛑', box: 'border-red-500/40 bg-red-500/10', label: 'text-red-600 dark:text-red-400' },
+};
+
+const ADMONITION_RE = /^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*/;
+
+function extractAdmonition(children: React.ReactNode): { kind: AdmonitionKind; children: React.ReactNode } | null {
+  const items = React.Children.toArray(children);
+  const firstEl = items.find((c): c is React.ReactElement<{ children?: React.ReactNode }> => React.isValidElement(c));
+  if (!firstEl) return null;
+  const inner = React.Children.toArray((firstEl.props as { children?: React.ReactNode }).children);
+  const firstText = inner[0];
+  if (typeof firstText !== 'string') return null;
+  const match = ADMONITION_RE.exec(firstText);
+  if (!match) return null;
+  const kind = match[1] as AdmonitionKind;
+  const strippedFirst = firstText.slice(match[0].length);
+  const rebuiltFirst = React.cloneElement(firstEl, undefined, ...(strippedFirst ? [strippedFirst] : []), ...inner.slice(1));
+  const rest = items.filter(c => c !== firstEl);
+  return { kind, children: [rebuiltFirst, ...rest] };
+}
+
+const ArtifactBlockquote: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const admonition = extractAdmonition(children);
+  if (!admonition) {
+    return (
+      <blockquote className='my-2 border-l-2 border-border pl-3 text-foreground/70'>{children}</blockquote>
+    );
+  }
+  const style = ADMONITION_STYLES[admonition.kind];
+  return (
+    <div className={cnJoin('my-3 rounded-lg border p-3', style.box)}>
+      <p className={cnJoin('mb-1 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.4px]', style.label)}>
+        <span aria-hidden>{style.icon}</span>
+        {admonition.kind.charAt(0) + admonition.kind.slice(1).toLowerCase()}
+      </p>
+      <div className='text-sm leading-[1.6] text-foreground/85 [&>p]:m-0'>{admonition.children}</div>
+    </div>
+  );
+};
+
+function cnJoin(...parts: string[]): string {
+  return parts.join(' ');
+}
+
+const DocumentPanel: React.FC<{
+  messageId: string;
+  label: string;
+  trackCategory: string;
+  title: string;
+  desc?: string | undefined;
+  document?: string | undefined;
+  body?: React.ReactNode;
+  footer?: React.ReactNode;
+  onClose?: () => void;
+}> = ({ messageId, label, trackCategory, title, desc, document, body, footer, onClose }) => {
+  const markdownComponents = useMemo(
+    () => ({
+      ...createMarkdownComponents(messageId || 'artifact-document', undefined, { richArtifactContent: true }),
+      blockquote: ArtifactBlockquote,
+    }),
+    [messageId],
+  );
+  return (
+    <div className='flex h-full flex-col bg-background'>
+      <PanelHeader label={label} trackCategory={trackCategory} onClose={onClose} />
+      <div className='flex-1 overflow-y-auto px-6 py-5'>
+        <div className='mx-auto flex max-w-3xl flex-col gap-5'>
+          <div className='flex flex-col gap-1'>
+            <h1 className='text-2xl font-semibold leading-[1.2] text-foreground'>{title}</h1>
+            {desc && (
+              <p className='text-sm leading-[1.5] tracking-[-0.15px] text-foreground/70'>{desc}</p>
+            )}
+          </div>
+          {body}
+          {document && (
+            <>
+              <div className='h-px w-full bg-border' />
+              <MarkdownMessageRenderer content={document} markdownComponents={markdownComponents} />
+            </>
+          )}
+        </div>
+      </div>
+      {footer && (
+        <div className='flex-shrink-0 border-t border-border bg-foreground/[0.03] px-6 py-3'>
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const ArtifactPreview: React.FC<ArtifactPreviewProps> = ({
+  open,
+  onOpenChange,
+  label,
+  messageId,
+  title,
+  desc,
+  document,
+  conversationId,
+  footer,
+  body,
+  trackCategory = 'ARTIFACT_PREVIEW',
+  idPrefix = 'artifact-preview',
+}) => {
+  const { channelId } = useParams<{ channelId?: string }>();
+  const { isMobile } = usePlatform();
+  const close = (): void => onOpenChange(false);
+
+  const documentPanel = (
+    <>
+      <Dialog.Title className='sr-only'>{title}</Dialog.Title>
+      <Dialog.Description className='sr-only'>{desc ?? `${label} details`}</Dialog.Description>
+      <DocumentPanel
+        messageId={messageId}
+        label={label}
+        trackCategory={trackCategory}
+        title={title}
+        desc={desc}
+        document={document}
+        body={body}
+        footer={footer}
+        {...(isMobile || !conversationId ? { onClose: close } : {})}
+      />
+    </>
+  );
+
+  const threadPanel =
+    isMobile || !conversationId ? undefined : (
+      <InsideArtifactPreviewContext.Provider value={true}>
+        <PreviewThreadPanel
+          {...(channelId ? { channelId } : {})}
+          conversationId={conversationId}
+          onClose={close}
+        />
+      </InsideArtifactPreviewContext.Provider>
+    );
+
+  return (
+    <PreviewSplitDialog
+      open={open}
+      onClose={close}
+      idPrefix={idPrefix}
+      isMobile={isMobile}
+      left={documentPanel}
+      right={threadPanel}
+      overlayClassName='bg-black/80'
+      contentClassName='bg-black data-[state=closed]:fade-out transition-all ease-in-out duration-300 data-[state=open]:fade-in'
+      bodyClassName='bg-background'
+    />
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/ConnectAccountNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ConnectAccountNode.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { ExternalLink } from 'lucide-react';
+import type { FlowComponent } from '@xyne/shared';
+import { McpServerIcon } from '../../ClawAgents/McpServerIcon';
+import { cn } from '../../../utils/classNames';
+
+interface ConnectAccountNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+type ConnectAccountProps = {
+  displayName: string;
+  authUrl: string;
+  reason?: string;
+  serverType?: string;
+};
+
+type ProviderDisplay = {
+  name: string;
+  detail?: string;
+};
+
+const isConnectAccountProps = (value: unknown): value is ConnectAccountProps => {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return typeof record['displayName'] === 'string' && typeof record['authUrl'] === 'string';
+};
+
+const providerTypeFromName = (displayName: string): string => {
+  const normalized = displayName.toLowerCase();
+  if (normalized.includes('google') || normalized.includes('gmail')) return 'google';
+  if (normalized.includes('microsoft') || normalized.includes('outlook')) return 'microsoft';
+  return displayName.trim().toLowerCase().replace(/[_\s]+/g, '-');
+};
+
+const providerDisplayFromName = (displayName: string): ProviderDisplay => {
+  const match = /^(.*?)\s*\((.*?)\)\s*$/.exec(displayName.trim());
+  if (!match) return { name: displayName.trim() };
+
+  const name = match[1]?.trim() || displayName.trim();
+  const detail = match[2]?.trim();
+  return detail ? { name, detail } : { name };
+};
+
+export const ConnectAccountNode: React.FC<ConnectAccountNodeProps> = ({ node }) => {
+  if (!isConnectAccountProps(node.props)) return null;
+  const props = node.props;
+
+  const serverType = props.serverType || providerTypeFromName(props.displayName);
+  const provider = providerDisplayFromName(props.displayName);
+  const reason = props.reason?.trim();
+  const detail = reason || (provider.detail ? `Required for ${provider.detail}.` : 'Required before this agent can use the account.');
+
+  return (
+    <div
+      className='flex w-[450px] max-w-full items-center gap-3 rounded-xl border border-border bg-muted/40 p-3'
+      style={node.style}
+    >
+      <McpServerIcon server={{ type: serverType, name: provider.name }} size='md' />
+      <div className='min-w-0 flex-1'>
+        <div className='flex items-center gap-2'>
+          <p className='truncate text-base font-semibold leading-[1.25] text-foreground'>Connect {provider.name}</p>
+          <span className='shrink-0 rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] bg-muted text-muted-foreground'>
+            Required
+          </span>
+        </div>
+        <p className='mt-0.5 line-clamp-2 text-sm leading-[1.4] text-foreground/70'>{detail}</p>
+      </div>
+
+      <a
+        href={props.authUrl}
+        target='_blank'
+        rel='noopener noreferrer'
+        className={cn(
+          'inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-3',
+          'text-sm font-medium leading-none text-foreground',
+          'hover:bg-foreground/[0.04]',
+        )}
+        data-track-category='CONNECT_ACCOUNT_ARTIFACT'
+        data-track-name='CONNECT_ACCOUNT'
+      >
+        Connect
+        <ExternalLink size={14} strokeWidth={2} />
+      </a>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/EntityUpdateNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/EntityUpdateNode.tsx
@@ -1,0 +1,558 @@
+import React, { useContext, useMemo, useState } from 'react';
+import { PatchDiff } from '@pierre/diffs/react';
+import { MaximizeFourArrow, Spinner, CheckTickSingle, MultipleCrossCancelDefault } from '@xyne/icons';
+import { useFlow } from '../FlowContext';
+import type { FlowComponent, EntityUpdateProps } from '@xyne/shared';
+import { ArtifactPreview, InsideArtifactPreviewContext } from './ArtifactPreview';
+import { McpServerIcon } from '../../ClawAgents/McpServerIcon';
+import { useTheme } from '../../../hooks/useTheme';
+import { cn } from '../../../utils/classNames';
+import { getDiffThemeType } from './diffTheme';
+
+/**
+ * Entity-update artifact — the owner-facing approval card for a proposed
+ * agent/subagent update. ONE component serves BOTH kinds (`props.kind` only
+ * changes labels), and the card updates in place across phases on the same
+ * message, exactly like the agentCreation card:
+ *
+ *   pending  → summary + field changes + system-prompt diff, with
+ *              Approve / Decline. The buttons submit the existing
+ *              `${kind}-update-approve` / `-decline` actionIds; the request
+ *              identity (requestId, approverUserId) rides in flowJSON.data.
+ *   approved → applied. "Approved" chip, no buttons.
+ *   rejected → declined. "Rejected" chip, no buttons.
+ *
+ * The diff arrives as structured hunks (computed server-side); this component
+ * owns ALL presentation. `truncated` marks a display-capped diff — the full
+ * proposed content is applied via the request's integrity hash, not this view.
+ *
+ * Wire contract: one component of type 'entityUpdate'. Source of truth + zod:
+ * packages/shared/src/validation/flowSchema.ts (`entityUpdateComponentSchema`).
+ * Emitted by xyne-claw-shared's buildEntityUpdateApprovalFlow; phase
+ * transitions updateMessage the SAME message (flow-action.ts).
+ */
+interface EntityUpdateNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+export const EntityUpdateNode: React.FC<EntityUpdateNodeProps> = ({ node }) => {
+  const props = node.props as EntityUpdateProps | undefined;
+  const { executeAction, conversationId, messageId } = useFlow();
+  const insidePreview = useContext(InsideArtifactPreviewContext);
+  const [pending, setPending] = useState<'approve' | 'decline' | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
+  const diff = props?.diff;
+  const promptPatch = useMemo(() => (diff ? buildPromptPatch(diff.hunks) : null), [diff]);
+
+  if (!props) return null;
+
+  const kindLabel = props.kind === 'agent' ? 'Agent' : 'Subagent';
+  const isPending = props.phase === 'pending';
+  const isApproved = props.phase === 'approved';
+
+  const submit = async (decision: 'approve' | 'decline'): Promise<void> => {
+    if (pending !== null) return;
+    setPending(decision);
+    try {
+      await executeAction({ type: 'submit', actionId: `${props.kind}-update-${decision}` });
+      // On a decision, drop the expanded preview back to the thread view.
+      setExpanded(false);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  // A large deletion with little addition smells like a truncated "full
+  // replacement" — warn the owner to check the tail before approving.
+  const shrinkWarning = !!diff && diff.removed > 30 && diff.removed > diff.added * 3;
+  // Compact card shows the first hunks; the full diff lives in the expanded view.
+  const visibleHunks = diff ? diff.hunks.slice(0, 3) : [];
+  const hiddenHunkCount = diff ? diff.hunks.length - visibleHunks.length : 0;
+  const fieldChanges = props.fieldChanges ?? [];
+  const toolChange = fieldChanges.find(fc => fc.label.toLowerCase() === 'tools');
+  const scalarFieldChanges = fieldChanges.filter(fc => fc.label.toLowerCase() !== 'tools');
+
+  // Footer controls — shared by the compact card AND the preview footer.
+  const footerContent = isPending ? (
+    <div className='flex flex-wrap items-center gap-2'>
+      <button
+        type='button'
+        onClick={() => void submit('approve')}
+        disabled={pending !== null}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='ENTITY_UPDATE_ARTIFACT'
+        data-track-name='CLICK_APPROVE'
+      >
+        {pending === 'approve' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'approve' ? 'Applying…' : 'Approve'}
+      </button>
+      <button
+        type='button'
+        onClick={() => void submit('decline')}
+        disabled={pending !== null}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-muted-foreground',
+          'hover:bg-foreground/[0.04] hover:text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='ENTITY_UPDATE_ARTIFACT'
+        data-track-name='CLICK_DECLINE'
+      >
+        {pending === 'decline' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'decline' ? 'Declining…' : 'Decline'}
+      </button>
+    </div>
+  ) : (
+    <div className='flex items-center gap-2'>
+      {isApproved ? (
+        <span className='flex size-4 items-center justify-center rounded-full bg-emerald-600'>
+          <CheckTickSingle size={12} strokeWidth={1.33} absoluteStrokeWidth className='text-white' />
+        </span>
+      ) : (
+        <span className='flex size-4 items-center justify-center rounded-full bg-destructive'>
+          <MultipleCrossCancelDefault size={10} className='text-white' />
+        </span>
+      )}
+      <span className='text-xs leading-[1.2] text-muted-foreground'>
+        {withDecisionTime(
+          `${isApproved ? 'Approved & applied' : 'Declined'}${props.decidedBy ? ` by ${props.decidedBy}` : ''}`,
+          props.decidedAt,
+        )}
+      </span>
+    </div>
+  );
+
+  // Full-diff content for the expanded view: field changes + shrink warning +
+  // EVERY hunk (the compact card caps at 3).
+  const previewBody = (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-2 rounded-lg border border-border bg-background/60 p-3'>
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className='font-mono text-xs leading-[1.3] text-muted-foreground'>{kindLabel.toLowerCase()}</span>
+          <span className='rounded-md border border-border bg-background px-1.5 py-0.5 font-mono text-xs leading-[1.4] text-muted-foreground'>
+            @{props.targetKey}
+          </span>
+          <StatusChip
+            label={isPending ? 'Review' : isApproved ? 'Approved' : 'Rejected'}
+            tone={isPending ? 'muted' : isApproved ? 'approved' : 'rejected'}
+          />
+        </div>
+        {props.summary && (
+          <p className='text-sm leading-[1.55] text-foreground/85'>{props.summary}</p>
+        )}
+      </div>
+
+      {toolChange && <CapabilityDelta from={toolChange.from} to={toolChange.to} />}
+      {scalarFieldChanges.length > 0 && <FieldChangesPanel changes={scalarFieldChanges} />}
+      {shrinkWarning && diff && (
+        <div className='rounded-lg border border-destructive/60 bg-destructive/5 p-2.5 text-sm leading-[1.5] text-destructive'>
+          ⚠️ This update removes {diff.removed} lines but adds only {diff.added}. Verify the tail before approving.
+        </div>
+      )}
+      {diff && diff.hunks.length > 0 && (
+        <div className='flex flex-col gap-2'>
+          <DiffSectionHeader added={diff.added} removed={diff.removed} diffStyle={diffStyle} onDiffStyleChange={setDiffStyle} />
+          {promptPatch && <PromptPatchDiff patch={promptPatch} diffStyle={diffStyle} />}
+          {props.truncated && (
+            <p className='text-xs leading-[1.4] text-muted-foreground'>
+              Diff truncated for display — the full proposed content is stored on the request and applied exactly as
+              reviewed (integrity-hashed).
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <CardShell style={node.style}>
+      <div className={cn('flex flex-col gap-3 p-4', props.phase === 'rejected' && 'opacity-70')}>
+        {/* Header: mono kind label + phase chip + expand */}
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+              {kindLabel} update
+            </span>
+            {isPending ? (
+              <StatusChip label='Review' tone='muted' />
+            ) : isApproved ? (
+              <StatusChip label='Approved' tone='approved' />
+            ) : (
+              <StatusChip label='Rejected' tone='rejected' />
+            )}
+          </div>
+          {!insidePreview && (
+            <button
+              type='button'
+              onClick={() => setExpanded(true)}
+              aria-label='Expand update details'
+              className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='ENTITY_UPDATE_ARTIFACT'
+              data-track-name='EXPAND_UPDATE'
+            >
+              <MaximizeFourArrow size={16} className='shrink-0' />
+            </button>
+          )}
+        </div>
+
+        {/* Target + proposer + diff stats */}
+        <div className='flex flex-col gap-1'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <p className='text-lg font-semibold leading-[1.2] text-foreground'>{props.targetName}</p>
+            <span className='rounded-md border border-border bg-background px-1.5 py-0.5 font-mono text-xs leading-[1.4] text-muted-foreground'>
+              @{props.targetKey}
+            </span>
+          </div>
+          <p className='text-xs leading-[1.4] text-muted-foreground tabular-nums'>
+            proposed by {props.proposerName}
+            {diff && (
+              <>
+                {'  ·  '}
+                <span className='text-emerald-600 dark:text-emerald-400'>+{diff.added}</span>
+                {' / '}
+                <span className='text-destructive'>−{diff.removed}</span>
+              </>
+            )}
+          </p>
+        </div>
+
+        {props.summary && (
+          <p className='text-sm leading-[1.5] text-foreground/80'>
+            <span className='font-medium'>Summary:</span> {props.summary}
+          </p>
+        )}
+
+        {/* Scalar field changes — visible at a glance, before the prompt diff */}
+        {toolChange && <CapabilityDelta from={toolChange.from} to={toolChange.to} compact />}
+        {scalarFieldChanges.length > 0 && <FieldChangesPanel changes={scalarFieldChanges} compact />}
+
+        {shrinkWarning && diff && (
+          <div className='rounded-lg border border-destructive/60 bg-destructive/5 p-2.5 text-sm leading-[1.5] text-destructive'>
+            ⚠️ This update removes {diff.removed} lines but adds only {diff.added}. If the proposer claimed a
+            &quot;full replacement&quot;, the prompt may have been truncated — verify the tail before approving.
+          </div>
+        )}
+
+        {/* System-prompt diff */}
+        {diff && diff.hunks.length > 0 && (
+          <div className='flex flex-col gap-1.5'>
+            <DiffSectionHeader added={diff.added} removed={diff.removed} diffStyle={diffStyle} onDiffStyleChange={setDiffStyle} />
+            {promptPatch && (
+              <div className='max-h-[280px] overflow-auto rounded-lg border border-border'>
+                <PromptPatchDiff patch={buildPromptPatch(visibleHunks)} diffStyle={diffStyle} />
+              </div>
+            )}
+            {hiddenHunkCount > 0 && !insidePreview && (
+              <button
+                type='button'
+                onClick={() => setExpanded(true)}
+                className='self-start text-xs font-medium text-muted-foreground underline hover:text-foreground'
+                data-track-category='ENTITY_UPDATE_ARTIFACT'
+                data-track-name='SHOW_FULL_DIFF'
+              >
+                View full diff ({hiddenHunkCount} more hunk{hiddenHunkCount === 1 ? '' : 's'})
+              </button>
+            )}
+            {props.truncated && (
+              <p className='text-xs leading-[1.4] text-muted-foreground'>
+                Diff truncated for display — the full proposed content is stored on the request and applied exactly as
+                reviewed (integrity-hashed).
+              </p>
+            )}
+          </div>
+        )}
+
+        {props.note && <p className='text-xs leading-[1.4] text-amber-600 dark:text-amber-400'>{props.note}</p>}
+      </div>
+
+      {/* Footer — Approve/Decline while pending, audit line once decided */}
+      <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>{footerContent}</div>
+
+      <ArtifactPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        label={`${kindLabel} update`}
+        messageId={messageId ?? ''}
+        title={props.targetName}
+        desc={`@${props.targetKey} · proposed by ${props.proposerName}`}
+        conversationId={conversationId ?? undefined}
+        footer={footerContent}
+        body={previewBody}
+        trackCategory='ENTITY_UPDATE_ARTIFACT'
+      />
+    </CardShell>
+  );
+};
+
+interface FieldChange {
+  label: string;
+  from: string;
+  to: string;
+}
+
+const splitList = (value: string): string[] =>
+  value
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+
+const CapabilityDelta: React.FC<{ from: string; to: string; compact?: boolean }> = ({ from, to, compact = false }) => {
+  const before = splitList(from);
+  const after = splitList(to);
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  const added = after.filter(tool => !beforeSet.has(tool));
+  const removed = before.filter(tool => !afterSet.has(tool));
+  const kept = after.filter(tool => beforeSet.has(tool));
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-2 rounded-lg border border-border bg-background/60',
+        compact ? 'p-2.5' : 'p-3',
+      )}
+    >
+      <div className='flex items-center justify-between gap-3'>
+        <p className='text-xs font-medium uppercase tracking-[0.4px] text-muted-foreground'>Capabilities</p>
+        <p className='text-xs leading-[1.3] text-muted-foreground tabular-nums'>
+          {before.length} → {after.length}
+        </p>
+      </div>
+      <div className='flex flex-wrap gap-1.5'>
+        {added.map(tool => <ToolDeltaChip key={`add-${tool}`} label={tool} tone='added' />)}
+        {removed.map(tool => <ToolDeltaChip key={`remove-${tool}`} label={tool} tone='removed' />)}
+        {!compact && kept.map(tool => <ToolDeltaChip key={`keep-${tool}`} label={tool} tone='kept' />)}
+        {added.length === 0 && removed.length === 0 && kept.length === 0 && (
+          <span className='text-sm leading-[1.5] text-muted-foreground'>No tools selected.</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const ToolDeltaChip: React.FC<{ label: string; tone: 'added' | 'removed' | 'kept' }> = ({ label, tone }) => (
+  <span
+    className={cn(
+      'inline-flex h-9 max-w-full items-center gap-1.5 rounded-[10px] border py-1 pl-1 pr-2',
+      'text-sm font-semibold leading-none',
+      tone === 'added' && 'border-emerald-500/25 bg-emerald-500/10 text-foreground',
+      tone === 'removed' && 'border-destructive/25 bg-destructive/10 text-muted-foreground',
+      tone === 'kept' && 'border-border bg-foreground/[0.06] text-foreground',
+    )}
+  >
+    <McpServerIcon server={serverFromToolLabel(label)} size='chip' />
+    <span className={cn('truncate', tone === 'removed' && 'line-through')}>{label}</span>
+    {tone === 'removed' ? (
+      <MultipleCrossCancelDefault size={12} className='shrink-0 text-muted-foreground/70' />
+    ) : (
+      <CheckTickSingle
+        size={16}
+        strokeWidth={1.33}
+        absoluteStrokeWidth
+        className={cn(
+          'shrink-0',
+          tone === 'added' ? 'text-emerald-600 dark:text-emerald-400' : 'text-[#0062ff]',
+        )}
+      />
+    )}
+  </span>
+);
+
+const TOOL_TYPE_ALIASES: Record<string, string> = {
+  google: 'google',
+  gmail: 'gmail',
+  mail: 'gmail',
+  gdrive: 'google-drive',
+  drive: 'google-drive',
+  'google-drive': 'google-drive',
+  microsoft: 'microsoft',
+  outlook: 'microsoft',
+  office: 'microsoft',
+  slack: 'slack',
+  github: 'github',
+  gitlab: 'gitlab',
+  figma: 'figma',
+  notion: 'notion',
+  salesforce: 'salesforce',
+  stripe: 'stripe',
+  bitbucket: 'bitbucket',
+};
+
+const serverFromToolLabel = (label: string): { type: string; name: string } => {
+  const normalized = label.trim().toLowerCase().replace(/[_\s]+/g, '-');
+  return {
+    type: TOOL_TYPE_ALIASES[normalized] ?? normalized,
+    name: label,
+  };
+};
+
+const FieldChangesPanel: React.FC<{ changes: FieldChange[]; compact?: boolean }> = ({ changes, compact = false }) => (
+  <div
+    className={cn(
+      'flex flex-col gap-1 rounded-lg border border-border bg-background/60',
+      compact ? 'p-2.5' : 'p-3',
+    )}
+  >
+    <p className='text-xs font-medium uppercase tracking-[0.4px] text-muted-foreground'>Field changes</p>
+    {changes.map((fc, i) => (
+      <div key={`${fc.label}-${i}`} className='flex flex-col gap-1 py-0.5'>
+        <p className='text-sm font-medium leading-[1.4] text-foreground/85'>{fc.label}</p>
+        <div className='flex flex-wrap items-center gap-1.5 text-sm leading-[1.5]'>
+          <ValuePill value={fc.from || '∅'} tone='old' />
+          <span className='text-muted-foreground'>→</span>
+          <ValuePill value={fc.to || '∅'} tone='new' />
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+const ValuePill: React.FC<{ value: string; tone: 'old' | 'new' }> = ({ value, tone }) => (
+  <span
+    className={cn(
+      'max-w-full rounded-md px-1.5 py-0.5 text-xs leading-[1.4]',
+      tone === 'old' && 'bg-muted text-muted-foreground line-through',
+      tone === 'new' && 'bg-foreground/[0.06] text-foreground',
+    )}
+  >
+    {value}
+  </span>
+);
+
+type DiffHunk = NonNullable<EntityUpdateProps['diff']>['hunks'][number];
+
+const buildPromptPatch = (hunks: DiffHunk[]): string => [
+  'diff --git a/system-prompt.md b/system-prompt.md',
+  '--- a/system-prompt.md',
+  '+++ b/system-prompt.md',
+  ...hunks.flatMap(hunk => [
+    hunk.header,
+    ...hunk.lines.map(line => `${line.kind === 'add' ? '+' : line.kind === 'del' ? '-' : ' '}${line.text}`),
+  ]),
+].join('\n');
+
+const DiffSectionHeader: React.FC<{
+  added: number;
+  removed: number;
+  diffStyle: 'unified' | 'split';
+  onDiffStyleChange: (style: 'unified' | 'split') => void;
+}> = ({ added, removed, diffStyle, onDiffStyleChange }) => (
+  <div className='flex flex-wrap items-center justify-between gap-3'>
+    <p className='text-xs font-medium uppercase tracking-[0.4px] text-muted-foreground'>System prompt changes</p>
+    <div className='flex items-center gap-2'>
+      <div className='inline-flex rounded-md border border-border bg-muted/50 p-0.5'>
+        {(['unified', 'split'] as const).map(style => (
+          <button
+            key={style}
+            type='button'
+            onClick={() => onDiffStyleChange(style)}
+            className={cn(
+              'rounded px-2 py-0.5 text-xs font-medium capitalize leading-[1.4] transition-colors',
+              diffStyle === style
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            data-track-category='ENTITY_UPDATE_ARTIFACT'
+            data-track-name={style === 'split' ? 'VIEW_SPLIT_DIFF' : 'VIEW_UNIFIED_DIFF'}
+          >
+            {style}
+          </button>
+        ))}
+      </div>
+      <p className='font-mono text-xs leading-[1.3] tabular-nums'>
+        <span className='text-emerald-600 dark:text-emerald-400'>+{added}</span>
+        <span className='text-muted-foreground'> / </span>
+        <span className='text-destructive'>-{removed}</span>
+      </p>
+    </div>
+  </div>
+);
+
+const PromptPatchDiff: React.FC<{ patch: string; diffStyle: 'unified' | 'split' }> = ({ patch, diffStyle }) => {
+  const { theme } = useTheme();
+  const themeType = getDiffThemeType(theme);
+
+  return (
+    <div
+      className='overflow-hidden rounded-lg border border-border bg-background'
+      style={{
+        '--diffs-light-bg': 'hsl(var(--background))',
+        '--diffs-dark-bg': 'hsl(var(--background))',
+        '--diffs-light': 'hsl(var(--foreground))',
+        '--diffs-dark': 'hsl(var(--foreground))',
+        '--diffs-font-size': '12px',
+        '--diffs-line-height': '18px',
+        '--diffs-font-family':
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        '--diffs-header-font-family': 'Inter, ui-sans-serif, system-ui, sans-serif',
+      } as React.CSSProperties}
+    >
+      <PatchDiff
+        patch={patch}
+        disableWorkerPool
+        options={{
+          diffStyle,
+          diffIndicators: 'classic',
+          disableFileHeader: true,
+          disableLineNumbers: true,
+          hunkSeparators: 'metadata',
+          lineDiffType: 'word',
+          overflow: 'wrap',
+          themeType,
+          tokenizeMaxLineLength: 300,
+        }}
+      />
+    </div>
+  );
+};
+
+const CardShell: React.FC<{
+  children: React.ReactNode;
+  style?: React.CSSProperties | undefined;
+}> = ({ children, style }) => (
+  <div
+    className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+    style={style}
+  >
+    {children}
+  </div>
+);
+
+const StatusChip: React.FC<{ label: string; tone: 'approved' | 'muted' | 'rejected' }> = ({ label, tone }) => (
+  <span className='flex h-[18px] items-center'>
+    <span
+      className={cn(
+        'rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px]',
+        tone === 'muted' && 'bg-muted text-muted-foreground',
+        tone === 'rejected' && 'bg-destructive/10 text-destructive',
+        tone === 'approved' && 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+      )}
+    >
+      {label}
+    </span>
+  </span>
+);
+
+// Relative within a day, absolute after — same convention as the plan card.
+const withDecisionTime = (label: string, iso?: string): string => {
+  if (!iso) return label;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return label;
+  const diffMs = Date.now() - d.getTime();
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  if (diffMs >= 0 && diffMs < ONE_DAY_MS) {
+    const mins = Math.floor(diffMs / 60000);
+    if (mins < 1) return `${label} · just now`;
+    if (mins < 60) return `${label} · ${mins} ${mins === 1 ? 'min' : 'mins'} ago`;
+    const hrs = Math.floor(mins / 60);
+    return `${label} · ${hrs} ${hrs === 1 ? 'hr' : 'hrs'} ago`;
+  }
+  return `${label} · ${d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}`;
+};

--- a/apps/dashboard/src/components/flowUI/nodes/McpConfigureNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/McpConfigureNode.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo, useState } from 'react';
+import { KeyRound } from 'lucide-react';
+import type { FlowComponent } from '@xyne/shared';
+import { McpServerIcon } from '../../ClawAgents/McpServerIcon';
+import { cn } from '../../../utils/classNames';
+import { useFlow } from '../FlowContext';
+
+interface McpConfigureNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+type CredentialField = {
+  name: string;
+  label: string;
+  type: 'text' | 'password';
+  placeholder?: string;
+  optional?: boolean;
+};
+
+type McpConfigureProps = {
+  serverType: string;
+  serverName: string;
+  mcpServerId: string;
+  reason?: string;
+  fields: CredentialField[];
+};
+
+const isMcpConfigureProps = (value: unknown): value is McpConfigureProps => {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record['serverType'] === 'string' &&
+    typeof record['serverName'] === 'string' &&
+    typeof record['mcpServerId'] === 'string' &&
+    Array.isArray(record['fields']) &&
+    record['fields'].every((field) => {
+      if (!field || typeof field !== 'object') return false;
+      const f = field as Record<string, unknown>;
+      return (
+        typeof f['name'] === 'string' &&
+        typeof f['label'] === 'string' &&
+        (f['type'] === 'text' || f['type'] === 'password')
+      );
+    })
+  );
+};
+
+const titleForServer = (name: string): string => {
+  const trimmed = name.trim();
+  if (!trimmed) return 'MCP';
+  return trimmed.replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+export const McpConfigureNode: React.FC<McpConfigureNodeProps> = ({ node }) => {
+  const { state, updateFieldValue, executeAction, isSubmitting } = useFlow();
+  const [showErrors, setShowErrors] = useState(false);
+
+  const props = isMcpConfigureProps(node.props) ? node.props : null;
+  const requiredMissing = useMemo(() => {
+    if (!props) return [];
+    return props.fields
+      .filter((field) => !field.optional)
+      .filter((field) => {
+        const value = state.values[field.name];
+        return typeof value !== 'string' || value.trim().length === 0;
+      })
+      .map((field) => field.name);
+  }, [props, state.values]);
+
+  if (!props) return null;
+
+  const title = titleForServer(props.serverName);
+  const missing = new Set(requiredMissing);
+
+  const onSubmit = async (): Promise<void> => {
+    setShowErrors(true);
+    if (requiredMissing.length > 0) return;
+    await executeAction({ type: 'submit', actionId: 'mcp-configure-submit', errorMessage: `Could not configure ${title}` });
+  };
+
+  return (
+    <div
+      className='w-[500px] max-w-full rounded-xl border border-border bg-muted/40 p-3'
+      style={node.style}
+    >
+      <div className='flex items-start gap-3'>
+        <McpServerIcon server={{ type: props.serverType, name: props.serverName }} size='md' />
+        <div className='min-w-0 flex-1'>
+          <div className='flex min-w-0 items-center gap-2'>
+            <p className='truncate text-base font-semibold leading-[1.25] text-foreground'>Configure {title}</p>
+            <span className='shrink-0 rounded px-1 py-px text-xs font-semibold leading-[18px] bg-muted text-muted-foreground'>
+              Required
+            </span>
+          </div>
+          <p className='mt-0.5 line-clamp-2 text-sm leading-[1.4] text-foreground/70'>
+            {props.reason?.trim() || `Add credentials so this agent can use ${title}.`}
+          </p>
+        </div>
+      </div>
+
+      <div className='mt-3 grid gap-2'>
+        {props.fields.map((field) => {
+          const rawValue = state.values[field.name];
+          const value = typeof rawValue === 'string' ? rawValue : '';
+          const hasError = showErrors && missing.has(field.name);
+
+          return (
+            <label key={field.name} className='grid gap-1.5'>
+              <span className='text-xs font-medium leading-none text-foreground/75'>
+                {field.label}
+                {field.optional ? <span className='font-normal text-muted-foreground'> optional</span> : null}
+              </span>
+              <input
+                type={field.type}
+                value={value}
+                placeholder={field.placeholder}
+                autoComplete='off'
+                onChange={(event) => updateFieldValue(field.name, event.target.value)}
+                data-track-category='MCP_CONFIGURE_ARTIFACT'
+                data-track-name='MCP_CONFIGURE_FIELD_CHANGE'
+                className={cn(
+                  'h-9 rounded-lg border bg-background px-3 text-sm text-foreground outline-none',
+                  'placeholder:text-muted-foreground/70 focus:border-ring focus:ring-2 focus:ring-ring/25',
+                  hasError ? 'border-destructive focus:border-destructive focus:ring-destructive/20' : 'border-border',
+                )}
+              />
+              {hasError ? <span className='text-xs text-destructive'>Required</span> : null}
+            </label>
+          );
+        })}
+      </div>
+
+      <div className='mt-3 flex justify-end'>
+        <button
+          type='button'
+          onClick={() => {
+            void onSubmit();
+          }}
+          disabled={isSubmitting}
+          className={cn(
+            'inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-background px-3',
+            'text-sm font-medium leading-none text-foreground hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-60',
+          )}
+          data-track-category='MCP_CONFIGURE_ARTIFACT'
+          data-track-name='MCP_CONFIGURE_SUBMIT'
+        >
+          <KeyRound size={14} strokeWidth={2} />
+          {isSubmitting ? 'Configuring' : 'Configure'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -16,6 +16,12 @@ import { LinkNode } from './LinkNode';
 import { PlanNode } from './PlanNode';
 import { PrNode } from './PrNode';
 import { CallScheduleNode } from './CallScheduleNode';
+import { AgentCreationNode } from './AgentCreationNode';
+import { EntityUpdateNode } from './EntityUpdateNode';
+import { SkillCreationNode } from './SkillCreationNode';
+import { SkillUpdateNode } from './SkillUpdateNode';
+import { ConnectAccountNode } from './ConnectAccountNode';
+import { McpConfigureNode } from './McpConfigureNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
 // is kept in ./PrApprovalNode.tsx but unlinked so 'pr_approval' isn't a live artifact.
 
@@ -64,6 +70,12 @@ NodeRegistry.register('plan', PlanNode);
 NodeRegistry.register('pr', PrNode);
 // NodeRegistry.register('pr_approval', PrApprovalNode); // unlinked for now
 NodeRegistry.register('call_schedule', CallScheduleNode);
+NodeRegistry.register('connectAccount', ConnectAccountNode);
+NodeRegistry.register('mcpConfigure', McpConfigureNode);
+NodeRegistry.register('agentCreation', AgentCreationNode);
+NodeRegistry.register('entityUpdate', EntityUpdateNode);
+NodeRegistry.register('skillCreation', SkillCreationNode);
+NodeRegistry.register('skillUpdate', SkillUpdateNode);
 
 /**
  * Kept for backward compatibility with existing callers/imports.

--- a/apps/dashboard/src/components/flowUI/nodes/PlanPreview.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/PlanPreview.tsx
@@ -1,40 +1,21 @@
-import React, { useMemo, createContext } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
-import { PreviewSplitDialog, PreviewThreadPanel } from '../../ui/PreviewSplitDialog';
-import { useParams } from 'react-router-dom';
-import { MultipleCrossCancelDefault } from '@xyne/icons';
-import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
-import { createMarkdownComponents } from '../../../utils/markdownComponents';
-import { usePlatform } from '../../../hooks/usePlatform';
+import React from 'react';
+import { ArtifactPreview, InsideArtifactPreviewContext } from './ArtifactPreview';
 
 /**
- * True inside PlanPreview's right-hand thread panel. The thread re-renders the
- * SAME plan message as a live card, which would otherwise show its own Maximize
- * button and let the user stack a second full-screen preview on top. PlanNode
- * reads this and hides its Maximize when set, so the nested stack is unreachable.
+ * Back-compat alias: PlanNode (and any nested-card guard) reads this to hide its
+ * Maximize inside the preview's thread panel. The context itself now lives in
+ * ArtifactPreview and is shared by every artifact card (plan, agent creation,
+ * entity update).
  */
-export const InsidePlanPreviewContext = createContext(false);
+export const InsidePlanPreviewContext = InsideArtifactPreviewContext;
 
 /**
  * PlanPreview — the EXPANDED plan view.
  *
- * The compact plan card (PlanNode) only BRIEFS the plan (title + short todos).
- * Expanding opens this split screen — modeled on the Spaces attachment preview
- * (left = the artifact, right = the thread), but a SEPARATE component so the two
- * can evolve independently:
- *
- *   LEFT  → the todo checklist (`todos`, the same selection state as the card)
- *           above the detailed plan `document` (agent-authored markdown), rendered
- *           with the same canonical MarkdownMessageRenderer chat uses. The document
- *           is shown only when present.
- *   RIGHT → the live thread (ThreadMessages), the same conversation the card is in.
- *
- * Rendered INSIDE PlanNode, so it shares the live flow props (document/phase/todos
- * update live) and the flow-action round-trip. `footer` carries the phase-specific
- * controls (proposed → Approve/Reject; executing/done → audit + progress); on a
- * decision PlanNode closes this view (`onOpenChange(false)`) so the user drops back
- * to the thread. On mobile the thread panel is dropped (document only), mirroring
- * the attachment viewer.
+ * Thin wrapper over the shared ArtifactPreview split screen (left = artifact,
+ * right = live thread): it pins the plan's header label, analytics category and
+ * historical dialog id prefix. See ArtifactPreview for the layout contract;
+ * `todos` maps to the generic `body` slot.
  */
 interface PlanPreviewProps {
   open: boolean;
@@ -50,141 +31,16 @@ interface PlanPreviewProps {
   conversationId?: string | undefined;
   /** Phase-specific controls shown in the left panel footer (actions / audit). */
   footer?: React.ReactNode;
-  /** The todo checklist — the SAME selection state as the compact card (radios for
-   *  proposed, status rows for executing/done). Shown above the document. */
+  /** The todo checklist — the SAME selection state as the compact card. */
   todos?: React.ReactNode;
 }
 
-const PanelHeader: React.FC<{ label: string; onClose?: (() => void) | undefined }> = ({
-  label,
-  onClose,
-}) => (
-  <div className='flex h-14 flex-shrink-0 items-center justify-between border-b border-border px-5'>
-    <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
-      {label}
-    </span>
-    {onClose && (
-      <button
-        type='button'
-        onClick={onClose}
-        aria-label='Close'
-        className='rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-        data-track-category='PLAN_ARTIFACT'
-        data-track-name='CLOSE_PLAN_PREVIEW'
-      >
-        <MultipleCrossCancelDefault size={18} />
-      </button>
-    )}
-  </div>
+export const PlanPreview: React.FC<PlanPreviewProps> = ({ todos, ...rest }) => (
+  <ArtifactPreview
+    {...rest}
+    label='Plan'
+    body={todos}
+    trackCategory='PLAN_ARTIFACT'
+    idPrefix='plan-preview'
+  />
 );
-
-const DocumentPanel: React.FC<{
-  messageId: string;
-  title: string;
-  desc?: string | undefined;
-  document?: string | undefined;
-  todos?: React.ReactNode;
-  footer?: React.ReactNode;
-  onClose?: () => void;
-}> = ({ messageId, title, desc, document, todos, footer, onClose }) => {
-  const markdownComponents = useMemo(
-    () => createMarkdownComponents(messageId || 'plan-document'),
-    [messageId],
-  );
-  return (
-    <div className='flex h-full flex-col bg-background'>
-      <PanelHeader label='Plan' onClose={onClose} />
-      <div className='flex-1 overflow-y-auto px-6 py-5'>
-        <div className='mx-auto flex max-w-3xl flex-col gap-5'>
-          <div className='flex flex-col gap-1'>
-            <h1 className='text-2xl font-semibold leading-[1.2] text-foreground'>{title}</h1>
-            {desc && (
-              <p className='text-sm leading-[1.5] tracking-[-0.15px] text-foreground/70'>{desc}</p>
-            )}
-          </div>
-          {/* The interactive checklist (same selection state as the compact card) — shown
-              up top so it's the first thing on open, mirroring the plan node. */}
-          {todos}
-          {document && (
-            <>
-              <div className='h-px w-full bg-border' />
-              <MarkdownMessageRenderer content={document} markdownComponents={markdownComponents} />
-            </>
-          )}
-        </div>
-      </div>
-      {footer && (
-        <div className='flex-shrink-0 border-t border-border bg-foreground/[0.03] px-6 py-3'>
-          {footer}
-        </div>
-      )}
-    </div>
-  );
-};
-
-export const PlanPreview: React.FC<PlanPreviewProps> = ({
-  open,
-  onOpenChange,
-  messageId,
-  title,
-  desc,
-  document,
-  conversationId,
-  footer,
-  todos,
-}) => {
-  const { channelId } = useParams<{ channelId?: string }>();
-  const { isMobile } = usePlatform();
-  const close = (): void => onOpenChange(false);
-
-  const documentPanel = (
-    <>
-      {/* Radix needs a Title/Description descendant of Dialog.Content (which the
-          shared shell renders); keep them screen-reader only. */}
-      <Dialog.Title className='sr-only'>{title}</Dialog.Title>
-      <Dialog.Description className='sr-only'>{desc ?? 'Plan details'}</Dialog.Description>
-      <DocumentPanel
-        messageId={messageId}
-        title={title}
-        desc={desc}
-        document={document}
-        todos={todos}
-        footer={footer}
-        // Close button lives on the document panel only when there is no thread
-        // panel to carry it (mobile / no conversation) — matching the viewer.
-        {...(isMobile || !conversationId ? { onClose: close } : {})}
-      />
-    </>
-  );
-
-  const threadPanel =
-    isMobile || !conversationId ? undefined : (
-      // Mark the thread subtree so the nested (same) plan card hides its own
-      // Maximize — no second full-screen preview stacked on top.
-      <InsidePlanPreviewContext.Provider value={true}>
-        <PreviewThreadPanel
-          {...(channelId ? { channelId } : {})}
-          conversationId={conversationId}
-          onClose={close}
-        />
-      </InsidePlanPreviewContext.Provider>
-    );
-
-  // Same shell as the attachment viewer (FileViewerModal) — only the panels differ:
-  // the plan document takes the place of the attachment.
-  return (
-    <PreviewSplitDialog
-      open={open}
-      onClose={close}
-      idPrefix='plan-preview'
-      isMobile={isMobile}
-      left={documentPanel}
-      right={threadPanel}
-      // Identical chrome to the attachment viewer: same 70/30 split (shell defaults),
-      // same overlay darkness and dark content frame. Only the panels' content differs.
-      overlayClassName='bg-black/80'
-      contentClassName='bg-black data-[state=closed]:fade-out transition-all ease-in-out duration-300 data-[state=open]:fade-in'
-      bodyClassName='bg-background'
-    />
-  );
-};

--- a/apps/dashboard/src/components/flowUI/nodes/SkillCreationNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/SkillCreationNode.tsx
@@ -1,0 +1,207 @@
+import React, { useContext, useState } from 'react';
+import { MaximizeFourArrow, Spinner, CheckTickSingle, MultipleCrossCancelDefault } from '@xyne/icons';
+import { useFlow } from '../FlowContext';
+import type { FlowComponent, SkillCreationProps } from '@xyne/shared';
+import { ArtifactPreview, InsideArtifactPreviewContext } from './ArtifactPreview';
+import { cn } from '../../../utils/classNames';
+
+interface SkillCreationNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+export const SkillCreationNode: React.FC<SkillCreationNodeProps> = ({ node }) => {
+  const props = node.props as SkillCreationProps | undefined;
+  if (!props) return null;
+
+  const { executeAction, conversationId, messageId } = useFlow();
+  const insidePreview = useContext(InsideArtifactPreviewContext);
+  const [expanded, setExpanded] = useState(false);
+  const [pending, setPending] = useState<'approve' | 'decline' | null>(null);
+
+  const isPending = props.phase === 'pending';
+  const isCreated = props.phase === 'created';
+  const contentLineCount = props.content ? props.content.split('\n').length : 0;
+
+  const submit = async (actionId: 'approve-write' | 'decline-write'): Promise<void> => {
+    if (pending !== null) return;
+    setPending(actionId === 'approve-write' ? 'approve' : 'decline');
+    try {
+      await executeAction({ type: 'submit', actionId });
+      setExpanded(false);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const footerContent = isPending ? (
+    <div className='flex flex-wrap items-center gap-2'>
+      <button
+        type='button'
+        onClick={() => void submit('approve-write')}
+        disabled={pending !== null}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='SKILL_CREATION_ARTIFACT'
+        data-track-name='CLICK_APPROVE'
+      >
+        {pending === 'approve' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'approve' ? 'Creating...' : 'Approve'}
+      </button>
+      <button
+        type='button'
+        onClick={() => void submit('decline-write')}
+        disabled={pending !== null}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-muted-foreground',
+          'hover:bg-foreground/[0.04] hover:text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='SKILL_CREATION_ARTIFACT'
+        data-track-name='CLICK_DECLINE'
+      >
+        {pending === 'decline' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'decline' ? 'Declining...' : 'Decline'}
+      </button>
+    </div>
+  ) : (
+    <div className='flex items-center gap-2'>
+      {isCreated ? (
+        <span className='flex size-4 items-center justify-center rounded-full bg-emerald-600'>
+          <CheckTickSingle size={12} strokeWidth={1.33} absoluteStrokeWidth className='text-white' />
+        </span>
+      ) : (
+        <span className='flex size-4 items-center justify-center rounded-full bg-destructive'>
+          <MultipleCrossCancelDefault size={10} className='text-white' />
+        </span>
+      )}
+      <span className='text-xs leading-[1.2] text-muted-foreground'>
+        {withDecisionTime(isCreated ? 'Created' : 'Declined', props.decidedAt)}
+      </span>
+    </div>
+  );
+
+  const previewBody = (
+    <div className='flex flex-col gap-3'>
+      {props.description && (
+        <div className='rounded-lg border border-border bg-background/60 p-3'>
+          <p className='text-xs font-medium uppercase tracking-[0.4px] text-muted-foreground'>Description</p>
+          <p className='mt-1 text-sm leading-[1.5] text-foreground/85'>{props.description}</p>
+        </div>
+      )}
+      <div className='flex flex-wrap gap-1.5'>
+        <MetaChip>SKILL.md</MetaChip>
+        {contentLineCount > 0 && <MetaChip>{contentLineCount} lines</MetaChip>}
+      </div>
+    </div>
+  );
+
+  return (
+    <CardShell style={node.style}>
+      <div className={cn('flex flex-col gap-3 p-4', props.phase === 'rejected' && 'opacity-70')}>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>Skill</span>
+            <StatusChip
+              label={isPending ? 'Review' : isCreated ? 'Created' : 'Rejected'}
+              tone={isPending ? 'muted' : isCreated ? 'created' : 'rejected'}
+            />
+          </div>
+          {!insidePreview && (
+            <button
+              type='button'
+              onClick={() => setExpanded(true)}
+              aria-label='Expand skill details'
+              className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='SKILL_CREATION_ARTIFACT'
+              data-track-name='EXPAND_SKILL'
+            >
+              <MaximizeFourArrow size={16} className='shrink-0' />
+            </button>
+          )}
+        </div>
+
+        <div className='flex flex-col gap-1.5'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <p className='text-lg font-semibold leading-[1.2] text-foreground'>{props.name}</p>
+            <SlugPill slug={props.slug} />
+          </div>
+          {props.description && (
+            <p className='text-sm leading-[1.5] tracking-[-0.15px] text-foreground/80'>{props.description}</p>
+          )}
+        </div>
+
+        <div className='flex flex-wrap gap-1.5'>
+          <MetaChip>SKILL.md</MetaChip>
+          {contentLineCount > 0 && <MetaChip>{contentLineCount} lines</MetaChip>}
+        </div>
+        {props.note && <p className='text-xs leading-[1.4] text-amber-600 dark:text-amber-400'>{props.note}</p>}
+      </div>
+
+      <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>{footerContent}</div>
+
+      <ArtifactPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        label='Skill'
+        messageId={messageId ?? ''}
+        title={props.name}
+        desc={`@${props.slug}`}
+        document={props.content}
+        conversationId={conversationId ?? undefined}
+        footer={footerContent}
+        body={previewBody}
+        trackCategory='SKILL_CREATION_ARTIFACT'
+      />
+    </CardShell>
+  );
+};
+
+const CardShell: React.FC<{ children: React.ReactNode; style?: React.CSSProperties | undefined }> = ({ children, style }) => (
+  <div className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40' style={style}>
+    {children}
+  </div>
+);
+
+const SlugPill: React.FC<{ slug: string }> = ({ slug }) => (
+  <span className='rounded-md border border-border bg-background px-1.5 py-0.5 font-mono text-xs leading-[1.4] text-muted-foreground'>
+    @{slug}
+  </span>
+);
+
+const MetaChip: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <span className='rounded-md bg-foreground/[0.06] px-1.5 py-0.5 text-xs leading-[1.4] text-muted-foreground'>
+    {children}
+  </span>
+);
+
+const StatusChip: React.FC<{ label: string; tone: 'created' | 'muted' | 'rejected' }> = ({ label, tone }) => (
+  <span className='flex h-[18px] items-center'>
+    <span
+      className={cn(
+        'rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px]',
+        tone === 'muted' && 'bg-muted text-muted-foreground',
+        tone === 'rejected' && 'bg-destructive/10 text-destructive',
+        tone === 'created' && 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+      )}
+    >
+      {label}
+    </span>
+  </span>
+);
+
+const formatDecisionTime = (iso?: string): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+};
+
+const withDecisionTime = (label: string, iso?: string): string => {
+  const t = formatDecisionTime(iso);
+  return t ? `${label} - ${t}` : label;
+};

--- a/apps/dashboard/src/components/flowUI/nodes/SkillUpdateNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/SkillUpdateNode.tsx
@@ -1,0 +1,364 @@
+import React, { useContext, useMemo, useState } from 'react';
+import { PatchDiff } from '@pierre/diffs/react';
+import { MaximizeFourArrow, Spinner, CheckTickSingle, MultipleCrossCancelDefault } from '@xyne/icons';
+import { useFlow } from '../FlowContext';
+import type { FlowComponent, SkillUpdateProps } from '@xyne/shared';
+import { ArtifactPreview, InsideArtifactPreviewContext } from './ArtifactPreview';
+import { useTheme } from '../../../hooks/useTheme';
+import { cn } from '../../../utils/classNames';
+import { getDiffThemeType } from './diffTheme';
+
+interface SkillUpdateNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+export const SkillUpdateNode: React.FC<SkillUpdateNodeProps> = ({ node }) => {
+  const props = node.props as SkillUpdateProps | undefined;
+  const { executeAction, conversationId, messageId } = useFlow();
+  const insidePreview = useContext(InsideArtifactPreviewContext);
+  const [pending, setPending] = useState<'approve' | 'decline' | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
+  const diff = props?.diff;
+  const visibleHunks = useMemo(() => (diff ? diff.hunks.slice(0, 3) : []), [diff]);
+  const fullPatch = useMemo(() => (diff ? buildSkillPatch(diff.hunks) : null), [diff]);
+  const compactPatch = useMemo(() => (diff ? buildSkillPatch(visibleHunks) : null), [diff, visibleHunks]);
+
+  if (!props) return null;
+
+  const isPending = props.phase === 'pending';
+  const isApproved = props.phase === 'approved';
+  const shrinkWarning = !!diff && diff.removed > 30 && diff.removed > diff.added * 3;
+  const hiddenHunkCount = diff ? diff.hunks.length - visibleHunks.length : 0;
+
+  const submit = async (decision: 'approve' | 'decline'): Promise<void> => {
+    if (pending !== null) return;
+    setPending(decision);
+    try {
+      await executeAction({ type: 'submit', actionId: `skill-update-${decision}` });
+      setExpanded(false);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  const footerContent = isPending ? (
+    <div className='flex flex-wrap items-center gap-2'>
+      <button
+        type='button'
+        onClick={() => void submit('approve')}
+        disabled={pending !== null}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='SKILL_UPDATE_ARTIFACT'
+        data-track-name='CLICK_APPROVE'
+      >
+        {pending === 'approve' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'approve' ? 'Applying...' : 'Approve'}
+      </button>
+      <button
+        type='button'
+        onClick={() => void submit('decline')}
+        disabled={pending !== null}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5',
+          'text-sm font-medium leading-[1.2] text-muted-foreground',
+          'hover:bg-foreground/[0.04] hover:text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='SKILL_UPDATE_ARTIFACT'
+        data-track-name='CLICK_DECLINE'
+      >
+        {pending === 'decline' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'decline' ? 'Declining...' : 'Decline'}
+      </button>
+    </div>
+  ) : (
+    <div className='flex items-center gap-2'>
+      {isApproved ? (
+        <span className='flex size-4 items-center justify-center rounded-full bg-emerald-600'>
+          <CheckTickSingle size={12} strokeWidth={1.33} absoluteStrokeWidth className='text-white' />
+        </span>
+      ) : (
+        <span className='flex size-4 items-center justify-center rounded-full bg-destructive'>
+          <MultipleCrossCancelDefault size={10} className='text-white' />
+        </span>
+      )}
+      <span className='text-xs leading-[1.2] text-muted-foreground'>
+        {withDecisionTime(`${isApproved ? 'Approved and applied' : 'Declined'}${props.decidedBy ? ` by ${props.decidedBy}` : ''}`, props.decidedAt)}
+      </span>
+    </div>
+  );
+
+  const diffBlock = (patch: string | null): React.ReactNode => {
+    if (patch) {
+      return <SkillPatchDiff patch={patch} diffStyle={diffStyle} />;
+    }
+    if (props.diffText) {
+      return (
+        <pre className='overflow-auto rounded-lg border border-border bg-background p-3 font-mono text-xs leading-[1.5] text-foreground'>
+          {props.diffText}
+        </pre>
+      );
+    }
+    return <p className='text-sm leading-[1.5] text-muted-foreground'>No markdown diff available.</p>;
+  };
+
+  const previewBody = (
+    <div className='flex flex-col gap-4'>
+      <SummaryPanel props={props} />
+      {shrinkWarning && diff && <ShrinkWarning added={diff.added} removed={diff.removed} />}
+      <div className='flex flex-col gap-2'>
+        <DiffSectionHeader added={diff?.added} removed={diff?.removed} diffStyle={diffStyle} onDiffStyleChange={setDiffStyle} />
+        {diffBlock(fullPatch)}
+        {props.truncated && <TruncatedNote />}
+      </div>
+    </div>
+  );
+
+  return (
+    <CardShell style={node.style}>
+      <div className={cn('flex flex-col gap-3 p-4', props.phase === 'rejected' && 'opacity-70')}>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>Skill update</span>
+            <StatusChip
+              label={isPending ? 'Review' : isApproved ? 'Approved' : 'Rejected'}
+              tone={isPending ? 'muted' : isApproved ? 'approved' : 'rejected'}
+            />
+          </div>
+          {!insidePreview && (
+            <button
+              type='button'
+              onClick={() => setExpanded(true)}
+              aria-label='Expand skill update'
+              className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='SKILL_UPDATE_ARTIFACT'
+              data-track-name='EXPAND_UPDATE'
+            >
+              <MaximizeFourArrow size={16} className='shrink-0' />
+            </button>
+          )}
+        </div>
+
+        <div className='flex flex-col gap-1'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <p className='text-lg font-semibold leading-[1.2] text-foreground'>{props.skillName}</p>
+            <SlugPill slug={props.skillSlug} />
+          </div>
+          <p className='text-xs leading-[1.4] text-muted-foreground tabular-nums'>
+            proposed by {props.proposerName}
+            {diff && (
+              <>
+                {'  ·  '}
+                <span className='text-emerald-600 dark:text-emerald-400'>+{diff.added}</span>
+                {' / '}
+                <span className='text-destructive'>-{diff.removed}</span>
+              </>
+            )}
+          </p>
+        </div>
+
+        {props.summary && (
+          <p className='text-sm leading-[1.5] text-foreground/80'>
+            <span className='font-medium'>Summary:</span> {props.summary}
+          </p>
+        )}
+
+        {shrinkWarning && diff && <ShrinkWarning added={diff.added} removed={diff.removed} compact />}
+
+        <div className='flex flex-col gap-1.5'>
+          <DiffSectionHeader added={diff?.added} removed={diff?.removed} diffStyle={diffStyle} onDiffStyleChange={setDiffStyle} />
+          <div className='max-h-[280px] overflow-auto rounded-lg border border-border'>
+            {diffBlock(compactPatch)}
+          </div>
+          {hiddenHunkCount > 0 && !insidePreview && (
+            <button
+              type='button'
+              onClick={() => setExpanded(true)}
+              className='self-start text-xs font-medium text-muted-foreground underline hover:text-foreground'
+              data-track-category='SKILL_UPDATE_ARTIFACT'
+              data-track-name='SHOW_FULL_DIFF'
+            >
+              View full diff ({hiddenHunkCount} more hunk{hiddenHunkCount === 1 ? '' : 's'})
+            </button>
+          )}
+          {props.truncated && <TruncatedNote />}
+        </div>
+
+        {props.note && <p className='text-xs leading-[1.4] text-amber-600 dark:text-amber-400'>{props.note}</p>}
+      </div>
+
+      <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>{footerContent}</div>
+
+      <ArtifactPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        label='Skill update'
+        messageId={messageId ?? ''}
+        title={props.skillName}
+        desc={`@${props.skillSlug} - proposed by ${props.proposerName}`}
+        conversationId={conversationId ?? undefined}
+        footer={footerContent}
+        body={previewBody}
+        trackCategory='SKILL_UPDATE_ARTIFACT'
+      />
+    </CardShell>
+  );
+};
+
+const SummaryPanel: React.FC<{ props: SkillUpdateProps }> = ({ props }) => (
+  <div className='flex flex-col gap-2 rounded-lg border border-border bg-background/60 p-3'>
+    <div className='flex flex-wrap items-center gap-2'>
+      <span className='font-mono text-xs leading-[1.3] text-muted-foreground'>skill</span>
+      <SlugPill slug={props.skillSlug} />
+      <StatusChip
+        label={props.phase === 'pending' ? 'Review' : props.phase === 'approved' ? 'Approved' : 'Rejected'}
+        tone={props.phase === 'pending' ? 'muted' : props.phase === 'approved' ? 'approved' : 'rejected'}
+      />
+    </div>
+    {props.summary && <p className='text-sm leading-[1.55] text-foreground/85'>{props.summary}</p>}
+  </div>
+);
+
+const ShrinkWarning: React.FC<{ added: number; removed: number; compact?: boolean }> = ({ added, removed, compact }) => (
+  <div className={cn('rounded-lg border border-destructive/60 bg-destructive/5 text-sm leading-[1.5] text-destructive', compact ? 'p-2.5' : 'p-3')}>
+    This update removes {removed} lines but adds only {added}. Verify the tail before approving.
+  </div>
+);
+
+const TruncatedNote: React.FC = () => (
+  <p className='text-xs leading-[1.4] text-muted-foreground'>
+    Diff truncated for display. The full proposed content is stored on the request and applied by integrity hash.
+  </p>
+);
+
+type DiffHunk = NonNullable<SkillUpdateProps['diff']>['hunks'][number];
+
+const buildSkillPatch = (hunks: DiffHunk[]): string => [
+  'diff --git a/SKILL.md b/SKILL.md',
+  '--- a/SKILL.md',
+  '+++ b/SKILL.md',
+  ...hunks.flatMap(hunk => [
+    hunk.header,
+    ...hunk.lines.map(line => `${line.kind === 'add' ? '+' : line.kind === 'del' ? '-' : ' '}${line.text}`),
+  ]),
+].join('\n');
+
+const DiffSectionHeader: React.FC<{
+  added?: number | undefined;
+  removed?: number | undefined;
+  diffStyle: 'unified' | 'split';
+  onDiffStyleChange: (style: 'unified' | 'split') => void;
+}> = ({ added, removed, diffStyle, onDiffStyleChange }) => (
+  <div className='flex flex-wrap items-center justify-between gap-3'>
+    <p className='text-xs font-medium uppercase tracking-[0.4px] text-muted-foreground'>SKILL.md changes</p>
+    <div className='flex items-center gap-2'>
+      <div className='inline-flex rounded-md border border-border bg-muted/50 p-0.5'>
+        {(['unified', 'split'] as const).map(style => (
+          <button
+            key={style}
+            type='button'
+            onClick={() => onDiffStyleChange(style)}
+            className={cn(
+              'rounded px-2 py-0.5 text-xs font-medium capitalize leading-[1.4] transition-colors',
+              diffStyle === style ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+            )}
+            data-track-category='SKILL_UPDATE_ARTIFACT'
+            data-track-name={style === 'split' ? 'VIEW_SPLIT_DIFF' : 'VIEW_UNIFIED_DIFF'}
+          >
+            {style}
+          </button>
+        ))}
+      </div>
+      {added !== undefined && removed !== undefined && (
+        <p className='font-mono text-xs leading-[1.3] tabular-nums'>
+          <span className='text-emerald-600 dark:text-emerald-400'>+{added}</span>
+          <span className='text-muted-foreground'> / </span>
+          <span className='text-destructive'>-{removed}</span>
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+const SkillPatchDiff: React.FC<{ patch: string; diffStyle: 'unified' | 'split' }> = ({ patch, diffStyle }) => {
+  const { theme } = useTheme();
+  const themeType = getDiffThemeType(theme);
+
+  return (
+    <div
+      className='overflow-hidden rounded-lg border border-border bg-background'
+      style={{
+        '--diffs-light-bg': 'hsl(var(--background))',
+        '--diffs-dark-bg': 'hsl(var(--background))',
+        '--diffs-light': 'hsl(var(--foreground))',
+        '--diffs-dark': 'hsl(var(--foreground))',
+        '--diffs-font-size': '12px',
+        '--diffs-line-height': '18px',
+        '--diffs-font-family':
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        '--diffs-header-font-family': 'Inter, ui-sans-serif, system-ui, sans-serif',
+      } as React.CSSProperties}
+    >
+      <PatchDiff
+        patch={patch}
+        disableWorkerPool
+        options={{
+          diffStyle,
+          diffIndicators: 'classic',
+          disableFileHeader: true,
+          disableLineNumbers: true,
+          hunkSeparators: 'metadata',
+          lineDiffType: 'word',
+          overflow: 'wrap',
+          themeType,
+          tokenizeMaxLineLength: 300,
+        }}
+      />
+    </div>
+  );
+};
+
+const CardShell: React.FC<{ children: React.ReactNode; style?: React.CSSProperties | undefined }> = ({ children, style }) => (
+  <div className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40' style={style}>
+    {children}
+  </div>
+);
+
+const SlugPill: React.FC<{ slug: string }> = ({ slug }) => (
+  <span className='rounded-md border border-border bg-background px-1.5 py-0.5 font-mono text-xs leading-[1.4] text-muted-foreground'>
+    @{slug}
+  </span>
+);
+
+const StatusChip: React.FC<{ label: string; tone: 'approved' | 'muted' | 'rejected' }> = ({ label, tone }) => (
+  <span className='flex h-[18px] items-center'>
+    <span
+      className={cn(
+        'rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px]',
+        tone === 'muted' && 'bg-muted text-muted-foreground',
+        tone === 'rejected' && 'bg-destructive/10 text-destructive',
+        tone === 'approved' && 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+      )}
+    >
+      {label}
+    </span>
+  </span>
+);
+
+const formatDecisionTime = (iso?: string): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+};
+
+const withDecisionTime = (label: string, iso?: string): string => {
+  const t = formatDecisionTime(iso);
+  return t ? `${label} - ${t}` : label;
+};

--- a/apps/dashboard/src/components/flowUI/nodes/diffTheme.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/diffTheme.ts
@@ -1,0 +1,19 @@
+import type { Theme } from '../../../hooks/useTheme';
+
+export const getDiffThemeType = (theme: Theme): 'dark' | 'light' => {
+  if (theme === 'midnight') return 'dark';
+  if (typeof document === 'undefined') return 'light';
+
+  const root = document.documentElement;
+  if (root.getAttribute('data-theme') === 'midnight') return 'dark';
+
+  const styles = getComputedStyle(root);
+  const background = styles.getPropertyValue('--background').trim();
+  const lightness = /(\d+(?:\.\d+)?)%\s*$/.exec(background)?.[1];
+  if (lightness !== undefined) {
+    return Number(lightness) < 50 ? 'dark' : 'light';
+  }
+
+  if (styles.colorScheme.split(/\s+/).includes('dark')) return 'dark';
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};

--- a/apps/dashboard/src/components/ui/MessageBubble/MarkdownMessageRenderer.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MarkdownMessageRenderer.tsx
@@ -33,6 +33,7 @@ const messageSanitizeSchema = {
   attributes: {
     ...defaultSchema.attributes,
     span: [...(defaultSchema.attributes?.['span'] ?? []), 'className', ...MENTION_DATA_ATTRS],
+    input: [...(defaultSchema.attributes?.['input'] ?? []), 'checked'],
   },
   // Preserve the synthetic `cite:` / `cite-group:` link schemes emitted by
   // `linkifyAndGroupClawCitations` — rehype-sanitize strips unknown href

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -24,6 +24,11 @@ export interface ClawCitationContext {
   toolNumbers: ReadonlyMap<string, number>;
 }
 
+export interface MarkdownComponentOptions {
+  /** Enables allowlisted rich blocks for artifact documents. Normal chat stays plain markdown. */
+  richArtifactContent?: boolean;
+}
+
 // ─── Code Block ──────────────────────────────────────────────────────────────
 
 interface CodeProps extends React.HTMLAttributes<HTMLElement> {
@@ -36,8 +41,10 @@ const CodeBlock = ({
   className,
   children,
   node: _node,
+  messageId,
+  richArtifactContent,
   ...props
-}: CodeProps & { messageId: string }): React.ReactElement => {
+}: CodeProps & { messageId: string; richArtifactContent?: boolean }): React.ReactElement => {
   const [copied, setCopied] = useState(false);
 
   const match = /language-(\w+)/.exec(String(className ?? ''));
@@ -49,10 +56,14 @@ const CodeBlock = ({
       ? children.replace(/\n$/, '')
       : '';
 
+  if (richArtifactContent && (language === 'badge' || language === 'badges')) {
+    return <BadgeFence source={codeString} />;
+  }
+
   // ── Mermaid ──
   if (language === 'mermaid') {
     return (
-      <MermaidBlock chart={codeString} messageId={(props as { messageId: string }).messageId} />
+      <MermaidBlock chart={codeString} messageId={messageId} />
     );
   }
 
@@ -61,7 +72,7 @@ const CodeBlock = ({
     return (
       <FilesystemBlock
         jsonSource={codeString}
-        messageId={(props as { messageId: string }).messageId}
+        messageId={messageId}
       />
     );
   }
@@ -124,6 +135,52 @@ const CodeBlock = ({
   );
 };
 
+type BadgeTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+
+const BADGE_TONES: Record<BadgeTone, string> = {
+  neutral: 'border-border bg-muted text-muted-foreground',
+  info: 'border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  success: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  danger: 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400',
+};
+
+const parseBadgeLine = (raw: string): { tone: BadgeTone; label: string } | null => {
+  const line = raw.trim();
+  if (!line) return null;
+  const match = /^(neutral|info|success|warning|danger)\s*:\s*(.+)$/i.exec(line);
+  if (!match) return { tone: 'neutral', label: line };
+  const [, tone, label] = match;
+  if (!tone || !label) return null;
+  return { tone: tone.toLowerCase() as BadgeTone, label: label.trim() };
+};
+
+const BadgeFence: React.FC<{ source: string }> = ({ source }) => {
+  const badges = source
+    .split(/[\n,]/)
+    .map(parseBadgeLine)
+    .filter((badge): badge is { tone: BadgeTone; label: string } => !!badge && badge.label.length > 0);
+
+  if (badges.length === 0) return <></>;
+
+  return (
+    <div className='my-3 flex flex-wrap gap-1.5'>
+      {badges.map((badge, index) => (
+        <span
+          key={`${badge.tone}-${badge.label}-${index}`}
+          className={[
+            'inline-flex max-w-full items-center rounded-md border px-1.5 py-0.5',
+            'text-xs font-medium leading-[1.4]',
+            BADGE_TONES[badge.tone],
+          ].join(' ')}
+        >
+          {badge.label}
+        </span>
+      ))}
+    </div>
+  );
+};
+
 // ─── createMarkdownComponents ─────────────────────────────────────────────────
 
 /**
@@ -136,9 +193,16 @@ const CodeBlock = ({
 export const createMarkdownComponents = (
   messageId: string,
   citationCtx?: ClawCitationContext,
+  options?: MarkdownComponentOptions,
 ): Components => ({
   // Override <code> — handles both inline and block (via className presence)
-  code: (props: CodeProps): React.ReactElement => <CodeBlock {...props} messageId={messageId} />,
+  code: (props: CodeProps): React.ReactElement => (
+    <CodeBlock
+      {...props}
+      messageId={messageId}
+      richArtifactContent={options?.richArtifactContent === true}
+    />
+  ),
 
   // Override <pre> to render a plain fragment — CodeBlock renders its own <pre>
   // internally, so we don't want a double-wrapped <pre><pre>.

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260801090000_add_experiment_mode/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260801090000_add_experiment_mode/migration.sql
@@ -1,0 +1,45 @@
+-- CreateTable: ExperimentRun — durable state for Spaces /experiment loops.
+CREATE TABLE "experiment_runs" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "agentSlug" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT,
+    "focus" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'running',
+    "epoch" INTEGER NOT NULL DEFAULT 1,
+    "deadlineAt" TIMESTAMP(3) NOT NULL,
+    "currentHypothesis" TEXT,
+    "currentSessionId" TEXT,
+    "lastEpochEndedAt" TIMESTAMP(3),
+    "sandboxNote" TEXT,
+    "finalReport" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "experiment_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: ExperimentFinding — ledger entries recorded by the experiment runtime.
+CREATE TABLE "experiment_findings" (
+    "id" TEXT NOT NULL,
+    "experimentId" TEXT NOT NULL,
+    "epoch" INTEGER NOT NULL,
+    "status" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "hypothesis" TEXT NOT NULL,
+    "note" TEXT,
+    "proofArtifactPath" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "experiment_findings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "experiment_runs_conversationId_status_idx" ON "experiment_runs"("conversationId", "status");
+CREATE INDEX "experiment_findings_experimentId_idx" ON "experiment_findings"("experimentId");
+
+-- AddForeignKey
+ALTER TABLE "experiment_findings" ADD CONSTRAINT "experiment_findings_experimentId_fkey" FOREIGN KEY ("experimentId") REFERENCES "experiment_runs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260801120000_experiment_provider_override/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260801120000_experiment_provider_override/migration.sql
@@ -1,0 +1,3 @@
+-- Per-experiment LLM pin (providerOverride on epoch dispatch).
+ALTER TABLE "experiment_runs" ADD COLUMN "provider" TEXT;
+ALTER TABLE "experiment_runs" ADD COLUMN "modelId" TEXT;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1771,6 +1771,51 @@ model ActiveGoal {
   @@map("active_goals")
 }
 
+model ExperimentRun {
+  id                String              @id @default(cuid())
+  conversationId    String
+  channelId         String
+  agentSlug         String
+  userId            String
+  orgId             String?
+  focus             String?
+  /// Per-experiment LLM pin, forwarded as providerOverride on every epoch
+  /// dispatch. NULL = the agent's normal provider resolution.
+  provider          String?
+  modelId           String?
+  status            String              @default("running") /// running | finishing | done | aborted
+  epoch             Int                 @default(1)
+  deadlineAt        DateTime
+  currentHypothesis String?             @db.Text
+  currentSessionId  String?
+  lastEpochEndedAt  DateTime?
+  sandboxNote       String?
+  finalReport       String?             @db.Text
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+  findings          ExperimentFinding[]
+
+  @@index([conversationId, status])
+  @@map("experiment_runs")
+}
+
+model ExperimentFinding {
+  id                String        @id @default(cuid())
+  experimentId      String
+  experiment        ExperimentRun @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  epoch             Int
+  status            String /// conjecture | proved | refuted
+  title             String
+  hypothesis        String        @db.Text
+  note              String?       @db.Text
+  proofArtifactPath String?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  @@index([experimentId])
+  @@map("experiment_findings")
+}
+
 /// Output of the FailureCurator — a structured "why this agent is
 /// failing and what to change" finding, evidenced by 2+ AgentRun
 /// sessionIds. Generated hourly by the curator worker; reviewed and

--- a/apps/xyne-claw-auth/backend/scripts/claude-key-usage.js
+++ b/apps/xyne-claw-auth/backend/scripts/claude-key-usage.js
@@ -1,0 +1,87 @@
+/**
+ * READ-ONLY report: who shares / uses the Claude key configured on a given
+ * agent (default: xyne-spaces-architect).
+ *
+ * Run inside the claw-auth pod (it has DATABASE_URL + @prisma/client):
+ *   kubectx prod
+ *   POD=$(kubectl get pods -n xyne-apps -o name | grep claw-auth | head -1)
+ *   kubectl exec -i -n xyne-apps $POD -- node < scripts/claude-key-usage.js
+ *
+ * Only SELECTs — no writes.
+ */
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+const SLUG = process.env.TARGET_SLUG || "xyne-spaces-architect";
+const PROVIDER = "claude";
+
+async function main() {
+  // 1. The agent + its claude credential row
+  const agents = await prisma.$queryRawUnsafe(
+    `SELECT a.id, a.slug, a.name, a."orgId", a."ownerUserId", u.email AS owner_email
+       FROM agents a LEFT JOIN users u ON u.id = a."ownerUserId"
+      WHERE a.slug = $1`, SLUG);
+  if (agents.length === 0) { console.log(`No agent with slug ${SLUG}`); return; }
+  for (const a of agents) {
+    console.log(`\n=== Agent ${a.slug} (${a.name}) org=${a.orgId} owner=${a.owner_email ?? a.ownerUserId} ===`);
+    const creds = await prisma.$queryRawUnsafe(
+      `SELECT "sharedCredentialId", ("encryptedKey" IS NOT NULL) AS has_dedicated_key,
+              "authType", model, "createdByUserId", "updatedAt"
+         FROM agent_provider_credentials WHERE "agentId" = $1 AND provider = $2`, a.id, PROVIDER);
+    if (creds.length === 0) { console.log("  (no claude credential row on this agent)"); continue; }
+    const cred = creds[0];
+    console.log(`  credential: ${cred.sharedCredentialId ? `BOUND to shared ${cred.sharedCredentialId}` : "DEDICATED (agent-local key)"} authType=${cred.authType} model=${cred.model ?? "-"} updated=${cred.updatedAt?.toISOString?.() ?? cred.updatedAt}`);
+
+    let boundSlugs = [a.slug];
+    if (cred.sharedCredentialId) {
+      // 2. The shared row + every binding (agents + users)
+      const shared = await prisma.$queryRawUnsafe(
+        `SELECT s.id, s.name, s."orgId", s."authType", s.model, u.email AS owner_email, s."updatedAt"
+           FROM shared_provider_credentials s LEFT JOIN users u ON u.id = s."ownerUserId"
+          WHERE s.id = $1`, cred.sharedCredentialId);
+      console.log(`  shared credential: "${shared[0]?.name}" org=${shared[0]?.orgId ?? "PLATFORM-WIDE"} connectedBy=${shared[0]?.owner_email} lastRotated=${shared[0]?.updatedAt?.toISOString?.() ?? ""}`);
+
+      const agentBindings = await prisma.$queryRawUnsafe(
+        `SELECT ag.slug, ag.name, ag."orgId", ou.email AS owner_email, apc."updatedAt"
+           FROM agent_provider_credentials apc
+           JOIN agents ag ON ag.id = apc."agentId"
+           LEFT JOIN users ou ON ou.id = ag."ownerUserId"
+          WHERE apc."sharedCredentialId" = $1 AND apc.provider = $2
+          ORDER BY ag.slug`, cred.sharedCredentialId, PROVIDER);
+      console.log(`\n  -- AGENTS sharing this key (${agentBindings.length}) --`);
+      for (const b of agentBindings) console.log(`  ${b.slug.padEnd(30)} ${String(b.name).padEnd(28)} org=${b.orgId} owner=${b.owner_email ?? "-"}`);
+      boundSlugs = agentBindings.map((b) => b.slug);
+
+      const userBindings = await prisma.$queryRawUnsafe(
+        `SELECT uu.email, upc."updatedAt"
+           FROM user_provider_credentials upc JOIN users uu ON uu.id = upc."userId"
+          WHERE upc."sharedCredentialId" = $1 AND upc.provider = $2 ORDER BY uu.email`, cred.sharedCredentialId, PROVIDER);
+      console.log(`\n  -- USERS with a personal binding to this key (${userBindings.length}) --`);
+      for (const u of userBindings) console.log(`  ${u.email}`);
+    }
+
+    // 3. Usage: claude runs on the bound agents, last 30 days, by agent and by user
+    const slugList = boundSlugs.map((_, i) => `$${i + 1}`).join(",");
+    const byAgent = await prisma.$queryRawUnsafe(
+      `SELECT "agentSlug", COUNT(*)::int AS runs,
+              COALESCE(SUM("tokensIn"),0)::bigint AS tokens_in, COALESCE(SUM("tokensOut"),0)::bigint AS tokens_out,
+              MAX("startedAt") AS last_run
+         FROM agent_runs
+        WHERE provider = 'claude' AND "agentSlug" IN (${slugList}) AND "startedAt" > now() - interval '30 days'
+        GROUP BY "agentSlug" ORDER BY runs DESC`, ...boundSlugs);
+    console.log(`\n  -- CLAUDE RUNS by agent (last 30d) --`);
+    for (const r of byAgent) console.log(`  ${r.agentSlug.padEnd(30)} runs=${String(r.runs).padEnd(6)} in=${r.tokens_in} out=${r.tokens_out} last=${r.last_run?.toISOString?.() ?? r.last_run}`);
+
+    const byUser = await prisma.$queryRawUnsafe(
+      `SELECT u.email, COUNT(*)::int AS runs,
+              COALESCE(SUM(r."tokensIn"),0)::bigint AS tokens_in, COALESCE(SUM(r."tokensOut"),0)::bigint AS tokens_out,
+              MAX(r."startedAt") AS last_run
+         FROM agent_runs r JOIN users u ON u.id = r."userId"
+        WHERE r.provider = 'claude' AND r."agentSlug" IN (${slugList}) AND r."startedAt" > now() - interval '30 days'
+        GROUP BY u.email ORDER BY runs DESC LIMIT 25`, ...boundSlugs);
+    console.log(`\n  -- CLAUDE RUNS by user (last 30d, top 25) --`);
+    for (const r of byUser) console.log(`  ${String(r.email).padEnd(40)} runs=${String(r.runs).padEnd(6)} in=${r.tokens_in} out=${r.tokens_out} last=${r.last_run?.toISOString?.() ?? r.last_run}`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());

--- a/apps/xyne-claw-auth/backend/scripts/provider-audit.js
+++ b/apps/xyne-claw-auth/backend/scripts/provider-audit.js
@@ -1,0 +1,91 @@
+/**
+ * READ-ONLY audit: EVERY credential for the given providers across ALL orgs —
+ * every shared_provider_credentials row (with all agent/user bindings), every
+ * DEDICATED agent credential, and 30d usage per agent.
+ *
+ * Run inside the claw-auth pod:
+ *   kubectl exec -i -n $NS $POD -- node < scripts/provider-audit.js
+ * Providers default to claude,codex; override: PROVIDERS=claude kubectl exec …
+ *
+ * Only SELECTs — no writes, nothing decrypted.
+ */
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+const PROVIDERS = (process.env.PROVIDERS || "claude,codex").split(",").map((s) => s.trim());
+
+const fmtDate = (d) => (d?.toISOString ? d.toISOString().slice(0, 16) : String(d ?? "-"));
+
+async function usageBySlugs(provider, slugs) {
+  if (slugs.length === 0) return [];
+  const ph = slugs.map((_, i) => `$${i + 2}`).join(",");
+  return prisma.$queryRawUnsafe(
+    `SELECT "agentSlug", COUNT(*)::int AS runs,
+            COALESCE(SUM("tokensIn"),0)::bigint AS t_in, COALESCE(SUM("tokensOut"),0)::bigint AS t_out,
+            COALESCE(SUM("tokensCacheRead"),0)::bigint AS t_cache, MAX("startedAt") AS last_run
+       FROM agent_runs
+      WHERE provider = $1 AND "agentSlug" IN (${ph}) AND "startedAt" > now() - interval '30 days'
+      GROUP BY "agentSlug" ORDER BY runs DESC`, provider, ...slugs);
+}
+
+async function main() {
+  for (const provider of PROVIDERS) {
+    console.log(`\n################ PROVIDER: ${provider} ################`);
+
+    // ── 1. Every shared credential row, all orgs ─────────────────────────────
+    const shared = await prisma.$queryRawUnsafe(
+      `SELECT s.id, s.name, s."orgId", o.name AS org_name, s."authType", u.email AS owner_email, s."updatedAt"
+         FROM shared_provider_credentials s
+         LEFT JOIN organizations o ON o.id = s."orgId"
+         LEFT JOIN users u ON u.id = s."ownerUserId"
+        WHERE s.provider = $1 ORDER BY s."orgId" NULLS FIRST, s.name`, provider);
+
+    console.log(`\n== SHARED credentials (${shared.length}) ==`);
+    for (const s of shared) {
+      console.log(`\n▶ "${s.name}" id=${s.id} org=${s.org_name ?? s.orgId ?? "PLATFORM-WIDE"} connectedBy=${s.owner_email ?? "-"} authType=${s.authType ?? "-"} lastRotated=${fmtDate(s.updatedAt)}`);
+      const agentBindings = await prisma.$queryRawUnsafe(
+        `SELECT ag.slug, ag.name, ag."orgId", ou.email AS owner_email
+           FROM agent_provider_credentials apc
+           JOIN agents ag ON ag.id = apc."agentId"
+           LEFT JOIN users ou ON ou.id = ag."ownerUserId"
+          WHERE apc."sharedCredentialId" = $1 AND apc.provider = $2 ORDER BY ag.slug`, s.id, provider);
+      for (const b of agentBindings)
+        console.log(`   agent ${b.slug.padEnd(30)} owner=${(b.owner_email ?? "-").padEnd(35)} org=${b.orgId}`);
+      const userBindings = await prisma.$queryRawUnsafe(
+        `SELECT uu.email FROM user_provider_credentials upc JOIN users uu ON uu.id = upc."userId"
+          WHERE upc."sharedCredentialId" = $1 AND upc.provider = $2 ORDER BY uu.email`, s.id, provider);
+      for (const u of userBindings) console.log(`   user  ${u.email} (personal binding)`);
+
+      const usage = await usageBySlugs(provider, agentBindings.map((b) => b.slug));
+      for (const r of usage)
+        console.log(`   30d   ${r.agentSlug.padEnd(30)} runs=${String(r.runs).padEnd(6)} out=${r.t_out} in=${r.t_in} cacheRead=${r.t_cache} last=${fmtDate(r.last_run)}`);
+    }
+
+    // ── 2. DEDICATED agent credentials (own key, not bound to any shared row) ─
+    const dedicated = await prisma.$queryRawUnsafe(
+      `SELECT ag.slug, ag.name, ag."orgId", ou.email AS owner_email, apc."authType", apc."updatedAt", cu.email AS created_by
+         FROM agent_provider_credentials apc
+         JOIN agents ag ON ag.id = apc."agentId"
+         LEFT JOIN users ou ON ou.id = ag."ownerUserId"
+         LEFT JOIN users cu ON cu.id = apc."createdByUserId"
+        WHERE apc.provider = $1 AND apc."sharedCredentialId" IS NULL AND apc."encryptedKey" IS NOT NULL
+        ORDER BY ag.slug`, provider);
+    console.log(`\n== DEDICATED agent keys (${dedicated.length}) — separate credentials, not your shared row ==`);
+    for (const d of dedicated)
+      console.log(`   ${d.slug.padEnd(30)} owner=${(d.owner_email ?? "-").padEnd(35)} connectedBy=${d.created_by ?? "-"} authType=${d.authType ?? "-"} updated=${fmtDate(d.updatedAt)}`);
+    const dedUsage = await usageBySlugs(provider, dedicated.map((d) => d.slug));
+    for (const r of dedUsage)
+      console.log(`   30d   ${r.agentSlug.padEnd(30)} runs=${String(r.runs).padEnd(6)} out=${r.t_out} in=${r.t_in} last=${fmtDate(r.last_run)}`);
+
+    // ── 3. PERSONAL user keys (dedicated, not bound) ─────────────────────────
+    const personal = await prisma.$queryRawUnsafe(
+      `SELECT uu.email, upc."authType", upc."updatedAt"
+         FROM user_provider_credentials upc JOIN users uu ON uu.id = upc."userId"
+        WHERE upc.provider = $1 AND upc."sharedCredentialId" IS NULL AND upc."encryptedKey" IS NOT NULL
+        ORDER BY uu.email`, provider);
+    console.log(`\n== PERSONAL user keys (${personal.length}) ==`);
+    for (const p of personal) console.log(`   ${p.email.padEnd(40)} authType=${p.authType ?? "-"} updated=${fmtDate(p.updatedAt)}`);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); }).finally(() => prisma.$disconnect());

--- a/apps/xyne-claw-auth/backend/src/lib/agent-tool-selection.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-tool-selection.ts
@@ -1,0 +1,69 @@
+/**
+ * Categorize a FLAT list of tool tokens (as accepted by the agent-authoring
+ * tools create-agent / create-subagent / update-agent / update-subagent) into
+ * the `config.tools` buckets the rest of the system reads
+ * (readConfigToolSelection in routes/agents.ts).
+ *
+ * Scope (deliberate): only the two buckets that are unambiguous and safe to set
+ * from a flat token are resolved here —
+ *   - `subagents` ← exact match on a catalog subagent NAME
+ *   - `custom`    ← exact match on a custom tool SLUG (e.g. "web-search")
+ * Anything else (MCP server tools, gateway service tools) needs a source-scoped
+ * selection key whose bucket depends on integration state; mis-bucketing there
+ * would silently mis-wire the agent. Those tokens are returned as `unknown` so
+ * the caller can report them back and the author can wire them via the UI. This
+ * matches the tools' "unknown entries are skipped and reported" contract.
+ */
+
+import type { AvailableToolsCatalog } from "../routes/tools.js";
+
+export interface CategorizedToolSelection {
+  /** Selected subagent names (empty unless allowSubagents). */
+  subagents: string[];
+  /** Selected custom tool slugs. */
+  custom: string[];
+  /** Tokens that matched no subagent name or custom tool slug. */
+  unknown: string[];
+}
+
+/**
+ * @param tools flat list of tool slugs / subagent names supplied by the author
+ * @param catalog org tool catalog from buildAvailableToolsCatalog
+ * @param opts.allowSubagents whether subagent selection is valid for this target
+ *        (agents: yes; subagents cannot themselves nest subagents → false)
+ */
+export function categorizeToolSelection(
+  tools: string[],
+  catalog: AvailableToolsCatalog,
+  opts: { allowSubagents: boolean },
+): CategorizedToolSelection {
+  const subagentNames = new Set(catalog.subagents.map((s) => s.name));
+  const customSlugs = new Set(catalog.customGroups.flatMap((g) => g.tools.map((t) => t.slug)));
+
+  const subagents = new Set<string>();
+  const custom = new Set<string>();
+  const unknown: string[] = [];
+
+  for (const raw of tools) {
+    const token = raw.trim();
+    if (!token) continue;
+    if (opts.allowSubagents && subagentNames.has(token)) {
+      subagents.add(token);
+    } else if (customSlugs.has(token)) {
+      custom.add(token);
+    } else {
+      unknown.push(token);
+    }
+  }
+
+  return { subagents: [...subagents], custom: [...custom], unknown };
+}
+
+/** Build the `config.tools` object from a categorized selection, omitting empty
+ *  buckets so a tool-less agent gets `{}` rather than `{ tools: {...empties} }`. */
+export function toConfigTools(sel: CategorizedToolSelection): { subagents?: string[]; custom?: string[] } {
+  return {
+    ...(sel.subagents.length > 0 ? { subagents: sel.subagents } : {}),
+    ...(sel.custom.length > 0 ? { custom: sel.custom } : {}),
+  };
+}

--- a/apps/xyne-claw-auth/backend/src/lib/entity-update.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/entity-update.ts
@@ -1,0 +1,391 @@
+/**
+ * Shared machinery for the update-agent / update-subagent propose→approve flow,
+ * the multi-field sibling of the skill-update flow in routes/skills.ts. Both
+ * agent and subagent updates:
+ *   - apply anchored systemPrompt edits (or a small full replacement) to a
+ *     working copy, exactly like update-skill (tool args scale with the CHANGE,
+ *     so a long prompt never gets truncated as one argument),
+ *   - additionally carry scalar field changes (name/description/model/tools/…),
+ *   - store the whole proposal as JSON in agent_requests.proposedContent, keyed
+ *     by targetType + agentSlug (the slug for agents, the name for subagents),
+ *   - DM the OWNER a diff card and apply only on their approval.
+ *
+ * The prompt diff/hash helpers are reused verbatim from the skill-diff package.
+ */
+
+import { normalizeSkillContent, hashSkillContent, computeSkillDiff, buildEntityUpdateApprovalFlow } from "xyne-claw-shared";
+import { agentRepository, subagentDefinitionRepository, agentRequestRepository } from "../repositories/index.js";
+import { buildAvailableToolsCatalog } from "../routes/tools.js";
+import { categorizeToolSelection, toConfigTools } from "./agent-tool-selection.js";
+import { getWorkspaceIdForUser } from "./spaces-db.js";
+import { spacesAppFetch } from "./spaces-api.js";
+import { writeAuditLog } from "./audit.js";
+import { decrypt } from "../crypto.js";
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("entity-update");
+
+export type EntityKind = "agent" | "subagent";
+
+const FULL_REPLACEMENT_MAX_CHARS = 8_000;
+
+export interface PromptEdit { oldText: string; newText: string }
+
+export interface EntityUpdateBody {
+  promptEdits?: Array<{ oldText?: string; newText?: string }>;
+  systemPrompt?: string;
+  // Agent scalars
+  name?: string;
+  modelId?: string;
+  color?: string;
+  // Shared scalar
+  description?: string;
+  // Subagent scalars
+  paramName?: string;
+  paramDescription?: string;
+  // Selection (both) — a flat list that REPLACES the current tool selection
+  tools?: string[];
+  summary?: string;
+}
+
+/** JSON stored in agent_requests.proposedContent. */
+interface EntityUpdatePayload {
+  /** Final system prompt — present only when the prompt is being changed. */
+  systemPrompt?: string;
+  /** Changed scalar fields, verbatim (tools stays a flat string[]). */
+  fields?: Record<string, string | string[]>;
+}
+
+export interface FieldChange { label: string; from: string; to: string }
+
+type ComputeError = { ok: false; code: 400 | 409; error: string };
+type ComputeOk = {
+  ok: true;
+  payload: EntityUpdatePayload;
+  promptChanged: boolean;
+  diff?: ReturnType<typeof computeSkillDiff>;
+  fieldChanges: FieldChange[];
+  baseContentHash: string;
+};
+
+/** Apply anchored {oldText,newText} edits to `current`, mirroring the skill
+ *  route: each oldText must appear exactly once. */
+function applyPromptEdits(current: string, edits: PromptEdit[]): { ok: true; content: string } | ComputeError {
+  let working = normalizeSkillContent(current);
+  for (const [i, e] of edits.entries()) {
+    if (!e.oldText) return { ok: false, code: 400, error: `promptEdits[${i}].oldText is required` };
+    const first = working.indexOf(e.oldText);
+    if (first === -1) {
+      return { ok: false, code: 400, error: `promptEdits[${i}].oldText not found in the current system prompt — copy it EXACTLY (read the current definition first; it may have changed).` };
+    }
+    if (working.indexOf(e.oldText, first + 1) !== -1) {
+      return { ok: false, code: 400, error: `promptEdits[${i}].oldText matches more than once — include more surrounding context to make it unique.` };
+    }
+    working = working.slice(0, first) + e.newText + working.slice(first + e.oldText.length);
+  }
+  return { ok: true, content: working };
+}
+
+function normalizeEdits(raw: EntityUpdateBody["promptEdits"]): PromptEdit[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((e): e is { oldText: string; newText: string } =>
+      !!e && typeof e.oldText === "string" && e.oldText.length > 0 && typeof e.newText === "string")
+    .map((e) => ({ oldText: e.oldText, newText: e.newText }));
+}
+
+/** Which scalar fields each kind accepts, as [payloadKey, label, currentValue]. */
+function scalarSpecForKind(kind: EntityKind, current: CurrentEntity): Array<{ key: string; label: string; current: string }> {
+  if (kind === "agent") {
+    return [
+      { key: "name", label: "Name", current: current.name },
+      { key: "description", label: "Description", current: current.description },
+      { key: "modelId", label: "Model", current: current.modelId ?? "" },
+      { key: "color", label: "Color", current: current.color ?? "" },
+    ];
+  }
+  return [
+    { key: "description", label: "Description", current: current.description },
+    { key: "paramName", label: "Input name", current: current.paramName ?? "" },
+    { key: "paramDescription", label: "Input description", current: current.paramDescription ?? "" },
+  ];
+}
+
+interface CurrentEntity {
+  systemPrompt: string;
+  name: string;
+  description: string;
+  modelId?: string | null;
+  color?: string | null;
+  paramName?: string | null;
+  paramDescription?: string | null;
+  /** Current flat tool selection, for the tools field-change display. */
+  currentToolSelection: string[];
+}
+
+/**
+ * Pure: turn an update body + the current entity into a proposal payload, the
+ * prompt diff, and the human-readable field changes. No DB writes.
+ */
+export function computeEntityUpdate(kind: EntityKind, current: CurrentEntity, body: EntityUpdateBody): ComputeOk | ComputeError {
+  // 1) System prompt
+  const edits = normalizeEdits(body.promptEdits);
+  let proposedPrompt = current.systemPrompt;
+  let promptChanged = false;
+  if (edits.length > 0) {
+    const applied = applyPromptEdits(current.systemPrompt, edits);
+    if (!applied.ok) return applied;
+    proposedPrompt = applied.content;
+    promptChanged = normalizeSkillContent(proposedPrompt) !== normalizeSkillContent(current.systemPrompt);
+  } else if (typeof body.systemPrompt === "string" && body.systemPrompt.trim()) {
+    if (normalizeSkillContent(current.systemPrompt).length > FULL_REPLACEMENT_MAX_CHARS) {
+      return { ok: false, code: 400, error: `This system prompt is ${current.systemPrompt.length} chars — too large for full-replacement mode (tool arguments get truncated). Use \`promptEdits\` (anchored {oldText,newText}) instead.` };
+    }
+    proposedPrompt = body.systemPrompt;
+    promptChanged = normalizeSkillContent(proposedPrompt) !== normalizeSkillContent(current.systemPrompt);
+  }
+
+  // Shrink guard — a proposal that deletes most of the prompt is almost always
+  // a truncated "full replacement" (mirrors the skill route's hard guard).
+  if (promptChanged) {
+    const baseLen = normalizeSkillContent(current.systemPrompt).length;
+    const newLen = normalizeSkillContent(proposedPrompt).length;
+    if (baseLen > 2_000 && newLen < baseLen * 0.6) {
+      return { ok: false, code: 400, error: `Proposed system prompt is ${newLen} chars vs the current ${baseLen} — it removes over 40% of the prompt. If intentional, make the deletions via explicit \`promptEdits\` so the diff shows exactly what is removed.` };
+    }
+  }
+
+  // 2) Scalar fields
+  const payload: EntityUpdatePayload = {};
+  const fieldChanges: FieldChange[] = [];
+  const fields: Record<string, string | string[]> = {};
+  for (const spec of scalarSpecForKind(kind, current)) {
+    const proposed = body[spec.key as keyof EntityUpdateBody];
+    if (typeof proposed === "string") {
+      const next = proposed.trim();
+      if (next !== spec.current) {
+        fields[spec.key] = next;
+        fieldChanges.push({ label: spec.label, from: spec.current, to: next });
+      }
+    }
+  }
+
+  // 3) Tools — a flat list that REPLACES the current selection.
+  if (Array.isArray(body.tools)) {
+    const nextTools = [...new Set(body.tools.filter((t) => typeof t === "string" && t.trim()).map((t) => t.trim()))];
+    const cur = [...current.currentToolSelection].sort();
+    const nxt = [...nextTools].sort();
+    if (JSON.stringify(cur) !== JSON.stringify(nxt)) {
+      fields["tools"] = nextTools;
+      fieldChanges.push({ label: "Tools", from: current.currentToolSelection.join(", "), to: nextTools.join(", ") });
+    }
+  }
+
+  if (promptChanged) payload.systemPrompt = normalizeSkillContent(proposedPrompt);
+  if (Object.keys(fields).length > 0) payload.fields = fields;
+
+  if (!promptChanged && Object.keys(fields).length === 0) {
+    return { ok: false, code: 409, error: "Your update is identical to the current definition — nothing to propose." };
+  }
+
+  return {
+    ok: true,
+    payload,
+    promptChanged,
+    ...(promptChanged ? { diff: computeSkillDiff(current.systemPrompt, proposedPrompt) } : {}),
+    fieldChanges,
+    baseContentHash: hashSkillContent(current.systemPrompt),
+  };
+}
+
+/** Flatten an agent's config.tools (subagents + custom) into a display list. */
+export function agentToolSelectionFromConfig(config: unknown): string[] {
+  const tools = (config && typeof config === "object" && !Array.isArray(config))
+    ? (config as Record<string, unknown>)["tools"]
+    : undefined;
+  const rec = (tools && typeof tools === "object" && !Array.isArray(tools)) ? (tools as Record<string, unknown>) : {};
+  const out: string[] = [];
+  for (const key of ["subagents", "custom"]) {
+    const list = rec[key];
+    if (Array.isArray(list)) for (const v of list) if (typeof v === "string") out.push(v);
+  }
+  return out;
+}
+
+/** Flatten a subagent's tools JSON (custom only) into a display list. */
+export function subagentToolSelectionFromConfig(tools: unknown): string[] {
+  const rec = (tools && typeof tools === "object" && !Array.isArray(tools)) ? (tools as Record<string, unknown>) : {};
+  const list = rec["custom"];
+  return Array.isArray(list) ? list.filter((v): v is string => typeof v === "string") : [];
+}
+
+type ResolveResult =
+  | { ok: true; status: "approved" | "rejected"; alreadyResolved?: boolean }
+  | { ok: false; code: 400 | 403 | 404 | 409; error: string };
+
+/**
+ * Apply (or reject) an agent/subagent update request on the owner's decision.
+ * Re-reads the LIVE definition, re-derives the approver from it (never trusts
+ * the card), verifies the proposal integrity hash, and applies atomically after
+ * an idempotent claim. Called by flow-action.ts and the REST parity routes.
+ */
+export async function resolveEntityUpdateRequest(kind: EntityKind, requestId: string, callerUserId: string, decision: "approve" | "reject"): Promise<ResolveResult> {
+  const requestType = `${kind}_update`;
+  const request = await agentRequestRepository.findById(requestId);
+  if (!request || request.requestType !== requestType || !request.agentSlug) {
+    return { ok: false, code: 404, error: `${kind} update request not found` };
+  }
+  const orgId = request.orgId;
+  const targetKey = request.agentSlug;
+
+  // Re-derive the owner from the LIVE row.
+  let ownerUserId: string | null;
+  let displayName: string;
+  if (kind === "agent") {
+    const agent = await agentRepository.findBySlug(targetKey, orgId);
+    if (!agent) return { ok: false, code: 404, error: "Agent not found" };
+    ownerUserId = agent.ownerUserId ?? null;
+    displayName = agent.name;
+  } else {
+    const sub = await subagentDefinitionRepository.findByName(targetKey, orgId);
+    if (!sub) return { ok: false, code: 404, error: "Subagent not found" };
+    ownerUserId = sub.createdByUserId ?? null;
+    displayName = sub.name;
+  }
+  if (!ownerUserId) return { ok: false, code: 409, error: `This ${kind} has no owner to approve an update.` };
+  if (callerUserId !== ownerUserId) return { ok: false, code: 403, error: "Only the owner can approve this update." };
+
+  if (request.status !== "pending") {
+    return { ok: true, status: request.status === "approved" ? "approved" : "rejected", alreadyResolved: true };
+  }
+  const alreadyResolved = async (): Promise<ResolveResult> => {
+    const fresh = await agentRequestRepository.findById(request.id);
+    return { ok: true, status: fresh?.status === "approved" ? "approved" : "rejected", alreadyResolved: true };
+  };
+
+  if (decision === "reject") {
+    const claim = await agentRequestRepository.claimPendingEntityUpdate(request.id, requestType, "rejected", callerUserId);
+    if (claim.count === 0) return alreadyResolved();
+    await writeAuditLog({ actorUserId: callerUserId, eventType: "REQUEST_REJECTED", targetId: targetKey, description: `Rejected ${kind} update of "${displayName}"` });
+    return { ok: true, status: "rejected" };
+  }
+
+  const claim = await agentRequestRepository.claimPendingEntityUpdate(request.id, requestType, "approved", callerUserId);
+  if (claim.count === 0) return alreadyResolved();
+
+  try {
+    const proposedRaw = request.proposedContent ?? "";
+    if (hashSkillContent(proposedRaw) !== (request.proposedContentHash ?? "")) {
+      await agentRequestRepository.revertEntityUpdateToPending(request.id).catch(() => {});
+      return { ok: false, code: 409, error: "Proposed content failed integrity check" };
+    }
+    let payload: EntityUpdatePayload;
+    try { payload = JSON.parse(proposedRaw) as EntityUpdatePayload; }
+    catch {
+      await agentRequestRepository.revertEntityUpdateToPending(request.id).catch(() => {});
+      return { ok: false, code: 409, error: "Proposed content is not valid JSON" };
+    }
+    await applyEntityPayload(kind, targetKey, orgId, payload);
+  } catch (err) {
+    await agentRequestRepository.revertEntityUpdateToPending(request.id).catch(() => {});
+    throw err;
+  }
+
+  await writeAuditLog({ actorUserId: callerUserId, eventType: "REQUEST_APPROVED", targetId: targetKey, description: `Approved ${kind} update of "${displayName}" proposed by ${request.requesterId}` });
+  return { ok: true, status: "approved" };
+}
+
+/** Persist an approved payload. tools[] is re-categorized against the CURRENT
+ *  catalog at apply time (so a token that became valid since propose still
+ *  wires up); config.tools is merged so non-tools config keys survive. */
+async function applyEntityPayload(kind: EntityKind, targetKey: string, orgId: string, payload: EntityUpdatePayload): Promise<void> {
+  const fields = payload.fields ?? {};
+  if (kind === "agent") {
+    const data: Record<string, unknown> = {};
+    if (typeof payload.systemPrompt === "string") data["systemPrompt"] = payload.systemPrompt;
+    if (typeof fields["name"] === "string") data["name"] = fields["name"];
+    if (typeof fields["description"] === "string") data["description"] = fields["description"];
+    if (typeof fields["modelId"] === "string") data["modelId"] = fields["modelId"];
+    if (typeof fields["color"] === "string") data["color"] = fields["color"];
+    if (Array.isArray(fields["tools"])) {
+      const agent = await agentRepository.findBySlug(targetKey, orgId);
+      const existingConfig = (agent?.config && typeof agent.config === "object" && !Array.isArray(agent.config))
+        ? (agent.config as Record<string, unknown>) : {};
+      const catalog = await buildAvailableToolsCatalog(undefined, orgId);
+      const sel = categorizeToolSelection(fields["tools"] as string[], catalog, { allowSubagents: true });
+      if (sel.unknown.length > 0) log.info(`[entity-update] agent ${targetKey} apply: skipped unknown tools ${sel.unknown.join(",")}`);
+      data["config"] = { ...existingConfig, tools: toConfigTools(sel) };
+    }
+    await agentRepository.update(targetKey, orgId, data);
+    return;
+  }
+  const data: Record<string, unknown> = {};
+  if (typeof payload.systemPrompt === "string") data["systemPrompt"] = payload.systemPrompt;
+  if (typeof fields["description"] === "string") data["description"] = fields["description"];
+  if (typeof fields["paramName"] === "string") data["paramName"] = fields["paramName"];
+  if (typeof fields["paramDescription"] === "string") data["paramDescription"] = fields["paramDescription"];
+  if (Array.isArray(fields["tools"])) {
+    const catalog = await buildAvailableToolsCatalog(undefined, orgId);
+    const sel = categorizeToolSelection(fields["tools"] as string[], catalog, { allowSubagents: false });
+    if (sel.unknown.length > 0) log.info(`[entity-update] subagent ${targetKey} apply: skipped unknown tools ${sel.unknown.join(",")}`);
+    data["tools"] = sel.custom.length > 0 ? { custom: sel.custom } : {};
+  }
+  await subagentDefinitionRepository.update(targetKey, orgId, data);
+}
+
+/**
+ * DM the OWNER a diff card, posting AS the given (already authorized) agent —
+ * the sibling of notifyApproverOfSkillUpdateInSpaces. Best-effort: the request
+ * row is authoritative, so a failed DM only skips the card.
+ */
+export async function notifyApproverOfEntityUpdateInSpaces(args: {
+  kind: EntityKind;
+  approverUserId: string;
+  requestId: string;
+  targetKey: string;
+  targetName: string;
+  proposerName: string;
+  diff?: ReturnType<typeof computeSkillDiff>;
+  fieldChanges: FieldChange[];
+  summary?: string | null;
+  agent: { slug: string; spacesAppId: string | null; spacesAppToken: string | null; spacesAppUserId: string | null };
+}): Promise<void> {
+  try {
+    const { agent } = args;
+    if (!agent.spacesAppId || !agent.spacesAppToken || !agent.spacesAppUserId) {
+      log.info(`[entity-update] owner DM skipped for ${args.targetKey}: agent ${agent.slug} not Spaces-registered`);
+      return;
+    }
+    const [ciphertext, iv, authTag] = agent.spacesAppToken.split(":");
+    if (!ciphertext || !iv || !authTag) return;
+    const token = decrypt(ciphertext, iv, authTag, CONFIG.encryptionKey);
+
+    const workspaceId = (await getWorkspaceIdForUser(args.approverUserId, `${args.kind}-update-owner-dm`)) ?? "";
+    if (!workspaceId) {
+      log.warn(`[entity-update] owner DM skipped for ${args.targetKey}: no workspaceId for approver ${args.approverUserId}`);
+      return;
+    }
+    const dm = (await spacesAppFetch("/channel/openDm", { targetUserId: args.approverUserId, workspaceId }, token)) as { channelId: string };
+
+    const flow = buildEntityUpdateApprovalFlow({
+      kind: args.kind,
+      requestId: args.requestId,
+      approverUserId: args.approverUserId,
+      targetKey: args.targetKey,
+      targetName: args.targetName,
+      proposerName: args.proposerName,
+      ...(args.diff ? { diff: args.diff } : {}),
+      fieldChanges: args.fieldChanges,
+      ...(args.summary ? { summary: args.summary } : {}),
+      agentSlug: agent.slug,
+      spacesAppId: agent.spacesAppId,
+      spacesBaseUrl: CONFIG.spacesAppUrl,
+    });
+
+    await spacesAppFetch("/chat/postMessage", { channelId: dm.channelId, flow, userId: agent.spacesAppUserId }, token);
+    log.info(`[entity-update] sent ${args.kind}-update DM to approver ${args.approverUserId} for ${args.targetKey}`);
+  } catch (err) {
+    log.warn(`[entity-update] owner DM failed for ${args.targetKey}:`, err instanceof Error ? err.message : String(err));
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/lib/experiment.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/experiment.ts
@@ -1,0 +1,270 @@
+import type { ExperimentFinding, ExperimentRun } from "@prisma/client";
+import { CONFIG } from "../config.js";
+import { experimentRepository, agentRepository } from "../repositories/index.js";
+import { setSession, type SessionContext } from "./session-context.js";
+import { registerRunRecovery } from "../queue/run-recovery-worker.js";
+import { createTraceId, createLogger } from "../logger.js";
+import { decryptStoredField } from "../surfaces/spaces/client.js";
+
+const log = createLogger("experiment");
+
+const MAX_DURATION_MS = 8 * 60 * 60 * 1000;
+const DEFAULT_DURATION_MS = 60 * 60 * 1000;
+
+export type ExperimentCommand =
+  | { sub: "start"; durationMs: number; focus?: string; provider?: string; model?: string; invalidProvider?: string }
+  | { sub: "status" }
+  | { sub: "stop" };
+
+/** Providers a /experiment run may pin (must stay a subset of the /internal/run
+ *  proxy's OVERRIDABLE set — personal-cred providers still require the
+ *  requester's own key, enforced by the proxy at dispatch time). */
+export const EXPERIMENT_PROVIDERS = new Set(["spaces", "litellm", "claude", "codex", "copilot"]);
+
+const LEADING_MENTIONS = /^(?:@[\w.\-]+(?:\s+[\w.\-]+)*\s*)+/;
+
+export function parseExperimentCommand(text: string | undefined | null): ExperimentCommand | null {
+  if (!text) return null;
+  const trimmed = text.trim().replace(LEADING_MENTIONS, "");
+  if (!trimmed.toLowerCase().startsWith("/experiment")) return null;
+  const rest = trimmed.slice("/experiment".length).trim();
+  if (!rest) return { sub: "start", durationMs: DEFAULT_DURATION_MS };
+  const [first, ...tail] = rest.split(/\s+/);
+  const firstLower = first?.toLowerCase() ?? "";
+  if (firstLower === "status") return { sub: "status" };
+  if (firstLower === "stop") return { sub: "stop" };
+
+  let durationMs = DEFAULT_DURATION_MS;
+  let focusParts = rest.split(/\s+/);
+  const durationMatch = /^(\d+)(m|h)$/i.exec(firstLower);
+  if (durationMatch) {
+    const amount = Number(durationMatch[1]);
+    durationMs = durationMatch[2]!.toLowerCase() === "h"
+      ? amount * 60 * 60 * 1000
+      : amount * 60 * 1000;
+    focusParts = tail;
+  }
+  durationMs = Math.min(Math.max(durationMs, 1), MAX_DURATION_MS);
+  const { focusParts: cleanedFocusParts, provider, model, invalidProvider } = extractProviderOverride(focusParts);
+  const focus = normalizeFocus(cleanedFocusParts.join(" "));
+  const resolvedProvider = invalidProvider === undefined
+    ? provider ?? (model ? "spaces" : undefined)
+    : undefined;
+  return {
+    sub: "start",
+    durationMs,
+    ...(focus ? { focus } : {}),
+    ...(resolvedProvider ? { provider: resolvedProvider } : {}),
+    ...(model ? { model } : {}),
+    ...(invalidProvider !== undefined ? { invalidProvider } : {}),
+  };
+}
+
+function normalizeFocus(raw: string): string | undefined {
+  const value = raw.trim().replace(/^focus=/i, "").trim();
+  return value ? value.slice(0, 1000) : undefined;
+}
+
+function extractProviderOverride(parts: string[]): {
+  focusParts: string[];
+  provider?: string;
+  model?: string;
+  invalidProvider?: string;
+} {
+  let provider: string | undefined;
+  let model: string | undefined;
+  let invalidProvider: string | undefined;
+  const focusParts: string[] = [];
+
+  for (const part of parts) {
+    const match = /^([^=]+)=(.*)$/.exec(part);
+    const key = match?.[1]?.toLowerCase();
+    if (key === "provider") {
+      const rawProvider = match?.[2] ?? "";
+      const normalizedProvider = rawProvider.toLowerCase();
+      if (EXPERIMENT_PROVIDERS.has(normalizedProvider)) {
+        provider = normalizedProvider;
+      } else {
+        invalidProvider = rawProvider;
+      }
+      continue;
+    }
+    if (key === "model") {
+      const rawModel = match?.[2] ?? "";
+      if (rawModel) model = rawModel;
+      continue;
+    }
+    focusParts.push(part);
+  }
+
+  return {
+    focusParts,
+    ...(provider !== undefined ? { provider } : {}),
+    ...(model !== undefined ? { model } : {}),
+    ...(invalidProvider !== undefined ? { invalidProvider } : {}),
+  };
+}
+
+function formatRemaining(deadlineAt: Date): string {
+  const ms = Math.max(0, deadlineAt.getTime() - Date.now());
+  const minutes = Math.ceil(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rem = minutes % 60;
+  return rem ? `${hours}h ${rem}m` : `${hours}h`;
+}
+
+export function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rem = minutes % 60;
+  return rem ? `${hours}h ${rem}m` : `${hours}h`;
+}
+
+export function buildLedgerMarkdown(run: ExperimentRun, findings: ExperimentFinding[]): string {
+  const groups = {
+    conjecture: findings.filter((f) => f.status === "conjecture"),
+    proved: findings.filter((f) => f.status === "proved"),
+    refuted: findings.filter((f) => f.status === "refuted"),
+  };
+  const lines = [
+    `# /experiment ledger`,
+    ``,
+    `- Epoch: ${run.epoch}`,
+    `- Deadline: ${run.deadlineAt.toISOString()}`,
+    `- Remaining: ${formatRemaining(run.deadlineAt)}`,
+    `- Focus: ${run.focus?.trim() || "(none)"}`,
+    ``,
+  ];
+  // Cap what each group renders: this markdown is injected into EVERY later
+  // epoch's task, so unbounded growth compounds over an 8h run. Newest entries
+  // win (they carry the freshest context); older ones stay in the DB and the
+  // status/report paths, just not in the per-epoch prompt.
+  const MAX_PER_GROUP = 20;
+  const appendGroup = (heading: string, rows: ExperimentFinding[]) => {
+    lines.push(`## ${heading}`);
+    if (rows.length === 0) {
+      lines.push(`- (none)`, ``);
+      return;
+    }
+    const shown = rows.slice(-MAX_PER_GROUP);
+    if (rows.length > shown.length) {
+      lines.push(`- (… ${rows.length - shown.length} older entr${rows.length - shown.length === 1 ? "y" : "ies"} omitted — full ledger is in the database)`);
+    }
+    for (const f of shown) {
+      lines.push(`- [epoch ${f.epoch}] ${f.title}`);
+      lines.push(`  Hypothesis: ${f.hypothesis}`);
+      if (f.note?.trim()) lines.push(`  Note: ${f.note.trim()}`);
+      if (f.proofArtifactPath?.trim()) lines.push(`  Proof: ${f.proofArtifactPath.trim()}`);
+    }
+    lines.push(``);
+  };
+  appendGroup("Open conjectures", groups.conjecture);
+  appendGroup("Proved", groups.proved);
+  appendGroup("Refuted", groups.refuted);
+  return lines.join("\n").trimEnd();
+}
+
+export function buildEpochTask(run: ExperimentRun, ledgerMarkdown: string): string {
+  const remaining = formatRemaining(run.deadlineAt);
+  const finalInstruction = run.status === "finishing"
+    ? "\n\nDeadline reached - call end-experiment with your final report now."
+    : "";
+  return [
+    `You are in /experiment mode, epoch ${run.epoch}.`,
+    `Deadline: ${run.deadlineAt.toISOString()} (${remaining} remaining).`,
+    ``,
+    `Read the ledger below before doing anything. Do NOT re-test refuted hypotheses. Pick or advance ONE hypothesis. Use your sandbox tools to gather PROOF: a failing test, benchmark, profile, trace, log, or other concrete artifact. Record every conjecture/proof/refutation via the experiment-ledger tool.`,
+    `You cannot end before the deadline - end-experiment will refuse until the deadline has been reached.`,
+    run.sandboxNote?.trim() ? `\nSandbox note:\n${run.sandboxNote.trim()}` : "",
+    finalInstruction,
+    ``,
+    ledgerMarkdown,
+  ].filter((part) => part !== "").join("\n");
+}
+
+export async function dispatchExperimentEpoch(run: ExperimentRun): Promise<{ sessionId: string }> {
+  const findings = await experimentRepository.listFindings(run.id);
+  const ledger = buildLedgerMarkdown(run, findings);
+  const task = buildEpochTask(run, ledger);
+  const traceId = createTraceId();
+  const agent = run.orgId
+    ? await agentRepository.findBySlug(run.agentSlug, run.orgId)
+    : null;
+  if (!agent) throw new Error(`Experiment dispatch missing agent ${run.agentSlug} org=${run.orgId ?? ""}`);
+  if (!agent.spacesAppToken || !agent.spacesAppId || !agent.spacesAppUserId) {
+    throw new Error(`Experiment dispatch agent ${run.agentSlug} missing Spaces app identity`);
+  }
+  const appToken = decryptStoredField(agent.spacesAppToken);
+
+  const dispatchPayload = {
+    userId: run.userId,
+    task,
+    conversationId: run.conversationId,
+    agentSlug: run.agentSlug,
+    orgId: run.orgId ?? agent.orgId,
+    eventType: "APP_MENTIONED",
+    traceId,
+    callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/result`,
+    progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
+    channelId: run.channelId,
+    ...(run.provider
+      ? { providerOverride: { provider: run.provider, ...(run.modelId ? { model: run.modelId } : {}) } }
+      : {}),
+    experiment: {
+      id: run.id,
+      epoch: run.epoch,
+      deadlineAt: run.deadlineAt.toISOString(),
+      ...(run.focus ? { focus: run.focus } : {}),
+    },
+  };
+
+  const res = await fetch(`${CONFIG.internalUrl}/claw/api/v1/internal/run`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+    },
+    body: JSON.stringify(dispatchPayload),
+  });
+  const body = await res.json() as { success?: boolean; sessionId?: string; error?: string };
+  if (!res.ok || !body.success || !body.sessionId) {
+    throw new Error(`Experiment dispatch failed: HTTP ${res.status} ${body.error ?? ""}`.trim());
+  }
+
+  const sessionContext: SessionContext = {
+    mentionedUserId: agent.spacesAppUserId,
+    targetUserId: run.userId,
+    senderId: run.userId,
+    senderName: run.userId,
+    channelId: run.channelId,
+    channelName: run.channelId,
+    conversationId: run.conversationId,
+    task,
+    agentId: agent.id,
+    agentOrgId: run.orgId ?? agent.orgId,
+    agentSlug: run.agentSlug,
+    responseMode: "conversation",
+    appToken,
+    spacesAppId: agent.spacesAppId,
+    spacesAppUserId: agent.spacesAppUserId,
+    traceId,
+    rootAgentSlug: run.agentSlug,
+  };
+  await setSession(body.sessionId, sessionContext);
+  await registerRunRecovery({
+    rootSessionId: body.sessionId,
+    maxRetries: CONFIG.runRecoveryMaxRetries,
+    timeoutMs: CONFIG.runRecoveryTimeoutMs,
+    retryBackoffMs: CONFIG.runRecoveryBackoffMs,
+    dispatchPayload,
+    sessionContext,
+  });
+  await experimentRepository.update(run.id, {
+    currentSessionId: body.sessionId,
+    epoch: run.epoch,
+  });
+  log.info(`[experiment] dispatched epoch=${run.epoch} id=${run.id} session=${body.sessionId}`);
+  return { sessionId: body.sessionId };
+}

--- a/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
@@ -173,6 +173,8 @@ export type SpacesAuthCaller =
   | "write-action"
   | "clone-owner-dm"
   | "skill-update-owner-dm"
+  | "agent-update-owner-dm"
+  | "subagent-update-owner-dm"
   | "unknown";
 
 export async function getSpacesAuthForUser(

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -34,6 +34,7 @@ import { adminBackfillSigningSecretsRouter } from "./routes/admin-backfill-signi
 import { dashboardRouter } from "./routes/dashboard.js";
 import { agentChatRouter, agentChatInternalRouter } from "./routes/agent-chat.js";
 import { sessionsArchiveRouter } from "./routes/sessions-archive.js";
+import { experimentsInternalRouter } from "./routes/experiments-internal.js";
 import { errorPipelineIngestRouter, errorPipelineInternalRouter } from "./routes/error-pipeline.js";
 import { ERROR_PIPELINE } from "./config.js";
 import { runner as errorPipelineRunner } from "./error-pipeline/runner/runner.js";
@@ -74,6 +75,7 @@ import { initDailyBriefWorker, closeDailyBriefWorker } from "./queue/daily-brief
 import { closeDailyBriefQueue } from "./queue/daily-brief-queue.js";
 import { initDailyBriefCron } from "./services/dailyBriefCron.js";
 import { initRunRecoveryWorker, closeRunRecoveryWorker } from "./queue/run-recovery-worker.js";
+import { initExperimentSupervisor, closeExperimentSupervisor } from "./queue/experiment-supervisor.js";
 import { initDigitalTwinBackfillWorker } from "./queue/digital-twin-backfill-worker.js";
 import { initAgentBackfillWorker, closeAgentBackfillWorker } from "./queue/agent-backfill-worker.js";
 import { closeAgentBackfillQueue } from "./queue/agent-backfill-queue.js";
@@ -187,6 +189,7 @@ app.use(`${BASE}/daily-brief`, requireAuth, dailyBriefRouter);
 app.use(`${BASE}/internal/agent-chat`, requireStrictS2S, agentChatInternalRouter); // progress/callback from xyne-claw
 app.use(`${BASE}/internal/twin-draft`, requireInternalS2S, twinDraftInternalRouter);  // Spaces → approve/decline an in-thread Twin reply draft (INTERNAL_S2S_KEY)
 app.use(`${BASE}/internal/sessions`, requireStrictS2S, sessionsArchiveRouter);     // archive/restore session JSONLs to GCS — S2S only (transcripts)
+app.use(`${BASE}/internal/experiments`, requireStrictS2S, experimentsInternalRouter);
 app.use(`${BASE}/error-pipeline`, errorPipelineIngestRouter); // Grafana webhook ingest (JWT-authed inside)
 app.use(`${BASE}/internal/error-pipeline`, requireStrictS2S, errorPipelineInternalRouter); // run-result callback from xyne-claw (S2S only)
 app.use(`${BASE}/internal/tts`, requireStrictS2S, ttsRouter);
@@ -313,6 +316,7 @@ listen(CONFIG.port, () => {
     // Normal API pod: the full background fleet, no runner.
     initScheduledJobsWorker();
     initRunRecoveryWorker();
+    initExperimentSupervisor();
     initDigitalTwinBackfillWorker();
     initAgentBackfillWorker();
     initEvalImportWorker();
@@ -351,6 +355,7 @@ async function shutdown(signal: string): Promise<void> {
     stopBitbucketStatsBackgroundRefresh();
     await closeWorker().catch(() => {});
     await closeRunRecoveryWorker().catch(() => {});
+    closeExperimentSupervisor();
     await closeEvalImportWorker().catch(() => {});
     await closeEvalGenerationWorker().catch(() => {});
     await closeEvalJudgeWorker().catch(() => {});

--- a/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
@@ -88,6 +88,23 @@ interface KbResolution {
    */
   filesById: Map<string, {
     name: string;
+    /**
+     * Slash-separated path from the ROOT collection down to and including the
+     * file name (e.g. `services/release-deploy/service.md`). Files sitting
+     * directly in the root have a path equal to their name.
+     *
+     * Rendered by kb-list-files and kb-search: a convention-based KB layout
+     * produces dozens of identically-named files (`service.md`, `people.md`,
+     * `00-index.md`) and `name` alone makes them indistinguishable in tool
+     * output — the model can't tell which area a hit belongs to.
+     */
+    path: string;
+    /**
+     * Immediate parent collection's name. `collectionName` is deliberately the
+     * ROOT collection's name (citations want the top-level label), so this is
+     * the only place the containing folder's name survives.
+     */
+    folderName: string;
     collectionId: string;
     collectionName: string;
     vespaDocId: string;
@@ -96,8 +113,27 @@ interface KbResolution {
     rootCollectionId?: string;
     folderId: string;
   }>;
-  /** Flat lookup of every accessible collection: id → { name, root id }. */
-  collectionsById: Map<string, { name: string; rootCollectionId: string }>;
+  /**
+   * Flat lookup of every accessible collection: id → { name, root id, parent id }.
+   *
+   * `parentId` is the IMMEDIATE parent (null at a root) and is taken from the
+   * tree walk, not the payload's own `parentId` field, so it can't disagree
+   * with the structure we actually traversed. The grant checks below follow
+   * this chain link by link — see `ancestorChain`.
+   */
+  collectionsById: Map<string, { name: string; rootCollectionId: string; parentId: string | null }>;
+  /**
+   * Every accessible collection node — roots AND sub-folders — keyed by id,
+   * with `children`/`items` intact.
+   *
+   * kb-list-files walks this to render the folder tree. The flat `filesById`
+   * map can't express nesting: its `collectionId` is the file's IMMEDIATE
+   * parent, so an exact-match filter on a root collection id returns nothing
+   * for any KB that keeps its content in sub-folders, and no tool ever emitted
+   * the sub-folder ids the model would need to drill in. That dead end is what
+   * this map exists to close.
+   */
+  nodesById: Map<string, KbCollectionNode>;
   /**
    * Translation map for Vespa hits: Vespa's `docId` on the file schema is
    * `collectionItem.fileId` (see backend/src/zero/vespa-injection/core/mapper.ts),
@@ -143,6 +179,8 @@ async function resolveKbContext(
   // Build flat lookups for nice citations and file→collection backlinks.
   const filesById = new Map<string, {
     name: string;
+    path: string;
+    folderName: string;
     collectionId: string;
     collectionName: string;
     vespaDocId: string;
@@ -151,7 +189,8 @@ async function resolveKbContext(
     rootCollectionId?: string;
     folderId: string;
   }>();
-  const collectionsById = new Map<string, { name: string; rootCollectionId: string }>();
+  const collectionsById = new Map<string, { name: string; rootCollectionId: string; parentId: string | null }>();
+  const nodesById = new Map<string, KbCollectionNode>();
   const vespaDocIdToItemId = new Map<string, string>();
   const walk = (
     n: KbCollectionNode,
@@ -159,8 +198,15 @@ async function resolveKbContext(
     rootId: string,
     rootProjectId: string | undefined,
     rootChannelId: string | undefined,
+    // Slash-terminated path from the root collection down to `n`, EXCLUDING the
+    // root's own name ("" at the root, "services/release-deploy/" three levels in).
+    pathPrefix: string,
+    // Immediate parent's id — null at a root. Taken from the traversal rather
+    // than `n.parentId` so it always agrees with the tree we actually walked.
+    parentId: string | null,
   ): void => {
-    collectionsById.set(n.id, { name: n.name, rootCollectionId: rootId });
+    collectionsById.set(n.id, { name: n.name, rootCollectionId: rootId, parentId });
+    nodesById.set(n.id, n);
     // Files directly in the ROOT collection use the '_' sentinel for folder
     // (matches the v2 KB route convention — see dashboard/searchNavigation.ts).
     // Files in any sub-folder use that sub-folder's id as folderId.
@@ -168,6 +214,8 @@ async function resolveKbContext(
     for (const f of n.items ?? []) {
       filesById.set(f.id, {
         name: f.name,
+        path: `${pathPrefix}${f.name}`,
+        folderName: n.name,
         collectionId: n.id,
         collectionName: rootName,
         vespaDocId: f.fileId,
@@ -178,7 +226,9 @@ async function resolveKbContext(
       });
       if (f.fileId) vespaDocIdToItemId.set(f.fileId, f.id);
     }
-    for (const c of n.children ?? []) walk(c, rootName, rootId, rootProjectId, rootChannelId);
+    for (const c of n.children ?? []) {
+      walk(c, rootName, rootId, rootProjectId, rootChannelId, `${pathPrefix}${c.name}/`, n.id);
+    }
   };
   for (const root of tree) {
     // Channel-scoped collections store the channelId in `scopeId` when
@@ -186,7 +236,7 @@ async function resolveKbContext(
     // channel — the file viewer route still needs a placeholder so we treat
     // it as undefined and downstream link builders fall back gracefully.
     const channelId = root.scopeType === "CHANNEL" ? root.scopeId : undefined;
-    walk(root, root.name, root.id, root.projectId, channelId);
+    walk(root, root.name, root.id, root.projectId, channelId, "", null);
   }
 
   // Best-effort fetch of the user's workspaceId for citation deep-links. We
@@ -208,9 +258,40 @@ async function resolveKbContext(
     accessibleFileIds: files,
     filesById,
     collectionsById,
+    nodesById,
     vespaDocIdToItemId,
     ...(workspaceId ? { workspaceId } : {}),
   };
+}
+
+/**
+ * Every collection id from `startId` up to its root, INCLUDING `startId`.
+ *
+ * Follows the parent chain one link at a time. The previous implementation
+ * hopped straight from a collection to its `rootCollectionId`, skipping every
+ * level in between — so a grant on an intermediate folder (`services/`) never
+ * matched a file nested deeper (`services/release-deploy/service.md`), and the
+ * grant silently read as empty even though the KB picker had accepted it.
+ *
+ * `seen` guards against a cycle in the payload: a malformed parent chain would
+ * otherwise spin this loop forever and hang the request.
+ */
+function* ancestorChain(ctx: KbResolution, startId: string): Generator<string> {
+  const seen = new Set<string>();
+  let cursor: string | null = startId;
+  while (cursor && !seen.has(cursor)) {
+    seen.add(cursor);
+    yield cursor;
+    cursor = ctx.collectionsById.get(cursor)?.parentId ?? null;
+  }
+}
+
+/** Does any whole-collection grant sit on `collectionId` or one of its ancestors? */
+function grantedViaAncestor(ctx: KbResolution, collectionId: string): boolean {
+  for (const id of ancestorChain(ctx, collectionId)) {
+    if (ctx.grants.some(g => g.fileId === null && g.collectionId === id)) return true;
+  }
+  return false;
 }
 
 /** Is `fileId` covered by the agent's grants AND still accessible to the user? */
@@ -221,22 +302,12 @@ function fileAllowed(ctx: KbResolution, fileId: string): boolean {
   if (ctx.scope === "USER") return true;
   const file = ctx.filesById.get(fileId);
   if (!file) return false;
-  // Walk up the collection tree to a root; check if any ancestor (incl. the
-  // immediate parent and the root) is granted as a whole-collection grant,
-  // OR if this specific fileId is granted as a single-file grant.
+  // Single-file grant on exactly this file.
   for (const g of ctx.grants) {
     if (g.fileId === fileId) return true;
   }
-  // Whole-collection grant: anywhere from the file's collection up to the root.
-  let cursor: string | undefined = file.collectionId;
-  while (cursor) {
-    const matched = ctx.grants.some(g => g.fileId === null && g.collectionId === cursor);
-    if (matched) return true;
-    const parent = ctx.collectionsById.get(cursor);
-    if (!parent) break;
-    cursor = parent.rootCollectionId === cursor ? undefined : parent.rootCollectionId;
-  }
-  return false;
+  // Whole-collection grant anywhere from the file's own folder up to the root.
+  return grantedViaAncestor(ctx, file.collectionId);
 }
 
 /** Is `collectionId` covered by the agent's grants? */
@@ -245,19 +316,19 @@ function collectionAllowed(ctx: KbResolution, collectionId: string): boolean {
   // USER scope: every collection the user can see in spaces is allowed.
   if (ctx.scope === "USER") return true;
   // Whole-collection grant on this id OR an ancestor.
-  let cursor: string | undefined = collectionId;
-  while (cursor) {
-    const matched = ctx.grants.some(g => g.fileId === null && g.collectionId === cursor);
-    if (matched) return true;
-    const node = ctx.collectionsById.get(cursor);
-    if (!node) break;
-    cursor = node.rootCollectionId === cursor ? undefined : node.rootCollectionId;
-  }
-  // Or a single-file grant whose file lives inside this collection.
+  if (grantedViaAncestor(ctx, collectionId)) return true;
+  // Or a single-file grant on a file somewhere BELOW this collection — the
+  // folders between the root and a granted file have to be listable or the
+  // grant is unreachable by navigation (kb-search would be the only way in).
+  // Listing one of these folders is not a leak: every row it renders is itself
+  // re-checked, so only the granted file and the folders on its path appear.
   for (const g of ctx.grants) {
     if (!g.fileId) continue;
     const f = ctx.filesById.get(g.fileId);
-    if (f?.collectionId === collectionId) return true;
+    if (!f) continue;
+    for (const id of ancestorChain(ctx, f.collectionId)) {
+      if (id === collectionId) return true;
+    }
   }
   return false;
 }
@@ -354,6 +425,9 @@ export async function handleKbListResources(args: { userId: string; agentSlug: s
       id: root.id,
       name: root.name,
       fileCount: countAccessibleFilesInTree(root),
+      // Surfaced so the model knows a collection whose files all live in
+      // sub-folders still has something to drill into.
+      folderCount: (root.children ?? []).length,
     }));
     if (rootRows.length === 0) {
       return { content: "You currently have no accessible collections in spaces — nothing for this agent to read." };
@@ -365,13 +439,17 @@ export async function handleKbListResources(args: { userId: string; agentSlug: s
     lines.push(`<resources scope="USER" count="${rootRows.length}">`);
     for (const r of rootRows) {
       lines.push(
-        `  <collection id="${escapeXmlAttr(r.id)}" name="${escapeXmlAttr(r.name)}" file_count="${r.fileCount}" />`,
+        `  <collection id="${escapeXmlAttr(r.id)}" name="${escapeXmlAttr(r.name)}" ` +
+          `file_count="${r.fileCount}" folder_count="${r.folderCount}" />`,
       );
     }
     lines.push(`</resources>`);
     lines.push(
       `\nThis agent is user-scoped: it can read anything you can read in spaces. ` +
-        `Use \`kb-list-files\` to enumerate a collection or \`kb-search\` to find a file by name.`,
+        `Use \`kb-list-files\` to enumerate a collection (it lists sub-folders too — pass ` +
+        `\`depth\` to expand them) or \`kb-search\` to find a file by name. ` +
+        `\`file_count\` is recursive, so a collection with 0 folders shown at the top level ` +
+        `may still hold everything one level down.`,
     );
     return { content: lines.join("\n") };
   }
@@ -406,8 +484,16 @@ export async function handleKbListResources(args: { userId: string; agentSlug: s
     if (r.kind === "collection") {
       // No cite token — Citation type has no "collection" kind. The LLM can
       // still reference the collection by id when calling kb-list-files.
+      // Counts are recursive/immediate respectively so a granted collection
+      // whose content all sits in sub-folders doesn't look empty here.
+      const node = ctx.nodesById.get(r.id);
       lines.push(
-        `  <collection id="${escapeXmlAttr(r.id)}" name="${escapeXmlAttr(r.name)}" />`,
+        `  <collection id="${escapeXmlAttr(r.id)}" name="${escapeXmlAttr(r.name)}"` +
+          (node
+            ? ` file_count="${countAllowedFilesInTree(ctx, node)}"` +
+              ` folder_count="${countAllowedChildFolders(ctx, node)}"`
+            : "") +
+          ` />`,
       );
     } else {
       // Citation token format: `[clf-<toolCallId>#<chunkIndex>]`. The literal
@@ -658,7 +744,7 @@ export async function handleKbSearch(args: {
     ? data.data.groups.flatMap(g => g.results ?? [])
     : (data.data.results ?? []);
 
-  type Hit = { fileId: string; name: string; collectionId: string; collectionName: string; snippet?: string };
+  type Hit = { fileId: string; name: string; path?: string; collectionId: string; collectionName: string; snippet?: string };
   const hits: Hit[] = [];
   const seen = new Set<string>();
   let droppedNoIds = 0;
@@ -692,6 +778,9 @@ export async function handleKbSearch(args: {
     hits.push({
       fileId: itemId,
       name: r.title || fileMeta?.name || itemId,
+      // Convention-based KBs repeat file names across folders (`service.md` in
+      // every area). Without the path the model can't tell the hits apart.
+      ...(fileMeta?.path ? { path: fileMeta.path } : {}),
       collectionId,
       collectionName: r.subtitle || fileMeta?.collectionName || collectionId,
       ...(typeof r.context === "string" && r.context.trim() ? { snippet: r.context.trim() } : {}),
@@ -723,6 +812,7 @@ export async function handleKbSearch(args: {
     const h = hits[i]!;
     lines.push(
       `  <hit rank="${i + 1}" id="${escapeXmlAttr(h.fileId)}" name="${escapeXmlAttr(h.name)}" ` +
+        (h.path ? `path="${escapeXmlAttr(h.path)}" ` : "") +
         `collection="${escapeXmlAttr(h.collectionName)}" cite="[clf-__TOOL_CALL_ID__#${i}]">`,
     );
     if (h.snippet) {
@@ -742,10 +832,34 @@ export async function handleKbSearch(args: {
 
 // ── kb-list-files ────────────────────────────────────────────────────────────
 
+/** Recursive count of files under `n` that this agent + user may actually read. */
+function countAllowedFilesInTree(ctx: KbResolution, n: KbCollectionNode): number {
+  let total = 0;
+  for (const f of n.items ?? []) if (fileAllowed(ctx, f.id)) total++;
+  for (const c of n.children ?? []) total += countAllowedFilesInTree(ctx, c);
+  return total;
+}
+
+/** Count of `n`'s IMMEDIATE sub-folders that are in scope. */
+function countAllowedChildFolders(ctx: KbResolution, n: KbCollectionNode): number {
+  let total = 0;
+  for (const c of n.children ?? []) if (collectionAllowed(ctx, c.id)) total++;
+  return total;
+}
+
+/**
+ * Row cap for one kb-list-files call. A deep `depth: -1` on a large KB would
+ * otherwise dump thousands of rows into the model's context. When we hit it we
+ * say so explicitly — a silently truncated listing reads as "that's everything"
+ * and sends the agent down the same blind-search path this tool exists to avoid.
+ */
+const LIST_FILES_MAX_ROWS = 400;
+
 export async function handleKbListFiles(args: {
   userId: string;
   agentSlug: string;
   collectionId: string;
+  depth?: number;
 }): Promise<KbHandlerResult> {
   const ctx = await resolveKbContext(args.userId, args.agentSlug);
   if ("error" in ctx) return { content: ctx.error, isError: true };
@@ -753,36 +867,101 @@ export async function handleKbListFiles(args: {
   if (!collectionAllowed(ctx, args.collectionId)) {
     return { content: `Collection \`${args.collectionId}\` is not in this agent's allowed scope.`, isError: true };
   }
-
-  const matches: Array<{ fileId: string; name: string }> = [];
-  for (const [fileId, info] of ctx.filesById) {
-    if (info.collectionId !== args.collectionId) continue;
-    if (!fileAllowed(ctx, fileId)) continue;
-    matches.push({ fileId, name: info.name });
+  const root = ctx.nodesById.get(args.collectionId);
+  if (!root) {
+    return { content: `Collection \`${args.collectionId}\` is not in this agent's allowed scope.`, isError: true };
   }
-  if (matches.length === 0) return { content: `No accessible files in collection \`${args.collectionId}\`.` };
 
-  const c = ctx.collectionsById.get(args.collectionId);
-  // Same XML + inline `cite="[clf-__TOOL_CALL_ID__#N]"` pattern as
-  // kb-get-chunks — N matches each citation's chunkIndex so the dashboard
-  // resolves a clickable chip per file row.
+  // depth 1 (default) — this collection's own files, plus its immediate
+  // sub-folders as unexpanded <folder> rows. depth N expands N levels; depth -1
+  // walks the whole subtree. Sub-folders MUST be emitted at every depth: their
+  // ids are otherwise unobtainable (kb-list-resources only ever surfaces roots
+  // or granted rows), which left the model unable to reach anything not sitting
+  // directly in the collection it was pointed at.
+  const rawDepth =
+    typeof args.depth === "number" && Number.isFinite(args.depth) ? Math.trunc(args.depth) : 1;
+  const maxDepth = rawDepth < 0 ? Number.POSITIVE_INFINITY : Math.max(1, Math.min(rawDepth, 10));
+
+  const body: string[] = [];
+  const citations: Citation[] = [];
+  let fileRows = 0;
+  let folderRows = 0;
+  let unexpandedFolders = 0;
+  let truncated = false;
+
+  const indent = (level: number): string => "  ".repeat(level + 1);
+
+  const render = (node: KbCollectionNode, level: number): void => {
+    for (const f of node.items ?? []) {
+      if (!fileAllowed(ctx, f.id)) continue;
+      if (fileRows + folderRows >= LIST_FILES_MAX_ROWS) {
+        truncated = true;
+        return;
+      }
+      const meta = ctx.filesById.get(f.id);
+      // Same inline `cite="[clf-__TOOL_CALL_ID__#N]"` pattern as kb-get-chunks —
+      // N matches the citation's chunkIndex so the dashboard resolves a
+      // clickable chip per file row.
+      body.push(
+        `${indent(level)}<file id="${escapeXmlAttr(f.id)}" name="${escapeXmlAttr(f.name)}"` +
+          (meta?.path ? ` path="${escapeXmlAttr(meta.path)}"` : "") +
+          ` cite="[clf-__TOOL_CALL_ID__#${fileRows}]" />`,
+      );
+      citations.push(fileCitation(ctx, f.id, f.name, node.id, fileRows));
+      fileRows++;
+    }
+    for (const c of node.children ?? []) {
+      if (!collectionAllowed(ctx, c.id)) continue;
+      if (fileRows + folderRows >= LIST_FILES_MAX_ROWS) {
+        truncated = true;
+        return;
+      }
+      folderRows++;
+      const open =
+        `${indent(level)}<folder id="${escapeXmlAttr(c.id)}" name="${escapeXmlAttr(c.name)}" ` +
+        `file_count="${countAllowedFilesInTree(ctx, c)}" ` +
+        `folder_count="${countAllowedChildFolders(ctx, c)}"`;
+      if (level + 1 < maxDepth) {
+        body.push(`${open}>`);
+        render(c, level + 1);
+        body.push(`${indent(level)}</folder>`);
+      } else {
+        // Not expanded at this depth — the id is what the model needs to drill in.
+        body.push(`${open} />`);
+        unexpandedFolders++;
+      }
+    }
+  };
+
+  render(root, 0);
+
+  if (fileRows === 0 && folderRows === 0) {
+    return { content: `Collection \`${args.collectionId}\` has no files or sub-folders you can access.` };
+  }
+
   const lines: string[] = [];
   lines.push(
     `<files collection_id="${escapeXmlAttr(args.collectionId)}"` +
-      (c?.name ? ` collection_name="${escapeXmlAttr(c.name)}"` : "") +
-      ` count="${matches.length}">`,
+      (root.name ? ` collection_name="${escapeXmlAttr(root.name)}"` : "") +
+      ` depth="${rawDepth < 0 ? "all" : maxDepth}"` +
+      ` file_count="${fileRows}" folder_count="${folderRows}">`,
   );
-  const citations: Citation[] = [];
-  for (let i = 0; i < matches.length; i++) {
-    const m = matches[i]!;
-    lines.push(
-      `  <file id="${escapeXmlAttr(m.fileId)}" name="${escapeXmlAttr(m.name)}" ` +
-        `cite="[clf-__TOOL_CALL_ID__#${i}]" />`,
-    );
-    citations.push(fileCitation(ctx, m.fileId, m.name, args.collectionId, i));
-  }
+  lines.push(...body);
   lines.push(`</files>`);
-  return { content: lines.join("\n"), citations };
+
+  if (truncated) {
+    lines.push(
+      `\nTruncated at ${LIST_FILES_MAX_ROWS} rows — this is NOT the full listing. ` +
+        `Call \`kb-list-files\` on a specific folder id to narrow, or \`kb-search\` to jump straight to a file.`,
+    );
+  }
+  if (unexpandedFolders > 0) {
+    lines.push(
+      `\n${unexpandedFolders} folder(s) shown collapsed. Call \`kb-list-files\` with a folder's ` +
+        `id to open it, or re-run with \`depth\` (e.g. 3, or -1 for the whole tree).`,
+    );
+  }
+  return { content: lines.join("\n"), ...(citations.length > 0 ? { citations } : {}) };
 }
 
 // ── kb-read-file ─────────────────────────────────────────────────────────────
@@ -817,7 +996,7 @@ export async function handleKbReadFile(args: {
     // search — out of scope for v1).
     const looksTextual = /^(text\/|application\/(json|xml|x-yaml|yaml|markdown))/.test(contentType);
     const text = buffer.toString("utf8");
-    const isLikelyBinary = text.includes(" ") || /[\x00-\x08\x0E-\x1F]/.test(text.slice(0, 200));
+    const isLikelyBinary = text.includes("") || /[\x00-\x08\x0E-\x1F]/.test(text.slice(0, 200));
 
     // Single-result read still emits the same `[clf-__TOOL_CALL_ID__#0]` token
     // shape as kb-get-chunks so the dashboard chip resolves via the matching

--- a/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
@@ -996,7 +996,10 @@ export async function handleKbReadFile(args: {
     // search — out of scope for v1).
     const looksTextual = /^(text\/|application\/(json|xml|x-yaml|yaml|markdown))/.test(contentType);
     const text = buffer.toString("utf8");
-    const isLikelyBinary = text.includes("") || /[\x00-\x08\x0E-\x1F]/.test(text.slice(0, 200));
+    // NB: match the NUL via the regex escape below, never a raw 0x00 byte in a
+    // string literal. A literal NUL lived here once and got silently stripped,
+    // leaving `includes("")` — always true, so every file reported as binary.
+    const isLikelyBinary = /\x00/.test(text) || /[\x00-\x08\x0E-\x1F]/.test(text.slice(0, 200));
 
     // Single-result read still emits the same `[clf-__TOOL_CALL_ID__#0]` token
     // shape as kb-get-chunks so the dashboard chip resolves via the matching

--- a/apps/xyne-claw-auth/backend/src/mcp/kb-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-tools.ts
@@ -35,6 +35,9 @@ export const KB_TOOLS: McpToolInfo[] = [
       "  • Allowlist mode — returns the explicit collections/files granted on this agent.\n" +
       "  • User-scoped mode — returns the calling user's root collections (with file counts). Drill into a " +
       "specific one via `kb-list-files`, or hunt by name via `kb-search`.\n" +
+      "This tool lists TOP-LEVEL entries only — it never shows what is inside a collection. `file_count` is " +
+      "recursive and `folder_count` counts immediate sub-folders; when either is non-zero, call `kb-list-files` " +
+      "(with `depth`) to see the actual layout before concluding anything about what the KB contains.\n" +
       "Either way, the result is the authoritative list of what you can read — do NOT attempt kb-read-file " +
       "on anything not surfaced here (or via kb-list-files / kb-search); it will be rejected at the access layer.",
     inputSchema: {
@@ -87,13 +90,34 @@ export const KB_TOOLS: McpToolInfo[] = [
   {
     name: "kb-list-files",
     description:
-      "List all files inside an allowed collection (root or sub-folder). Use when the user wants an inventory " +
-      "of what's in a specific collection rather than a search. `collectionId` MUST be one that appears in " +
-      "kb-list-resources — otherwise the call is rejected.",
+      "Directory listing for an allowed collection — the `ls` of the Knowledge Base. Use when you want an " +
+      "inventory of what exists rather than a relevance search. `collectionId` MUST be one that appears in " +
+      "kb-list-resources (or a folder id returned by an earlier kb-list-files) — otherwise the call is rejected.\n\n" +
+      "Returns BOTH:\n" +
+      "  • `<file>` rows — with `id` (pass to kb-read-file / kb-search-within-doc) and `path` (the full path " +
+      "from the root collection, e.g. `services/release-deploy/service.md`).\n" +
+      "  • `<folder>` rows — sub-folders, with their `id`, a recursive `file_count`, and `folder_count`. " +
+      "Collapsed folders are rendered self-closing; re-call with that folder's `id` to open it.\n\n" +
+      "## Depth\n" +
+      "`depth` defaults to 1: the collection's own files plus its immediate sub-folders, collapsed. Pass a " +
+      "larger number to expand that many levels, or `-1` for the entire subtree. **If a collection looks " +
+      "empty of files but reports folders, you have not seen its contents yet — expand them.** Many KBs keep " +
+      "everything in sub-folders (`services/<area>/service.md`), so a depth-1 listing of the root is only the " +
+      "skeleton. Prefer `depth: -1` on a small collection (a few hundred files) to get the whole map in one call; " +
+      "output is capped at 400 rows and says so explicitly when it truncates.",
     inputSchema: {
       type: "object",
       properties: {
-        collectionId: { type: "string", description: "Required. The collection id to enumerate." },
+        collectionId: { type: "string", description: "Required. The collection or folder id to enumerate." },
+        depth: {
+          type: "number",
+          minimum: -1,
+          maximum: 10,
+          default: 1,
+          description:
+            "How many levels to expand. 1 (default) = this collection's files + collapsed sub-folder rows. " +
+            "N = expand N levels. -1 = the whole subtree. Use -1 or a high value when you need the full layout.",
+        },
       },
       required: ["collectionId"],
       additionalProperties: false,

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-corpus-scan.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-corpus-scan.ts
@@ -158,6 +158,7 @@ export function buildCorpusScanYql(
   const ts = area.timestampField;
   if (scope.after) conditions.push(`${ts} >= "${scope.after}"`);
   if (scope.before) conditions.push(`${ts} < "${scope.before}"`);
+  if (conditions.length === 0) conditions.push("true");
 
   // max(200) comfortably covers year buckets (decades) and month buckets
   // (16+ years) while bounding a pathological grouping.

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-evidence-pack.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-evidence-pack.ts
@@ -1,0 +1,143 @@
+/**
+ * spaces-evidence-pack — pure construction + validation for the EXTRACT tool.
+ *
+ * The extraction half of the corpus-analysis method: run a fixed spec once,
+ * deterministically, and emit a bounded, dated pack of snippets —
+ * `{docId, date, area, channel, term, snippet}` — that becomes the writer's
+ * only input and the verifier's CLOSED SET for citations. Extraction is dumb
+ * by design: no ranking judgment, no summarizing, predictable from the spec.
+ *
+ * Pack invariants (each is a documented failure mode of the naive approach):
+ *   • CAPS, always — an uncapped extraction on a common term is a firehose
+ *     that drowns the writer. Caps are per time-bucket, which also forces
+ *     SPREAD: for "the same ask, years apart" you want the earliest members
+ *     of each bucket, not the ten loudest members overall.
+ *   • DATES travel with every snippet — trend/timeline/audit questions are
+ *     impossible if extraction drops the date.
+ *   • Deterministic order — within a bucket, members are fetched oldest-first
+ *     (timestamp asc), so re-running the same spec yields the same pack.
+ *
+ * Like vespa-corpus-scan.ts this module is tool-free and side-effect-free;
+ * the MCP tool in xyne-spaces-tools.ts feeds the YQL to queryDirect(), which
+ * injects the ACL + workspace guards — the builder never emits either.
+ */
+
+import { esc } from "./vespa-direct.js";
+import {
+  validateCorpusScan,
+  type ValidatedScan,
+  type CorpusScanBucket,
+  type CorpusScanScope,
+} from "./vespa-corpus-scan.js";
+
+export const MAX_PACK_PER_BUCKET = 10;
+export const DEFAULT_PACK_PER_BUCKET = 6;
+/** Hard bound on term×bucket fetch queries per call — keeps one pack call from
+ *  fanning out into an unbounded query storm on a long-history corpus. When the
+ *  discovered buckets exceed this, the NEWEST buckets win and the skip is
+ *  reported in the coverage note. */
+export const MAX_BUCKET_FETCHES = 24;
+export const MAX_SNIPPET_CHARS = 400;
+
+export interface EvidencePackRequest {
+  searchArea: string;
+  topic: string;
+  terms: string[];
+  scope?: CorpusScanScope;
+  bucket: CorpusScanBucket;
+  perBucket?: number;
+}
+
+export interface ValidatedPack {
+  scan: ValidatedScan;
+  topic: string;
+  perBucket: number;
+}
+
+export function validateEvidencePack(req: EvidencePackRequest): ValidatedPack {
+  const topic = String(req.topic ?? "").trim();
+  if (!topic) throw new Error("evidence-pack: spec.topic is required — packs are per-topic artifacts.");
+
+  // Area / terms / scope / bucket rules are identical to corpus-scan —
+  // extraction and counting must agree on what a term and a scope mean.
+  const scan = validateCorpusScan({
+    searchArea: req.searchArea,
+    terms: req.terms,
+    ...(req.scope !== undefined ? { scope: req.scope } : {}),
+    bucket: req.bucket,
+  });
+
+  const perBucket = req.perBucket ?? DEFAULT_PACK_PER_BUCKET;
+  if (!Number.isInteger(perBucket) || perBucket < 1 || perBucket > MAX_PACK_PER_BUCKET) {
+    throw new Error(`evidence-pack: perBucket must be an integer 1..${MAX_PACK_PER_BUCKET} (got ${String(req.perBucket)}).`);
+  }
+
+  return { scan, topic, perBucket };
+}
+
+/** The dd/mm/yyyy date range covering one bucket key (year "2026" or month
+ *  "202606"), in the literal format queryDirect's convertDateLiteralsToMs
+ *  rewrites to epoch ms. Upper bound is exclusive. */
+export function bucketRange(bucketKey: number, bucket: CorpusScanBucket): { after: string; before: string } {
+  if (bucket === "year") {
+    return { after: `01/01/${bucketKey}`, before: `01/01/${bucketKey + 1}` };
+  }
+  const year = Math.trunc(bucketKey / 100);
+  const month = bucketKey % 100;
+  const nextYear = month === 12 ? year + 1 : year;
+  const nextMonth = month === 12 ? 1 : month + 1;
+  const mm = (m: number) => String(m).padStart(2, "0");
+  return { after: `01/${mm(month)}/${year}`, before: `01/${mm(nextMonth)}/${nextYear}` };
+}
+
+/**
+ * YQL for one bucket fetch: the spec's conditions confined to the bucket's
+ * date range, members returned oldest-first. No grouping, no relevance — the
+ * caller passes the term as queryDirect's @query binding and the `unranked`
+ * profile; `order by` makes the selection deterministic.
+ */
+export function buildPackFetchYql(
+  scan: ValidatedScan,
+  range: { after: string; before: string },
+): string {
+  const { area, scope } = scan;
+  const conditions: string[] = ["userInput(@query)", ...area.baseConditions];
+
+  if (scope.channels && scope.channels.length > 0) {
+    const channelField = area.fields.find(f => f.name === "channelId");
+    const column = channelField?.vespaField ?? "channelId";
+    const ors = scope.channels.map(id => `${column} contains "${esc(id)}"`);
+    conditions.push(ors.length === 1 ? ors[0]! : `(${ors.join(" or ")})`);
+  }
+
+  const ts = area.timestampField;
+  // The bucket range is intersected with any spec-level after/before — the
+  // narrower bound wins on each side simply by ANDing all four.
+  if (scope.after) conditions.push(`${ts} >= "${scope.after}"`);
+  if (scope.before) conditions.push(`${ts} < "${scope.before}"`);
+  conditions.push(`${ts} >= "${range.after}"`);
+  conditions.push(`${ts} < "${range.before}"`);
+
+  return `select * from sources ${area.source} where ${conditions.join(" and ")} order by ${ts} asc`;
+}
+
+/** dd/mm/yyyy in IST from an epoch-ms timestamp — the same date discipline the
+ *  answer rules require, applied at extraction so packs never carry raw epochs. */
+export function formatIstDate(epochMs: number): string {
+  if (!Number.isFinite(epochMs) || epochMs <= 0) return "unknown";
+  const d = new Date(epochMs + 5.5 * 3600 * 1000);
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}/${d.getUTCFullYear()}`;
+}
+
+/** Snippet hygiene: strip Vespa <hi> highlight markup, collapse whitespace,
+ *  cap length. A pack row is a few hundred characters of context around the
+ *  match — the writer can fetch the full document by id as an escalation. */
+export function toSnippet(context: string | undefined): string {
+  const clean = String(context ?? "")
+    .replace(/<\/?hi>/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return clean.length > MAX_SNIPPET_CHARS ? `${clean.slice(0, MAX_SNIPPET_CHARS)}…` : clean;
+}

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
@@ -687,8 +687,11 @@ function buildAreaClauses(
     const emb = area.embeddingFields ?? [];
     // Hybrid works with grouping too — buildYqlFromParams pins default_native
     // below whenever a query is present, so queryDirect sends input.query(e).
-    // Only an explicit `unranked` (or a schema with no embedding) drops the NN.
-    const scored = emb.length > 0 && params.rankProfile !== "unranked";
+    // An explicit `unranked`, a schema with no embedding, or a SORT drops the
+    // NN: sorted queries run unranked (`order by` replaces ranking, and file's
+    // default_native has a global-phase rerank Vespa refuses to sort under),
+    // so `e` is never supplied and the vector clause would break.
+    const scored = emb.length > 0 && params.rankProfile !== "unranked" && !params.sort?.by;
     if (scored) {
       const targetHits = Math.max(params.hits ?? 20, 100);
       const nn = emb.map(f => `({targetHits:${targetHits}} nearestNeighbor(${f}, e))`).join(" or ");
@@ -854,7 +857,11 @@ export function buildYqlFromParams(
     // default_native so queryDirect sends input.query(e)=embed(hf-embedder, @query) that the
     // nearestNeighbor clause needs. (Its auto-pick would fall to `unranked` for
     // a grouping query and drop `e`, breaking the vector clause.)
-    rankProfile = "default_native";
+    // EXCEPT under sort: `order by` replaces ranking entirely, and schemas
+    // whose default_native carries a global-phase rerank (file) 400 with
+    // "Sorting is not supported with global phase" — so sorted queries run
+    // unranked (buildAreaClauses drops their NN clause for the same reason).
+    rankProfile = hasSort ? "unranked" : "default_native";
   }
 
   return { yql, query, ...(rankProfile ? { rankProfile } : {}) };

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -5697,8 +5697,10 @@ const spacesCorpusScan: ToolDef = {
     "- Counts OVER TIME, trends, or anything needing a fair denominator → THIS tool.\n" +
     "- NEVER answer a how-many question by counting a page of search hits — that is a ranked sample, not a total.\n\n" +
     "## Reading the result\n" +
-    "`counts[term][bucket]` are real Vespa totals (lexical match, ACL-respected). `corpusTotals[bucket]` is the " +
-    "same scope with no term — the denominator. `shares[term][bucket]` = count ÷ that bucket's total, precomputed " +
+    "`counts[term][bucket]` are real Vespa totals (lexical match, ACL-respected). `termTotals[term]` is that term's " +
+    "total over the WHOLE scanned window — use it for any \"how many total\" number; NEVER sum bucket rows yourself. " +
+    "`corpusTotals[bucket]` is the same scope with no term — the denominator (`windowTotal` = its whole-window sum). " +
+    "`shares[term][bucket]` = count ÷ that bucket's total, precomputed " +
     "so you never do the division yourself. Compare SHARES across buckets, not raw counts: the corpus grows over " +
     "time, so raw counts read as fake growth.\n\n" +
     "## Notes\n" +
@@ -5802,8 +5804,14 @@ const spacesCorpusScan: ToolDef = {
 
       const counts: Record<string, Record<number, number>> = {};
       const shares: Record<string, Record<number, string>> = {};
+      // Whole-window totals computed HERE so the model never sums buckets by
+      // hand — a live run hand-summed 7 month buckets and shipped 1,713 where
+      // the true total was 2,152. Any "how many total" number must come from
+      // termTotals / windowTotal, not model arithmetic over the bucket rows.
+      const termTotals: Record<string, number> = {};
       scan.terms.forEach((term, i) => {
         counts[term] = termBuckets[i] ?? {};
+        termTotals[term] = Object.values(counts[term]).reduce((a, b) => a + b, 0);
         const s: Record<number, string> = {};
         for (const [bucketKey, n] of Object.entries(counts[term])) {
           const total = corpusTotals?.[Number(bucketKey)];
@@ -5811,6 +5819,7 @@ const spacesCorpusScan: ToolDef = {
         }
         shares[term] = s;
       });
+      const windowTotal = Object.values(corpusTotals ?? {}).reduce((a, b) => a + b, 0);
 
       const scopeNote = autoBounded
         ? `\nNote: month scans are auto-bounded to the last 24 months (after=${scan.scope.after}); pass scope.after to override.`
@@ -5822,7 +5831,7 @@ const spacesCorpusScan: ToolDef = {
         `Queries executed (${scan.terms.length} term + 1 denominator, identical scope):\n` +
         `  term YQL:   ${termYql}\n` +
         `  totals YQL: ${totalsYql}\n\n` +
-        JSON.stringify({ counts, corpusTotals, shares, ...(hasScope ? { scope: scan.scope } : {}) }, null, 1),
+        JSON.stringify({ counts, termTotals, corpusTotals, windowTotal, shares, ...(hasScope ? { scope: scan.scope } : {}) }, null, 1),
       );
       // Same channel spaces-vespa-search uses — the dashboard debug panel
       // reads _meta.debug; it never reaches the model's context.

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -9,6 +9,7 @@ import { interact, search, memorySearch, spacesFetch, spacesFetchBuffer, spacesF
 import { esc, queryDirect, type DirectSearchResponse } from "./vespa-direct.js";
 import { buildYqlFromParams, AREA_NAMES, AREA_ALIASES, describeAreasForPrompt } from "./vespa-search-areas.js";
 import { validateCorpusScan, buildCorpusScanYql, parseBucketKey, termToQuery, MAX_SCAN_TERMS, type CorpusScanScope } from "./vespa-corpus-scan.js";
+import { validateEvidencePack, bucketRange, buildPackFetchYql, formatIstDate, toSnippet, MAX_PACK_PER_BUCKET, DEFAULT_PACK_PER_BUCKET, MAX_BUCKET_FETCHES } from "./vespa-evidence-pack.js";
 import { getWorkspaceIdForUser } from "../../lib/spaces-db.js";
 import type { Citation } from "xyne-claw-shared";
 import { extractCleanTextFromFlowJson, isFlowJsonContent } from "xyne-claw-shared";
@@ -5842,9 +5843,188 @@ const spacesCorpusScan: ToolDef = {
   },
 };
 
+// ── spaces-evidence-pack ─────────────────────────────────────────────────────
+// The EXTRACT tool (corpus playbook Step 3): run a fixed spec once and emit a
+// bounded, dated pack — the writer's only input and the verifier's closed set.
+// Dumb by design: caps per time-bucket (which forces spread across time),
+// deterministic oldest-first order within a bucket, dates on every row.
+// Query construction/validation live in vespa-evidence-pack.ts (pure,
+// unit-testable); this handler fans out through queryDirect (ACL + workspace
+// guards injected there).
+const spacesEvidencePack: ToolDef = {
+  name: "spaces-evidence-pack",
+  description:
+    "EXTRACT a deterministic, capped, dated evidence pack for one topic — the input for a written analysis. " +
+    "Runs a fixed spec (terms + scope) over ONE area, discovers which time buckets have matches, and returns up to " +
+    "perBucket snippets per bucket, each row carrying {docId, date, channel, term, snippet}. Rows within a bucket " +
+    "are the EARLIEST members (timestamp asc) — deterministic and spread across time, not relevance-ranked.\n\n" +
+    "## When to use\n" +
+    "- A multi-topic or shareable analysis where writing happens under contract: the pack is the writer's ONLY " +
+    "evidence source and the closed set that verification checks citations against.\n" +
+    "- NOT for everyday lookups — plain questions use spaces-vespa-search; counting uses spaces-corpus-scan.\n\n" +
+    "## The contract\n" +
+    "1. Write this tool's JSON output VERBATIM to a sandbox data file (the pack artifact) before any writing starts.\n" +
+    "2. The writer cites only pack rows; claims not supported by a pack row don't go in the analysis.\n" +
+    "3. Numbers about the topic come from the returned counts/termTotals or from sandbox code over them — never " +
+    "from tallying pack rows (the pack is capped; counts are not).\n\n" +
+    "## Notes\n" +
+    `- perBucket 1..${MAX_PACK_PER_BUCKET} (default ${DEFAULT_PACK_PER_BUCKET}). At most ${MAX_BUCKET_FETCHES} term×bucket fetches per call — ` +
+    "when history is longer, the NEWEST buckets win and the skip is reported in coverage.\n" +
+    "- Terms follow corpus-scan semantics: lexical, exact phrase for multi-word terms, up to " +
+    `${MAX_SCAN_TERMS} per call.\n` +
+    "- One call = one topic = one pack. Fan out calls per topic for a multi-topic spec.\n" +
+    "- Only available when DIRECT_VESPA_SEARCH is enabled.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      searchArea: {
+        type: "string",
+        enum: [...AREA_NAMES, ...Object.keys(AREA_ALIASES)],
+        description: "The area to extract from — same areas as spaces-vespa-search.",
+      },
+      topic: { type: "string", description: "The topic this pack is for (names the artifact; one pack per topic)." },
+      terms: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+        maxItems: MAX_SCAN_TERMS,
+        description: "Terms/phrases defining the topic's evidence set, matched lexically (multi-word = exact phrase).",
+      },
+      scope: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          channels: { type: "array", items: { type: "string" }, description: "Channel ids to confine the spec to (OR'd)." },
+          after: { type: "string", description: "Inclusive lower bound, dd/mm/yy (IST)." },
+          before: { type: "string", description: "Exclusive upper bound, dd/mm/yy (IST)." },
+        },
+        description: "Spec-level filters, applied identically to counting and extraction.",
+      },
+      bucket: { type: "string", enum: ["year", "month"], description: "Time bucket that caps + spreads the pack." },
+      perBucket: { type: "number", description: `Max rows per term per bucket (1..${MAX_PACK_PER_BUCKET}, default ${DEFAULT_PACK_PER_BUCKET}).` },
+    },
+    required: ["searchArea", "topic", "terms", "bucket"],
+  },
+  async handler(args, ctx) {
+    if (!CONFIG.directVespaSearch) {
+      return err("spaces-evidence-pack requires DIRECT_VESPA_SEARCH=true.");
+    }
+    try {
+      const validated = validateEvidencePack({
+        searchArea: String(args["searchArea"] ?? ""),
+        topic: String(args["topic"] ?? ""),
+        terms: Array.isArray(args["terms"]) ? (args["terms"] as unknown[]).map(String) : [],
+        ...(args["scope"] !== undefined ? { scope: args["scope"] as CorpusScanScope } : {}),
+        bucket: args["bucket"] as "year" | "month",
+        ...(args["perBucket"] !== undefined ? { perBucket: Number(args["perBucket"]) } : {}),
+      });
+      const { scan, topic, perBucket } = validated;
+
+      const workspaceId = await getWorkspaceIdForUser(ctx.userId);
+      if (!workspaceId) return err("Could not resolve your workspaceId — cannot run a workspace-scoped extraction.");
+
+      const debugPayloads: Array<{ stage: string; yql: string; vespaParams: Record<string, unknown> }> = [];
+
+      // Phase 1 — discover which buckets have matches, per term (the same
+      // grouping census corpus-scan runs). This is what makes the fetch list
+      // finite and the coverage note honest.
+      const censusYql = buildCorpusScanYql(scan, { withTerm: true });
+      const termBucketCounts = await Promise.all(scan.terms.map(async term => {
+        const res = await queryDirect(censusYql, termToQuery(term), ctx.userId, 0, 0, CONFIG.vespaQueryEndpoint, "unranked", undefined, workspaceId);
+        const executed = res.data.debug?.payloads?.[0];
+        debugPayloads.push({ stage: `evidence-pack census: "${term}"`, yql: executed?.yql ?? censusYql, vespaParams: executed?.vespaParams ?? {} });
+        const buckets: Record<number, number> = {};
+        for (const g of res.data.groups ?? []) {
+          const key = parseBucketKey(g.groupValue);
+          if (key !== null && g.count > 0) buckets[key] = g.count;
+        }
+        return buckets;
+      }));
+
+      const counts: Record<string, Record<number, number>> = {};
+      const termTotals: Record<string, number> = {};
+      scan.terms.forEach((term, i) => {
+        counts[term] = termBucketCounts[i] ?? {};
+        termTotals[term] = Object.values(counts[term]).reduce((a, b) => a + b, 0);
+      });
+
+      // Phase 2 — build the fetch list (term × non-empty bucket), newest
+      // buckets first, hard-capped so one call can't become a query storm.
+      const fetchList: Array<{ term: string; bucketKey: number }> = [];
+      scan.terms.forEach(term => {
+        for (const key of Object.keys(counts[term] ?? {})) fetchList.push({ term, bucketKey: Number(key) });
+      });
+      fetchList.sort((a, b) => b.bucketKey - a.bucketKey);
+      const skipped = fetchList.splice(MAX_BUCKET_FETCHES);
+
+      const rowsNested = await Promise.all(fetchList.map(async ({ term, bucketKey }) => {
+        const yql = buildPackFetchYql(scan, bucketRange(bucketKey, scan.bucket));
+        const res = await queryDirect(yql, termToQuery(term), ctx.userId, perBucket, 0, CONFIG.vespaQueryEndpoint, "unranked", undefined, workspaceId, true);
+        const executed = res.data.debug?.payloads?.[0];
+        debugPayloads.push({ stage: `evidence-pack fetch: "${term}" @ ${bucketKey}`, yql: executed?.yql ?? yql, vespaParams: executed?.vespaParams ?? {} });
+        const results = (!res.data.grouped ? res.data.results : []) ?? [];
+        return results.map(r => {
+          const raw = (r.rawFields ?? {}) as Record<string, unknown>;
+          const ts = Number(raw[scan.area.timestampField] ?? NaN);
+          return {
+            docId: r.id,
+            date: formatIstDate(ts),
+            _ts: Number.isFinite(ts) ? ts : 0,
+            area: scan.areaName,
+            channel: typeof raw["channelId"] === "string" && raw["channelId"] ? String(raw["channelId"]) : (r.title || undefined),
+            term,
+            bucket: bucketKey,
+            snippet: toSnippet(r.context),
+          };
+        });
+      }));
+
+      // Dedupe by docId (a doc matching two terms appears once, first term
+      // wins), then order the pack oldest-first — the shape trend/timeline
+      // writing wants to read.
+      const seen = new Set<string>();
+      const pack = rowsNested.flat()
+        .filter(row => {
+          if (!row.docId || seen.has(row.docId)) return false;
+          seen.add(row.docId);
+          return true;
+        })
+        .sort((a, b) => a._ts - b._ts)
+        .map(({ _ts, ...row }) => row);
+
+      const coverage = {
+        bucketsFetched: fetchList.length,
+        bucketsSkipped: skipped.length,
+        note: skipped.length > 0
+          ? `Fetch cap hit: the ${skipped.length} OLDEST term×bucket cells were not extracted (oldest skipped bucket: ${Math.min(...skipped.map(s => s.bucketKey))}). Narrow the scope or split the spec to cover them.`
+          : "All non-empty buckets extracted.",
+        capNote: `Pack rows are capped at ${perBucket}/term/bucket (earliest-first) — the pack is a bounded SAMPLE of each bucket; counts/termTotals are the real totals.`,
+      };
+
+      const hasScope = Object.keys(scan.scope).length > 0;
+      const result = ok(
+        `Evidence pack "${topic}" over area "${scan.areaName}" (bucket: ${scan.bucket}; cap ${perBucket}/term/bucket; deterministic oldest-first; lexical; ACL-scoped to you).\n` +
+        `CONTRACT: write this JSON verbatim to a sandbox data file as the pack artifact. Writers cite only pack rows; ` +
+        `numbers come from counts/termTotals (or sandbox code over them), never from tallying the capped pack.\n\n` +
+        JSON.stringify({
+          topic,
+          spec: { area: scan.areaName, terms: scan.terms, bucket: scan.bucket, perBucket, ...(hasScope ? { scope: scan.scope } : {}) },
+          counts,
+          termTotals,
+          coverage,
+          pack,
+        }, null, 1),
+      );
+      return { ...result, _meta: { debug: { payloads: debugPayloads } } };
+    } catch (e) {
+      return directError("evidence-pack error", e);
+    }
+  },
+};
+
 export const tools: ToolDef[] = [
   spacesWhoami,
-  ...(CONFIG.directVespaSearch ? [spacesVespaSchema, spacesVespaQuery, spacesVespaSearch, spacesCorpusScan] : []),
+  ...(CONFIG.directVespaSearch ? [spacesVespaSchema, spacesVespaQuery, spacesVespaSearch, spacesCorpusScan, spacesEvidencePack] : []),
   spacesSearch,
   spacesSearchV2,
   spacesMyItems,

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -11,6 +11,7 @@ import { buildYqlFromParams, AREA_NAMES, AREA_ALIASES, describeAreasForPrompt } 
 import { validateCorpusScan, buildCorpusScanYql, parseBucketKey, termToQuery, MAX_SCAN_TERMS, type CorpusScanScope } from "./vespa-corpus-scan.js";
 import { getWorkspaceIdForUser } from "../../lib/spaces-db.js";
 import type { Citation } from "xyne-claw-shared";
+import { extractCleanTextFromFlowJson, isFlowJsonContent } from "xyne-claw-shared";
 import { CONFIG } from "../../config.js";
 import { createLogger } from "../../logger.js";
 
@@ -934,6 +935,13 @@ function decodeHtmlEntities(s: string): string {
  */
 function cleanSnippet(text: string): string {
   if (!text || typeof text !== "string") return text ?? "";
+  // Flow JSON (app/bot block messages) hide their real content in a
+  // `data-flow-json` attribute; the tag-strip below would drop it, so flatten
+  // the block tree first. Falls through to normal handling when empty.
+  if (isFlowJsonContent(text)) {
+    const flowText = extractCleanTextFromFlowJson(text);
+    if (flowText) return flowText;
+  }
   // Fast path: nothing tag-shaped → just decode entities + trim.
   if (!/<[a-z!/][^>]*>/i.test(text)) return decodeHtmlEntities(text).trim();
   const s = text

--- a/apps/xyne-claw-auth/backend/src/queue/experiment-supervisor.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/experiment-supervisor.ts
@@ -1,0 +1,96 @@
+import { experimentRepository, agentRunRepository, agentRepository } from "../repositories/index.js";
+import { dispatchExperimentEpoch } from "../lib/experiment.js";
+import { spacesAppFetch } from "../lib/spaces-api.js";
+import { decryptStoredField } from "../surfaces/spaces/client.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("experiment-supervisor");
+
+const INTERVAL_MS = 60_000;
+const STALE_MS = 10 * 60_000;
+const FORCE_DONE_AFTER_MS = 15 * 60_000;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+async function postNotice(run: { channelId: string; conversationId: string; agentSlug: string; orgId: string | null; finalReport?: string | null }): Promise<void> {
+  if (!run.orgId) return;
+  const agent = await agentRepository.findBySlug(run.agentSlug, run.orgId);
+  if (!agent?.spacesAppToken || !agent.spacesAppUserId) return;
+  const appToken = decryptStoredField(agent.spacesAppToken);
+  await spacesAppFetch("/chat/postMessage", {
+    channelId: run.channelId,
+    conversationId: run.conversationId,
+    markdownText: run.finalReport?.trim()
+      ? `**/experiment ended**\n\n${run.finalReport.trim()}`
+      : "**/experiment ended**\n\n(experiment ended without final report)",
+    userId: agent.spacesAppUserId,
+    metadata: { contentFormat: "markdown" },
+  }, appToken);
+}
+
+async function sessionIsActive(sessionId: string | null): Promise<boolean> {
+  if (!sessionId) return false;
+  const row = await agentRunRepository.findBySessionId(sessionId).catch(() => null);
+  return row?.status === "running";
+}
+
+async function tickOnce(): Promise<void> {
+  const runs = await experimentRepository.listActive();
+  const now = Date.now();
+  for (const run of runs) {
+    try {
+      const deadlineMs = run.deadlineAt.getTime();
+      if (now > deadlineMs + FORCE_DONE_AFTER_MS) {
+        await experimentRepository.update(run.id, {
+          status: "done",
+          finalReport: run.finalReport ?? "(experiment ended without final report)",
+        });
+        await postNotice({ ...run, finalReport: run.finalReport ?? "(experiment ended without final report)" }).catch((err) => {
+          log.warn(`[experiment] force-done notice failed id=${run.id}: ${err instanceof Error ? err.message : String(err)}`);
+        });
+        continue;
+      }
+
+      // NEVER dispatch while the current epoch session is live — a long quiet
+      // epoch (agent grinding in the sandbox without touching the run row) is
+      // normal, and dispatching over it double-runs the agent in one thread
+      // (session-lock collisions). Run-recovery owns hung-session handling.
+      const active = await sessionIsActive(run.currentSessionId);
+      if (active) continue;
+      // Inactive but recently touched = the immediate continuation hook is (or
+      // was just) handling the epoch handoff — don't race it. Only rescue runs
+      // that are BOTH inactive and quiet past the stale window.
+      const stale = now - run.updatedAt.getTime() > STALE_MS;
+      if (!stale) continue;
+
+      if (now < deadlineMs && run.status === "running") {
+        const next = await experimentRepository.update(run.id, {
+          epoch: { increment: 1 },
+          lastEpochEndedAt: new Date(),
+        });
+        await dispatchExperimentEpoch(next);
+      } else if (now >= deadlineMs && run.status === "running") {
+        const finishing = await experimentRepository.update(run.id, {
+          status: "finishing",
+          epoch: { increment: 1 },
+          lastEpochEndedAt: new Date(),
+        });
+        await dispatchExperimentEpoch(finishing);
+      }
+    } catch (err) {
+      log.warn(`[experiment] supervisor tick failed id=${run.id}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+export function initExperimentSupervisor(): void {
+  if (timer) return;
+  timer = setInterval(() => { void tickOnce(); }, INTERVAL_MS);
+  void tickOnce();
+  log.info("[experiment] supervisor started");
+}
+
+export function closeExperimentSupervisor(): void {
+  if (timer) clearInterval(timer);
+  timer = null;
+}

--- a/apps/xyne-claw-auth/backend/src/repositories/agentRequestRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRequestRepository.ts
@@ -172,4 +172,78 @@ export const agentRequestRepository = {
       where: { id },
       data: { status: "pending", reviewerId: null, reviewNote: null },
     }),
+
+  // ── Agent / subagent update requests ──────────────────────────────────────
+  // Same shape as the skill-update rows (proposedContent holds the proposal —
+  // for agents/subagents a JSON payload of systemPrompt + scalar fields), but
+  // targetType is "agent" | "subagent" and the target key (agent slug or
+  // subagent name) is stored in agentSlug. There is no partial-unique index for
+  // these, so the transactional supersede is what keeps one pending proposal per
+  // (target, proposer): a new proposal rejects the proposer's prior pending one.
+
+  findPendingEntityUpdate: (targetType: "agent" | "subagent", targetKey: string, requesterId: string) =>
+    prisma.agentRequest.findFirst({
+      where: { targetType, agentSlug: targetKey, requesterId, requestType: `${targetType}_update`, status: "pending" },
+    }),
+
+  supersedeAndCreateEntityUpdate: (data: {
+    targetType: "agent" | "subagent";
+    agentId?: string | null;
+    /** agent slug or subagent name — stored in agentSlug. */
+    targetKey: string;
+    requesterId: string;
+    orgId: string;
+    proposedContent: string;
+    baseContentHash: string;
+    proposedContentHash: string;
+    requestNote?: string | null;
+  }) =>
+    prisma.$transaction(async (tx) => {
+      const requestType = `${data.targetType}_update`;
+      const superseded = await tx.agentRequest.updateMany({
+        where: {
+          targetType: data.targetType,
+          agentSlug: data.targetKey,
+          requesterId: data.requesterId,
+          requestType,
+          status: "pending",
+        },
+        data: {
+          status: "rejected",
+          reviewerId: data.requesterId,
+          reviewNote: "Superseded by a newer proposal from the same proposer",
+        },
+      });
+      const request = await tx.agentRequest.create({
+        data: {
+          targetType: data.targetType,
+          requestType,
+          agentId: data.agentId ?? null,
+          agentSlug: data.targetKey,
+          requesterId: data.requesterId,
+          orgId: data.orgId,
+          proposedContent: data.proposedContent,
+          baseContentHash: data.baseContentHash,
+          proposedContentHash: data.proposedContentHash,
+          requestNote: data.requestNote ?? null,
+        },
+      });
+      return { request, supersededCount: superseded.count };
+    }),
+
+  /** Atomically claim a pending agent/subagent update (pending→status only if
+   *  still pending). count===1 → this caller owns applying it. Scoped by
+   *  requestType so it can never claim a clone / skill-update row. */
+  claimPendingEntityUpdate: (id: string, requestType: string, status: "approved" | "rejected", reviewerId: string, reviewNote?: string | null) =>
+    prisma.agentRequest.updateMany({
+      where: { id, requestType, status: "pending" },
+      data: { status, reviewerId, reviewNote: reviewNote ?? null },
+    }),
+
+  /** Roll a claimed agent/subagent update back to pending if applying fails. */
+  revertEntityUpdateToPending: (id: string) =>
+    prisma.agentRequest.update({
+      where: { id },
+      data: { status: "pending", reviewerId: null, reviewNote: null },
+    }),
 };

--- a/apps/xyne-claw-auth/backend/src/repositories/experimentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/experimentRepository.ts
@@ -1,0 +1,138 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../db.js";
+
+export type ExperimentStatus = "running" | "finishing" | "done" | "aborted";
+export type ExperimentFindingStatus = "conjecture" | "proved" | "refuted";
+
+export const experimentRepository = {
+  createRun(args: {
+    conversationId: string;
+    channelId: string;
+    agentSlug: string;
+    userId: string;
+    orgId?: string | null;
+    focus?: string | null;
+    provider?: string | null;
+    modelId?: string | null;
+    deadlineAt: Date;
+  }) {
+    return prisma.experimentRun.create({
+      data: {
+        conversationId: args.conversationId,
+        channelId: args.channelId,
+        agentSlug: args.agentSlug,
+        userId: args.userId,
+        orgId: args.orgId ?? null,
+        focus: args.focus ?? null,
+        provider: args.provider ?? null,
+        modelId: args.modelId ?? null,
+        deadlineAt: args.deadlineAt,
+      },
+    });
+  },
+
+  findActiveByConversation(conversationId: string) {
+    return prisma.experimentRun.findFirst({
+      where: { conversationId, status: { in: ["running", "finishing"] } },
+      orderBy: { createdAt: "desc" },
+    });
+  },
+
+  findById(id: string) {
+    return prisma.experimentRun.findUnique({ where: { id } });
+  },
+
+  update(id: string, data: Prisma.ExperimentRunUpdateInput) {
+    return prisma.experimentRun.update({ where: { id }, data });
+  },
+
+  addFinding(args: {
+    experimentId: string;
+    epoch: number;
+    status: ExperimentFindingStatus;
+    title: string;
+    hypothesis: string;
+    note?: string | null;
+    proofArtifactPath?: string | null;
+  }) {
+    return prisma.experimentFinding.create({
+      data: {
+        experimentId: args.experimentId,
+        epoch: args.epoch,
+        status: args.status,
+        title: args.title,
+        hypothesis: args.hypothesis,
+        note: args.note ?? null,
+        proofArtifactPath: args.proofArtifactPath ?? null,
+      },
+    });
+  },
+
+  async upsertFindingByTitle(args: {
+    experimentId: string;
+    epoch: number;
+    status: ExperimentFindingStatus;
+    title: string;
+    hypothesis: string;
+    note?: string | null;
+    proofArtifactPath?: string | null;
+  }) {
+    const existing = await prisma.experimentFinding.findFirst({
+      where: { experimentId: args.experimentId, title: args.title },
+      orderBy: { createdAt: "asc" },
+    });
+    if (existing) {
+      return prisma.experimentFinding.update({
+        where: { id: existing.id },
+        data: {
+          epoch: args.epoch,
+          status: args.status,
+          hypothesis: args.hypothesis,
+          note: args.note ?? null,
+          proofArtifactPath: args.proofArtifactPath ?? null,
+        },
+      });
+    }
+    return this.addFinding(args);
+  },
+
+  async updateFindingStatus(args: {
+    id?: string;
+    experimentId?: string;
+    title?: string;
+    status: ExperimentFindingStatus;
+    note?: string | null;
+    proofArtifactPath?: string | null;
+  }) {
+    const where = args.id
+      ? { id: args.id }
+      : args.experimentId && args.title
+        ? { experimentId: args.experimentId, title: args.title }
+        : null;
+    if (!where) throw new Error("updateFindingStatus requires id or experimentId+title");
+    const existing = await prisma.experimentFinding.findFirst({ where });
+    if (!existing) return null;
+    return prisma.experimentFinding.update({
+      where: { id: existing.id },
+      data: {
+        status: args.status,
+        ...(args.note !== undefined ? { note: args.note } : {}),
+        ...(args.proofArtifactPath !== undefined ? { proofArtifactPath: args.proofArtifactPath } : {}),
+      },
+    });
+  },
+
+  listFindings(experimentId: string) {
+    return prisma.experimentFinding.findMany({
+      where: { experimentId },
+      orderBy: [{ status: "asc" }, { createdAt: "asc" }],
+    });
+  },
+
+  listActive() {
+    return prisma.experimentRun.findMany({
+      where: { status: { in: ["running", "finishing"] } },
+      orderBy: { updatedAt: "asc" },
+    });
+  },
+};

--- a/apps/xyne-claw-auth/backend/src/repositories/index.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/index.ts
@@ -19,6 +19,7 @@ export { skillRepository } from "./skillRepository.js";
 export { subagentDefinitionRepository } from "./subagentDefinitionRepository.js";
 export { subagentShareRepository } from "./subagentShareRepository.js";
 export { activeGoalRepository } from "./activeGoalRepository.js";
+export { experimentRepository } from "./experimentRepository.js";
 export { evalRepository } from "./evalRepository.js";
 export type { EvalTurnInput, ImportConversationInput } from "./evalRepository.js";
 export { searchEvalRepository, computeSearchEvalSummary, toMetricsSummary } from "./searchEvalRepository.js";

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -4,7 +4,7 @@ import crypto from "node:crypto";
 import { Prisma } from "@prisma/client";
 import { agentRepository, agentShareRepository, agentRequestRepository, userRepository, userAgentConfigRepository, userProviderCredentialsRepository, agentProviderCredentialsRepository, sharedProviderCredentialRepository, skillRepository } from "../repositories/index.js";
 import { validateSubagentInput, ValidationError as SubagentValidationError } from "../lib/subagent-resolver.js";
-import { getSubagentDefinition, buildCloneApprovalFlow } from "xyne-claw-shared";
+import { getSubagentDefinition, buildCloneApprovalFlow, hashSkillContent } from "xyne-claw-shared";
 import { spacesAppFetch } from "../lib/spaces-api.js";
 import { getWorkspaceIdForUser } from "../lib/spaces-db.js";
 import { prisma } from "../db.js";
@@ -21,7 +21,15 @@ import {
   getRequesterId,
   getOrgId,
   isClawAdmin,
+  getAgentEditAccess,
 } from "../middleware/agent-acl.js";
+import { canProposerPostAsAgent } from "./skills.js";
+import {
+  computeEntityUpdate,
+  resolveEntityUpdateRequest,
+  notifyApproverOfEntityUpdateInSpaces,
+  agentToolSelectionFromConfig,
+} from "../lib/entity-update.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { writeAuditLog } from "../lib/audit.js";
 import { buildAvailableToolsCatalog } from "./tools.js";
@@ -4073,5 +4081,129 @@ router.delete(
     }
   },
 );
+
+// ── update-agent: propose a change to an existing agent ────────────────────
+// The update-agent tool POSTs here. Applies systemPrompt edits + scalar changes
+// to a working copy, records an agent_update AgentRequest, and DMs the owner the
+// diff. Never applies here — see resolveEntityUpdateRequest (flow-action.ts).
+// Mirrors POST /skills/:slug/propose-update.
+router.post("/:slug/propose-update", async (req: Request<{ slug: string }>, res: Response) => {
+  try {
+    const requesterId = getRequesterId(req);
+    if (!requesterId) { res.status(401).json({ success: false, error: "x-user-id required" }); return; }
+    const orgId = getOrgId(req);
+    if (!orgId) { res.status(400).json({ success: false, error: "orgId is required" }); return; }
+
+    const body = req.body as {
+      promptEdits?: Array<{ oldText?: string; newText?: string }>;
+      systemPrompt?: string; name?: string; description?: string; modelId?: string; color?: string;
+      tools?: string[]; summary?: string; agentSlug?: string;
+    };
+
+    const agent = await agentRepository.findBySlug(req.params.slug, orgId);
+    if (!agent) { res.status(404).json({ success: false, error: "Agent not found" }); return; }
+
+    // Only the owner or a contributor (share role EDITOR/CONTRIBUTOR) may
+    // propose an update. Unlike skills (open-propose), agents are owned
+    // resources with an ACL — reject the proposal outright otherwise.
+    const editAccess = await getAgentEditAccess(requesterId, agent.slug, orgId);
+    if (!editAccess?.canEdit) {
+      res.status(403).json({ success: false, error: "Only the agent owner or a contributor can propose updates." });
+      return;
+    }
+
+    const computed = computeEntityUpdate("agent", {
+      systemPrompt: agent.systemPrompt,
+      name: agent.name,
+      description: agent.description ?? "",
+      modelId: agent.modelId,
+      color: agent.color,
+      currentToolSelection: agentToolSelectionFromConfig(agent.config),
+    }, body);
+    if (!computed.ok) { res.status(computed.code).json({ success: false, error: computed.error }); return; }
+
+    if (!agent.ownerUserId) { res.status(409).json({ success: false, error: "This agent has no owner to approve an update." }); return; }
+
+    const proposedContent = JSON.stringify(computed.payload);
+    const outcome = await agentRequestRepository.supersedeAndCreateEntityUpdate({
+      targetType: "agent",
+      agentId: agent.id,
+      targetKey: agent.slug,
+      requesterId,
+      orgId,
+      proposedContent,
+      baseContentHash: computed.baseContentHash,
+      proposedContentHash: hashSkillContent(proposedContent),
+      requestNote: body.summary?.trim() || null,
+    });
+    if (outcome.supersededCount > 0) {
+      log.info(`[agents/propose-update] superseded ${outcome.supersededCount} stale pending proposal(s) for ${agent.slug} by ${requesterId}`);
+    }
+
+    await writeAuditLog({ actorUserId: requesterId, eventType: "REQUEST_CREATED", targetId: agent.id, description: `agent_update request for "${agent.name}" (${agent.slug})` });
+
+    const requester = await userRepository.findById(requesterId);
+    const proposerName = requester?.name ?? requester?.email ?? "A user";
+    if (body.agentSlug) {
+      const access = await getAgentEditAccess(requesterId, body.agentSlug, orgId);
+      if (canProposerPostAsAgent(access)) {
+        void notifyApproverOfEntityUpdateInSpaces({
+          kind: "agent",
+          approverUserId: agent.ownerUserId,
+          requestId: outcome.request.id,
+          targetKey: agent.slug,
+          targetName: agent.name,
+          proposerName,
+          ...(computed.diff ? { diff: computed.diff } : {}),
+          fieldChanges: computed.fieldChanges,
+          summary: body.summary?.trim() || null,
+          agent: access.agent,
+        });
+      } else {
+        log.warn(`[agents/propose-update] owner DM skipped for ${agent.slug}: requester ${requesterId} not authorized to post as agent ${body.agentSlug}`);
+      }
+    }
+
+    res.status(202).json({
+      success: true,
+      data: {
+        requestId: outcome.request.id,
+        status: "pending_approval",
+        ...(outcome.supersededCount > 0 ? { supersededPreviousProposal: true } : {}),
+      },
+    });
+  } catch (err) {
+    log.error("[agents] propose-update error:", err);
+    res.status(500).json({ success: false, error: "Internal server error" });
+  }
+});
+
+// REST parity (used by tests / non-card callers). The card path in
+// flow-action.ts calls resolveEntityUpdateRequest directly.
+router.post("/agent-update-requests/:requestId/approve", async (req: Request<{ requestId: string }>, res: Response) => {
+  try {
+    const callerUserId = getRequesterId(req);
+    if (!callerUserId) { res.status(401).json({ success: false, error: "x-user-id required" }); return; }
+    const result = await resolveEntityUpdateRequest("agent", req.params.requestId, callerUserId, "approve");
+    if (!result.ok) { res.status(result.code).json({ success: false, error: result.error }); return; }
+    res.json({ success: true, alreadyResolved: result.alreadyResolved ?? false });
+  } catch (err) {
+    log.error("[agents] approve agent-update error:", err);
+    res.status(500).json({ success: false, error: "Internal server error" });
+  }
+});
+
+router.post("/agent-update-requests/:requestId/reject", async (req: Request<{ requestId: string }>, res: Response) => {
+  try {
+    const callerUserId = getRequesterId(req);
+    if (!callerUserId) { res.status(401).json({ success: false, error: "x-user-id required" }); return; }
+    const result = await resolveEntityUpdateRequest("agent", req.params.requestId, callerUserId, "reject");
+    if (!result.ok) { res.status(result.code).json({ success: false, error: result.error }); return; }
+    res.json({ success: true, alreadyResolved: result.alreadyResolved ?? false });
+  } catch (err) {
+    log.error("[agents] reject agent-update error:", err);
+    res.status(500).json({ success: false, error: "Internal server error" });
+  }
+});
 
 export { router as agentsRouter };

--- a/apps/xyne-claw-auth/backend/src/routes/experiments-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/experiments-internal.ts
@@ -1,0 +1,111 @@
+import { Router, type Request, type Response } from "express";
+import { experimentRepository } from "../repositories/index.js";
+import { buildLedgerMarkdown } from "../lib/experiment.js";
+
+export const experimentsInternalRouter = Router();
+
+function counts(findings: Array<{ status: string }>): { conjecture: number; proved: number; refuted: number } {
+  return {
+    conjecture: findings.filter((f) => f.status === "conjecture").length,
+    proved: findings.filter((f) => f.status === "proved").length,
+    refuted: findings.filter((f) => f.status === "refuted").length,
+  };
+}
+
+function notFound(res: Response): void {
+  res.status(404).json({ success: false, error: "experiment not found" });
+}
+
+function validStatus(value: unknown): value is "conjecture" | "proved" | "refuted" {
+  return value === "conjecture" || value === "proved" || value === "refuted";
+}
+
+experimentsInternalRouter.get("/:id/ledger", async (req: Request<{ id: string }>, res: Response) => {
+  const run = await experimentRepository.findById(req.params.id);
+  if (!run) return notFound(res);
+  const findings = await experimentRepository.listFindings(run.id);
+  res.json({
+    success: true,
+    data: {
+      markdown: buildLedgerMarkdown(run, findings),
+      counts: counts(findings),
+      deadlineAt: run.deadlineAt.toISOString(),
+      epoch: run.epoch,
+    },
+  });
+});
+
+experimentsInternalRouter.post("/:id/findings", async (req: Request<{ id: string }>, res: Response) => {
+  const run = await experimentRepository.findById(req.params.id);
+  if (!run) return notFound(res);
+  const body = req.body as {
+    epoch?: unknown;
+    status?: unknown;
+    title?: unknown;
+    hypothesis?: unknown;
+    note?: unknown;
+    proofArtifactPath?: unknown;
+  };
+  if (typeof body.epoch !== "number" || !validStatus(body.status) || typeof body.title !== "string" || typeof body.hypothesis !== "string") {
+    res.status(400).json({ success: false, error: "invalid finding body" });
+    return;
+  }
+  // Length caps: findings feed straight into every later epoch's task prompt
+  // (buildLedgerMarkdown), so uncapped text compounds across an 8h run.
+  const row = await experimentRepository.upsertFindingByTitle({
+    experimentId: run.id,
+    epoch: body.epoch,
+    status: body.status,
+    title: body.title.slice(0, 200),
+    hypothesis: body.hypothesis.slice(0, 2000),
+    note: typeof body.note === "string" ? body.note.slice(0, 2000) : null,
+    proofArtifactPath: typeof body.proofArtifactPath === "string" ? body.proofArtifactPath.slice(0, 500) : null,
+  });
+  res.json({ success: true, data: { id: row.id } });
+});
+
+experimentsInternalRouter.post("/:id/hypothesis", async (req: Request<{ id: string }>, res: Response) => {
+  const run = await experimentRepository.findById(req.params.id);
+  if (!run) return notFound(res);
+  const body = req.body as { epoch?: unknown; text?: unknown };
+  if (typeof body.epoch !== "number" || typeof body.text !== "string") {
+    res.status(400).json({ success: false, error: "invalid hypothesis body" });
+    return;
+  }
+  // Only currentHypothesis — NEVER the run's epoch counter. The caller sends
+  // its dispatch-time epoch, so a zombie session from a recovered epoch would
+  // otherwise rewind run.epoch under the live one.
+  await experimentRepository.update(run.id, { currentHypothesis: body.text.slice(0, 500) });
+  res.json({ success: true });
+});
+
+experimentsInternalRouter.post("/:id/sandbox-note", async (req: Request<{ id: string }>, res: Response) => {
+  const run = await experimentRepository.findById(req.params.id);
+  if (!run) return notFound(res);
+  const body = req.body as { note?: unknown };
+  if (typeof body.note !== "string") {
+    res.status(400).json({ success: false, error: "invalid sandbox-note body" });
+    return;
+  }
+  await experimentRepository.update(run.id, { sandboxNote: body.note.slice(0, 2000) });
+  res.json({ success: true });
+});
+
+experimentsInternalRouter.post("/:id/complete", async (req: Request<{ id: string }>, res: Response) => {
+  const run = await experimentRepository.findById(req.params.id);
+  if (!run) return notFound(res);
+  const body = req.body as { report?: unknown };
+  if (typeof body.report !== "string") {
+    res.status(400).json({ success: false, error: "invalid complete body" });
+    return;
+  }
+  // Only a live experiment can complete — a zombie session must not resurrect
+  // an aborted run or overwrite an already-recorded final report.
+  if (run.status !== "running" && run.status !== "finishing") {
+    res.status(409).json({ success: false, error: `experiment is ${run.status}` });
+    return;
+  }
+  await experimentRepository.update(run.id, { finalReport: body.report.slice(0, 20000), status: "done" });
+  res.json({ success: true });
+});
+

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -15,13 +15,13 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
 import { CONFIG } from "../config.js";
 import { prisma } from "../db.js";
-import { decrypt } from "../crypto.js";
+import { decrypt, encrypt } from "../crypto.js";
 import { executeTwinApprovalDelivery } from "../lib/twin-delivery.js";
 import { verifySpacesSignature } from "../middleware/verify-spaces-signature.js";
 import { agentRunRepository } from "../repositories/index.js";
 import { recordTwinApprovalOutcome } from "../services/twinResponseFeedback.js";
 import type { FlowDefinition } from "xyne-claw-shared";
-import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
+import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, buildAgentCreationFlow, agentCreationPropsFromToolParams, buildSkillCreationFlow, skillCreationPropsFromToolParams, PLAN_COMPONENT_ID } from "xyne-claw-shared";
 import { clearActivePlanCard, setPlanExecMeta, clearPlanExecMeta, normalizePlanTitle } from "../lib/session-context.js";
 import { executeTool as executeGatewayTool } from "../mcpgateway/services/execution.js";
 import { GATEWAY_KEY_PREFIX, parseGatewayCatalogSource } from "../mcpgateway/key-format.js";
@@ -38,16 +38,69 @@ import { visibleAgentWhereForRunningUser } from "../lib/callable-agent-resolver.
 import { emitAgentWorkingSignal } from "../surfaces/spaces/client.js";
 import { resolveFastMode } from "../lib/fast-mode.js";
 import { isClawAdmin } from "../middleware/agent-acl.js";
+import { buildGoogleConsentUrl } from "./google-oauth.js";
+import { buildMicrosoftConsentUrl } from "./microsoft-oauth.js";
 import { registerRunRecovery } from "../queue/run-recovery-worker.js";
+import { validateCredentials } from "../validation.js";
+import { hasConnectorDefinition, resolveConnectorDefinition } from "../mcp/connector-definitions.js";
+import { evictSession } from "../mcp/runner.js";
+import { syncToolsForServer } from "../tool-sync.js";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("flow-action");
+
+const AGENT_CREATION_OAUTH_TOOLS = new Map<string, { serverType: string; displayName: string }>([
+  ["google", { serverType: "google", displayName: "Google" }],
+  ["gmail", { serverType: "google", displayName: "Google" }],
+  ["google-drive", { serverType: "google", displayName: "Google" }],
+  ["drive", { serverType: "google", displayName: "Google" }],
+  ["microsoft", { serverType: "microsoft", displayName: "Microsoft" }],
+  ["outlook", { serverType: "microsoft", displayName: "Microsoft" }],
+  ["office", { serverType: "microsoft", displayName: "Microsoft" }],
+]);
 
 const router = Router();
 const DEFAULT_GATEWAY_TENANT = process.env.ALLOWED_TENANTS
   ?.split(",")
   .map((tenant) => tenant.trim())
   .find((tenant) => tenant.length > 0);
+
+async function agentCreationConnectLinksForUser(
+  params: Record<string, unknown>,
+  userId: string,
+): Promise<Array<{ serverType: string; displayName: string; authUrl: string }>> {
+  const selectedTools = Array.isArray(params["tools"])
+    ? (params["tools"] as unknown[]).filter((tool): tool is string => typeof tool === "string")
+    : [];
+  if (selectedTools.length === 0) return [];
+
+  const wanted = new Map<string, string>();
+  for (const tool of selectedTools) {
+    const normalized = tool.trim().toLowerCase().replace(/[_\s]+/g, "-");
+    const oauthTool = AGENT_CREATION_OAUTH_TOOLS.get(normalized);
+    if (oauthTool) wanted.set(oauthTool.serverType, oauthTool.displayName);
+  }
+  if (wanted.size === 0) return [];
+
+  const existing = await prisma.userMcpConnection.findMany({
+    where: { userId, mcpServer: { type: { in: [...wanted.keys()] } } },
+    select: { mcpServer: { select: { type: true } } },
+  });
+  for (const conn of existing) wanted.delete(conn.mcpServer.type);
+
+  const links: Array<{ serverType: string; displayName: string; authUrl: string }> = [];
+  for (const [serverType, displayName] of wanted) {
+    try {
+      const authUrl = serverType === "google"
+        ? buildGoogleConsentUrl(userId)
+        : buildMicrosoftConsentUrl(userId);
+      links.push({ serverType, displayName, authUrl });
+    } catch (err) {
+      log.warn(`[flow-action] could not build ${serverType} connect URL for create-agent card:`, err instanceof Error ? err.message : String(err));
+    }
+  }
+  return links;
+}
 
 function resolveGatewayTenantForApproval(): string | null {
   return DEFAULT_GATEWAY_TENANT ?? null;
@@ -509,6 +562,88 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
   let resp: AppActionResponse;
 
   try {
+    if (actionType === "mcp-configure") {
+      const configureUserId = data["userId"] as string | undefined;
+      const mcpServerId = data["mcpServerId"] as string | undefined;
+      const serverType = data["serverType"] as string | undefined;
+      const serverName = data["serverName"] as string | undefined;
+      const agentSlug = data["agentSlug"] as string | undefined;
+      const spacesAppId = data["spacesAppId"] as string | undefined;
+
+      if (actionId !== "mcp-configure-submit") {
+        res.status(400).json({ type: "error", message: "Unknown MCP configure action" } satisfies AppActionResponse);
+        return;
+      }
+      if (!configureUserId || !mcpServerId || !serverType) {
+        res.status(400).json({ type: "error", message: "Missing MCP configure fields" } satisfies AppActionResponse);
+        return;
+      }
+      if (!callerUserId || callerUserId !== configureUserId) {
+        log.error(`[flow-action] mcp-configure: unauthorized — caller ${callerUserId ?? "(none)"} != expected ${configureUserId}`);
+        res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
+        return;
+      }
+
+      const server = await prisma.mcpServer.findUnique({ where: { id: mcpServerId } });
+      if (!server || server.type !== serverType || !server.enabled) {
+        res.status(404).json({ type: "error", message: "MCP server not found" } satisfies AppActionResponse);
+        return;
+      }
+
+      const definition = await resolveConnectorDefinition(server.type);
+      const fields = definition?.credentialFields ?? [];
+      if (!definition || fields.length === 0) {
+        res.status(400).json({ type: "error", message: `${server.name} does not accept user credentials` } satisfies AppActionResponse);
+        return;
+      }
+
+      const credentials: Record<string, unknown> = {};
+      for (const field of fields) {
+        const value = values[field.name];
+        if (typeof value === "string") {
+          const trimmed = value.trim();
+          if (trimmed.length > 0 || !field.optional) credentials[field.name] = trimmed;
+        }
+      }
+
+      const validation = await validateCredentials(server.type, credentials);
+      if (!validation.valid) {
+        res.status(400).json({ type: "error", message: validation.error ?? "Invalid credentials" } satisfies AppActionResponse);
+        return;
+      }
+
+      const encrypted = encrypt(JSON.stringify(credentials), CONFIG.encryptionKey);
+      await prisma.userMcpConnection.upsert({
+        where: { userId_mcpServerId: { userId: configureUserId, mcpServerId } },
+        create: {
+          userId: configureUserId,
+          mcpServerId,
+          encryptedCreds: encrypted.ciphertext,
+          iv: encrypted.iv,
+          authTag: encrypted.authTag,
+        },
+        update: {
+          encryptedCreds: encrypted.ciphertext,
+          iv: encrypted.iv,
+          authTag: encrypted.authTag,
+        },
+      });
+
+      await evictSession(configureUserId, server.type).catch((err) => {
+        log.error(`[flow-action] mcp-configure: evictSession failed for ${server.type}:`, err);
+      });
+      if (await hasConnectorDefinition(server.type)) {
+        syncToolsForServer(configureUserId, server.type, server.name, credentials).catch((err) => {
+          log.error(`[flow-action] mcp-configure: tool sync failed for ${server.type}:`, err);
+        });
+      }
+
+      const label = serverName || server.name;
+      void replaceFlowCardWithText(messageId, agentSlug, `✅ **${label} configured.**`, conversationId, undefined, spacesAppId);
+      res.json({ type: "close_screen", finalMessage: `${label} configured.` } satisfies AppActionResponse);
+      return;
+    }
+
     // ── 1. Write tool approval (HITL) ─────────────────────────────────────────
     if (actionType === "write") {
       const serverType = data["serverType"] as string;
@@ -535,6 +670,38 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       }
 
       if (actionId === "decline-write") {
+        // create-agent: update the SAME card in place to the 'rejected' phase
+        // (matches the pending → rejected transition) instead of a text line.
+        if (serverType === "agent" && tool === "create-agent") {
+          try {
+            const p = JSON.parse(paramsStr) as Record<string, unknown>;
+            const rejectedFlow = buildAgentCreationFlow("rejected", {
+              ...agentCreationPropsFromToolParams(p),
+              decidedAt: new Date().toISOString(),
+            });
+            resp = { type: "close_screen", finalMessage: "❌ Agent creation declined." };
+            res.json(resp);
+            void replaceFlowCardWithFlow(messageId, agentSlug, rejectedFlow, conversationId, undefined, spacesAppId);
+            return;
+          } catch (err) {
+            log.warn(`[flow-action] create-agent decline card build failed, falling back to text:`, err instanceof Error ? err.message : String(err));
+          }
+        }
+        if (serverType === "agent" && tool === "create-skill") {
+          try {
+            const p = JSON.parse(paramsStr) as Record<string, unknown>;
+            const rejectedFlow = buildSkillCreationFlow("rejected", {
+              ...skillCreationPropsFromToolParams(p),
+              decidedAt: new Date().toISOString(),
+            });
+            resp = { type: "close_screen", finalMessage: "❌ Skill creation declined." };
+            res.json(resp);
+            void replaceFlowCardWithFlow(messageId, agentSlug, rejectedFlow, conversationId, undefined, spacesAppId);
+            return;
+          } catch (err) {
+            log.warn(`[flow-action] create-skill decline card build failed, falling back to text:`, err instanceof Error ? err.message : String(err));
+          }
+        }
         resp = { type: "close_screen", finalMessage: "❌ Action declined." };
         res.json(resp);
         void replaceFlowCardWithText(messageId, agentSlug, "❌ **Action declined.**", conversationId, undefined, spacesAppId);
@@ -784,11 +951,12 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       }
 
       // ── create-skill: persist an agent-authored skill on approval ──────────
-      // serverType "skill" has no MCP connector; the write is applied directly
-      // via skillRepository, owned by the approving user (writeUserId, already
+      // create-skill now shares the "agent" serverType (grouped under the Agent
+      // tool source) — routed by tool name. The write is applied directly via
+      // skillRepository, owned by the approving user (writeUserId, already
       // verified === callerUserId above) in their org. HMAC over {serverType,
       // tool, params, userId} was verified above, so params are trusted here.
-      if (serverType === "skill") {
+      if (serverType === "agent" && tool === "create-skill") {
         const { skillRepository } = await import("../repositories/index.js");
         const name = String(params["name"] ?? "").trim();
         const description = String(params["description"] ?? "").trim();
@@ -830,7 +998,162 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         log.info(`[flow-action] create-skill approved slug=${slug} owner=${writeUserId} org=${skillOrgId}`);
         resp = { type: "close_screen", finalMessage: `✅ Skill "${name}" created.` };
         res.json(resp);
-        void replaceFlowCardWithText(messageId, agentSlug, `✅ **Skill created:** ${name} (\`${slug}\`)`, conversationId, undefined, spacesAppId);
+        void replaceFlowCardWithFlow(
+          messageId,
+          agentSlug,
+          buildSkillCreationFlow("created", {
+            ...skillCreationPropsFromToolParams(params),
+            decidedAt: new Date().toISOString(),
+          }),
+          conversationId,
+          undefined,
+          spacesAppId,
+        );
+        return;
+      }
+
+      // ── create-agent: persist an agent-authored agent on approval ──────────
+      // serverType "agent" has no MCP connector; the write is applied directly
+      // via agentRepository, owned by the approving user (writeUserId) in their
+      // org. Mirrors the "skill" branch above. tools[] is categorized into
+      // config.tools; unknown tokens are reported, never mis-wired.
+      if (serverType === "agent" && tool === "create-agent") {
+        const { agentRepository } = await import("../repositories/index.js");
+        const name = String(params["name"] ?? "").trim();
+        const description = String(params["description"] ?? "").trim();
+        const systemPrompt = String(params["systemPrompt"] ?? "");
+        const modelId = String(params["modelId"] ?? "").trim();
+        const color = String(params["color"] ?? "").trim();
+        const rawTools = Array.isArray(params["tools"])
+          ? (params["tools"] as unknown[]).filter((t): t is string => typeof t === "string")
+          : [];
+        let slug = String(params["slug"] ?? "").trim().toLowerCase();
+        if (!slug) slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80);
+        if (!name || !systemPrompt.trim() || !slug) {
+          res.json({ type: "error", message: "Agent name, slug and system prompt are required." } satisfies AppActionResponse);
+          return;
+        }
+        if (!/^[a-z0-9-]+$/.test(slug) || slug.startsWith("-") || slug.endsWith("-") || slug.includes("--")) {
+          res.json({ type: "error", message: "Invalid agent slug (use lowercase letters, digits and single hyphens)." } satisfies AppActionResponse);
+          return;
+        }
+        const user = await prisma.user.findUnique({ where: { id: writeUserId }, select: { orgId: true } });
+        const agentOrgId = user?.orgId;
+        if (!agentOrgId) {
+          res.json({ type: "error", message: "Could not resolve your organization to create the agent." } satisfies AppActionResponse);
+          return;
+        }
+        const existing = await agentRepository.findBySlug(slug, agentOrgId);
+        if (existing) {
+          const msg = `An agent with slug "${slug}" already exists.`;
+          resp = { type: "close_screen", finalMessage: `⚠️ ${msg}` };
+          res.json(resp);
+          void replaceFlowCardWithText(messageId, agentSlug, `⚠️ ${msg}`, conversationId, undefined, spacesAppId);
+          return;
+        }
+        let configTools: { subagents?: string[]; custom?: string[] } = {};
+        let unknownTools: string[] = [];
+        if (rawTools.length > 0) {
+          const { buildAvailableToolsCatalog } = await import("./tools.js");
+          const { categorizeToolSelection, toConfigTools } = await import("../lib/agent-tool-selection.js");
+          const catalog = await buildAvailableToolsCatalog(undefined, agentOrgId);
+          const sel = categorizeToolSelection(rawTools, catalog, { allowSubagents: true });
+          configTools = toConfigTools(sel);
+          unknownTools = sel.unknown;
+        }
+        const config = Object.keys(configTools).length > 0 ? { tools: configTools } : {};
+        await agentRepository.create({
+          slug,
+          name,
+          description,
+          systemPrompt: systemPrompt.trim(),
+          scope: "personal",
+          color: color || "#6366f1",
+          modelId: modelId || "",
+          config,
+          kbScope: "COLLECTIONS",
+          org: { connect: { id: agentOrgId } },
+          owner: { connect: { id: writeUserId } },
+        });
+        const note = unknownTools.length > 0 ? ` (skipped unknown tools: ${unknownTools.join(", ")})` : "";
+        log.info(`[flow-action] create-agent approved slug=${slug} owner=${writeUserId} org=${agentOrgId}${note}`);
+        resp = { type: "close_screen", finalMessage: `✅ Agent "${name}" created.${note}` };
+        res.json(resp);
+        void replaceFlowCardWithFlow(
+          messageId,
+          agentSlug,
+          buildAgentCreationFlow("created", {
+            ...agentCreationPropsFromToolParams(params),
+            connectLinks: await agentCreationConnectLinksForUser(params, writeUserId),
+            ...(note.trim() ? { note } : {}),
+            decidedAt: new Date().toISOString(),
+          }),
+          conversationId,
+          undefined,
+          spacesAppId,
+        );
+        return;
+      }
+
+      // ── create-subagent: persist an agent-authored subagent on approval ────
+      // serverType "subagent" mirrors "agent" but targets subagent_definitions
+      // (keyed by org+name). Subagents cannot nest subagents, so tool selection
+      // resolves custom tools only.
+      if (serverType === "agent" && tool === "create-subagent") {
+        const { subagentDefinitionRepository } = await import("../repositories/index.js");
+        const name = String(params["name"] ?? "").trim();
+        const description = String(params["description"] ?? "").trim();
+        const systemPrompt = String(params["systemPrompt"] ?? "");
+        const paramName = String(params["paramName"] ?? "").trim();
+        const paramDescription = String(params["paramDescription"] ?? "").trim();
+        const rawTools = Array.isArray(params["tools"])
+          ? (params["tools"] as unknown[]).filter((t): t is string => typeof t === "string")
+          : [];
+        if (!name || !systemPrompt.trim() || !paramName || !paramDescription) {
+          res.json({ type: "error", message: "Subagent name, system prompt, paramName and paramDescription are required." } satisfies AppActionResponse);
+          return;
+        }
+        const user = await prisma.user.findUnique({ where: { id: writeUserId }, select: { orgId: true } });
+        const subagentOrgId = user?.orgId;
+        if (!subagentOrgId) {
+          res.json({ type: "error", message: "Could not resolve your organization to create the subagent." } satisfies AppActionResponse);
+          return;
+        }
+        const existing = await subagentDefinitionRepository.findByName(name, subagentOrgId);
+        if (existing) {
+          const msg = `A subagent named "${name}" already exists.`;
+          resp = { type: "close_screen", finalMessage: `⚠️ ${msg}` };
+          res.json(resp);
+          void replaceFlowCardWithText(messageId, agentSlug, `⚠️ ${msg}`, conversationId, undefined, spacesAppId);
+          return;
+        }
+        let toolsConfig: { custom?: string[] } = {};
+        let unknownTools: string[] = [];
+        if (rawTools.length > 0) {
+          const { buildAvailableToolsCatalog } = await import("./tools.js");
+          const { categorizeToolSelection } = await import("../lib/agent-tool-selection.js");
+          const catalog = await buildAvailableToolsCatalog(undefined, subagentOrgId);
+          const sel = categorizeToolSelection(rawTools, catalog, { allowSubagents: false });
+          if (sel.custom.length > 0) toolsConfig = { custom: sel.custom };
+          unknownTools = sel.unknown;
+        }
+        await subagentDefinitionRepository.create({
+          name,
+          description,
+          systemPrompt: systemPrompt.trim(),
+          paramName,
+          paramDescription,
+          progressLabels: [],
+          tools: toolsConfig,
+          enabled: true,
+          createdByUserId: writeUserId,
+          org: { connect: { id: subagentOrgId } },
+        });
+        const note = unknownTools.length > 0 ? ` (skipped unknown tools: ${unknownTools.join(", ")})` : "";
+        log.info(`[flow-action] create-subagent approved name=${name} owner=${writeUserId} org=${subagentOrgId}${note}`);
+        resp = { type: "close_screen", finalMessage: `✅ Subagent "${name}" created.${note}` };
+        res.json(resp);
+        void replaceFlowCardWithText(messageId, agentSlug, `✅ **Subagent created:** ${name}${note}`, conversationId, undefined, spacesAppId);
         return;
       }
 
@@ -1385,6 +1708,68 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       resp = { type: "close_screen", finalMessage: finalText };
       res.json(resp);
       void replaceFlowCardWithText(messageId, skillAgentSlug, finalText, conversationId, undefined, skillSpacesAppId);
+      return;
+    }
+
+    // Agent / subagent update approval — sibling of skill-update. The card
+    // carries only requestId + approverUserId; resolveEntityUpdateRequest
+    // re-reads the live definition and re-derives the owner authoritatively.
+    if (actionType === "agent-update" || actionType === "subagent-update") {
+      const kind = actionType === "agent-update" ? "agent" : "subagent";
+      const requestId = data["requestId"] as string | undefined;
+      const approverUserId = data["approverUserId"] as string | undefined;
+      const entityAgentSlug = data["agentSlug"] as string | undefined;
+      const entitySpacesAppId = data["spacesAppId"] as string | undefined;
+
+      if (!requestId || !approverUserId) {
+        res.status(400).json({ type: "error", message: `Missing ${kind}-update fields in flowJSON.data` } satisfies AppActionResponse);
+        return;
+      }
+      if (!callerUserId || callerUserId !== approverUserId) {
+        log.error(`[flow-action] ${kind}-update: unauthorized — caller ${callerUserId ?? "(none)"} != expected ${approverUserId}`);
+        res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
+        return;
+      }
+
+      const { resolveEntityUpdateRequest } = await import("../lib/entity-update.js");
+      const decision = actionId === `${kind}-update-approve` ? "approve" : "reject";
+      const result = await resolveEntityUpdateRequest(kind, requestId, callerUserId, decision);
+
+      if (!result.ok) {
+        resp = { type: "close_screen", finalMessage: result.error };
+        res.json(resp);
+        void replaceFlowCardWithText(messageId, entityAgentSlug, `⚠️ ${result.error}`, conversationId, undefined, entitySpacesAppId);
+        return;
+      }
+
+      const label = kind === "agent" ? "Agent" : "Subagent";
+      const finalText = result.alreadyResolved
+        ? (result.status === "approved" ? `✅ **${label} update already applied.**` : `❌ **${label} update already declined.**`)
+        : (result.status === "approved" ? `✅ **${label} update approved & applied.**` : `❌ **${label} update declined.**`);
+      resp = { type: "close_screen", finalMessage: finalText };
+      res.json(resp);
+
+      // Flip the SAME entityUpdate card to its decided phase in place (like the
+      // agentCreation card): clone the node's props from the incoming flowJSON
+      // and stamp phase + decidedAt. Old-format cards (plain text/card
+      // primitives, still in flight from before the node existed) have no
+      // entityUpdate component — those fall back to the text replacement.
+      const entityNode = (flowJSON.components ?? []).find((c) => c.type === "entityUpdate");
+      if (entityNode?.props) {
+        const decidedProps: Record<string, unknown> = {
+          ...(entityNode.props as Record<string, unknown>),
+          phase: result.status === "approved" ? "approved" : "rejected",
+          decidedAt: new Date().toISOString(),
+          ...(result.alreadyResolved ? { note: "This request was already resolved when the button was tapped." } : {}),
+        };
+        const decidedFlow: FlowDefinition = {
+          ...flowJSON,
+          components: [{ id: "entity-update", type: "entityUpdate", props: decidedProps }],
+        };
+        void replaceFlowCardWithFlow(messageId, entityAgentSlug, decidedFlow, conversationId, undefined, entitySpacesAppId);
+      } else {
+        void replaceFlowCardWithText(messageId, entityAgentSlug, finalText, conversationId, undefined, entitySpacesAppId);
+      }
       return;
     }
 

--- a/apps/xyne-claw-auth/backend/src/routes/google-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/google-oauth.ts
@@ -98,26 +98,32 @@ export const googleOAuthProvider: OAuthTokenProvider = {
  * Start the Google OAuth flow. Returns the consent URL.
  * The frontend redirects the user to this URL.
  */
+/**
+ * Build the Google consent URL for a user. Extracted from the authorize route
+ * so other surfaces (e.g. the in-chat "Connect Google" card) can generate the
+ * same signed consent link without going through HTTP.
+ */
+export function buildGoogleConsentUrl(userId: string, redirectUri?: string): string {
+  // Default to the browser-based GET callback
+  const callbackUri = redirectUri ?? `${process.env["AUTH_SERVICE_URL"] ?? "http://localhost:3003"}/claw/api/v1/google/callback`;
+  const { clientId } = getGoogleCredentials();
+
+  const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", callbackUri);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("scope", GOOGLE_SCOPES.join(" "));
+  authUrl.searchParams.set("access_type", "offline");
+  authUrl.searchParams.set("prompt", "consent");
+  authUrl.searchParams.set("state", signOAuthState(userId));
+  return authUrl.toString();
+}
+
 router.post("/:userId/oauth/google/authorize", async (req: Request<{ userId: string }>, res: Response) => {
   try {
     const { userId } = req.params;
     const { redirectUri } = req.body as { redirectUri?: string };
-
-    // Default to the browser-based GET callback
-    const callbackUri = redirectUri ?? `${process.env["AUTH_SERVICE_URL"] ?? "http://localhost:3003"}/claw/api/v1/google/callback`;
-
-    const { clientId } = getGoogleCredentials();
-
-    const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
-    authUrl.searchParams.set("client_id", clientId);
-    authUrl.searchParams.set("redirect_uri", callbackUri);
-    authUrl.searchParams.set("response_type", "code");
-    authUrl.searchParams.set("scope", GOOGLE_SCOPES.join(" "));
-    authUrl.searchParams.set("access_type", "offline");
-    authUrl.searchParams.set("prompt", "consent");
-    authUrl.searchParams.set("state", signOAuthState(userId));
-
-    res.json({ success: true, data: { authUrl: authUrl.toString() } });
+    res.json({ success: true, data: { authUrl: buildGoogleConsentUrl(userId, redirectUri) } });
   } catch (err) {
     log.error("[google-oauth] authorize error:", err);
     res.status(500).json({ success: false, error: "Internal server error" });

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -974,7 +974,7 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
     // connector + credentials checks so they don't reject a valid call.
     //
     // SECURITY:
-    // - ALL four kb-* tools are read-only by design (see KB_TOOLS, writeTools
+    // - ALL kb-* tools are read-only by design (see KB_TOOL_NAMES, writeTools
     //   set to []). They intentionally bypass the write-action approval flow
     //   below — if a future change adds a mutating KB tool, it MUST be routed
     //   through validateWriteAction (above) instead of this branch.
@@ -1016,7 +1016,12 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
             });
             break;
           case "kb-list-files":
-            out = await handleKbListFiles({ userId, agentSlug, collectionId: String(p["collectionId"] ?? "") });
+            out = await handleKbListFiles({
+              userId,
+              agentSlug,
+              collectionId: String(p["collectionId"] ?? ""),
+              ...(typeof p["depth"] === "number" ? { depth: p["depth"] as number } : {}),
+            });
             break;
           case "kb-read-file":
             out = await handleKbReadFile({ userId, agentSlug, fileId: String(p["fileId"] ?? "") });

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -5,7 +5,7 @@ import { decrypt } from "../crypto.js";
 import { CONFIG } from "../config.js";
 import { listToolsForUser, callTool } from "../mcp/runner.js";
 import { agentRunRepository } from "../repositories/index.js";
-import type { McpToolInfo, McpServerTools } from "../mcp/types.js";
+import type { CredentialField, McpToolInfo, McpServerTools } from "../mcp/types.js";
 import { hasConnectorDefinition, resolveConnectorDefinition } from "../mcp/connector-definitions.js";
 import { BITBUCKET_CUSTOM_TOOLS, handleUploadPrScreenshot, handleGetPrComments, handleGetPrTemplate, buildUpstreamBitbucketCitation } from "../mcp/adapters/bitbucket.js";
 import { GRAFANA_CUSTOM_TOOLS, handleGrafanaQueryLogs, handleGrafanaListMetrics, handleGrafanaQueryMetrics, handleGrafanaQueryDatabase, buildUpstreamGrafanaCitation, prefixChunk } from "../mcp/adapters/grafana.js";
@@ -43,7 +43,10 @@ import {
   parseGatewayToolSelectionKey,
 } from "../mcpgateway/key-format.js";
 import { requiresGatewayToolApproval } from "../mcpgateway/tool-approval.js";
-import { buildAgentCallProposalFlow, parseToolsConfig, type AgentToolsConfig } from "xyne-claw-shared";
+import { buildAgentCallProposalFlow, buildConnectAccountFlow, buildMcpConfigureFlow, parseToolsConfig, type AgentToolsConfig, SUBAGENT_DEFINITIONS } from "xyne-claw-shared";
+import { OAUTH_SERVER_TYPES } from "../lib/oauth-server-types.js";
+import { buildGoogleConsentUrl } from "./google-oauth.js";
+import { buildMicrosoftConsentUrl } from "./microsoft-oauth.js";
 import { visibleAgentWhereForRunningUser } from "../lib/callable-agent-resolver.js";
 import { isClawAdmin } from "../middleware/agent-acl.js";
 import {
@@ -639,6 +642,80 @@ export function verifyActionSignature(action: Record<string, unknown>, signature
   }
 }
 
+/**
+ * A per-user OAuth provider the agent is configured to use but that the current
+ * user has NOT connected. Surfaced in the /mcp/tools response so the runtime can
+ * tell the model "you haven't connected X" instead of the tool silently vanishing.
+ */
+interface NeedsConnectionEntry {
+  serverType: string;
+  displayName: string;
+}
+
+interface ConnectableServer {
+  serverType: string;
+  displayName: string;
+  mode: "oauth" | "credentials";
+  mcpServerId?: string;
+  credentialFields?: readonly CredentialField[];
+}
+
+/** Friendly labels for the connectable OAuth providers. */
+const OAUTH_PROVIDER_LABELS: Record<string, string> = {
+  google: "Google (Gmail, Calendar, Drive, Contacts, Tasks)",
+  microsoft: "Microsoft 365 (Outlook, Calendar, OneDrive)",
+};
+
+async function resolveConnectableServer(serverType: string): Promise<ConnectableServer | null> {
+  if (OAUTH_SERVER_TYPES.has(serverType)) {
+    return { serverType, displayName: OAUTH_PROVIDER_LABELS[serverType] ?? serverType, mode: "oauth" };
+  }
+
+  const definition = await resolveConnectorDefinition(serverType);
+  if (!definition || definition.credentialFields.length === 0) return null;
+
+  const row = await prisma.mcpServer.findUnique({
+    where: { type: serverType },
+    select: { id: true, name: true, enabled: true },
+  });
+  if (!row?.enabled) return null;
+
+  return {
+    serverType,
+    displayName: row.name || serverType,
+    mode: "credentials",
+    mcpServerId: row.id,
+    credentialFields: definition.credentialFields,
+  };
+}
+
+async function computeNeedsConnection(
+  toolsConfig: AgentToolsConfig | undefined,
+  resolvedServerTypes: Set<string>,
+): Promise<NeedsConnectionEntry[]> {
+  if (!toolsConfig) return [];
+  const referenced: string[][] = [];
+  for (const name of toolsConfig.subagents ?? []) {
+    const def = SUBAGENT_DEFINITIONS.find((d) => d.name === name);
+    if (!def) continue;
+    referenced.push([def.serverType, ...(def.serverTypeAliases ?? [])]);
+  }
+
+  const out: NeedsConnectionEntry[] = [];
+  const emitted = new Set<string>();
+  for (const candidates of referenced) {
+    if (candidates.some((st) => resolvedServerTypes.has(st))) continue;
+    for (const st of candidates) {
+      const connectable = await resolveConnectableServer(st);
+      if (!connectable || emitted.has(connectable.serverType)) continue;
+      emitted.add(connectable.serverType);
+      out.push({ serverType: connectable.serverType, displayName: connectable.displayName });
+      break;
+    }
+  }
+  return out;
+}
+
 const router = Router();
 
 // Scope the Bearer gate to the subpaths this router actually serves
@@ -934,9 +1011,110 @@ router.get("/:sessionId/mcp/tools", async (req: Request<{ sessionId: string }>, 
       data.splice(0, data.length, ...enforceMcpToolsListing(data, strictAgentToolsConfig, sessionAgentTools.slug, entryTypes, sessionAgentTools.subagentToolRefs));
     }
 
-    res.json({ success: true, data });
+    // Which per-user providers the agent is configured for but this user hasn't
+    // connected/configured. Computed from the final resolved server set, so it
+    // reflects exactly what the model will and won't see.
+    const needsConnection = await computeNeedsConnection(
+      sessionAgentTools?.toolsConfig,
+      new Set(data.map((d) => d.serverType)),
+    );
+    if (needsConnection.length > 0) {
+      log.info(`[mcp/tools] needsConnection userId=${userId} agent=${agentSlug ?? "(none)"}: ${needsConnection.map((n) => n.serverType).join(",")}`);
+    }
+
+    res.json({ success: true, data, needsConnection });
   } catch (err) {
     log.error("[mcp/tools] error:", err);
+    res.status(500).json({ success: false, error: "Internal server error" });
+  }
+});
+
+/**
+ * POST /:sessionId/mcp/connect-card  body { serverType }
+ *
+ * Posts a connect/configure card into the run's Spaces thread so the user can
+ * authorize a provider the agent is configured for but hasn't connected. Called
+ * by the runtime's suggest-connection tool when the model decides the user needs
+ * it (see needsConnection in /mcp/tools).
+ * Posting lives here because this side owns the agent's Spaces app token + the
+ * signed consent-URL builders. Conversation/channel are resolved from the live
+ * session, mirroring propose-agent-call.
+ */
+router.post("/:sessionId/mcp/connect-card", async (req: Request<{ sessionId: string }>, res: Response) => {
+  try {
+    const userId = req.session!.userId;
+    const agentSlug = req.session?.agentSlug;
+    const spacesAppId = req.session?.spacesAppId;
+    const serverType = String((req.body as { serverType?: string })?.serverType ?? "").trim();
+
+    const connectable = await resolveConnectableServer(serverType);
+    if (!connectable) {
+      res.status(400).json({ success: false, error: `Unsupported connect provider: ${serverType || "(none)"}` });
+      return;
+    }
+
+    const orgId = await resolveSessionAgentOrgId(userId, spacesAppId);
+    const { getSession } = await import("./webhook.js");
+    const runContext = await getSession(req.params.sessionId);
+    const fallbackRun = runContext ? null : await agentRunRepository.findBySessionId(req.params.sessionId).catch(() => null);
+    const conversationId = runContext?.conversationId ?? fallbackRun?.conversationId ?? undefined;
+    const channelId = runContext?.channelId ?? fallbackRun?.channelId ?? undefined;
+    if (!conversationId || !channelId) {
+      res.status(409).json({ success: false, error: "current Spaces conversation/channel context is unavailable" });
+      return;
+    }
+
+    const agent = spacesAppId
+      ? await prisma.agent.findUnique({ where: { spacesAppId } })
+      : agentSlug && orgId
+        ? await prisma.agent.findUnique({ where: { orgId_slug: { orgId, slug: agentSlug } } })
+        : null;
+    if (!agent?.spacesAppToken || !agent.spacesAppUserId || !agent.spacesAppId) {
+      res.status(409).json({ success: false, error: "running agent has no Spaces app identity" });
+      return;
+    }
+
+    const flow = connectable.mode === "oauth"
+      ? buildConnectAccountFlow({
+        displayName: connectable.displayName,
+        authUrl: serverType === "google" ? buildGoogleConsentUrl(userId) : buildMicrosoftConsentUrl(userId),
+        serverType,
+      })
+      : buildMcpConfigureFlow({
+        serverType: connectable.serverType,
+        serverName: connectable.displayName,
+        mcpServerId: connectable.mcpServerId!,
+        fields: (connectable.credentialFields ?? []).map((field) => ({
+          name: field.name,
+          label: field.label,
+          type: field.type,
+          ...(field.placeholder ? { placeholder: field.placeholder } : {}),
+          ...(field.optional ? { optional: true } : {}),
+        })),
+        userId,
+        ...(agentSlug ? { agentSlug } : {}),
+        spacesAppId: agent.spacesAppId,
+      });
+    flow.data = { ...(flow.data ?? {}), spacesAppId: agent.spacesAppId };
+
+    const appToken = decryptStoredToken(agent.spacesAppToken);
+    const postRes = await fetch(`${CONFIG.spacesInternalUrl}/api/apps/chat/postMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${appToken}` },
+      body: JSON.stringify({ channelId, conversationId, flow, userId: agent.spacesAppUserId }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!postRes.ok) {
+      const body = await postRes.text().catch(() => "");
+      log.error(`[mcp/connect-card] postMessage failed (${postRes.status}): ${body.slice(0, 200)}`);
+      res.status(502).json({ success: false, error: `could not post connect card (${postRes.status})` });
+      return;
+    }
+
+    log.info(`[mcp/connect-card] posted serverType=${serverType} userId=${userId} agent=${agent.slug}`);
+    res.json({ success: true, data: { posted: true, serverType } });
+  } catch (err) {
+    log.error("[mcp/connect-card] error:", err);
     res.status(500).json({ success: false, error: "Internal server error" });
   }
 });

--- a/apps/xyne-claw-auth/backend/src/routes/microsoft-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/microsoft-oauth.ts
@@ -114,25 +114,31 @@ export const microsoftOAuthProvider: OAuthTokenProvider = {
  * Start the Microsoft OAuth flow. Returns the consent URL.
  * The frontend redirects the user to this URL.
  */
+/**
+ * Build the Microsoft consent URL for a user. Extracted from the authorize
+ * route so other surfaces (e.g. the in-chat "Connect Microsoft" card) can
+ * generate the same signed consent link without going through HTTP.
+ */
+export function buildMicrosoftConsentUrl(userId: string, redirectUri?: string): string {
+  const callbackUri = redirectUri ?? `${process.env["AUTH_SERVICE_URL"] ?? "http://localhost:3003"}/claw/api/v1/microsoft/callback`;
+  const { clientId, tenantId } = getMicrosoftCredentials();
+
+  const authUrl = new URL(`https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`);
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", callbackUri);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("scope", MICROSOFT_SCOPES.join(" "));
+  authUrl.searchParams.set("response_mode", "query");
+  authUrl.searchParams.set("prompt", "consent");
+  authUrl.searchParams.set("state", signOAuthState(userId));
+  return authUrl.toString();
+}
+
 router.post("/:userId/oauth/microsoft/authorize", async (req: Request<{ userId: string }>, res: Response) => {
   try {
     const { userId } = req.params;
     const { redirectUri } = req.body as { redirectUri?: string };
-
-    const callbackUri = redirectUri ?? `${process.env["AUTH_SERVICE_URL"] ?? "http://localhost:3003"}/claw/api/v1/microsoft/callback`;
-
-    const { clientId, tenantId } = getMicrosoftCredentials();
-
-    const authUrl = new URL(`https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`);
-    authUrl.searchParams.set("client_id", clientId);
-    authUrl.searchParams.set("redirect_uri", callbackUri);
-    authUrl.searchParams.set("response_type", "code");
-    authUrl.searchParams.set("scope", MICROSOFT_SCOPES.join(" "));
-    authUrl.searchParams.set("response_mode", "query");
-    authUrl.searchParams.set("prompt", "consent");
-    authUrl.searchParams.set("state", signOAuthState(userId));
-
-    res.json({ success: true, data: { authUrl: authUrl.toString() } });
+    res.json({ success: true, data: { authUrl: buildMicrosoftConsentUrl(userId, redirectUri) } });
   } catch (err) {
     log.error("[microsoft-oauth] authorize error:", err);
     res.status(500).json({ success: false, error: "Internal server error" });

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -44,6 +44,14 @@ const router = Router();
 
 const RUN_RETRY_DELAY_MS = 250;
 
+/** Loose shape check for the /experiment epoch context forwarded to the runtime. */
+function isExperimentContext(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj["id"] === "string" && obj["id"].trim() !== "" &&
+    typeof obj["deadlineAt"] === "string" && obj["deadlineAt"].trim() !== "";
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -1095,6 +1103,13 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       ...(effectiveMode ? { mode: effectiveMode } : {}),
       ...((req.body as { planContinuation?: boolean }).planContinuation === true ? { planContinuation: true } : {}),
       ...(generateFollowUpSuggestions === true ? { generateFollowUpSuggestions: true } : {}),
+      // /experiment epoch context (id/epoch/deadlineAt/focus) — set only by
+      // dispatchExperimentEpoch (lib/experiment.ts) via this same S2S proxy.
+      // Must be threaded through the allowlist or the runtime never injects the
+      // experiment tools and the mode is silently inert.
+      ...(isExperimentContext((req.body as { experiment?: unknown }).experiment)
+        ? { experiment: (req.body as { experiment?: unknown }).experiment }
+        : {}),
     };
 
     if (detached === true) {

--- a/apps/xyne-claw-auth/backend/src/routes/sessions-archive.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/sessions-archive.ts
@@ -173,6 +173,16 @@ sessionsArchiveRouter.get("/restore/:conversationId", async (req: Request, res: 
     res.json({ success: true, files });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    // A "Not Found" from GCS (missing bucket/objects) means the conversation
+    // was never archived — the documented "start fresh" case, not an error.
+    // Real GCS surfaces this via an empty listFiles(), but some backends (e.g.
+    // the local fake-gcs-server) throw a Not Found instead; normalize both to
+    // an empty archive so the caller starts a fresh local session.
+    if (/not\s*found/i.test(msg)) {
+      log.info(`[sessions-archive] no archive for conversationId=${conversationId} — treating as fresh`);
+      res.json({ success: true, files: [] });
+      return;
+    }
     log.error(`[sessions-archive] restore failed conversationId=${conversationId}: ${msg}`);
     res.status(500).json({ success: false, error: msg });
   }

--- a/apps/xyne-claw-auth/backend/src/routes/subagents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/subagents.ts
@@ -21,13 +21,22 @@ import {
   subagentDefinitionRepository,
   subagentShareRepository,
   userRepository,
+  agentRequestRepository,
 } from "../repositories/index.js";
-import { getRequesterId, getOrgId, isClawAdmin } from "../middleware/agent-acl.js";
+import { getRequesterId, getOrgId, isClawAdmin, getAgentEditAccess } from "../middleware/agent-acl.js";
 import {
   ValidationError,
   validateSubagentInput,
 } from "../lib/subagent-resolver.js";
-import { SUBAGENT_DEFINITIONS } from "xyne-claw-shared";
+import { SUBAGENT_DEFINITIONS, hashSkillContent } from "xyne-claw-shared";
+import { canProposerPostAsAgent } from "./skills.js";
+import {
+  computeEntityUpdate,
+  resolveEntityUpdateRequest,
+  notifyApproverOfEntityUpdateInSpaces,
+  subagentToolSelectionFromConfig,
+} from "../lib/entity-update.js";
+import { writeAuditLog } from "../lib/audit.js";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("subagents");
@@ -481,6 +490,124 @@ router.delete("/:name/shares/:userId", async (req: Request, res: Response) => {
     return res.json({ success: true });
   } catch (err) {
     log.error("[subagents] remove share error:", err);
+    return res.status(500).json({ success: false, error: "Internal server error" });
+  }
+});
+
+// ── update-subagent: propose a change to an existing subagent ──────────────
+// The update-subagent tool POSTs here. Mirrors POST /agents/:slug/propose-update
+// but targets subagent_definitions (keyed by org+name); the approver is the
+// subagent's creator. Never applies here — see resolveEntityUpdateRequest.
+router.post("/:name/propose-update", async (req: Request<{ name: string }>, res: Response) => {
+  try {
+    const requesterId = getRequesterId(req);
+    if (!requesterId) return res.status(401).json({ success: false, error: "x-user-id required" });
+    const orgId = getOrgId(req);
+    if (!orgId) return res.status(400).json({ success: false, error: "orgId is required" });
+
+    const body = req.body as {
+      promptEdits?: Array<{ oldText?: string; newText?: string }>;
+      systemPrompt?: string; description?: string; paramName?: string; paramDescription?: string;
+      tools?: string[]; summary?: string; agentSlug?: string;
+    };
+
+    const sub = await subagentDefinitionRepository.findByName(req.params.name, orgId);
+    if (!sub) return res.status(404).json({ success: false, error: "Subagent not found" });
+
+    // Only the owner, a contributor (EDITOR share), or a CLAW_ADMIN may propose
+    // an update — same ACL as every other subagent edit route. Reject otherwise.
+    if (!(await canEditSubagent(sub, requesterId))) {
+      return res.status(403).json({ success: false, error: "Only the subagent owner or a contributor can propose updates." });
+    }
+
+    const computed = computeEntityUpdate("subagent", {
+      systemPrompt: sub.systemPrompt,
+      name: sub.name,
+      description: sub.description,
+      paramName: sub.paramName,
+      paramDescription: sub.paramDescription,
+      currentToolSelection: subagentToolSelectionFromConfig(sub.tools),
+    }, body);
+    if (!computed.ok) return res.status(computed.code).json({ success: false, error: computed.error });
+
+    if (!sub.createdByUserId) return res.status(409).json({ success: false, error: "This subagent has no owner to approve an update." });
+
+    const proposedContent = JSON.stringify(computed.payload);
+    const outcome = await agentRequestRepository.supersedeAndCreateEntityUpdate({
+      targetType: "subagent",
+      targetKey: sub.name,
+      requesterId,
+      orgId,
+      proposedContent,
+      baseContentHash: computed.baseContentHash,
+      proposedContentHash: hashSkillContent(proposedContent),
+      requestNote: body.summary?.trim() || null,
+    });
+    if (outcome.supersededCount > 0) {
+      log.info(`[subagents/propose-update] superseded ${outcome.supersededCount} stale pending proposal(s) for ${sub.name} by ${requesterId}`);
+    }
+
+    await writeAuditLog({ actorUserId: requesterId, eventType: "REQUEST_CREATED", targetId: sub.id, description: `subagent_update request for "${sub.name}"` });
+
+    const requester = await userRepository.findById(requesterId);
+    const proposerName = requester?.name ?? requester?.email ?? "A user";
+    if (body.agentSlug) {
+      const access = await getAgentEditAccess(requesterId, body.agentSlug, orgId);
+      if (canProposerPostAsAgent(access)) {
+        void notifyApproverOfEntityUpdateInSpaces({
+          kind: "subagent",
+          approverUserId: sub.createdByUserId,
+          requestId: outcome.request.id,
+          targetKey: sub.name,
+          targetName: sub.name,
+          proposerName,
+          ...(computed.diff ? { diff: computed.diff } : {}),
+          fieldChanges: computed.fieldChanges,
+          summary: body.summary?.trim() || null,
+          agent: access.agent,
+        });
+      } else {
+        log.warn(`[subagents/propose-update] owner DM skipped for ${sub.name}: requester ${requesterId} not authorized to post as agent ${body.agentSlug}`);
+      }
+    }
+
+    return res.status(202).json({
+      success: true,
+      data: {
+        requestId: outcome.request.id,
+        status: "pending_approval",
+        ...(outcome.supersededCount > 0 ? { supersededPreviousProposal: true } : {}),
+      },
+    });
+  } catch (err) {
+    log.error("[subagents] propose-update error:", err);
+    return res.status(500).json({ success: false, error: "Internal server error" });
+  }
+});
+
+// REST parity (tests / non-card callers). Card path calls resolveEntityUpdateRequest.
+router.post("/subagent-update-requests/:requestId/approve", async (req: Request<{ requestId: string }>, res: Response) => {
+  try {
+    const callerUserId = getRequesterId(req);
+    if (!callerUserId) return res.status(401).json({ success: false, error: "x-user-id required" });
+    const result = await resolveEntityUpdateRequest("subagent", req.params.requestId, callerUserId, "approve");
+    if (!result.ok) return res.status(result.code).json({ success: false, error: result.error });
+    return res.json({ success: true, alreadyResolved: result.alreadyResolved ?? false });
+  } catch (err) {
+    log.error("[subagents] approve subagent-update error:", err);
+    return res.status(500).json({ success: false, error: "Internal server error" });
+  }
+});
+
+router.post("/subagent-update-requests/:requestId/reject", async (req: Request<{ requestId: string }>, res: Response) => {
+  try {
+    const callerUserId = getRequesterId(req);
+    if (!callerUserId) return res.status(401).json({ success: false, error: "x-user-id required" });
+    const result = await resolveEntityUpdateRequest("subagent", req.params.requestId, callerUserId, "reject");
+    if (!result.ok) return res.status(result.code).json({ success: false, error: result.error });
+    return res.json({ success: true, alreadyResolved: result.alreadyResolved ?? false });
+  } catch (err) {
+    log.error("[subagents] reject subagent-update error:", err);
     return res.status(500).json({ success: false, error: "Internal server error" });
   }
 });

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -88,9 +88,13 @@ import {
 } from "../lib/session-context.js";
 import { emitAgentWorkingSignal } from "../surfaces/spaces/client.js";
 import JSZip from "jszip";
-import { buildWriteApprovalFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, isTwinDelivery } from "xyne-claw-shared";
+import { buildWriteApprovalFlow, buildAgentCreationFlow, agentCreationPropsFromToolParams, buildSkillCreationFlow, skillCreationPropsFromToolParams, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, buildMcpConfigureFlow, isTwinDelivery, SUBAGENT_DEFINITIONS } from "xyne-claw-shared";
 import type { TwinDelivery } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
+import { buildGoogleConsentUrl } from "./google-oauth.js";
+import { buildMicrosoftConsentUrl } from "./microsoft-oauth.js";
+import { OAUTH_SERVER_TYPES } from "../lib/oauth-server-types.js";
+import { resolveConnectorDefinition } from "../mcp/connector-definitions.js";
 
 const clog = createLogger("webhook");
 
@@ -101,6 +105,16 @@ const clog = createLogger("webhook");
 // on every Spaces version. Once the Spaces fix is live in prod, set
 // SPACES_SUPPORTS_AGENT_PROGRESS=true in the deployment env, no code change.
 const USE_EPHEMERAL_PROGRESS = true;
+
+const AGENT_CREATION_OAUTH_TOOLS = new Map<string, { serverType: string; displayName: string }>([
+  ['google', { serverType: 'google', displayName: 'Google' }],
+  ['gmail', { serverType: 'google', displayName: 'Google' }],
+  ['google-drive', { serverType: 'google', displayName: 'Google' }],
+  ['drive', { serverType: 'google', displayName: 'Google' }],
+  ['microsoft', { serverType: 'microsoft', displayName: 'Microsoft' }],
+  ['outlook', { serverType: 'microsoft', displayName: 'Microsoft' }],
+  ['office', { serverType: 'microsoft', displayName: 'Microsoft' }],
+]);
 
 // Per-process dedup for the one-shot sandbox preview announce. Claw also
 // guards against re-emit on its side; this Set is the second layer in case
@@ -507,6 +521,128 @@ async function pendingActionTargetValidation(
   }
 }
 
+async function agentCreationConnectLinksForUser(
+  params: Record<string, unknown>,
+  userId: string,
+): Promise<Array<{ serverType: string; displayName: string; authUrl: string }>> {
+  const selectedTools = Array.isArray(params["tools"])
+    ? (params["tools"] as unknown[]).filter((tool): tool is string => typeof tool === "string")
+    : [];
+  if (selectedTools.length === 0) return [];
+
+  const wanted = new Map<string, string>();
+  for (const tool of selectedTools) {
+    const normalized = tool.trim().toLowerCase().replace(/[_\s]+/g, "-");
+    const oauthTool = AGENT_CREATION_OAUTH_TOOLS.get(normalized);
+    if (oauthTool) wanted.set(oauthTool.serverType, oauthTool.displayName);
+  }
+  if (wanted.size === 0) return [];
+
+  const existing = await prisma.userMcpConnection.findMany({
+    where: { userId, mcpServer: { type: { in: [...wanted.keys()] } } },
+    select: { mcpServer: { select: { type: true } } },
+  });
+  for (const conn of existing) wanted.delete(conn.mcpServer.type);
+
+  const links: Array<{ serverType: string; displayName: string; authUrl: string }> = [];
+  for (const [serverType, displayName] of wanted) {
+    try {
+      const authUrl = serverType === "google"
+        ? buildGoogleConsentUrl(userId)
+        : buildMicrosoftConsentUrl(userId);
+      links.push({ serverType, displayName, authUrl });
+    } catch (err) {
+      clog.warn(`[webhook/result] could not build ${serverType} connect URL for create-agent card: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return links;
+}
+
+async function agentCreationCredentialSetupFlowsForUser(
+  params: Record<string, unknown>,
+  userId: string,
+  ctx: SessionContext,
+): Promise<ReturnType<typeof buildMcpConfigureFlow>[]> {
+  const selectedTools = Array.isArray(params["tools"])
+    ? (params["tools"] as unknown[]).filter((tool): tool is string => typeof tool === "string")
+    : [];
+  if (selectedTools.length === 0) return [];
+
+  const selected = new Set(selectedTools.map((tool) => tool.trim()).filter(Boolean));
+  const candidateServerTypes: string[] = [];
+  for (const def of SUBAGENT_DEFINITIONS) {
+    if (!selected.has(def.name)) continue;
+    candidateServerTypes.push(def.serverType, ...(def.serverTypeAliases ?? []));
+  }
+
+  const uniqueCandidates = [...new Set(candidateServerTypes)].filter((serverType) => !OAUTH_SERVER_TYPES.has(serverType));
+  if (uniqueCandidates.length === 0) return [];
+
+  const existing = await prisma.userMcpConnection.findMany({
+    where: { userId, mcpServer: { type: { in: uniqueCandidates } } },
+    select: { mcpServer: { select: { type: true } } },
+  });
+  const connected = new Set(existing.map((conn) => conn.mcpServer.type));
+
+  const flows: ReturnType<typeof buildMcpConfigureFlow>[] = [];
+  const emittedSubagents = new Set<string>();
+  for (const def of SUBAGENT_DEFINITIONS) {
+    if (!selected.has(def.name) || emittedSubagents.has(def.name)) continue;
+    const candidates = [def.serverType, ...(def.serverTypeAliases ?? [])].filter((serverType) => !OAUTH_SERVER_TYPES.has(serverType));
+    if (candidates.some((serverType) => connected.has(serverType))) continue;
+
+    for (const serverType of candidates) {
+      const definition = await resolveConnectorDefinition(serverType);
+      if (!definition || definition.credentialFields.length === 0) continue;
+
+      const row = await prisma.mcpServer.findUnique({
+        where: { type: serverType },
+        select: { id: true, name: true, enabled: true },
+      });
+      if (!row?.enabled) continue;
+
+      emittedSubagents.add(def.name);
+      flows.push(buildMcpConfigureFlow({
+        serverType,
+        serverName: row.name || def.name,
+        mcpServerId: row.id,
+        fields: definition.credentialFields.map((field) => ({
+          name: field.name,
+          label: field.label,
+          type: field.type,
+          ...(field.placeholder ? { placeholder: field.placeholder } : {}),
+          ...(field.optional ? { optional: true } : {}),
+        })),
+        userId,
+        reason: `Required for the ${def.name} subagent.`,
+        ...(ctx.agentSlug ? { agentSlug: ctx.agentSlug } : {}),
+        ...(ctx.spacesAppId ? { spacesAppId: ctx.spacesAppId } : {}),
+      }));
+      break;
+    }
+  }
+  return flows;
+}
+
+async function postAgentCreationCredentialSetupCards(
+  params: Record<string, unknown>,
+  userId: string,
+  ctx: SessionContext,
+  appToken: string,
+): Promise<void> {
+  const flows = await agentCreationCredentialSetupFlowsForUser(params, userId, ctx);
+  for (const flow of flows) {
+    await spacesAppFetch("/chat/postMessage", {
+      channelId: ctx.channelId,
+      conversationId: ctx.conversationId,
+      flow: withSpacesAppId(flow, ctx.spacesAppId),
+      userId: ctx.spacesAppUserId,
+    }, appToken).catch((err) => {
+      clog.warn(`[webhook/result] failed to post MCP credential setup card: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
+}
+
 
 /**
  * Digital Twin (approval mode): open a DM with the mentioned user and send the
@@ -856,6 +992,37 @@ function formatActionDescription(tool: string, params: Record<string, unknown>, 
     if (slug) lines.push(`**Slug:** \`${slug}\``);
     if (description) lines.push(`**Description:** ${description}`);
     lines.push(``, `**Content (${content.length} chars):**`, "```md", content.slice(0, 1500) + (content.length > 1500 ? "\n…(truncated)" : ""), "```");
+    return lines.join("\n");
+  }
+
+  if (tool === "create-agent") {
+    const name = (params["name"] as string) ?? "";
+    const slug = (params["slug"] as string) ?? "";
+    const description = (params["description"] as string) ?? "";
+    const systemPrompt = (params["systemPrompt"] as string) ?? "";
+    const modelId = (params["modelId"] as string) ?? "";
+    const tools = Array.isArray(params["tools"]) ? (params["tools"] as unknown[]).filter((t): t is string => typeof t === "string") : [];
+    const lines = [`**Create Agent**`, ``, `**Name:** ${name}`];
+    if (slug) lines.push(`**Slug:** \`${slug}\``);
+    if (description) lines.push(`**Description:** ${description}`);
+    if (modelId) lines.push(`**Model:** \`${modelId}\``);
+    if (tools.length > 0) lines.push(`**Tools:** ${tools.map((t) => `\`${t}\``).join(", ")}`);
+    lines.push(``, `**System prompt (${systemPrompt.length} chars):**`, "```md", systemPrompt.slice(0, 1500) + (systemPrompt.length > 1500 ? "\n…(truncated)" : ""), "```");
+    return lines.join("\n");
+  }
+
+  if (tool === "create-subagent") {
+    const name = (params["name"] as string) ?? "";
+    const description = (params["description"] as string) ?? "";
+    const systemPrompt = (params["systemPrompt"] as string) ?? "";
+    const paramName = (params["paramName"] as string) ?? "";
+    const paramDescription = (params["paramDescription"] as string) ?? "";
+    const tools = Array.isArray(params["tools"]) ? (params["tools"] as unknown[]).filter((t): t is string => typeof t === "string") : [];
+    const lines = [`**Create Subagent**`, ``, `**Name:** ${name}`];
+    if (description) lines.push(`**Description:** ${description}`);
+    if (paramName) lines.push(`**Input:** \`${paramName}\`${paramDescription ? ` — ${paramDescription}` : ""}`);
+    if (tools.length > 0) lines.push(`**Tools:** ${tools.map((t) => `\`${t}\``).join(", ")}`);
+    lines.push(``, `**System prompt (${systemPrompt.length} chars):**`, "```md", systemPrompt.slice(0, 1500) + (systemPrompt.length > 1500 ? "\n…(truncated)" : ""), "```");
     return lines.join("\n");
   }
 
@@ -4559,7 +4726,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
 
           const actionDesc = formatActionDescription(action["tool"] as string, action["params"] as Record<string, unknown>, targetValidation);
 
-          const writeFlow = withSpacesAppId(buildWriteApprovalFlow(actionDesc, {
+          const writeAction = {
             serverType: action["serverType"] as string,
             tool: action["tool"] as string,
             params: action["params"] as Record<string, unknown>,
@@ -4568,7 +4735,21 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             agentSlug: ctx.agentSlug ?? "",
             channelId: ctx.channelId,
             conversationId: ctx.conversationId,
-          }), ctx.spacesAppId);
+          };
+          // create-agent/create-skill → rich artifact cards (pending phase,
+          // updates in place on approve/decline). Other write tools use the
+          // generic approval card. All carry the SAME signed action data.
+          const writeFlow = withSpacesAppId(
+            action["tool"] === "create-agent"
+              ? buildAgentCreationFlow("pending", {
+                ...agentCreationPropsFromToolParams(writeAction.params),
+                connectLinks: await agentCreationConnectLinksForUser(writeAction.params, writeAction.userId),
+              }, writeAction)
+              : action["tool"] === "create-skill"
+                ? buildSkillCreationFlow("pending", skillCreationPropsFromToolParams(writeAction.params), writeAction)
+                : buildWriteApprovalFlow(actionDesc, writeAction),
+            ctx.spacesAppId,
+          );
 
           if (action["tool"] === "spaces-memory-create" && (action["params"] as Record<string, unknown>)?.["content"]) {
             const memParams = action["params"] as Record<string, unknown>;
@@ -4582,16 +4763,19 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             form.append("userId", ctx.spacesAppUserId);
             form.append("flow", JSON.stringify(writeFlow));
             await spacesAppFetchMultipart("/files/filesUpload", form, token);
-          } else {
-            await spacesAppFetch("/chat/postMessage", {
-              channelId: ctx.channelId,
-              conversationId: ctx.conversationId,
-              flow: writeFlow,
-              userId: ctx.spacesAppUserId,
-            }, token);
-          }
-          copilotApprovalCardsSent += 1;
-        }
+	          } else {
+	            await spacesAppFetch("/chat/postMessage", {
+	              channelId: ctx.channelId,
+	              conversationId: ctx.conversationId,
+	              flow: writeFlow,
+	              userId: ctx.spacesAppUserId,
+	            }, token);
+	          }
+	          if (action["tool"] === "create-agent") {
+	            await postAgentCreationCredentialSetupCards(writeAction.params, writeAction.userId, ctx, token);
+	          }
+	          copilotApprovalCardsSent += 1;
+	        }
         log.info(`Copilot: posted ${copilotApprovalCardsSent}/${copilotPendingActions.length} write action approval(s)`);
       }
 
@@ -4972,7 +5156,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
 
         const actionDesc = formatActionDescription(action["tool"] as string, action["params"] as Record<string, unknown>, targetValidation);
 
-        const writeFlow = withSpacesAppId(buildWriteApprovalFlow(actionDesc, {
+        const writeAction = {
           serverType: action["serverType"] as string,
           tool: action["tool"] as string,
           params: action["params"] as Record<string, unknown>,
@@ -4981,7 +5165,21 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
           agentSlug: ctx.agentSlug ?? "",
           channelId: ctx.channelId,
           conversationId: ctx.conversationId,
-        }), ctx.spacesAppId);
+        };
+        // create-agent/create-skill → rich artifact cards (pending phase,
+        // updates in place on approve/decline). Other write tools use the
+        // generic approval card. All carry the SAME signed action data.
+        const writeFlow = withSpacesAppId(
+          action["tool"] === "create-agent"
+            ? buildAgentCreationFlow("pending", {
+              ...agentCreationPropsFromToolParams(writeAction.params),
+              connectLinks: await agentCreationConnectLinksForUser(writeAction.params, writeAction.userId),
+            }, writeAction)
+            : action["tool"] === "create-skill"
+              ? buildSkillCreationFlow("pending", skillCreationPropsFromToolParams(writeAction.params), writeAction)
+              : buildWriteApprovalFlow(actionDesc, writeAction),
+          ctx.spacesAppId,
+        );
 
         // Post in the same thread where the conversation happened
         if (action["tool"] === "spaces-memory-create" && (action["params"] as Record<string, unknown>)?.["content"]) {
@@ -4996,16 +5194,19 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
           form.append("userId", ctx.spacesAppUserId);
           form.append("flow", JSON.stringify(writeFlow));
           await spacesAppFetchMultipart("/files/filesUpload", form, token);
-        } else {
-          await spacesAppFetch("/chat/postMessage", {
-            channelId: ctx.channelId,
-            conversationId: ctx.conversationId,
-            flow: writeFlow,
-            userId: ctx.spacesAppUserId,
-          }, token);
-        }
-        approvalCardsSent += 1;
-      }
+	        } else {
+	          await spacesAppFetch("/chat/postMessage", {
+	            channelId: ctx.channelId,
+	            conversationId: ctx.conversationId,
+	            flow: writeFlow,
+	            userId: ctx.spacesAppUserId,
+	          }, token);
+	        }
+	        if (action["tool"] === "create-agent") {
+	          await postAgentCreationCredentialSetupCards(writeAction.params, writeAction.userId, ctx, token);
+	        }
+	        approvalCardsSent += 1;
+	      }
 
       log.info(`Sent ${approvalCardsSent}/${pendingActionsPayload.length} write action approval(s) to ${ctx.senderId}`);
     }

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -5223,6 +5223,21 @@ async function doRenderPlanCard(
   const ctx = await resolveSessionContext(sessionId, conversationId ?? null, agentSlug ?? null);
   if (!ctx || ctx.responseMode !== "conversation" || !ctx.channelId || !ctx.appToken) return;
 
+  // Per-agent opt-out (agent.config.postTodos === false): suppress the live
+  // plan/todo card in the Spaces thread for agents whose owner turned this off.
+  // Absent/true preserves the default (post), so existing agents are unchanged.
+  // This is the ONE choke point every kind:"plan" emitter funnels through
+  // (the runtime todo-write tool, run.ts onPlan, consume-claw-stream), so a
+  // single guard here covers every emitter and every dispatch surface. Read
+  // fresh from the agent row (a PK lookup) — mirrors how memoryEnabled is
+  // consumed at the point of use, and lets a mid-run config change take effect.
+  if (ctx.agentId) {
+    const cfgRow = await prisma.agent
+      .findUnique({ where: { id: ctx.agentId }, select: { config: true } })
+      .catch(() => null);
+    if ((cfgRow?.config as { postTodos?: boolean } | null)?.postTodos === false) return;
+  }
+
   // Deterministic per-conversation plan facts, written BEFORE Turn 2 dispatched
   // (so they're present even for the first todo-write): whether the plan was
   // auto-approved (chip), and the whitelist of approved todo titles (reject

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -20,6 +20,7 @@ import {
   chatMessageRepository,
   agentChainWorkflowRepository,
   activeGoalRepository,
+  experimentRepository,
 } from "../repositories/index.js";
 import { getValidClaudeBearer } from "../lib/claude-oauth-refresh.js";
 import { getValidCodexBearer } from "../lib/codex-oauth-refresh.js";
@@ -33,6 +34,7 @@ import { mintSessionToken } from "../lib/session-tokens.js";
 import { verifySpacesSignature } from "../middleware/verify-spaces-signature.js";
 import { coerceAutomationForwardResult } from "../lib/automation-result.js";
 import { parseSlashCommand } from "../lib/parseSlashCommand.js";
+import { parseExperimentCommand, formatDuration, dispatchExperimentEpoch, EXPERIMENT_PROVIDERS } from "../lib/experiment.js";
 import { resolveFastMode, setFastModeOverride } from "../lib/fast-mode.js";
 import { acquireTwinSlot, renameTwinSlot, releaseTwinSlot } from "../lib/twin-limiter.js";
 import { handleSlashCommandBeforeRun, persistGoalStart, recordTurnAndDecide } from "../services/goalRelooper.js";
@@ -72,6 +74,7 @@ import { getSpacesAuthForUser, spacesDbAvailable, getSpacesUserWorkspaceId, getW
 import { ensureUserExists, orgIdForSpacesUser } from "../lib/users-jit.js";
 import { finalizeOrphanedRun } from "../services/orphan-run-finalizer.js";
 import { requireStrictS2S, s2sKeyMatches, requireResultToken } from "../middleware/require-auth.js";
+import { isClawAdmin } from "../middleware/agent-acl.js";
 import { renderAttachmentsToPdf } from "../lib/result-pdf.js";
 import { renderMarkdownToHtml } from "../lib/result-html.js";
 import { sendStoredExternalResultCallback, type ExternalResultCallbackConfig } from "../surfaces/external-api/delivery.js";
@@ -450,6 +453,87 @@ import {
   zipAttachmentsToBuffer,
   prepareAgentResultForPosting,
 } from "../surfaces/spaces/attachments.js";
+
+function experimentCounts(findings: Array<{ status: string }>): { conjecture: number; proved: number; refuted: number } {
+  return {
+    conjecture: findings.filter((f) => f.status === "conjecture").length,
+    proved: findings.filter((f) => f.status === "proved").length,
+    refuted: findings.filter((f) => f.status === "refuted").length,
+  };
+}
+
+function formatExperimentStatus(
+  run: Awaited<ReturnType<typeof experimentRepository.findActiveByConversation>>,
+  findings: Array<{ status: string; title: string; epoch: number; createdAt: Date }>,
+): string {
+  if (!run) return "No active /experiment in this thread.";
+  const elapsedMs = Date.now() - run.createdAt.getTime();
+  const remainingMs = Math.max(0, run.deadlineAt.getTime() - Date.now());
+  const counts = experimentCounts(findings);
+  const recent = [...findings]
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, 5);
+  const icon = (status: string) => status === "proved" ? "✓" : status === "refuted" ? "✗" : "◉";
+  return [
+    `**/experiment status** — epoch ${run.epoch}`,
+    `Elapsed: ${formatDuration(elapsedMs)} · Remaining: ${formatDuration(remainingMs)}`,
+    ...(run.provider ? [`Model: ${formatExperimentModel(run.provider, run.modelId)}`] : []),
+    `Now: ${run.currentHypothesis?.trim() || "(no current hypothesis recorded)"}`,
+    `Findings: ${counts.conjecture} open · ${counts.proved} proved · ${counts.refuted} refuted`,
+    recent.length
+      ? ["", ...recent.map((f) => `${icon(f.status)} [epoch ${f.epoch}] ${f.title}`)].join("\n")
+      : "\nNo findings recorded yet.",
+  ].join("\n");
+}
+
+function formatExperimentModel(provider: string, modelId?: string | null): string {
+  return modelId?.trim() ? `${provider}/${modelId.trim()}` : `${provider} (default)`;
+}
+
+async function continueExperimentAfterResult(ctx: SessionContext, sessionId: string): Promise<boolean> {
+  const active = await experimentRepository.findActiveByConversation(ctx.conversationId);
+  if (!active) return false;
+  if (active.currentSessionId && active.currentSessionId !== sessionId) return false;
+
+  const now = Date.now();
+  if (active.status === "finishing") {
+    await experimentRepository.update(active.id, { status: "done", lastEpochEndedAt: new Date() });
+    return false;
+  }
+
+  // Rapid-fail brake: an epoch that died within seconds of STARTING (model
+  // outage, misconfig) must NOT chain instantly — that's an unbounded tight
+  // dispatch loop. Measured against the session's own startedAt (not the
+  // experiment row's updatedAt, which ledger writes also bump). Deferring
+  // leaves the run inactive; the supervisor's stale sweep re-dispatches after
+  // its window, turning a hot loop into ~1 retry/10min.
+  const MIN_EPOCH_MS = 30_000;
+  const epochRun = await agentRunRepository.findBySessionId(sessionId).catch(() => null);
+  const epochRanMs = epochRun?.startedAt ? now - epochRun.startedAt.getTime() : Number.POSITIVE_INFINITY;
+  if (epochRanMs < MIN_EPOCH_MS) {
+    clog.warn(`[experiment] epoch for ${active.id} lived only ${Math.round(epochRanMs / 1000)}s — deferring next epoch to supervisor (rapid-fail brake)`);
+    await experimentRepository.update(active.id, { lastEpochEndedAt: new Date() }).catch(() => undefined);
+    return true; // treated as handled: keep this thread's queue-drain semantics unchanged
+  }
+
+  if (now < active.deadlineAt.getTime()) {
+    const next = await experimentRepository.update(active.id, {
+      epoch: { increment: 1 },
+      lastEpochEndedAt: new Date(),
+    });
+    await dispatchExperimentEpoch(next);
+    return true;
+  }
+
+  const finishing = await experimentRepository.update(active.id, {
+    status: "finishing",
+    epoch: { increment: 1 },
+    lastEpochEndedAt: new Date(),
+  });
+  await dispatchExperimentEpoch(finishing);
+  return true;
+}
+
 function recordParam(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
@@ -1287,6 +1371,86 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
   const slash =
     rawSlash ??
     (autoGoalEnabled ? parseSlashCommand(`/goal ${userText}`) : null);
+  const experimentCommand = parseExperimentCommand(userText);
+
+  if (experimentCommand) {
+    const postExperimentReply = (markdownText: string) => spacesAppFetch("/chat/postMessage", {
+      channelId: payload.channelId,
+      conversationId: payload.conversationId,
+      markdownText,
+      userId: agent.spacesAppUserId,
+      metadata: { contentFormat: "markdown" },
+    }, agent.appToken).catch((err) => {
+      log.warn("Failed to post /experiment reply", { error: err instanceof Error ? err.message : String(err) });
+    });
+
+    if (experimentCommand.sub === "status") {
+      const run = await experimentRepository.findActiveByConversation(payload.conversationId);
+      const findings = run ? await experimentRepository.listFindings(run.id) : [];
+      await postExperimentReply(formatExperimentStatus(run, findings));
+      return;
+    }
+
+    if (experimentCommand.sub === "stop") {
+      const run = await experimentRepository.findActiveByConversation(payload.conversationId);
+      if (!run) {
+        await postExperimentReply("No active /experiment to stop.");
+        return;
+      }
+      const allowed = run.userId === payload.userId || await isClawAdmin(payload.userId);
+      if (!allowed) {
+        await postExperimentReply("Only the requester or a claw admin can stop this /experiment.");
+        return;
+      }
+      await experimentRepository.update(run.id, { status: "aborted", lastEpochEndedAt: new Date() });
+      await postExperimentReply("Stopped /experiment.");
+      return;
+    }
+
+    if (experimentCommand.invalidProvider !== undefined) {
+      await postExperimentReply([
+        `Invalid /experiment provider: ${experimentCommand.invalidProvider || "(empty)"}`,
+        `Valid providers: ${Array.from(EXPERIMENT_PROVIDERS).join(", ")}`,
+      ].join("\n"));
+      return;
+    }
+
+    const existing = await experimentRepository.findActiveByConversation(payload.conversationId);
+    if (existing) {
+      await postExperimentReply("An active /experiment is already running in this thread. Use `/experiment status` or `/experiment stop`.");
+      return;
+    }
+    const run = await experimentRepository.createRun({
+      conversationId: payload.conversationId,
+      channelId: payload.channelId,
+      agentSlug: agent.slug,
+      userId: payload.userId,
+      orgId: agent.orgId,
+      focus: experimentCommand.focus ?? null,
+      provider: experimentCommand.provider ?? null,
+      modelId: experimentCommand.model ?? null,
+      deadlineAt: new Date(Date.now() + experimentCommand.durationMs),
+    });
+    await postExperimentReply([
+      "**/experiment started**",
+      `Mode: time-boxed autonomous exploration`,
+      `Duration: ${formatDuration(experimentCommand.durationMs)}`,
+      ...(experimentCommand.provider ? [`Model: ${formatExperimentModel(experimentCommand.provider, experimentCommand.model)}`] : []),
+      `Focus: ${experimentCommand.focus?.trim() || "(none)"}`,
+      `Use \`/experiment status\` to inspect progress.`,
+    ].join("\n"));
+    try {
+      await dispatchExperimentEpoch(run);
+    } catch (err) {
+      // A silent failure here strands a zombie "active" run that blocks every
+      // future /experiment in this thread. Abort it and tell the user why.
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn("[experiment] initial dispatch failed", { error: msg });
+      await experimentRepository.update(run.id, { status: "aborted", lastEpochEndedAt: new Date() }).catch(() => undefined);
+      await postExperimentReply(`⚠️ /experiment could not start: ${msg.slice(0, 300)}\nThe experiment was aborted — fix the issue and start again.`);
+    }
+    return;
+  }
 
   // ── /queue ── show messages waiting behind the active run, then stop.
   if (slash?.kind === "queueShow") {
@@ -1324,6 +1488,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         "**Slash commands**",
         "- `/goal <condition>` — work autonomously until the condition is met",
         "- `/goal status` — show the active goal",
+        "- `/experiment <duration> [focus...]` — explore until the deadline · `/experiment status` · `/experiment stop`",
         "- `/stop` (or `/goal clear`) — stop the current run, drop queued messages, and clear any active goal",
         "- `/clear` — wipe this thread's context and start fresh",
         "- `/compact [focus]` — summarize & shrink the context, then continue",
@@ -3448,6 +3613,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
   // releases the slot — UNLESS a /goal turn is continuing (goalContinues),
   // which keeps the slot so the loop owns the conversation across turns.
   let goalContinues = false;
+  let experimentContinues = false;
   let skipQueueDrain = false;
   let resultConversationId = payload.conversationId ?? "";
   let resultAgentSlug = payload.agentSlug ?? "";
@@ -3683,6 +3849,12 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     await handleRunCompletion(sessionId, "completed").catch((err) => {
       clog.warn(`[webhook/result] Failed to mark ${sessionId} completed in run recovery:`, err instanceof Error ? err.message : err);
     });
+    if (ctx?.conversationId && ctx.agentSlug) {
+      experimentContinues = await continueExperimentAfterResult(ctx, sessionId).catch((err) => {
+        clog.warn(`[experiment] continuation hook failed session=${sessionId}:`, err instanceof Error ? err.message : String(err));
+        return false;
+      });
+    }
   }
 
   const isSessionLockedFailure = payload.status === "failed" && payload.error === "session_locked";
@@ -5396,7 +5568,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
         // Best-effort cleanup; the ingress key also has a TTL.
       }
     }
-    if (QUEUE_ENABLED && resultConversationId && resultAgentSlug && !goalContinues && !skipQueueDrain) {
+    if (QUEUE_ENABLED && resultConversationId && resultAgentSlug && !goalContinues && !experimentContinues && !skipQueueDrain) {
       await drainNextQueued(resultConversationId, resultAgentSlug, undefined, resultUserScope || undefined).catch(() => {});
     }
   }

--- a/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
@@ -157,6 +157,12 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
   // "Run autonomously" button (the `pendingGoalSuggestion` payload). Default
   // false so existing agents are unchanged.
   const [draftSuggestGoal, setDraftSuggestGoal] = useState(false);
+  // Per-agent opt-OUT: post the live plan/TODO card (from the todo-write tool)
+  // into the Spaces thread. Default true (post) so existing agents are
+  // unchanged; turning it off sets agent.config.postTodos=false, which
+  // suppresses the card at claw-auth's doRenderPlanCard choke point. The agent
+  // still tracks TODOs internally for loop discipline — only the render is hidden.
+  const [draftPostTodos, setDraftPostTodos] = useState(true);
   // Per-agent opt-in: when true, claw-auth's webhook wraps every user message
   // as `/goal <text>` before parsing, so every interaction with this agent
   // runs as an autonomous /goal loop. User-typed `/stop` and `/goal status`
@@ -282,6 +288,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
         setDraftResearchAgentProductId((agentData.config as { product_id?: string | null; RESEARCH_AGENT_PRODUCT_ID?: string | null }).product_id ?? (agentData.config as { RESEARCH_AGENT_PRODUCT_ID?: string | null }).RESEARCH_AGENT_PRODUCT_ID ?? "");
         setDraftResearchAgentRepositoryId((agentData.config as { repository_id?: string | null; RESEARCH_AGENT_REPOSITORY_ID?: string | null }).repository_id ?? (agentData.config as { RESEARCH_AGENT_REPOSITORY_ID?: string | null }).RESEARCH_AGENT_REPOSITORY_ID ?? "");
         setDraftSuggestGoal((agentData.config as { suggestGoal?: boolean }).suggestGoal === true);
+        setDraftPostTodos((agentData.config as { postTodos?: boolean }).postTodos !== false);
         setDraftAutoGoal((agentData.config as { autoGoal?: boolean }).autoGoal === true);
         setDraftPlanMode((agentData.config as { planMode?: boolean }).planMode === true);
         {
@@ -384,6 +391,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
     const baseResearchAgentProductId = (agent.config as { product_id?: string | null; RESEARCH_AGENT_PRODUCT_ID?: string | null }).product_id ?? (agent.config as { RESEARCH_AGENT_PRODUCT_ID?: string | null }).RESEARCH_AGENT_PRODUCT_ID ?? "";
     const baseResearchAgentRepositoryId = (agent.config as { repository_id?: string | null; RESEARCH_AGENT_REPOSITORY_ID?: string | null }).repository_id ?? (agent.config as { RESEARCH_AGENT_REPOSITORY_ID?: string | null }).RESEARCH_AGENT_REPOSITORY_ID ?? "";
     const baseSuggestGoal = (agent.config as { suggestGoal?: boolean }).suggestGoal === true;
+    const basePostTodos = (agent.config as { postTodos?: boolean }).postTodos !== false;
     const baseAutoGoal = (agent.config as { autoGoal?: boolean }).autoGoal === true;
     const basePlanMode = (agent.config as { planMode?: boolean }).planMode === true;
     const basePlanModePromptRaw = (agent.config as { planModePrompt?: string }).planModePrompt;
@@ -425,6 +433,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       draftResearchAgentProductId !== baseResearchAgentProductId ||
       draftResearchAgentRepositoryId !== baseResearchAgentRepositoryId ||
       draftSuggestGoal !== baseSuggestGoal ||
+      draftPostTodos !== basePostTodos ||
       draftAutoGoal !== baseAutoGoal ||
       draftPlanMode !== basePlanMode ||
       // Only counts as a change when plan mode is on (a prompt with no plan mode
@@ -441,7 +450,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       draftOutputRequireTools !== baseOutputRequireTools ||
       triggersChanged
     );
-  }, [agent, config, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers]);
+  }, [agent, config, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers]);
 
   /* ── handlers ──────────────────────────────────────────────────── */
 
@@ -513,6 +522,15 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
         nextConfig.suggestGoal = true;
       } else {
         delete nextConfig.suggestGoal;
+      }
+      // Post TODOs to the Spaces thread (agent.config.postTodos). Opt-OUT: the
+      // default is to post the live plan card, so we only persist the flag when
+      // it's turned OFF (postTodos:false). Turning it back on removes the key,
+      // restoring the default. Enforced at claw-auth's doRenderPlanCard.
+      if (draftPostTodos) {
+        delete nextConfig.postTodos;
+      } else {
+        nextConfig.postTodos = false;
       }
       if (draftVerifyResponses) {
         nextConfig.verifyResponses = true;
@@ -640,7 +658,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
     } finally {
       setSavingConfig(false);
     }
-  }, [agent, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers, config, savingConfig, dirty, userId, showSnackbar]);
+  }, [agent, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers, config, savingConfig, dirty, userId, showSnackbar]);
 
   const persistToolsConfig = useCallback(async (nextTools: AgentToolSelection): Promise<Agent> => {
     if (!agent) throw new Error("Agent not loaded");
@@ -1022,6 +1040,8 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
             researchAgentRepositoryOptions={researchAgentRepositoryOptions}
             draftSuggestGoal={draftSuggestGoal}
             onDraftSuggestGoalChange={setDraftSuggestGoal}
+            draftPostTodos={draftPostTodos}
+            onDraftPostTodosChange={setDraftPostTodos}
             draftVerifyResponses={draftVerifyResponses}
             onDraftVerifyResponsesChange={setDraftVerifyResponses}
             draftCitationReflection={draftCitationReflection}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailLeftColumn.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailLeftColumn.tsx
@@ -1530,6 +1530,13 @@ interface Props {
   // a one-click "Run autonomously" button at the end of multi-turn planning.
   draftSuggestGoal: boolean;
   onDraftSuggestGoalChange: (v: boolean) => void;
+  // Post TODOs to Spaces opt-OUT (agent.config.postTodos). Default ON: the
+  // live plan/TODO card from the todo-write tool is posted into the thread.
+  // Turning it OFF sets postTodos=false, suppressing the card at claw-auth's
+  // doRenderPlanCard. The agent still tracks TODOs internally for loop
+  // discipline — only the Spaces render is hidden.
+  draftPostTodos: boolean;
+  onDraftPostTodosChange: (v: boolean) => void;
   // Verify-responses opt-in (agent.config.verifyResponses). When on, the agent
   // delivers its final answer via the submit-response tool, which checks the
   // draft's factual claims against gathered tool evidence before it's posted.
@@ -1710,6 +1717,8 @@ export function AgentDetailLeftColumn({
   researchAgentRepositoryOptions,
   draftSuggestGoal,
   onDraftSuggestGoalChange,
+  draftPostTodos,
+  onDraftPostTodosChange,
   draftVerifyResponses,
   draftVerifyResponseCriteria,
   onDraftVerifyResponseCriteriaChange,
@@ -2547,7 +2556,7 @@ export function AgentDetailLeftColumn({
         label="Behaviour"
         tech="rules & autonomy"
         subtitle="extra rules applied on every turn"
-        summary={behaviorCount > 0 || draftSuggestGoal || draftAutoGoal || draftPlanMode ? "Customised" : "Defaults"}
+        summary={behaviorCount > 0 || draftSuggestGoal || draftAutoGoal || draftPlanMode || !draftPostTodos ? "Customised" : "Defaults"}
         open={activeTab === "behavior"}
         onToggle={() => toggleSection("behavior")}
       />
@@ -2756,6 +2765,38 @@ export function AgentDetailLeftColumn({
                 aria-label="Enable Suggest Goals"
               />
               <span className="text-[12px] text-xyne-fg-primary">{draftSuggestGoal ? "On" : "Off"}</span>
+            </label>
+          </div>
+        </div>
+      )}
+
+      {/* Post TODOs to Spaces — opt-OUT switch (agent.config.postTodos). The
+          todo-write tool renders a live, in-place checklist card in the thread
+          by default. Turning this OFF suppresses that card (claw-auth's
+          doRenderPlanCard early-returns) — the agent keeps tracking TODOs
+          internally, only the Spaces render is hidden. On by default; surface
+          when canEdit OR when already OFF so read-only viewers see the state. */}
+      {(canEdit || !draftPostTodos) && (
+        <div className="rounded-xl border border-xyne-border bg-xyne-surface p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-xyne-fg-tertiary">Post TODOs to Spaces</div>
+              <p className="text-[12px] leading-relaxed text-xyne-fg-secondary">
+                Show this agent&apos;s TODO checklist as a live, in-place-updating card in the thread while it works.
+                {" "}
+                <span className="text-xyne-fg-tertiary">Turn off for agents where the plan is noise (advice-only or single-shot agents). The agent still tracks its TODOs internally — only the card is hidden.</span>
+              </p>
+            </div>
+            <label className="flex shrink-0 items-center gap-2 select-none">
+              <input
+                type="checkbox"
+                checked={draftPostTodos}
+                onChange={(e) => onDraftPostTodosChange(e.target.checked)}
+                disabled={!canEdit}
+                className="h-4 w-4 cursor-pointer accent-xyne-accent disabled:cursor-not-allowed disabled:opacity-60"
+                aria-label="Post TODOs to Spaces"
+              />
+              <span className="text-[12px] text-xyne-fg-primary">{draftPostTodos ? "On" : "Off"}</span>
             </label>
           </div>
         </div>

--- a/apps/xyne-claw/skills/claw-platform-brain.md
+++ b/apps/xyne-claw/skills/claw-platform-brain.md
@@ -177,10 +177,26 @@ subagents (`SubagentSkill`).
 ## 7. Knowledge base
 
 `kbScope`: **COLLECTIONS** (agent allowlists specific Spaces collections via
-`AgentCollection`) or **USER** (inherits the calling user's full KB). KB tools
-(`kb-search`, `kb-list-resources`, `kb-read-file`, `kb-get-chunks`,
-`kb-search-within-doc`) auto-surface only when the agent has grants or USER scope.
+`AgentCollection`) or **USER** (inherits the calling user's full KB). Six read-only
+tools auto-surface when the agent has grants or USER scope: `kb-list-resources`
+(top-level inventory), **`kb-list-files`** (the `ls` — files *and* sub-folders;
+takes a collection **or folder** id, plus `depth`: 1 = collapsed children,
+N = expand N levels, -1 = whole subtree, capped at 400 rows), `kb-search`
+(Vespa over names + chunks), `kb-read-file`, `kb-search-within-doc`, `kb-get-chunks`.
 Flag a COLLECTIONS-scope agent with zero grants that clearly needs documents.
+
+Navigation: `kb-list-resources` → `kb-list-files` to map the layout →
+`kb-search` / `kb-search-within-doc` to locate → `kb-read-file` / `kb-get-chunks`
+to read. `kb-list-resources` is **top-level only** — a collection whose documents all
+live in sub-folders looks empty there, so check its `file_count` (recursive) and
+`folder_count` before concluding the KB is empty. File rows carry a root-relative
+`path`, which is the only way to tell apart the repeated names a
+convention-based layout produces (`services/<area>/service.md`).
+
+Grants nest: a whole-collection grant covers every file at or below it, at any
+depth (`services/` covers `services/release-deploy/service.md`). A single-file
+grant exposes that file plus the folders on its path, nothing else. Both layers
+still apply on every call — the allowlist, then the caller's live Spaces access.
 
 ---
 

--- a/apps/xyne-claw/skills/corpus-question-router-test.md
+++ b/apps/xyne-claw/skills/corpus-question-router-test.md
@@ -24,7 +24,10 @@ disease. The cure is to name what you are doing *before* touching a tool:
 > **OPERATE** — what function turns that set into the answer?
 
 State both in ONE visible line before the first data call, so a person can catch a wrong
-choice.
+choice. **The line lives in the first todo's title** — `Classify: READ+newest-state — <set>`
+— because the todo card is what the user actually sees; a classification that exists only in
+your reasoning is invisible and uncatchable. The todo is completed only once the line is
+visible.
 
 ## The four operations — a closed set
 
@@ -124,6 +127,12 @@ the model changed — only the primitive.
   surface is a silent undercount.
 - **Multi-word terms count as exact phrases.** "refund complaint" = that phrase. To count
   any-of-words, pass the words as separate terms.
+- **Derived arithmetic runs as code, not in your head.** When a sandbox is available, any
+  number the counting tool doesn't return directly — a sub-window sum, a difference, a
+  ratio, a top-N, a dedup, a verdict threshold — is computed by writing the tool's JSON
+  response to a sandbox file verbatim and running Python over it; the printed output is
+  copied verbatim into the answer. The script and its output are the audit trail. The
+  sandbox computes over tool outputs only — it is never a source of evidence.
 
 ## EXHAUST — how to be complete
 
@@ -183,7 +192,12 @@ Design → Count → Verify) and tick them off live.
 
 ## Non-negotiables — every answer, every operation
 
-- Every factual claim carries its citation.
+- Every factual claim carries its citation — **the doc id itself, verbatim, as a plain-text
+  token in the final answer** (`[clf-ab12#7]`, no backticks/code formatting, punctuation
+  outside); a prose source name may accompany a token, never replace it. **Verification is
+  two-part** (see `corpus-self-verify`): Part A — citation integrity — runs on EVERY answer,
+  including plain READ lookups; Part B — the full measurement checklist — runs whenever the
+  draft contains any MEASURE / EXHAUST / RELATE result.
 - "I couldn't find it" ≠ "it didn't happen" — say which one you mean.
 - Name the denominator on any comparison.
 - Never state a number that came from tallying a ranked page.

--- a/apps/xyne-claw/skills/corpus-question-router-test.md
+++ b/apps/xyne-claw/skills/corpus-question-router-test.md
@@ -130,9 +130,11 @@ the model changed — only the primitive.
 - **Derived arithmetic runs as code, not in your head.** When a sandbox is available, any
   number the counting tool doesn't return directly — a sub-window sum, a difference, a
   ratio, a top-N, a dedup, a verdict threshold — is computed by writing the tool's JSON
-  response to a sandbox file verbatim and running Python over it; the printed output is
-  copied verbatim into the answer. The script and its output are the audit trail. The
-  sandbox computes over tool outputs only — it is never a source of evidence.
+  response to a sandbox **data file verbatim** and running Python that **parses that file**;
+  the printed output is copied verbatim into the answer. Do not retype numbers into the
+  script body — retyping is transposition risk, the same species as the hand-sum. The
+  script and its output are the audit trail. The sandbox computes over tool outputs only —
+  it is never a source of evidence.
 
 ## EXHAUST — how to be complete
 
@@ -170,6 +172,26 @@ surfaces counted separately, scope, unit, numeric verdict bands), **self-verify 
 yourself, and proceed — no human sign-off.** The spec is an audit trail, not a gate. A wrong
 rule after locking means a new spec version and a re-run, never an in-place edit. Only pause
 for the user if they explicitly asked to review the plan first.
+
+**The written-analysis pipeline (spec → packs → stats → write → verify).** When the
+deliverable is a shareable analysis (a report someone will argue with), the loose loop above
+tightens into the full contract:
+
+1. **DESIGN** — the spec is a sandbox file (`spec.md`: topics as exact phrases, scope,
+   caps, verdict bands), self-verified and locked before any extraction.
+2. **EXTRACT** — one `spaces-evidence-pack` call per topic per surface; each returned JSON
+   is written **verbatim** to a sandbox data file (`packs/<topic>-<area>.json`). Packs are
+   capped and dated by construction; their `counts`/`termTotals` are the real totals.
+3. **COMPUTE** — one Python script parses the pack files and emits `stats.json` (totals,
+   shares, deltas, verdicts by the spec's bands). Printed output only; no retyping.
+4. **WRITE** — the analysis cites **only pack rows** and states numbers **only from
+   `stats.json`**. A claim with no pack row behind it doesn't go in. "Not visible in the
+   data" is an approved finding.
+5. **VERIFY** — before delivering: every cited row ∈ some pack file (closed-set check —
+   runnable as a script over the draft + packs), every number ∈ `stats.json`, and the
+   coverage note carries each pack's `coverage` field (buckets fetched/skipped, caps).
+
+Everyday questions never do this — the pipeline exists for artifacts, not answers.
 
 ## Show the method — name each step as you do it
 

--- a/apps/xyne-claw/skills/corpus-question-router-test.md
+++ b/apps/xyne-claw/skills/corpus-question-router-test.md
@@ -1,0 +1,191 @@
+---
+name: corpus-question-router-test
+description: Derive the method for any corpus question from a closed basis — SELECT the evidence set, name the OPERATION (read · measure · exhaust · relate), apply the modifiers, bind the machinery. READ THIS whenever a question contains "how many", "most", "trend", "all", "every", "did we actually", "was it done", "which is worst", "any issues", "status", "latest", or any ask that a ranked page of search hits cannot answer. Search's ranked page answers exactly one shape — "find me X"; every other shape needs a different primitive, and this skill derives which.
+---
+
+# Corpus Question Router — derive the method, don't memorize cases
+
+A search engine exposes exactly **five primitives** — there are no others:
+
+| Primitive | What it gives you |
+|---|---|
+| **match** (terms / filters) | *defines* an evidence set |
+| **rank** (relevance) | a **sample** of the set — the top-k loudest members |
+| **sort** (by an attribute, usually time) | the **ends** of the set — newest / oldest |
+| **aggregate** (count / group) | the set's **size and shape** |
+| **paginate** | the set's **members, exhaustively** |
+
+Every wrong corpus answer is the same one-line mistake: **using the sample primitive where
+another primitive was the answer.** A count answered from a page of hits, a "complete list"
+that is a top-k sample, a "current status" built from relevance-ranked history — all one
+disease. The cure is to name what you are doing *before* touching a tool:
+
+> **SELECT** — which documents are the evidence set?
+> **OPERATE** — what function turns that set into the answer?
+
+State both in ONE visible line before the first data call, so a person can catch a wrong
+choice.
+
+## The four operations — a closed set
+
+Given a selected set, there are only four things an answer can be built from:
+
+| Operation | Answer comes from | Machinery binding |
+|---|---|---|
+| **READ** | some members' content | `spaces-vespa-search` relevance hits, cited |
+| **MEASURE** | the set's size / distribution / change | `spaces-corpus-scan` (time-bucketed, with denominators) or `groupBy` + `hits:0`. **Never a hand-tally of a results page.** |
+| **EXHAUST** | *all* members | MEASURE the true size first, then paginate to a short page, then state coverage |
+| **RELATE** | two or more sets held against each other | one retrieval **per set**, evidence tagged per set — never one retrieval doing double duty |
+
+**This set is closed.** There is no fifth thing to do with a set of documents. When a
+question feels new, it is a new *combination* of operation × modifiers — derive it; never
+invent a new category. (Deriving is the skill; the table of examples below is just cells
+that occur often.)
+
+## The modifiers — orthogonal, apply to any operation
+
+- **Time scope:** the whole archive equally · a window · **the newest state**.
+  Newest-state (tell-words: *now, currently, latest, still, status, is it broken, any
+  issues*) binds the **sort** primitive: every hit surface gets a second probe sorted
+  newest-first (`sortBy` the date field `desc`, or a recent `after:` window; the probe may
+  be query-less — filters + sort alone reads a surface newest-first). Lead the synthesis
+  with the freshest findings. A current-state answer built only from relevance-ranked hits
+  is stale by construction.
+- **Set scope:** topic terms · field filters (channel, status, assignee, date) · person.
+- **Evidence rules (TRUST):** a statement found in a document is a **claim, not an
+  outcome** — outcome needs separate, later evidence or the explicit `[stated]` tag; every
+  comparison names its **denominator**; **absence is reported as absence** — "not found in
+  the corpus" never becomes "it didn't happen".
+
+## Worked derivations — familiar shapes as operation × modifiers
+
+| Question shape | Derivation | Binding |
+|---|---|---|
+| "what is / what happened with X" | READ | relevance hits, cited |
+| "explain / write up X" | READ, multi-set | one search per sub-topic |
+| "how did X evolve" | READ + time-ordered | date-filtered search, oldest→newest. See the timeline trap. |
+| "any issues now / status of X / is it broken" | READ + newest-state | recency probe per surface, freshest first. See the recency trap. |
+| "how many / is it growing" | MEASURE + time-bucketed | `spaces-corpus-scan`, shares not raw counts |
+| "who filed the most / breakdown by type" | MEASURE + grouped | `groupBy` + `hits:0`, denominator stated |
+| "all / every / the complete list" | EXHAUST | size first, page to exhaustion, state what's uncovered |
+| "did we ever / is there any" | MEASURE ≥ 1, or READ + absence rule | multi-angle; "not found" is a valid answer |
+| "did we actually do X" | RELATE: claim-set × outcome-set | TWO retrievals; tag `[stated]` / `[done]` / `[slipped]` |
+| "are there any X who are Y" | EXHAUST + RELATE | size the population, then pair evidence per member |
+| "A vs B, which is worse" | RELATE: set A × set B, each MEASURED | two counts, one shared denominator rule |
+| "which X DON'T have Y" | EXHAUST(X) minus MEMBERS(X∩Y) | exhaust the base set; absence per member is a claim about the corpus, not the world |
+
+The last three rows are shapes nobody wrote a rule for — they *derive*. That is the point.
+
+## Rules that outrank everything
+
+- **Composites decompose.** "Did we decide X, and did it happen?" = existence + RELATE.
+  Split until each part is a single operation; answer each with its own machinery; stitch.
+- **Unsure → READ, and say so.** Never silently run a full scan for a lookup; never
+  silently answer a MEASURE question from a page of hits.
+- **A ranked page is a SAMPLE, never a population.** Cite members from it; never state or
+  imply a count, a completeness, or a "latest" from it.
+- **The one-way valve.** The derivation is a first guess. Upgrading rigor (READ → MEASURE)
+  is always free. Downgrading requires a stated reason — legitimate: *"the count shows only
+  4, reading them directly"*; illegitimate: silently, because the scan feels like work.
+  What an operation **obliges** never bends; only the derivation is revisable.
+
+## Two traps — misbindings caught in production
+
+**The timeline trap.** "Did we do it?" loves to disguise itself as a timeline, because any
+topic *can* be told as a story. A timeline is a presentation, not machinery: routed as
+time-ordered READ, you narrate the decision as fact *because it was said* — without ever
+being forced to pair statement with outcome. Worked example: *"did we decide to deprecate
+UPI collect, and did it happen?"* — the tempting read is timeline; the correct derivation is
+existence **plus** RELATE. In our corpus both happened to exist, so the timeline route would
+have produced the same answer — by luck, not by construction.
+
+**The recency trap.** Relevance ranking answers "what has EVER been said about X" — never
+"what is true NOW". A report posted an hour ago competes in the top-k auction against years
+of accumulated matches and loses by construction; the failure is silent because the answer
+is fluent, fully cited, and stale. Worked example: *"does full screen search have any
+issue?"* — a plain relevance fan-out produced an answer whose newest fact was two days old,
+while that morning's bug thread never entered the top-20. The same question with a
+newest-first probe per surface caught the thread and cited it to the minute. Nothing about
+the model changed — only the primitive.
+
+## MEASURE — how to actually count
+
+- **Single-entity aggregates** ("who filed the most", "breakdown by type"):
+  `spaces-vespa-search` with `groupBy` + `hits: 0`. Per-group counts are real Vespa totals
+  over ALL matching documents, ACL-respected — not a sample.
+- **Trends and ratios over time** ("how many per year", "is it growing"):
+  `spaces-corpus-scan` with `bucket: "year"` / `"month"` — per-term counts **and**
+  `corpusTotals` **and** precomputed `shares` in one response.
+- **Always compare shares, not raw counts.** The corpus grows over time; raw counts turn
+  normal growth into fake trends. State the denominator in the answer.
+- **Fan out across surfaces, or say why you didn't.** The thing counted usually lives in
+  several areas (mail, tickets, chat). Count each surface separately — never sum across
+  surfaces (the same item can appear in several) — or name what you excluded. An unstated
+  surface is a silent undercount.
+- **Multi-word terms count as exact phrases.** "refund complaint" = that phrase. To count
+  any-of-words, pass the words as separate terms.
+
+## EXHAUST — how to be complete
+
+1. MEASURE the true population size first (`corpus-scan` or a `groupBy` count). When the
+   population is a derived condition no lexical term can count ("merchants live on both X
+   and Y"), run the closest **proxy count** (documents mentioning the topic) and state
+   coverage against it: *"~N docs mention X; I read the top k — this is what they confirm,
+   not a census."*
+2. Page the members to exhaustion — a full page means there's more; stop only at a short page.
+3. Report three things: what made the list, what was **excluded and why**, and what remains
+   uncovered. One pass always *looks* complete; only the size-first discipline can tell you
+   whether it is.
+
+## RELATE — how to hold sets against each other
+
+- One retrieval per set, each with its own scope — the claim-set and the outcome-set are
+  never the same query.
+- Tag every claim by which set supports it: `[stated]` / `[done]` / `[slipped]`.
+- For comparisons, both sides get the same denominator rule; for member-wise pairing
+  ("live on both"), each member carries evidence from each set separately.
+
+## Stating the plan before a count — keep it light
+
+The point of "design before results" is one thing only: **the definition is visible before
+the numbers arrive, so nobody (including you) can quietly bend it afterward.**
+
+**Default — one line, then run.** For any MEASURE / EXHAUST / RELATE answer, state what you
+are about to do before doing it:
+> *"Counting 'refund complaint' (exact phrase) in tickets and support mail, per year, share
+> of that year's total."*
+No canvas, no approval gate — the human can correct the definition if it's wrong.
+
+**For a bigger multi-topic analysis**, write the spec down (topics as exact phrases,
+surfaces counted separately, scope, unit, numeric verdict bands), **self-verify it, lock it
+yourself, and proceed — no human sign-off.** The spec is an audit trail, not a gate. A wrong
+rule after locking means a new spec version and a re-run, never an in-place edit. Only pause
+for the user if they explicitly asked to review the plan first.
+
+## Show the method — name each step as you do it
+
+For any MEASURE / EXHAUST / RELATE answer (anything beyond a plain READ), make the pipeline
+visible:
+
+**Simple answers — label the phases inline:**
+> **Classified** — current-state question (READ + newest-state).
+> **Plan** — "refund complaint" (exact phrase) in tickets + messages, per year, as a share.
+> **Counted / Found** — *(the result)*
+> **Answer** — …
+
+**Multi-step analyses — seed the task list with the pipeline phases** (Classify → Probe →
+Design → Count → Verify) and tick them off live.
+
+- Every MEASURE/EXHAUST/RELATE answer shows its **Classified** and its **Plan** — those two
+  are the whole reason the number is trustworthy.
+- A plain READ stays clean — no labels on a simple "what happened with X".
+- Keep each label to a phrase. The trace is scaffolding, not the answer.
+
+## Non-negotiables — every answer, every operation
+
+- Every factual claim carries its citation.
+- "I couldn't find it" ≠ "it didn't happen" — say which one you mean.
+- Name the denominator on any comparison.
+- Never state a number that came from tallying a ranked page.
+- Name gaps and conflicts instead of papering over them.
+- Report thin evidence as thin — do not pad.

--- a/apps/xyne-claw/skills/corpus-self-verify.md
+++ b/apps/xyne-claw/skills/corpus-self-verify.md
@@ -52,7 +52,9 @@ The check has two parts with different triggers:
    returned totals (`termTotals` / `windowTotal` when present); for any derived number the
    tool doesn't return (sub-window sums, differences, ratios, top-N, dedup, verdict bands),
    compute it in the **sandbox** from the tool's verbatim JSON and copy the printed output.
-   A derived number with no script behind it fails this check.
+   The JSON goes into a data file the script parses — numbers retyped into the script body
+   are transposition risk, not an audit trail. A derived number with no script behind it
+   fails this check.
 3. **Denominators match the numerators.** Every share is `count ÷ that bucket's own total`,
    and the term query and the total query used the identical scope and filters. A share built
    from mismatched filters is wrong even if it looks plausible.
@@ -79,6 +81,20 @@ If a check fails, correct the cause — the query, the phrase, the scope, the su
 re-run. Never hand-edit a number, invent or adjust a citation, or quietly drop a caveat to
 make a check pass. A number or citation that had to be hand-patched is a defect even if it
 happens to be right.
+
+## For a written analysis (packs + stats)
+
+When the deliverable was produced through the written-analysis pipeline (spec → evidence
+packs → stats → write), three checks are added on top of Parts A and B:
+
+1. **Citations are closed-set.** Every cited row exists in one of this analysis's pack
+   files — not merely "somewhere in the corpus". Run the membership check as a sandbox
+   script over the draft + pack files; a citation outside the packs means the writer
+   searched, which is the confirmation-bias hole the packs exist to close.
+2. **Numbers are closed-set.** Every figure in the draft appears in `stats.json`. A number
+   with no stats entry is a defect even if it happens to be right.
+3. **Coverage is carried forward.** The delivered analysis includes each pack's coverage
+   note (buckets fetched/skipped, caps) and the spec version it was produced under.
 
 ## For a locked analysis spec (replacing human approval)
 

--- a/apps/xyne-claw/skills/corpus-self-verify.md
+++ b/apps/xyne-claw/skills/corpus-self-verify.md
@@ -1,49 +1,84 @@
 ---
 name: corpus-self-verify
-description: Self-check a count / trend / ranking / audit / list answer BEFORE delivering it — autonomously, no human approval. Invoke this whenever you are about to state a number, a share, a trend verdict, a said-vs-done judgement, or a "complete list", and before locking an analysis spec. Verify your own work against the checklist below, fix anything that fails by re-running (never by hand-editing a number), and only then deliver.
+description: Self-check before delivering — autonomously, no human approval. Part A (EVERY answer, no exceptions) is citation integrity — every claim cites a doc id returned by a query run this session; absence stays absence. Part B (any count / trend / ranking / audit / complete list — Rule 7's trigger) is the full measurement checklist. Invoke this skill whenever you are about to state a number, a share, a trend verdict, a said-vs-done judgement, or a "complete list", and before locking an analysis spec. Fix failures by re-running (never by hand-editing a number), and only then deliver.
 ---
 
 # Corpus Self-Verify — check your own work before delivering
 
-The trust in a counted answer comes from a contract, not from confidence. Before you deliver
-any count / trend / ranking / audit / list answer — and before you treat an analysis spec as
-locked — run this checklist against your own draft. This is autonomous: do not ask the user
-to approve or confirm. If any check fails, fix it (re-run the query or the definition) and
-re-verify. Only deliver once every check passes.
+The trust in an answer comes from a contract, not from confidence. This check is autonomous:
+do not ask the user to approve or confirm. If any check fails, fix the cause (re-run the
+query or the definition) and re-verify. Only deliver once every applicable check passes.
 
-## The checklist
+The check has two parts with different triggers:
+
+- **Part A — citation integrity. Applies to EVERY answer**, including plain READ lookups.
+  These checks are cheap and unconditional; the system prompt restates them so they bind
+  even on turns where this skill isn't read.
+- **Part B — measurement integrity. Applies whenever the draft contains any MEASURE /
+  EXHAUST / RELATE result** — a count, trend, ranking, audit verdict, or complete list.
+  For these answers, read this skill and run both parts against the draft before delivering.
+
+## Part A — citation integrity (every answer)
+
+1. **Every factual claim carries a citation that exists.** Each claim traces to a doc id
+   that appeared in a query result *this session*. A claim with no backing query is removed
+   or re-fetched — never delivered from memory.
+2. **Citations are copied, never composed.** A doc id is pasted from a result, not
+   reconstructed from a pattern. If you cannot point to the exact result it came from, it is
+   not a citation.
+3. **The id itself ships in the final answer, as a plain-text token.** A citation IS the
+   doc id, verbatim, in square brackets with no code formatting: `[clf-ab12#7]` after the
+   claim, punctuation outside the brackets. Wrapping the token in backticks breaks the
+   citation renderer — the chip won't display — and a prose source name ("the Retry canvas")
+   may accompany the token, never replace it. Grounding that ships without its plain token is
+   unverifiable, which fails this check regardless of how careful the reasoning was. Both
+   observed failure modes happened at the final drafting step: correct ids collected, then
+   swapped for friendly labels (session 8) or wrapped in code formatting (session 9). The
+   draft you verify is the draft you deliver — do not reformat tokens after checking them.
+4. **Categorical claims match their evidence.** "X does not work when Y", "X requires Z" —
+   the cited snippet actually says that, not something adjacent to it. An absolute claim on
+   an approximate citation is an overreach.
+5. **Absence is reported as absence.** "Not found in the corpus" is said exactly so — never
+   silently converted to "it didn't happen", never padded when evidence is thin.
+
+## Part B — measurement integrity (any count / trend / ranking / audit / list)
 
 1. **Numbers came from a tool, not from hits.** Every number traces to a `spaces-corpus-scan`
    or `groupBy` result. If any figure came from counting a page of search results by hand, it
    is not a real count — re-run it as a count.
-2. **Denominators match the numerators.** Every share is `count ÷ that bucket's own total`,
+2. **Totals are the tool's or the sandbox's, not yours.** Never sum bucket rows by hand to
+   produce a period total — a live run hand-summed seven month buckets and delivered 1,713
+   where the true sum was 2,152, inside an otherwise fully compliant answer. Use the tool's
+   returned totals (`termTotals` / `windowTotal` when present); for any derived number the
+   tool doesn't return (sub-window sums, differences, ratios, top-N, dedup, verdict bands),
+   compute it in the **sandbox** from the tool's verbatim JSON and copy the printed output.
+   A derived number with no script behind it fails this check.
+3. **Denominators match the numerators.** Every share is `count ÷ that bucket's own total`,
    and the term query and the total query used the identical scope and filters. A share built
    from mismatched filters is wrong even if it looks plausible.
-3. **Multi-word terms were counted as exact phrases.** Sanity test: a phrase can never
+4. **Multi-word terms were counted as exact phrases.** Sanity test: a phrase can never
    out-count its own word (`"refund complaint"` ≤ `"refund"`). If it does, the phrase was
    matched loosely — re-run with the exact phrase.
-4. **Every relevant surface is counted, or the missing ones are named.** The thing counted
+5. **Every relevant surface is counted, or the missing ones are named.** The thing counted
    usually lives in more than one place (mail, tickets, chat). Either count each surface
    separately (never summed) or state which surface you counted and which you left out. An
    unstated surface is a silent undercount.
-5. **No claim overreaches the data.**
+6. **No claim overreaches the data.**
    - A decision is not called *done* without separate, later proof — a statement is `[stated]`
      until outcome evidence exists.
    - A trend is not claimed from raw counts — only from shares.
    - A complete list is not given without counting the true size first and naming what is
      uncovered.
-6. **Every claim carries a real citation.** No number or quote without a source that exists.
-7. **Absence is reported as absence.** "Not found in the corpus" is said as exactly that —
-   never silently converted to "it didn't happen", never padded when evidence is thin.
-8. **The numbers are internally sane.** Spot-check: a phrase ≤ its word; no bucket with a zero
+7. **The numbers are internally sane.** Spot-check: a phrase ≤ its word; no bucket with a zero
    total but a non-zero term; shares in a plausible range; the trend story matches the share
    column, not the raw column.
 
 ## On failure — fix the machine, not the number
 
 If a check fails, correct the cause — the query, the phrase, the scope, the surface list — and
-re-run. Never hand-edit a number or quietly drop a caveat to make a check pass. A number that
-had to be hand-patched is a defect even if it happens to be right.
+re-run. Never hand-edit a number, invent or adjust a citation, or quietly drop a caveat to
+make a check pass. A number or citation that had to be hand-patched is a defect even if it
+happens to be right.
 
 ## For a locked analysis spec (replacing human approval)
 

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -1505,7 +1505,11 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   const model = resolveModel(modelRegistry, provider, effectiveProviderConfig, {
     // Spaces default-model override — only the LiteLLM branch reads it;
     // provider-credential runs keep the model configured on the credential.
-    model: effectiveProviderConfig ? undefined : modelSettings?.model,
+    // Precedence on the platform branch: per-agent modelSettings.model, then
+    // the automation default model (batch runs), then LITELLM.model.
+    model: effectiveProviderConfig
+      ? undefined
+      : modelSettings?.model ?? (opts.automationRun ? LITELLM.automationModel : undefined),
     maxTokens: modelSettings?.maxTokens,
     litellmApiKey: opts.automationRun ? LITELLM.automationApiKey : undefined,
   });

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -739,7 +739,9 @@ export function resolveModel(
   // Per-agent overrides (agentConfig.modelSettings). `model` only applies to
   // the default LiteLLM branch — provider branches already receive an
   // overridden providerConfig.model from runTask. `maxTokens` applies to all.
-  overrides?: { model?: string | undefined; maxTokens?: number | undefined },
+  // `litellmApiKey` swaps the platform key on the default LiteLLM branch only
+  // (automation/scheduled runs use the low-priority automation key).
+  overrides?: { model?: string | undefined; maxTokens?: number | undefined; litellmApiKey?: string | undefined },
 ) {
   const maxTokens = overrides?.maxTokens ?? 16384;
   if (provider === "copilot" && providerConfig?.apiKey) {
@@ -926,7 +928,7 @@ export function resolveModel(
   const litellmModel = overrides?.model ?? LITELLM.model;
   modelRegistry.registerProvider("litellm", {
     baseUrl: LITELLM.url,
-    apiKey: LITELLM.apiKey,
+    apiKey: overrides?.litellmApiKey || LITELLM.apiKey,
     api: "openai-completions",
     authHeader: true,
     models: [
@@ -1271,6 +1273,9 @@ export interface PromptInjection {
 export interface RunTaskOptions {
   userId: string;
   task: string;
+  /** Automation/scheduled run — the default LiteLLM branch uses the
+   *  low-priority automation key so batch load never queues human mentions. */
+  automationRun?: boolean | undefined;
   // Optional fields use `| undefined` (not bare `?`) so call sites can pass
   // through possibly-undefined values under exactOptionalPropertyTypes.
   context?: string | undefined;
@@ -1502,6 +1507,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     // provider-credential runs keep the model configured on the credential.
     model: effectiveProviderConfig ? undefined : modelSettings?.model,
     maxTokens: modelSettings?.maxTokens,
+    litellmApiKey: opts.automationRun ? LITELLM.automationApiKey : undefined,
   });
 
   // Use persistent session if conversationId provided, otherwise in-memory

--- a/apps/xyne-claw/src/attachment-ingest.ts
+++ b/apps/xyne-claw/src/attachment-ingest.ts
@@ -86,6 +86,26 @@ const MD_CONVERTERS: ReadonlyArray<{
   { match: isHtmlAttachment, convert: htmlBufferToMarkdown, suffix: "" },
 ];
 
+/**
+ * Convert a single document buffer to markdown iff its type is convertible —
+ * the one reusable "is this convertible + convert it" decision, shared by the
+ * /run attachment pipeline above and skill-file materialization
+ * (session-skills.ts). Returns null for unsupported types. Throws whatever
+ * the underlying converter throws (corrupt file etc.) — callers decide
+ * whether that is fatal (attachments) or skippable (skill files).
+ */
+export async function documentBufferToMarkdown(
+  buf: Buffer,
+  fileName: string,
+  mimeType: string,
+): Promise<string | null> {
+  if (isPdfAttachment(fileName, mimeType)) return pdfBufferToMarkdown(buf, fileName);
+  for (const c of MD_CONVERTERS) {
+    if (c.match(fileName, mimeType)) return c.convert(buf, fileName);
+  }
+  return null;
+}
+
 async function convertAll(
   attachments: AttachmentInput[],
   convert: (buf: Buffer, fileName: string) => Promise<string>,

--- a/apps/xyne-claw/src/attachment-ingest.ts
+++ b/apps/xyne-claw/src/attachment-ingest.ts
@@ -56,6 +56,9 @@ export interface IngestedAttachments {
   textAttachments: TextAttachmentFile[];
   xlsxAttachments: AttachmentInput[];
   pdfAttachments: AttachmentInput[];
+  docxAttachments: AttachmentInput[];
+  pptxAttachments: AttachmentInput[];
+  htmlAttachments: AttachmentInput[];
 }
 
 /** Decode an attachment's base64 payload to bytes (handles data-URI prefixes). */
@@ -118,9 +121,10 @@ export async function ingestAttachments(
       mimeType: a.mimeType,
     }));
 
-  // Simple markdown converters (xlsx/docx/pptx/html). xlsx is pulled out as a
-  // named list because the prompt-builder references it; the others are only
-  // consumed as derived files.
+  // Simple markdown converters (xlsx/docx/pptx/html). Every list is returned by
+  // name: the prompt-builder needs them to advertise the derived `.context/`
+  // paths, and a type missing from that block is invisible to the agent even
+  // though its markdown sibling is on disk.
   const xlsxAttachments = all.filter((a) => isXlsxAttachment(a.fileName, a.mimeType));
   const docxAttachments = all.filter((a) => isDocxAttachment(a.fileName, a.mimeType));
   const pptxAttachments = all.filter((a) => isPptxAttachment(a.fileName, a.mimeType));
@@ -190,5 +194,8 @@ export async function ingestAttachments(
     textAttachments,
     xlsxAttachments,
     pdfAttachments,
+    docxAttachments,
+    pptxAttachments,
+    htmlAttachments,
   };
 }

--- a/apps/xyne-claw/src/config.ts
+++ b/apps/xyne-claw/src/config.ts
@@ -43,6 +43,13 @@ const litellmFastModel = process.env["LITELLM_FAST_MODEL"]?.trim() || litellmMod
 export const LITELLM = {
   url: process.env["LITELLM_URL"] ?? "http://localhost:4000",
   apiKey: process.env["LITELLM_API_KEY"] ?? "",
+  // Separate low-priority key for non-interactive load: automation/scheduled
+  // agent runs and background curators. Keeps batch traffic from saturating
+  // the interactive key's max_parallel_requests pool (prod incident 2026-07-29:
+  // email-followup-classifier + curators pinned the shared key at 50/50 slots,
+  // queueing human mentions for minutes). Falls back to the main key so the
+  // split can deploy before the second key is provisioned.
+  automationApiKey: process.env["LITELLM_AUTOMATION_API_KEY"]?.trim() || (process.env["LITELLM_API_KEY"] ?? ""),
   model: litellmModel,
   // Cheap-and-fast model used by judge/boss roles (chain-judge, goal-judge).
   // Boss decisions are short structured calls; running them on the same big

--- a/apps/xyne-claw/src/config.ts
+++ b/apps/xyne-claw/src/config.ts
@@ -50,6 +50,10 @@ export const LITELLM = {
   // queueing human mentions for minutes). Falls back to the main key so the
   // split can deploy before the second key is provisioned.
   automationApiKey: process.env["LITELLM_AUTOMATION_API_KEY"]?.trim() || (process.env["LITELLM_API_KEY"] ?? ""),
+  // Optional cheaper/faster model for automation/scheduled runs. Falls back to
+  // the main model, and a per-agent modelSettings.model still wins over this —
+  // it only replaces the PLATFORM DEFAULT for batch traffic.
+  automationModel: process.env["LITELLM_AUTOMATION_MODEL"]?.trim() || litellmModel,
   model: litellmModel,
   // Cheap-and-fast model used by judge/boss roles (chain-judge, goal-judge).
   // Boss decisions are short structured calls; running them on the same big

--- a/apps/xyne-claw/src/curator.ts
+++ b/apps/xyne-claw/src/curator.ts
@@ -29,7 +29,9 @@ import { createLogger } from "./logger.js";
 const log = createLogger("curator");
 
 const LITELLM_URL = (process.env["LITELLM_URL"] ?? "https://grid.ai.example.com").replace(/\/$/, "");
-const LITELLM_API_KEY = process.env["LITELLM_API_KEY"] ?? "";
+// Background job: prefer the low-priority automation key so curator bursts
+// can't queue interactive agent turns on the main key's parallel-slot pool.
+const LITELLM_API_KEY = process.env["LITELLM_AUTOMATION_API_KEY"]?.trim() || (process.env["LITELLM_API_KEY"] ?? "");
 const CURATOR_MODEL = process.env["MEMORY_CURATOR_MODEL"] ?? "claude-haiku-4-5-20251001";
 const CURATOR_TIMEOUT_MS = Number(process.env["MEMORY_CURATOR_TIMEOUT_MS"] ?? 600_000);
 

--- a/apps/xyne-claw/src/custom-tools.ts
+++ b/apps/xyne-claw/src/custom-tools.ts
@@ -9,7 +9,8 @@
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { getAllCustomTools, parseToolsConfig, PLATFORM_ONLY_CONFIG_KEYS, type ToolExecutionContext, type PendingQuestion, type PendingResponse } from "xyne-claw-shared";
-import { SERVER } from "./config.js";
+import { SERVER, PATHS } from "./config.js";
+import { join } from "node:path";
 
 import { createLogger } from "./logger.js";
 const log = createLogger("custom-tools");
@@ -207,8 +208,16 @@ export function loadCustomTools(
   const pinnedSandboxRepo = typeof agentConfig?.["sandboxRepo"] === "string"
     ? (agentConfig["sandboxRepo"] as string).trim()
     : "";
-  const toolMeta: Record<string, string> | undefined = (meta || pinnedSandboxRepo)
-    ? { ...(meta ?? {}), ...(pinnedSandboxRepo ? { sandboxRepo: pinnedSandboxRepo } : {}) }
+  // Absolute root of THIS run's materialized skills (`<dataDir>/session-skills/<sessionId>`).
+  // Injected so `sandbox-copy-in` can stream a skill's companion file into the
+  // sandbox server-side, confined to this root (mirrors the agent's skill read root).
+  const skillsRoot = sessionId ? join(PATHS.dataDir, "session-skills", sessionId) : "";
+  const toolMeta: Record<string, string> | undefined = (meta || pinnedSandboxRepo || skillsRoot)
+    ? {
+        ...(meta ?? {}),
+        ...(pinnedSandboxRepo ? { sandboxRepo: pinnedSandboxRepo } : {}),
+        ...(skillsRoot ? { skillsRoot } : {}),
+      }
     : undefined;
 
   const tools = customTools.map((ct) => {

--- a/apps/xyne-claw/src/experiment.ts
+++ b/apps/xyne-claw/src/experiment.ts
@@ -1,0 +1,301 @@
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { SERVER } from "./config.js";
+
+export interface ExperimentContext {
+  id: string;
+  epoch: number;
+  deadlineAt: string;
+  focus?: string;
+}
+
+type FindingStatus = "conjecture" | "proved" | "refuted";
+
+interface ExperimentEnvelope<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+interface LedgerData {
+  markdown: string;
+  counts: { conjecture: number; proved: number; refuted: number };
+  deadlineAt: string;
+  epoch: number;
+}
+
+const BASE_PATH = "/claw/api/v1/internal/experiments";
+
+function experimentUrl(id: string, suffix: string): string {
+  return `${SERVER.authServiceUrl.replace(/\/+$/, "")}${BASE_PATH}/${encodeURIComponent(id)}${suffix}`;
+}
+
+async function experimentFetch<T>(
+  id: string,
+  suffix: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(experimentUrl(id, suffix), {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      "x-s2s-key": SERVER.s2sKey,
+      ...init?.headers,
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+  const body = (await res.json()) as ExperimentEnvelope<T>;
+  if (!body.success || body.data === undefined) {
+    throw new Error(body.error ?? `Experiment service error: ${res.status}`);
+  }
+  return body.data;
+}
+
+async function experimentPostNoData(
+  id: string,
+  suffix: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const res = await fetch(experimentUrl(id, suffix), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-s2s-key": SERVER.s2sKey,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(10_000),
+  });
+  const body = (await res.json()) as ExperimentEnvelope<unknown>;
+  if (!body.success) {
+    throw new Error(body.error ?? `Experiment service error: ${res.status}`);
+  }
+}
+
+async function readLedger(ctx: ExperimentContext): Promise<LedgerData> {
+  return experimentFetch<LedgerData>(ctx.id, "/ledger", { method: "GET" });
+}
+
+function deadlineMs(ctx: ExperimentContext): number {
+  const parsed = Date.parse(ctx.deadlineAt);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function humanDuration(ms: number): string {
+  const totalMinutes = Math.max(0, Math.ceil(ms / 60_000));
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0 || days > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+function timeInfo(
+  ctx: ExperimentContext,
+  startedAtMs: number,
+): { elapsed: string; remaining: string; remainingMs: number; elapsedMs: number } {
+  const now = Date.now();
+  const deadline = deadlineMs(ctx);
+  const durationMs = Math.max(0, deadline - now);
+  const elapsedMs = Math.max(0, now - startedAtMs);
+  return {
+    elapsed: humanDuration(elapsedMs),
+    remaining: humanDuration(durationMs),
+    remainingMs: durationMs,
+    elapsedMs,
+  };
+}
+
+function textResult(text: string, details: Record<string, unknown> = {}) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details,
+  };
+}
+
+function asRecord(params: unknown): Record<string, unknown> {
+  return params && typeof params === "object" ? params as Record<string, unknown> : {};
+}
+
+export function buildExperimentTools(
+  ctx: ExperimentContext,
+  abortRun?: () => void,
+): ToolDefinition[] {
+  const startedAtMs = Date.now();
+  return [
+    {
+      name: "experiment-clock",
+      label: "Experiment Clock",
+      description: "Check how much time remains in the experiment and ledger stats.",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      async execute() {
+        const info = timeInfo(ctx, startedAtMs);
+        try {
+          const ledger = await readLedger(ctx);
+          return textResult(
+            [
+              `Elapsed: ${info.elapsed}`,
+              `Remaining: ${info.remaining}`,
+              `Epoch: ${ctx.epoch}`,
+              `Deadline: ${ctx.deadlineAt}`,
+              `Ledger counts: conjecture=${ledger.counts.conjecture}, proved=${ledger.counts.proved}, refuted=${ledger.counts.refuted}`,
+            ].join("\n"),
+            { counts: ledger.counts, remainingMs: info.remainingMs, elapsedMs: info.elapsedMs },
+          );
+        } catch (err) {
+          return textResult(
+            [
+              `Elapsed: ${info.elapsed}`,
+              `Remaining: ${info.remaining}`,
+              `Epoch: ${ctx.epoch}`,
+              `Deadline: ${ctx.deadlineAt}`,
+              `Ledger counts unavailable: ${err instanceof Error ? err.message : String(err)}`,
+            ].join("\n"),
+            { remainingMs: info.remainingMs, elapsedMs: info.elapsedMs, ledgerUnavailable: true },
+          );
+        }
+      },
+    },
+    {
+      name: "experiment-ledger",
+      label: "Experiment Ledger",
+      description: [
+        "Read or update the experiment ledger. Record EVERY hypothesis when you start on it",
+        "(action=hypothesis), then gather proof in the sandbox and record findings with",
+        "proofArtifactPath. The same title updates the existing finding. For sandbox-note:",
+        "Record your sandbox session id here the moment you create it, and REUSE that sandbox",
+        "in later epochs instead of creating a new one; only create a fresh one if the old id no longer responds.",
+      ].join(" "),
+      parameters: Type.Union([
+        Type.Object({ action: Type.Literal("read") }, { additionalProperties: false }),
+        Type.Object({
+          action: Type.Literal("record"),
+          status: Type.Union([
+            Type.Literal("conjecture"),
+            Type.Literal("proved"),
+            Type.Literal("refuted"),
+          ]),
+          title: Type.String(),
+          hypothesis: Type.String(),
+          note: Type.Optional(Type.String()),
+          proofArtifactPath: Type.Optional(Type.String()),
+        }, { additionalProperties: false }),
+        Type.Object({
+          action: Type.Literal("hypothesis"),
+          text: Type.String(),
+        }, { additionalProperties: false }),
+        Type.Object({
+          action: Type.Literal("sandbox-note"),
+          note: Type.String(),
+        }, { additionalProperties: false }),
+      ]),
+      async execute(_toolCallId: string, params: unknown) {
+        const p = asRecord(params);
+        try {
+          if (p["action"] === "read") {
+            const ledger = await readLedger(ctx);
+            return textResult(ledger.markdown, { counts: ledger.counts });
+          }
+          if (p["action"] === "record") {
+            const status = p["status"];
+            const title = p["title"];
+            const hypothesis = p["hypothesis"];
+            if (
+              status !== "conjecture" &&
+              status !== "proved" &&
+              status !== "refuted"
+            ) return textResult("Invalid status. Use conjecture, proved, or refuted.", { error: true });
+            if (typeof title !== "string" || typeof hypothesis !== "string") {
+              return textResult("Missing required title or hypothesis.", { error: true });
+            }
+            const payload: {
+              epoch: number;
+              status: FindingStatus;
+              title: string;
+              hypothesis: string;
+              note?: string;
+              proofArtifactPath?: string;
+            } = {
+              epoch: ctx.epoch,
+              status,
+              title,
+              hypothesis,
+              ...(typeof p["note"] === "string" ? { note: p["note"] } : {}),
+              ...(typeof p["proofArtifactPath"] === "string" ? { proofArtifactPath: p["proofArtifactPath"] } : {}),
+            };
+            const result = await experimentFetch<{ id: string }>(ctx.id, "/findings", {
+              method: "POST",
+              body: JSON.stringify(payload),
+            });
+            return textResult(`Finding recorded: ${result.id}`, { id: result.id });
+          }
+          if (p["action"] === "hypothesis") {
+            if (typeof p["text"] !== "string") {
+              return textResult("Missing required text.", { error: true });
+            }
+            await experimentPostNoData(ctx.id, "/hypothesis", {
+              epoch: ctx.epoch,
+              text: p["text"],
+            });
+            return textResult("Hypothesis recorded.");
+          }
+          if (p["action"] === "sandbox-note") {
+            if (typeof p["note"] !== "string") {
+              return textResult("Missing required note.", { error: true });
+            }
+            await experimentPostNoData(ctx.id, "/sandbox-note", { note: p["note"] });
+            return textResult("Sandbox note recorded.");
+          }
+          return textResult("Invalid action. Use read, record, hypothesis, or sandbox-note.", { error: true });
+        } catch (err) {
+          return textResult(
+            `Experiment ledger action failed: ${err instanceof Error ? err.message : String(err)}`,
+            { error: true },
+          );
+        }
+      },
+    },
+    {
+      name: "end-experiment",
+      label: "End Experiment",
+      description: "Complete the experiment after the deadline. This is the ONLY exit.",
+      parameters: Type.Object({
+        report: Type.String(),
+      }, { additionalProperties: false }),
+      async execute(_toolCallId: string, params: unknown) {
+        const p = asRecord(params);
+        const report = typeof p["report"] === "string" ? p["report"] : "";
+        const deadline = deadlineMs(ctx);
+        if (Date.now() < deadline) {
+          let open = "unknown";
+          try {
+            const ledger = await readLedger(ctx);
+            open = String(ledger.counts.conjecture);
+          } catch {
+            // Keep the refusal path available even when the ledger is temporarily down.
+          }
+          return textResult(
+            `❌ Cannot end: ${humanDuration(deadline - Date.now())} remain (epoch ${ctx.epoch}). Open conjectures: ${open}. Pick one and continue. Your report was NOT accepted.`,
+            { refused: true },
+          );
+        }
+        try {
+          await experimentPostNoData(ctx.id, "/complete", { report });
+          try {
+            abortRun?.();
+          } catch {
+            // Never let abort wiring hide a successful completion.
+          }
+          return textResult("Experiment complete — report recorded.");
+        } catch (err) {
+          return textResult(
+            `Experiment completion failed: ${err instanceof Error ? err.message : String(err)}`,
+            { error: true },
+          );
+        }
+      },
+    },
+  ];
+}

--- a/apps/xyne-claw/src/failure-curator.ts
+++ b/apps/xyne-claw/src/failure-curator.ts
@@ -23,7 +23,9 @@ const log = createLogger("failure-curator");
 import { fetchLiteLLMWithRetry } from "./litellm-retry.js";
 
 const LITELLM_URL = (process.env["LITELLM_URL"] ?? "https://grid.ai.example.com").replace(/\/$/, "");
-const LITELLM_API_KEY = process.env["LITELLM_API_KEY"] ?? "";
+// Background job: prefer the low-priority automation key so curator bursts
+// can't queue interactive agent turns on the main key's parallel-slot pool.
+const LITELLM_API_KEY = process.env["LITELLM_AUTOMATION_API_KEY"]?.trim() || (process.env["LITELLM_API_KEY"] ?? "");
 const CURATOR_MODEL = process.env["LITELLM_MODEL"] ?? "claude-haiku-4-5-20251001";
 const CURATOR_TIMEOUT_MS = Number(process.env["FAILURE_CURATOR_TIMEOUT_MS"] ?? 90_000);
 

--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -86,6 +86,39 @@ async function authFetch<T>(path: string, sessionToken: string, init?: RequestIn
   return body.data;
 }
 
+/** A per-user OAuth provider the agent is configured for but the user hasn't connected. */
+export interface NeedsConnectionEntry {
+  serverType: string;
+  displayName: string;
+}
+
+/**
+ * Like authFetch but returns the FULL envelope, so sidecar fields (e.g.
+ * `needsConnection` on /mcp/tools) survive — authFetch discards everything but
+ * `.data`.
+ */
+async function authFetchEnvelope<T>(
+  path: string,
+  sessionToken: string,
+  init?: RequestInit,
+): Promise<AuthResponse<T> & { needsConnection?: NeedsConnectionEntry[] }> {
+  const url = `${SERVER.authServiceUrl}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${sessionToken}`,
+      "x-s2s-key": SERVER.s2sKey,
+      ...init?.headers,
+    },
+  });
+  const body = (await res.json()) as AuthResponse<T> & { needsConnection?: NeedsConnectionEntry[] };
+  if (!body.success || body.data === undefined) {
+    throw new Error(body.error ?? `Auth service error: ${res.status}`);
+  }
+  return body;
+}
+
 function injectToolCallIdIntoClawCitations(content: string, toolCallId: string): string {
   if (!content || !toolCallId) return content;
   return content.split("__TOOL_CALL_ID__").join(toolCallId);
@@ -218,18 +251,21 @@ export async function loadMcpToolsForUser(
   onAttachment?: (a: Attachment) => void,
 ): Promise<{
   groups: McpToolGroup[];
+  needsConnection: NeedsConnectionEntry[];
   cleanup: () => Promise<void>;
   getPendingActions: () => Array<Record<string, unknown>>;
   getAttachments: () => Attachment[];
 }> {
   const permissions = toolPermissions ?? {};
-  const servers = await authFetch<McpServerTools[]>(
+  const toolsEnvelope = await authFetchEnvelope<McpServerTools[]>(
     `/claw/api/v1/sessions/${encodeURIComponent(sessionId)}/mcp/tools`,
     sessionToken,
   );
+  const servers = toolsEnvelope.data ?? [];
+  const needsConnection = toolsEnvelope.needsConnection ?? [];
 
   if (servers.length === 0) {
-    return { groups: [], cleanup: async () => {}, getPendingActions: () => [], getAttachments: () => [] };
+    return { groups: [], needsConnection, cleanup: async () => {}, getPendingActions: () => [], getAttachments: () => [] };
   }
 
   const pendingActions: Array<Record<string, unknown>> = [];
@@ -387,5 +423,59 @@ export async function loadMcpToolsForUser(
   const totalTools = groups.reduce((sum, g) => sum + g.tools.length, 0);
   log.info(`[mcp] Loaded ${totalTools} tools in ${groups.length} groups for session ${sessionId}`);
 
-  return { groups, cleanup: async () => {}, getPendingActions: () => pendingActions, getAttachments: () => mcpAttachments };
+  return { groups, needsConnection, cleanup: async () => {}, getPendingActions: () => pendingActions, getAttachments: () => mcpAttachments };
+}
+
+/**
+ * In-process tool the model calls to post a connect/configure card into the
+ * thread for per-user providers the agent is configured for but the user hasn't
+ * connected (see `needsConnection`). It delegates to claw-auth's connect-card
+ * endpoint, which owns the agent's Spaces app token plus OAuth and credential
+ * form construction. Injected only when `needsConnection` is non-empty.
+ */
+export function buildSuggestConnectionTool(
+  sessionId: string,
+  sessionToken: string,
+  needsConnection: NeedsConnectionEntry[],
+): ToolDefinition {
+  const providers = needsConnection.map((n) => n.serverType);
+  const byType = new Map(needsConnection.map((n) => [n.serverType, n.displayName]));
+  return {
+    name: "suggest-connection",
+    label: "Suggest account connection",
+    description:
+      "Post a connect/configure card in the current thread so the user can authorize or add credentials for an account this agent " +
+      "needs but hasn't connected. Call this ONCE when the user asks for something requiring an unconnected provider. " +
+      `Valid provider values: ${providers.join(", ")}.`,
+    parameters: Type.Object({
+      provider: Type.Unsafe<string>({
+        type: "string",
+        enum: providers,
+        description: "Which account to prompt the user to connect.",
+      }),
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const provider = String((params as Record<string, unknown> | undefined)?.["provider"] ?? "").trim();
+      if (!byType.has(provider)) {
+        return {
+          content: [{ type: "text" as const, text: `suggest-connection failed: unknown provider "${provider}". Valid: ${providers.join(", ")}.` }],
+          details: {},
+        };
+      }
+      try {
+        await authFetchEnvelope<{ posted: boolean }>(
+          `/claw/api/v1/sessions/${encodeURIComponent(sessionId)}/mcp/connect-card`,
+          sessionToken,
+          { method: "POST", body: JSON.stringify({ serverType: provider }) },
+        );
+        return {
+          content: [{ type: "text" as const, text: `Posted a setup card for ${byType.get(provider)} in the thread. Do not call suggest-connection again for the same provider.` }],
+          details: {},
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `suggest-connection failed: ${msg}` }], details: {} };
+      }
+    },
+  };
 }

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -33,7 +33,7 @@ import { SessionLockedError } from "../session-lock.js";
 import { isSafeId } from "../safe-id.js";
 import { sanitizeCitations } from "../citation-sanitizer.js";
 import { validateS2SKey } from "../middleware/auth.js";
-import { loadMcpToolsForUser } from "../mcp.js";
+import { loadMcpToolsForUser, buildSuggestConnectionTool } from "../mcp.js";
 import { loadCustomTools } from "../custom-tools.js";
 import { buildCopilotTool } from "../copilot.js";
 import {
@@ -1589,6 +1589,7 @@ async function processTask(
     const mcpOutputDir = toolOutputBaseDir(conversationId, workspaceDir);
     const {
       groups: mcpGroups,
+      needsConnection,
       cleanup,
       getPendingActions,
       getAttachments: getMcpAttachments,
@@ -2518,6 +2519,16 @@ async function processTask(
       log("Copilot mode — injected respond-to-user tool");
     }
 
+    // Connect-account suggestion tool: only present when the agent is configured
+    // for a per-user OAuth provider (Google/Microsoft) the user hasn't connected.
+    // Lets the model post a one-tap "Connect X" card instead of only mentioning
+    // the gap in prose. Default-on (bypasses the tools.custom gate) but scoped to
+    // the needsConnection set, so agents that need nothing never get it.
+    if (needsConnection.length > 0) {
+      allTools.push(buildSuggestConnectionTool(sessionId, sessionToken, needsConnection));
+      log(`Injected suggest-connection tool for: ${needsConnection.map((n) => n.serverType).join(",")}`);
+    }
+
     if (agentSlug && memoryEnabled) {
       allTools.push(buildMemorySearchTool(agentSlug, userId, sessionId, memoryBankId));
       log("Memory enabled — injected memory-search tool");
@@ -3206,9 +3217,15 @@ async function processTask(
           ...(channelName ? { channelName } : {}),
         })
       : "";
-    const effectiveSystemPrompt = (channelId
+    // Accounts the agent is configured to use but the user hasn't connected or
+    // configured. Told to the model so it surfaces the gap instead of
+    // fabricating results from a tool it never received.
+    const notConnectedGuide = needsConnection.length > 0
+      ? `\n\n## Accounts not connected\nThis agent is configured to use tools that require the user to connect an account or add credentials, but the user has NOT connected/configured: ${needsConnection.map((n) => `${n.displayName} [provider: ${n.serverType}]`).join("; ")}.\nIf the user asks for something that needs one of these (e.g. reading email/calendar/files or checking code tools), do NOT pretend to have access or fabricate results. Instead, call the \`suggest-connection\` tool with the matching provider to post a setup card in the thread, and briefly tell the user you've added it. Call it once per provider; then continue with whatever you can do without that account.`
+      : "";
+    const effectiveSystemPrompt = ((channelId
       ? `${basePrompt}${citationGuide}${SPACES_MENTION_GUIDE}`
-      : `${basePrompt}${citationGuide}`) + twinMandate;
+      : `${basePrompt}${citationGuide}`) + twinMandate) + notConnectedGuide;
     // Proof (twin mention flow only) that BOTH prompt changes actually reach the
     // model: the twin_deliver mandate + its who/where line in the SYSTEM prompt,
     // and the "@mentioned by" note in the USER-prompt context. Grep the run logs

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -1549,6 +1549,9 @@ async function processTask(
       textAttachments,
       xlsxAttachments,
       pdfAttachments,
+      docxAttachments,
+      pptxAttachments,
+      htmlAttachments,
     } = await ingestAttachments(attachments, log);
 
     const mergedContextFiles = [
@@ -3046,10 +3049,13 @@ async function processTask(
     }
 
     // Surface every derived context file to the agent — without this, files
-    // written under .context/ (xlsx → <name>.md, pdf → <name>.md) are
-    // invisible: the LLM sees only the user's free-text turn and replies
+    // written under .context/ (xlsx/pdf/docx/pptx → <name>.md, html in place)
+    // are invisible: the LLM sees only the user's free-text turn and replies
     // "I don't see any attachment". Each entry shows the ORIGINAL filename
-    // plus the path the agent's read tool should use.
+    // plus the path the agent's read tool should use. EVERY type that
+    // ingestAttachments converts must be listed below — docx/pptx/html were
+    // converted and written but never advertised here, which is how a working
+    // .docx conversion still produced "I don't see any attachment".
     // Advertise the SAME sanitized path that writeWorkspaceTextFiles actually
     // wrote. sanitizeRelativePath replaces every char outside [a-zA-Z0-9._-]
     // with "_", so "Juspay ecomm Issues Log.xlsx" lands at
@@ -3071,6 +3077,20 @@ async function processTask(
       ...pdfAttachments.map((a) => ({
         label: `${a.fileName} (pdf, text-extracted to markdown)`,
         path: toWorkspaceContextPath(`${a.fileName}.md`),
+      })),
+      ...docxAttachments.map((a) => ({
+        label: `${a.fileName} (docx, extracted to markdown)`,
+        path: toWorkspaceContextPath(`${a.fileName}.md`),
+      })),
+      ...pptxAttachments.map((a) => ({
+        label: `${a.fileName} (pptx, extracted to markdown)`,
+        path: toWorkspaceContextPath(`${a.fileName}.md`),
+      })),
+      // html converts in place — its MD_CONVERTERS suffix is "", so the derived
+      // file keeps the original filename rather than gaining a ".md".
+      ...htmlAttachments.map((a) => ({
+        label: `${a.fileName} (html, converted to markdown)`,
+        path: toWorkspaceContextPath(a.fileName),
       })),
     ];
     if (attachmentEntries.length > 0) {

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -36,6 +36,7 @@ import { validateS2SKey } from "../middleware/auth.js";
 import { loadMcpToolsForUser, buildSuggestConnectionTool } from "../mcp.js";
 import { loadCustomTools } from "../custom-tools.js";
 import { buildCopilotTool } from "../copilot.js";
+import { buildExperimentTools, type ExperimentContext } from "../experiment.js";
 import {
   buildVerifiedResponseTool,
   SUBMIT_RESPONSE_SYSTEM_INSTRUCTION,
@@ -173,6 +174,43 @@ function configFastModeEnabled(agentConfig: Record<string, unknown> | undefined)
 
 function effectiveFastMode(fastMode: boolean | undefined, agentConfig: Record<string, unknown> | undefined): boolean {
   return typeof fastMode === "boolean" ? fastMode : configFastModeEnabled(agentConfig);
+}
+
+function normalizeExperimentContext(raw: unknown): ExperimentContext | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const obj = raw as Record<string, unknown>;
+  const id = typeof obj["id"] === "string" ? obj["id"].trim() : "";
+  const deadlineAt = typeof obj["deadlineAt"] === "string" ? obj["deadlineAt"].trim() : "";
+  if (!id || !deadlineAt) return undefined;
+  const epochValue = obj["epoch"];
+  const epoch = typeof epochValue === "number" && Number.isFinite(epochValue)
+    ? epochValue
+    : typeof epochValue === "string" && epochValue.trim()
+      ? Number(epochValue)
+      : 0;
+  const focus = typeof obj["focus"] === "string" && obj["focus"].trim()
+    ? obj["focus"].trim()
+    : undefined;
+  return {
+    id,
+    epoch: Number.isFinite(epoch) ? epoch : 0,
+    deadlineAt,
+    ...(focus ? { focus } : {}),
+  };
+}
+
+function experimentRemaining(deadlineAt: string): string {
+  const deadlineMs = Date.parse(deadlineAt);
+  if (!Number.isFinite(deadlineMs)) return "unknown";
+  const totalMinutes = Math.max(0, Math.ceil((deadlineMs - Date.now()) / 60_000));
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0 || days > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return parts.join(" ");
 }
 
 function dedupeToolsByName(tools: ToolDefinition[]): ToolDefinition[] {
@@ -385,6 +423,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     senderName,
     channelName,
     mode,
+    experiment: rawExperiment,
     planContinuation,
     generateFollowUpSuggestions: shouldGenerateFollowUpSuggestions,
   } = req.body as {
@@ -499,12 +538,20 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
      *  and STOPS. 'auto' (or absent) ⇒ today's behavior, unchanged. Set by
      *  claw-auth, trust-gated on the matching agent config flag. */
     mode?: "plan" | "auto" | "daily_brief";
+    /** /experiment autonomous exploration mode context, forwarded by claw-auth. */
+    experiment?: {
+      id?: string;
+      epoch?: number;
+      deadlineAt?: string;
+      focus?: string;
+    };
     /** True when this run is Turn 2 (auto) dispatched right after a plan was
      *  approved (or a trivial plan auto-continued). Used only to emit a
      *  mode_switch debug event; behavior is identical to any other auto run. */
     planContinuation?: boolean;
     generateFollowUpSuggestions?: boolean;
   };
+  const experiment = normalizeExperimentContext(rawExperiment);
 
   // [AUTODBG] claw-side receipt of every /run forward (esp. automations). Confirms
   // the request crossed claw-auth → claw and which session id it arrived under
@@ -748,6 +795,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
       senderName,
       channelName,
       mode,
+      experiment,
       planContinuation,
       shouldGenerateFollowUpSuggestions,
       typeof callbackUrl === "string" ? callbackUrl : undefined,
@@ -871,6 +919,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
         senderName,
         channelName,
         mode,
+        experiment,
         planContinuation,
         shouldGenerateFollowUpSuggestions,
         typeof callbackUrl === "string" ? callbackUrl : undefined,
@@ -971,6 +1020,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     senderName,
     channelName,
     mode,
+    experiment,
     planContinuation,
     shouldGenerateFollowUpSuggestions,
     typeof callbackUrl === "string" ? callbackUrl : undefined,
@@ -1320,6 +1370,7 @@ async function processTask(
   senderName?: string,
   channelName?: string,
   mode?: "plan" | "auto" | "daily_brief",
+  experiment?: ExperimentContext,
   planContinuation?: boolean,
   shouldGenerateFollowUpSuggestions?: boolean,
   lateFollowUpCallbackUrl?: string,
@@ -1616,6 +1667,11 @@ async function processTask(
     if (agentSlug) meta["agentSlug"] = agentSlug;
     if (channelId) meta["channelId"] = channelId;
     if (conversationId) meta["conversationId"] = conversationId;
+    if (experiment) {
+      meta["experimentId"] = experiment.id;
+      meta["experimentEpoch"] = String(experiment.epoch);
+      meta["experimentDeadlineAt"] = experiment.deadlineAt;
+    }
     // Surface the run's trigger type so the sandbox tools can route scheduled /
     // automation runs to the shared read-only sbx-git sandbox instead of cloning
     // a per-project golden snapshot (see sandboxRepoSetup → resolveSbxGit).
@@ -2496,6 +2552,12 @@ async function processTask(
       allTools.push(buildEmitBriefTool(emitBriefRef, abortRun));
       log("Daily brief mode — injected terminal emit_brief tool");
     }
+    if (experiment) {
+      allTools.push(...buildExperimentTools(experiment, abortRun));
+      log(
+        `Experiment mode — injected experiment tools (epoch ${experiment.epoch}, remaining ${experimentRemaining(experiment.deadlineAt)})`,
+      );
+    }
 
     // Inject copilot respond-to-user tool if provider is copilot.
     // Defence-in-depth: also require an actual copilot config. Without this
@@ -3223,9 +3285,12 @@ async function processTask(
     const notConnectedGuide = needsConnection.length > 0
       ? `\n\n## Accounts not connected\nThis agent is configured to use tools that require the user to connect an account or add credentials, but the user has NOT connected/configured: ${needsConnection.map((n) => `${n.displayName} [provider: ${n.serverType}]`).join("; ")}.\nIf the user asks for something that needs one of these (e.g. reading email/calendar/files or checking code tools), do NOT pretend to have access or fabricate results. Instead, call the \`suggest-connection\` tool with the matching provider to post a setup card in the thread, and briefly tell the user you've added it. Call it once per provider; then continue with whatever you can do without that account.`
       : "";
+    const experimentGuide = experiment
+      ? `\n\n## Experiment mode\nYou are in a time-boxed experiment (epoch ${experiment.epoch}; deadline ${experiment.deadlineAt}; focus ${experiment.focus ?? "unspecified"}). You cannot finish early — end-experiment refuses before the deadline. Loop: read the ledger → declare a hypothesis (experiment-ledger action=hypothesis) → gather PROOF in the sandbox (failing test, benchmark delta, profile) → record the finding with its proof path. Never re-test refuted hypotheses. If your current lead dies, pick a different subsystem. Prose without a recorded finding is wasted time.`
+      : "";
     const effectiveSystemPrompt = ((channelId
       ? `${basePrompt}${citationGuide}${SPACES_MENTION_GUIDE}`
-      : `${basePrompt}${citationGuide}`) + twinMandate) + notConnectedGuide;
+      : `${basePrompt}${citationGuide}`) + twinMandate) + notConnectedGuide + experimentGuide;
     // Proof (twin mention flow only) that BOTH prompt changes actually reach the
     // model: the twin_deliver mandate + its who/where line in the SYSTEM prompt,
     // and the "@mentioned by" note in the USER-prompt context. Grep the run logs

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -3315,6 +3315,10 @@ async function processTask(
         userId,
         task,
         context: fullContext,
+        // Automation/scheduled runs draw from the low-priority LiteLLM key so
+        // batch fleets can't queue interactive mentions (same predicate as the
+        // read-only sandbox routing above).
+        automationRun: isReadOnlyJob,
         userName,
         userEmail,
         customTools: tools,

--- a/apps/xyne-claw/src/session-skills.ts
+++ b/apps/xyne-claw/src/session-skills.ts
@@ -15,6 +15,7 @@
 import { join, resolve } from "node:path";
 import { mkdir, writeFile, rm } from "node:fs/promises";
 import { PATHS } from "./config.js";
+import { documentBufferToMarkdown } from "./attachment-ingest.js";
 
 import { createLogger } from "./logger.js";
 const log = createLogger("session-skills");
@@ -66,6 +67,68 @@ function isBinaryContentType(contentType: string | undefined | null, relativePat
     ".bin", ".dat",
   ]);
   return BINARY_EXTS.has(ext);
+}
+
+// ── Skill-document markdown extraction ──────────────────────────────────────
+// Binary documents bundled in a skill (PDF/DOCX/XLSX/PPTX) are written to disk
+// as raw bytes for tool use — but the model can't read bytes, so a skill that
+// ships a handbook.pdf as KNOWLEDGE silently behaves as if it were empty. Fix:
+// at materialization we run the SAME converters the chat-attachment pipeline
+// uses (attachment-ingest.ts) and emit a `<name>.md` sibling next to the
+// binary. Raw file stays for tools; the .md sibling makes the text readable.
+// Always on: conversion never throws (error-stub contract), is size-capped
+// and time-boxed below, so there is nothing a kill switch would save us from.
+
+/** Skip conversion above this size — a hostile/huge document must not stall run startup. */
+const SKILL_MD_MAX_BYTES = 25 * 1024 * 1024;
+/** Per-file conversion budget; on timeout the raw binary is still materialized. */
+const SKILL_MD_TIMEOUT_MS = 20_000;
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolvePromise, reject) => {
+    const t = setTimeout(() => reject(new Error(`${label}: conversion timed out after ${ms}ms`)), ms);
+    p.then(
+      (v) => { clearTimeout(t); resolvePromise(v); },
+      (e) => { clearTimeout(t); reject(e); },
+    );
+  });
+}
+
+/**
+ * Best-effort: write `<binaryPath>.md` with the document's extracted text.
+ * Never throws — on failure/timeout/unsupported type the run proceeds with
+ * just the raw binary (exactly yesterday's behavior). `authorPaths` guards
+ * precedence: if the skill already ships `<binaryPath>.md`, the author's
+ * file wins and no auto-generated sibling is written.
+ */
+async function writeMarkdownSibling(
+  skillSubdir: string,
+  safePath: string,
+  buf: Buffer,
+  contentType: string | null | undefined,
+  authorPaths: ReadonlySet<string>,
+): Promise<void> {
+  const siblingRel = `${safePath}.md`;
+  if (authorPaths.has(siblingRel)) return; // author-provided .md wins
+  if (buf.length > SKILL_MD_MAX_BYTES) {
+    log.warn(`[skill] Skipped md-conversion of ${safePath}: ${buf.length} bytes > ${SKILL_MD_MAX_BYTES} cap`);
+    return;
+  }
+  const startedAt = Date.now();
+  try {
+    const markdown = await withTimeout(
+      documentBufferToMarkdown(buf, safePath, contentType ?? ""),
+      SKILL_MD_TIMEOUT_MS,
+      safePath,
+    );
+    if (markdown === null) return; // not a convertible document type
+    await writeFile(join(skillSubdir, siblingRel), markdown, "utf8");
+    log.info(`[skill] Converted ${safePath} → ${siblingRel} (${buf.length}B in ${Date.now() - startedAt}ms)`);
+  } catch (err) {
+    log.warn(
+      `[skill] md-conversion failed for ${safePath} after ${Date.now() - startedAt}ms (raw file kept): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 interface SplitContent {
@@ -209,6 +272,13 @@ export async function writeSessionSkills(
     // but re-check defensively here so a hand-rolled /run caller can't
     // smuggle in absolute paths or '..' traversal.
     if (skill.files && skill.files.length > 0) {
+      // Author-provided paths, normalized — used by writeMarkdownSibling so an
+      // intentional `doc.pdf.md` in the upload is never clobbered by ours.
+      const authorPaths = new Set(
+        skill.files
+          .map((f) => normalizeRelativePath(f.relativePath))
+          .filter((p): p is string => p !== null),
+      );
       for (const f of skill.files) {
         const safePath = normalizeRelativePath(f.relativePath);
         if (!safePath) {
@@ -220,6 +290,10 @@ export async function writeSessionSkills(
         if (isBinaryContentType(f.contentType, safePath)) {
           const buf = Buffer.from(f.content, "base64");
           await writeFile(filePath, buf);
+          // PDF/DOCX/XLSX/PPTX knowledge docs: also emit the extracted-text
+          // sibling so the model can read them (chat attachments already get
+          // this via the same converters in attachment-ingest.ts).
+          await writeMarkdownSibling(skillSubdir, safePath, buf, f.contentType, authorPaths);
         } else {
           await writeFile(filePath, f.content, "utf8");
         }

--- a/apps/xyne-claw/src/subagent-tools.ts
+++ b/apps/xyne-claw/src/subagent-tools.ts
@@ -22,7 +22,7 @@ import { workspacePath } from "./workspace.js";
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import { AGENT, LITELLM, SERVER } from "./config.js";
 import { ensureSessionDebugDir, sessionDir } from "./session-store.js";
-import { SUBAGENT_DEFINITIONS, getSandboxSession, probeSession, REPO_CONFIGS, buildSandboxStoreKey, type SubagentDefinition, type SetupStep } from "xyne-claw-shared";
+import { SUBAGENT_DEFINITIONS, findSubagentDefinitionForServer, getSandboxSession, probeSession, REPO_CONFIGS, buildSandboxStoreKey, type SubagentDefinition, type SetupStep } from "xyne-claw-shared";
 import type { McpToolGroup } from "./mcp.js";
 import { resolveModel, applyCopilotProxyIfNeeded, capCustomToolOutput, pushDebugProgress, pushInvocation, type CopilotConfig, type ClaudeConfig, type CodexConfig, type DebugEventRecord, type ProgressDest, type ToolInvocation } from "./agent.js";
 import { compactionExtension } from "./compaction-extension.js";
@@ -1468,7 +1468,7 @@ export function buildSubagentTools(
   };
 
   for (const group of groups) {
-    const def = SUBAGENT_DEFINITIONS.find((d) => d.serverType === group.serverType);
+    const def = findSubagentDefinitionForServer(group.serverType);
 
     if (def) {
       // Split write tools out as direct (they need user approval in the parent agent)
@@ -1514,7 +1514,7 @@ export function buildSubagentTools(
     }
 
     for (const [source, tools] of customBySource) {
-      const def = SUBAGENT_DEFINITIONS.find((d) => d.serverType === source);
+      const def = findSubagentDefinitionForServer(source);
       if (def && tools.length > 0) {
         const customSkills = subagentSkills?.[def.name] ?? subagentSkills?.["__default"];
         // The sandbox subagent must not see sandbox-destroy — child LLMs were

--- a/apps/xyne-claw/src/tool-catalog.ts
+++ b/apps/xyne-claw/src/tool-catalog.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { SUBAGENT_DEFINITIONS } from "xyne-claw-shared";
+import { SUBAGENT_DEFINITIONS, findSubagentDefinitionForServer } from "xyne-claw-shared";
 import type { McpToolGroup } from "./mcp.js";
 import type { CustomSubagentSpec } from "./subagent-tools.js";
 
@@ -105,7 +105,7 @@ export function buildToolCatalog(params: {
   const seen = new Set<string>();
 
   for (const group of params.groups) {
-    const def = SUBAGENT_DEFINITIONS.find((d) => d.serverType === group.serverType);
+    const def = findSubagentDefinitionForServer(group.serverType);
     if (!def) continue;
     const writeSet = new Set(group.writeTools.map(String));
     for (const tool of group.tools) {
@@ -146,7 +146,7 @@ export function buildFastModeDirectTools(params: {
   const remainingCustomTools: ToolDefinition[] = [];
 
   for (const group of params.groups) {
-    const def = SUBAGENT_DEFINITIONS.find((d) => d.serverType === group.serverType);
+    const def = findSubagentDefinitionForServer(group.serverType);
     if (!def) {
       directTools.push(...group.tools);
       continue;
@@ -163,7 +163,7 @@ export function buildFastModeDirectTools(params: {
   for (const tool of params.customTools ?? []) {
     const source = customToolSource(tool);
     const wrappedBySubagent = source
-      ? SUBAGENT_DEFINITIONS.some((def) => def.serverType === source)
+      ? findSubagentDefinitionForServer(source) !== undefined
       : false;
     if (!wrappedBySubagent) {
       remainingCustomTools.push(tool);

--- a/apps/xyne-claw/src/tool-resolution.ts
+++ b/apps/xyne-claw/src/tool-resolution.ts
@@ -1,0 +1,231 @@
+/**
+ * tool-resolution.ts — THE single derivation of an agent's effective toolset.
+ *
+ * Before this module, membership was derived twice (buildSubagentTools for
+ * normal mode; buildFastModeDirectTools + buildToolCatalog for fast mode) and
+ * authorized three times (run.ts main filter, run.ts nested-A2A filter, and
+ * catalog-source checks embedded in the main filter) — with real divergence:
+ * definition-less servers (github-mcp-npx) were invisible to the fast catalog
+ * while passing through normal mode, and the nested filter's fallthrough was
+ * permissive where the main one was per-source.
+ *
+ * This module resolves ONCE — wrap → classify writes → authorize, recording a
+ * reason for every exclusion — and the two modes become PRESENTATIONS of the
+ * same resolved set (see presentAsFastCatalog / the run.ts wiring). Invariant,
+ * enforced by test/tool-resolution.test.ts: fast mode's (catalog ∪ direct)
+ * name-set equals normal mode's effective membership for identical input.
+ *
+ * Diagnostics are first-class: a server that failed to list stays in
+ * `servers[]` with its error, and report() renders one line per server so a
+ * run's log (and search-tools misses) can say "github failed to load: X"
+ * instead of handing the model an absence it will confabulate a cause for.
+ */
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import {
+  findSubagentDefinitionForServer,
+  type AgentToolsConfig,
+  type SubagentDefinition,
+} from "xyne-claw-shared";
+import type { McpToolGroup } from "./mcp.js";
+
+/** A listed (or failed) tool server, wrapper-resolved. */
+export interface ResolvedServer {
+  serverType: string;
+  serverName: string;
+  /** Definition wrapping this server (alias-aware) — null for def-less servers,
+   *  which remain first-class under the pseudo-source `server:<type>`. */
+  wrapper: SubagentDefinition | null;
+  tools: ToolDefinition[];
+  writeTools: ReadonlySet<string>;
+  /** Listing failure — server is kept visible so absence ≠ silence. */
+  error?: string;
+}
+
+export type ToolVerdict =
+  | { allowed: true; reason: string }
+  | { allowed: false; reason: string };
+
+export interface ResolvedTool {
+  tool: ToolDefinition;
+  server: ResolvedServer;
+  /** Catalog/source label: `subagent:<wrapper>` or `server:<type>`. */
+  source: string;
+  isWrite: boolean;
+  verdict: ToolVerdict;
+}
+
+export interface ToolResolution {
+  servers: ResolvedServer[];
+  tools: ResolvedTool[];
+  allowed: ResolvedTool[];
+  /** One line per server: counts, verdicts, and load errors. */
+  report(): string;
+  /** Human hints for servers that contributed nothing — failed or fully denied.
+   *  Surfaced on search-tools misses so agents report facts, not theories. */
+  missingServerHints(): string[];
+}
+
+export interface ResolveToolsInput {
+  groups: McpToolGroup[];
+  /** Servers that failed to list — carried through as error entries. */
+  failedGroups?: Array<{ serverType: string; serverName: string; error: string }>;
+  toolsConfig?: AgentToolsConfig | undefined;
+}
+
+function extractRuntimeToolName(name: string): string {
+  const idx = name.lastIndexOf("__");
+  return idx >= 0 ? name.slice(idx + 2) : name;
+}
+
+/**
+ * The direct-pick name matching, ported VERBATIM from run.ts selectedAsDirect
+ * (five conventions — bare, suffix, prefixed-config, normalized, selectionKey).
+ * Load-bearing for existing agent configs; do not "simplify".
+ */
+export function matchesDirectPick(tool: ToolDefinition, allowedDirect: readonly string[]): boolean {
+  const norm = (s: string): string => s.toLowerCase().replace(/_/g, "-");
+  const toolSelectionKey = (tool as { selectionKey?: string }).selectionKey;
+  return allowedDirect.some(
+    (d) =>
+      tool.name === d ||
+      tool.name.endsWith(d) ||
+      d.endsWith(`__${tool.name}`) ||
+      norm(tool.name) === norm(d) ||
+      (toolSelectionKey ? d === toolSelectionKey : false),
+  );
+}
+
+/**
+ * Authorization for one tool. Grant units, in precedence order:
+ *  - no toolsConfig at all → everything allowed (backwards compatible);
+ *  - wrapper servers: allowed iff `tools.subagents` names the wrapper;
+ *  - def-less servers: allowed iff `tools.subagents` names the serverType
+ *    (its coherent grant unit — fixes the old fast-mode path where these
+ *    tools were dumped into directTools and killed by the name-gate),
+ *    OR the individual tool is direct/custom/gateway-picked;
+ *  - individual picks (direct 5-way match, custom selectionKey, gateway
+ *    serviceName) admit a tool regardless of wrapper grant, matching the
+ *    main filter's historical directTools branch.
+ */
+function authorize(
+  tool: ToolDefinition,
+  server: ResolvedServer,
+  cfg: AgentToolsConfig | undefined,
+): ToolVerdict {
+  if (!cfg) return { allowed: true, reason: "no tools config (all tools)" };
+  const subagents = new Set(cfg.subagents ?? []);
+  const custom = new Set(cfg.custom ?? []);
+  const gateway = new Set(cfg.gateway ?? []);
+
+  const grantUnit = server.wrapper?.name ?? server.serverType;
+  if (subagents.has(grantUnit)) {
+    return { allowed: true, reason: `subagent grant "${grantUnit}"` };
+  }
+  if (matchesDirectPick(tool, cfg.direct ?? [])) {
+    return { allowed: true, reason: "direct pick" };
+  }
+  const selectionKey = (tool as { selectionKey?: string }).selectionKey;
+  if (selectionKey && custom.has(selectionKey)) {
+    return { allowed: true, reason: `custom pick "${selectionKey}"` };
+  }
+  const serviceName = (tool as { serviceName?: string }).serviceName;
+  if (serviceName && gateway.has(serviceName)) {
+    return { allowed: true, reason: `gateway grant "${serviceName}"` };
+  }
+  return {
+    allowed: false,
+    reason: `not granted (needs tools.subagents:"${grantUnit}" or a direct/custom/gateway pick)`,
+  };
+}
+
+export function resolveTools(input: ResolveToolsInput): ToolResolution {
+  const servers: ResolvedServer[] = [];
+  const tools: ResolvedTool[] = [];
+
+  for (const group of input.groups) {
+    const wrapper = findSubagentDefinitionForServer(group.serverType) ?? null;
+    const server: ResolvedServer = {
+      serverType: group.serverType,
+      serverName: group.serverName,
+      wrapper,
+      tools: group.tools,
+      writeTools: new Set(group.writeTools.map(String)),
+    };
+    servers.push(server);
+    const source = wrapper ? `subagent:${wrapper.name}` : `server:${group.serverType}`;
+    for (const tool of group.tools) {
+      tools.push({
+        tool,
+        server,
+        source,
+        isWrite: server.writeTools.has(extractRuntimeToolName(tool.name)),
+        verdict: authorize(tool, server, input.toolsConfig),
+      });
+    }
+  }
+
+  for (const failed of input.failedGroups ?? []) {
+    servers.push({
+      serverType: failed.serverType,
+      serverName: failed.serverName,
+      wrapper: findSubagentDefinitionForServer(failed.serverType) ?? null,
+      tools: [],
+      writeTools: new Set(),
+      error: failed.error,
+    });
+  }
+
+  const allowed = tools.filter((t) => t.verdict.allowed);
+
+  const report = (): string =>
+    servers
+      .map((s) => {
+        if (s.error) return `${s.serverType}: FAILED to list (${s.error})`;
+        const mine = tools.filter((t) => t.server === s);
+        const ok = mine.filter((t) => t.verdict.allowed);
+        const denied = mine.length - ok.length;
+        const writes = ok.filter((t) => t.isWrite).length;
+        const via = s.wrapper ? `subagent:${s.wrapper.name}` : "def-less";
+        return `${s.serverType} (${via}): ${mine.length} tools, ${ok.length} allowed (${writes} write)${denied ? `, ${denied} denied: ${mine.find((t) => !t.verdict.allowed)?.verdict.reason}` : ""}`;
+      })
+      .join("\n");
+
+  const missingServerHints = (): string[] => {
+    const hints: string[] = [];
+    for (const s of servers) {
+      if (s.error) {
+        hints.push(`Server "${s.serverType}" failed to load its tools: ${s.error}`);
+        continue;
+      }
+      const mine = tools.filter((t) => t.server === s);
+      if (mine.length > 0 && mine.every((t) => !t.verdict.allowed)) {
+        hints.push(
+          `Server "${s.serverType}" is connected but excluded by this agent's tools config (${mine[0]?.verdict.reason}).`,
+        );
+      }
+    }
+    return hints;
+  };
+
+  return { servers, tools, allowed, report, missingServerHints };
+}
+
+// ── Fast-mode presentation ──────────────────────────────────────────────────
+
+export interface FastPresentation {
+  /** Always-active: allowed write tools (a human approves writes elsewhere in
+   *  the flow — burying them behind load-tools would only add latency). */
+  directTools: ResolvedTool[];
+  /** Lazy catalog: allowed read tools, loadable via search-tools/load-tools. */
+  catalogTools: ResolvedTool[];
+}
+
+/** Fast mode = same membership, lazy presentation. Writes direct, reads lazy. */
+export function presentAsFastCatalog(resolution: ToolResolution): FastPresentation {
+  const directTools: ResolvedTool[] = [];
+  const catalogTools: ResolvedTool[] = [];
+  for (const t of resolution.allowed) {
+    (t.isWrite ? directTools : catalogTools).push(t);
+  }
+  return { directTools, catalogTools };
+}

--- a/apps/xyne-claw/src/user-memory-curator.ts
+++ b/apps/xyne-claw/src/user-memory-curator.ts
@@ -36,7 +36,9 @@ import { createLogger } from "./logger.js";
 const log = createLogger("user-memory-curator");
 
 const LITELLM_URL = (process.env["LITELLM_URL"] ?? "https://grid.ai.example.com").replace(/\/$/, "");
-const LITELLM_API_KEY = process.env["LITELLM_API_KEY"] ?? "";
+// Background job: prefer the low-priority automation key so curator bursts
+// can't queue interactive agent turns on the main key's parallel-slot pool.
+const LITELLM_API_KEY = process.env["LITELLM_AUTOMATION_API_KEY"]?.trim() || (process.env["LITELLM_API_KEY"] ?? "");
 // Model name passed to LiteLLM for the distill call. Reads from `LITELLM_MODEL`
 // to share the same env var with other LiteLLM-backed paths in this service
 // (avoids having to keep two model env vars in sync when we upgrade Haiku).

--- a/apps/xyne-claw/test/session-skills-md.test.ts
+++ b/apps/xyne-claw/test/session-skills-md.test.ts
@@ -1,0 +1,127 @@
+/**
+ * session-skills-md.test.ts — markdown-sibling extraction for binary skill
+ * documents (PDF/DOCX/…) at materialization time. Covers the report's
+ * validation plan: unsupported types produce nothing, corrupt documents never
+ * fail the materialization (raw binary kept, no .md), and an author-provided
+ * `<name>.pdf.md` always wins over auto-generation.
+ */
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { readFile, access } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// PATHS.dataDir is read at module load — point it at a temp dir BEFORE the
+// import so test artifacts never land in ./data.
+process.env["XYNE_CLAW_DATA_DIR"] = join(tmpdir(), `skill-md-test-${Date.now()}`);
+
+const { writeSessionSkills, deleteSessionSkills } = await import("../src/session-skills.js");
+const { documentBufferToMarkdown } = await import("../src/attachment-ingest.js");
+
+/** Minimal single-page PDF with the literal text "Hello Skill" — small enough
+ *  to inline, real enough for unpdf's extractText. */
+const MINIMAL_PDF = Buffer.from(
+  `%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 72 720 Td (Hello Skill) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+trailer<</Size 6/Root 1 0 R>>
+startxref
+0
+%%EOF`,
+  "latin1",
+);
+
+const scopes: string[] = [];
+function scope(name: string): string {
+  const s = `${name}-${Date.now()}`;
+  scopes.push(s);
+  return s;
+}
+
+afterEach(async () => {
+  while (scopes.length) await deleteSessionSkills(scopes.pop()!);
+});
+
+const baseSkill = { name: "Doc Skill", slug: "doc-skill", content: "# Doc skill\nRead the bundled docs." };
+
+describe("documentBufferToMarkdown", () => {
+  it("returns null for unsupported types", async () => {
+    expect(await documentBufferToMarkdown(Buffer.from("PNGDATA"), "logo.png", "image/png")).toBeNull();
+    expect(await documentBufferToMarkdown(Buffer.from("bytes"), "data.bin", "application/octet-stream")).toBeNull();
+  });
+
+  it("extracts text from a PDF buffer", async () => {
+    const md = await documentBufferToMarkdown(MINIMAL_PDF, "hello.pdf", "application/pdf");
+    expect(md).not.toBeNull();
+    expect(md).toContain("Hello Skill");
+  });
+});
+
+describe("writeSessionSkills markdown siblings", () => {
+  it("writes <name>.pdf.md next to a bundled PDF", async () => {
+    const s = scope("pdf-ok");
+    const dir = await writeSessionSkills(s, [
+      {
+        ...baseSkill,
+        files: [{ relativePath: "docs/hello.pdf", content: MINIMAL_PDF.toString("base64"), contentType: "application/pdf" }],
+      },
+    ]);
+    expect(dir).not.toBeNull();
+    const raw = await readFile(join(dir!, "doc-skill", "docs", "hello.pdf"));
+    expect(raw.subarray(0, 4).toString("latin1")).toBe("%PDF");
+    const md = await readFile(join(dir!, "doc-skill", "docs", "hello.pdf.md"), "utf8");
+    expect(md).toContain("Hello Skill");
+  });
+
+  it("keeps the raw binary and writes a visible error stub for a corrupt PDF (never throws)", async () => {
+    const s = scope("pdf-corrupt");
+    const dir = await writeSessionSkills(s, [
+      {
+        ...baseSkill,
+        files: [{ relativePath: "broken.pdf", content: Buffer.from("not a pdf at all").toString("base64"), contentType: "application/pdf" }],
+      },
+    ]);
+    expect(dir).not.toBeNull();
+    await access(join(dir!, "doc-skill", "broken.pdf")); // raw file materialized
+    // pdfBufferToMarkdown never throws — corrupt input yields an error-stub
+    // sibling (same contract as chat attachments) so the failure is visible
+    // to the model instead of silent.
+    const md = await readFile(join(dir!, "doc-skill", "broken.pdf.md"), "utf8");
+    expect(md).toContain("Failed to extract PDF text");
+  });
+
+  it("never clobbers an author-provided .pdf.md sibling", async () => {
+    const s = scope("author-md");
+    const authored = "# Authored summary — do not overwrite";
+    const dir = await writeSessionSkills(s, [
+      {
+        ...baseSkill,
+        files: [
+          { relativePath: "guide.pdf", content: MINIMAL_PDF.toString("base64"), contentType: "application/pdf" },
+          { relativePath: "guide.pdf.md", content: authored, contentType: "text/markdown" },
+        ],
+      },
+    ]);
+    const md = await readFile(join(dir!, "doc-skill", "guide.pdf.md"), "utf8");
+    expect(md).toBe(authored);
+  });
+
+  it("writes no sibling for non-document binaries", async () => {
+    const s = scope("png");
+    const dir = await writeSessionSkills(s, [
+      {
+        ...baseSkill,
+        files: [{ relativePath: "logo.png", content: Buffer.from("fakepng").toString("base64"), contentType: "image/png" }],
+      },
+    ]);
+    await access(join(dir!, "doc-skill", "logo.png"));
+    await expect(access(join(dir!, "doc-skill", "logo.png.md"))).rejects.toThrow();
+  });
+});

--- a/apps/xyne-claw/test/tool-catalog-alias.test.ts
+++ b/apps/xyne-claw/test/tool-catalog-alias.test.ts
@@ -1,0 +1,54 @@
+/**
+ * tool-catalog-alias.test.ts — regression for the 2026-07-30 incident: prod's
+ * active GitHub connector is registered as serverType "github-mcp-npx", which
+ * had no SUBAGENT_DEFINITIONS entry, so buildToolCatalog dropped its whole
+ * group and fast-mode agents saw ZERO GitHub tools (while normal mode passed
+ * them through fine). Alias-aware lookup must route alias types into the fast
+ * catalog under the canonical subagent source, and the write split must
+ * behave identically for alias and canonical types.
+ */
+import { describe, it, expect } from "vitest";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { findSubagentDefinitionForServer } from "xyne-claw-shared";
+import { buildToolCatalog, buildFastModeDirectTools } from "../src/tool-catalog.js";
+import type { McpToolGroup } from "../src/mcp.js";
+
+function tool(name: string, description = `${name} desc`): ToolDefinition {
+  return { name, description, parameters: { type: "object", properties: {} } } as unknown as ToolDefinition;
+}
+
+const githubNpxGroup: McpToolGroup = {
+  serverType: "github-mcp-npx",
+  serverName: "GitHub",
+  tools: [tool("GitHub__create_pull_request"), tool("GitHub__search_code"), tool("GitHub__merge_pull_request")],
+  writeTools: ["merge_pull_request"],
+};
+
+describe("subagent definition alias lookup", () => {
+  it("resolves github-mcp-npx to the github definition", () => {
+    const def = findSubagentDefinitionForServer("github-mcp-npx");
+    expect(def?.name).toBe("github");
+    expect(findSubagentDefinitionForServer("github")?.name).toBe("github");
+  });
+
+  it("still returns undefined for genuinely unknown server types", () => {
+    expect(findSubagentDefinitionForServer("no-such-server")).toBeUndefined();
+  });
+});
+
+describe("fast-mode catalog with alias server type", () => {
+  it("includes alias-group read tools under the canonical subagent source", () => {
+    const items = buildToolCatalog({ groups: [githubNpxGroup] });
+    const names = items.map((i) => i.entry.name);
+    expect(names).toContain("GitHub__create_pull_request");
+    expect(names).toContain("GitHub__search_code");
+    // write tools never enter the lazy catalog — they go always-active direct
+    expect(names).not.toContain("GitHub__merge_pull_request");
+    for (const i of items) expect(i.entry.source).toBe("subagent:github");
+  });
+
+  it("splits alias-group write tools into always-active direct tools", () => {
+    const { directTools } = buildFastModeDirectTools({ groups: [githubNpxGroup] });
+    expect(directTools.map((t) => t.name)).toEqual(["GitHub__merge_pull_request"]);
+  });
+});

--- a/apps/xyne-claw/test/tool-resolution.test.ts
+++ b/apps/xyne-claw/test/tool-resolution.test.ts
@@ -1,0 +1,106 @@
+/**
+ * tool-resolution.test.ts — the single-derivation contract:
+ *  - alias and def-less servers are first-class (the github-mcp-npx incident);
+ *  - authorization matches the historical run.ts filter semantics (5-way
+ *    direct match, subagent grants, custom/gateway picks, no-config = all);
+ *  - every exclusion carries a reason; failed servers stay visible;
+ *  - PARITY: fast presentation (direct ∪ catalog) ≡ allowed set.
+ */
+import { describe, it, expect } from "vitest";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { resolveTools, presentAsFastCatalog, matchesDirectPick } from "../src/tool-resolution.js";
+import type { McpToolGroup } from "../src/mcp.js";
+
+function tool(name: string, extra?: Record<string, unknown>): ToolDefinition {
+  return { name, description: `${name} d`, parameters: { type: "object", properties: {} }, ...extra } as unknown as ToolDefinition;
+}
+function group(serverType: string, tools: ToolDefinition[], writeTools: string[] = []): McpToolGroup {
+  return { serverType, serverName: serverType, tools, writeTools };
+}
+
+const bitbucket = group("bitbucket", [tool("Bitbucket__get_pull_request"), tool("Bitbucket__create_pull_request")], ["create_pull_request"]);
+const githubNpx = group("github-mcp-npx", [tool("GitHub__search_code"), tool("GitHub__merge_pull_request")], ["merge_pull_request"]);
+const defLess = group("research-agent-mcp", [tool("Research__lookup")]);
+const gatewayGroup = group("gateway-svc", [tool("Mettle__query", { serviceName: "mettle" })]);
+
+describe("resolveTools", () => {
+  it("no toolsConfig → everything allowed (backwards compatible)", () => {
+    const r = resolveTools({ groups: [bitbucket, githubNpx, defLess] });
+    expect(r.allowed.length).toBe(5);
+    expect(r.tools.every((t) => t.verdict.allowed)).toBe(true);
+  });
+
+  it("alias server resolves to canonical wrapper and its allowlist identity", () => {
+    const r = resolveTools({ groups: [githubNpx], toolsConfig: { subagents: ["github"] } });
+    expect(r.allowed.map((t) => t.tool.name).sort()).toEqual(["GitHub__merge_pull_request", "GitHub__search_code"]);
+    expect(r.allowed[0]?.source).toBe("subagent:github");
+  });
+
+  it("def-less server grants by serverType in tools.subagents", () => {
+    const r = resolveTools({ groups: [defLess], toolsConfig: { subagents: ["research-agent-mcp"] } });
+    expect(r.allowed.map((t) => t.tool.name)).toEqual(["Research__lookup"]);
+    expect(r.allowed[0]?.source).toBe("server:research-agent-mcp");
+  });
+
+  it("ungranted servers are denied WITH a reason (never silently absent)", () => {
+    const r = resolveTools({ groups: [githubNpx], toolsConfig: { subagents: ["bitbucket"] } });
+    expect(r.allowed).toEqual([]);
+    expect(r.tools[0]?.verdict.allowed).toBe(false);
+    expect(r.tools[0]?.verdict.reason).toContain("github");
+    expect(r.missingServerHints().join(" ")).toContain("github-mcp-npx");
+  });
+
+  it("individual direct pick admits a tool without its wrapper grant", () => {
+    const r = resolveTools({ groups: [bitbucket], toolsConfig: { subagents: [], direct: ["Bitbucket__get_pull_request"] } });
+    expect(r.allowed.map((t) => t.tool.name)).toEqual(["Bitbucket__get_pull_request"]);
+  });
+
+  it("gateway serviceName grant admits gateway tools", () => {
+    const r = resolveTools({ groups: [gatewayGroup], toolsConfig: { subagents: [], gateway: ["mettle"] } });
+    expect(r.allowed.map((t) => t.tool.name)).toEqual(["Mettle__query"]);
+  });
+
+  it("failed servers stay visible in servers[], report(), and hints", () => {
+    const r = resolveTools({
+      groups: [bitbucket],
+      failedGroups: [{ serverType: "github-mcp-npx", serverName: "GitHub", error: "spawn timeout" }],
+      toolsConfig: { subagents: ["bitbucket"] },
+    });
+    expect(r.servers.some((s) => s.error === "spawn timeout")).toBe(true);
+    expect(r.report()).toContain("FAILED to list (spawn timeout)");
+    expect(r.missingServerHints().join(" ")).toContain("spawn timeout");
+  });
+
+  it("write classification uses the runtime tool name (suffix after __)", () => {
+    const r = resolveTools({ groups: [bitbucket, githubNpx] });
+    const writes = r.tools.filter((t) => t.isWrite).map((t) => t.tool.name).sort();
+    expect(writes).toEqual(["Bitbucket__create_pull_request", "GitHub__merge_pull_request"]);
+  });
+});
+
+describe("matchesDirectPick — the five historical conventions", () => {
+  it("bare, suffix, prefixed-config, normalized, selectionKey", () => {
+    expect(matchesDirectPick(tool("user-send-message"), ["user-send-message"])).toBe(true);
+    expect(matchesDirectPick(tool("Xyne__user-send-message"), ["user-send-message"])).toBe(true);
+    expect(matchesDirectPick(tool("apps-send-message"), ["xyne-spaces-app-tools__apps-send-message"])).toBe(true);
+    expect(matchesDirectPick(tool("Xyne_Spaces_App_Tools__apps-send-message"), ["xyne-spaces-app-tools__apps-send-message"])).toBe(true);
+    expect(matchesDirectPick(tool("anything", { selectionKey: "custom:webfetch" }), ["custom:webfetch"])).toBe(true);
+    expect(matchesDirectPick(tool("unrelated"), ["other-tool"])).toBe(false);
+  });
+});
+
+describe("presentAsFastCatalog — parity invariant", () => {
+  it("direct ∪ catalog ≡ allowed, split exactly by isWrite", () => {
+    const r = resolveTools({
+      groups: [bitbucket, githubNpx, defLess],
+      toolsConfig: { subagents: ["bitbucket", "github", "research-agent-mcp"] },
+    });
+    const { directTools, catalogTools } = presentAsFastCatalog(r);
+    const union = [...directTools, ...catalogTools].map((t) => t.tool.name).sort();
+    expect(union).toEqual(r.allowed.map((t) => t.tool.name).sort());
+    expect(directTools.every((t) => t.isWrite)).toBe(true);
+    expect(catalogTools.every((t) => !t.isWrite)).toBe(true);
+    // the incident case: github-mcp-npx read tool present in the fast catalog
+    expect(catalogTools.map((t) => t.tool.name)).toContain("GitHub__search_code");
+  });
+});

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -26,7 +26,13 @@ export type FlowComponentType =
   | 'plan'
   | 'pr'
   | 'pr_approval'
-  | 'call_schedule';
+  | 'call_schedule'
+  | 'connectAccount'
+  | 'mcpConfigure'
+  | 'agentCreation'
+  | 'entityUpdate'
+  | 'skillCreation'
+  | 'skillUpdate';
 
 export interface FlowComponent {
   id: string;
@@ -188,4 +194,3 @@ export function isFlowDefinition(obj: unknown): obj is FlowDefinition {
     Array.isArray((obj as Record<string, unknown>).components)
   );
 }
-

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -335,6 +335,184 @@ export type ExecTodoStatus = ExecTodo['status'];
 export type PlanProps = z.infer<typeof planPropsSchema>;
 export type PlanPhase = PlanProps['phase'];
 
+// ── Agent-creation artifact ─────────────────────────────────────────────────
+// A single card for the create-agent HITL flow that updates IN PLACE across
+// three phases on the same message (like the plan card):
+//   pending  → shows the proposed agent + Approve/Decline buttons (the buttons
+//              reuse the write-tool actionIds; the signed action rides in
+//              flowJSON.data, not props).
+//   created  → approved; Created chip, no buttons.
+//   rejected → declined; Rejected chip, no buttons.
+// The system prompt is carried on every phase so the card can reveal it when the
+// node is expanded. Field set is phase-INVARIANT (presentation varies, not the
+// shape) so a flat object beats a four-branch discriminated union — same
+// reasoning as the PR card above. `.strict()` so the emitter can't drift.
+export const agentCreationPhaseSchema = z.enum(['pending', 'created', 'rejected']);
+
+export const agentCreationPropsSchema = z
+  .object({
+    phase: agentCreationPhaseSchema,
+    name: z.string().min(1),
+    slug: z.string().min(1),
+    description: z.string().optional(),
+    // The full system prompt — revealed in the expanded view. Optional so a
+    // rejected card can omit it if the emitter chooses.
+    systemPrompt: z.string().optional(),
+    modelId: z.string().optional(),
+    // Granted tool/subagent identifiers, shown as capability chips.
+    tools: z.array(z.string()).optional(),
+    connectLinks: z.array(z.object({
+      serverType: z.string().min(1),
+      displayName: z.string().min(1),
+      authUrl: z.string().url(),
+    }).strict()).optional(),
+    // A muted footnote (e.g. "skipped unknown tools: …").
+    note: z.string().optional(),
+    // Audit for the decided phases.
+    decidedBy: z.string().optional(),
+    decidedAt: z.string().optional(),
+  })
+  .strict();
+
+export const agentCreationComponentSchema = baseComponentSchema.extend({
+  type: z.literal('agentCreation'),
+  props: agentCreationPropsSchema,
+});
+
+export type AgentCreationProps = z.infer<typeof agentCreationPropsSchema>;
+export type AgentCreationPhase = AgentCreationProps['phase'];
+
+// ── Entity-update artifact ──────────────────────────────────────────────────
+// The owner-facing approval card for a proposed agent/subagent update. ONE node
+// type serves both kinds (they differ only in labels), updated IN PLACE across
+// phases on the same message, exactly like the agentCreation card:
+//   pending  → diff + field changes + Approve/Decline (actionIds
+//              `${kind}-update-approve` / `-decline`; request identity rides in
+//              flowJSON.data, not props).
+//   approved → applied; Approved chip, no buttons.
+//   rejected → declined; Rejected chip, no buttons.
+// The diff is precomputed server-side (computeSkillDiff) and shipped as
+// structured hunks so the renderer owns presentation; `truncated` says the
+// visible diff was capped (the FULL content is applied via the integrity hash).
+export const entityUpdatePhaseSchema = z.enum(['pending', 'approved', 'rejected']);
+export const entityUpdateKindSchema = z.enum(['agent', 'subagent']);
+
+export const entityUpdateDiffLineSchema = z
+  .object({
+    kind: z.enum(['ctx', 'add', 'del']),
+    text: z.string(),
+  })
+  .strict();
+
+export const entityUpdateDiffHunkSchema = z
+  .object({
+    header: z.string(),
+    lines: z.array(entityUpdateDiffLineSchema),
+  })
+  .strict();
+
+export const entityUpdatePropsSchema = z
+  .object({
+    phase: entityUpdatePhaseSchema,
+    kind: entityUpdateKindSchema,
+    /** Display name of the target definition. */
+    targetName: z.string().min(1),
+    /** slug (agent) or name (subagent) of the target. */
+    targetKey: z.string().min(1),
+    proposerName: z.string().min(1),
+    summary: z.string().optional(),
+    /** Changed scalar fields (rename, model swap, …). */
+    fieldChanges: z.array(z.object({ label: z.string(), from: z.string(), to: z.string() }).strict()).optional(),
+    /** systemPrompt diff. Absent when only scalars changed. */
+    diff: z
+      .object({
+        added: z.number().int().nonnegative(),
+        removed: z.number().int().nonnegative(),
+        hunks: z.array(entityUpdateDiffHunkSchema),
+      })
+      .strict()
+      .optional(),
+    /** True when the visible hunks were capped for display. */
+    truncated: z.boolean().optional(),
+    /** Muted footnote (e.g. "already resolved elsewhere"). */
+    note: z.string().optional(),
+    // Audit for the decided phases.
+    decidedBy: z.string().optional(),
+    decidedAt: z.string().optional(),
+  })
+  .strict();
+
+export const entityUpdateComponentSchema = baseComponentSchema.extend({
+  type: z.literal('entityUpdate'),
+  props: entityUpdatePropsSchema,
+});
+
+export type EntityUpdateProps = z.infer<typeof entityUpdatePropsSchema>;
+export type EntityUpdatePhase = EntityUpdateProps['phase'];
+export type EntityUpdateDiffHunk = z.infer<typeof entityUpdateDiffHunkSchema>;
+
+// ── Skill creation / update artifacts ───────────────────────────────────────
+// Skill creation reuses the write-tool approval path (`approve-write` /
+// `decline-write`) but renders as a first-class artifact so the proposed
+// SKILL.md can be reviewed as rich markdown in the expanded document preview.
+export const skillCreationPhaseSchema = z.enum(['pending', 'created', 'rejected']);
+
+export const skillCreationPropsSchema = z
+  .object({
+    phase: skillCreationPhaseSchema,
+    name: z.string().min(1),
+    slug: z.string().min(1),
+    description: z.string().optional(),
+    content: z.string().optional(),
+    note: z.string().optional(),
+    decidedBy: z.string().optional(),
+    decidedAt: z.string().optional(),
+  })
+  .strict();
+
+export const skillCreationComponentSchema = baseComponentSchema.extend({
+  type: z.literal('skillCreation'),
+  props: skillCreationPropsSchema,
+});
+
+export type SkillCreationProps = z.infer<typeof skillCreationPropsSchema>;
+export type SkillCreationPhase = SkillCreationProps['phase'];
+
+// Skill update mirrors entityUpdate's structured diff, but the target is always
+// a SKILL.md document and the buttons use the dedicated skill-update action ids.
+export const skillUpdatePhaseSchema = z.enum(['pending', 'approved', 'rejected']);
+
+export const skillUpdatePropsSchema = z
+  .object({
+    phase: skillUpdatePhaseSchema,
+    skillName: z.string().min(1),
+    skillSlug: z.string().min(1),
+    proposerName: z.string().min(1),
+    summary: z.string().optional(),
+    diff: z
+      .object({
+        added: z.number().int().nonnegative(),
+        removed: z.number().int().nonnegative(),
+        hunks: z.array(entityUpdateDiffHunkSchema),
+      })
+      .strict()
+      .optional(),
+    diffText: z.string().optional(),
+    truncated: z.boolean().optional(),
+    note: z.string().optional(),
+    decidedBy: z.string().optional(),
+    decidedAt: z.string().optional(),
+  })
+  .strict();
+
+export const skillUpdateComponentSchema = baseComponentSchema.extend({
+  type: z.literal('skillUpdate'),
+  props: skillUpdatePropsSchema,
+});
+
+export type SkillUpdateProps = z.infer<typeof skillUpdatePropsSchema>;
+export type SkillUpdatePhase = SkillUpdateProps['phase'];
+
 // ── PR artifact ───────────────────────────────────────────────────────────
 // A read-only status card for a pull request. Unlike the plan, the field set is
 // status-INVARIANT: every status carries the same fields, and the only thing
@@ -500,6 +678,50 @@ export type DurationMinutes = z.infer<typeof durationMinutesSchema>;
 export type CallScheduleProps = z.infer<typeof callSchedulePropsSchema>;
 export type CallSchedulePhase = CallScheduleProps['phase'];
 
+export const connectAccountPropsSchema = z
+  .object({
+    displayName: z.string().min(1),
+    authUrl: z.string().url(),
+    reason: z.string().optional(),
+    serverType: z.string().optional(),
+  })
+  .strict();
+
+export const connectAccountComponentSchema = baseComponentSchema.extend({
+  type: z.literal('connectAccount'),
+  props: connectAccountPropsSchema,
+});
+
+export type ConnectAccountProps = z.infer<typeof connectAccountPropsSchema>;
+
+export const mcpCredentialFieldSchema = z
+  .object({
+    name: z.string().min(1),
+    label: z.string().min(1),
+    type: z.enum(['text', 'password']),
+    placeholder: z.string().optional(),
+    optional: z.boolean().optional(),
+  })
+  .strict();
+
+export const mcpConfigurePropsSchema = z
+  .object({
+    serverType: z.string().min(1),
+    serverName: z.string().min(1),
+    mcpServerId: z.string().min(1),
+    reason: z.string().optional(),
+    fields: z.array(mcpCredentialFieldSchema).min(1),
+  })
+  .strict();
+
+export const mcpConfigureComponentSchema = baseComponentSchema.extend({
+  type: z.literal('mcpConfigure'),
+  props: mcpConfigurePropsSchema,
+});
+
+export type McpCredentialField = z.infer<typeof mcpCredentialFieldSchema>;
+export type McpConfigureProps = z.infer<typeof mcpConfigurePropsSchema>;
+
 // Recursive container schemas need z.lazy
 export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
   z.discriminatedUnion('type', [
@@ -520,6 +742,12 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     prComponentSchema,
     prApprovalComponentSchema,
     callScheduleComponentSchema,
+    connectAccountComponentSchema,
+    mcpConfigureComponentSchema,
+    agentCreationComponentSchema,
+    entityUpdateComponentSchema,
+    skillCreationComponentSchema,
+    skillUpdateComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema
     baseComponentSchema.extend({
       type: z.literal('row'),

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -27,7 +27,13 @@ type FlowComponentType =
   | 'divider'
   | 'image'
   | 'link'
-  | 'plan';
+  | 'plan'
+  | 'connectAccount'
+  | 'mcpConfigure'
+  | 'agentCreation'
+  | 'entityUpdate'
+  | 'skillCreation'
+  | 'skillUpdate';
 
 interface FlowComponentStyle {
   padding?: string;
@@ -314,21 +320,47 @@ export class FlowBuilder {
 // ── Pre-built Flow factories used by webhook.ts ───────────────────────────────
 
 /**
+ * An HMAC-signed pending write action, as produced by claw-auth's /actions/sign.
+ * Rides in flowJSON.data so flow-action.ts can verify + execute it on approval.
+ */
+export interface WriteAction {
+  serverType: string;
+  tool: string;
+  params: Record<string, unknown>;
+  userId: string;
+  signature: string;
+  agentSlug: string;
+  channelId?: string;
+  conversationId?: string;
+}
+
+/**
+ * The flowJSON.data payload flow-action's `actionType === "write"` branch reads.
+ * SINGLE source of truth for this shape — every card that carries a signed write
+ * action (generic approval card, agentCreation card, …) must build its data
+ * here, so a new field can never be added to one card and missed on another.
+ */
+function writeActionData(action: WriteAction): Record<string, unknown> {
+  return {
+    actionType: 'write',
+    serverType: action.serverType,
+    tool: action.tool,
+    params: JSON.stringify(action.params),
+    userId: action.userId,
+    signature: action.signature,
+    agentSlug: action.agentSlug,
+    ...(action.channelId !== undefined ? { channelId: action.channelId } : {}),
+    ...(action.conversationId !== undefined ? { conversationId: action.conversationId } : {}),
+  };
+}
+
+/**
  * Write tool approval — Approve/Decline buttons for HITL write actions.
  * Context data is stored in flowJSON.data so flow-action.ts can execute the tool.
  */
 export function buildWriteApprovalFlow(
   actionDesc: string,
-  action: {
-    serverType: string;
-    tool: string;
-    params: Record<string, unknown>;
-    userId: string;
-    signature: string;
-    agentSlug: string;
-    channelId?: string;
-    conversationId?: string;
-  },
+  action: WriteAction,
 ): FlowDefinition {
   return new FlowBuilder(`write-approval-${crypto.randomUUID()}`)
     .setTitle('Action Approval')
@@ -346,17 +378,7 @@ export function buildWriteApprovalFlow(
       FlowBuilder.button('approve-continue', '✓  Approve & Continue', { type: 'submit', actionId: 'approve-continue', successMessage: 'Approved — continuing' }, { variant: 'secondary' }),
       FlowBuilder.button('decline', '✕  Decline', { type: 'submit', actionId: 'decline-write' }, { variant: 'destructive' }),
     ])
-    .setData({
-      actionType: 'write',
-      serverType: action.serverType,
-      tool: action.tool,
-      params: JSON.stringify(action.params),
-      userId: action.userId,
-      signature: action.signature,
-      agentSlug: action.agentSlug,
-      ...(action.channelId !== undefined ? { channelId: action.channelId } : {}),
-      ...(action.conversationId !== undefined ? { conversationId: action.conversationId } : {}),
-    })
+    .setData(writeActionData(action))
     .build();
 }
 
@@ -372,16 +394,9 @@ export function buildWriteResultFlow(opts: {
   heading: string;
   details: Array<{ label: string; value: string }>;
   errorText?: string;
-  retry?: {
-    serverType: string;
-    params: Record<string, unknown>;
-    userId: string;
-    signature: string;
-    agentSlug: string;
-    channelId?: string;
-    conversationId?: string;
-    spacesAppId?: string;
-  };
+  /** The same signed action, re-submitted verbatim by the Retry buttons
+   *  (params unchanged → signature still valid). `tool` comes from opts.tool. */
+  retry?: Omit<WriteAction, 'tool'> & { spacesAppId?: string };
 }): FlowDefinition {
   const b = new FlowBuilder(`write-result-${crypto.randomUUID()}`)
     .setTitle(opts.ok ? 'Action Completed' : 'Action Failed')
@@ -402,15 +417,7 @@ export function buildWriteResultFlow(opts: {
       FlowBuilder.button('retry', '↻  Retry', { type: 'submit', actionId: 'retry-write', successMessage: 'Retrying' }, { variant: 'primary' }),
       FlowBuilder.button('retry-continue', '↻  Retry & Continue', { type: 'submit', actionId: 'retry-continue', successMessage: 'Retrying' }, { variant: 'secondary' }),
     ]).setData({
-      actionType: 'write',
-      serverType: opts.retry.serverType,
-      tool: opts.tool,
-      params: JSON.stringify(opts.retry.params),
-      userId: opts.retry.userId,
-      signature: opts.retry.signature,
-      agentSlug: opts.retry.agentSlug,
-      ...(opts.retry.channelId !== undefined ? { channelId: opts.retry.channelId } : {}),
-      ...(opts.retry.conversationId !== undefined ? { conversationId: opts.retry.conversationId } : {}),
+      ...writeActionData({ ...opts.retry, tool: opts.tool }),
       ...(opts.retry.spacesAppId !== undefined ? { spacesAppId: opts.retry.spacesAppId } : {}),
     });
   }
@@ -718,6 +725,205 @@ export function buildAgentCallProposalFlow(
     .build();
 }
 
+export function buildConnectAccountFlow(context: {
+  displayName: string;
+  authUrl: string;
+  reason?: string;
+  serverType?: string;
+}): FlowDefinition {
+  return new FlowBuilder(`connect-account-${crypto.randomUUID()}`)
+    .addComponent({
+      id: 'connect-account',
+      type: 'connectAccount',
+      props: {
+        displayName: context.displayName,
+        authUrl: context.authUrl,
+        ...(context.reason?.trim() ? { reason: context.reason.trim() } : {}),
+        ...(context.serverType?.trim() ? { serverType: context.serverType.trim() } : {}),
+      },
+    })
+    .setData({ actionType: 'connect-account' })
+    .build();
+}
+
+export function buildMcpConfigureFlow(context: {
+  serverType: string;
+  serverName: string;
+  mcpServerId: string;
+  fields: Array<{ name: string; label: string; type: 'text' | 'password'; placeholder?: string; optional?: boolean }>;
+  reason?: string;
+  userId: string;
+  agentSlug?: string;
+  spacesAppId?: string;
+}): FlowDefinition {
+  return new FlowBuilder(`mcp-configure-${context.serverType}-${crypto.randomUUID()}`)
+    .addComponent({
+      id: 'mcp-configure',
+      type: 'mcpConfigure',
+      props: {
+        serverType: context.serverType,
+        serverName: context.serverName,
+        mcpServerId: context.mcpServerId,
+        fields: context.fields.map((field) => ({
+          name: field.name,
+          label: field.label,
+          type: field.type,
+          ...(field.placeholder ? { placeholder: field.placeholder } : {}),
+          ...(field.optional ? { optional: true } : {}),
+        })),
+        ...(context.reason?.trim() ? { reason: context.reason.trim() } : {}),
+      },
+    })
+    .setData({
+      actionType: 'mcp-configure',
+      userId: context.userId,
+      mcpServerId: context.mcpServerId,
+      serverType: context.serverType,
+      serverName: context.serverName,
+      ...(context.agentSlug ? { agentSlug: context.agentSlug } : {}),
+      ...(context.spacesAppId ? { spacesAppId: context.spacesAppId } : {}),
+    })
+    .build();
+}
+
+/**
+ * create-agent HITL card — a single `agentCreation` node that updates IN PLACE
+ * across phases (like the plan card), keyed on the SAME message:
+ *
+ *   pending  → proposed agent + Approve/Decline. The buttons (rendered by the
+ *              node) submit the write-tool actionIds; the HMAC-signed action is
+ *              carried in flowJSON.data (identical shape to buildWriteApprovalFlow)
+ *              so the existing write persistence path runs unchanged.
+ *   created  → approved. Created chip, prompt still expandable, setup hint.
+ *   rejected → declined. Rejected chip.
+ *
+ * Rendered by apps/dashboard AgentCreationNode; validated by @xyne/shared
+ * agentCreationComponentSchema (both must ship together — the dashboard rejects
+ * an unknown component type). screenId is keyed on the slug so phase updates to
+ * the same agent reconcile to the same card.
+ */
+/**
+ * Derive the agentCreation card's display props from a create-agent tool's raw
+ * params. Shared by the pending (webhook), created, and rejected (flow-action)
+ * emit sites so the in-place card update always shows the same agent details.
+ * Only present fields are assigned (no explicit `undefined`).
+ */
+/** The displayable fields of an agentCreation card, shared by all three phases. */
+export interface AgentCreationCardProps {
+  name: string;
+  slug: string;
+  description?: string;
+  systemPrompt?: string;
+  modelId?: string;
+  tools?: string[];
+  connectLinks?: Array<{ serverType: string; displayName: string; authUrl: string }>;
+}
+
+/** Trimmed non-empty string, or undefined. */
+function trimmedOrUndefined(value: unknown): string | undefined {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function agentCreationPropsFromToolParams(params: Record<string, unknown>): AgentCreationCardProps {
+  const name = trimmedOrUndefined(params['name']);
+  // Mirror flow-action's create branch: an omitted slug derives from the name.
+  const slug =
+    trimmedOrUndefined(params['slug'])?.toLowerCase() ??
+    name?.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80);
+
+  const description = trimmedOrUndefined(params['description']);
+  const systemPrompt = trimmedOrUndefined(params['systemPrompt']);
+  const modelId = trimmedOrUndefined(params['modelId']);
+  const tools = Array.isArray(params['tools'])
+    ? (params['tools'] as unknown[]).filter((t): t is string => typeof t === 'string')
+    : [];
+
+  const props: AgentCreationCardProps = { name: name ?? 'Agent', slug: slug || 'agent' };
+  if (description) props.description = description;
+  if (systemPrompt) props.systemPrompt = systemPrompt;
+  if (modelId) props.modelId = modelId;
+  if (tools.length > 0) props.tools = tools;
+  return props;
+}
+
+export function buildAgentCreationFlow(
+  phase: 'pending' | 'created' | 'rejected',
+  agent: AgentCreationCardProps & {
+    note?: string;
+    decidedBy?: string;
+    decidedAt?: string;
+  },
+  action?: WriteAction,
+): FlowDefinition {
+  // Node props: phase + name/slug always; every other field only when non-empty
+  // (the zod schema is .strict(), and empty strings would render as blank rows).
+  const props: Record<string, unknown> = { phase, name: agent.name, slug: agent.slug };
+  const optionalStringProps = ['description', 'systemPrompt', 'modelId', 'note', 'decidedBy', 'decidedAt'] as const;
+  for (const field of optionalStringProps) {
+    const value = agent[field]?.trim();
+    if (value) props[field] = value;
+  }
+  if (agent.tools && agent.tools.length > 0) props['tools'] = agent.tools;
+  if (agent.connectLinks && agent.connectLinks.length > 0) props['connectLinks'] = agent.connectLinks;
+
+  const builder = new FlowBuilder(`agent-creation-${agent.slug}`)
+    .setTitle('Agent')
+    .addComponent({ id: 'agent-creation', type: 'agentCreation', props });
+
+  // Pending carries the signed write action (the node's Approve/Decline buttons
+  // submit the standard approve-write/decline-write actionIds against it);
+  // decided phases have no action to run.
+  builder.setData(phase === 'pending' && action ? writeActionData(action) : { actionType: `agent-${phase}` });
+  return builder.build();
+}
+
+/** The displayable fields of a create-skill approval card. */
+export interface SkillCreationCardProps {
+  name: string;
+  slug: string;
+  description?: string;
+  content?: string;
+}
+
+export function skillCreationPropsFromToolParams(params: Record<string, unknown>): SkillCreationCardProps {
+  const name = trimmedOrUndefined(params['name']);
+  const slug =
+    trimmedOrUndefined(params['slug'])?.toLowerCase() ??
+    name?.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80);
+  const description = trimmedOrUndefined(params['description']);
+  const content = trimmedOrUndefined(params['content']);
+
+  const props: SkillCreationCardProps = { name: name ?? 'Skill', slug: slug || 'skill' };
+  if (description) props.description = description;
+  if (content) props.content = content;
+  return props;
+}
+
+export function buildSkillCreationFlow(
+  phase: 'pending' | 'created' | 'rejected',
+  skill: SkillCreationCardProps & {
+    note?: string;
+    decidedBy?: string;
+    decidedAt?: string;
+  },
+  action?: WriteAction,
+): FlowDefinition {
+  const props: Record<string, unknown> = { phase, name: skill.name, slug: skill.slug };
+  const optionalStringProps = ['description', 'content', 'note', 'decidedBy', 'decidedAt'] as const;
+  for (const field of optionalStringProps) {
+    const value = skill[field]?.trim();
+    if (value) props[field] = value;
+  }
+
+  const builder = new FlowBuilder(`skill-creation-${skill.slug}`)
+    .setTitle('Skill')
+    .addComponent({ id: 'skill-creation', type: 'skillCreation', props });
+
+  builder.setData(phase === 'pending' && action ? writeActionData(action) : { actionType: `skill-${phase}` });
+  return builder.build();
+}
+
 /**
  * Agent clone approval — raised when a viewer without owner/contributor
  * rights requests a clone. DM'd to the SOURCE agent's owner with
@@ -785,32 +991,6 @@ const DIFF_CARD_MAX_HUNKS = 6;
 const DIFF_CARD_MAX_LINES = 60;
 const DIFF_LINE_MAX_CHARS = 160;
 
-/** mrkdwn-neutralize a raw diff line so `*`/`_`/backticks in skill content
- *  don't format-bomb the card. Zero-width-space after each marker keeps the
- *  visible text identical while defeating the parser. */
-function neutralizeMrkdwn(line: string): string {
-  return line.replace(/([*_~`])/g, "$1​");
-}
-
-function diffLineComponent(id: string, kind: 'ctx' | 'add' | 'del', text: string): FlowComponent {
-  const clipped = text.length > DIFF_LINE_MAX_CHARS ? `${text.slice(0, DIFF_LINE_MAX_CHARS)}…` : text;
-  const prefix = kind === 'add' ? '+ ' : kind === 'del' ? '− ' : '  ';
-  const style: FlowComponentStyle =
-    kind === 'add'
-      ? { backgroundColor: 'rgba(46,160,67,0.15)', borderLeft: '3px solid #2ea043', padding: '1px 8px' }
-      : kind === 'del'
-        ? { backgroundColor: 'rgba(248,81,73,0.15)', borderLeft: '3px solid #f85149', padding: '1px 8px' }
-        : { padding: '1px 8px', borderLeft: '3px solid transparent' };
-  return {
-    id,
-    type: 'text',
-    // Bypass mdToMrkdwn (FlowBuilder.text would convert) — diff content must
-    // render verbatim, so neutralize markers instead.
-    props: { content: prefix + neutralizeMrkdwn(clipped), size: 'sm', ...(kind === 'ctx' ? { variant: 'muted' } : {}) },
-    style,
-  };
-}
-
 /**
  * Skill-update approval — raised by the `update-skill` tool, DM'd to the
  * skill's owner. Git-style rendering (2026-07-15 redesign): header + stat
@@ -840,68 +1020,39 @@ export function buildSkillUpdateApprovalFlow(
     spacesBaseUrl?: string;
   },
 ): FlowDefinition {
-  const b = new FlowBuilder(`skill-update-${crypto.randomUUID()}`)
-    .setTitle('Skill Update Request')
-    .addHeading('title', `Skill update: ${context.skillName}`, 3);
-
-  const stats = context.diff ? `  ·  *+${context.diff.added}* / *−${context.diff.removed}*  ·  ${context.diff.hunks.length} hunk${context.diff.hunks.length === 1 ? '' : 's'}` : '';
-  b.addText('meta', `proposed by *${context.proposerName}* on \`${context.skillSlug}\`${stats}`, { variant: 'muted', size: 'sm' });
-
-  if (context.summary) {
-    b.addText('summary', `*Summary:* ${context.summary.length > 300 ? `${context.summary.slice(0, 300)}…` : context.summary}`);
-  }
-
-  // Shrink warning — a proposal that deletes much more than it adds is the
-  // signature of truncated tool arguments (a "full replacement" that lost its
-  // tail), which destroyed a 318-rule skill on 2026-07-15. Make it unmissable.
-  if (context.diff && context.diff.removed > 30 && context.diff.removed > context.diff.added * 3) {
-    b.addCard('shrink-warning', [
-      FlowBuilder.text(
-        'shrink-warning-text',
-        `⚠️ *This update REMOVES ${context.diff.removed} lines but adds only ${context.diff.added}.* If the proposer claimed a "full replacement", the content may have been truncated — verify the tail of the skill before approving.`,
-        { variant: 'danger' },
-      ),
-    ], { border: '1px solid #f85149', borderRadius: '6px', padding: '8px' });
-  }
-
-  b.addDivider('d1');
-
-  if (context.diff && context.diff.hunks.length > 0) {
+  let diff = context.diff;
+  let truncated = false;
+  if (diff && diff.hunks.length > 0) {
     let linesUsed = 0;
-    let hunksRendered = 0;
-    let truncated = false;
-    for (const [hi, hunk] of context.diff.hunks.entries()) {
-      if (hunksRendered >= DIFF_CARD_MAX_HUNKS || linesUsed >= DIFF_CARD_MAX_LINES) { truncated = true; break; }
-      const children: FlowComponent[] = [
-        { id: `h${hi}-header`, type: 'text', props: { content: hunk.header, variant: 'muted', size: 'xs' }, style: { padding: '2px 8px' } },
-      ];
-      for (const [li, line] of hunk.lines.entries()) {
+    const hunks: typeof diff.hunks = [];
+    for (const hunk of diff.hunks) {
+      if (hunks.length >= DIFF_CARD_MAX_HUNKS || linesUsed >= DIFF_CARD_MAX_LINES) { truncated = true; break; }
+      const lines: typeof hunk.lines = [];
+      for (const line of hunk.lines) {
         if (linesUsed >= DIFF_CARD_MAX_LINES) { truncated = true; break; }
-        children.push(diffLineComponent(`h${hi}-l${li}`, line.kind, line.text));
+        const text = line.text.length > DIFF_LINE_MAX_CHARS ? `${line.text.slice(0, DIFF_LINE_MAX_CHARS)}…` : line.text;
+        lines.push({ ...line, text });
         linesUsed++;
       }
-      b.addCard(`hunk-${hi}`, children, {
-        border: '1px solid rgba(128,128,128,0.25)',
-        borderRadius: '6px',
-        padding: '4px 0',
-        margin: '4px 0',
-        maxHeight: '320px',
-        overflowY: 'auto',
-      });
-      hunksRendered++;
+      hunks.push({ header: hunk.header, lines });
     }
-    if (truncated) {
-      b.addText('diff-truncated', `_… diff truncated for display (showing ${linesUsed} lines across ${hunksRendered} hunks). The FULL proposed content is stored on the request and applied exactly as reviewed by the integrity hash._`, { variant: 'muted', size: 'sm' });
-    }
-  } else if (context.diffText) {
-    b.addText('diff', context.diffText);
+    diff = { ...diff, hunks };
   }
 
-  b.addDivider('d2')
-    .addRow('actions', [
-      FlowBuilder.button('approve', '✓  Approve', { type: 'submit', actionId: 'skill-update-approve', successMessage: 'Approved' }, { variant: 'primary' }),
-      FlowBuilder.button('decline', '✕  Decline', { type: 'submit', actionId: 'skill-update-decline' }, { variant: 'destructive' }),
-    ])
+  const props: Record<string, unknown> = {
+    phase: 'pending',
+    skillName: context.skillName,
+    skillSlug: context.skillSlug,
+    proposerName: context.proposerName,
+  };
+  if (context.summary?.trim()) props['summary'] = context.summary.trim();
+  if (diff && diff.hunks.length > 0) props['diff'] = diff;
+  if (!diff && context.diffText?.trim()) props['diffText'] = context.diffText.trim();
+  if (truncated) props['truncated'] = true;
+
+  return new FlowBuilder(`skill-update-${context.skillSlug}`)
+    .setTitle('Skill Update Request')
+    .addComponent({ id: 'skill-update', type: 'skillUpdate', props })
     .setData({
       actionType: 'skill-update',
       requestId: context.requestId,
@@ -909,6 +1060,94 @@ export function buildSkillUpdateApprovalFlow(
       skillSlug: context.skillSlug,
       ...(context.agentSlug ? { agentSlug: context.agentSlug } : {}),
       ...(context.spacesAppId ? { spacesAppId: context.spacesAppId } : {}),
-    });
-  return b.build();
+    })
+    .build();
+}
+
+/**
+ * Agent- / subagent-update approval — raised by the `update-agent` /
+ * `update-subagent` tools and DM'd to the definition's owner. Emits ONE
+ * `entityUpdate` node (rendered by the dashboard's EntityUpdateNode, shared by
+ * both kinds) in phase 'pending'; flow-action.ts flips the SAME card to
+ * 'approved' / 'rejected' in place on the owner's decision.
+ *
+ * The systemPrompt diff and scalar "Field changes" ship as STRUCTURED props —
+ * presentation lives entirely in the renderer. The diff is capped here for
+ * display (`truncated`); the FULL proposed content is stored on the request and
+ * applied exactly as reviewed via the integrity hash. `kind` drives the labels
+ * and the actionType / actionIds the owner's click routes to (`agent-update` /
+ * `subagent-update`, resolved in flow-action.ts).
+ */
+export function buildEntityUpdateApprovalFlow(
+  context: {
+    kind: 'agent' | 'subagent';
+    requestId: string;
+    approverUserId: string;
+    /** slug (agent) or name (subagent) of the target definition. */
+    targetKey: string;
+    /** Display name shown in the heading. */
+    targetName: string;
+    proposerName: string;
+    /** systemPrompt diff (computeSkillDiff). Omit when only scalars changed. */
+    diff?: { hunks: Array<{ header: string; lines: Array<{ kind: 'ctx' | 'add' | 'del'; text: string }> }>; added: number; removed: number };
+    /** Unused by the node renderer; kept for signature compatibility. */
+    diffText?: string;
+    /** Changed scalar fields, rendered as a compact "Field changes" list. */
+    fieldChanges?: Array<{ label: string; from: string; to: string }>;
+    summary?: string;
+    /** The posting agent's slug (for card collapse after approve/decline). */
+    agentSlug?: string;
+    spacesAppId?: string;
+    spacesBaseUrl?: string;
+  },
+): FlowDefinition {
+  const kindLabel = context.kind === 'agent' ? 'Agent' : 'Subagent';
+  const clip = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max)}…` : s);
+
+  // Cap the SHIPPED diff — messages should stay small and the renderer bounded.
+  let diff: { added: number; removed: number; hunks: Array<{ header: string; lines: Array<{ kind: 'ctx' | 'add' | 'del'; text: string }> }> } | undefined;
+  let truncated = false;
+  if (context.diff) {
+    const hunks: NonNullable<typeof diff>['hunks'] = [];
+    let linesUsed = 0;
+    for (const hunk of context.diff.hunks) {
+      if (hunks.length >= DIFF_CARD_MAX_HUNKS || linesUsed >= DIFF_CARD_MAX_LINES) { truncated = true; break; }
+      const lines = hunk.lines.slice(0, DIFF_CARD_MAX_LINES - linesUsed);
+      if (lines.length < hunk.lines.length) truncated = true;
+      linesUsed += lines.length;
+      hunks.push({ header: hunk.header, lines });
+    }
+    diff = { added: context.diff.added, removed: context.diff.removed, hunks };
+  }
+
+  const props: Record<string, unknown> = {
+    phase: 'pending',
+    kind: context.kind,
+    targetName: context.targetName,
+    targetKey: context.targetKey,
+    proposerName: context.proposerName,
+  };
+  if (context.summary?.trim()) props['summary'] = clip(context.summary.trim(), 300);
+  if (context.fieldChanges && context.fieldChanges.length > 0) {
+    props['fieldChanges'] = context.fieldChanges.map((fc) => ({
+      label: fc.label,
+      from: clip(fc.from, 120),
+      to: clip(fc.to, 120),
+    }));
+  }
+  if (diff) props['diff'] = diff;
+  if (truncated) props['truncated'] = true;
+
+  return new FlowBuilder(`${context.kind}-update-${crypto.randomUUID()}`)
+    .setTitle(`${kindLabel} Update Request`)
+    .addComponent({ id: 'entity-update', type: 'entityUpdate', props })
+    .setData({
+      actionType: `${context.kind}-update`,
+      requestId: context.requestId,
+      approverUserId: context.approverUserId,
+      targetKey: context.targetKey,
+      ...(context.agentSlug ? { agentSlug: context.agentSlug } : {}),
+      ...(context.spacesAppId ? { spacesAppId: context.spacesAppId } : {}),
+    })
+    .build();
 }

--- a/packages/xyne-claw-shared/src/flow/flow-text.ts
+++ b/packages/xyne-claw-shared/src/flow/flow-text.ts
@@ -1,0 +1,92 @@
+import type { FlowComponent } from "./builder.js";
+
+/**
+ * Flow JSON message helpers.
+ *
+ * App/bot "block" messages (e.g. Unified Alerts) are stored as an HTML envelope:
+ *   <div data-flow-json="{…&quot;-escaped JSON…}">Flow JSON</div>
+ * The only visible text node ("Flow JSON") is a placeholder — the real content
+ * lives inside the escaped `data-flow-json` attribute as a component tree whose
+ * text nodes carry their text in `props.content`.
+ *
+ * This is the single shared implementation used by every reader that needs the
+ * human-readable body of such a message (agent message reads, notification
+ * previews, mention scanning). Do NOT re-implement tree-walking inline — import
+ * from here so the behaviour cannot drift.
+ */
+
+const FLOW_JSON_ATTR = /data-flow-json="([^"]+)"/;
+
+/** True when a stored message body carries a Flow JSON payload. */
+export function isFlowJsonContent(content: string): boolean {
+  return typeof content === "string" && content.includes("data-flow-json");
+}
+
+/**
+ * Parse the escaped `data-flow-json` attribute into its component list.
+ * Returns null when there is no Flow JSON payload or the JSON is malformed.
+ */
+export function parseFlowJsonComponents(content: string): FlowComponent[] | null {
+  if (typeof content !== "string") return null;
+  const match = content.match(FLOW_JSON_ATTR);
+  const escaped = match?.[1];
+  if (escaped === undefined) return null;
+  try {
+    const json = escaped
+      .replace(/&quot;/g, '"')
+      .replace(/&#10;/g, "\n")
+      .replace(/&#13;/g, "\r")
+      // Repair stray backslashes that are NOT valid JSON escape sequences.
+      // Slack mrkdwn leaves fragments like "\1" / "\6" in the content, which
+      // are invalid JSON escapes; without this, JSON.parse aborts the ENTIRE
+      // message and the alert falls back to the bare "Flow JSON" placeholder.
+      .replace(/\\(?!["\\/bfnrtu])/g, "\\\\");
+    const flow = JSON.parse(json) as { components?: unknown };
+    return Array.isArray(flow.components) ? (flow.components as FlowComponent[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Depth-first collect of every non-empty text `props.content`, in tree order. */
+function collectContent(components: FlowComponent[], out: string[]): void {
+  for (const comp of components) {
+    if (!comp || typeof comp !== "object") continue;
+    const content = comp.props?.["content"];
+    if (typeof content === "string" && content.trim()) out.push(content.trim());
+    if (Array.isArray(comp.children)) collectContent(comp.children, out);
+  }
+}
+
+/**
+ * Flatten a Flow JSON message body to plain text, preserving Slack-style mrkdwn
+ * tokens (`<userid:…>`, `<url|label>`, …). Returns "" for non-flow content or
+ * for cards whose text is not carried in text `props.content` (e.g. `plan`),
+ * so callers can fall back to their default handling.
+ */
+export function extractTextFromFlowJson(content: string): string {
+  const components = parseFlowJsonComponents(content);
+  if (!components) return "";
+  const out: string[] = [];
+  collectContent(components, out);
+  return out.join(" ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Like {@link extractTextFromFlowJson} but strips Slack-style mrkdwn tokens so
+ * the result is clean prose suitable for model input or a notification preview.
+ */
+export function extractCleanTextFromFlowJson(content: string): string {
+  const raw = extractTextFromFlowJson(content);
+  if (!raw) return "";
+  return raw
+    .replace(/<userid:[^>]+>/g, "")
+    .replace(/<channelid:[^>]+>/g, "#channel")
+    .replace(/<broadcast:channel>/gi, "@channel ")
+    .replace(/<broadcast:here>/gi, "@here ")
+    .replace(/<broadcast:([^>]+)>/gi, "@$1")
+    .replace(/<([^|>]+)\|([^>]+)>/g, "$2")
+    .replace(/<(https?:[^>]+)>/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/packages/xyne-claw-shared/src/flow/skill-update-flow.test.ts
+++ b/packages/xyne-claw-shared/src/flow/skill-update-flow.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildSkillUpdateApprovalFlow } from "./builder.js";
-import { computeSkillDiff, formatSkillDiffForCard } from "../skill-diff/index.js";
+import { computeSkillDiff } from "../skill-diff/index.js";
 
 function flatten(flow: any): any[] {
   const out: any[] = [];
@@ -14,14 +14,14 @@ function flatten(flow: any): any[] {
 }
 
 describe("buildSkillUpdateApprovalFlow", () => {
-  const diff = formatSkillDiffForCard(computeSkillDiff("old body", "new body\nmore"));
+  const diff = computeSkillDiff("old body", "new body\nmore");
   const flow = buildSkillUpdateApprovalFlow({
     requestId: "req-1",
     approverUserId: "owner-1",
     skillSlug: "jenkins-investigation",
     skillName: "Jenkins Investigation",
     proposerName: "Anurag",
-    diffText: diff,
+    diff,
     summary: "add step",
     agentSlug: "architect",
     spacesBaseUrl: "https://spaces.example.com",
@@ -39,19 +39,21 @@ describe("buildSkillUpdateApprovalFlow", () => {
     expect(JSON.stringify(data)).not.toContain("```diff");
   });
 
-  it("renders the diff inside a fenced block in a text node", () => {
+  it("renders a dedicated skillUpdate node with structured diff props", () => {
     const nodes = flatten(flow);
-    const textWithDiff = nodes.find((n) => n.type === "text" && String(n.props?.content ?? "").includes("```diff"));
-    expect(textWithDiff).toBeTruthy();
-    expect(String(textWithDiff.props.content)).toContain("+new body");
+    const skillNode = nodes.find((n) => n.type === "skillUpdate");
+    expect(skillNode).toBeTruthy();
+    expect(skillNode.props.skillName).toBe("Jenkins Investigation");
+    expect(skillNode.props.skillSlug).toBe("jenkins-investigation");
+    expect(skillNode.props.summary).toBe("add step");
+    expect(skillNode.props.diff.added).toBe(diff.added);
+    expect(skillNode.props.diff.removed).toBe(diff.removed);
+    expect(JSON.stringify(skillNode.props.diff)).toContain("new body");
   });
 
-  it("has Approve and Decline submit buttons with the skill-update action ids", () => {
+  it("uses node-owned Approve and Decline buttons via the skill-update action ids", () => {
     const nodes = flatten(flow);
-    const buttons = nodes.filter((n) => n.type === "button");
-    const actionIds = buttons.map((b) => b.props?.action?.actionId);
-    expect(actionIds).toContain("skill-update-approve");
-    expect(actionIds).toContain("skill-update-decline");
-    for (const b of buttons) expect(b.props.action.type).toBe("submit");
+    expect(nodes.some((n) => n.type === "button")).toBe(false);
+    expect(nodes.some((n) => n.type === "skillUpdate")).toBe(true);
   });
 });

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -23,6 +23,7 @@ export { createSkillTool, updateSkillTool } from "./tools/skill-management/index
 export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
+export { isFlowJsonContent, parseFlowJsonComponents, extractTextFromFlowJson, extractCleanTextFromFlowJson } from "./flow/flow-text.js";
 export type { Todo, TodoStatus, PlanPhase, PlanTodoInput } from "./flow/plan-flow.js";
 export { todoTools, todoWriteTool, todoReadTool, getPlan, clearPlan, PLAN_TOOL_SLUGS, isPlanToolSlug } from "./tools/todo/todo-tools.js";
 export { isReadOnlyJob } from "./tools/sandbox/repo-configs.js";

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -2,7 +2,7 @@ export type { ToolDefinition, ToolInputSchema, ConfigField, ToolExecutionContext
 export { getAllCustomTools, getCustomTool, getToolsBySource } from "./tools/registry.js";
 export { takeLlmCitations, peekLlmCitations, recordLlmCitations } from "./tools/add-citations/tools.js";
 export { respondToUser, COPILOT_SYSTEM_INSTRUCTION } from "./tools/respond-to-user/index.js";
-export { SUBAGENT_DEFINITIONS, getSubagentDefinition, parseToolsConfig, type SubagentDefinition, type AgentToolsConfig } from "./tools/subagents/index.js";
+export { SUBAGENT_DEFINITIONS, getSubagentDefinition, findSubagentDefinitionForServer, parseToolsConfig, type SubagentDefinition, type AgentToolsConfig } from "./tools/subagents/index.js";
 export { PLATFORM_ONLY_CONFIG_KEYS, stripPlatformConfigKeys } from "./tools/platform-config-keys.js";
 export { getSandboxSession, probeSession, buildSandboxStoreKey, REPO_CONFIGS, SBX_GIT, type RepoSetupConfig, type SetupStep } from "./tools/sandbox/index.js";
 export type { Citation, CitationIconKey } from "./types/citation.js";

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -20,7 +20,7 @@ export {
 } from "./skill-diff/index.js";
 export type { SkillDiff, SkillForAuthz, ApproverResolution, SkillApprovalAuthz } from "./skill-diff/index.js";
 export { createSkillTool, updateSkillTool } from "./tools/skill-management/index.js";
-export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow } from "./flow/builder.js";
+export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildConnectAccountFlow, buildMcpConfigureFlow, buildAgentCreationFlow, agentCreationPropsFromToolParams, buildSkillCreationFlow, skillCreationPropsFromToolParams, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildEntityUpdateApprovalFlow } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
 export { isFlowJsonContent, parseFlowJsonComponents, extractTextFromFlowJson, extractCleanTextFromFlowJson } from "./flow/flow-text.js";

--- a/packages/xyne-claw-shared/src/tools/agent-management/index.ts
+++ b/packages/xyne-claw-shared/src/tools/agent-management/index.ts
@@ -1,0 +1,1 @@
+export { createAgentTool, createSubagentTool, updateAgentTool, updateSubagentTool } from "./tools.js";

--- a/packages/xyne-claw-shared/src/tools/agent-management/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/agent-management/tools.ts
@@ -1,0 +1,419 @@
+/**
+ * Agent- and subagent-management custom tools — let an agent author and revise
+ * Claw agents and subagent definitions with human approval, reusing the exact
+ * HITL machinery that backs create-skill / update-skill rather than a new
+ * approval system. See xyne-claw-shared/src/tools/skill-management/tools.ts for
+ * the sibling implementation these mirror.
+ *
+ *   create-agent     → WRITE tool. The pod signs a pending action; claw-auth's
+ *   create-subagent    webhook renders an Approve/Decline card to the REQUESTER
+ *                      (self-approval of a draft). On approve, flow-action's
+ *                      `serverType==="agent"` / `"subagent"` branch persists the
+ *                      row owned by the approver in their org. Nothing is written
+ *                      until approval.
+ *
+ *   update-agent     → NON-write tools that PROPOSE a change. They cannot
+ *   update-subagent    self-apply because the approver is the agent's / subagent's
+ *                      OWNER, who may be a different user. execute() posts to
+ *                      claw-auth's /agents/:slug/propose-update (or
+ *                      /subagents/:name/propose-update), which applies the
+ *                      systemPrompt edits + scalar changes to a working copy,
+ *                      computes the diff, records an AgentRequest, and DMs the
+ *                      owner a card showing the diff. The owner's click drives the
+ *                      actual update via flow-action's `actionType==="agent-update"`
+ *                      / `"subagent-update"`.
+ *
+ * As with skills, persistence is deliberately kept OUT of the pod: the pod never
+ * has DB access, and centralizing the write in claw-auth keeps one source of
+ * truth (and one place that enforces ownership + validation).
+ */
+
+import type { ToolDefinition, ToolExecutionContext, ToolInputSchema } from "../types.js";
+
+// ── Result envelope ──────────────────────────────────────────────────────────
+// Every execute() returns a JSON string the model parses. These two helpers are
+// the only places that define its shape.
+
+function toolError(message: string): string {
+  return JSON.stringify({ error: message });
+}
+
+function toolOk(payload: Record<string, unknown>): string {
+  return JSON.stringify(payload);
+}
+
+// ── Param parsing ────────────────────────────────────────────────────────────
+
+/** Slugs must be lowercase kebab so they map cleanly to the DB unique key. */
+function normalizeSlug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+/** Optional string param → trimmed value, or undefined for absent/empty. */
+function asTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Optional list of tool slugs / subagent names → trimmed + deduped, or undefined. */
+function asNameList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const names = value
+    .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
+    .map((v) => v.trim());
+  const deduped = [...new Set(names)];
+  return deduped.length > 0 ? deduped : undefined;
+}
+
+/** An anchored replacement applied to the current systemPrompt. */
+interface PromptEdit {
+  oldText: string;
+  newText: string;
+}
+
+function asPromptEdit(value: unknown): PromptEdit | null {
+  if (value === null || typeof value !== "object") return null;
+  const { oldText, newText } = value as { oldText?: unknown; newText?: unknown };
+  if (typeof oldText !== "string" || oldText.length === 0) return null;
+  if (typeof newText !== "string") return null;
+  return { oldText, newText };
+}
+
+/**
+ * Parse params["promptEdits"]. Malformed entries are an ERROR, not silently
+ * dropped: skipping one edit out of several would propose a partial prompt
+ * change the model never intended, and the owner would approve a wrong diff.
+ */
+function parsePromptEdits(raw: unknown): { edits: PromptEdit[] } | { error: string } {
+  if (raw === undefined || raw === null) return { edits: [] };
+  if (!Array.isArray(raw)) {
+    return { error: "promptEdits must be an array of {oldText, newText} objects." };
+  }
+  const edits: PromptEdit[] = [];
+  for (const [index, entry] of raw.entries()) {
+    const edit = asPromptEdit(entry);
+    if (!edit) {
+      return { error: `promptEdits[${index}] is invalid: expected {oldText: non-empty string, newText: string}.` };
+    }
+    edits.push(edit);
+  }
+  return { edits };
+}
+
+/**
+ * Collect the defined optional fields of `params` per a {field → parser} spec.
+ * Only fields whose parser returns a value end up in the result — this replaces
+ * per-field `...(x !== undefined ? { x } : {})` spreads at the call sites.
+ */
+type FieldParser = (value: unknown) => unknown;
+
+function collectDefined(
+  params: Record<string, unknown>,
+  spec: Record<string, FieldParser>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [field, parse] of Object.entries(spec)) {
+    const value = parse(params[field]);
+    if (value !== undefined) out[field] = value;
+  }
+  return out;
+}
+
+// ── claw-auth transport ──────────────────────────────────────────────────────
+// Env is read lazily inside execute() (not at module load) so the values are
+// picked up from the pod environment at call time and are trivially stubbable
+// in tests.
+
+function authUrl(): string {
+  return (process.env["XYNE_CLAW_AUTH_URL"] ?? "http://xyne-claw-auth.xyne-apps.svc.cluster.local:3003").replace(/\/$/, "");
+}
+
+function s2sKey(): string {
+  return process.env["XYNE_CLAW_S2S_KEY"] ?? "";
+}
+
+/** Who is proposing, and as which agent — read from the tool context. */
+function resolveProposer(
+  context: ToolExecutionContext | undefined,
+): { userId: string; agentSlug: string | undefined } | { error: string } {
+  const userId = context?.meta?.["userId"];
+  if (!userId) return { error: "Cannot propose update: missing requesting user id in tool context." };
+  return { userId, agentSlug: context?.meta?.["agentSlug"] };
+}
+
+/**
+ * POST to a claw-auth propose-update route. Both update tools speak the same
+ * request shape (systemPrompt edits + scalar overrides + tools + summary) and
+ * interpret the same status codes, so the transport lives here once.
+ */
+async function proposeUpdate(
+  path: string,
+  targetLabel: "Agent" | "Subagent",
+  body: Record<string, unknown>,
+  context: ToolExecutionContext | undefined,
+): Promise<string> {
+  const proposer = resolveProposer(context);
+  if ("error" in proposer) return toolError(proposer.error);
+  const key = s2sKey();
+  if (!key) {
+    return toolError("XYNE_CLAW_S2S_KEY not set in claw-pod environment — the update tool cannot authenticate to claw-auth.");
+  }
+
+  const url = `${authUrl()}${path}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-s2s-key": key,
+        "x-user-id": proposer.userId,
+      },
+      body: JSON.stringify({ ...body, agentSlug: proposer.agentSlug }),
+      signal: AbortSignal.timeout(20_000),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return toolError(`Failed to reach claw-auth at ${url}: ${msg}`);
+  }
+
+  const text = await res.text();
+  let json: { success?: boolean; error?: string; data?: unknown } = {};
+  try { json = text ? JSON.parse(text) : {}; } catch { /* non-JSON body */ }
+
+  if (res.status === 404) return toolError(`${targetLabel} not found in your org. Check the slug/name.`);
+  if (res.status === 409) return toolError(json.error ?? "Your update is identical to the current definition — nothing to propose.");
+  if (!res.ok || json.success === false) return toolError(json.error ?? `propose-update failed (HTTP ${res.status})`);
+
+  return toolOk({
+    status: "proposed",
+    message: `Update proposed. The ${targetLabel.toLowerCase()} owner has been sent a DM showing the diff and can approve or decline it.`,
+    data: json.data ?? null,
+  });
+}
+
+// ── Shared schema fragments (identical across the two update tools) ──────────
+
+const PROMPT_EDITS_SCHEMA = {
+  type: "array",
+  description: "PREFERRED for system-prompt changes. Anchored replacements applied in order to the CURRENT system prompt. Each oldText must appear exactly once.",
+  items: {
+    type: "object",
+    properties: {
+      oldText: { type: "string", description: "Exact snippet copied from the current system prompt (unique within it)." },
+      newText: { type: "string", description: "Replacement text (empty string deletes the snippet)." },
+    },
+    required: ["oldText", "newText"],
+  },
+} as const;
+
+const SYSTEM_PROMPT_SCHEMA = {
+  type: "string",
+  description: "Full system-prompt replacement — small prompts (<~8K chars) only; rejected for larger ones. Prefer `promptEdits`.",
+} as const;
+
+const SUMMARY_SCHEMA = {
+  type: "string",
+  description: "Optional short note describing what changed and why — shown to the owner alongside the diff.",
+} as const;
+
+function toolListSchema(description: string): Record<string, unknown> {
+  return { type: "array", description, items: { type: "string" } };
+}
+
+// ── Shared update executor ───────────────────────────────────────────────────
+
+/**
+ * Build the execute() for an update tool. The two tools differ only in how the
+ * target is identified, which scalar fields they accept, and which route they
+ * post to — everything else (promptEdits parsing, nothing-to-update guard,
+ * transport) is identical.
+ */
+function makeUpdateExecute(opts: {
+  targetLabel: "Agent" | "Subagent";
+  /** Param that identifies the target ("slug" or "name") + how to clean it. */
+  idParam: "slug" | "name";
+  cleanId: (raw: string) => string;
+  /** Optional body fields: {field → parser}. `summary` is included here but is
+   *  a note, not a change — see the nothing-to-update guard. */
+  bodyFields: Record<string, FieldParser>;
+  /** Human list of the change-carrying fields, for the nothing-to-update error. */
+  changeFieldsHint: string;
+  routeFor: (id: string) => string;
+}): ToolDefinition["execute"] {
+  return async (params, context) => {
+    const rawId = typeof params[opts.idParam] === "string" ? (params[opts.idParam] as string) : "";
+    const id = opts.cleanId(rawId);
+    if (!id) return toolError(`${opts.idParam} is required`);
+
+    const parsed = parsePromptEdits(params["promptEdits"]);
+    if ("error" in parsed) return toolError(parsed.error);
+
+    const body = collectDefined(params, opts.bodyFields);
+    if (parsed.edits.length > 0) body["promptEdits"] = parsed.edits;
+
+    // `summary` annotates a change; alone it is not one.
+    const hasChange = parsed.edits.length > 0 || Object.keys(body).some((field) => field !== "summary");
+    if (!hasChange) {
+      return toolError(`Nothing to update: provide promptEdits/systemPrompt and/or a scalar field (${opts.changeFieldsHint}).`);
+    }
+
+    return proposeUpdate(opts.routeFor(id), opts.targetLabel, body, context);
+  };
+}
+
+// ── create-agent / create-subagent ───────────────────────────────────────────
+
+/** Fallback body for approval-gated write tools — the pod intercepts these in
+ *  xyne-claw/custom-tools.ts BEFORE execute runs (it signs a pending action
+ *  instead). This must never persist; the real create happens in claw-auth's
+ *  flow-action branch after approval. */
+function approvalGatedStub(what: string): ToolDefinition["execute"] {
+  return async () =>
+    `${what} is an approval-gated write tool: the user will receive an Approve/Decline card. The ${what.replace("create-", "")} is only created after they approve.`;
+}
+
+export const createAgentTool: ToolDefinition = {
+  slug: "create-agent",
+  name: "Create Agent",
+  description:
+    "Draft a NEW Claw agent and submit it for approval. " +
+    "The user sees an Approve/Decline card with the agent name, description and system prompt; NOTHING is saved until they approve. " +
+    "On approval the agent is created as a PERSONAL agent owned by the approving user in their org. " +
+    "Provide: name (human title), slug (optional — auto-derived from name if omitted), description (one line shown in the agent picker), systemPrompt (the agent's instructions), and optionally modelId, color, and tools. " +
+    "`tools` is a flat list of tool slugs (e.g. 'web-search') and/or subagent names to grant the agent; unknown entries are reported back and skipped. " +
+    "Use this when the user asks you to 'create an agent', 'build me an agent', or 'set up a new agent'.",
+  source: "custom:agent",
+  isWriteTool: true,
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string", description: "Human-readable agent title, e.g. 'Ticket Triage'. Required." },
+      slug: { type: "string", description: "Optional kebab-case slug, e.g. 'ticket-triage'. Auto-derived from name when omitted." },
+      description: { type: "string", description: "One-line description shown in the agent picker. Required." },
+      systemPrompt: { type: "string", description: "The agent's system prompt / instructions. Required." },
+      modelId: { type: "string", description: "Optional model id (e.g. 'claude-sonnet-5'). Defaults to the org default when omitted." },
+      color: { type: "string", description: "Optional hex color for the agent avatar, e.g. '#6366f1'." },
+      tools: toolListSchema("Optional flat list of tool slugs and/or subagent names to grant this agent. Unknown entries are skipped and reported."),
+    },
+    required: ["name", "description", "systemPrompt"],
+  },
+  execute: approvalGatedStub("create-agent"),
+};
+
+export const createSubagentTool: ToolDefinition = {
+  slug: "create-subagent",
+  name: "Create Subagent",
+  description:
+    "Draft a NEW Claw subagent definition and submit it for approval. A subagent is a specialised worker an agent can delegate a single task to. " +
+    "The user sees an Approve/Decline card; NOTHING is saved until they approve. On approval it is created in the approver's org, authored by them. " +
+    "Provide: name (unique per org, used as the delegation tool name), description, systemPrompt (the subagent's instructions), paramName (the single input parameter name the caller passes, e.g. 'task'), paramDescription (what that parameter should contain), and optionally tools (a flat list of tool slugs the subagent may use). " +
+    "Use this when the user asks you to 'create a subagent' or 'add a specialised worker'.",
+  source: "custom:agent",
+  isWriteTool: true,
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string", description: "Unique subagent name (per org), used as the delegation tool name, e.g. 'log-summarizer'. Required." },
+      description: { type: "string", description: "One-line description of what the subagent does. Required." },
+      systemPrompt: { type: "string", description: "The subagent's system prompt / instructions. Required." },
+      paramName: { type: "string", description: "Name of the single input parameter the caller passes, e.g. 'task'. Required." },
+      paramDescription: { type: "string", description: "What the input parameter should contain. Required." },
+      tools: toolListSchema("Optional flat list of tool slugs the subagent may use. Unknown entries are skipped and reported."),
+    },
+    required: ["name", "description", "systemPrompt", "paramName", "paramDescription"],
+  },
+  execute: approvalGatedStub("create-subagent"),
+};
+
+// ── update-agent / update-subagent ───────────────────────────────────────────
+
+export const updateAgentTool: ToolDefinition = {
+  slug: "update-agent",
+  name: "Update Agent",
+  description:
+    "Propose an update to an EXISTING Claw agent. You do not apply the change directly — the agent's owner receives a DM showing the diff and approves or declines it. " +
+    "For the system prompt, PREFER `promptEdits`: an array of {oldText, newText} anchored replacements. oldText must be copied EXACTLY from the current prompt and be unique within it; newText replaces it. Edits scale with the CHANGE size, so they work on prompts of any length. " +
+    "`systemPrompt` (full replacement) is a convenience for SMALL prompts only (<~8K chars); the server rejects full replacements of larger prompts because a big body does not survive as a tool argument (it gets truncated). " +
+    "Scalar fields — description, modelId, color, name — may be given directly as new values; omit a field to leave it unchanged. " +
+    "`tools` (a flat list of tool slugs / subagent names) REPLACES the agent's tool selection when provided. " +
+    "Always read the current agent first so your oldText anchors are exact. Re-proposing is safe: a new proposal replaces your earlier still-pending one for the same agent.",
+  source: "custom:agent",
+  inputSchema: {
+    type: "object",
+    properties: {
+      slug: { type: "string", description: "Slug of the existing agent to update, e.g. 'ticket-triage'. Required." },
+      promptEdits: PROMPT_EDITS_SCHEMA,
+      systemPrompt: SYSTEM_PROMPT_SCHEMA,
+      name: { type: "string", description: "Optional new human-readable title." },
+      description: { type: "string", description: "Optional new one-line description." },
+      modelId: { type: "string", description: "Optional new model id." },
+      color: { type: "string", description: "Optional new hex color." },
+      tools: toolListSchema("Optional flat list of tool slugs / subagent names — REPLACES the agent's current tool selection when provided."),
+      summary: SUMMARY_SCHEMA,
+    },
+    required: ["slug"],
+  },
+  execute: makeUpdateExecute({
+    targetLabel: "Agent",
+    idParam: "slug",
+    cleanId: normalizeSlug,
+    bodyFields: {
+      systemPrompt: asTrimmedString,
+      name: asTrimmedString,
+      description: asTrimmedString,
+      modelId: asTrimmedString,
+      color: asTrimmedString,
+      tools: asNameList,
+      summary: asTrimmedString,
+    },
+    changeFieldsHint: "name, description, modelId, color, tools",
+    routeFor: (slug) => `/claw/api/v1/agents/${encodeURIComponent(slug)}/propose-update`,
+  }),
+};
+
+export const updateSubagentTool: ToolDefinition = {
+  slug: "update-subagent",
+  name: "Update Subagent",
+  description:
+    "Propose an update to an EXISTING Claw subagent definition. You do not apply the change directly — the subagent's owner receives a DM showing the diff and approves or declines it. " +
+    "For the system prompt, PREFER `promptEdits`: an array of {oldText, newText} anchored replacements copied EXACTLY from the current prompt (each unique). `systemPrompt` full replacement is allowed for SMALL prompts only (<~8K chars); larger full replacements are rejected (truncation risk). " +
+    "Scalar fields — description, paramName, paramDescription — may be given directly as new values; omit to leave unchanged. `tools` (a flat list of tool slugs) REPLACES the subagent's tool selection when provided. " +
+    "Identify the subagent by its `name`. Always read the current subagent first so your oldText anchors are exact. Re-proposing replaces your earlier still-pending proposal for the same subagent.",
+  source: "custom:agent",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string", description: "Name of the existing subagent to update, e.g. 'log-summarizer'. Required." },
+      promptEdits: PROMPT_EDITS_SCHEMA,
+      systemPrompt: SYSTEM_PROMPT_SCHEMA,
+      description: { type: "string", description: "Optional new one-line description." },
+      paramName: { type: "string", description: "Optional new input parameter name." },
+      paramDescription: { type: "string", description: "Optional new input parameter description." },
+      tools: toolListSchema("Optional flat list of tool slugs — REPLACES the subagent's current tool selection when provided."),
+      summary: SUMMARY_SCHEMA,
+    },
+    required: ["name"],
+  },
+  execute: makeUpdateExecute({
+    targetLabel: "Subagent",
+    idParam: "name",
+    cleanId: (raw) => raw.trim(),
+    bodyFields: {
+      systemPrompt: asTrimmedString,
+      description: asTrimmedString,
+      paramName: asTrimmedString,
+      paramDescription: asTrimmedString,
+      tools: asNameList,
+      summary: asTrimmedString,
+    },
+    changeFieldsHint: "description, paramName, paramDescription, tools",
+    routeFor: (name) => `/claw/api/v1/subagents/${encodeURIComponent(name)}/propose-update`,
+  }),
+};

--- a/packages/xyne-claw-shared/src/tools/registry.ts
+++ b/packages/xyne-claw-shared/src/tools/registry.ts
@@ -202,6 +202,7 @@ register(sandbox.sandboxRun);
 register(sandbox.sandboxRunDetached);
 register(sandbox.sandboxPollJob);
 register(sandbox.sandboxWriteFile);
+register(sandbox.sandboxCopyIn);
 register(sandbox.sandboxReadFile);
 register(sandbox.sandboxDeliverFiles);
 register(sandbox.sandboxDestroy);

--- a/packages/xyne-claw-shared/src/tools/registry.ts
+++ b/packages/xyne-claw-shared/src/tools/registry.ts
@@ -28,6 +28,7 @@ import * as todo from "./todo/index.js";
 import * as orchestrator from "./orchestrator/index.js";
 import * as agentIntrospect from "./agent-introspect/index.js";
 import * as skillManagement from "./skill-management/index.js";
+import * as agentManagement from "./agent-management/index.js";
 import * as videoExplainer from "./video-explainer/index.js";
 
 /** All custom tools, keyed by slug */
@@ -179,6 +180,15 @@ register(postmanSbx.postmanSbxRunCollection);
 // personal skill) and update-skill (proposes a diff to the skill owner via DM).
 register(skillManagement.createSkillTool);
 register(skillManagement.updateSkillTool);
+
+// Register agent-management tools — create-agent / create-subagent (write tools:
+// draft + approve → personal agent/subagent owned by the approver) and
+// update-agent / update-subagent (propose a diff to the owner via DM). Mirrors
+// the skill-management tools above; approval + persistence live in claw-auth.
+register(agentManagement.createAgentTool);
+register(agentManagement.createSubagentTool);
+register(agentManagement.updateAgentTool);
+register(agentManagement.updateSubagentTool);
 
 // Register plan-tracking tools (todo-write / todo-read). The agent maintains an
 // explicit todo list that renders as a live, in-place-updating card in the

--- a/packages/xyne-claw-shared/src/tools/sandbox/copy-in.test.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/copy-in.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { sandboxCopyIn } from "./tools.js";
+import type { ToolExecutionContext } from "../types.js";
+
+// A run context that has a materialized skills root + a plausible session owner.
+// The path-confinement / validation branches all return BEFORE any sandbox
+// session lookup, so these cases never need a live SESSION_STORE entry.
+function ctx(skillsRoot: string | undefined): ToolExecutionContext {
+  return {
+    config: {},
+    meta: {
+      userId: "u1",
+      conversationId: "c1",
+      agentSlug: "a1",
+      ...(skillsRoot ? { skillsRoot } : {}),
+    },
+  };
+}
+
+describe("sandbox-copy-in tool definition", () => {
+  it("is a custom sandbox tool with the expected slug", () => {
+    expect(sandboxCopyIn.slug).toBe("sandbox-copy-in");
+    expect(sandboxCopyIn.source).toBe("custom:sandbox");
+  });
+
+  it("requires sessionId and skillPath", () => {
+    expect(sandboxCopyIn.inputSchema.required).toEqual(
+      expect.arrayContaining(["sessionId", "skillPath"]),
+    );
+  });
+
+  it("is NOT an approval-gated write tool (server-side copy, no user data mutation)", () => {
+    // It writes into an ephemeral sandbox the agent already owns — same trust
+    // level as sandbox-write-file, which is also not approval-gated.
+    expect(sandboxCopyIn.isWriteTool).toBeFalsy();
+  });
+});
+
+describe("sandbox-copy-in path confinement", () => {
+  const ROOT = "/data/session-skills/sess-123";
+
+  it("refuses when no skills are materialized for the run", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", skillPath: "slug/scripts/run.sh" },
+      ctx(undefined),
+    );
+    expect(out.toLowerCase()).toContain("no skills are materialized");
+  });
+
+  it("rejects an empty skillPath", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", skillPath: "   " },
+      ctx(ROOT),
+    );
+    expect(out.toLowerCase()).toContain("non-empty");
+  });
+
+  it("rejects '..' traversal that escapes the skills root", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", skillPath: "../../etc/passwd" },
+      ctx(ROOT),
+    );
+    expect(out.toLowerCase()).toContain("escapes the skill directory");
+  });
+
+  it("rejects a sibling-prefix escape (root-name is a prefix, not a parent)", async () => {
+    // /data/session-skills/sess-123-evil must NOT be accepted just because it
+    // starts with the root string — the separator check guards this.
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", skillPath: "../sess-123-evil/secret" },
+      ctx(ROOT),
+    );
+    expect(out.toLowerCase()).toContain("escapes the skill directory");
+  });
+
+  it("neutralizes a leading '/' into the root instead of treating it as absolute", async () => {
+    // path.join strips the leading slash, so '/etc/shadow' resolves to
+    // <root>/etc/shadow — confined inside the root, NOT an escape. It clears
+    // confinement and fails later on the missing session (safe outcome).
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "no-such-session", skillPath: "/etc/shadow" },
+      ctx(ROOT),
+    );
+    expect(out).toContain("no-such-session");
+    expect(out.toLowerCase()).toContain("not found");
+  });
+
+  it("refuses paths that resolve to a credential file even inside the root", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", skillPath: "slug/.ssh/id_rsa" },
+      ctx(ROOT),
+    );
+    expect(out.toLowerCase()).toContain("credential");
+  });
+
+  it("passes confinement for a normal in-root path, then fails only on the missing session", async () => {
+    // A legit relative path clears every validation branch and reaches the
+    // session lookup — proving the guards don't false-reject valid input.
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "no-such-session", skillPath: "slug/scripts/run.sh" },
+      ctx(ROOT),
+    );
+    expect(out).toContain("no-such-session");
+    expect(out.toLowerCase()).toContain("not found");
+  });
+});

--- a/packages/xyne-claw-shared/src/tools/sandbox/experiment-idle-timeout.test.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/experiment-idle-timeout.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { experimentIdleTimeoutMs } from "./tools.js";
+import type { ToolExecutionContext } from "../types.js";
+
+function ctx(deadlineAt?: string): ToolExecutionContext {
+  return {
+    config: {},
+    meta: deadlineAt ? { experimentDeadlineAt: deadlineAt } : {},
+  };
+}
+
+describe("experimentIdleTimeoutMs", () => {
+  const now = Date.parse("2026-08-01T00:00:00.000Z");
+
+  it("returns undefined when experiment deadline meta is absent", () => {
+    vi.setSystemTime(now);
+    expect(experimentIdleTimeoutMs(ctx())).toBeUndefined();
+  });
+
+  it("returns undefined when experiment deadline meta is unparseable", () => {
+    vi.setSystemTime(now);
+    expect(experimentIdleTimeoutMs(ctx("not-a-date"))).toBeUndefined();
+  });
+
+  it("floors near deadlines to 30 minutes", () => {
+    vi.setSystemTime(now);
+    expect(experimentIdleTimeoutMs(ctx(new Date(now + 5 * 60_000).toISOString()))).toBe(30 * 60_000);
+  });
+
+  it("caps far deadlines to 3 hours", () => {
+    vi.setSystemTime(now);
+    expect(experimentIdleTimeoutMs(ctx(new Date(now + 10 * 60 * 60_000).toISOString()))).toBe(3 * 60 * 60_000);
+  });
+
+  it("uses deadline plus 20 minutes for mid-range deadlines", () => {
+    vi.setSystemTime(now);
+    expect(experimentIdleTimeoutMs(ctx(new Date(now + 60 * 60_000).toISOString()))).toBe(80 * 60_000);
+  });
+});

--- a/packages/xyne-claw-shared/src/tools/sandbox/index.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/index.ts
@@ -4,6 +4,7 @@ export {
   sandboxRunDetached,
   sandboxPollJob,
   sandboxWriteFile,
+  sandboxCopyIn,
   sandboxReadFile,
   sandboxDeliverFiles,
   sandboxDestroy,

--- a/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
@@ -3,6 +3,8 @@ import type { Session } from "@xyne/kata-sdk";
 import type { ToolDefinition, ToolExecutionContext } from "../types.js";
 import { redactSecrets, redactAndStringify } from "./redact.js";
 import { rotateTemplate, isSameTemplateFamily } from "./template-rotation.js";
+import { readFile } from "node:fs/promises";
+import { resolve, join, sep } from "node:path";
 
 // Build a redacted `Error: ...` string from a caught error. Several tool
 // catch blocks interpolate err.message straight into tool output, which can
@@ -758,6 +760,107 @@ export const sandboxWriteFile: ToolDefinition = {
       if (isStaleSessionError(err)) {
         evictSession(session);
         return `Error: Session ${sessionId} died (sandbox pod replaced). Call sandbox-repo-setup to re-provision.`;
+      }
+      return sandboxErr(err);
+    }
+  },
+};
+
+/**
+ * Copy a companion file from THIS run's materialized skill directory directly
+ * into the sandbox — server-side, so the bytes never round-trip through the
+ * model's context (no token cost, no base64 corruption of binaries, no
+ * truncation of large scripts). This is the ergonomic path for "a skill ships
+ * a script, run it in the sandbox": instead of reading the file into context
+ * and re-emitting it through sandbox-write-file, point at the skill file and
+ * the runtime streams the bytes across.
+ *
+ * Confinement: the source is resolved ONLY under this run's session-skills
+ * root (`context.meta.skillsRoot`, injected by the claw runtime as
+ * `<dataDir>/session-skills/<sessionId>` — the SAME directory the agent's
+ * read tools are granted). Absolute inputs and `..` traversal that escape that
+ * root are rejected, so this can't read another user's session or arbitrary
+ * pod files.
+ */
+export const sandboxCopyIn: ToolDefinition = {
+  slug: "sandbox-copy-in",
+  name: "Sandbox Copy Skill File",
+  description:
+    "Copy a companion file bundled with a loaded skill (a script or asset in the skill's folder) directly into a sandbox session, WITHOUT pasting its content. " +
+    "Prefer this over sandbox-write-file when a skill ships a script/binary you need to run in the sandbox: the file is streamed server-side, so large or binary files stay intact and don't bloat context. " +
+    "`skillPath` is relative to the skill directory shown in the skill's <location> (e.g. 'sandbox-record-video/scripts/recorder.mjs').",
+  source: "custom:sandbox",
+  configSchema: SANDBOX_CONFIG_SCHEMA,
+  inputSchema: {
+    type: "object",
+    properties: {
+      sessionId: {
+        type: "string",
+        description: "Sandbox session ID returned by sandbox-create / sandbox-repo-setup",
+      },
+      skillPath: {
+        type: "string",
+        description:
+          "Path of the skill companion file RELATIVE to this run's session-skills root, e.g. '<skill-slug>/scripts/run.sh'. Leading '/' and '..' are rejected.",
+      },
+      destPath: {
+        type: "string",
+        description: "Absolute destination path inside the sandbox (default: /workspace/<basename of skillPath>).",
+      },
+    },
+    required: ["sessionId", "skillPath"],
+  },
+
+  async execute(params, context) {
+    if (!context) return "Error: No execution context available.";
+    const sessionId = params["sessionId"] as string;
+    const skillPathRaw = params["skillPath"] as string;
+    const destPathRaw = params["destPath"] as string | undefined;
+
+    const skillsRoot = context.meta?.["skillsRoot"];
+    if (!skillsRoot) {
+      return "Error: No skills are materialized for this run (context.meta.skillsRoot is unset), so there is nothing to copy in. Use sandbox-write-file for ad-hoc content.";
+    }
+    if (typeof skillPathRaw !== "string" || skillPathRaw.trim().length === 0) {
+      return "Error: skillPath must be a non-empty path relative to the skill directory.";
+    }
+
+    // Confine the source to THIS run's session-skills root. Reject absolute
+    // inputs and any '..' traversal that escapes the root — otherwise this
+    // becomes an arbitrary pod-file / cross-session read primitive.
+    const rootAbs = resolve(skillsRoot);
+    const sourceAbs = resolve(join(rootAbs, skillPathRaw));
+    if (sourceAbs !== rootAbs && !sourceAbs.startsWith(rootAbs + sep)) {
+      return "Error: skillPath escapes the skill directory. Pass a path relative to the skill folder (no leading '/' and no '..').";
+    }
+    if (isCredentialPath(sourceAbs)) {
+      return JSON.stringify({ error: "Refused: path looks like a credential file" });
+    }
+
+    const destPath =
+      typeof destPathRaw === "string" && destPathRaw.trim().length > 0
+        ? destPathRaw.trim()
+        : `/workspace/${sourceAbs.split("/").pop()}`;
+
+    const session = SESSION_STORE.get(sessionId);
+    if (!session) return `Error: Session ${sessionId} not found.`;
+    if (!isSessionOwnedByContext(session, sessionId, context)) {
+      return unauthorizedSessionMessage(sessionId);
+    }
+    const roWrite = readOnlyGuard(session, { write: true });
+    if (roWrite) return roWrite;
+
+    try {
+      const buf = await readFile(sourceAbs);
+      await session.files.write(destPath, buf);
+      return JSON.stringify({ skillPath: skillPathRaw, destPath, bytes: buf.length, copied: true });
+    } catch (err) {
+      if (isStaleSessionError(err)) {
+        evictSession(session);
+        return `Error: Session ${sessionId} died (sandbox pod replaced). Call sandbox-repo-setup to re-provision.`;
+      }
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return `Error: Skill file not found at '${skillPathRaw}'. Check the path relative to the skill's <location> directory.`;
       }
       return sandboxErr(err);
     }

--- a/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
@@ -3,8 +3,11 @@ import type { Session } from "@xyne/kata-sdk";
 import type { ToolDefinition, ToolExecutionContext } from "../types.js";
 import { redactSecrets, redactAndStringify } from "./redact.js";
 import { rotateTemplate, isSameTemplateFamily } from "./template-rotation.js";
+import { createLogger } from "../../logger.js";
 import { readFile } from "node:fs/promises";
 import { resolve, join, sep } from "node:path";
+
+const sandboxLog = createLogger("sandbox-tools");
 
 // Build a redacted `Error: ...` string from a caught error. Several tool
 // catch blocks interpolate err.message straight into tool output, which can
@@ -207,6 +210,36 @@ function storeKeyFromContext(context: { meta?: Record<string, string> } | undefi
     context?.meta?.["conversationId"],
     context?.meta?.["agentSlug"],
   );
+}
+
+const EXPERIMENT_IDLE_SLACK_MS = 20 * 60_000;
+const EXPERIMENT_IDLE_FLOOR_MS = 30 * 60_000;
+const EXPERIMENT_IDLE_CAP_MS = 3 * 60 * 60_000;
+
+export function experimentIdleTimeoutMs(ctx: ToolExecutionContext): number | undefined {
+  const raw = ctx.meta?.["experimentDeadlineAt"];
+  if (!raw) return undefined;
+  const deadlineMs = Date.parse(raw);
+  if (!Number.isFinite(deadlineMs)) return undefined;
+  const wantedMs = deadlineMs - Date.now() + EXPERIMENT_IDLE_SLACK_MS;
+  return Math.min(EXPERIMENT_IDLE_CAP_MS, Math.max(EXPERIMENT_IDLE_FLOOR_MS, wantedMs));
+}
+
+function idleTimeoutForSessionCreation(
+  context: ToolExecutionContext,
+  explicitIdleTimeoutMs: number | undefined,
+  fallbackIdleTimeoutMs: number,
+): number {
+  if (explicitIdleTimeoutMs !== undefined) return explicitIdleTimeoutMs;
+  const experimentIdleMs = experimentIdleTimeoutMs(context);
+  if (experimentIdleMs !== undefined) {
+    sandboxLog.info(
+      `[sandbox] applying experiment idle timeout default: ${Math.ceil(experimentIdleMs / 60_000)} min`,
+      { experimentIdleTimeoutMs: experimentIdleMs },
+    );
+    return experimentIdleMs;
+  }
+  return fallbackIdleTimeoutMs;
 }
 
 function rememberSession(storeKey: string | undefined, session: Session, template?: string, owner?: SessionOwner): void {
@@ -462,7 +495,11 @@ export const sandboxCreate: ToolDefinition = {
     const storeKey = storeKeyFromContext(context);
     if (!storeKey) return "Error: No userId/conversationId in context.";
     const timeoutMs = (params["timeoutMs"] as number | undefined) ?? 60 * 60 * 1000;
-    const idleTimeoutMs = (params["idleTimeoutMs"] as number | undefined) ?? 10 * 60 * 1000;
+    const idleTimeoutMs = idleTimeoutForSessionCreation(
+      context,
+      params["idleTimeoutMs"] as number | undefined,
+      10 * 60 * 1000,
+    );
     // A UI-pinned sandbox repo wins over whatever template the LLM passed —
     // a pinned agent must always get its own sandbox, never the legacy kata one.
     const pinnedTemplate = await pinnedTemplateForContext(context);
@@ -1224,7 +1261,7 @@ export function makeRepoSetupTool(config: RepoSetupConfig): ToolDefinition {
         const client = makeClient(context.config, config.template);
         const session = await client.createSession({
           timeoutMs: noRepoDuration,
-          idleTimeoutMs: config.idleTimeoutMs || 60 * 60 * 1000,
+          idleTimeoutMs: idleTimeoutForSessionCreation(context, undefined, config.idleTimeoutMs || 60 * 60 * 1000),
           template: config.template,
         });
         rememberSession(storeKey, session, config.template, ownerFromContext(context));
@@ -1368,7 +1405,7 @@ export function makeRepoSetupTool(config: RepoSetupConfig): ToolDefinition {
       const client = makeClient(context.config, claimTemplate);
       const session = await client.createSession({
         timeoutMs: sessionDurationMs,
-        idleTimeoutMs: config.idleTimeoutMs || 60 * 60 * 1000,
+        idleTimeoutMs: idleTimeoutForSessionCreation(context, undefined, config.idleTimeoutMs || 60 * 60 * 1000),
         template: claimTemplate,
         readyTimeoutMs: config.readyTimeoutMs || 10 * 60 * 1000,
       });
@@ -1826,7 +1863,11 @@ async function resolveSbxGit(requestedRepo: string, context: ToolExecutionContex
   // Boot the one shared read-only sandbox (repos are cloned in its prebake).
   try {
     const client = makeClient(context.config, SBX_GIT.template);
-    const session = await client.createSession({ timeoutMs: SBX_GIT.sessionTimeoutMs, template: SBX_GIT.template });
+    const session = await client.createSession({
+      timeoutMs: SBX_GIT.sessionTimeoutMs,
+      idleTimeoutMs: idleTimeoutForSessionCreation(context, undefined, 10 * 60 * 1000),
+      template: SBX_GIT.template,
+    });
     // No owner → shared across conversations; mark it so ownership checks pass.
     rememberSession(key, session, SBX_GIT.template);
     bindCaller(session);

--- a/packages/xyne-claw-shared/src/tools/skill-management/skill-tools.test.ts
+++ b/packages/xyne-claw-shared/src/tools/skill-management/skill-tools.test.ts
@@ -4,7 +4,7 @@ import { createSkillTool, updateSkillTool } from "./tools.js";
 describe("createSkillTool definition", () => {
   it("is an approval-gated write tool", () => {
     expect(createSkillTool.slug).toBe("create-skill");
-    expect(createSkillTool.source).toBe("custom:skill");
+    expect(createSkillTool.source).toBe("custom:agent");
     expect(createSkillTool.isWriteTool).toBe(true);
   });
   it("requires name, description and content", () => {
@@ -21,13 +21,11 @@ describe("createSkillTool definition", () => {
 describe("updateSkillTool definition", () => {
   it("is a proposal (non-write) tool", () => {
     expect(updateSkillTool.slug).toBe("update-skill");
-    expect(updateSkillTool.source).toBe("custom:skill-update");
+    expect(updateSkillTool.source).toBe("custom:agent");
     expect(updateSkillTool.isWriteTool).toBeFalsy();
   });
-  it("requires slug and content", () => {
-    expect(updateSkillTool.inputSchema.required).toEqual(
-      expect.arrayContaining(["slug", "content"]),
-    );
+  it("requires only slug (content vs edits is validated in execute)", () => {
+    expect(updateSkillTool.inputSchema.required).toEqual(["slug"]);
   });
 });
 
@@ -38,9 +36,9 @@ describe("updateSkillTool.execute validation", () => {
     const out = JSON.parse(await updateSkillTool.execute({ content: "x" }, ctx));
     expect(out.error).toMatch(/slug is required/i);
   });
-  it("errors when content empty", async () => {
+  it("errors when neither edits nor content provided", async () => {
     const out = JSON.parse(await updateSkillTool.execute({ slug: "s", content: "   " }, ctx));
-    expect(out.error).toMatch(/content is required/i);
+    expect(out.error).toMatch(/edits.*or.*content/i);
   });
   it("errors when requesting user id absent from context", async () => {
     const out = JSON.parse(await updateSkillTool.execute({ slug: "s", content: "x" }, { config: {}, meta: {} }));

--- a/packages/xyne-claw-shared/src/tools/skill-management/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/skill-management/tools.ts
@@ -53,7 +53,7 @@ export const createSkillTool: ToolDefinition = {
     "On approval the skill is created as a PERSONAL skill owned by the approving user. " +
     "Provide: name (human title), slug (optional — auto-derived from name if omitted), description (one line shown in the skill picker), and content (the full SKILL.md markdown body). " +
     "Use this when the user asks you to 'create a skill', 'save this as a skill', or 'turn these instructions into a skill'.",
-  source: "custom:skill",
+  source: "custom:agent",
   isWriteTool: true,
   inputSchema: {
     type: "object",
@@ -84,7 +84,7 @@ export const updateSkillTool: ToolDefinition = {
     "SMALL SKILLS ONLY: `content` (full replacement) is a convenience for skills under ~8K chars, where a whole-body rewrite is cheaper than quoting old+new via edits. The server REJECTS full replacements of larger skills — a large body does not survive as a tool argument (it gets truncated and destroys the skill). " +
     "Always read the current skill first so your oldText anchors are exact. " +
     "Re-proposing is safe: a new proposal automatically replaces your earlier still-pending one for the same skill.",
-  source: "custom:skill-update",
+  source: "custom:agent",
   inputSchema: {
     type: "object",
     properties: {

--- a/packages/xyne-claw-shared/src/tools/subagents/definitions.ts
+++ b/packages/xyne-claw-shared/src/tools/subagents/definitions.ts
@@ -28,6 +28,13 @@ export interface SubagentDefinition {
   paramDescription: string;
   /** MCP server type this subagent wraps — matches serverType from /mcp/tools */
   serverType: string;
+  /** Additional serverTypes this definition also wraps. Prod can register the
+   *  same logical connector under a second type (e.g. the DB-provisioned
+   *  "github-mcp-npx" next to the code adapter's "github"); without an alias
+   *  the extra type has no definition and its tools become invisible to the
+   *  fast-mode catalog while passing through fine in normal mode. Alias types
+   *  share this definition's wrapper name, prompt, and allowlist identity. */
+  serverTypeAliases?: string[];
   /** Optional per-subagent reasoning level. When set, overrides the global
    *  AGENT.thinkingLevel for THIS subagent's child session. Retrieval-heavy
    *  subagents (spaces) benefit from "high"; cheap structured-fetch ones
@@ -190,6 +197,10 @@ Return structured findings (lists of {repo, number, title, state, url} when surf
     paramName: "question",
     paramDescription: "What to look up on GitHub. Include the owner/repo (e.g. 'anthropics/anthropic-sdk-python'), PR / issue numbers, branch names, file paths, or a code search expression.",
     serverType: "github",
+    // Prod's active GitHub connector is DB-registered under this second type
+    // (the code adapter's "github" is vestigial there). Without the alias its
+    // tools are invisible to the fast-mode catalog (2026-07-30 incident).
+    serverTypeAliases: ["github-mcp-npx"],
   },
 
   // ── Grafana ─────────────────────────────────────────────────────
@@ -1564,6 +1575,19 @@ If a query fails, include the error text and suggest a corrected index or query 
 /** Helper to get a definition by name */
 export function getSubagentDefinition(name: string): SubagentDefinition | undefined {
   return SUBAGENT_DEFINITIONS.find((d) => d.name === name);
+}
+
+/**
+ * Resolve the definition wrapping a given MCP serverType, honouring aliases.
+ * THE lookup for "which subagent owns this server's tools" — every call site
+ * (normal-mode wrapper build, fast-mode catalog + direct split) must use this
+ * instead of matching `d.serverType` inline, or alias-registered servers
+ * (github-mcp-npx) silently fall out of one mode but not the other.
+ */
+export function findSubagentDefinitionForServer(serverType: string): SubagentDefinition | undefined {
+  return SUBAGENT_DEFINITIONS.find(
+    (d) => d.serverType === serverType || (d.serverTypeAliases?.includes(serverType) ?? false),
+  );
 }
 
 

--- a/packages/xyne-claw-shared/src/tools/subagents/index.ts
+++ b/packages/xyne-claw-shared/src/tools/subagents/index.ts
@@ -1,6 +1,7 @@
 export {
   SUBAGENT_DEFINITIONS,
   getSubagentDefinition,
+  findSubagentDefinitionForServer,
   parseToolsConfig,
   type SubagentDefinition,
   type AgentToolsConfig,


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #92 (original author: @anuragdvd).

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
