### PR TITLE
feat: hold Cmd/Ctrl+Shift+Space push-to-talk for composer voice input

### DIFF
--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -348,6 +348,78 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       return () => document.removeEventListener('keydown', onKeyDown, true);
     }, [isVoiceRecording]);
 
+    useEffect(() => {
+      if (disabled) return;
+
+      const HOLD_TO_TALK_MS = 700;
+      let armTimer: number | null = null;
+      let gestureActive = false; // this gesture is the one that started recording
+      const pressed = { mod: false, shift: false, space: false };
+      const comboHeld = (): boolean => pressed.mod && pressed.shift && pressed.space;
+
+      const clearArm = (): void => {
+        if (armTimer !== null) {
+          window.clearTimeout(armTimer);
+          armTimer = null;
+        }
+      };
+
+      const endGesture = (): void => {
+        clearArm();
+        if (gestureActive) {
+          gestureActive = false;
+          voiceInputRef.current?.stopRecording();
+        }
+      };
+
+      const onKeyDown = (e: KeyboardEvent): void => {
+        if (e.key === 'Meta' || e.key === 'Control') pressed.mod = true;
+        if (e.key === 'Shift') pressed.shift = true;
+        if (e.code === 'Space') pressed.space = true;
+
+        if (e.code !== 'Space') return;
+        if (!(e.metaKey || e.ctrlKey) || !e.shiftKey) return;
+        if (e.isComposing) return; // don't fight IME composition
+        e.preventDefault();
+        if (e.repeat) return; // ignore auto-repeat — arm once per physical press
+        if (gestureActive || armTimer !== null) return;
+
+        armTimer = window.setTimeout(() => {
+          armTimer = null;
+          if (!comboHeld()) return;
+          gestureActive = true;
+          voiceInputRef.current?.startRecording();
+        }, HOLD_TO_TALK_MS);
+      };
+
+      const onKeyUp = (e: KeyboardEvent): void => {
+        if (e.key === 'Meta' || e.key === 'Control') pressed.mod = false;
+        if (e.key === 'Shift') pressed.shift = false;
+        if (e.code === 'Space') pressed.space = false;
+        if (!comboHeld()) endGesture();
+      };
+
+      const onInterrupt = (): void => {
+        pressed.mod = false;
+        pressed.shift = false;
+        pressed.space = false;
+        endGesture();
+      };
+
+      document.addEventListener('keydown', onKeyDown, true);
+      document.addEventListener('keyup', onKeyUp, true);
+      window.addEventListener('blur', onInterrupt);
+      document.addEventListener('visibilitychange', onInterrupt);
+      return () => {
+        clearArm();
+        if (gestureActive) voiceInputRef.current?.stopRecording();
+        document.removeEventListener('keydown', onKeyDown, true);
+        document.removeEventListener('keyup', onKeyUp, true);
+        window.removeEventListener('blur', onInterrupt);
+        document.removeEventListener('visibilitychange', onInterrupt);
+      };
+    }, [disabled]);
+
     const handleTyping = onTyping;
 
     // Helper function to upload a single file as draft attachment

--- a/apps/dashboard/src/components/ui/InputBox/VoiceInput.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/VoiceInput.tsx
@@ -132,6 +132,14 @@ function revealMoreWords(target: string, shown: string, words: number): string {
 
 export interface VoiceInputHandle {
   toggle: () => void;
+  /** Push-to-talk START: begin recording if currently idle. No-op if already
+   *  recording, transcribing, disabled, or the composer is sending. Idempotent,
+   *  and race-safe against an in-flight getUserMedia() (a stop requested before
+   *  capture actually begins is honoured the moment it does). */
+  startRecording: () => void;
+  /** Push-to-talk STOP: stop an in-progress (or still-starting) recording.
+   *  No-op if nothing is recording or starting. */
+  stopRecording: () => void;
   /** Called by the composer right before it sends: strips any unfinalized interim
    *  text from the editor and aborts an active voice stream (no drain), so nothing
    *  in flight leaks into the next message. No-op when no stream is active. */
@@ -644,11 +652,60 @@ export const VoiceInput = forwardRef<VoiceInputHandle, VoiceInputProps>(
       clearVoiceStreamCloseTimer,
     ]);
 
-    // Expose toggle() so MobileEditor's onVoiceToggle can call it via ref
-    useImperativeHandle(ref, () => ({ toggle: handleVoiceToggle, abortForSend }), [
-      handleVoiceToggle,
-      abortForSend,
+    // Push-to-talk plumbing. startVoiceRecording() is async (it awaits
+    // getUserMedia), so a release that lands DURING that await must not leak a
+    // hot mic: we remember that a stop was requested and apply it as soon as the
+    // recorder actually exists.
+    const pttStartingRef = useRef(false);
+    const pttStopRequestedRef = useRef(false);
+
+    const startRecordingHold = useCallback((): void => {
+      if (isVoiceRecording || isVoiceTranscribing || disabled || isSending) return;
+      if (pttStartingRef.current) return;
+      pttStartingRef.current = true;
+      pttStopRequestedRef.current = false;
+      void (async () => {
+        try {
+          await startVoiceRecording();
+        } finally {
+          pttStartingRef.current = false;
+          if (pttStopRequestedRef.current) {
+            pttStopRequestedRef.current = false;
+            stopVoiceRecording();
+          }
+        }
+      })();
+    }, [
+      isVoiceRecording,
+      isVoiceTranscribing,
+      disabled,
+      isSending,
+      startVoiceRecording,
+      stopVoiceRecording,
     ]);
+
+    const stopRecordingHold = useCallback((): void => {
+      // Still awaiting getUserMedia: defer the stop until capture begins.
+      if (pttStartingRef.current) {
+        pttStopRequestedRef.current = true;
+        return;
+      }
+      if (!isVoiceRecording) return;
+      stopVoiceRecording();
+    }, [isVoiceRecording, stopVoiceRecording]);
+
+    // Expose toggle() (button / mod+shift+m) plus explicit start/stop for
+    // hold-to-talk, so a held gesture never inverts an already-active toggle.
+    useImperativeHandle(
+      ref,
+      () => ({
+        toggle: handleVoiceToggle,
+        startRecording: startRecordingHold,
+        stopRecording: stopRecordingHold,
+        abortForSend,
+      }),
+      [handleVoiceToggle, startRecordingHold, stopRecordingHold, abortForSend],
+    );
 
     // Release microphone, WebSocket, the reveal timer, and the force-close safety net
     // on unmount — otherwise the safety-net timeout can outlive this component and


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #79 (original author: @XyneSpaces).

## What
Adds a push-to-talk gesture to the composer (`InputBox`). Holding **Cmd/Ctrl + Shift + Space for 700ms** starts voice input, and recording continues until the user releases any of those keys. This is additive — the existing mic button and the `mod+shift+m` toggle are unchanged.

## Why
Today the only ways to start voice input are clicking the mic button or pressing the `mod+shift+m` toggle, both of which require a second action to stop. Push-to-talk gives a hands-free "hold, talk, release" dictation flow.

## How
- **`VoiceInput.tsx`** — `VoiceInputHandle` now exposes explicit `startRecording()` / `stopRecording()` alongside the existing `toggle()`. These are used instead of `toggle()` so a held gesture can never invert a recording the user already started with the button. `startRecording` is race-safe against the in-flight `getUserMedia()` await: a stop requested before capture actually begins is applied the moment the recorder exists (via `pttStartingRef` / `pttStopRequestedRef`).
- **`InputBox.tsx`** — a new `useEffect` adds raw `keydown`/`keyup` listeners (mirroring the existing spacebar push-to-talk in `CallControls.tsx`). On keydown of the combo it arms a 700ms timer; if still held, it calls `startRecording()`. On release of ANY of the three keys it stops.

## Key design decisions / gotchas handled
- Kept OUTSIDE the catalog shortcut system (`useShortcutById`) on purpose: that system is keydown-only and has no key-release or hold-duration concept, so it cannot express press-and-hold.
- macOS: the browser does not reliably deliver Space's `keyup` while Meta (Cmd) is held, so release is detected on ANY of Meta/Shift/Space going up — not just Space — to guarantee the mic turns off.
- Ignores keyboard auto-repeat (`e.repeat`) so the 700ms timer arms once per physical press.
- `e.preventDefault()` on the combo stops Space from typing into the editor while held; skips IME composition (`e.isComposing`).
- Safety nets: `blur` / `visibilitychange` and effect-cleanup all force-stop the gesture so a backgrounded tab or unmount can't leave the mic hot.

## Testing
- `tsc --noEmit` (tsconfig.app.json): 0 errors in the two changed files.
- `eslint` on both files: 0 errors.
- Manual matrix to run: macOS Chrome/Safari + Windows Chrome; tap-without-hold (<700ms) does nothing; hold→release starts+stops cleanly; releasing Shift-first vs Space-first both stop; button-toggle then hold does not invert; tab-blur mid-hold stops the mic.