### PR TITLE
feature: add workspace logo/profile image support

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1744,6 +1744,7 @@ export const workspaceTable = table("workspaces")
     workspaceType: string().optional(),
     joinPolicy: string().optional(),
     landingChannelId: string().optional(),
+    logo: string().optional(),
     createdAt: number(),
     updatedAt: number(),
   })

--- a/apps/backend/prisma/migrations/20260731120000_add_workspace_logo/migration.sql
+++ b/apps/backend/prisma/migrations/20260731120000_add_workspace_logo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."workspaces" ADD COLUMN     "logo" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1960,6 +1960,7 @@ model Workspace {
   workspaceType String?
   joinPolicy    String?
   landingChannelId String?
+  logo             String?         // Object-storage path to workspace logo/profile image (served via GET /api/workspaces/:id/logo)
   createdAt   DateTime         @default(now())
   updatedAt   DateTime         @updatedAt
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -61,6 +61,7 @@ import { slackMigrationWorker } from '@/workers/slackMigrationWorker';
 import { registerAllExternalSources } from '@/integrations/core/externalSourceRegistry';
 import publicUserRoutes from '@/routes/publicUserRoutes';
 import userRoutes from '@/routes/users';
+import workspaceRoutes from '@/routes/workspaces';
 import notificationRoutes from '@/routes/notifications';
 import draftRoutes from '@/routes/draftAttachments';
 import callRoutes from '@/routes/calls';
@@ -527,6 +528,7 @@ export class App {
     this.app.use('/api/organizations', authMiddleware.authenticate, organizationRoutes);
     this.app.use('/api/invitations', invitationRoutes);
     this.app.use('/api/users', authMiddleware.authenticate, userRoutes);
+    this.app.use('/api/workspaces', authMiddleware.authenticate, workspaceRoutes);
     this.app.use('/api/user-groups', authMiddleware.authenticate, userGroupRoutes); // User groups (teams)
     this.app.use('/api/forms', authMiddleware.authenticate, formsRoutes); // Forms routes
     this.app.use('/api/zero', zeroRoutes); // Zero sync routes (uses authenticateZero middleware in route file)
@@ -674,6 +676,7 @@ export class App {
     this.app.use('/api/conversations', authMiddleware.authenticate, conversationRoutes);
     this.app.use('/api/organizations', authMiddleware.authenticate, organizationRoutes);
     this.app.use('/api/users', authMiddleware.authenticate, userRoutes);
+    this.app.use('/api/workspaces', authMiddleware.authenticate, workspaceRoutes);
     this.app.use('/api/user-groups', authMiddleware.authenticate, userGroupRoutes); // User groups (teams)
     this.app.use('/api/user-assignment-state', userAssignmentStateRoutes); // User assignment state routes (auth handled in route file)
     // this.app.use('/api/messages', authMiddleware.authenticate, reactionRoutes); // Reactions routes

--- a/apps/backend/src/controllers/workspaceController.ts
+++ b/apps/backend/src/controllers/workspaceController.ts
@@ -1,0 +1,148 @@
+import { Request, Response } from 'express';
+import { WorkspaceRole } from '@prisma/client';
+import { workspaceLogoService } from '../services/workspaceLogoService';
+import { getStorageService } from '../services/storage';
+import { logger } from '../utils/logger';
+
+const storageService = getStorageService();
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * WorkspaceController — workspace logo/profile-image endpoints.
+ *
+ * SECURITY: these endpoints write `workspaces.logo` directly via Prisma and
+ * therefore BYPASS the Zero mutation ACL (WorkspacesACL) that normally guards
+ * workspace edits. Because the logo is a shared resource, the mutating routes
+ * must independently enforce that the caller is an ADMIN/OWNER of the SAME
+ * workspace named in the path — mirroring both checks the Zero ACL performs
+ * (verifyWorkspaceAdminOrOwnerFromContext + workspaceId match).
+ */
+export class WorkspaceController {
+  /**
+   * Assert the caller is an ADMIN/OWNER of the workspace identified by :id.
+   * Returns true when authorized; otherwise writes the response and returns false.
+   */
+  private assertWorkspaceAdmin(req: Request, res: Response): boolean {
+    const user = req.user;
+    if (!user) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return false;
+    }
+
+    const { id } = req.params;
+    // An admin may only manage the logo of their own current workspace.
+    if (!id || id !== user.workspaceId) {
+      res.status(403).json({ error: 'Cannot modify a workspace you are not a member of' });
+      return false;
+    }
+
+    if (user.role !== WorkspaceRole.ADMIN && user.role !== WorkspaceRole.OWNER) {
+      res.status(403).json({ error: 'Only workspace admins can change the workspace logo' });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * POST /api/workspaces/:id/logo
+   * Upload / replace the workspace logo. Admin/owner only.
+   */
+  uploadLogo = async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!this.assertWorkspaceAdmin(req, res)) return;
+
+      const file = req.file;
+      if (!file) {
+        res.status(400).json({ error: 'No file provided' });
+        return;
+      }
+
+      if (!ALLOWED_TYPES.includes(file.mimetype)) {
+        res.status(400).json({ error: 'Invalid file type. Only JPG, PNG, and WebP are allowed.' });
+        return;
+      }
+
+      if (file.size > MAX_FILE_SIZE) {
+        res.status(413).json({ error: 'File too large. Maximum size is 5MB.' });
+        return;
+      }
+
+      const logoPath = await workspaceLogoService.uploadWorkspaceLogo(req.params.id, file);
+      res.status(200).json({ logo: logoPath });
+    } catch (error) {
+      logger.error('Error uploading workspace logo:', error);
+      res.status(500).json({ error: 'Failed to upload workspace logo' });
+    }
+  };
+
+  /**
+   * DELETE /api/workspaces/:id/logo
+   * Remove the workspace logo. Admin/owner only.
+   */
+  deleteLogo = async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!this.assertWorkspaceAdmin(req, res)) return;
+
+      await workspaceLogoService.deleteWorkspaceLogo(req.params.id);
+      res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('Error deleting workspace logo:', error);
+      res.status(500).json({ error: 'Failed to delete workspace logo' });
+    }
+  };
+
+  /**
+   * GET /api/workspaces/:id/logo
+   * Stream the workspace logo. Readable by any authenticated member.
+   *
+   * Cache strategy mirrors the user profile-picture endpoint: the stored path
+   * includes a timestamp and changes on every upload, so a long-lived cache is
+   * safe (a new logo => new path => new URL).
+   */
+  streamLogo = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const workspace = await workspaceLogoService.getWorkspace(id);
+
+      if (!workspace?.logo) {
+        res.status(404).json({ error: 'Workspace logo not found' });
+        return;
+      }
+
+      const storagePath = workspace.logo;
+      const fileExists = await storageService.fileExists(storagePath);
+      if (!fileExists) {
+        res.status(404).json({ error: 'Workspace logo file not found' });
+        return;
+      }
+
+      const metadata = await storageService.getFileMetadata(storagePath);
+      const contentType = metadata.contentType || 'image/png';
+      const fileSize = parseInt(String(metadata.size || '0'), 10);
+
+      res.setHeader('Content-Type', contentType);
+      if (fileSize > 0) res.setHeader('Content-Length', fileSize);
+      res.setHeader('Cache-Control', 'public, max-age=31536000');
+
+      const stream = await storageService.createReadStream(storagePath);
+      stream.pipe(res);
+
+      stream.on('error', (error: Error) => {
+        logger.error('Stream error for workspace logo:', error);
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Failed to stream workspace logo' });
+        }
+      });
+    } catch (error) {
+      logger.error('Error streaming workspace logo:', error);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Failed to stream workspace logo' });
+      }
+    }
+  };
+}
+
+export const workspaceController = new WorkspaceController();

--- a/apps/backend/src/routes/workspaces.ts
+++ b/apps/backend/src/routes/workspaces.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { workspaceController } from '../controllers/workspaceController';
+import { uploadConfig } from '../middleware/upload';
+
+const router = Router();
+
+// Workspace logo / profile image.
+// Mutating routes are admin/owner-gated inside the controller (these bypass the
+// Zero mutation ACL, so authorization is enforced here explicitly).
+router.post('/:id/logo', uploadConfig.single('logo'), workspaceController.uploadLogo); // Upload/replace workspace logo
+router.delete('/:id/logo', workspaceController.deleteLogo);                            // Remove workspace logo
+router.get('/:id/logo', workspaceController.streamLogo);                               // Stream workspace logo (any member)
+
+export default router;

--- a/apps/backend/src/services/workspaceLogoService.ts
+++ b/apps/backend/src/services/workspaceLogoService.ts
@@ -1,0 +1,103 @@
+import { PrismaClient } from '@prisma/client';
+import { v4 as uuidv4 } from 'uuid';
+import { getStorageService } from './storage';
+import { DatabaseClient } from '@/database/client';
+import { logger } from '../utils/logger';
+
+/**
+ * WorkspaceLogoService
+ *
+ * Owns the workspace logo/profile-image lifecycle. Mirrors the user
+ * profile-picture flow (userManagementService.uploadProfilePicture): the image
+ * bytes are stored in object storage and only the storage PATH is persisted on
+ * the workspace row. The image is served back through a streaming endpoint
+ * (GET /api/workspaces/:id/logo), never as a public URL.
+ *
+ * Because `workspaces` is a Zero-replicated table, writing the `logo` path via
+ * Prisma here is picked up by Zero's replication stream and poked to every
+ * connected client automatically — the UI updates reactively without a reload.
+ */
+export class WorkspaceLogoService {
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = DatabaseClient.getInstance();
+  }
+
+  async getWorkspace(workspaceId: string) {
+    return this.prisma.workspace.findUnique({ where: { id: workspaceId } });
+  }
+
+  /**
+   * Upload a new logo for a workspace and persist its storage path.
+   * Returns the storage path written to `workspaces.logo`.
+   */
+  async uploadWorkspaceLogo(workspaceId: string, file: Express.Multer.File): Promise<string> {
+    try {
+      const timestamp = Date.now();
+      const uuid = uuidv4();
+      const filename = file.originalname.replace(/[^a-zA-Z0-9.-]/g, '_');
+      const filePath = `workspace-logos/${workspaceId}/${timestamp}-${uuid}-${filename}`;
+
+      const uploadResult = await getStorageService().uploadFile(file.buffer, {
+        filename: filePath,
+        contentType: file.mimetype,
+        metadata: {
+          workspaceId,
+          originalName: file.originalname,
+          uploadedAt: new Date().toISOString(),
+        },
+      });
+
+      // Store only the storage path (not a full URL); served via streaming endpoint.
+      await this.prisma.workspace.update({
+        where: { id: workspaceId },
+        data: { logo: uploadResult.path },
+      });
+
+      logger.info(`Workspace logo uploaded for workspace ${workspaceId}`, {
+        filePath: uploadResult.path,
+      });
+      return uploadResult.path;
+    } catch (error) {
+      logger.error(`Error uploading workspace logo for workspace ${workspaceId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Clear a workspace's logo. Best-effort deletes the stored object, then
+   * always nulls the column so the row is consistent even if the blob delete
+   * fails.
+   */
+  async deleteWorkspaceLogo(workspaceId: string): Promise<void> {
+    try {
+      const workspace = await this.prisma.workspace.findUnique({
+        where: { id: workspaceId },
+        select: { logo: true },
+      });
+
+      if (workspace?.logo) {
+        try {
+          await getStorageService().deleteFile(workspace.logo);
+        } catch (deleteError) {
+          logger.warn(`Failed to delete workspace logo object for ${workspaceId}, clearing column anyway`, {
+            error: deleteError,
+          });
+        }
+      }
+
+      await this.prisma.workspace.update({
+        where: { id: workspaceId },
+        data: { logo: null },
+      });
+
+      logger.info(`Workspace logo cleared for workspace ${workspaceId}`);
+    } catch (error) {
+      logger.error(`Error deleting workspace logo for workspace ${workspaceId}:`, error);
+      throw error;
+    }
+  }
+}
+
+export const workspaceLogoService = new WorkspaceLogoService();

--- a/apps/dashboard/src/hooks/useWorkspaceLogo.ts
+++ b/apps/dashboard/src/hooks/useWorkspaceLogo.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiInstance } from '../services/clients/apiClient';
+
+/**
+ * Fetch the authenticated workspace logo and return it as a blob URL.
+ *
+ * Cache strategy mirrors the user profile-picture hook: the stored `logo` path
+ * includes a timestamp and changes on every upload, so keying the query on it
+ * guarantees a fresh fetch when the logo changes and a cache hit otherwise.
+ */
+export const useWorkspaceLogoUrl = (
+  workspaceId: string | undefined,
+  logoPath: string | null | undefined,
+): {
+  url: string | undefined;
+  isLoading: boolean;
+} => {
+  const { data: blobUrl, isLoading } = useQuery<string | undefined>({
+    queryKey: ['workspace-logo', workspaceId, logoPath],
+    queryFn: async () => {
+      if (!workspaceId || !logoPath) return undefined;
+
+      const cacheParam = encodeURIComponent(logoPath);
+      const url = `/workspaces/${workspaceId}/logo?v=${cacheParam}`;
+
+      const response = await apiInstance.get(url, { responseType: 'blob' });
+      const blob = response.data as Blob;
+      return URL.createObjectURL(blob);
+    },
+    enabled: !!workspaceId && !!logoPath && !logoPath.startsWith('http'),
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const isHttpUrl = logoPath?.startsWith('http');
+  const url = isHttpUrl ? (logoPath ?? undefined) : blobUrl;
+
+  return { url, isLoading: isHttpUrl ? false : isLoading };
+};

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/GeneralAndMembersTab.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/GeneralAndMembersTab.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState, useEffect, useMemo, useRef } from 'react';
-import { Save, Users, Search, Shield, User, X, Loader2, AlertTriangle } from 'lucide-react';
+import { Save, Users, Search, Shield, User, X, Loader2, AlertTriangle, ImagePlus, Trash2 } from 'lucide-react';
 import { Button } from '../../components/ui/Button/Button';
 import Input from '../../components/ui/Input/Input';
 import { useSelf, useUsers, useUserSearch } from '../../hooks/useUsers';
@@ -20,6 +20,8 @@ import type { User as UserType } from '../../machines/stateMachine';
 import { WorkspaceRole } from '@xyne/shared';
 import { usePlatform } from '../../hooks/usePlatform';
 import { WorkspaceChannelEmailCard } from '../../components/xyne-desk/WorkspaceChannelEmailCard/WorkspaceChannelEmailCard';
+import { useWorkspaceLogoUrl } from '../../hooks/useWorkspaceLogo';
+import { uploadWorkspaceLogo, deleteWorkspaceLogo } from '../../services/workspace/workspaceLogoService';
 
 const Card = ({
   children,
@@ -71,6 +73,11 @@ export const GeneralAndMembersTab = ({
   const [hasChanges, setHasChanges] = useState(false);
   const { isMobile } = usePlatform();
   const workspaceNameInputRef = useRef<HTMLInputElement>(null);
+  const logoInputRef = useRef<HTMLInputElement>(null);
+  const [isUploadingLogo, setIsUploadingLogo] = useState(false);
+  const isWorkspaceAdmin =
+    self?.role === WorkspaceRole.ADMIN || self?.role === WorkspaceRole.OWNER;
+  const { url: logoUrl } = useWorkspaceLogoUrl(workspaceId, workspace?.logo);
 
   // Load workspace data when available
   useEffect(() => {
@@ -121,6 +128,32 @@ export const GeneralAndMembersTab = ({
     );
     toast.success('Workspace settings saved');
     setHasChanges(false);
+  };
+
+  const handleLogoSelect = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file || !workspaceId) return;
+    setIsUploadingLogo(true);
+    try {
+      await uploadWorkspaceLogo(workspaceId, file);
+    } catch {
+      // error toast handled in service
+    } finally {
+      setIsUploadingLogo(false);
+    }
+  };
+
+  const handleRemoveLogo = async (): Promise<void> => {
+    if (!workspaceId) return;
+    setIsUploadingLogo(true);
+    try {
+      await deleteWorkspaceLogo(workspaceId);
+    } catch {
+      // error toast handled in service
+    } finally {
+      setIsUploadingLogo(false);
+    }
   };
 
   // Members section state
@@ -209,6 +242,62 @@ export const GeneralAndMembersTab = ({
         {/* Settings Form */}
         <Card className='p-6'>
           <div className='space-y-6'>
+            {/* Workspace Logo */}
+            <div>
+              <label className='block text-sm font-medium text-foreground mb-2'>
+                Workspace Logo
+              </label>
+              <div className='flex items-center gap-4'>
+                <div className='h-16 w-16 rounded-xl border border-border bg-muted overflow-hidden flex items-center justify-center shrink-0'>
+                  {logoUrl ? (
+                    <img src={logoUrl} alt='Workspace logo' className='h-full w-full object-cover' />
+                  ) : (
+                    <span className='text-lg font-semibold text-muted-foreground'>
+                      {(workspace?.name || '?').charAt(0).toUpperCase()}
+                    </span>
+                  )}
+                </div>
+                {isWorkspaceAdmin && (
+                  <div className='flex items-center gap-2'>
+                    <input
+                      ref={logoInputRef}
+                      type='file'
+                      accept='image/jpeg,image/png,image/webp'
+                      className='hidden'
+                      onChange={e => void handleLogoSelect(e)}
+                    />
+                    <Button
+                      variant='outline'
+                      onClick={() => logoInputRef.current?.click()}
+                      disabled={isUploadingLogo}
+                      className='gap-2'
+                    >
+                      {isUploadingLogo ? (
+                        <Loader2 className='w-4 h-4 animate-spin' />
+                      ) : (
+                        <ImagePlus className='w-4 h-4' />
+                      )}
+                      {workspace?.logo ? 'Change' : 'Upload'}
+                    </Button>
+                    {workspace?.logo && (
+                      <Button
+                        variant='ghost'
+                        onClick={() => void handleRemoveLogo()}
+                        disabled={isUploadingLogo}
+                        className='gap-2 text-destructive hover:text-destructive'
+                      >
+                        <Trash2 className='w-4 h-4' />
+                        Remove
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+              <p className='text-xs text-muted-foreground mt-1.5'>
+                JPG, PNG, or WebP. Max 5MB. Shown across the workspace.
+              </p>
+            </div>
+
             {/* Workspace Name */}
             <div>
               <label

--- a/apps/dashboard/src/services/workspace/workspaceLogoService.ts
+++ b/apps/dashboard/src/services/workspace/workspaceLogoService.ts
@@ -1,0 +1,57 @@
+import { apiInstance } from '../clients/apiClient';
+import { toast } from 'sonner';
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Upload / replace a workspace's logo. Admin/owner only (enforced server-side).
+ * The image bytes go to object storage; the workspace row's `logo` path is
+ * updated server-side and synced back to all clients via Zero.
+ *
+ * @returns the stored logo path (also arrives via Zero shortly after)
+ */
+export const uploadWorkspaceLogo = async (
+  workspaceId: string,
+  file: File,
+): Promise<string> => {
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    toast.error('Invalid file type. Only JPG, PNG, and WebP are allowed.');
+    throw new Error('Invalid file type');
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    toast.error('File too large. Maximum size is 5MB.');
+    throw new Error('File too large');
+  }
+
+  try {
+    const formData = new FormData();
+    formData.append('logo', file);
+
+    const response = await apiInstance.post<{ logo: string }>(
+      `/workspaces/${workspaceId}/logo`,
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    );
+
+    toast.success('Workspace logo updated successfully');
+    return response.data.logo;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to upload workspace logo';
+    toast.error(message);
+    throw error;
+  }
+};
+
+/**
+ * Remove a workspace's logo. Admin/owner only (enforced server-side).
+ */
+export const deleteWorkspaceLogo = async (workspaceId: string): Promise<void> => {
+  try {
+    await apiInstance.delete(`/workspaces/${workspaceId}/logo`);
+    toast.success('Workspace logo removed');
+  } catch (error) {
+    toast.error('Failed to remove workspace logo');
+    throw error;
+  }
+};

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1574,6 +1574,7 @@ export const workspaceTable = table('workspaces')
     workspaceType: string().optional(),
     joinPolicy: string().optional(),
     landingChannelId: string().optional(),
+    logo: string().optional(),
   })
   .primaryKey('id');
 


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #80 (original author: @XyneSpaces).

## What
Adds the ability to attach an image/logo to each workspace, and to add/update/remove it from workspace settings.

## Backend
- New nullable column `workspaces.logo` — stores the object-storage **path** (not a public URL), mirroring how `User.picture` works. Includes the Prisma migration (`20260731120000_add_workspace_logo`) and the hand-synced Zero schema in both `packages/shared/src/zero/schema.ts` and `apps/backend/prisma/generated/zero/schema.ts`.
- New REST endpoints (blob traffic does not go through Zero):
  - `POST /api/workspaces/:id/logo` — upload/replace (multipart, field `logo`)
  - `GET /api/workspaces/:id/logo` — stream the image (any authenticated member)
  - `DELETE /api/workspaces/:id/logo` — remove
- Files: `services/workspaceLogoService.ts`, `controllers/workspaceController.ts`, `routes/workspaces.ts`, registered under `/api/workspaces` in `app.ts`. Upload uses the existing memory-storage multer (`uploadConfig`) and the storage service, mirroring the user profile-picture flow. Validates JPG/PNG/WebP, max 5MB.

## Security
These REST endpoints write `workspaces.logo` directly via Prisma and therefore **bypass the Zero mutation ACL** (`WorkspacesACL`) that normally guards workspace edits. Because the logo is a shared resource, the mutating routes independently enforce that the caller is an **ADMIN/OWNER of the same workspace named in the path** (`params.id === req.user.workspaceId` + role check) — mirroring both checks the Zero ACL performs. Read/stream is allowed for any authenticated member.

## Dashboard
- Workspace logo upload / change / remove UI in Workspace Management → General settings (visible only to admins/owners).
- `services/workspace/workspaceLogoService.ts` (upload/delete) and `hooks/useWorkspaceLogo.ts` (blob-URL fetch with cache-busting on the stored path), mirroring the user profile-picture pattern. The path column syncs back to clients via Zero, so the UI updates reactively.

## Propagation note
`workspaces` is a Zero-replicated table. The backend writes the `logo` path via Prisma; Zero's logical-replication stream picks up the change and pokes all connected clients, so no Zero mutator whitelist change is needed.

## Validation
- Backend `tsc --noEmit`: 0 errors.
- Dashboard `tsc --noEmit`: 0 errors.
- Prisma + Zero clients regenerated; migration applied to the dev DB.