### PR TITLE
fix: align ask-user-question with XYNE_CLAW_AUTH_URL and introduce AskQuestionNode

### DIFF
--- a/apps/dashboard/src/components/flowUI/nodes/AskQuestionNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/AskQuestionNode.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useState } from 'react';
+import { CheckTickSingle, Spinner } from '@xyne/icons';
+import { useFlow } from '../FlowContext';
+import type { FlowComponent, AskQuestionProps } from '@xyne/shared';
+import { Button } from '../../ui/Button/Button';
+import { cn } from '../../../utils/classNames';
+
+/**
+ * Ask-question artifact — a single-question HITL card.
+ *
+ * `props.phase` is the discriminant:
+ *   pending  → user picks one option and submits.
+ *   answered → read-only outcome showing the selected answer.
+ *
+ * Source-of-truth schema: shared/src/validation/flowSchema.ts
+ * (`askQuestionComponentSchema`). Backend emits this component and later
+ * updates the same message in place (same screenId + same component id
+ * `ask-question`) to flip from pending → answered.
+ */
+interface AskQuestionNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+export const AskQuestionNode: React.FC<AskQuestionNodeProps> = ({ node }) => {
+  const props = node.props as AskQuestionProps | undefined;
+  if (!props) return null;
+
+  if (props.phase === 'answered') {
+    return <AnsweredQuestion node={node} props={props} />;
+  }
+  return <PendingQuestion node={node} props={props} />;
+};
+
+const PendingQuestion: React.FC<{
+  node: FlowComponent;
+  props: Extract<AskQuestionProps, { phase: 'pending' }>;
+}> = ({ node, props }) => {
+  const { state, updateFieldValue, executeAction, isSubmitting, validateAllFields } = useFlow();
+  const [submitting, setSubmitting] = useState(false);
+
+  const selectedValue = (state.values[node.id] as string) || '';
+
+  useEffect(() => {
+    if (state.values[node.id] === undefined && props.options[0]) {
+      updateFieldValue(node.id, props.options[0]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node.id]);
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!selectedValue || submitting || isSubmitting) return;
+    const isValid = validateAllFields();
+    if (!isValid) return;
+    setSubmitting(true);
+    try {
+      await executeAction({ type: 'submit', actionId: 'user-answer' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const locked = submitting || isSubmitting;
+
+  return (
+    <CardShell style={node.style}>
+      <div className='flex flex-col gap-4 p-4'>
+        <div className='flex flex-col gap-1'>
+          <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+            Question
+          </span>
+          <p className='text-base font-medium leading-[1.3] text-foreground'>{props.question}</p>
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          {props.options.map(option => (
+            <label
+              key={option}
+              className={cn(
+                'flex items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors',
+                !locked && 'hover:bg-foreground/[0.03] cursor-pointer',
+                locked && 'cursor-not-allowed opacity-60',
+              )}
+            >
+              <input
+                type='radio'
+                name={node.id}
+                value={option}
+                checked={selectedValue === option}
+                disabled={locked}
+                onChange={() => updateFieldValue(node.id, option)}
+                className='mt-0.5 h-4 w-4 shrink-0 text-primary border-border focus:ring-ring'
+              />
+              <span className='text-sm leading-[1.4] text-foreground/90'>{option}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
+        <Button
+          onClick={() => void handleSubmit()}
+          disabled={!selectedValue || locked}
+          variant='default'
+          size='sm'
+          loading={locked}
+        >
+          {locked ? (
+            <>
+              <Spinner size={14} className='animate-spin mr-1.5' />
+              Submitting…
+            </>
+          ) : (
+            'Submit'
+          )}
+        </Button>
+      </div>
+    </CardShell>
+  );
+};
+
+const AnsweredQuestion: React.FC<{
+  node: FlowComponent;
+  props: Extract<AskQuestionProps, { phase: 'answered' }>;
+}> = ({ node, props }) => {
+  const auditText = props.answeredBy
+    ? withAnswerTime(`Answered by ${props.answeredBy}`, props.answeredAt)
+    : withAnswerTime('Answered', props.answeredAt);
+
+  return (
+    <CardShell style={node.style}>
+      <div className='flex flex-col gap-4 p-4'>
+        <div className='flex flex-col gap-1'>
+          <div className='flex items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+              Question
+            </span>
+            <span className='rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]'>
+              Answered
+            </span>
+          </div>
+          <p className='text-base font-medium leading-[1.3] text-foreground'>{props.question}</p>
+        </div>
+
+        <div className='flex items-start gap-3 rounded-lg bg-foreground/[0.03] px-3 py-2.5'>
+          <span className='mt-0.5 flex size-4 items-center justify-center rounded-full bg-foreground/80'>
+            <CheckTickSingle size={12} strokeWidth={1.33} absoluteStrokeWidth className='text-background' />
+          </span>
+          <div className='flex flex-col gap-0.5'>
+            <span className='text-sm font-medium text-foreground'>{props.answer}</span>
+            {auditText && <span className='text-xs text-muted-foreground'>{auditText}</span>}
+          </div>
+        </div>
+      </div>
+    </CardShell>
+  );
+};
+
+const CardShell: React.FC<{
+  children: React.ReactNode;
+  style?: React.CSSProperties | undefined;
+}> = ({ children, style }) => (
+  <div
+    className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+    style={style}
+  >
+    {children}
+  </div>
+);
+
+const formatAnswerTime = (iso?: string): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+
+  const diffMs = Date.now() - d.getTime();
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  if (diffMs >= 0 && diffMs < ONE_DAY_MS) {
+    const mins = Math.floor(diffMs / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} ${mins === 1 ? 'min' : 'mins'} ago`;
+    const hrs = Math.floor(mins / 60);
+    return `${hrs} ${hrs === 1 ? 'hr' : 'hrs'} ago`;
+  }
+
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+const withAnswerTime = (label: string, iso?: string): string => {
+  const t = formatAnswerTime(iso);
+  return t ? `${label} · ${t}` : label;
+};

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -14,6 +14,7 @@ import { ImageNode } from './ImageNode';
 import { TableNode } from './TableNode';
 import { LinkNode } from './LinkNode';
 import { PlanNode } from './PlanNode';
+import { AskQuestionNode } from './AskQuestionNode';
 import { PrNode } from './PrNode';
 import { CallScheduleNode } from './CallScheduleNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
@@ -61,6 +62,7 @@ NodeRegistry.register('image', ImageNode);
 NodeRegistry.register('table', TableNode);
 NodeRegistry.register('link', LinkNode);
 NodeRegistry.register('plan', PlanNode);
+NodeRegistry.register('ask_question', AskQuestionNode);
 NodeRegistry.register('pr', PrNode);
 // NodeRegistry.register('pr_approval', PrApprovalNode); // unlinked for now
 NodeRegistry.register('call_schedule', CallScheduleNode);

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -21,7 +21,7 @@ import { verifySpacesSignature } from "../middleware/verify-spaces-signature.js"
 import { agentRunRepository } from "../repositories/index.js";
 import { recordTwinApprovalOutcome } from "../services/twinResponseFeedback.js";
 import type { FlowDefinition } from "xyne-claw-shared";
-import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
+import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, buildAskQuestionFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
 import { clearActivePlanCard, setPlanExecMeta, clearPlanExecMeta, normalizePlanTitle } from "../lib/session-context.js";
 import { executeTool as executeGatewayTool } from "../mcpgateway/services/execution.js";
 import { GATEWAY_KEY_PREFIX, parseGatewayCatalogSource } from "../mcpgateway/key-format.js";
@@ -989,9 +989,9 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       // Acknowledge immediately so the widget closes
       resp = { type: "close_screen", finalMessage: `✅ You answered: "${answer}"` };
       res.json(resp);
-      void replaceFlowCardWithText(messageId, answerAgentSlug, `✅ You answered: **"${answer}"**`, answerConversationId);
 
-      // Fire-and-forget: start new /run with the answer as context
+      // Fire-and-forget: start new /run with the answer as context and update
+      // the question card in place to the answered phase.
       try {
         const { getQuestion, deleteQuestion } = await import("./pending-questions.js");
         const { setSession } = await import("./webhook.js");
@@ -999,6 +999,38 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         const question = await getQuestion(questionId);
         const questionText = question?.question ?? "a question";
         const optionsList = question?.options?.join(", ") ?? "";
+
+        // Resolve the answering user's display name for the audit footer.
+        const answerUser = callerUserId
+          ? await prisma.user.findUnique({ where: { id: callerUserId }, select: { name: true } })
+          : null;
+
+        const answeredFlow = buildAskQuestionFlow(
+          questionText,
+          question?.options ?? [],
+          {
+            questionId,
+            agentSlug: answerAgentSlug,
+            channelId: answerChannelId,
+            conversationId: answerConversationId,
+            userId: answerUserId,
+            spacesAppId: answerSpacesAppId,
+          },
+          {
+            phase: 'answered',
+            answer,
+            answeredBy: answerUser?.name ?? undefined,
+            answeredAt: new Date().toISOString(),
+          },
+        );
+        void replaceFlowCardWithFlow(
+          messageId,
+          answerAgentSlug,
+          answeredFlow,
+          answerConversationId,
+          undefined,
+          answerSpacesAppId,
+        );
 
         const agent = await findAgentForFlow(answerAgentSlug, answerSpacesAppId);
         const appToken = agent?.spacesAppToken

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -88,7 +88,7 @@ import {
 } from "../lib/session-context.js";
 import { emitAgentWorkingSignal } from "../surfaces/spaces/client.js";
 import JSZip from "jszip";
-import { buildWriteApprovalFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, isTwinDelivery } from "xyne-claw-shared";
+import { buildWriteApprovalFlow, buildTwinApprovalFlow, buildAskQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, isTwinDelivery } from "xyne-claw-shared";
 import type { TwinDelivery } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 
@@ -4908,7 +4908,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     const pendingQuestions = (payload as { pendingQuestions?: Array<{ questionId: string; question: string; options: string[] }> }).pendingQuestions;
     if (pendingQuestions?.length) {
       for (const q of pendingQuestions) {
-        const questionFlow = withSpacesAppId(buildUserQuestionFlow(q.question, q.options, {
+        const questionFlow = withSpacesAppId(buildAskQuestionFlow(q.question, q.options, {
           questionId: q.questionId,
           agentSlug: ctx.agentSlug ?? "",
           channelId: ctx.channelId,

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -24,6 +24,7 @@ export type FlowComponentType =
   | 'link'
   | 'table'
   | 'plan'
+  | 'ask_question'
   | 'pr'
   | 'pr_approval'
   | 'call_schedule';

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -328,6 +328,37 @@ export const planComponentSchema = baseComponentSchema.extend({
   props: planPropsSchema,
 });
 
+// ── Ask-question artifact ────────────────────────────────────────────────
+// A single-question, single-answer HITL card. The lifecycle is the discriminant:
+//   pending  → user picks one option and submits.
+//   answered → read-only outcome showing the selected answer.
+export const askQuestionPropsSchema = z.discriminatedUnion('phase', [
+  z
+    .object({
+      phase: z.literal('pending'),
+      question: z.string().min(1),
+      options: z.array(z.string().min(1)).min(2).max(4),
+    })
+    .strict(),
+  z
+    .object({
+      phase: z.literal('answered'),
+      question: z.string().min(1),
+      answer: z.string().min(1),
+      answeredBy: z.string().optional(),
+      answeredAt: z.string().optional(),
+    })
+    .strict(),
+]);
+
+export const askQuestionComponentSchema = baseComponentSchema.extend({
+  type: z.literal('ask_question'),
+  props: askQuestionPropsSchema,
+});
+
+export type AskQuestionProps = z.infer<typeof askQuestionPropsSchema>;
+export type AskQuestionPhase = AskQuestionProps['phase'];
+
 // TS mirrors inferred from the schema so the two can't drift.
 export type ProposedTodo = z.infer<typeof proposedTodoSchema>;
 export type ExecTodo = z.infer<typeof execTodoSchema>;
@@ -517,6 +548,7 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     linkComponentSchema,
     tableComponentSchema,
     planComponentSchema,
+    askQuestionComponentSchema,
     prComponentSchema,
     prApprovalComponentSchema,
     callScheduleComponentSchema,

--- a/packages/xyne-claw-shared/src/flow/ask-question-flow.test.ts
+++ b/packages/xyne-claw-shared/src/flow/ask-question-flow.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildAskQuestionFlow, ASK_QUESTION_COMPONENT_ID } from './ask-question-flow.js';
+
+describe('buildAskQuestionFlow', () => {
+  const context = {
+    questionId: 'q-1',
+    agentSlug: 'test-agent',
+    channelId: 'chan-1',
+    conversationId: 'conv-1',
+    userId: 'user-1',
+  };
+
+  it('produces a pending ask_question flow with the correct shape', () => {
+    const flow = buildAskQuestionFlow('Which colour?', ['Red', 'Blue'], context);
+    expect(flow.version).toBe('2.0');
+    expect(flow.screenId).toBe('agent-question-q-1');
+
+    const comp = flow.components[0];
+    expect(comp.id).toBe(ASK_QUESTION_COMPONENT_ID);
+    expect(comp.type).toBe('ask_question');
+    expect(comp.props).toEqual({
+      phase: 'pending',
+      question: 'Which colour?',
+      options: ['Red', 'Blue'],
+    });
+    expect(flow.data).toEqual({
+      actionType: 'user-answer',
+      questionId: 'q-1',
+      agentSlug: 'test-agent',
+      channelId: 'chan-1',
+      conversationId: 'conv-1',
+      userId: 'user-1',
+    });
+  });
+
+  it('produces an answered ask_question flow with the correct shape', () => {
+    const flow = buildAskQuestionFlow('Which colour?', ['Red', 'Blue'], context, {
+      phase: 'answered',
+      answer: 'Blue',
+      answeredBy: 'Alice',
+      answeredAt: '2026-07-31T20:00:00Z',
+    });
+
+    const comp = flow.components[0];
+    expect(comp.props).toEqual({
+      phase: 'answered',
+      question: 'Which colour?',
+      answer: 'Blue',
+      answeredBy: 'Alice',
+      answeredAt: '2026-07-31T20:00:00Z',
+    });
+  });
+});

--- a/packages/xyne-claw-shared/src/flow/ask-question-flow.ts
+++ b/packages/xyne-claw-shared/src/flow/ask-question-flow.ts
@@ -1,0 +1,89 @@
+/**
+ * Ask-question card — renders an agent's question as a FlowUI v2.0
+ * `ask_question` component (dashboard: components/flowUI/nodes/AskQuestionNode.tsx).
+ *
+ * Lifecycle is phase-discriminated:
+ *   pending  → interactive: user picks one option, then submits.
+ *   answered → read-only outcome showing the selected answer.
+ *
+ * Post once via Spaces postMessage({ flow }), then re-render IN PLACE via
+ * updateMessage({ flowJSON }) as the phase changes (same screenId
+ * `agent-question` + same component id `ask-question` → the card updates without
+ * a new message). Source-of-truth schema + zod validation lives in
+ * @xyne/shared: shared/src/validation/flowSchema.ts (`askQuestionComponentSchema`).
+ */
+
+import { FlowBuilder, type FlowComponent, type FlowDefinition } from './builder.js';
+
+/** Stable component id — the state.values key AskQuestionNode reads/writes and
+ *  the key flow-action.ts reads the user's selection from. */
+export const ASK_QUESTION_COMPONENT_ID = 'ask-question';
+
+/** Phase of the ask-question card — picks the component layout. */
+export type AskQuestionPhase = 'pending' | 'answered';
+
+export interface AskQuestionContext {
+  questionId: string;
+  agentSlug: string;
+  channelId: string;
+  conversationId: string;
+  userId: string;
+  spacesAppId?: string | undefined;
+}
+
+/**
+ * Build the ask-question card as a single `ask_question` component.
+ * `opts.context` carries flow-level routing (actionType 'user-answer' +
+ * questionId/agentSlug/conversationId/channelId/userId/spacesAppId) that
+ * flow-action.ts reads on submit.
+ */
+export function buildAskQuestionFlow(
+  question: string,
+  options: string[],
+  context: AskQuestionContext,
+  opts?: {
+    phase?: AskQuestionPhase;
+    answer?: string;
+    answeredBy?: string;
+    answeredAt?: string;
+    screenId?: string;
+  },
+): FlowDefinition {
+  const phase: AskQuestionPhase = opts?.phase ?? 'pending';
+  const screenId = opts?.screenId ?? `agent-question-${context.questionId}`;
+
+  const props: Record<string, unknown> =
+    phase === 'pending'
+      ? {
+          phase: 'pending',
+          question,
+          options,
+        }
+      : {
+          phase: 'answered',
+          question,
+          answer: opts?.answer ?? '',
+          ...(opts?.answeredBy ? { answeredBy: opts.answeredBy } : {}),
+          ...(opts?.answeredAt ? { answeredAt: opts.answeredAt } : {}),
+        };
+
+  const component: FlowComponent = {
+    id: ASK_QUESTION_COMPONENT_ID,
+    type: 'ask_question',
+    props,
+  };
+
+  return new FlowBuilder(screenId)
+    .setTitle('Question')
+    .addComponent(component)
+    .setData({
+      actionType: 'user-answer',
+      questionId: context.questionId,
+      agentSlug: context.agentSlug,
+      channelId: context.channelId,
+      conversationId: context.conversationId,
+      userId: context.userId,
+      ...(context.spacesAppId ? { spacesAppId: context.spacesAppId } : {}),
+    })
+    .build();
+}

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -27,7 +27,8 @@ type FlowComponentType =
   | 'divider'
   | 'image'
   | 'link'
-  | 'plan';
+  | 'plan'
+  | 'ask_question';
 
 interface FlowComponentStyle {
   padding?: string;

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -23,7 +23,9 @@ export { createSkillTool, updateSkillTool } from "./tools/skill-management/index
 export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
+export { buildAskQuestionFlow, ASK_QUESTION_COMPONENT_ID } from "./flow/ask-question-flow.js";
 export type { Todo, TodoStatus, PlanPhase, PlanTodoInput } from "./flow/plan-flow.js";
+export type { AskQuestionPhase, AskQuestionContext } from "./flow/ask-question-flow.js";
 export { todoTools, todoWriteTool, todoReadTool, getPlan, clearPlan, PLAN_TOOL_SLUGS, isPlanToolSlug } from "./tools/todo/todo-tools.js";
 export { isReadOnlyJob } from "./tools/sandbox/repo-configs.js";
 export { buildHtmlDocument, sanitizeHtmlBody } from "./tools/create-report/template.js";

--- a/packages/xyne-claw-shared/src/tools/ask-question/tools.test.ts
+++ b/packages/xyne-claw-shared/src/tools/ask-question/tools.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { askUserQuestion } from './tools.js';
+
+describe('askUserQuestion', () => {
+  it('resolves XYNE_CLAW_AUTH_URL from context config and posts to that URL', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await askUserQuestion.execute(
+      { question: 'Which colour?', options: ['Red', 'Blue'] },
+      {
+        config: { XYNE_CLAW_AUTH_URL: 'http://auth-service:3003' },
+        s2sKey: 'test-s2s',
+        meta: {
+          userId: 'user-1',
+          agentSlug: 'test-agent',
+          channelId: 'chan-1',
+          conversationId: 'conv-1',
+        },
+        pendingQuestions: [],
+      } as any,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://auth-service:3003/claw/api/v1/pending-questions');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'x-s2s-key': 'test-s2s',
+    });
+    expect(result).toContain('STOP');
+    expect(result).toContain('Which colour?');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns an error when options count is invalid', async () => {
+    const result = await askUserQuestion.execute(
+      { question: 'Which colour?', options: ['Red'] },
+      { config: {}, pendingQuestions: [] } as any,
+    );
+    expect(result).toContain('provide 2-4 options');
+  });
+});

--- a/packages/xyne-claw-shared/src/tools/ask-question/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/ask-question/tools.ts
@@ -2,8 +2,8 @@ import crypto from "node:crypto";
 import type { ToolDefinition } from "../types.js";
 
 export const ASK_QUESTION_CONFIG_SCHEMA = {
-  CLAW_AUTH_URL: {
-    label: "Claw Auth Service URL",
+  XYNE_CLAW_AUTH_URL: {
+    label: "Xyne Claw Auth Service URL",
     default: "http://localhost:3003",
     required: true as const,
     placeholder: "http://localhost:3003",
@@ -44,7 +44,7 @@ export const askUserQuestion: ToolDefinition = {
     }
 
     const meta = context.meta ?? {};
-    const authUrl = context.config["CLAW_AUTH_URL"] ?? "http://localhost:3003";
+    const authUrl = context.config["XYNE_CLAW_AUTH_URL"] ?? "http://localhost:3003";
     const questionId = crypto.randomUUID();
 
     // Store question in xyne-claw-auth Redis


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #82 (original author: @XyneSpaces).

This PR fixes the non-working `ask-user-question` tool and refactors its UI into a first-class FlowUI component.

Changes:
- Fix `CLAW_AUTH_URL` → `XYNE_CLAW_AUTH_URL` in `packages/xyne-claw-shared/src/tools/ask-question/tools.ts` so the tool reaches the deployed `xyne-claw-auth` service instead of localhost:3003.
- Add `ask_question` FlowComponentType and schemas in `@xyne/shared`.
- Add `buildAskQuestionFlow` builder in `packages/xyne-claw-shared/src/flow/ask-question-flow.ts`.
- Add `AskQuestionNode.tsx` renderer with `pending`/`answered` phases and register it in the dashboard NodeRegistry.
- Update `webhook.ts` to emit `buildAskQuestionFlow` and `flow-action.ts` to replace the card in-place on user answer.
- Add unit tests for tool URL resolution and the flow builder.

Verification: @pot-verifier PASSED.