### PR TITLE
feat: render Obsidian-flavored markdown for attachments without XSS

### DIFF
--- a/apps/dashboard/src/components/FileViewer/ReadmeViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/ReadmeViewer.tsx
@@ -2,22 +2,14 @@ import React, { useEffect, useState, useMemo, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
-import rehypeRaw from 'rehype-raw';
-import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypeSanitize from 'rehype-sanitize';
 import type { Components } from 'react-markdown';
 import { BaseViewerProps } from './utils';
-
-// Sanitize schema for file-provided markdown. Starts from rehype-sanitize's
-// safe defaults (scripts / event handlers stripped; img `src` and anchor
-// `href` restricted to http(s)/mailto) and additionally preserves the
-// `checked` attribute so GFM task-list checkboxes still render their state.
-const markdownSanitizeSchema = {
-  ...defaultSchema,
-  attributes: {
-    ...defaultSchema.attributes,
-    input: [...(defaultSchema.attributes?.['input'] ?? []), 'checked'],
-  },
-};
+import {
+  obsidianRemarkPlugins,
+  obsidianSanitizeSchema,
+  obsidianComponents,
+} from './obsidian';
 
 // Loading spinner
 const LoadingSpinner: React.FC = () => (
@@ -213,9 +205,12 @@ export const ReadmeViewer: React.FC<BaseViewerProps> = memo(({ source }) => {
         <div className='min-h-screen px-10 py-10 md:px-15 lg:px-20'>
           <div className='max-w-4xl mx-auto'>
             <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeRaw, [rehypeSanitize, markdownSanitizeSchema], rehypeHighlight]}
-              components={markdownComponents}
+              remarkPlugins={[remarkGfm, ...obsidianRemarkPlugins]}
+              // SECURITY: rehype-raw is intentionally NOT used here. Attachment
+              // files are untrusted, so raw HTML in a .md is never parsed to DOM;
+              // obsidianSanitizeSchema is then the single allow-list gate.
+              rehypePlugins={[[rehypeSanitize, obsidianSanitizeSchema], rehypeHighlight]}
+              components={{ ...markdownComponents, ...obsidianComponents }}
             >
               {markdownContent}
             </ReactMarkdown>

--- a/apps/dashboard/src/components/FileViewer/obsidian/components.tsx
+++ b/apps/dashboard/src/components/FileViewer/obsidian/components.tsx
@@ -1,0 +1,99 @@
+/* react-markdown component overrides for the inert Obsidian nodes emitted by the
+ * remark plugins. Keyed on element type + data-* on the hast node. These render
+ * children/text only — no dangerouslySetInnerHTML, no links out of wikilinks. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import type { Components } from 'react-markdown';
+
+const CALLOUT_TONE: Record<string, string> = {
+  note: 'border-blue-500 bg-blue-500/10',
+  info: 'border-blue-500 bg-blue-500/10',
+  todo: 'border-blue-500 bg-blue-500/10',
+  tip: 'border-teal-500 bg-teal-500/10',
+  hint: 'border-teal-500 bg-teal-500/10',
+  important: 'border-teal-500 bg-teal-500/10',
+  abstract: 'border-teal-500 bg-teal-500/10',
+  summary: 'border-teal-500 bg-teal-500/10',
+  success: 'border-green-500 bg-green-500/10',
+  check: 'border-green-500 bg-green-500/10',
+  done: 'border-green-500 bg-green-500/10',
+  question: 'border-amber-500 bg-amber-500/10',
+  faq: 'border-amber-500 bg-amber-500/10',
+  warning: 'border-amber-500 bg-amber-500/10',
+  caution: 'border-amber-500 bg-amber-500/10',
+  attention: 'border-amber-500 bg-amber-500/10',
+  failure: 'border-red-500 bg-red-500/10',
+  danger: 'border-red-500 bg-red-500/10',
+  error: 'border-red-500 bg-red-500/10',
+  bug: 'border-red-500 bg-red-500/10',
+  example: 'border-purple-500 bg-purple-500/10',
+  quote: 'border-gray-500 bg-gray-500/10',
+  cite: 'border-gray-500 bg-gray-500/10',
+};
+
+const propsOf = (node: any): Record<string, any> => (node?.properties ?? {}) as Record<string, any>;
+const classOf = (node: any): string => {
+  const c = propsOf(node).className;
+  return Array.isArray(c) ? c.join(' ') : String(c ?? '');
+};
+
+export const obsidianComponents: Components = {
+  div: ({ node, children }: any) => {
+    const c = classOf(node);
+    if (c.includes('obsidian-callout-header')) {
+      return (
+        <div className='obsidian-callout-header flex items-center gap-2 font-semibold mb-1 text-foreground'>
+          {children}
+        </div>
+      );
+    }
+    if (c.includes('obsidian-callout')) {
+      const type = String(propsOf(node).dataCallout ?? 'note');
+      const tone = CALLOUT_TONE[type] ?? 'border-gray-500 bg-gray-500/10';
+      return (
+        <div className={`obsidian-callout border-l-4 rounded-md px-4 py-3 my-4 ${tone}`}>
+          {children}
+        </div>
+      );
+    }
+    return <div className={c}>{children}</div>;
+  },
+  span: ({ node, children }: any) => {
+    const p = propsOf(node);
+    if (p.dataWikilink !== undefined) {
+      return (
+        <span
+          className='obsidian-wikilink text-action-primary bg-action-primary/10 rounded px-1 py-0.5 cursor-default'
+          title={`Wikilink: ${String(p.dataWikilink)} (not linked in preview)`}
+        >
+          {children}
+        </span>
+      );
+    }
+    if (p.dataTag !== undefined) {
+      return (
+        <span className='obsidian-tag inline-block text-xs rounded-full bg-muted text-action-primary px-2 py-0.5 mx-0.5'>
+          {children}
+        </span>
+      );
+    }
+    if (p.dataEmbed !== undefined) {
+      return (
+        <span className='obsidian-embed block border border-dashed border-border rounded-md bg-muted/40 text-muted-foreground text-sm px-3 py-2 my-3'>
+          {children}
+        </span>
+      );
+    }
+    return <span className={classOf(node)}>{children}</span>;
+  },
+  mark: ({ children }: any) => (
+    <mark className='obsidian-highlight bg-yellow-300/60 dark:bg-yellow-500/40 text-foreground rounded px-0.5'>
+      {children}
+    </mark>
+  ),
+  caption: ({ children }: any) => (
+    <caption className='obsidian-properties-caption text-left text-xs uppercase tracking-wide text-muted-foreground mb-1'>
+      {children}
+    </caption>
+  ),
+};

--- a/apps/dashboard/src/components/FileViewer/obsidian/index.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/index.ts
@@ -1,0 +1,30 @@
+/* Obsidian-flavored markdown support for the attachment "rendered" view.
+ *
+ * All Obsidian syntax is expanded at the REMARK (mdast) stage into inert,
+ * allow-listed nodes; nothing here emits raw HTML. Wire order matters:
+ *  - properties table needs the frontmatter node from remark-frontmatter
+ *  - embeds run before wikilinks so `![[...]]` is consumed before `[[...]]`
+ *
+ * Consumed by ReadmeViewer together with `obsidianSanitizeSchema` (the single
+ * security gate, used WITHOUT rehype-raw) and `obsidianComponents`. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkPropertiesTable from './remarkPropertiesTable';
+import remarkObsidianCallouts from './remarkObsidianCallouts';
+import remarkObsidianEmbeds from './remarkObsidianEmbeds';
+import remarkWikiLinks from './remarkWikiLinks';
+import remarkObsidianTags from './remarkObsidianTags';
+import remarkHighlight from './remarkHighlight';
+
+export const obsidianRemarkPlugins: any[] = [
+  [remarkFrontmatter, ['yaml']],
+  remarkPropertiesTable,
+  remarkObsidianCallouts,
+  remarkObsidianEmbeds,
+  remarkWikiLinks,
+  remarkObsidianTags,
+  remarkHighlight,
+];
+
+export { obsidianSanitizeSchema } from './sanitizeSchema';
+export { obsidianComponents } from './components';

--- a/apps/dashboard/src/components/FileViewer/obsidian/labels.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/labels.ts
@@ -1,0 +1,39 @@
+/* Obsidian callout type → display label + icon + tone.
+ * Tone is a stable key consumed by the component layer (obsidianComponents). */
+export type CalloutMeta = { label: string; icon: string; tone: string };
+
+const LABELS: Record<string, CalloutMeta> = {
+  note: { label: 'Note', icon: '✎', tone: 'blue' },
+  info: { label: 'Info', icon: 'ℹ', tone: 'blue' },
+  todo: { label: 'Todo', icon: '☑', tone: 'blue' },
+  tip: { label: 'Tip', icon: '★', tone: 'teal' },
+  hint: { label: 'Tip', icon: '★', tone: 'teal' },
+  important: { label: 'Important', icon: '❗', tone: 'teal' },
+  abstract: { label: 'Abstract', icon: '❋', tone: 'teal' },
+  summary: { label: 'Summary', icon: '❋', tone: 'teal' },
+  success: { label: 'Success', icon: '✔', tone: 'green' },
+  check: { label: 'Success', icon: '✔', tone: 'green' },
+  done: { label: 'Done', icon: '✔', tone: 'green' },
+  question: { label: 'Question', icon: '?', tone: 'amber' },
+  faq: { label: 'FAQ', icon: '?', tone: 'amber' },
+  warning: { label: 'Warning', icon: '⚠', tone: 'amber' },
+  caution: { label: 'Caution', icon: '⚠', tone: 'amber' },
+  attention: { label: 'Attention', icon: '⚠', tone: 'amber' },
+  failure: { label: 'Failure', icon: '✘', tone: 'red' },
+  danger: { label: 'Danger', icon: '⚡', tone: 'red' },
+  error: { label: 'Error', icon: '✘', tone: 'red' },
+  bug: { label: 'Bug', icon: '⌾', tone: 'red' },
+  example: { label: 'Example', icon: '❖', tone: 'purple' },
+  quote: { label: 'Quote', icon: '❝', tone: 'gray' },
+  cite: { label: 'Quote', icon: '❝', tone: 'gray' },
+};
+
+export function calloutMeta(type: string): CalloutMeta {
+  return (
+    LABELS[type] ?? {
+      label: type.charAt(0).toUpperCase() + type.slice(1),
+      icon: '◆',
+      tone: 'gray',
+    }
+  );
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/mdastText.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/mdastText.ts
@@ -1,0 +1,52 @@
+/* Minimal mdast helpers — deliberately dependency-free (no unist-util-visit).
+ * Splits `text` nodes by a regex into a mix of text + custom inline nodes.
+ * Never descends into code / inlineCode or already-produced obsidian nodes,
+ * so Obsidian syntax inside a fenced code block stays literal. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type Node = any;
+
+const SKIP = new Set(['code', 'inlineCode', 'obsidianEmbed', 'obsidianInline']);
+
+/** build() may return a single node, an array of nodes, or null (= keep literal match text). */
+export function replaceInText(
+  tree: Node,
+  regex: RegExp,
+  build: (m: RegExpExecArray) => Node | Node[] | null,
+): void {
+  const recurse = (node: Node): void => {
+    if (!node || SKIP.has(node.type) || !Array.isArray(node.children)) return;
+    const next: Node[] = [];
+    for (const child of node.children) {
+      if (child && child.type === 'text' && typeof child.value === 'string') {
+        next.push(...splitText(child.value, regex, build));
+      } else {
+        recurse(child);
+        next.push(child);
+      }
+    }
+    node.children = next;
+  };
+  recurse(tree);
+}
+
+function splitText(
+  value: string,
+  regex: RegExp,
+  build: (m: RegExpExecArray) => Node | Node[] | null,
+): Node[] {
+  const flags = regex.flags.includes('g') ? regex.flags : regex.flags + 'g';
+  const re = new RegExp(regex.source, flags);
+  const out: Node[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(value)) !== null) {
+    if (m.index > last) out.push({ type: 'text', value: value.slice(last, m.index) });
+    const built = build(m);
+    if (Array.isArray(built)) out.push(...built);
+    else out.push(built ?? { type: 'text', value: m[0] });
+    last = m.index + m[0].length;
+    if (re.lastIndex === m.index) re.lastIndex++; // guard against zero-length loops
+  }
+  if (last < value.length) out.push({ type: 'text', value: value.slice(last) });
+  return out.length ? out : [{ type: 'text', value }];
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/remarkHighlight.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/remarkHighlight.ts
@@ -1,0 +1,13 @@
+/* Obsidian highlight: `==text==` → <mark>. Inert, no attributes beyond class. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { replaceInText } from './mdastText';
+
+export default function remarkHighlight() {
+  return (tree: any): void => {
+    replaceInText(tree, /==([^=\n]+)==/, (m) => ({
+      type: 'obsidianInline',
+      data: { hName: 'mark', hProperties: { className: ['obsidian-highlight'] } },
+      children: [{ type: 'text', value: m[1] }],
+    }));
+  };
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/remarkObsidianCallouts.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/remarkObsidianCallouts.ts
@@ -1,0 +1,47 @@
+/* Obsidian callouts: `> [!type] Optional title` blockquotes.
+ * Transforms the blockquote (in-place) into an inert styled container by
+ * setting data.hName/hProperties — mdast-util-to-hast emits <div data-callout>.
+ * No raw HTML is produced; the sanitize allow-list keeps only div+data-callout. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { calloutMeta } from './labels';
+
+export default function remarkObsidianCallouts() {
+  return (tree: any): void => {
+    const recurse = (node: any): void => {
+      if (!node || !Array.isArray(node.children)) return;
+      for (const child of node.children) {
+        if (child && child.type === 'blockquote') convert(child);
+        recurse(child);
+      }
+    };
+    recurse(tree);
+  };
+}
+
+function convert(bq: any): void {
+  const first = bq.children?.[0];
+  if (!first || first.type !== 'paragraph' || !Array.isArray(first.children)) return;
+  const t0 = first.children[0];
+  if (!t0 || t0.type !== 'text') return;
+
+  const m = /^\[!([A-Za-z][\w-]*)\]([+-]?)[ \t]?([^\n]*)/.exec(t0.value);
+  if (!m) return;
+
+  const type = m[1].toLowerCase();
+  const custom = (m[3] || '').trim();
+  // Drop the marker line; keep any body text that followed on later lines.
+  t0.value = t0.value.slice(m[0].length);
+  const paraEmpty = first.children.every((c: any) => c.type === 'text' && !c.value.trim());
+  if (paraEmpty) bq.children.shift();
+
+  const meta = calloutMeta(type);
+  bq.data = {
+    hName: 'div',
+    hProperties: { className: ['obsidian-callout'], dataCallout: type },
+  };
+  bq.children.unshift({
+    type: 'paragraph',
+    data: { hName: 'div', hProperties: { className: ['obsidian-callout-header'] } },
+    children: [{ type: 'text', value: `${meta.icon}  ${custom || meta.label}` }],
+  });
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/remarkObsidianEmbeds.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/remarkObsidianEmbeds.ts
@@ -1,0 +1,22 @@
+/* Obsidian embeds/transclusion: `![[Note#Heading]]`.
+ * SECURITY: an attachment has no vault to resolve against, so we NEVER fetch or
+ * resolve the target (prevents SSRF / tracking). It renders as an inert
+ * placeholder span. Runs BEFORE the wikilink pass so the leading `!` is consumed. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { replaceInText } from './mdastText';
+
+export default function remarkObsidianEmbeds() {
+  return (tree: any): void => {
+    replaceInText(tree, /!\[\[([^\]\n]+)\]\]/, (m) => {
+      const target = m[1].trim();
+      return {
+        type: 'obsidianEmbed',
+        data: {
+          hName: 'span',
+          hProperties: { className: ['obsidian-embed'], dataEmbed: target },
+        },
+        children: [{ type: 'text', value: `⧉ Embedded note “${target}” — preview not available` }],
+      };
+    });
+  };
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/remarkObsidianTags.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/remarkObsidianTags.ts
@@ -1,0 +1,20 @@
+/* Obsidian inline tags: `#tag`, `#nested/tag`.
+ * Rendered as an inert chip span (not a link). The leading boundary character
+ * (start-of-text or whitespace / open-paren) is preserved as its own text node
+ * so we don't tag `#` inside words, URLs (`example.com/#x`) or hex colours after
+ * a non-boundary character. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { replaceInText } from './mdastText';
+
+export default function remarkObsidianTags() {
+  return (tree: any): void => {
+    replaceInText(tree, /(^|[\s(])#([A-Za-z][\w-]*(?:\/[\w-]+)*)/, (m) => [
+      { type: 'text', value: m[1] },
+      {
+        type: 'obsidianInline',
+        data: { hName: 'span', hProperties: { className: ['obsidian-tag'], dataTag: m[2] } },
+        children: [{ type: 'text', value: `#${m[2]}` }],
+      },
+    ]);
+  };
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/remarkPropertiesTable.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/remarkPropertiesTable.ts
@@ -1,0 +1,89 @@
+/* Obsidian "Properties" (YAML frontmatter) → a rendered key/value table.
+ * remark-frontmatter parses the leading `---` fence into a `yaml` node; this
+ * plugin turns that node into an inert <table>.
+ *
+ * SECURITY: we do NOT use a YAML library here — a deliberately tiny line parser
+ * that only ever produces strings. This removes any chance of YAML code-exec
+ * (e.g. `!!js/function`) and any dependency risk. Values are plain text only. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export default function remarkPropertiesTable() {
+  return (tree: any): void => {
+    if (!Array.isArray(tree.children)) return;
+    for (let i = 0; i < tree.children.length; i++) {
+      const n = tree.children[i];
+      if (n && n.type === 'yaml' && typeof n.value === 'string') {
+        const rows = parseProps(n.value);
+        if (rows.length) tree.children[i] = buildTable(rows);
+      }
+    }
+  };
+}
+
+function parseProps(src: string): Array<[string, string]> {
+  const rows: Array<[string, string]> = [];
+  let curKey: string | null = null;
+  let listBuf: string[] = [];
+  const flush = (): void => {
+    if (curKey !== null) {
+      rows.push([curKey, listBuf.join(', ')]);
+      curKey = null;
+      listBuf = [];
+    }
+  };
+  for (const raw of src.split('\n')) {
+    const line = raw.replace(/\s+$/, '');
+    if (!line.trim()) continue;
+    const li = /^\s*-\s+(.*)$/.exec(line);
+    if (li && curKey !== null) {
+      listBuf.push(strip(li[1]));
+      continue;
+    }
+    const kv = /^([A-Za-z0-9_.\- ]+):\s*(.*)$/.exec(line);
+    if (kv) {
+      flush();
+      const key = kv[1].trim();
+      const val = strip(kv[2]);
+      if (val === '') {
+        curKey = key;
+        listBuf = [];
+      } else {
+        rows.push([key, val]);
+      }
+    }
+  }
+  flush();
+  return rows;
+}
+
+function strip(s: string): string {
+  return s.trim().replace(/^['"]|['"]$/g, '');
+}
+
+function cell(hName: string, value: string, className: string) {
+  return {
+    type: 'obsidianCell',
+    data: { hName, hProperties: { className: [className] } },
+    children: [{ type: 'text', value }],
+  };
+}
+
+function buildTable(rows: Array<[string, string]>) {
+  const body = rows.map(([k, v]) => ({
+    type: 'obsidianRow',
+    data: { hName: 'tr' },
+    children: [cell('th', k, 'obsidian-prop-key'), cell('td', v, 'obsidian-prop-val')],
+  }));
+  return {
+    type: 'obsidianTable',
+    data: { hName: 'table', hProperties: { className: ['obsidian-properties'] } },
+    children: [
+      {
+        type: 'obsidianCaption',
+        data: { hName: 'caption', hProperties: { className: ['obsidian-properties-caption'] } },
+        children: [{ type: 'text', value: 'Properties' }],
+      },
+      { type: 'obsidianBody', data: { hName: 'tbody' }, children: body },
+    ],
+  };
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/remarkWikiLinks.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/remarkWikiLinks.ts
@@ -1,0 +1,23 @@
+/* Obsidian wikilinks: `[[Note]]` and `[[Note|alias]]`.
+ * SECURITY: rendered as an INERT span, never an <a href>. There is no vault to
+ * resolve to in an attachment, and turning arbitrary target text into a link
+ * would open protocol-injection / open-redirect surface for zero benefit. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { replaceInText } from './mdastText';
+
+export default function remarkWikiLinks() {
+  return (tree: any): void => {
+    replaceInText(tree, /\[\[([^\]\n|]+)(?:\|([^\]\n]+))?\]\]/, (m) => {
+      const target = m[1].trim();
+      const alias = (m[2] || m[1]).trim();
+      return {
+        type: 'obsidianInline',
+        data: {
+          hName: 'span',
+          hProperties: { className: ['obsidian-wikilink'], dataWikilink: target },
+        },
+        children: [{ type: 'text', value: alias }],
+      };
+    });
+  };
+}

--- a/apps/dashboard/src/components/FileViewer/obsidian/sanitizeSchema.ts
+++ b/apps/dashboard/src/components/FileViewer/obsidian/sanitizeSchema.ts
@@ -1,0 +1,36 @@
+/* Hardened rehype-sanitize allow-list for UNTRUSTED attachment markdown.
+ *
+ * This schema is the single security gate for the Obsidian render path. It is
+ * used WITHOUT rehype-raw, so raw HTML in the file is never parsed into the DOM
+ * to begin with; this allow-list then keeps only the inert Obsidian constructs
+ * our remark plugins emit (styled div/span/mark + a properties table).
+ *
+ * Never added: script, iframe, object, embed, form, style attr, on* handlers.
+ * href/src protocols stay at rehype-sanitize defaults (http/https/mailto). */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { defaultSchema } from 'rehype-sanitize';
+
+const A = (defaultSchema.attributes ?? {}) as Record<string, any[]>;
+const merge = (tag: string, extra: any[]): any[] => [...(A[tag] ?? []), ...extra];
+
+export const obsidianSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'div', 'span', 'mark', 'caption'],
+  attributes: {
+    ...A,
+    '*': merge('*', ['className']),
+    input: merge('input', ['checked']),
+    // Inert Obsidian constructs — data-* carry semantics for the component layer.
+    div: ['className', 'dataCallout'],
+    span: ['className', 'dataWikilink', 'dataTag', 'dataEmbed'],
+    mark: ['className'],
+    // Properties table.
+    table: merge('table', ['className']),
+    tbody: merge('tbody', ['className']),
+    tr: merge('tr', ['className']),
+    th: merge('th', ['className']),
+    td: merge('td', ['className']),
+    caption: ['className'],
+  },
+  protocols: { ...defaultSchema.protocols },
+};


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #84 (original author: @XyneSpaces).

## What & why
Attachment `.md` files rendered in the "rendered" view (FileViewer → ReadmeViewer) now support **Obsidian-flavored markdown**: callouts, wikilinks, inline tags, `==highlights==`, embeds/transclusion, and a Properties (frontmatter) table — while guaranteeing no remote code execution / XSS from untrusted attachment content.

## Changes
- New module `apps/dashboard/src/components/FileViewer/obsidian/`:
  - `remarkObsidianCallouts` — `> [!note] Title` → styled admonition (`<div data-callout>`), colored by type.
  - `remarkWikiLinks` — `[[Note]]`, `[[Note|alias]]` → inert `<span>` chips (never `<a href>`).
  - `remarkObsidianTags` — `#tag`, `#nested/tag` → inert chips.
  - `remarkHighlight` — `==text==` → `<mark>`.
  - `remarkObsidianEmbeds` — `![[Note]]` → inert placeholder (no fetch/SSRF).
  - `remarkPropertiesTable` — YAML frontmatter → `<table>` using a tiny string-only line parser (no YAML lib, so no `!!js` code-exec surface).
  - `sanitizeSchema` — hardened `rehype-sanitize` allow-list (adds only `div/span/mark` + properties table; no `script/iframe/object/style/on*`; href protocols stay http/https/mailto).
  - `components` — react-markdown overrides for the inert Obsidian nodes; `mdastText` — dependency-free mdast text-splitter (no `unist-util-visit`).
- `ReadmeViewer.tsx`:
  - Wires `remarkGfm + obsidian remark plugins`.
  - **Removes `rehype-raw`** from this path — untrusted attachment HTML is never parsed into the DOM.
  - Swaps the sanitize schema to the hardened `obsidianSanitizeSchema` (now the single security gate).

## Security
- Obsidian syntax is expanded at the remark (mdast) stage into inert, allow-listed nodes — nothing emits raw HTML.
- With `rehype-raw` gone, raw `<script>`, `<img onerror>`, `<iframe>`, `<svg onload>` in a `.md` render as literal text; `javascript:`/`vbscript:` hrefs are stripped by sanitize.
- Wikilinks/tags/embeds are inert spans, never links — no protocol-injection / open-redirect surface.

## Testing (POT)
- Built a standalone Vite harness mounting the real production `ReadmeViewer` against a fixture mixing rich Obsidian syntax with active XSS payloads, plus a live tripwire banner (`window.__xss`, inline-handler / injected-script / iframe / `javascript:`-href counters).
- Result: all constructs render correctly and the banner stays **"XSS BLOCKED — 0 inline handlers · 0 injected scripts · 0 iframes · 0 js: hrefs · window.__xss=false"**. Video recording attached in the originating chat thread.

## Notes
- No dependency changes (`remark-frontmatter` already present).
- The POT harness (`apps/dashboard/obsidian-pot/`) is intentionally NOT committed.