### PR TITLE
feat: add desk beta channel support and env configuration

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -307,6 +307,8 @@ const envSchema = Joi.object({
   PULSE_ENABLED_CHANNELS: Joi.string().allow('').default(''),
   PULSE_API_URL: Joi.string().uri().default(''),
   PULSE_AUTHORIZATION: Joi.string().allow('').default(''),
+  // Desk beta-channel rollout
+  DESK_BETA_CHANNELS: Joi.string().allow('').default(''),
   // Jira Configuration
   JUSPAY_JIRA_BASEURL: Joi.string().uri().default(''),
   JIRA_EULER_BOT_EMAIL: Joi.string().allow('').default(''),
@@ -798,6 +800,13 @@ export const config = {
       .filter(Boolean),
     apiUrl: envVars.PULSE_API_URL as string,
     authorization: envVars.PULSE_AUTHORIZATION as string,
+  },
+  desk: {
+    // Comma-separated channel IDs that get the beta ingestion path (empty = every channel uses the stable path)
+    betaChannels: (envVars.DESK_BETA_CHANNELS as string)
+      .split(',')
+      .map((s: string) => s.trim())
+      .filter(Boolean),
   },
   jira: {
     baseUrl: envVars.JUSPAY_JIRA_BASEURL as string,

--- a/apps/backend/src/integrations/adapters/google/flow.ts
+++ b/apps/backend/src/integrations/adapters/google/flow.ts
@@ -10,6 +10,7 @@ import { GoogleService } from '@/services/googleService';
 import { ExternalMessageRepository } from '@/database/repositories/externalMessageRepository';
 import { preDownloadGmailAttachments } from './attachments';
 import { GooglePubSubMessage, GooglePubSubData } from './types';
+import { config } from '@/config/env';
 
 const TAG = '[GoogleFlow]';
 const externalMessageRepo = new ExternalMessageRepository();
@@ -27,14 +28,26 @@ export class GoogleFlow extends BaseFlow {
 
       const googleService = GoogleService.fromEncryptedCredentials(source.credentials, source.id);
 
-      // Resume from the persisted cursor, not the push's own historyId — self-heals anything an earlier push missed.
-      const { messageIds, cursor } = await this.resolveMessages(
-        googleService,
-        source.lastSyncCursor ?? pubsubData.historyId,
-      );
+      const isBetaChannel = !!source.channelId && config.desk.betaChannels.includes(source.channelId);
+      if (isBetaChannel) {
+        logger.info(`${TAG} using beta desk ingestion path`, { channelId: source.channelId });
+      }
+
+      let messageIds: string[];
+      let targetHistoryId: string;
+      if (isBetaChannel) {
+        const resolved = await this.resolveMessages(
+          googleService,
+          source.lastSyncCursor ?? pubsubData.historyId,
+        );
+        messageIds = resolved.messageIds;
+        targetHistoryId = resolved.cursor ?? pubsubData.historyId;
+      } else {
+        messageIds = await this.resolveMessageIds(googleService, pubsubData.historyId);
+        targetHistoryId = pubsubData.historyId;
+      }
       if (messageIds.length === 0) return { authenticated: false };
 
-      const targetHistoryId = cursor ?? pubsubData.historyId;
       logger.info(`${TAG} [BATCH_RESOLVED] channelId=${source.channelId}`, {
         sourceName: source.name,
         historyId: targetHistoryId,
@@ -80,7 +93,7 @@ export class GoogleFlow extends BaseFlow {
         const parsedEmailNoAttachments = { ...parsedEmail, attachments: [] };
 
         payloads.push({
-          pubsubData: { ...pubsubData, historyId: undefined },
+          pubsubData: isBetaChannel ? { ...pubsubData, historyId: undefined } : pubsubData,
           parsedEmail: parsedEmailNoAttachments,
           ...(preDownloadedAttachments.length > 0 && { preDownloadedAttachments }),
         });
@@ -88,7 +101,7 @@ export class GoogleFlow extends BaseFlow {
       }
 
       // Cursor only advances once every message in the batch has synced.
-      if (lastRealIndex >= 0) payloads[lastRealIndex].pubsubData.historyId = targetHistoryId;
+      if (isBetaChannel && lastRealIndex >= 0) payloads[lastRealIndex].pubsubData.historyId = targetHistoryId;
 
       return payloads;
     } catch (error: any) {
@@ -144,6 +157,22 @@ export class GoogleFlow extends BaseFlow {
     } catch {
       logger.error(`${TAG} Failed to fetch recent messages`);
       return { messageIds: [], cursor: null };
+    }
+  }
+
+  /** Try history first, fall back to most recent message (stable/default path) */
+  private async resolveMessageIds(googleService: GoogleService, historyId: string): Promise<string[]> {
+    try {
+      return await googleService.listMessagesFromHistory(historyId);
+    } catch {
+      logger.warn(`${TAG} History fetch failed, trying recent messages`);
+    }
+
+    try {
+      return await googleService.listRecentMessages(1);
+    } catch {
+      logger.error(`${TAG} Failed to fetch recent messages`);
+      return [];
     }
   }
 }


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #71 (original author: @Revanthvenkatpasupuleti).

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
