### PR TITLE
feat: XYNE-17815 digital twin in thread UI UX

### DIFF
--- a/apps/backend/prisma/migrations/20260722120000_twin_drafts_in_draft_messages/migration.sql
+++ b/apps/backend/prisma/migrations/20260722120000_twin_drafts_in_draft_messages/migration.sql
@@ -1,36 +1,11 @@
--- Digital Twin reply drafts move from Redis into the draft_messages table.
--- Adds a NULLABLE origin discriminator (null=legacy user | 'user' | 'twin') + a
--- twin-only stringified-JSON metadata payload, and replaces the one-draft-per-thread
--- unique constraint with a PARTIAL unique index scoped to `origin IS DISTINCT FROM
--- 'twin'` so a thread can hold multiple twin drafts alongside the user's single
--- composer draft (legacy null rows count as the user's draft until backfilled).
-
--- AlterTable: origin is a NULLABLE plain TEXT column with NO default (DB enums are
--- frozen — values 'user'|'twin' are validated app-side, not by a Postgres enum type).
--- A null origin means a legacy user draft (rows that predate this column) — treated as
--- 'user' everywhere and backfilled later. New user drafts write 'user' explicitly; twin
--- proposals write 'twin'. Keeps the add a fast metadata-only op (no rewrite).
--- metadata is stringified JSON (TEXT), not JSONB.
 ALTER TABLE "public"."draft_messages"
   ADD COLUMN "origin" TEXT,
   ADD COLUMN "metadata" TEXT;
 
--- DropIndex: the old unconditional unique (one row per channel/conversation/message/user).
--- Plain DROP (fast metadata op, brief lock) — deliberately NOT CONCURRENTLY: this DB has
--- Zero DDL event triggers that fire on ddl_command_start, so DROP INDEX CONCURRENTLY can
--- never be the "first action in transaction" and errors. The expensive index BUILDs below
--- stay CONCURRENTLY (which the Zero trigger tolerates).
 DROP INDEX IF EXISTS "public"."draft_messages_channelId_conversationId_messageId_userId_key";
 
--- CreateIndex: twin read path (userDrafts scoped to origin='user' / twinDrafts to 'twin').
--- CONCURRENTLY to avoid an ACCESS EXCLUSIVE lock while the index builds.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "draft_messages_userId_origin_idx" ON "public"."draft_messages"("userId", "origin");
 
--- CreateIndex: partial unique — at most one NON-twin (user or legacy-null) draft per
--- (channel, conversation, message, user). `IS DISTINCT FROM 'twin'` also covers legacy
--- null rows, so the one-composer-draft-per-thread invariant holds before the null
--- backfill; twin drafts stay unconstrained (multiple per thread). Built CONCURRENTLY;
--- the DROP above already removed the same-named old index so there is no name clash.
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "draft_messages_channelId_conversationId_messageId_userId_key"
   ON "public"."draft_messages"("channelId", "conversationId", "messageId", "userId")
   WHERE "origin" IS DISTINCT FROM 'twin';

--- a/apps/backend/prisma/migrations/20260722120000_twin_drafts_in_draft_messages/migration.sql
+++ b/apps/backend/prisma/migrations/20260722120000_twin_drafts_in_draft_messages/migration.sql
@@ -1,0 +1,36 @@
+-- Digital Twin reply drafts move from Redis into the draft_messages table.
+-- Adds a NULLABLE origin discriminator (null=legacy user | 'user' | 'twin') + a
+-- twin-only stringified-JSON metadata payload, and replaces the one-draft-per-thread
+-- unique constraint with a PARTIAL unique index scoped to `origin IS DISTINCT FROM
+-- 'twin'` so a thread can hold multiple twin drafts alongside the user's single
+-- composer draft (legacy null rows count as the user's draft until backfilled).
+
+-- AlterTable: origin is a NULLABLE plain TEXT column with NO default (DB enums are
+-- frozen — values 'user'|'twin' are validated app-side, not by a Postgres enum type).
+-- A null origin means a legacy user draft (rows that predate this column) — treated as
+-- 'user' everywhere and backfilled later. New user drafts write 'user' explicitly; twin
+-- proposals write 'twin'. Keeps the add a fast metadata-only op (no rewrite).
+-- metadata is stringified JSON (TEXT), not JSONB.
+ALTER TABLE "public"."draft_messages"
+  ADD COLUMN "origin" TEXT,
+  ADD COLUMN "metadata" TEXT;
+
+-- DropIndex: the old unconditional unique (one row per channel/conversation/message/user).
+-- Plain DROP (fast metadata op, brief lock) — deliberately NOT CONCURRENTLY: this DB has
+-- Zero DDL event triggers that fire on ddl_command_start, so DROP INDEX CONCURRENTLY can
+-- never be the "first action in transaction" and errors. The expensive index BUILDs below
+-- stay CONCURRENTLY (which the Zero trigger tolerates).
+DROP INDEX IF EXISTS "public"."draft_messages_channelId_conversationId_messageId_userId_key";
+
+-- CreateIndex: twin read path (userDrafts scoped to origin='user' / twinDrafts to 'twin').
+-- CONCURRENTLY to avoid an ACCESS EXCLUSIVE lock while the index builds.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "draft_messages_userId_origin_idx" ON "public"."draft_messages"("userId", "origin");
+
+-- CreateIndex: partial unique — at most one NON-twin (user or legacy-null) draft per
+-- (channel, conversation, message, user). `IS DISTINCT FROM 'twin'` also covers legacy
+-- null rows, so the one-composer-draft-per-thread invariant holds before the null
+-- backfill; twin drafts stay unconstrained (multiple per thread). Built CONCURRENTLY;
+-- the DROP above already removed the same-named old index so there is no name clash.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "draft_messages_channelId_conversationId_messageId_userId_key"
+  ON "public"."draft_messages"("channelId", "conversationId", "messageId", "userId")
+  WHERE "origin" IS DISTINCT FROM 'twin';

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -3971,12 +3971,27 @@ model DraftMessage {
   userId          String      // User who is drafting (no FK constraint)
   content         String      // Draft content
   hasAttachment   Boolean     @default(false) // Whether the draft has attachments
+  // Who authored this draft. NULL = a legacy user draft (rows that predate this
+  // column; treated as 'user' everywhere and backfilled later). 'user' = the
+  // owner's own composer draft (at most one per thread, guarded by the partial
+  // unique index below). 'twin' = a Digital Twin proposal; a thread can hold
+  // several (one per @mention) alongside the user's own. Nullable + no default
+  // keeps the column add a fast metadata-only op and avoids a custom-enum default;
+  // new user drafts write 'user' explicitly, twin proposals write 'twin'.
+  // Plain String (not a DB enum — enums are frozen); values 'user'|'twin' are
+  // validated app-side. null = legacy user draft (see above).
+  origin          String? // 'user' | 'twin' | null (legacy user draft)
+  metadata        String?      // twin-only: stringified JSON TwinReplyDraft payload (null for user drafts)
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 
   @@index([channelId, conversationId, messageId, userId]) // Fast lookup of user's draft for a conversation
   @@index([userId, id]) // for userDrafts
-  @@unique([channelId, conversationId, messageId, userId])
+  @@index([userId, origin]) // twin read path (userDrafts fetches all origins; the stateMachine splits user vs twin)
+  // NOTE: the old @@unique([channelId, conversationId, messageId, userId]) is
+  // replaced by a PARTIAL unique index scoped to `origin IS DISTINCT FROM 'twin'`
+  // (raw SQL in the migration), so twin drafts can be multiple-per-thread while a
+  // non-twin (user or legacy-null) draft is at most one per thread.
   @@map("draft_messages")
   @@schema("public")
 }

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -3971,27 +3971,14 @@ model DraftMessage {
   userId          String      // User who is drafting (no FK constraint)
   content         String      // Draft content
   hasAttachment   Boolean     @default(false) // Whether the draft has attachments
-  // Who authored this draft. NULL = a legacy user draft (rows that predate this
-  // column; treated as 'user' everywhere and backfilled later). 'user' = the
-  // owner's own composer draft (at most one per thread, guarded by the partial
-  // unique index below). 'twin' = a Digital Twin proposal; a thread can hold
-  // several (one per @mention) alongside the user's own. Nullable + no default
-  // keeps the column add a fast metadata-only op and avoids a custom-enum default;
-  // new user drafts write 'user' explicitly, twin proposals write 'twin'.
-  // Plain String (not a DB enum — enums are frozen); values 'user'|'twin' are
-  // validated app-side. null = legacy user draft (see above).
-  origin          String? // 'user' | 'twin' | null (legacy user draft)
-  metadata        String?      // twin-only: stringified JSON TwinReplyDraft payload (null for user drafts)
+  origin          String?     // 'user' | 'twin' | null (legacy user draft)
+  metadata        String?     // twin-only: stringified JSON TwinReplyDraft payload (null for user drafts)
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 
   @@index([channelId, conversationId, messageId, userId]) // Fast lookup of user's draft for a conversation
   @@index([userId, id]) // for userDrafts
-  @@index([userId, origin]) // twin read path (userDrafts fetches all origins; the stateMachine splits user vs twin)
-  // NOTE: the old @@unique([channelId, conversationId, messageId, userId]) is
-  // replaced by a PARTIAL unique index scoped to `origin IS DISTINCT FROM 'twin'`
-  // (raw SQL in the migration), so twin drafts can be multiple-per-thread while a
-  // non-twin (user or legacy-null) draft is at most one per thread.
+  @@index([userId, origin])
   @@map("draft_messages")
   @@schema("public")
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -197,6 +197,9 @@ import emojiRoutes from '@/routes/emojis';
 import applicationBackfillRoutes from '@/routes/applicationBackfill';
 import { appRoutes } from '@/apps';
 import { ChatController } from '@/apps/controllers/chatController';
+import { ReactionController } from '@/controllers/reactionController';
+import { unifiedDMService } from '@/bots/unified/services/unified-dm-service';
+import { coerceTwinReplyDraft, destinationNameLookup, createTwinReplyDraft } from '@/services/twinReplyDraftService';
 import userMigrationRoutes from '@/routes/userMigration';
 import internalRoutes from '@/routes/internal';
 import collectionsRoutes from '@/routes/collections';
@@ -558,6 +561,71 @@ export class App {
       // Only the trusted S2S postAsUser route sets this; app-token callers never do.
       (req as Request & { isPostAsUser?: boolean }).isPostAsUser = true;
       void new ChatController().postMessage(req, res);
+    });
+    // React AS a user (S2S) — the reaction counterpart to postAsUser. Used by the
+    // Digital Twin approval flow so an approved emoji reaction shows as the user.
+    this.app.post('/api/internal/reactAsUser', validateS2SKey, (req: Request, res: Response) => {
+      void new ReactionController().reactAsUser(req, res);
+    });
+    // Get-or-create a 1:1 DM channel between two users (S2S). Used by the Digital
+    // Twin approval flow to resolve a `dm`/`dm_sender` reply destination into a
+    // channelId before posting AS the user (via postAsUser). Returns { channelId }.
+    this.app.post('/api/internal/getOrCreateDm', validateS2SKey, async (req: Request, res: Response) => {
+      try {
+        const { userId, targetUserId, workspaceId } = (req.body ?? {}) as {
+          userId?: string; targetUserId?: string; workspaceId?: string;
+        };
+        if (!userId || !targetUserId || !workspaceId) {
+          res.status(400).json({ error: 'userId, targetUserId and workspaceId are required' });
+          return;
+        }
+        const channelId = await unifiedDMService.getOrCreateDirectMessage(userId, targetUserId, workspaceId);
+        res.json({ channelId });
+      } catch (err) {
+        logger.error('[getOrCreateDm] failed', err);
+        res.status(500).json({ error: 'Internal error' });
+      }
+    });
+    // Create a Digital Twin in-thread reply draft (S2S). Written by claw-auth
+    // after a twin run (instead of the old approval DM) as a draft_messages row
+    // (origin='twin'); Zero replication surfaces it live to the owner. The owner
+    // approves/declines it through the /reply-draft/:draftId endpoints.
+    this.app.post('/api/internal/twin-reply-draft', validateS2SKey, async (req: Request, res: Response) => {
+      try {
+        const parsed = coerceTwinReplyDraft(req.body);
+        if ('error' in parsed) {
+          res.status(400).json({ error: parsed.error });
+          return;
+        }
+        // Resolve the destination's human NAME for the "posts to …" label. The
+        // Twin forwards only ids for channel/thread/dm; Spaces owns the channel
+        // and user tables, so we look the name up here. Best-effort and
+        // fail-open — a missing name only degrades the label, never the draft.
+        const lookup = destinationNameLookup(parsed.draft);
+        if (lookup) {
+          try {
+            const prisma = DatabaseClient.getInstance();
+            if (lookup.field === 'destinationChannelName') {
+              const chan = await prisma.channel.findUnique({ where: { id: lookup.id }, select: { name: true } });
+              if (chan?.name) parsed.draft.destinationChannelName = chan.name;
+            } else {
+              const target = await prisma.user.findUnique({ where: { id: lookup.id }, select: { name: true, displayName: true } });
+              const name = target?.displayName || target?.name;
+              if (name) parsed.draft.destinationUserName = name;
+            }
+          } catch (err) {
+            logger.warn('[twin-reply-draft] destination name resolution failed', err);
+          }
+        }
+        // Persist as a draft_messages row; Zero replicates it to the owner's
+        // open clients live (a Twin run is async — seconds — so the owner is
+        // usually already in the thread), so no bespoke socket is needed.
+        await createTwinReplyDraft(parsed.draft);
+        res.json({ ok: true });
+      } catch (err) {
+        logger.error('[twin-reply-draft] create failed', err);
+        res.status(500).json({ error: 'Internal error' });
+      }
     });
     this.app.post(
       '/api/internal/automations/claw-callback/:executionId/:stepName',

--- a/apps/backend/src/bots/unified/services/unified-dm-service.ts
+++ b/apps/backend/src/bots/unified/services/unified-dm-service.ts
@@ -128,6 +128,18 @@ class UnifiedDMService {
     const definition = await unifiedBotUserService.getBotDefinition(botUserId);
     return definition?.id ?? null;
   }
+
+  /**
+   * Get or create a 1:1 DM channel between two HUMAN users. Same mechanics as a
+   * bot DM (a 2-member DM channel keyed on the sorted user ids), just named for
+   * the user↔user case. Used by the Digital Twin approval flow so an approved
+   * reply can be delivered as a DM to a specific person (the mention sender, or
+   * anyone else the Twin chose). Returns the DM channel id.
+   */
+  async getOrCreateDirectMessage(userAId: string, userBId: string, workspaceId: string): Promise<string> {
+    const channel = await this.getOrCreateBotDM(userAId, userBId, workspaceId);
+    return channel.id;
+  }
 }
 
 // Export singleton instance

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -307,6 +307,14 @@ const envSchema = Joi.object({
   PULSE_ENABLED_CHANNELS: Joi.string().allow('').default(''),
   PULSE_API_URL: Joi.string().uri().default(''),
   PULSE_AUTHORIZATION: Joi.string().allow('').default(''),
+  // Thread catch-up summary — comma-separated channel IDs, or "all" for every channel (empty = disabled everywhere)
+  THREAD_SUMMARY_ENABLED_CHANNELS: Joi.string().allow('').default(''),
+  THREAD_SUMMARY_MIN_MESSAGES: Joi.number().integer().min(0).default(6),
+  THREAD_SUMMARY_MESSAGE_LIMIT: Joi.number().integer().min(1).default(300),
+  THREAD_SUMMARY_LLM_TIMEOUT_MS: Joi.number().integer().min(1).default(300000),
+  THREAD_SUMMARY_MIN_SUMMARY_MAX_TOKENS: Joi.number().integer().min(1).default(4000),
+  THREAD_SUMMARY_MAX_SUMMARY_MAX_TOKENS: Joi.number().integer().min(1).default(20000),
+  THREAD_SUMMARY_TRANSCRIPT_CHARS_PER_MAX_TOKEN: Joi.number().integer().min(1).default(10),
   // Jira Configuration
   JUSPAY_JIRA_BASEURL: Joi.string().uri().default(''),
   JIRA_EULER_BOT_EMAIL: Joi.string().allow('').default(''),
@@ -798,6 +806,19 @@ export const config = {
       .filter(Boolean),
     apiUrl: envVars.PULSE_API_URL as string,
     authorization: envVars.PULSE_AUTHORIZATION as string,
+  },
+  threadSummary: {
+    // Comma-separated channel IDs that have the AI thread catch-up summary enabled, or "all" for every channel (empty = disabled everywhere)
+    enabledChannels: (envVars.THREAD_SUMMARY_ENABLED_CHANNELS as string)
+      .split(',')
+      .map((s: string) => s.trim())
+      .filter(Boolean),
+    minMessages: envVars.THREAD_SUMMARY_MIN_MESSAGES as number,
+    messageLimit: envVars.THREAD_SUMMARY_MESSAGE_LIMIT as number,
+    llmTimeoutMs: envVars.THREAD_SUMMARY_LLM_TIMEOUT_MS as number,
+    minSummaryMaxTokens: envVars.THREAD_SUMMARY_MIN_SUMMARY_MAX_TOKENS as number,
+    maxSummaryMaxTokens: envVars.THREAD_SUMMARY_MAX_SUMMARY_MAX_TOKENS as number,
+    transcriptCharsPerMaxToken: envVars.THREAD_SUMMARY_TRANSCRIPT_CHARS_PER_MAX_TOKEN as number,
   },
   jira: {
     baseUrl: envVars.JUSPAY_JIRA_BASEURL as string,

--- a/apps/backend/src/controllers/conversationController.ts
+++ b/apps/backend/src/controllers/conversationController.ts
@@ -26,6 +26,20 @@ import { logger } from '../utils/logger';
 import { ChannelUserStatusRepository } from '@/database/repositories/channelUserStatusRepository';
 import { messageMetadataService } from '@/services/messageMetadataService';
 import { unreadService } from '../services/unreadService';
+import {
+  canRecommendThreadSummary,
+  getOrGenerateThreadSummary,
+  getCachedSummary,
+  deleteCachedSummary,
+  isThreadSummaryEnabledForChannel,
+  consumeThreadRecommendation,
+  hasPendingRecommendations,
+} from '@/services/threadSummaryService';
+import {
+  getTwinReplyDraftById,
+  deleteTwinReplyDraftById,
+  type TwinReplyDraft,
+} from '@/services/twinReplyDraftService';
 import { MessagesSideEffectHandler } from '../zero/side-effects/tables/messages-handler';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { messageSchema } from '@/vespa/src/types';
@@ -2064,6 +2078,278 @@ export class ConversationController {
       res.status(200).json({ success: true, data });
     } catch (error) {
       logger.error('[agentProgress/get] error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * GET /:conversationId/summary
+   *
+   * On-demand AI summary of the thread, shared across all members. Cached by
+   * "as of" message — only makes a fresh LLM call if new messages have
+   * landed since the last summary was generated; otherwise returns the
+   * existing one instantly. Manual summary generation is available whenever
+   * the feature is enabled for the channel; only automatic recommendations
+   * are gated by THREAD_SUMMARY_MIN_MESSAGES.
+   */
+  getSummary = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { conversationId } = req.params;
+      const userId = req.user!.id;
+      if (!conversationId) {
+        res.status(400).json({ error: 'Conversation ID is required' });
+        return;
+      }
+
+      const conversation = await this.conversationRepository.findById(conversationId);
+      if (!conversation) {
+        res.status(404).json({ error: 'Conversation not found' });
+        return;
+      }
+
+      const channel = await this.channelRepository.findById(conversation.channelId);
+      if (channel?.visibility === 'PRIVATE') {
+        const isParticipant = await this.channelParticipantRepository.isParticipant(
+          conversation.channelId,
+          userId
+        );
+        if (!isParticipant) {
+          res.status(403).json({
+            error: 'Access denied - not a channel participant',
+            code: 'NOT_CHANNEL_PARTICIPANT',
+          });
+          return;
+        }
+      }
+
+      if (!isThreadSummaryEnabledForChannel(conversation.channelId)) {
+        res.status(204).end();
+        return;
+      }
+
+      const result = await getOrGenerateThreadSummary(conversationId, { enforceMinMessages: false });
+      if (!result) {
+        res.status(204).end();
+        return;
+      }
+
+      res.status(200).json({ success: true, ...result });
+    } catch (error) {
+      logger.error('[getSummary] error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * GET /:conversationId/recommendation
+   *
+   * Whether the requesting user should see the "you were just added" catch-up
+   * summary for this thread — and if so, the summary content itself, in the
+   * same round trip. Backed by a one-time flag set by the real-time
+   * ConversationParticipant insert side effect (not inferred from
+   * lastReadAt/joinedAt timestamps — see threadSummaryService for why
+   * that broke down). Consumes the flag on read, so it's only ever surfaced
+   * once per genuine add.
+   *
+   * Deliberately bundled with a cache READ here (not generation — rather than
+   * making the client separately call GET /summary right after) — this is
+   * the only path that can ever empty out the pending set, so this is also
+   * the only place that needs to check afterward whether to tear the cache
+   * down. Doing the read and that check in the same request means there's no
+   * race to guess a delay around: by the time the pending-check below runs,
+   * `result` is already computed and on its way to the client regardless of
+   * what happens to the cache next. A plain GET /summary (the manual header
+   * button) never touches the pending set at all, so it needs none of this.
+   *
+   * Uses getCachedSummary, NOT getOrGenerateThreadSummary — this
+   * endpoint never triggers an LLM call itself. Generation is exclusively
+   * the job of the two side-effect handlers (pre-warm on add, keep-warm on
+   * message); by the time a genuinely-recommended user opens the thread, the
+   * pre-warm has almost always already populated the cache. If it somehow
+   * hasn't (pre-warm still in flight or failed), this just serves nothing
+   * rather than making the request itself pay for a fresh generation.
+   */
+  getRecommendation = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { conversationId } = req.params;
+      const userId = req.user!.id;
+      if (!conversationId) {
+        res.status(400).json({ error: 'Conversation ID is required' });
+        return;
+      }
+
+      const conversation = await this.conversationRepository.findById(conversationId);
+      if (!conversation || !isThreadSummaryEnabledForChannel(conversation.channelId)) {
+        res.status(200).json({ success: true, recommended: false, enabled: false });
+        return;
+      }
+
+      const channel = await this.channelRepository.findById(conversation.channelId);
+      if (channel?.visibility === 'PRIVATE') {
+        const isParticipant = await this.channelParticipantRepository.isParticipant(
+          conversation.channelId,
+          userId
+        );
+        if (!isParticipant) {
+          res.status(403).json({
+            error: 'Access denied - not a channel participant',
+            code: 'NOT_CHANNEL_PARTICIPANT',
+          });
+          return;
+        }
+      }
+
+      if (!(await canRecommendThreadSummary(conversationId))) {
+        res.status(200).json({ success: true, recommended: false, enabled: true });
+        return;
+      }
+
+      const recommended = await consumeThreadRecommendation(conversationId, userId);
+      if (!recommended) {
+        res.status(200).json({ success: true, recommended: false, enabled: true });
+        return;
+      }
+
+      const cached = await getCachedSummary(conversationId);
+      const summary = cached && { content: cached.content, cached: true, asOfMessageId: cached.asOfMessageId };
+      res.status(200).json({ success: true, recommended: true, enabled: true, summary });
+
+      if (!(await hasPendingRecommendations(conversationId))) {
+        await deleteCachedSummary(conversationId);
+      }
+    } catch (error) {
+      logger.error('[getRecommendation] error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  // ── Digital Twin in-thread reply draft (owner-only) ────────────────────────
+
+  /**
+   * The caller reads their own pending twin proposals directly from Zero (the
+   * `twinDrafts` query → draft_messages where origin='twin'), so there is no
+   * GET endpoint here — only approve/decline (below), keyed by the draft row id.
+   */
+
+  /**
+   * Forward an approve/decline to claw-auth, which owns the Twin's tested
+   * delivery + feedback pipeline (post-as-user / react-as-user / destination
+   * resolution / TwinResponseFeedback). The delivery-execution context is read
+   * from the SERVER-SIDE Redis draft (never the client body), so the client
+   * can't tamper with where the reply lands. S2S-authed with the shared claw key.
+   */
+  private forwardTwinDraftAction = async (
+    draft: TwinReplyDraft,
+    action: 'approve' | 'decline',
+    actorUserId: string,
+    editedMessage?: string,
+  ): Promise<{ ok: boolean; status: number; error?: string; posted?: { channelId: string; conversationId?: string } }> => {
+    const base = config.xyneClaw.authUrl.replace(/\/+$/, '');
+    const url = `${base}/claw/api/v1/internal/twin-draft/action`;
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // Spaces↔claw-auth shared key (Spaces does not hold XYNE_CLAW_S2S_KEY);
+          // claw-auth validates it via requireInternalS2S.
+          ...(config.internalS2sKey ? { 'x-s2s-key': config.internalS2sKey } : {}),
+        },
+        body: JSON.stringify({
+          action,
+          actorUserId,
+          ...(editedMessage !== undefined ? { editedMessage } : {}),
+          draft,
+        }),
+        signal: AbortSignal.timeout(30_000),
+      });
+      const text = await resp.text().catch(() => '');
+      if (!resp.ok) {
+        return { ok: false, status: resp.status, error: text.slice(0, 300) };
+      }
+      let posted: { channelId: string; conversationId?: string } | undefined;
+      try {
+        const parsed = JSON.parse(text) as { posted?: { channelId?: string; conversationId?: string } };
+        if (parsed?.posted?.channelId) {
+          posted = {
+            channelId: parsed.posted.channelId,
+            ...(parsed.posted.conversationId ? { conversationId: parsed.posted.conversationId } : {}),
+          };
+        }
+      } catch {
+        // no posted target (react-only) — fine
+      }
+      return { ok: true, status: 200, ...(posted ? { posted } : {}) };
+    } catch (err) {
+      logger.error('[twin-draft-action] forward to claw-auth failed:', err);
+      return { ok: false, status: 502, error: err instanceof Error ? err.message : String(err) };
+    }
+  };
+
+  /**
+   * POST /reply-drafts/:draftId/approve  { editedMessage? }
+   *
+   * Deliver the (possibly edited) draft. Reads the twin proposal server-side by
+   * its row id (owner-scoped), forwards to claw-auth to post/react as the user +
+   * record accepted feedback, and only removes the row when delivery SUCCEEDED
+   * (a transient failure leaves it intact for retry). Deleting the row clears the
+   * dock/badge on every open client via Zero replication — no socket needed.
+   */
+  approveReplyDraft = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { draftId } = req.params;
+      const userId = req.user!.id;
+      if (!draftId) {
+        res.status(400).json({ error: 'Draft ID is required' });
+        return;
+      }
+      const draft = await getTwinReplyDraftById(draftId, userId);
+      if (!draft) {
+        res.status(404).json({ error: 'No draft to approve', code: 'NO_DRAFT' });
+        return;
+      }
+      const editedRaw = (req.body as { editedMessage?: unknown } | undefined)?.editedMessage;
+      const editedMessage = typeof editedRaw === 'string' ? editedRaw : undefined;
+
+      const result = await this.forwardTwinDraftAction(draft, 'approve', userId, editedMessage);
+      if (!result.ok) {
+        // Keep the draft — the user can retry the approval.
+        res.status(502).json({ error: 'Failed to deliver reply', detail: result.error });
+        return;
+      }
+      await deleteTwinReplyDraftById(draftId, userId);
+      res.status(200).json({ success: true, ...(result.posted ? { posted: result.posted } : {}) });
+    } catch (error) {
+      logger.error('[approveReplyDraft] error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * POST /reply-drafts/:draftId/decline
+   *
+   * The user rejects the draft. Records declined feedback (best-effort) and drops
+   * the row regardless — declining is the user's choice, so it always clears even
+   * if the feedback callback fails.
+   */
+  declineReplyDraft = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { draftId } = req.params;
+      const userId = req.user!.id;
+      if (!draftId) {
+        res.status(400).json({ error: 'Draft ID is required' });
+        return;
+      }
+      const draft = await getTwinReplyDraftById(draftId, userId);
+      if (!draft) {
+        res.status(204).end(); // already gone — treat as success
+        return;
+      }
+      await this.forwardTwinDraftAction(draft, 'decline', userId); // best-effort feedback
+      await deleteTwinReplyDraftById(draftId, userId);
+      res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('[declineReplyDraft] error:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   };

--- a/apps/backend/src/controllers/reactionController.ts
+++ b/apps/backend/src/controllers/reactionController.ts
@@ -4,6 +4,7 @@ import { MessageRepository } from '../database/repositories/messageRepository';
 
 import { logger } from '../utils/logger';
 import { redisService } from '../services/redisService';
+import { messageMetadataService } from '../services/messageMetadataService';
 import {
   ReactionResponse,
   GetReactionsResponse,
@@ -186,6 +187,91 @@ export class ReactionController {
       logger.info(`Reaction toggled: ${decodedEmoji} by user ${userId} on message ${messageId} (${result.added ? 'added' : 'removed'})`);
     } catch (error) {
       logger.error('Error toggling reaction:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+
+  /**
+   * S2S: add a reaction to a message AS a specific user (userId from the body,
+   * not req.user). Mirrors /api/internal/postAsUser but for reactions — used by
+   * the Digital Twin approval flow: when the user approves a "react" delivery,
+   * claw-auth posts the emoji AS the user through this endpoint, so the reaction
+   * shows as coming from the person (consistent with the Twin acting as them).
+   * Idempotent: a duplicate reaction (already reacted) is treated as success.
+   */
+  async reactAsUser(req: Request, res: Response): Promise<void> {
+    try {
+      const { messageId, emojiName, userId } = (req.body ?? {}) as {
+        messageId?: string;
+        emojiName?: string;
+        userId?: string;
+      };
+
+      if (!messageId || !emojiName || !userId) {
+        res.status(400).json({ error: 'messageId, emojiName and userId are required' });
+        return;
+      }
+      const emoji = emojiName.trim();
+      if (!emoji || emoji.length > 100) {
+        res.status(400).json({ error: 'Invalid emoji name' });
+        return;
+      }
+
+      try {
+        await reactionRepository.addReaction({ messageId, userId, emojiName: emoji });
+      } catch (error: any) {
+        // Unique-constraint = the user already reacted with this emoji → success.
+        if (error?.code !== 'P2002') throw error;
+      }
+
+      // CRITICAL for real-time render: the chat UI derives the reaction pill
+      // EXCLUSIVELY from the message's denormalized `reactions_md` column (Zero
+      // replicates it to every client) — NOT from the raw reaction rows written
+      // above, and NOT from the Redis broadcast below (no chat client subscribes
+      // to `reaction_updated`). The normal UI reaction path updates reactions_md
+      // via a Zero mutator; this S2S path bypasses Zero, so we must update
+      // reactions_md ourselves or the emoji never appears (the row lands in the
+      // DB but is invisible — exactly the Digital Twin react bug). Run it even on
+      // the P2002 "already reacted" path: addReactionToData is a set-union
+      // (idempotent per emoji+user), so this self-heals a column left stale by an
+      // earlier bypassed write. Do it BEFORE responding so the caller only sees
+      // success once the client-visible state is actually updated.
+      const conversationId = await messageRepository.getConversationIdByMessageId(messageId);
+      try {
+        await messageMetadataService.addReaction(messageId, emoji, userId);
+        // If this message is a conversation's initial (root) message, its
+        // reaction also lives in conversations.initial_message_md — keep it in
+        // sync (no-op when messageId isn't the initial message).
+        if (conversationId) await messageMetadataService.syncInitialMessageMd(conversationId);
+      } catch (mdError) {
+        logger.error('[reactAsUser] failed to update reactions_md — emoji may not render:', mdError);
+      }
+
+      const reactions = await reactionRepository.getMessageReactions(messageId, userId);
+      res.status(200).json({ success: true, reactions });
+
+      // Best-effort legacy Redis broadcast. Kept harmless, but it is NOT what
+      // renders the reaction — the real-time render comes from Zero replicating
+      // the reactions_md update above. No chat client subscribes to this event.
+      try {
+        if (conversationId) {
+          await redisService.broadcastMessageToSession(conversationId, {
+            messageId: `reaction-${messageId}-${Date.now()}`,
+            conversationId,
+            senderId: 'system',
+            senderName: 'System',
+            content: JSON.stringify({ type: 'reaction_updated', data: reactions, messageId }),
+            msgType: 'SYSTEM',
+            createdAt: new Date(),
+          });
+        }
+      } catch (broadcastError) {
+        logger.error('Error broadcasting reactAsUser update:', broadcastError);
+      }
+
+      logger.info(`[reactAsUser] ${emoji} as user ${userId} on message ${messageId}`);
+    } catch (error) {
+      logger.error('Error in reactAsUser:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   }

--- a/apps/backend/src/routes/conversations.ts
+++ b/apps/backend/src/routes/conversations.ts
@@ -8,6 +8,15 @@ const conversationController = new ConversationController();
 // Static route must be registered before any /:conversationId routes.
 router.get('/threads', conversationController.getUserThreads);
 
+// Digital Twin in-thread reply draft — approve / decline a proposal by its row
+// id (owner-only; forwards delivery + feedback to claw-auth, then deletes the
+// row so Zero clears the dock/badge). The caller READS proposals directly from
+// Zero (twinDrafts query), so there is no GET here. Registered BEFORE the
+// `/:conversationId/...` routes so "reply-drafts" is never captured as a
+// conversationId.
+router.post('/reply-drafts/:draftId/approve', conversationController.approveReplyDraft);
+router.post('/reply-drafts/:draftId/decline', conversationController.declineReplyDraft);
+
 // Keep replyToConversation for file upload handling
 router.post('/:conversationId/messages', uploadMultiple, conversationController.replyToConversation);
 
@@ -19,6 +28,13 @@ router.get('/by-message/:messageId', conversationController.getConversationByMes
 
 // Read current ephemeral agent-progress signals for a conversation (dashboard rehydrate on thread open)
 router.get('/:conversationId/agent-progress', conversationController.getAgentProgress);
+
+// On-demand AI thread summary — generates or returns the cached one if no new messages since
+router.get('/:conversationId/summary', conversationController.getSummary);
+
+// One-time "you were just added" recommendation flag — set by the real-time
+// participant-insert side effect, consumed (cleared) on read.
+router.get('/:conversationId/recommendation', conversationController.getRecommendation);
 
 // Cancel an in-flight agent run for the given conversation
 router.post('/:conversationId/agent-cancel', conversationController.cancelAgentRun);

--- a/apps/backend/src/services/pythonQuery/validator.ts
+++ b/apps/backend/src/services/pythonQuery/validator.ts
@@ -12,6 +12,7 @@ export const ALLOWED_MODELS = new Set([
   'channel',
   'channelParticipant',
   'conversation',
+  'conversationParticipant',
   'message',
   'workflow',
   'workflowExecution',

--- a/apps/backend/src/services/redisService.ts
+++ b/apps/backend/src/services/redisService.ts
@@ -129,6 +129,30 @@ class RedisService {
     }
   }
 
+  /**
+   * Remove one or more members from a Redis set using SREM.
+   * Returns the number removed; 0 if Redis isn't initialized.
+   */
+  async srem(key: string, ...members: string[]): Promise<number> {
+    if (!this.redis) {
+      logger.warn('[REDIS] Cannot srem - Redis not initialized');
+      return 0;
+    }
+    return await this.redis.srem(key, ...members);
+  }
+
+  /**
+   * Get the number of members in a Redis set using SCARD.
+   * Returns 0 if the key doesn't exist.
+   */
+  async scard(key: string): Promise<number> {
+    if (!this.redis) {
+      logger.warn('[REDIS] Cannot scard - Redis not initialized');
+      return 0;
+    }
+    return await this.redis.scard(key);
+  }
+
   // Session participant management
   async addParticipantToSession(sessionId: string, userId: string): Promise<void> {
     if (!this.redis) throw new Error('Redis not initialized');

--- a/apps/backend/src/services/threadSummaryService.ts
+++ b/apps/backend/src/services/threadSummaryService.ts
@@ -1,0 +1,378 @@
+import { db } from '@/database/client';
+import { config } from '@/config/env';
+import { MessageType } from '@prisma/client';
+import { LLMClient, createUserMessage } from '@framework';
+import { logger } from '@/utils/logger';
+import { redisService } from '@/services/redisService';
+import { extractPlainTextFromHtml } from '@/utils/contentUtils';
+
+function computeSummaryMaxTokens(transcriptLength: number): number {
+  const { minSummaryMaxTokens, maxSummaryMaxTokens, transcriptCharsPerMaxToken } = config.threadSummary;
+  const scaled = Math.ceil(transcriptLength / transcriptCharsPerMaxToken);
+  return Math.min(maxSummaryMaxTokens, Math.max(minSummaryMaxTokens, scaled));
+}
+
+export interface CachedSummaryEntry {
+  content: string;
+  asOfMessageId: string;
+}
+
+// Shared across the whole app (dedupes LLM calls across users/replicas) and
+// survives backend restarts, unlike a plain in-process Map. Entries expire
+// on their own via SUMMARY_CACHE_TTL_SECONDS, so there's no manual eviction
+// to maintain.
+const SUMMARY_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+function summaryCacheKey(conversationId: string): string {
+  return `thread-summary:${conversationId}`;
+}
+
+/**
+ * Rollout gate — THREAD_SUMMARY_ENABLED_CHANNELS env var, same pattern as
+ * Pulse's per-channel allowlist. Checked at every entry point (pre-warm on
+ * add, keep-warm on message, and both HTTP endpoints) rather than relying on
+ * the pending-recommendation flag alone to indirectly suppress it, so a
+ * manual button click on a disabled channel can't bypass it either.
+ *
+ * The literal value "all" (case-insensitive) turns it on for every channel,
+ * so a full rollout doesn't require enumerating every channel ID.
+ */
+export function isThreadSummaryEnabledForChannel(channelId: string | null | undefined): boolean {
+  const { enabledChannels } = config.threadSummary;
+  if (enabledChannels.some((c) => c.toLowerCase() === 'all')) return true;
+  return !!channelId && enabledChannels.includes(channelId);
+}
+
+/** Read-only — whatever's currently cached, or undefined. Never triggers generation. */
+export async function getCachedSummary(conversationId: string): Promise<CachedSummaryEntry | undefined> {
+  try {
+    const raw = await redisService.get(summaryCacheKey(conversationId));
+    if (!raw) return undefined;
+    return JSON.parse(raw) as CachedSummaryEntry;
+  } catch (error) {
+    logger.warn('[ThreadSummaryService] Redis read failed, treating as cache miss', { error });
+    return undefined;
+  }
+}
+
+async function setCachedSummary(conversationId: string, entry: CachedSummaryEntry): Promise<void> {
+  try {
+    await redisService.set(summaryCacheKey(conversationId), JSON.stringify(entry), SUMMARY_CACHE_TTL_SECONDS);
+  } catch (error) {
+    logger.warn('[ThreadSummaryService] Redis write failed, summary generated but not cached', { error });
+  }
+}
+
+let llmClient: LLMClient | null | undefined;
+
+/** Lazily constructed — undefined until first use, null if no API key is configured. */
+function getLlmClient(): LLMClient | null {
+  if (llmClient === undefined) {
+    const apiKey = config.llm.litellmApiKey;
+    llmClient = apiKey
+      ? new LLMClient({
+          provider: {
+            type: 'litellm',
+            config: { apiKey, baseUrl: config.llm.litellmBaseUrl, timeout: 60000 },
+          },
+          defaultModel: config.workflow.defaultModelName,
+        })
+      : null;
+  }
+  return llmClient;
+}
+
+export interface ThreadSummaryResult {
+  content: string;
+  /** True if this was served from the existing cached summary — no LLM call was made. */
+  cached: boolean;
+  /**
+   * The messageId this content was actually generated from. Lets the client
+   * tell a genuinely up-to-date summary apart from a stale one served as a
+   * fallback (LLM failure / no client configured) — the client compares this
+   * against the latest message it has and only then treats it as current.
+   */
+  asOfMessageId: string;
+}
+
+// Tagging a brand-new participant in a message fires TWO independent side
+// effects off the same underlying insert — the new ConversationParticipant
+// row (pre-warms the cache) and the message itself (keepThreadSummaryWarm,
+// which by then sees the recommendation flag already set and also
+// generates). Both call getOrGenerateThreadSummary for the same
+// conversationId within the same instant, and without this, both would
+// independently miss the not-yet-written cache and make their own LLM call.
+// Keyed by conversationId + min-message behavior so a concurrent second (or
+// third) caller on the same path just awaits the same in-flight generation
+// instead of duplicating it.
+const inFlightGenerations = new Map<string, Promise<ThreadSummaryResult | null>>();
+
+async function hasEnoughMessagesForRecommendation(conversationId: string): Promise<boolean> {
+  const messageCount = await db.message.count({
+    where: { conversationId, isDeleted: false, msgType: { not: MessageType.SYSTEM } },
+  });
+  return messageCount > config.threadSummary.minMessages;
+}
+
+export async function canRecommendThreadSummary(conversationId: string): Promise<boolean> {
+  return hasEnoughMessagesForRecommendation(conversationId);
+}
+
+/**
+ * Get the thread's summary, generating (or regenerating) it only if there are
+ * messages newer than the last time it was summarized. Shared by both the
+ * "recommend on add" side effect, the on-demand header button, and the
+ * "keep it warm on new messages" hook, so there's a single cache per
+ * conversation regardless of who/what triggers it.
+ *
+ * Cached in Redis, NOT as a Message row — the summary isn't shared/visible
+ * chat content, it's a dedupe cache the frontend also mirrors per-user in
+ * localStorage for instant redisplay. Redis (over a plain in-process cache)
+ * means this survives backend restarts and stays consistent across replicas
+ * in a multi-instance deployment.
+ *
+ * Deliberately a single direct LLM call, not routed through the xyne-claw
+ * agent pipeline — a one-shot summarization doesn't need session/tool
+ * overhead, and this needs to be fast enough for a user to wait on a click.
+ */
+export function getOrGenerateThreadSummary(
+  conversationId: string,
+  options: { enforceMinMessages?: boolean } = {},
+): Promise<ThreadSummaryResult | null> {
+  const enforceMinMessages = options.enforceMinMessages ?? true;
+  const inFlightKey = `${conversationId}:${enforceMinMessages ? 'min-gated' : 'manual'}`;
+  const inFlight = inFlightGenerations.get(inFlightKey);
+  if (inFlight) return inFlight;
+
+  const promise = generateThreadSummary(conversationId, { enforceMinMessages }).finally(() => {
+    inFlightGenerations.delete(inFlightKey);
+  });
+  inFlightGenerations.set(inFlightKey, promise);
+  return promise;
+}
+
+async function generateThreadSummary(
+  conversationId: string,
+  options: { enforceMinMessages: boolean },
+): Promise<ThreadSummaryResult | null> {
+  if (options.enforceMinMessages && !(await hasEnoughMessagesForRecommendation(conversationId))) {
+    return null;
+  }
+
+  const latestMessage = await db.message.findFirst({
+    where: { conversationId, isDeleted: false, msgType: { not: MessageType.SYSTEM } },
+    orderBy: { createdAt: 'desc' },
+    select: { messageId: true },
+  });
+  if (!latestMessage) {
+    return null;
+  }
+
+  const existingSummary = await getCachedSummary(conversationId);
+
+  if (existingSummary && existingSummary.asOfMessageId === latestMessage.messageId) {
+    return { content: existingSummary.content, cached: true, asOfMessageId: latestMessage.messageId };
+  }
+
+  const client = getLlmClient();
+  if (!client) {
+    logger.warn('[ThreadSummaryService] No LLM client configured, skipping thread summary');
+    return existingSummary
+      ? { content: existingSummary.content, cached: true, asOfMessageId: existingSummary.asOfMessageId }
+      : null;
+  }
+
+  // Fetch the LATEST N messages (desc), then reverse to chronological order
+  // for the prompt — not the oldest N. For threads over the limit, taking
+  // from the oldest end would summarize ancient history while the cache
+  // still claims to be current as of the actual latest message, silently
+  // dropping everything recent (exactly what the recency-weighting
+  // instruction above depends on actually being in the transcript).
+  const messages = (
+    await db.message.findMany({
+      where: { conversationId, isDeleted: false, msgType: { not: MessageType.SYSTEM } },
+      orderBy: { createdAt: 'desc' },
+      take: config.threadSummary.messageLimit,
+    })
+  ).reverse();
+
+  const senderIds = [...new Set(messages.map((m) => m.senderId))];
+  const senders = await db.user.findMany({
+    where: { id: { in: senderIds } },
+    select: { id: true, name: true },
+  });
+  const senderNameById = new Map(senders.map((u) => [u.id, u.name || 'Unknown']));
+
+  // Message content is HTML (rich-text composer output), not plain text —
+  // feeding raw markup into the prompt wastes tokens and risks the model
+  // trying to "summarize" tags instead of the actual conversation.
+  const transcript = messages
+    .map((m) => `${senderNameById.get(m.senderId) ?? 'Unknown'}: ${extractPlainTextFromHtml(m.content)}`)
+    .join('\n');
+
+  const prompt =
+    'Summarize this chat thread for someone who has not read it.\n\n' +
+    'Output a markdown "- " list. Nothing else. No intro line, no heading, no closing line.\n\n' +
+    'HARD LIMITS:\n' +
+    '- Maximum 4 points. Most threads need 2-3.\n' +
+    '- Maximum 10 words per point.\n' +
+    '- Maximum 40 words total.\n\n' +
+    'Each point states an outcome or a decision. Never explain why.\n' +
+    'Each point must be intelligible on its own. Name the system or feature it ' +
+    'refers to. Never assume the reader saw the previous point.\n\n' +
+    'Cut all of the following:\n' +
+    '- causes and root causes (no "because", "due to", "caused by", "traced to")\n' +
+    '- subordinate clauses (no "which", "that", "after", "while")\n' +
+    '- who did the work, unless someone is tagged and still owes a task\n' +
+    '- adjectives and adverbs\n' +
+    '- status verbs that carry no information' +
+    'Focus on the newest messages. Drop resolved topics the thread has moved past.\n\n' +
+    'No "you". No "the team". State the fact.\n\n' +
+    'Bold only person names and system or service names, using **double asterisks**. ' +
+    'Nothing else gets bolded.\n\n' +
+    `Thread:\n${transcript}`;
+
+  const baseMaxTokens = computeSummaryMaxTokens(transcript.length);
+  const { llmTimeoutMs, maxSummaryMaxTokens } = config.threadSummary;
+
+  // Escalating token budgets across retries: glm-latest is a reasoning model
+  // that can spend its whole budget on a hidden chain-of-thought before writing
+  // anything (finishReason 'length' → empty or mid-word-truncated content, e.g.
+  // "**Juned"). `enable_thinking:false` is meant to disable that but the gateway
+  // doesn't always honour it, so a second attempt with ~2x room usually lands a
+  // COMPLETE summary. A truncated result is accepted only as a last resort.
+  const budgets = [baseMaxTokens, Math.min(maxSummaryMaxTokens * 2, baseMaxTokens * 2)];
+
+  let summaryText: string | null = null;
+  for (let attempt = 0; attempt < budgets.length && !summaryText; attempt++) {
+    const maxTokens = budgets[attempt]!;
+    try {
+      // The timeout side of Promise.race is never implicitly cancelled when
+      // client.generate() wins the race — without clearing it explicitly, its
+      // setTimeout keeps the process alive and fires anyway (harmlessly, since
+      // the race already settled) up to the configured timeout after every single
+      // successful call. Not just theoretical: under real summary traffic this
+      // is a dangling timer per request.
+      let timeoutHandle: NodeJS.Timeout;
+      const response = await Promise.race([
+        client.generate({
+          model: config.workflow.defaultModelName,
+          messages: [createUserMessage(prompt)],
+          parameters: { maxTokens },
+          extraBody: { chat_template_kwargs: { enable_thinking: false } },
+        }),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(() => reject(new Error(`LLM call timed out after ${llmTimeoutMs}ms`)), llmTimeoutMs);
+        }),
+      ]).finally(() => clearTimeout(timeoutHandle));
+
+      const content = response.content?.trim() || null;
+      const truncated = response.finishReason === 'length';
+      const isLastAttempt = attempt === budgets.length - 1;
+      if (content && !truncated) {
+        summaryText = content; // clean, complete summary
+      } else if (content && isLastAttempt) {
+        summaryText = content; // truncated, but it's our last shot — better than nothing
+        logger.warn('[ThreadSummaryService] using truncated summary after retries', { finishReason: response.finishReason });
+      } else {
+        logger.warn('[ThreadSummaryService] summary attempt unusable, will retry if budget left', {
+          attempt,
+          finishReason: response.finishReason,
+          hadContent: !!content,
+        });
+      }
+    } catch (error) {
+      logger.warn('[ThreadSummaryService] LLM call failed for thread summary', { attempt, error });
+    }
+  }
+
+  if (!summaryText) {
+    return existingSummary
+      ? { content: existingSummary.content, cached: true, asOfMessageId: existingSummary.asOfMessageId }
+      : null;
+  }
+
+  await setCachedSummary(conversationId, { content: summaryText, asOfMessageId: latestMessage.messageId });
+
+  logger.info(`[ThreadSummaryService] Generated thread summary for conversation ${conversationId}`);
+  return { content: summaryText, cached: false, asOfMessageId: latestMessage.messageId };
+}
+
+/**
+ * Called by conversationController's getSummary once every user who was
+ * flagged for a thread's recommendation has seen it (checked right after
+ * that request already read/returned this cache's content, so there's no
+ * race to worry about) — at that point nobody's left waiting on this cache,
+ * so there's no reason to keep it around or keep paying to regenerate it as
+ * new messages land. A later on-demand button click just computes a fresh
+ * one from scratch.
+ */
+export async function deleteCachedSummary(conversationId: string): Promise<void> {
+  try {
+    await redisService.del(summaryCacheKey(conversationId));
+  } catch (error) {
+    logger.warn('[ThreadSummaryService] Redis delete failed', { error });
+  }
+}
+
+/**
+ * Tracks which users still need to see the "you were just added" catch-up
+ * summary for a thread — ONE Redis set per conversation (SADD/SREM/SCARD),
+ * not one flag key per user. A user's id is added the instant they're
+ * genuinely added by someone else (the real ConversationParticipant insert
+ * side effect — not inferred from lastReadAt/joinedAt timestamps, see the
+ * git history for why that broke down), and removed the moment they've seen
+ * it. Once the set empties out, getRecommendation tears deleteCachedSummary
+ * down too — see there.
+ *
+ * Uses real Redis SET operations (not a hand-rolled JSON array in a string
+ * key) specifically so add/remove is atomic — two users being consumed at
+ * nearly the same moment can't clobber each other's removal the way a
+ * naive read-modify-write on a JSON blob could.
+ */
+const PENDING_USERS_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+function pendingUsersKey(conversationId: string): string {
+  return `thread-pending-users:${conversationId}`;
+}
+
+/** Called once by the real-time participant-insert event when someone else adds/mentions this user into a conversation they weren't part of. */
+export async function flagThreadRecommendation(conversationId: string, userId: string): Promise<void> {
+  try {
+    const key = pendingUsersKey(conversationId);
+    await redisService.sadd(key, userId);
+    await redisService.expire(key, PENDING_USERS_TTL_SECONDS);
+  } catch (error) {
+    logger.warn('[ThreadSummaryService] Redis write failed, recommendation flag not set', { error });
+  }
+}
+
+/**
+ * Check + consume in one step — atomically removes userId from the pending
+ * set if present (so it's only ever surfaced once).
+ */
+export async function consumeThreadRecommendation(conversationId: string, userId: string): Promise<boolean> {
+  try {
+    const removedCount = await redisService.srem(pendingUsersKey(conversationId), userId);
+    return removedCount > 0;
+  } catch (error) {
+    logger.warn('[ThreadSummaryService] Redis read/write failed, assuming no pending recommendation', { error });
+    return false;
+  }
+}
+
+/**
+ * Whether anyone is still waiting to see this thread's recommendation — used
+ * both by the "keep it warm on new messages" hook (stop regenerating once
+ * the pending audience is gone) and by getRecommendation (tear the cache
+ * down once nobody's left pending, checked after it's already served its
+ * result).
+ */
+export async function hasPendingRecommendations(conversationId: string): Promise<boolean> {
+  try {
+    return (await redisService.scard(pendingUsersKey(conversationId))) > 0;
+  } catch (error) {
+    logger.warn('[ThreadSummaryService] Redis read failed, assuming no pending recommendations', { error });
+    return false;
+  }
+}

--- a/apps/backend/src/services/twinReplyDraft.ts
+++ b/apps/backend/src/services/twinReplyDraft.ts
@@ -1,0 +1,158 @@
+/**
+ * Digital Twin in-thread reply draft — PURE types + validation/projection.
+ *
+ * Deliberately dependency-free (no DB, no logger, no config) so it can be
+ * unit-tested in isolation without pulling the whole service graph. The DB IO
+ * (create/read/delete against the draft_messages table) lives in
+ * `twinReplyDraftService.ts`, which re-exports everything here.
+ *
+ * See twinReplyDraftService.ts for the storage/owner-only model.
+ */
+
+export type TwinDraftAction = 'react' | 'reply' | 'react_and_reply';
+
+/** A slimmed tool-invocation carrying only what the frontend citation chip
+ *  needs (`toolCallId` + `citations`) — baked by claw-auth's buildThreadCitationMeta. */
+export interface TwinDraftCitation {
+  toolCallId: string;
+  citations: unknown[];
+}
+
+export interface TwinReplyDraft {
+  // ── identity / surface (the first two are also the Redis key) ──
+  /** Origin conversation the user was mentioned in — where the draft SURFACES. */
+  conversationId: string;
+  /** The owner (= mentionedUserId). The ONLY user who may read/act on this draft. */
+  ownerUserId: string;
+  /** Origin channel of the mention. */
+  channelId: string;
+
+  // ── what to deliver ──
+  action: TwinDraftAction;
+  /** Reply body in the user's own voice (reply / react_and_reply). */
+  message?: string;
+  /** Emoji for react / react_and_reply. */
+  emoji?: string;
+
+  // ── why (private "Why?" panel; never posted) ──
+  /** Rationale markdown; factual claims carry `[clf-…#n]` tokens. */
+  reasoning?: string;
+  /** Baked citation lookup (buildThreadCitationMeta.clawCitations) for the chips. */
+  clawCitations?: TwinDraftCitation[];
+  /** iconKey → data:URI map (buildThreadCitationMeta.clawCitationIcons). */
+  clawCitationIcons?: Record<string, string>;
+
+  // ── where it posts (resolved by claw-auth at approve time from these) ──
+  destinationKind: string; // origin_thread | origin_channel | dm_sender | dm | channel | thread
+  destinationChannelId?: string;
+  destinationConversationId?: string;
+  destinationUserId?: string;
+  destinationChannelName?: string;
+  /** Human name of the DM recipient (dm / dm_sender), resolved for display. */
+  destinationUserName?: string;
+  destinationReason?: string;
+
+  // ── execution context forwarded to claw-auth on approve/decline ──
+  sourceMessageId?: string;
+  mentionedUserId: string;
+  workspaceId: string;
+  senderId?: string;
+  senderName?: string;
+  channelName?: string;
+  incomingTask?: string;
+  agentSlug?: string;
+  spacesAppId?: string;
+  /** claw run/session that produced this draft — keys the feedback row. */
+  sessionId: string;
+
+  createdAt: number;
+}
+
+/** Validate an unknown value from the S2S create body into a TwinReplyDraft.
+ *  Rejects anything missing the required identity/routing fields. Returns the
+ *  normalized draft (with createdAt stamped) or an error string. */
+export function coerceTwinReplyDraft(
+  body: unknown,
+): { draft: TwinReplyDraft } | { error: string } {
+  if (!body || typeof body !== 'object') return { error: 'body must be an object' };
+  const b = body as Record<string, unknown>;
+  const str = (k: string): string | undefined => (typeof b[k] === 'string' && (b[k] as string).length > 0 ? (b[k] as string) : undefined);
+
+  const conversationId = str('conversationId');
+  const ownerUserId = str('ownerUserId') ?? str('mentionedUserId');
+  const channelId = str('channelId');
+  const mentionedUserId = str('mentionedUserId') ?? ownerUserId;
+  const workspaceId = str('workspaceId');
+  const sessionId = str('sessionId');
+  const action = b['action'];
+  if (!conversationId) return { error: 'conversationId is required' };
+  if (!ownerUserId) return { error: 'ownerUserId (or mentionedUserId) is required' };
+  if (!channelId) return { error: 'channelId is required' };
+  if (!workspaceId) return { error: 'workspaceId is required' };
+  if (!sessionId) return { error: 'sessionId is required' };
+  if (action !== 'react' && action !== 'reply' && action !== 'react_and_reply') {
+    return { error: 'action must be react | reply | react_and_reply' };
+  }
+
+  const citations = Array.isArray(b['clawCitations']) ? (b['clawCitations'] as TwinDraftCitation[]) : undefined;
+  const icons = b['clawCitationIcons'] && typeof b['clawCitationIcons'] === 'object'
+    ? (b['clawCitationIcons'] as Record<string, string>)
+    : undefined;
+
+  const draft: TwinReplyDraft = {
+    conversationId,
+    ownerUserId,
+    channelId,
+    action,
+    mentionedUserId: mentionedUserId!,
+    workspaceId,
+    sessionId,
+    destinationKind: str('destinationKind') ?? 'origin_thread',
+    createdAt: Date.now(),
+    ...(str('message') !== undefined ? { message: str('message') } : {}),
+    ...(str('emoji') !== undefined ? { emoji: str('emoji') } : {}),
+    ...(str('reasoning') !== undefined ? { reasoning: str('reasoning') } : {}),
+    ...(citations ? { clawCitations: citations } : {}),
+    ...(icons ? { clawCitationIcons: icons } : {}),
+    ...(str('destinationChannelId') !== undefined ? { destinationChannelId: str('destinationChannelId') } : {}),
+    ...(str('destinationConversationId') !== undefined ? { destinationConversationId: str('destinationConversationId') } : {}),
+    ...(str('destinationUserId') !== undefined ? { destinationUserId: str('destinationUserId') } : {}),
+    ...(str('destinationChannelName') !== undefined ? { destinationChannelName: str('destinationChannelName') } : {}),
+    ...(str('destinationUserName') !== undefined ? { destinationUserName: str('destinationUserName') } : {}),
+    ...(str('destinationReason') !== undefined ? { destinationReason: str('destinationReason') } : {}),
+    ...(str('sourceMessageId') !== undefined ? { sourceMessageId: str('sourceMessageId') } : {}),
+    ...(str('senderId') !== undefined ? { senderId: str('senderId') } : {}),
+    ...(str('senderName') !== undefined ? { senderName: str('senderName') } : {}),
+    ...(str('channelName') !== undefined ? { channelName: str('channelName') } : {}),
+    ...(str('incomingTask') !== undefined ? { incomingTask: str('incomingTask') } : {}),
+    ...(str('agentSlug') !== undefined ? { agentSlug: str('agentSlug') } : {}),
+    ...(str('spacesAppId') !== undefined ? { spacesAppId: str('spacesAppId') } : {}),
+  };
+  return { draft };
+}
+
+/**
+ * Decide which destination id (if any) still needs a human NAME resolved for the
+ * owner-facing "posts to …" label, and which field to write it to. Pure: the
+ * caller performs the actual DB lookup (channels/users live in Spaces).
+ *
+ * The Twin agent forwards only ids for `channel`/`thread`/`dm` (it looks the id
+ * up via its Spaces tools but never carries the name), so those need resolving.
+ * `origin_thread` needs nothing ("this thread"); `origin_channel` reuses the
+ * origin `channelName`; `dm_sender` reuses `senderName` — all already carried.
+ * Returns null when no lookup is needed (name already present or not applicable).
+ */
+export function destinationNameLookup(
+  d: Pick<TwinReplyDraft, 'destinationKind' | 'destinationChannelId' | 'destinationChannelName' | 'destinationUserId' | 'destinationUserName'>,
+):
+  | { field: 'destinationChannelName'; id: string }
+  | { field: 'destinationUserName'; id: string }
+  | null {
+  if ((d.destinationKind === 'channel' || d.destinationKind === 'thread') && !d.destinationChannelName && d.destinationChannelId) {
+    return { field: 'destinationChannelName', id: d.destinationChannelId };
+  }
+  if (d.destinationKind === 'dm' && !d.destinationUserName && d.destinationUserId) {
+    return { field: 'destinationUserName', id: d.destinationUserId };
+  }
+  return null;
+}

--- a/apps/backend/src/services/twinReplyDraftService.ts
+++ b/apps/backend/src/services/twinReplyDraftService.ts
@@ -1,0 +1,116 @@
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+import type { TwinReplyDraft } from './twinReplyDraft';
+
+/**
+ * Digital Twin in-thread reply draft — DB IO layer.
+ *
+ * A twin proposal is stored as an ordinary `draft_messages` row with
+ * `origin = 'twin'` (owner = the mentioned user, `userId`). Zero's per-user
+ * replication delivers it live to the owner's client (the `twinDrafts` query),
+ * so there is no bespoke fetch or socket — the row appearing IS the notification,
+ * and deleting it clears the dock/badge everywhere.
+ *
+ * Owner-only by construction: the read/act paths always scope to
+ * `userId = req.user.id AND origin = 'twin'`, and Zero's drafts ACL already
+ * restricts every draft_messages row to its own `userId`.
+ *
+ * The rich twin payload (action/emoji/reasoning/citations/destination/sessionId/…)
+ * rides in the row's `metadata` JSON; `content` mirrors the reply text. Unlike a
+ * user draft there is NO unique constraint, so a thread can hold several twin
+ * proposals (one per @mention). Rows live until the owner approves or declines
+ * (both delete the row); an ignored proposal simply stays.
+ *
+ * Pure types + validation/projection live in `./twinReplyDraft` and are
+ * re-exported here so existing importers are unaffected.
+ */
+export * from './twinReplyDraft';
+
+const db = (): ReturnType<typeof DatabaseClient.getInstance> => DatabaseClient.getInstance();
+
+/** Parse the stringified-JSON twin payload from a row's `metadata` (TEXT column).
+ *  Returns null for empty/absent/malformed metadata (treated as "no draft"). */
+function parseTwinMetadata(metadata: string | null | undefined): TwinReplyDraft | null {
+  if (!metadata) return null;
+  try {
+    return JSON.parse(metadata) as TwinReplyDraft;
+  } catch (error) {
+    logger.warn('[TwinReplyDraft] metadata parse failed, ignoring row', { error });
+    return null;
+  }
+}
+
+/**
+ * Persist a twin proposal as a draft_messages row. Called only by the S2S create
+ * route. A re-run of the twin for the SAME trigger (same owner + thread +
+ * sourceMessageId) replaces its prior proposal; distinct triggers accumulate as
+ * separate drafts in the thread.
+ */
+export async function createTwinReplyDraft(draft: TwinReplyDraft): Promise<void> {
+  const prisma = db();
+  // Best-effort dedup: drop a stale proposal for the same @mention before insert.
+  // metadata is stringified JSON (TEXT), so we can't filter by JSON path in SQL —
+  // fetch this thread's twin proposals and match sourceMessageId in JS.
+  if (draft.sourceMessageId) {
+    try {
+      const existing = await prisma.draftMessage.findMany({
+        where: {
+          userId: draft.ownerUserId,
+          conversationId: draft.conversationId,
+          origin: 'twin',
+        },
+        select: { id: true, metadata: true },
+      });
+      const staleIds = existing
+        .filter(row => parseTwinMetadata(row.metadata)?.sourceMessageId === draft.sourceMessageId)
+        .map(row => row.id);
+      if (staleIds.length > 0) {
+        await prisma.draftMessage.deleteMany({ where: { id: { in: staleIds } } });
+      }
+    } catch (error) {
+      logger.warn('[TwinReplyDraft] dedup delete failed (harmless duplicate possible)', { error });
+    }
+  }
+  await prisma.draftMessage.create({
+    data: {
+      workspaceId: draft.workspaceId,
+      channelId: draft.channelId,
+      conversationId: draft.conversationId,
+      userId: draft.ownerUserId,
+      content: draft.message ?? '',
+      hasAttachment: false,
+      origin: 'twin',
+      metadata: JSON.stringify(draft),
+      createdAt: new Date(draft.createdAt),
+      updatedAt: new Date(draft.createdAt),
+    },
+  });
+}
+
+/** Read one twin proposal by its row id, scoped to the owner. Returns the full
+ *  stored TwinReplyDraft (from `metadata`) — the delivery context approve/decline
+ *  forward to claw-auth — or null if it's gone / not the caller's / not a twin. */
+export async function getTwinReplyDraftById(
+  id: string,
+  ownerUserId: string,
+): Promise<TwinReplyDraft | null> {
+  try {
+    const row = await db().draftMessage.findFirst({
+      where: { id, userId: ownerUserId, origin: 'twin' },
+      select: { metadata: true },
+    });
+    return parseTwinMetadata(row?.metadata);
+  } catch (error) {
+    logger.warn('[TwinReplyDraft] read failed, treating as no draft', { error });
+    return null;
+  }
+}
+
+/** Remove a twin proposal once approved/declined (consumed). Owner-scoped. */
+export async function deleteTwinReplyDraftById(id: string, ownerUserId: string): Promise<void> {
+  try {
+    await db().draftMessage.deleteMany({ where: { id, userId: ownerUserId, origin: 'twin' } });
+  } catch (error) {
+    logger.warn('[TwinReplyDraft] delete failed', { error });
+  }
+}

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -1449,11 +1449,13 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
             updatedAt: timestamp,
           });
 
-          // Query for drafts in this channel for this user (follows backend logic)
+          // Query for the user's OWN drafts in this channel (origin='user' so a
+          // twin proposal is never mistaken for the composer draft).
           const channelDrafts = await tx.run(
             zql.draft_messages
               .where('channelId', channelId)
-              .where('userId', authData.sub),
+              .where('userId', authData.sub)
+              .where('origin', 'user'),
           );
 
           // Find the channel-level draft (conversationId === null)
@@ -1470,6 +1472,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
               userId: authData.sub,
               content: draftMessage,
               hasAttachment: draft?.hasAttachment || false,
+              origin: 'user',
               updatedAt: timestamp,
               createdAt: draft?.createdAt || timestamp,
             });
@@ -2383,7 +2386,8 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
             // Legacy path: scan the current draft and transfer everything.
             const channelDrafts = await tx.run(zql.draft_messages
               .where('channelId', channelId)
-              .where('userId', authData.sub));
+              .where('userId', authData.sub)
+            .where('origin', 'user'));
 
             const draft = channelDrafts.find(d => d.conversationId === null);
 
@@ -3024,7 +3028,8 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
               .one()),
             tx.run(zql.draft_messages
               .where('channelId', conversation.channelId)
-              .where('userId', authData.sub)),
+              .where('userId', authData.sub)
+              .where('origin', 'user')),
           ]);
           if (!channel) {
             throw new Error("Channel doesn't exists");
@@ -4968,6 +4973,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
               .where('channelId', channelId)
               .where('conversationId', conversationId)
               .where('userId', authData.sub)
+              .where('origin', 'user')
               .one(),
           );
 
@@ -4982,6 +4988,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
               userId: authData.sub,
               content: draftMessage,
               hasAttachment: draft?.hasAttachment || false,
+              origin: 'user',
               updatedAt: timestamp,
               createdAt: draft?.createdAt || timestamp,
             });
@@ -5042,6 +5049,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
               .where('channelId', channelId)
               .where('conversationId', conversationId)
               .where('userId', authData.sub)
+              .where('origin', 'user')
               .one(),
           );
 
@@ -5056,6 +5064,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
               userId: authData.sub,
               content: draftMessage,
               hasAttachment: draft?.hasAttachment || false,
+              origin: 'user',
               updatedAt: timestamp,
               createdAt: draft?.createdAt || timestamp,
             });
@@ -11444,7 +11453,8 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
             timestamp,
           },
         }) => {
-          // 1. Check if draft exists for this channel/conversation/user
+          // 1. Check if a USER draft exists for this channel/conversation/user
+          // (origin='user' so we never attach the composer's files onto a twin draft)
           let existingDraft = null;
           if (conversationId) {
             existingDraft = await tx.run(
@@ -11452,13 +11462,15 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
                 .where('channelId', channelId)
                 .where('userId', authData.sub)
                 .where('conversationId', conversationId)
+                .where('origin', 'user')
                 .one(),
             );
           } else {
             const channelDrafts = await tx.run(
               zql.draft_messages
                 .where('channelId', channelId)
-                .where('userId', authData.sub),
+                .where('userId', authData.sub)
+                .where('origin', 'user'),
             );
             existingDraft = channelDrafts.find(draft => draft.conversationId === null);
           }
@@ -11475,6 +11487,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
               userId: authData.sub,
               content: content || '',
               hasAttachment: true,
+              origin: 'user',
               createdAt: timestamp,
               updatedAt: timestamp,
             });
@@ -14834,7 +14847,8 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           const channelDrafts = await tx.run(
             zql.draft_messages
               .where("channelId", channelId)
-              .where("userId", ctx.userID),
+              .where("userId", ctx.userID)
+              .where("origin", "user"),
           );
           const existingDraft = channelDrafts.find(
             (d) =>
@@ -14996,7 +15010,10 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           }
 
           const channelDrafts = await tx.run(
-            zql.draft_messages.where('channelId', scheduled.channelId).where('userId', ctx.userID)
+            zql.draft_messages
+              .where('channelId', scheduled.channelId)
+              .where('userId', ctx.userID)
+              .where('origin', 'user')
           );
           const existingDraft = channelDrafts.find(
             (d) => d.conversationId === (scheduled.conversationId ?? null) && d.messageId === null
@@ -15026,6 +15043,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
             userId: ctx.userID,
             content: scheduled.content,
             hasAttachment,
+            origin: 'user',
             createdAt: timestamp,
             updatedAt: timestamp,
           });
@@ -15070,7 +15088,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
       /** Delete a draft message by ID (only the owner can delete their own draft) */
       delete: defineMutator(z.object({ id: z.string() }), async ({ tx, ctx, args: { id } }) => {
         const draft = await tx.run(
-          zql.draft_messages.where('id', id).where('userId', ctx.userID).one()
+          zql.draft_messages.where('id', id).where('userId', ctx.userID).where('origin', 'user').one()
         );
         if (!draft) {
           throw new Error('Draft not found');
@@ -15088,7 +15106,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
         }),
         async ({ tx, ctx, args: { id, content, timestamp } }) => {
           const draft = await tx.run(
-            zql.draft_messages.where('id', id).where('userId', ctx.userID).one()
+            zql.draft_messages.where('id', id).where('userId', ctx.userID).where('origin', 'user').one()
           );
           if (!draft) {
             throw new Error('Draft not found');
@@ -15109,7 +15127,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
         }),
         async ({ tx, ctx, args: { id, timestamp } }) => {
           const draft = await tx.run(
-            zql.draft_messages.where('id', id).where('userId', ctx.userID).one()
+            zql.draft_messages.where('id', id).where('userId', ctx.userID).where('origin', 'user').one()
           );
           if (!draft) {
             throw new Error('Draft not found');

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -2422,6 +2422,11 @@ export const queries = defineQueries({
   }),
 
   userDrafts: defineQuery(({ ctx }) => {
+    // All of the caller's OWN draft_messages rows, both origins: composer drafts
+    // (origin='user') and pending Digital Twin proposals (origin='twin', whose
+    // userId IS the mentioned owner). A single owner-scoped query keeps one Zero
+    // subscription; the stateMachine splits them into `draftMessages` (user) and
+    // `twinDrafts` (twin) so the composer/Drafts UI never sees twin rows.
     return zql.draft_messages.where('userId', ctx.userID).related('attachments');
   }),
 

--- a/apps/backend/src/zero/side-effects/tables/conversation-participants-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/conversation-participants-handler.ts
@@ -1,8 +1,15 @@
 import { notificationService } from '@/services/notificationService';
+import { getOrGenerateThreadSummary, isThreadSummaryEnabledForChannel, flagThreadRecommendation } from '@/services/threadSummaryService';
+import { db } from '@/database/client';
 import { BaseSideEffectHandler } from '../base-handler';
 import type { ConversationParticipantPreviousValue, SideEffectJobConfig } from '../types';
 import { logger } from '@/utils/logger';
 import { NotificationType } from '@prisma/client';
+
+// How long the onInsert side effect keeps retrying/awaiting the participant row
+// to settle before giving up (the thread-recommendation flag write races the
+// participant insert). Matches the original twin-recap handler.
+const ON_INSERT_TIMEOUT_MS = 45_000;
 
 /**
  * When a user's conversation_participants row is updated with a new lastReadAt,
@@ -10,6 +17,66 @@ import { NotificationType } from '@prisma/client';
  * notification tray for that thread can be cleared.
  */
 export class ConversationParticipantsSideEffectHandler extends BaseSideEffectHandler {
+  async onInsert(job: SideEffectJobConfig): Promise<void> {
+    logger.info(`[ConversationParticipantsHandler] onInsert entity=${job.entityId} actor=${this.ctx.userID}`);
+    // The timeout side of Promise.race is never implicitly cancelled when
+    // processInsert wins (the common case) — without clearing it explicitly,
+    // its setTimeout keeps firing (harmlessly, since the race already
+    // settled) up to ON_INSERT_TIMEOUT_MS after every single participant
+    // insert, accumulating dangling timers under load.
+    let timeoutHandle: NodeJS.Timeout;
+    try {
+      await Promise.race([
+        this.processInsert(job),
+        new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error(`onInsert timed out after ${ON_INSERT_TIMEOUT_MS}ms`)),
+            ON_INSERT_TIMEOUT_MS,
+          );
+        }),
+      ]).finally(() => clearTimeout(timeoutHandle));
+    } catch (error) {
+      logger.error(`[ConversationParticipantsHandler] Failed to process onInsert for entity ${job.entityId}:`, error);
+    }
+  }
+
+  private async processInsert(job: SideEffectJobConfig): Promise<void> {
+    const participant = await db.conversationParticipant.findUnique({
+      where: { id: job.entityId },
+      select: { conversationId: true, userId: true, channelId: true },
+    });
+
+    if (!participant) {
+      logger.warn(`[ConversationParticipantsHandler] No conversationParticipant row found for entity ${job.entityId}`);
+      return;
+    }
+
+    const { conversationId, userId, channelId } = participant;
+
+    if (this.ctx.userID === userId) {
+      // Self-joined (e.g. by replying) — no need to catch them up.
+      logger.info(`[ConversationParticipantsHandler] Skipping self-join: user ${userId} in conversation ${conversationId}`);
+      return;
+    }
+
+    if (!isThreadSummaryEnabledForChannel(channelId)) {
+      return;
+    }
+
+    // This is the one moment we know with certainty — not inferred later
+    // from lastReadAt/joinedAt timestamps (which broke down in practice,
+    // see threadSummaryService) — that `userId` was genuinely just
+    // added by someone else. Flag it once for the frontend to consume.
+    await flagThreadRecommendation(conversationId, userId);
+
+    // Pre-warm the in-memory thread-summary cache (see threadSummaryService)
+    // so it's ready immediately instead of the newly-added participant
+    // having to click-and-wait. The cache is shared across users to dedupe
+    // LLM calls; anyone can also trigger/refresh it on demand via the
+    // thread panel button.
+    await getOrGenerateThreadSummary(conversationId);
+  }
+
   async onUpdate(job: SideEffectJobConfig): Promise<void> {
     const prev = job.previousValue as ConversationParticipantPreviousValue | undefined;
     const args = job.args as { lastReadAt?: number } | undefined;

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -37,6 +37,7 @@ import { matchKeywordsForUsers } from '@/utils/keywordMatchUtils';
 import type { BotDefinition } from '@/bots/unified/types/unified-bot';
 import { messageMetadataService } from '@/services/messageMetadataService';
 import { prefetchFilterData, type PrefetchedFilterData } from '@/services/notificationFilterService';
+import { getOrGenerateThreadSummary, isThreadSummaryEnabledForChannel, hasPendingRecommendations } from '@/services/threadSummaryService';
 
 const messageAttachmentRepository = new MessageAttachmentRepository();
 const channelRepository = new ChannelRepository();
@@ -810,6 +811,28 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
 
     // Queue Vespa indexing for message attachments
     await this.queueVespaIndexingForAttachments(messageId);
+
+    // Keep an already-requested thread catch-up summary warm as new messages
+    // land, so whoever's still waiting on it gets it fully up-to-date the moment
+    // they open the thread. Fire-and-forget, gated on there still being a pending
+    // recommendation for this conversation (NOT merely a cache blob existing,
+    // which can outlive the pending audience) so it doesn't regenerate forever
+    // for nobody in particular.
+    if (message.msgType === 'USER') {
+      this.keepThreadSummaryWarm(conversationId, channelId).catch(error => {
+        logger.error('[MessagesSideEffect] Failed to keep thread summary warm:', {
+          conversationId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+  }
+
+  private async keepThreadSummaryWarm(conversationId: string, channelId: string): Promise<void> {
+    if (!isThreadSummaryEnabledForChannel(channelId)) return;
+    if (!(await hasPendingRecommendations(conversationId))) return;
+
+    await getOrGenerateThreadSummary(conversationId);
   }
 
   /**

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -79,6 +79,7 @@
     "@tanstack/react-store": "0.8.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.2",
+    "@terrastruct/d2": "^0.1.33",
     "@tiptap/core": "3.29.2",
     "@tiptap/extension-blockquote": "^3.8.0",
     "@tiptap/extension-bold": "^3.8.0",

--- a/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
@@ -71,7 +71,7 @@ export function AgentProgressIndicator({
   if (agents.length === 0) return null;
 
   return (
-    <div className='flex items-center gap-2 h-5 bg-background'>
+    <div className='mb-2 flex items-center gap-2 h-5 bg-background'>
       <div className='flex flex-wrap gap-3 text-[11px] text-muted-foreground flex-1 min-w-0'>
         {agents.map(a => (
           <span key={a.agentUserId ?? a.agentSlug ?? 'agent'} style={rowStyle}>

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -68,8 +68,19 @@ import type { CommandItem } from '../../ui/Selectors/Selectors.types';
 import { setThreadLastRead } from '../../../machines/stateMachine';
 import { BlockNoteEditor } from '@blocknote/core';
 import { sanitizeHtmlString } from '../../../utils/sanitizer';
+import type { TwinEditSession } from '../TwinReplyDraft/twinReplyDraftApi';
 
 const CHAT_MESSAGE_SENT_EVENT = 'xyne:chat-message-sent';
+
+/** Convert Twin-draft text to safe editor HTML while preserving blank lines. */
+function draftTextToHtml(text: string): string {
+  const escape = (value: string): string =>
+    value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return text
+    .split('\n')
+    .map(line => `<p>${line ? escape(line) : '<br>'}</p>`)
+    .join('');
+}
 
 function dispatchChatMessageSentEvent(channelId: string): void {
   window.dispatchEvent(new CustomEvent(CHAT_MESSAGE_SENT_EVENT, { detail: { channelId } }));
@@ -100,6 +111,14 @@ interface ChatInputProps {
   hasTicket?: boolean;
   isForwardedContent?: boolean;
   threadParticipantIds?: ReadonlySet<string>;
+  /** A dock (e.g. the Twin drafts tray) rendered above the editor inside the
+   *  composer, so the composer's activity indicator floats above the whole unit.
+   *  Forwarded straight to InputBox's dockSlot. */
+  dockSlot?: React.ReactNode;
+  /** When set, the composer is editing a Digital Twin draft: it loads the draft
+   *  text, highlights itself, suppresses draft persistence, and routes Send to
+   *  the twin approve endpoint instead of a plain thread post. */
+  twinEdit?: TwinEditSession | undefined;
 }
 
 const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
@@ -119,6 +138,8 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
       hasTicket = false,
       isForwardedContent = false,
       threadParticipantIds,
+      dockSlot,
+      twinEdit,
     },
     ref,
   ) => {
@@ -405,6 +426,36 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
       return undefined;
     }, [initialContent, messageId, draft]);
 
+    // Drive the composer's content across Twin-edit sessions. On entering (or
+    // switching to) a draft we SNAPSHOT the user's own composer HTML, then load
+    // the draft text; on leaving we restore that snapshot verbatim. Keyed on the
+    // draft id so re-renders while editing never clobber the user's in-progress
+    // edits. Snapshotting (rather than re-reading the debounced channel draft)
+    // preserves the last keystrokes; clearTextOnly (not clearContent) leaves the
+    // user's staged attachments intact — clearContent would delete them.
+    const twinEditDraftIdRef = useRef<string | null>(null);
+    const preTwinEditHtmlRef = useRef<string>('');
+    useEffect(() => {
+      const activeId = twinEdit?.draftId ?? null;
+      // twinEdit.message is consumed only on entry; the guard makes a mid-session
+      // message re-sync a deliberate no-op so it can't overwrite the user's edits.
+      if (activeId === twinEditDraftIdRef.current) return;
+      const box = inputBoxRef.current;
+      if (activeId) {
+        preTwinEditHtmlRef.current = box?.getHtml?.() ?? '';
+        box?.clearTextOnly();
+        if (twinEdit?.message) box?.insertContent(draftTextToHtml(twinEdit.message));
+        box?.focus();
+      } else {
+        // Leaving edit mode: restore the user's own content exactly as it was.
+        box?.clearTextOnly();
+        const restore = preTwinEditHtmlRef.current;
+        if (restore) box?.insertContent(restore);
+        preTwinEditHtmlRef.current = '';
+      }
+      twinEditDraftIdRef.current = activeId;
+    }, [twinEdit?.draftId, twinEdit?.message]);
+
     const { displayName: channelName, avatarUserId } = useChannelDisplayName(
       channel,
       context.userID,
@@ -500,8 +551,10 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
       (html: string, text: string): void => {
         try {
           const processedHtml = processMessageForSending(html, allUsersForMentionResolution);
-          // Do not save drafts while editing a message
-          if (messageId) return;
+          // Do not save drafts while editing a message, or while editing a Twin
+          // draft in the composer (its text isn't the user's own channel draft —
+          // persisting it would clobber the real draft we restore on exit).
+          if (messageId || twinEdit) return;
           // Save or remove draft
           if (text.trim()) {
             saveDraft(lookupId, processedHtml, text);
@@ -512,11 +565,30 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
           // Unable to save draft
         }
       },
-      [lookupId, messageId],
+      [lookupId, messageId, twinEdit],
     );
 
     const handleSendMessage = useCallback(
       (_plainText: string, html: string, files: File[]): void => {
+        // Editing a Twin draft in the composer: Send approves the draft — the
+        // approve endpoint posts to the draft's server-resolved destination (which
+        // may not be this thread) and records the twin's learning feedback, so it
+        // must NOT fall through to a plain thread post. Empty content is a no-op.
+        if (twinEdit) {
+          if (isOffline) {
+            toast.warning("You're offline", {
+              description: 'You can send this reply once you reconnect.',
+            });
+            return;
+          }
+          const edited = _plainText.trim();
+          if (!edited) return;
+          // onApprove owns the outcome: on success it clears the session (which
+          // restores the composer via the effect above); on failure it toasts and
+          // keeps the session so the edit survives — so we must NOT clear here.
+          twinEdit.onApprove(edited);
+          return;
+        }
         if (isOffline) {
           toast.warning("You're offline", {
             description: messageId
@@ -812,6 +884,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         user?.id,
         context.workspaceId,
         allowThreadBroadcastMentions,
+        twinEdit,
       ],
     );
 
@@ -892,6 +965,10 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
           </div>
         ) : (
           <>
+            <AgentProgressIndicator
+              sessionId={agentProgressConversationId ?? currentSessionId}
+              conversationId={agentProgressConversationId}
+            />
             {showOfflineBanner && (
               <div className='px-3 py-1.5 bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded text-xs text-amber-700 dark:text-amber-300 flex items-center justify-between mx-3 mb-1'>
                 <div className='flex items-center gap-1.5'>
@@ -969,10 +1046,11 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
               }
               commandItems={channelCommands}
               onCommandSelect={handleCommandSelect}
-              {...(editorValue !== undefined && { value: editorValue })}
+              {...(!twinEdit && editorValue !== undefined && { value: editorValue })}
               {...(messageId && onCancel && { onCancel: handleCancelEdit })}
               {...(conversationId && { conversationId })}
               className={className}
+              dockSlot={dockSlot}
               features={{
                 richText: true,
                 commands: true,

--- a/apps/dashboard/src/components/Chat/DraftsPanel/TwinDraftsPanel.tsx
+++ b/apps/dashboard/src/components/Chat/DraftsPanel/TwinDraftsPanel.tsx
@@ -1,0 +1,110 @@
+import { type ReactElement, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Sparkles } from 'lucide-react';
+import { Virtuoso } from 'react-virtuoso';
+import { useSelector } from '@xstate/react';
+import { stateMachineActor } from '../../../machines/stateMachine';
+import type { Conversation } from '@xyne/shared';
+import { formatDistanceToNow } from 'date-fns';
+import { MessageCard, RecipientAvatar, useRecipientName } from '../MessageCard';
+import { rowToTwinReplyDraftView } from '../TwinReplyDraft/twinReplyDraftApi';
+
+/** The subset of a twin draft row this panel needs (structural, so it doesn't
+ *  depend on the opaque Zero-derived `TwinDraftDB` alias). */
+interface TwinDraftItem {
+  id: string;
+  channelId: string;
+  conversationId?: string | null;
+  createdAt: number;
+  metadata?: unknown;
+}
+
+/**
+ * A row for one pending Digital Twin proposal in the Drafts & Sent page. Unlike a
+ * user draft it isn't sent/edited/deleted from here — clicking opens the thread,
+ * where the in-composer dock lets the owner review + approve/decline it.
+ */
+const TwinDraftRow = ({ draft }: { draft: TwinDraftItem }): ReactElement => {
+  const navigate = useNavigate();
+  const view = rowToTwinReplyDraftView(draft);
+
+  // avatarHelpers only access conversation?.channelId, so a partial object is safe
+  const channelRef = { channelId: draft.channelId } as Conversation;
+  const recipientName = useRecipientName(null, channelRef);
+  const displayName = draft.conversationId ? `${recipientName} · thread` : recipientName;
+
+  const preview =
+    view?.action === 'react'
+      ? `Reacts ${view.emoji ?? ''}`.trim()
+      : view?.message?.trim() || '(no message)';
+  const timestamp = formatDistanceToNow(new Date(draft.createdAt), { addSuffix: true });
+
+  const handleClick = (): void => {
+    void navigate(
+      draft.conversationId
+        ? `/chat/dir/${draft.channelId}/${draft.conversationId}#origin=${draft.conversationId}`
+        : `/chat/dir/${draft.channelId}`,
+    );
+  };
+
+  return (
+    <MessageCard
+      recipientAvatar={<RecipientAvatar conversation={channelRef} />}
+      recipientName={displayName}
+      contentPreview={
+        <span className='inline-flex items-center gap-1.5'>
+          <Sparkles size={12} className='shrink-0 text-muted-foreground' />
+          {preview}
+        </span>
+      }
+      timestamp={timestamp}
+      className='rounded-xl'
+      onClick={handleClick}
+      // Twin drafts are reviewed inside the thread (click opens it) — no inline row actions.
+      actions={null}
+    />
+  );
+};
+
+// ─── Panel ────────────────────────────────────────────────────────────────────
+
+const TwinDraftsPanel = (): ReactElement => {
+  const twinDrafts = useSelector(stateMachineActor, state => state.context.twinDrafts);
+
+  const items = useMemo<TwinDraftItem[]>(
+    () => [...twinDrafts].sort((a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id)),
+    [twinDrafts],
+  );
+
+  return (
+    <div className='flex-1 h-full flex flex-col overflow-hidden bg-background'>
+      <div className='flex-1 overflow-y-auto p-6'>
+        {items.length === 0 ? (
+          <div className='flex flex-col items-center justify-center h-full p-8 text-center'>
+            <Sparkles className='text-muted-foreground mb-4' size={48} />
+            <p className='text-muted-foreground text-lg font-medium mb-2'>No twin drafts</p>
+            <p className='text-muted-foreground text-sm max-w-md'>
+              Replies the Digital Twin drafts for you, awaiting your approval, will appear here
+            </p>
+          </div>
+        ) : (
+          <Virtuoso<TwinDraftItem>
+            data={items}
+            className='h-full'
+            style={{ height: '100%' }}
+            computeItemKey={(_, item) => item.id}
+            itemContent={(_, draft) => (
+              <div className='mb-4 first:mt-1.5'>
+                <TwinDraftRow draft={draft} />
+              </div>
+            )}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+TwinDraftsPanel.displayName = 'TwinDraftsPanel';
+
+export default TwinDraftsPanel;

--- a/apps/dashboard/src/components/Chat/ReplyLayout/ReplyLayoutV2.tsx
+++ b/apps/dashboard/src/components/Chat/ReplyLayout/ReplyLayoutV2.tsx
@@ -5,6 +5,7 @@ import AvatarGroup from '../../ui/Avatar/AvatarGroup';
 import { formatRelativeTime } from '../../../utils/dateUtils';
 import { ViewNewerRepliesButton } from '../../ui/MessageBubble/ThreadMessageIndicators';
 import { parseRepliesMd } from '@xyne/shared';
+import { useTwinDraftBadge } from '../TwinReplyDraft/TwinDraftBadgeContext';
 
 const ReplyLayoutV2: React.FC<{
   replies: ThreadData;
@@ -30,6 +31,13 @@ const ReplyLayoutV2: React.FC<{
   messageId,
 }) => {
   const { channelId } = useParams<{ channelId: string }>();
+  // A pending Twin draft for THIS thread (from the bulk badge context). Shown as
+  // the "Twin draft" pill even when the thread has no replies yet — the freshest,
+  // highest-value case, which the reply-count guards below would otherwise hide.
+  const twinBadge = useTwinDraftBadge(replies?.conversation?.conversationId);
+  // Surface a pending Twin draft using the SAME "1 draft" / "and 1 draft"
+  // treatment as a user's own draft — no separate pill in the channel list.
+  const showTwinDraft = !isThreadOpen && !!twinBadge;
 
   // For showInChannel messages, show "View newer replies" only if there are newer replies in the parent thread
   // parentReplyCount is the current reply count in the original thread
@@ -50,7 +58,15 @@ const ReplyLayoutV2: React.FC<{
   if (showInChannel && !isCallMessage) return null;
 
   const hasDraft = draft || hasDraftAttachments;
-  if ((!replies || replies.replyCount === 0) && (!hasDraft || isThreadOpen)) return null;
+  if ((!replies || replies.replyCount === 0) && (!hasDraft || isThreadOpen) && !showTwinDraft)
+    return null;
+
+  // A thread can carry BOTH the user's own composer draft AND a pending Twin
+  // draft — count each so the indicator reads "1 draft" or "2 drafts". Same
+  // neutral draft UI for both (no separate Twin styling in the channel list).
+  const zeroReplyDraftCount = (hasDraft ? 1 : 0) + (showTwinDraft ? 1 : 0);
+  const inlineDraftCount = (draft && !isThreadOpen ? 1 : 0) + (showTwinDraft ? 1 : 0);
+  const draftWord = (n: number): string => `${n} draft${n > 1 ? 's' : ''}`;
 
   const repliesData = parseRepliesMd(replies.conversation?.replies_md);
   const repliers = repliesData.repliers;
@@ -76,14 +92,16 @@ const ReplyLayoutV2: React.FC<{
         {/* Replier Avatars */}
         {repliers.length > 0 && <AvatarGroup userIds={repliers} size='sm' count={3} />}
         {!replies || replies.replyCount === 0 ? (
-          <div className='flex items-center gap-1 font-medium text-primary'>
-            <PencilIcon size={10} />
-            {'1 draft'}
-          </div>
+          zeroReplyDraftCount > 0 ? (
+            <div className='flex items-center gap-1 font-medium text-primary'>
+              <PencilIcon size={10} />
+              {draftWord(zeroReplyDraftCount)}
+            </div>
+          ) : null
         ) : (
           <span className='font-medium text-foreground'>
-            {replies.replyCount} {replies.replyCount === 1 ? 'reply' : 'replies'}{' '}
-            {draft && !isThreadOpen && ' and 1 draft'}
+            {replies.replyCount} {replies.replyCount === 1 ? 'reply' : 'replies'}
+            {inlineDraftCount > 0 && ` and ${draftWord(inlineDraftCount)}`}
           </span>
         )}
 

--- a/apps/dashboard/src/components/Chat/ThreadCatchupSummary/ThreadCatchupSummary.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadCatchupSummary/ThreadCatchupSummary.tsx
@@ -1,0 +1,145 @@
+import { ReactElement, useMemo } from 'react';
+import { Loader2, ScrollText, X } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Button } from '../../ui/Button';
+import Tooltip from '../../ui/Tooltip';
+import { cn } from '../../../utils/classNames';
+import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
+import { createMarkdownComponents } from '../../../utils/markdownComponents';
+
+// Slides straight down from the header and fades in — no `scale`. Scaling a
+// full-width, edge-to-edge panel from slightly-shrunk to 100% reads as a
+// "pop"/zoom (its left and right edges visibly snap outward), not a
+// dropdown. A pure vertical slide is what actually looks like something
+// unfurling downward from the header bar above it.
+//
+// A tween with an explicit duration (not a spring) — a fast/stiff spring
+// settles too quickly to read as "dropping," and a spring's effective
+// duration is hard to reason about directly. -28px of travel over 0.35s
+// with a decelerating ease gives it enough distance and time to actually
+// look like it's coming down and settling, not just fading in place.
+//
+// Deliberately does NOT animate `height`. Framer Motion resolves 'auto' to a
+// measured px value under the hood (render once to measure, snap back,
+// then interpolate) — on a panel whose natural size can itself change right
+// after mount (loading -> content), that measurement step keeps producing a
+// visible second jump no matter how the height transition is tuned. Since
+// opacity/y are plain scalars with no layout measurement involved, animating
+// only those is glitch-proof regardless of content or timing.
+const dropdownVariants = {
+  initial: { opacity: 0, y: -28 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.35, ease: [0.16, 1, 0.3, 1] },
+  },
+  exit: {
+    opacity: 0,
+    y: -28,
+    transition: { duration: 0.2, ease: [0.4, 0, 1, 1] },
+  },
+} as const;
+
+interface ThreadCatchupSummaryButtonProps {
+  isRecommended: boolean;
+  loading: boolean;
+  onClick: () => void;
+}
+
+/** Header button — present once the feature is enabled; glows if a summary was already ready when the viewer opened the thread. */
+export function ThreadCatchupSummaryButton({
+  isRecommended,
+  loading,
+  onClick,
+}: ThreadCatchupSummaryButtonProps): ReactElement {
+  return (
+    <Tooltip content={loading ? 'Generating summary…' : 'Thread summary'}>
+      <Button
+        size='sm'
+        variant='outline'
+        onClick={onClick}
+        disabled={loading}
+        aria-label='Show thread summary'
+        data-track-category='THREAD_PANEL'
+        data-track-name='TOGGLE_CATCHUP_SUMMARY'
+        className={cn(
+          'relative flex items-center justify-between gap-2 border rounded-lg !p-2 transition-all duration-100 text-foreground bg-background border-border',
+          isRecommended && 'ring-2 ring-pink-400',
+        )}
+      >
+        {loading ? (
+          <Loader2 size={18} className='text-pink-500 animate-spin' />
+        ) : (
+          <ScrollText size={18} className={isRecommended ? 'text-pink-500' : undefined} />
+        )}
+        {isRecommended && !loading && (
+          <span className='absolute -top-1 -right-1 h-2 w-2 rounded-full bg-pink-500 animate-pulse' />
+        )}
+      </Button>
+    </Tooltip>
+  );
+}
+
+interface ThreadCatchupSummaryPanelProps {
+  content: string | undefined;
+  loading: boolean;
+  onClose: () => void;
+}
+
+/**
+ * The summary display — auto-shown (no Yes/No ask) for someone who was just
+ * added to the thread, or opened manually via the header button. Deliberately
+ * minimal: an icon + light-weight "Thread Summary" label directly above
+ * muted/italic body text, plus a dismiss X — no card chrome, no separate
+ * header row, no avatar. Same component/style for both the automatic and
+ * manual cases, so there's one consistent look regardless of how it opened.
+ */
+export function ThreadCatchupSummaryPanel({
+  content,
+  loading,
+  onClose,
+}: ThreadCatchupSummaryPanelProps): ReactElement {
+  const markdownComponents = useMemo(() => createMarkdownComponents('thread-catchup-summary'), []);
+
+  return (
+    <motion.div variants={dropdownVariants} initial='initial' animate='animate' exit='exit'>
+      <div className='flex items-start justify-between gap-2 px-4 py-3'>
+        <ScrollText size={16} className='text-muted-foreground shrink-0 mt-0.5' />
+        {/* "Thread Summary" label sits above the content (light weight,
+            upright) — the summary itself reads as muted/italic body copy
+            below it. Capped + internally scrollable so a long summary
+            can't push the actual thread messages out of view. */}
+        <div className='flex-1 min-w-0 max-h-64 overflow-y-auto'>
+          <div className='text-sm font-medium text-muted-foreground'>Thread Summary</div>
+          {/* opacity-* (not text-muted-foreground/N) — the markdown
+              renderer's own elements (e.g. <strong> for bold names) set
+              their own explicit color, which wins over inherited text
+              color from this wrapper. `opacity` is a compositing property
+              applied to the whole rendered subtree regardless of each
+              child's own color, so it actually lightens everything. */}
+          <div className='text-sm italic text-muted-foreground opacity-70'>
+            {content ? (
+              <MarkdownMessageRenderer content={content} markdownComponents={markdownComponents} />
+            ) : loading ? (
+              <span className='flex items-center gap-2'>
+                <Loader2 size={14} className='animate-spin' />
+                Generating summary…
+              </span>
+            ) : (
+              <span>No thread summary available for this thread yet.</span>
+            )}
+          </div>
+        </div>
+        <Button
+          size='sm'
+          variant='ghost'
+          className='h-6 w-6 p-0 shrink-0 text-muted-foreground hover:text-muted-foreground'
+          onClick={onClose}
+          aria-label='Dismiss summary'
+        >
+          <X size={14} />
+        </Button>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/dashboard/src/components/Chat/ThreadCatchupSummary/ThreadCatchupSummary.utils.ts
+++ b/apps/dashboard/src/components/Chat/ThreadCatchupSummary/ThreadCatchupSummary.utils.ts
@@ -1,0 +1,21 @@
+import type { QueryResultType } from '@rocicorp/zero';
+import { queries } from '../../../zero/queries';
+
+export type ThreadCatchupMessages = QueryResultType<typeof queries.conversationMessagesV2>;
+export type ThreadCatchupMessage = ThreadCatchupMessages[number];
+
+/**
+ * The most recent message's id — used to tell whether a cached catch-up
+ * summary (server-side ThreadSummaryCache, or the localStorage copy) is
+ * stale, by comparing against its `asOfMessageId`.
+ *
+ * The summary is no longer stored as a Message row (see
+ * backend/src/services/threadSummaryService.ts) — every entry in
+ * `messages` is real thread content, so this is just the last one, no
+ * filtering needed.
+ */
+export function findLatestMessageId(
+  messages: readonly ThreadCatchupMessage[] | undefined,
+): string | undefined {
+  return messages && messages.length > 0 ? messages[messages.length - 1]?.messageId : undefined;
+}

--- a/apps/dashboard/src/components/Chat/ThreadCatchupSummary/threadSummaryApi.ts
+++ b/apps/dashboard/src/components/Chat/ThreadCatchupSummary/threadSummaryApi.ts
@@ -1,0 +1,67 @@
+import { apiInstance } from '../../../services/clients/apiClient';
+
+export interface ThreadSummaryResponse {
+  success: boolean;
+  content: string;
+  cached: boolean;
+  /** The messageId this content was actually generated from — lets the client tell a genuinely fresh summary apart from a stale fallback. */
+  asOfMessageId: string;
+}
+
+/**
+ * Fetch (or trigger generation of) the shared thread summary. The backend
+ * only makes a fresh LLM call if new messages have landed since the last
+ * summary — otherwise it returns the cached one immediately. Resolves to
+ * `null` if the backend can't produce a summary for this request.
+ */
+export async function fetchThreadSummary(
+  conversationId: string,
+): Promise<ThreadSummaryResponse | null> {
+  const res = await apiInstance.get<ThreadSummaryResponse>(
+    `/conversations/${conversationId}/summary`,
+    {
+      validateStatus: status => status === 200 || status === 204,
+    },
+  );
+  if (res.status === 204) {
+    return null;
+  }
+  return res.data;
+}
+
+interface ThreadRecommendationResponse {
+  success: boolean;
+  recommended: boolean;
+  /** Whether the thread summary feature is enabled for this channel at all (THREAD_SUMMARY_ENABLED_CHANNELS rollout gate) — false means the header button shouldn't render. */
+  enabled: boolean;
+  /** Only present when recommended is true — generated in the same request. */
+  summary?: ThreadSummaryResponse;
+}
+
+export interface ThreadRecommendationResult {
+  recommended: boolean;
+  enabled: boolean;
+  summary: ThreadSummaryResponse | undefined;
+}
+
+/**
+ * One-time "you were just added" flag, set by the real-time participant-
+ * insert side effect (not inferred from lastReadAt/joinedAt timestamps —
+ * that broke down for existing participants with a stale-null read state).
+ * The backend consumes/clears the flag on read, so this only ever returns
+ * `recommended: true` once per genuine add — and bundles the summary content
+ * in that same response, so a genuine recommendation never needs a second,
+ * separate content fetch.
+ */
+export async function fetchThreadRecommendation(
+  conversationId: string,
+): Promise<ThreadRecommendationResult> {
+  const res = await apiInstance.get<ThreadRecommendationResponse>(
+    `/conversations/${conversationId}/recommendation`,
+  );
+  return {
+    recommended: res.data.recommended,
+    enabled: res.data.enabled,
+    summary: res.data.summary,
+  };
+}

--- a/apps/dashboard/src/components/Chat/ThreadCatchupSummary/useThreadCatchupSummary.ts
+++ b/apps/dashboard/src/components/Chat/ThreadCatchupSummary/useThreadCatchupSummary.ts
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { findLatestMessageId, type ThreadCatchupMessages } from './ThreadCatchupSummary.utils';
+import {
+  fetchThreadRecommendation,
+  fetchThreadSummary,
+  type ThreadSummaryResponse,
+} from './threadSummaryApi';
+
+interface ThreadCatchupSummaryState {
+  /** Whether the channel has the feature enabled (THREAD_SUMMARY_ENABLED_CHANNELS). */
+  isAvailable: boolean;
+  isRecommended: boolean;
+  expanded: boolean;
+  loading: boolean;
+  /** The summary text to display — undefined if what we're holding is stale, even mid-refresh. */
+  content: string | undefined;
+  toggleExpanded: () => void;
+  /** Bumps every time the panel opens (manual click or auto-recommend) — pass straight through to ThreadList's scrollToTrailingContentSignal so opening it scrolls it into view. */
+  scrollSignal: number;
+}
+
+/**
+ * Minimum number of UNREAD messages (from other people, since the user last read
+ * this thread) before the recap is offered as a quiet, manually-openable tab. A
+ * recap only earns its place once there's genuinely something to CATCH UP on —
+ * keyed on unread, NOT total thread length, so a long thread you've already read
+ * (or one with only a line or two of new activity) doesn't get a pointless recap.
+ * (The "you were just added" auto-recommendation bypasses this, since the backend
+ * only recommends when it already has a worthwhile summary.) Tune this to taste.
+ */
+const MIN_UNREAD_FOR_RECAP = 10;
+
+interface CachedSummary {
+  content: string;
+  asOfMessageId: string;
+}
+
+function localStorageKey(
+  userId: string | undefined,
+  conversationId: string | undefined,
+): string | undefined {
+  return userId && conversationId ? `xyne:thread-summary:${userId}:${conversationId}` : undefined;
+}
+
+/** Per-user local cache of the last-fetched summary — purely a client-side redisplay optimization, not the source of truth (the backend's in-memory cache is). Swallows storage errors (quota, private browsing) since this is a nice-to-have, not critical. */
+function readCachedSummary(key: string | undefined): CachedSummary | undefined {
+  if (!key) return undefined;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<CachedSummary>;
+    if (typeof parsed.content === 'string' && typeof parsed.asOfMessageId === 'string') {
+      return { content: parsed.content, asOfMessageId: parsed.asOfMessageId };
+    }
+  } catch {
+    // malformed/corrupted entry — ignore, treat as no cache
+  }
+  return undefined;
+}
+
+function writeCachedSummary(key: string | undefined, value: CachedSummary): void {
+  if (!key) return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // quota exceeded / private browsing — non-critical, just skip persisting
+  }
+}
+
+/**
+ * Drives the thread-summary UI: the always-on header button and the summary
+ * panel itself — which
+ * auto-opens (no Yes/No ask) for someone who was genuinely just added/
+ * mentioned into the thread by someone else, and can also be toggled
+ * manually via the header button any time.
+ *
+ * "Was I just added" is answered by a one-time backend flag
+ * (fetchThreadRecommendation), set in real time by the actual
+ * ConversationParticipant insert side effect — NOT inferred from
+ * `lastReadAt`/`joinedAt` timestamps. That approach was tried first and
+ * broke down: `lastReadAt` only updates via a client-side unmount effect
+ * that doesn't reliably fire (hard refreshes, tab closes, etc. skip it), so
+ * existing participants often look identical to genuinely new ones. The
+ * real-time flag has no such ambiguity — it's set exactly once, at the
+ * exact moment someone else's action adds this specific user.
+ *
+ * Storage model for the summary content itself: NOT a Message row — cached
+ * in-process on the backend (dedupes LLM calls across users/visits) and
+ * then persisted per-user in this browser's localStorage for instant
+ * redisplay, keyed by `userId:conversationId`.
+ *
+ * ThreadPannel stays mounted across thread switches (nav updates props, not
+ * a remount), so all state here must be explicitly reset when conversationId
+ * changes — otherwise one thread's summary/expanded state leaks into the
+ * next thread the user opens.
+ */
+export function useThreadCatchupSummary(
+  conversationId: string | undefined,
+  userId: string | undefined,
+  messages: ThreadCatchupMessages | undefined,
+  /** The user's lastReadAt for this thread (epoch ms; 0 if never read). Captured
+   *  once at open to derive the unread count that gates the recap. */
+  lastReadAt: number,
+  isMessagesLoaded: boolean,
+  isThreadParticipant: boolean,
+): ThreadCatchupSummaryState {
+  const latestMessageId = findLatestMessageId(messages);
+  const storageKey = localStorageKey(userId, conversationId);
+
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [content, setContent] = useState<string | undefined>(undefined);
+  // The messageId whatever's in `content` was actually generated from. Kept
+  // separate from `content` itself so freshness can be re-checked on every
+  // render against the current message list.
+  const [contentAsOfMessageId, setContentAsOfMessageId] = useState<string | undefined>(undefined);
+  // Whether the backend's one-time "you were just added" flag was set for
+  // this user on this conversation.
+  const [isFirstVisitWithSummary, setIsFirstVisitWithSummary] = useState(false);
+  // Starts false (button hidden) until fetchThreadRecommendation's response
+  // confirms this channel actually has the feature turned on — see the
+  // THREAD_SUMMARY_ENABLED_CHANNELS rollout gate on the backend. Avoids a
+  // show-then-hide flash for the (currently default) case of a channel
+  // that's not enabled: the button just never appears rather than
+  // appearing then vanishing once the check resolves.
+  const [isFeatureEnabled, setIsFeatureEnabled] = useState(false);
+  const [scrollSignal, setScrollSignal] = useState(0);
+  const capturedRef = useRef(false);
+  // Guards the once-per-thread background pre-generation (reset on conv change).
+  const preGeneratedRef = useRef(false);
+  // The user's lastReadAt captured at thread OPEN (not "now"), so the unread count
+  // that gates the recap reflects "what I missed since last time" and doesn't
+  // collapse to 0 as the user reads down the thread. null until first capture.
+  const [unreadBaseline, setUnreadBaseline] = useState<number | null>(null);
+
+  // Every transition into "open" — whether the user clicked the header
+  // button or it auto-opened for a recommendation — bumps scrollSignal, so
+  // ThreadList scrolls it into view. Closing doesn't (nothing to scroll to).
+  useEffect(() => {
+    if (expanded) setScrollSignal(s => s + 1);
+  }, [expanded]);
+
+  // Reset everything the instant conversationId changes, synchronously
+  // during render (React's documented pattern for this) so no stale value
+  // from the previous thread ever flashes on screen.
+  const prevConversationIdRef = useRef(conversationId);
+  if (prevConversationIdRef.current !== conversationId) {
+    prevConversationIdRef.current = conversationId;
+    setExpanded(false);
+    setLoading(false);
+    setContent(undefined);
+    setContentAsOfMessageId(undefined);
+    setIsFirstVisitWithSummary(false);
+    setIsFeatureEnabled(false);
+    setUnreadBaseline(null);
+    capturedRef.current = false;
+    preGeneratedRef.current = false;
+  }
+
+  const applyResult = useCallback(
+    (result: ThreadSummaryResponse | null | undefined) => {
+      setContent(result?.content);
+      setContentAsOfMessageId(result?.asOfMessageId);
+      if (result?.content && result.asOfMessageId) {
+        writeCachedSummary(storageKey, {
+          content: result.content,
+          asOfMessageId: result.asOfMessageId,
+        });
+      }
+    },
+    [storageKey],
+  );
+
+  // On first load: show any locally-cached summary instantly, and check the
+  // backend's one-time "you were just added" flag (consumed on read — see
+  // threadSummaryService on the backend). A single request — the
+  // backend bundles the summary content into this same response when
+  // recommended, so there's no separate follow-up content fetch (and
+  // nothing here to race against on the backend side).
+  useEffect(() => {
+    if (capturedRef.current || !isMessagesLoaded || !conversationId) return;
+    capturedRef.current = true;
+
+    // Snapshot the read position at open — before the user reads / the server
+    // marks-read — so the unread count that gates the recap stays stable.
+    setUnreadBaseline(lastReadAt);
+
+    const cached = readCachedSummary(storageKey);
+    if (cached) {
+      setContent(cached.content);
+      setContentAsOfMessageId(cached.asOfMessageId);
+    }
+
+    // Deliberately no `loading` state around this check — it fires on every
+    // thread visit, and the vast majority aren't recommendations, so a
+    // spinner here would flicker the header button on ordinary opens for no
+    // reason. When it IS a recommendation, the content arrives in this same
+    // response (see fetchThreadRecommendation), so `expanded` and `content`
+    // land together — nothing is ever shown loading in between.
+    fetchThreadRecommendation(conversationId)
+      .then(({ recommended, enabled, summary }) => {
+        setIsFeatureEnabled(enabled);
+        setIsFirstVisitWithSummary(recommended);
+        if (!recommended) return;
+        setExpanded(true);
+        applyResult(summary);
+      })
+      .catch(() => {
+        setIsFeatureEnabled(false);
+        setIsFirstVisitWithSummary(false);
+      });
+  }, [isMessagesLoaded, storageKey, conversationId, applyResult, lastReadAt]);
+
+  const refresh = useCallback(async () => {
+    if (!conversationId) return;
+    setLoading(true);
+    try {
+      const result = await fetchThreadSummary(conversationId);
+      applyResult(result);
+    } finally {
+      setLoading(false);
+    }
+  }, [conversationId, applyResult]);
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded(value => !value);
+  }, []);
+
+  // Only used to decide whether an *open* needs a fetch, not whether to keep
+  // displaying what we already have — see the effect below.
+  const isContentFresh =
+    contentAsOfMessageId !== undefined && contentAsOfMessageId === latestMessageId;
+
+  // Fetch exactly once per open (closed -> open transition), not on every
+  // subsequent message while it stays open. Once someone's read a summary,
+  // the backend tears its cache down (see deleteCachedSummary) precisely so
+  // nobody keeps paying to regenerate it for an audience that's moved on —
+  // the viewer sending another message of their own while the panel happens
+  // to still be open shouldn't force a fresh regeneration. Closing and
+  // reopening (or the header button) does, since that's a new open.
+  const hasFetchedForOpenRef = useRef(false);
+  useEffect(() => {
+    if (!expanded) {
+      hasFetchedForOpenRef.current = false;
+      return;
+    }
+    if (hasFetchedForOpenRef.current) return;
+    hasFetchedForOpenRef.current = true;
+    if (!isContentFresh && !loading) {
+      void refresh();
+    }
+  }, [expanded, isContentFresh, loading, refresh]);
+
+  // How many messages from OTHERS landed since I last read this thread (my own
+  // messages aren't something I need to "catch up" on). Keyed on unread — NOT the
+  // total thread length — and off the baseline captured at open, so it's the
+  // count of what I actually missed. Zero until the baseline is captured.
+  const unreadFromOthers = useMemo(() => {
+    if (unreadBaseline === null || messages === undefined) return 0;
+    let count = 0;
+    for (const m of messages) {
+      if (m.senderId === userId) continue;
+      if (new Date(m.createdAt).getTime() > unreadBaseline) count += 1;
+    }
+    return count;
+  }, [messages, userId, unreadBaseline]);
+  const hasEnoughUnread = unreadFromOthers >= MIN_UNREAD_FOR_RECAP;
+
+  // Did I send the most recent message? Then I've engaged with the thread —
+  // there's nothing to "catch up" on, so the recap retires. This is what makes
+  // it disappear once I reply (the shared server-side summary stays for other
+  // users who haven't caught up; this only gates MY view).
+  const userSentLatest =
+    !!userId &&
+    messages !== undefined &&
+    messages.length > 0 &&
+    messages[messages.length - 1]?.senderId === userId;
+
+  // Recap is offered when the channel has the feature on, I HAVEN'T just replied,
+  // AND either the backend recommended it (I was just added — so I'm now in the
+  // thread) OR I'm a participant with ENOUGH UNREAD to be worth catching up on.
+  // This keeps the recap off short / already-caught-up / not-mine threads while
+  // preserving the auto-recommend flow for people freshly pulled in.
+  const isAvailable =
+    isFeatureEnabled &&
+    !userSentLatest &&
+    (isFirstVisitWithSummary || (isThreadParticipant && hasEnoughUnread));
+
+  // PRE-GENERATE the moment the recap becomes available for this thread — i.e.
+  // on thread open, NOT only when the Recap tab is opened — so switching to the
+  // tab shows a ready summary instead of a 10s+ spinner. Fires once per thread
+  // (preGeneratedRef reset on conversation change); the server-side cache dedupes
+  // across users/visits so this stays cheap.
+  useEffect(() => {
+    if (preGeneratedRef.current || !isAvailable || !isMessagesLoaded) return;
+    preGeneratedRef.current = true;
+    if (!isContentFresh && !loading) void refresh();
+  }, [isAvailable, isMessagesLoaded, isContentFresh, loading, refresh]);
+
+  return {
+    isAvailable,
+    isRecommended: isAvailable && isFirstVisitWithSummary,
+    expanded,
+    loading,
+    content,
+    toggleExpanded,
+    scrollSignal,
+  };
+}

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -136,6 +136,14 @@ const ThreadList = ({
   const [isNearTop, setIsNearTop] = useState(true);
   const [hasOverflow, setHasOverflow] = useState(false);
   const [isScrolling, setIsScrolling] = useState(false);
+  // Mirror of isNearBottom readable synchronously inside the ResizeObserver (React
+  // state would be stale there). Lets the observer re-pin to the bottom when the
+  // viewport shrinks (e.g. the Twin tray expands) — but ONLY if the user was
+  // already at the bottom, so a scrolled-up reader is never yanked down.
+  const isNearBottomRef = useRef(isNearBottom);
+  useEffect(() => {
+    isNearBottomRef.current = isNearBottom;
+  }, [isNearBottom]);
 
   const threadTicketId = useMemo(() => {
     if (!isTicketThread || !conversation) return '';
@@ -338,7 +346,15 @@ const ThreadList = ({
     };
 
     const observer = new ResizeObserver(() => {
+      // If the reader was pinned to the bottom before this resize (e.g. the Twin
+      // tray expanded and shrank the viewport), keep them pinned so the latest
+      // messages stay visible instead of sliding behind the taller composer.
+      const wasNearBottom = isNearBottomRef.current;
       recomputeOverflow();
+      if (wasNearBottom) {
+        container.scrollTop = container.scrollHeight - container.clientHeight;
+        setIsNearBottom(true);
+      }
     });
 
     observer.observe(container);

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -73,6 +73,14 @@ import { useZero } from '../../hooks/useZero';
 import { logger, Event } from '../../utils/logger';
 import { XyneAIStar } from '../icons/xyne-ai';
 import { dataLoadDuration, safeRecordMetric } from '../../services/otel';
+import { ThreadAssistDock, type TwinSourceInfo } from './TwinReplyDraft/ThreadAssistDock';
+import { TwinReasoningDrawer } from './TwinReplyDraft/TwinReasoningDrawer';
+import { useThreadAssist } from './TwinReplyDraft/useThreadAssist';
+import type {
+  PostedTarget,
+  TwinReplyDraftView,
+  TwinEditSession,
+} from './TwinReplyDraft/twinReplyDraftApi';
 import { getDraft } from '../../hooks/useDraft';
 import { v4 as uuidv4 } from 'uuid';
 import { xyneAIActor, type ThreadInfo } from '../../machines/xyneAIMachine';
@@ -211,6 +219,17 @@ export const ThreadMessages = ({
     return source;
   }, [propConversationParticipant, conversation?.participants]);
 
+  // `threadConversation` filters `participants` to the current user, so a
+  // truthy row means the viewer is a thread participant, including when they
+  // were tagged/added before posting. This gates the catch-up recap.
+  const isThreadParticipant = useMemo(() => {
+    const source =
+      propConversationParticipant !== undefined
+        ? propConversationParticipant
+        : conversation?.participants;
+    return !!source;
+  }, [propConversationParticipant, conversation?.participants]);
+
   const ticket = useMemo(() => parseTicketMd(conversation?.ticket_md), [conversation?.ticket_md]);
   const derivedTicketId = ticketId || conversation?.ticketId || '';
 
@@ -252,6 +271,16 @@ export const ThreadMessages = ({
     }
     return set;
   }, [messages]);
+  const assist = useThreadAssist(
+    derivedConversationId,
+    currentUser?.id,
+    messages,
+    // The recap is gated on how many UNREAD messages (from others) I have here,
+    // captured at open — not total thread length. Pass my last-read position.
+    conversationParticipant.lastReadAt ?? 0,
+    isMessagesLoaded,
+    isThreadParticipant,
+  );
   const [isScheduleCallModalOpen, setIsScheduleCallModalOpen] = useState(false);
   const channel = useChannel(derivedChannelId);
   const { displayName: channelDisplayName } = useChannelDisplayName(channel, currentUser?.id ?? '');
@@ -325,6 +354,165 @@ export const ThreadMessages = ({
   // Navigation for thread summary
   const navigate = useNavigate();
   const location = useLocation();
+
+  // After the Twin's draft is sent, take the user to where it posted (unless
+  // that's the thread they're already in). React-only deliveries return null.
+  const handleTwinPosted = useCallback(
+    (target: PostedTarget | null) => {
+      if (!target?.channelId) return;
+      const sameThread =
+        target.channelId === derivedChannelId &&
+        (target.conversationId ?? '') === (derivedConversationId ?? '');
+      if (sameThread) return;
+      const path = target.conversationId
+        ? `${baseRoute}/${target.channelId}/${target.conversationId}#origin=${target.conversationId}`
+        : `${baseRoute}/${target.channelId}`;
+      void navigate(path);
+    },
+    [navigate, baseRoute, derivedChannelId, derivedConversationId],
+  );
+
+  // The "Why?" reasoning + run-debugger side drawer (overlays the thread's right
+  // edge; dismissible). Opened from a proposal's Why? button — holds THAT
+  // proposal (a thread can have several), or undefined when closed.
+  const [reasoningDraft, setReasoningDraft] = useState<TwinReplyDraftView | undefined>(undefined);
+
+  // A Twin draft being edited IN the composer (the dock hands editing off so the
+  // real message box takes over, with a highlight + back button). We track the id
+  // and look the draft up live, so the session ends by itself when the row syncs
+  // away (e.g. after approve/decline).
+  const [twinEditDraftId, setTwinEditDraftId] = useState<string | null>(null);
+  const editingTwinDraft = useMemo(
+    () => assist.reply.drafts.find(d => d.id === twinEditDraftId) ?? null,
+    [assist.reply.drafts, twinEditDraftId],
+  );
+  useEffect(() => {
+    if (twinEditDraftId && !editingTwinDraft) setTwinEditDraftId(null);
+  }, [twinEditDraftId, editingTwinDraft]);
+
+  // Leave edit mode. The tray's `collapsed` state was never touched (edit only
+  // closes the body via its own `editing` flag), so clearing the draft id lets the
+  // body spring back open — landing the user on the expanded tray.
+  const exitTwinEdit = (): void => {
+    setTwinEditDraftId(null);
+  };
+
+  const twinEditSession: TwinEditSession | undefined = editingTwinDraft
+    ? {
+        draftId: editingTwinDraft.id,
+        message: editingTwinDraft.message ?? '',
+        ...(editingTwinDraft.senderName ? { senderName: editingTwinDraft.senderName } : {}),
+        // Send from the composer = approve with the edited text. The approve
+        // endpoint posts to the draft's server-resolved destination and records
+        // the twin's learning feedback — a plain thread post would do neither.
+        // On success we end the session (restoring the expanded tray); on failure
+        // we keep it open, toast, and let the user retry with their edit.
+        onApprove: (editedText: string) => {
+          void (async () => {
+            try {
+              const posted = await assist.reply.approve(
+                editingTwinDraft.id,
+                editedText || undefined,
+              );
+              exitTwinEdit();
+              handleTwinPosted(posted);
+            } catch {
+              toast.error('Failed to send reply', {
+                description: 'Your edit was kept — please try again.',
+              });
+            }
+          })();
+        },
+      }
+    : undefined;
+
+  // Index this thread's messages by id so the twin dock can resolve the message
+  // each draft is replying to — for the tab label (first ~10 chars), the
+  // one-line preview, and the jump-to-message affordance.
+  const messagesById = useMemo(() => {
+    const map = new Map<string, { content?: unknown }>();
+    for (const m of messages) map.set(m.messageId, m);
+    return map;
+  }, [messages]);
+
+  const resolveTwinSource = useCallback(
+    (draft: TwinReplyDraftView): TwinSourceInfo => {
+      const srcId = draft.sourceMessageId;
+      const srcMsg = srcId ? messagesById.get(srcId) : undefined;
+      const rawContent = srcMsg && typeof srcMsg.content === 'string' ? srcMsg.content : undefined;
+      let text: string | undefined;
+      if (rawContent && typeof DOMParser !== 'undefined') {
+        try {
+          text =
+            (
+              new DOMParser().parseFromString(rawContent, 'text/html').body.textContent || ''
+            ).trim() || undefined;
+        } catch {
+          text = undefined;
+        }
+      }
+      const onJump =
+        srcId && derivedConversationId
+          ? () => {
+              const el = document.getElementById(
+                `thread-message-${derivedConversationId}-${srcId}`,
+              );
+              if (!el) return;
+              el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+              // Brief tint so the jump target is obvious (mirrors link-nav highlight).
+              el.animate(
+                [{ backgroundColor: 'rgba(99,102,241,0.14)' }, { backgroundColor: 'transparent' }],
+                { duration: 1400, easing: 'ease-out' },
+              );
+            }
+          : undefined;
+      return {
+        ...(draft.senderName ? { name: draft.senderName } : {}),
+        ...(text ? { text } : {}),
+        ...(onJump ? { onJump } : {}),
+      };
+    },
+    [messagesById, derivedConversationId],
+  );
+
+  // The Twin assist dock. `twinDock` fuses onto the composer below it; the
+  // `attached={false}` variant is used on the threads-page preview where there
+  // is no composer, so it closes into a self-contained card.
+  const renderTwinDock = (attached: boolean) =>
+    assist.available ? (
+      <ThreadAssistDock
+        key='twin-dock'
+        hasRecap={assist.hasRecap}
+        hasReply={assist.hasReply}
+        tab={assist.tab}
+        onTabChange={assist.setTab}
+        collapsed={assist.collapsed}
+        onToggleCollapse={assist.toggleCollapse}
+        recap={assist.recap}
+        reply={assist.reply}
+        onPosted={handleTwinPosted}
+        onOpenReasoning={setReasoningDraft}
+        resolveSource={resolveTwinSource}
+        attached={attached}
+        // Only the composer-fused dock delegates editing to the composer; the
+        // standalone preview card (no composer) keeps its inline textarea. When a
+        // draft is being edited, onEditBack puts the dock into edit mode (edit
+        // header + collapsed body + glow) — it no longer swaps to a separate bar.
+        {...(attached && { onBeginEdit: (d: TwinReplyDraftView) => setTwinEditDraftId(d.id) })}
+        {...(attached && editingTwinDraft && { onEditBack: exitTwinEdit })}
+      />
+    ) : null;
+  const twinDock = renderTwinDock(true);
+  const twinDockCard = renderTwinDock(false);
+
+  const reasoningDrawer = (
+    <TwinReasoningDrawer
+      open={!!reasoningDraft}
+      draft={reasoningDraft}
+      conversationId={derivedConversationId ?? ''}
+      onClose={() => setReasoningDraft(undefined)}
+    />
+  );
 
   // Check if the route is /threads (with optional workspace prefix)
   const isThreadsRoute = location.pathname.endsWith('/chat/dir/threads');
@@ -773,6 +961,7 @@ export const ThreadMessages = ({
       >
         {/* Drag and Drop Overlay */}
         <DragAndDropOverlay isVisible={isDragging} />
+        {reasoningDrawer}
         <Tabs.Root
           value={underTicketActiveTab}
           onValueChange={value => setUnderTicketActiveTab(value as UnderTicketTabType)}
@@ -884,8 +1073,14 @@ export const ThreadMessages = ({
                   placeholder='Reply to this thread...'
                   hasTicket={hasTicketInMessages}
                   threadParticipantIds={threadParticipantIds}
+                  dockSlot={twinDock}
+                  twinEdit={twinEditSession}
                 />
               </div>
+            ) : previewCardMode && assist.hasReply ? (
+              // Threads-page preview: surface the Twin draft even when the viewer
+              // isn't a channel member (no composer here — just review/act on it).
+              <div className='px-4 pb-4 bg-background'>{twinDockCard}</div>
             ) : (
               <JoinChannel
                 channelId={derivedChannelId}
@@ -936,6 +1131,7 @@ export const ThreadMessages = ({
         <DragAndDropOverlay isVisible={isDragging} />
         {/* pt-3 only (not py-3): a second padded header always follows this one, and its
             own pt-3 supplies the 12px below — py-3 here would double it to 24px. */}
+        {reasoningDrawer}
         {showHeader && (
           <div className='flex gap-2 items-center justify-between w-full pl-2 pr-3 pt-3'>
             <div className='flex gap-2 items-center min-w-0'>
@@ -1196,8 +1392,14 @@ export const ThreadMessages = ({
                         placeholder='Reply to this thread...'
                         hasTicket={hasTicketInMessages}
                         threadParticipantIds={threadParticipantIds}
+                        dockSlot={twinDock}
+                        twinEdit={twinEditSession}
                       />
                     </div>
+                  ) : previewCardMode && assist.hasReply ? (
+                    // Threads-page preview: surface the Twin draft even when the
+                    // viewer isn't a channel member (no composer here).
+                    <div className='px-4 pb-4 bg-background'>{twinDockCard}</div>
                   ) : (
                     <JoinChannel
                       channelId={derivedChannelId}
@@ -1451,8 +1653,14 @@ export const ThreadMessages = ({
                       placeholder='Reply to this thread...'
                       hasTicket={hasTicketInMessages}
                       threadParticipantIds={threadParticipantIds}
+                      dockSlot={twinDock}
+                      twinEdit={twinEditSession}
                     />
                   </div>
+                ) : previewCardMode && assist.hasReply ? (
+                  // Threads-page preview: surface the Twin draft even when the
+                  // viewer isn't a channel member (no composer here).
+                  <div className='px-4 pb-4 bg-background'>{twinDockCard}</div>
                 ) : (
                   <JoinChannel
                     channelId={derivedChannelId}

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/ThreadAssistDock.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/ThreadAssistDock.tsx
@@ -1,0 +1,883 @@
+import { ReactElement, ReactNode, useMemo, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Loader2,
+  CornerDownLeft,
+  Hash,
+  AtSign,
+  ChevronUp,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ArrowUp,
+  ArrowLeft,
+  Pencil,
+  MessageSquareX,
+} from 'lucide-react';
+import { Button } from '../../ui/Button';
+import { XyneAIStar } from '../../icons/xyne-ai';
+import { cn } from '../../../utils/classNames';
+import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
+import { createMarkdownComponents } from '../../../utils/markdownComponents';
+import type { TwinReplyDraftView, PostedTarget } from './twinReplyDraftApi';
+import type { AssistTab } from './useThreadAssist';
+
+// Mount / vanish of the whole dock (used by the composer's AnimatePresence).
+const expand = {
+  initial: { opacity: 0, y: 6 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] } },
+  exit: { opacity: 0, y: 6, transition: { duration: 0.14, ease: [0.4, 0, 1, 1] } },
+} as const;
+
+// The body opens/closes as a real height spring (height: 0 ↔ auto) — animating
+// the height property, not a `layout` transform, so content never distorts. A
+// small `bounce` gives the subtle overshoot on expand/collapse.
+const bodySpring = { type: 'spring', bounce: 0.2, duration: 0.4 } as const;
+
+// A single draft card sliding out while the next slides in — the smooth
+// transition the pager and post-send auto-advance rely on. A fixed body height
+// keeps the card size stable so swaps never jump.
+const swap = {
+  initial: { opacity: 0, x: 12 },
+  animate: { opacity: 1, x: 0, transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] } },
+  exit: { opacity: 0, x: -12, transition: { duration: 0.13, ease: [0.4, 0, 1, 1] } },
+} as const;
+
+/**
+ * Resolved triggering-message info for a draft: who sent the message the twin is
+ * replying to, its text (drives the one-line preview) and a jump-to-message
+ * handler. Supplied by ThreadPannel, which holds the thread's messages + the
+ * scroll target. Any field may be absent (e.g. the source message isn't in the
+ * loaded window) — the UI degrades gracefully.
+ */
+export interface TwinSourceInfo {
+  name?: string;
+  text?: string;
+  onJump?: () => void;
+}
+
+interface ThreadAssistDockProps {
+  hasRecap: boolean;
+  hasReply: boolean;
+  tab: AssistTab;
+  onTabChange: (t: AssistTab) => void;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  recap: { content: string | undefined; loading: boolean };
+  reply: {
+    /** This thread's pending Twin proposals, newest-first (may be several). */
+    drafts: TwinReplyDraftView[];
+    /** Draft ids with an approve/decline in flight (per-card spinners). */
+    pending: ReadonlySet<string>;
+    approve: (draftId: string, edited?: string) => Promise<PostedTarget | null>;
+    decline: (draftId: string) => Promise<void>;
+  };
+  /** Called after a successful send with where the reply landed (for redirect). */
+  onPosted: (target: PostedTarget | null) => void;
+  /** Open the reasoning/debug side drawer for a specific proposal (the "Why?" button). */
+  onOpenReasoning: (draft: TwinReplyDraftView) => void;
+  /** Resolve the triggering message for a draft (sender, text, jump-to-message). */
+  resolveSource?: (draft: TwinReplyDraftView) => TwinSourceInfo;
+  /** True when a composer sits below (in-thread): tucks the dock's lower edge
+   *  behind the still-rounded composer, so expanding it reads as a layered panel.
+   *  False = standalone preview card. */
+  attached?: boolean;
+  /** Hand editing off to the message composer (highlight + back button). When
+   *  provided (there IS a composer), the Edit action calls this instead of the
+   *  in-card textarea; when absent (preview card, no composer) editing stays
+   *  inline. */
+  onBeginEdit?: (draft: TwinReplyDraftView) => void;
+  /** When set, the dock is in composer-edit mode: it shows the "Editing draft"
+   *  header (clickable → back), collapses its body (the draft is down in the
+   *  composer), and glows. Presence of this callback IS the edit flag. */
+  onEditBack?: () => void;
+}
+
+/**
+ * The Digital Twin's in-thread assist surface: a rounded panel tucked behind the
+ * message composer. Expanding its header reveals the panel while the composer
+ * keeps its own rounded foreground silhouette.
+ *
+ *  - Collapsed it is a slim "N AI replies ready" bar carrying the senders it is
+ *    replying to (or a neutral recap bar when there's only a recap).
+ *  - Expanded it shows ONE draft at a time — a sleek, fully-clickable header
+ *    (red star + "Reply to <sender>", ‹ n/N › pager), the destination ("Reply in
+ *    this thread" + "Only you can see this"), a one-line preview of the message
+ *    being replied to (jumps to it), a fixed-height draft body, and Send / Edit /
+ *    Reject (right-aligned) · Why?. Collapse/expand springs with a subtle bounce.
+ */
+export function ThreadAssistDock({
+  hasRecap,
+  hasReply,
+  tab,
+  onTabChange,
+  collapsed,
+  onToggleCollapse,
+  recap,
+  reply,
+  onPosted,
+  onOpenReasoning,
+  resolveSource,
+  attached = true,
+  onBeginEdit,
+  onEditBack,
+}: ThreadAssistDockProps): ReactElement {
+  const drafts = reply.drafts;
+  const replyCount = drafts.length;
+  // Which draft is showing (internal — the top-level recap/reply tab is owned by
+  // useThreadAssist). Clamped in render so a shrinking list (a draft was
+  // sent/rejected) never points past the end and instead advances to the next.
+  const [sel, setSel] = useState(0);
+  // The dock is keyed stably across threads (it doesn't remount on navigation),
+  // so reset the selected index when the thread changes — otherwise a fresh
+  // thread could open on draft #2. Guarded setState-in-render (React re-renders).
+  const convId = drafts[0]?.conversationId;
+  const convRef = useRef(convId);
+  if (convRef.current !== convId) {
+    convRef.current = convId;
+    if (sel !== 0) setSel(0);
+  }
+  const active = replyCount > 0 ? Math.min(sel, replyCount - 1) : 0;
+  const selectedDraft = tab === 'reply' && replyCount > 0 ? drafts[active] : undefined;
+  const selectedSource = selectedDraft ? resolveSource?.(selectedDraft) : undefined;
+
+  // Distinct senders of the messages we're replying to — the names the collapsed
+  // bar lists ("Devesh, Anurag, Shekhar").
+  const senderNames = useMemo(() => {
+    const seen = new Set<string>();
+    const names: string[] = [];
+    for (const d of drafts) {
+      const name = (resolveSource?.(d)?.name ?? d.senderName ?? '').trim();
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        names.push(name);
+      }
+    }
+    return names;
+  }, [drafts, resolveSource]);
+
+  const goTo = (index: number): void => {
+    setSel(Math.max(0, Math.min(index, replyCount - 1)));
+  };
+
+  const headerName = selectedSource?.name ?? selectedDraft?.senderName;
+  // Composer-edit mode: the draft is down in the composer, so the tray shows the
+  // "Editing draft" header and closes its body (via the same accordion, which
+  // masks the header swap with a downward motion).
+  const editing = !!onEditBack;
+  const bodyOpen = !collapsed && !editing;
+
+  return (
+    <motion.div
+      variants={expand}
+      initial='initial'
+      animate='animate'
+      exit='exit'
+      className={attached ? '-mb-3' : undefined}
+    >
+      {/* Always (collapsed AND expanded) a negative margin tucks the tray's bottom
+          12px BEHIND the composer (which keeps its rounded top and paints over the
+          tuck) — so it reads as tucked INTO the composer, emerging from behind it
+          on expand. Preview (no composer): a standalone rounded card. The header is
+          always shown; the body reveals/hides as a height spring. In edit mode the
+          card gets a soft twin glow that continues into the composer below. */}
+      <div
+        className={cn(
+          'overflow-hidden border border-input bg-card',
+          attached ? 'rounded-t-2xl border-b-0' : 'rounded-2xl',
+          // editing && 'bg-gradient-to-b from-blue-400/[0.14] to-red-blue/[0.05]',
+        )}
+      >
+        {editing ? (
+          <EditHeader senderName={headerName} onBack={onEditBack} />
+        ) : collapsed ? (
+          <CollapsedBar
+            hasReply={hasReply}
+            replyCount={replyCount}
+            senderNames={senderNames}
+            recapLabel={hasRecap ? 'Thread recap' : 'Suggested reply'}
+            onExpand={onToggleCollapse}
+          />
+        ) : (
+          // Sleek header — the WHOLE row collapses the dock (interactive controls
+          // opt back in via pointer-events). Star + "Reply to <sender>".
+          <ExpandedHeader
+            tab={tab}
+            hasRecap={hasRecap}
+            hasReply={hasReply}
+            replyCount={replyCount}
+            active={active}
+            senderName={headerName}
+            onGoTo={goTo}
+            onTabChange={onTabChange}
+            onCollapse={onToggleCollapse}
+          />
+        )}
+
+        <AnimatePresence initial={false}>
+          {bodyOpen && (
+            <motion.div
+              key='body'
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ height: bodySpring, opacity: { duration: 0.15 } }}
+              className='overflow-hidden'
+            >
+              <div className='px-3.5 pb-3 pt-2'>
+                {tab === 'recap' ? (
+                  <RecapPane content={recap.content} loading={recap.loading} />
+                ) : selectedDraft ? (
+                  <AnimatePresence mode='wait' initial={false}>
+                    <motion.div
+                      key={selectedDraft.id}
+                      variants={swap}
+                      initial='initial'
+                      animate='animate'
+                      exit='exit'
+                    >
+                      <ReplyCard
+                        draft={selectedDraft}
+                        source={selectedSource}
+                        loading={reply.pending.has(selectedDraft.id)}
+                        approve={edited => reply.approve(selectedDraft.id, edited)}
+                        decline={() => reply.decline(selectedDraft.id)}
+                        onPosted={onPosted}
+                        onOpenReasoning={() => onOpenReasoning(selectedDraft)}
+                        {...(onBeginEdit && { onBeginEdit: () => onBeginEdit(selectedDraft) })}
+                      />
+                    </motion.div>
+                  </AnimatePresence>
+                ) : (
+                  <div className='text-sm text-muted-foreground'>No reply draft.</div>
+                )}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+}
+
+/** The header shown while a draft is being edited in the composer: a back arrow +
+ *  the Xyne star + "Editing draft · reply to <sender>". The WHOLE row goes back
+ *  (a full-bleed overlay button behind the content), matching the collapse/expand
+ *  headers — click anywhere to return to the drafts tray. */
+function EditHeader({
+  senderName,
+  onBack,
+}: {
+  senderName?: string | undefined;
+  onBack: () => void;
+}): ReactElement {
+  return (
+    <div className='relative flex h-[42px] select-none items-center gap-1.5 px-2 pb-3'>
+      <button
+        type='button'
+        onClick={onBack}
+        aria-label='Back to drafts'
+        data-track-category='twin-dock'
+        data-track-name='edit-back'
+        className='absolute inset-0 cursor-pointer transition-colors hover:bg-muted/20'
+      />
+      <span className='pointer-events-none relative flex h-7 w-7 shrink-0 items-center justify-center text-muted-foreground'>
+        <ArrowLeft size={16} />
+      </span>
+      <span className='pointer-events-none relative flex min-w-0 items-center gap-1.5 text-[13px] font-medium text-foreground'>
+        <span className='flex shrink-0'>
+          <XyneAIStar size={14} />
+        </span>
+        <span className='truncate'>
+          Editing draft
+          {senderName ? (
+            <span className='font-normal text-muted-foreground/70'> · reply to {senderName}</span>
+          ) : null}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+/** The slim bar the dock closes to. For replies it echoes the design's "N AI
+ *  replies ready · <senders>" with a soft accent tint; for a bare recap it falls
+ *  back to a neutral label. The whole bar expands the dock. */
+function CollapsedBar({
+  hasReply,
+  replyCount,
+  senderNames,
+  recapLabel,
+  onExpand,
+}: {
+  hasReply: boolean;
+  replyCount: number;
+  senderNames: string[];
+  recapLabel: string;
+  onExpand: () => void;
+}): ReactElement {
+  if (hasReply) {
+    return (
+      <button
+        onClick={onExpand}
+        aria-label='Expand AI replies'
+        data-track-category='twin-dock'
+        data-track-name='expand'
+        // Neutral surface, matching the context pill (bg-muted). The gradient
+        // Xyne star supplies the only accent. pb-3 keeps content clear of the
+        // bottom 12px that tucks behind the composer.
+        className='flex h-[42px] w-full select-none items-center gap-2 bg-muted/60 px-3 pb-3 text-left transition-colors hover:bg-muted'
+      >
+        <span className='flex shrink-0'>
+          <XyneAIStar size={14} />
+        </span>
+        <span className='shrink-0 text-[13px] font-semibold text-foreground'>
+          {replyCount === 1 ? '1 AI reply ready' : `${replyCount} AI replies ready`}
+        </span>
+        {senderNames.length > 0 && (
+          <>
+            <AvatarCluster names={senderNames} />
+            <span className='min-w-0 truncate text-[13px] text-muted-foreground'>
+              {senderNames.join(', ')}
+            </span>
+          </>
+        )}
+        <ChevronUp size={15} className='ml-auto shrink-0 text-muted-foreground' />
+      </button>
+    );
+  }
+  return (
+    <button
+      onClick={onExpand}
+      aria-label='Expand'
+      data-track-category='twin-dock'
+      data-track-name='expand'
+      className='flex h-[42px] w-full select-none items-center gap-2.5 bg-muted/60 px-3 pb-3 text-left transition-colors hover:bg-muted'
+    >
+      <span className='text-xs font-semibold text-foreground'>{recapLabel}</span>
+      <ChevronUp size={15} className='ml-auto text-muted-foreground' />
+    </button>
+  );
+}
+
+/** The sleek, fully-clickable expanded header: red star + "Reply to <sender>"
+ *  (or the recap label), an optional Recap/Reply toggle, the ‹ n/N › pager, and
+ *  a collapse chevron.
+ *
+ *  The whole row collapses the dock via a full-bleed overlay <button> BEHIND the
+ *  content (keyboard-accessible, no nested-interactive-element ARIA violation).
+ *  Non-interactive content is `pointer-events-none` so clicks fall through to the
+ *  overlay; the toggle/pager opt back in with `pointer-events-auto`. */
+function ExpandedHeader({
+  tab,
+  hasRecap,
+  hasReply,
+  replyCount,
+  active,
+  senderName,
+  onGoTo,
+  onTabChange,
+  onCollapse,
+}: {
+  tab: AssistTab;
+  hasRecap: boolean;
+  hasReply: boolean;
+  replyCount: number;
+  active: number;
+  senderName?: string | undefined;
+  onGoTo: (index: number) => void;
+  onTabChange: (t: AssistTab) => void;
+  onCollapse: () => void;
+}): ReactElement {
+  const showToggle = hasRecap && hasReply;
+  return (
+    <div className='relative flex h-9 select-none items-center gap-2 border-b border-border/60 px-3'>
+      <button
+        type='button'
+        onClick={onCollapse}
+        aria-label='Collapse'
+        data-track-category='twin-dock'
+        data-track-name='collapse'
+        className='absolute inset-0 cursor-pointer transition-colors hover:bg-muted/30'
+      />
+      {/* When a recap AND replies both exist, show them as two tabs (Replies /
+          Recap). Otherwise just the single title. */}
+      {showToggle ? (
+        <div className='pointer-events-auto relative flex items-center gap-1'>
+          <HeaderTab
+            active={tab === 'reply'}
+            onClick={() => onTabChange('reply')}
+            icon={<XyneAIStar size={13} />}
+            label='Replies'
+          />
+          <HeaderTab active={tab === 'recap'} onClick={() => onTabChange('recap')} label='Recap' />
+        </div>
+      ) : tab === 'recap' ? (
+        <span className='pointer-events-none relative text-[13px] font-semibold text-foreground'>
+          Thread recap
+        </span>
+      ) : (
+        <span className='pointer-events-none relative flex min-w-0 items-center gap-1.5 text-[13px] font-semibold text-foreground'>
+          <span className='flex shrink-0'>
+            <XyneAIStar size={14} />
+          </span>
+          <span className='truncate'>
+            {senderName ? `Reply to ${senderName}` : 'Suggested reply'}
+          </span>
+        </span>
+      )}
+
+      <div className='pointer-events-none relative ml-auto flex items-center gap-1.5'>
+        {tab === 'reply' && replyCount > 1 && (
+          <Pager active={active} total={replyCount} onGoTo={onGoTo} />
+        )}
+        <ChevronDown size={16} className='text-muted-foreground' />
+      </div>
+    </div>
+  );
+}
+
+/** A pill tab in the expanded header (Replies / Recap). */
+function HeaderTab({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon?: ReactElement;
+  label: string;
+}): ReactElement {
+  return (
+    <button
+      onClick={onClick}
+      data-track-category='twin-dock'
+      data-track-name={`tab-${label.toLowerCase()}`}
+      className={cn(
+        'pointer-events-auto flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs transition-colors',
+        active
+          ? 'bg-muted font-semibold text-foreground'
+          : 'font-medium text-muted-foreground hover:bg-muted/50',
+      )}
+    >
+      {icon && <span className='flex shrink-0'>{icon}</span>}
+      {label}
+    </button>
+  );
+}
+
+/** Overlapping sender avatars for the collapsed bar (max 3, hashed colours). */
+function AvatarCluster({ names }: { names: string[] }): ReactElement {
+  return (
+    <div className='flex shrink-0 -space-x-1.5'>
+      {names.slice(0, 3).map((n, i) => (
+        <SourceAvatar key={`${n}-${i}`} name={n} size={16} />
+      ))}
+    </div>
+  );
+}
+
+/** ‹ n / N › pager for stepping through a thread's several draft proposals.
+ *  `pointer-events-auto` so its buttons work while the surrounding header lets
+ *  clicks fall through to the collapse overlay. */
+function Pager({
+  active,
+  total,
+  onGoTo,
+}: {
+  active: number;
+  total: number;
+  onGoTo: (index: number) => void;
+}): ReactElement {
+  // Cyclic: wrap around at the ends so you can keep clicking the same arrow.
+  const btn =
+    'pointer-events-auto flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground';
+  return (
+    <div className='flex items-center'>
+      <button
+        onClick={() => onGoTo((active - 1 + total) % total)}
+        aria-label='Previous draft'
+        data-track-category='twin-dock'
+        data-track-name='pager-prev'
+        className={btn}
+      >
+        <ChevronLeft size={14} />
+      </button>
+      <span
+        role='status'
+        aria-live='polite'
+        className='min-w-[34px] text-center text-[11px] tabular-nums text-muted-foreground'
+      >
+        {active + 1} / {total}
+      </span>
+      <button
+        onClick={() => onGoTo((active + 1) % total)}
+        aria-label='Next draft'
+        data-track-category='twin-dock'
+        data-track-name='pager-next'
+        className={btn}
+      >
+        <ChevronRight size={14} />
+      </button>
+    </div>
+  );
+}
+
+/** A small deterministic palette for source-message avatars — colour picked by a
+ *  stable hash of the sender name so the same person is always the same colour. */
+const AVATAR_COLORS = [
+  '#e11d48',
+  '#7c3aed',
+  '#0891b2',
+  '#d97706',
+  '#059669',
+  '#2563eb',
+  '#db2777',
+  '#4f46e5',
+];
+function avatarColor(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return AVATAR_COLORS[h % AVATAR_COLORS.length]!;
+}
+
+/** Initial-in-a-circle avatar for the message's sender (no user lookup needed —
+ *  the draft carries the sender name). Colour is hashed so senders stay distinct. */
+function SourceAvatar({
+  name,
+  size = 16,
+}: {
+  name?: string | undefined;
+  size?: number;
+}): ReactElement {
+  const label = (name ?? '').trim();
+  const initial = (label[0] ?? '?').toUpperCase();
+  return (
+    <span
+      className='inline-flex shrink-0 items-center justify-center rounded-full font-semibold uppercase leading-none text-white'
+      style={{
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.52),
+        backgroundColor: avatarColor(label),
+      }}
+    >
+      {initial}
+    </span>
+  );
+}
+
+function RecapPane({
+  content,
+  loading,
+}: {
+  content: string | undefined;
+  loading: boolean;
+}): ReactElement {
+  const markdownComponents = useMemo(() => createMarkdownComponents('thread-recap'), []);
+  return (
+    <div className='max-h-56 overflow-y-auto'>
+      {/* Lightweight recap: soften markdown emphasis (no heavy black headings /
+          bold) so it reads as a quiet summary, not a shouting block. */}
+      <div className='text-[13px] font-normal leading-relaxed text-muted-foreground [&_h1]:text-[13px] [&_h1]:font-medium [&_h2]:text-[13px] [&_h2]:font-medium [&_h3]:text-[13px] [&_h3]:font-medium [&_h1]:text-foreground/80 [&_h2]:text-foreground/80 [&_h3]:text-foreground/80 [&_strong]:font-medium [&_strong]:text-foreground/80 [&_p]:my-1 [&_ul]:my-1 [&_li]:my-0.5'>
+        {content ? (
+          <MarkdownMessageRenderer content={content} markdownComponents={markdownComponents} />
+        ) : loading ? (
+          <span className='flex items-center gap-2'>
+            <Loader2 size={14} className='animate-spin' /> Generating summary…
+          </span>
+        ) : (
+          <span>No summary available for this thread yet.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Icon + reply verb + "where" clause for the reply's destination. Kept as a
+ *  verb ("reply"/"post"/"send") + clause ("in this thread") so it composes both
+ *  standalone ("Reply in this thread") and after a reaction ("React 👍 and reply
+ *  in this thread"). Names are resolved server-side; falls back to a generic
+ *  noun when the name is unavailable. */
+function destinationInfo(draft: TwinReplyDraftView): {
+  icon: ReactElement;
+  verb: string;
+  where: ReactElement;
+} {
+  const chan = draft.destinationChannelName;
+  const B = ({ children }: { children: ReactNode }) => (
+    <b className='font-medium text-muted-foreground/80'>{children}</b>
+  );
+  switch (draft.destinationKind) {
+    case 'origin_channel':
+      return {
+        icon: <Hash size={12} />,
+        verb: 'post',
+        where: (
+          <>
+            to <B>{draft.channelName ? `#${draft.channelName}` : 'this channel'}</B>
+          </>
+        ),
+      };
+    case 'channel':
+      return {
+        icon: <Hash size={12} />,
+        verb: 'post',
+        where: (
+          <>
+            to <B>{chan ? `#${chan}` : 'another channel'}</B>
+          </>
+        ),
+      };
+    case 'thread':
+      return {
+        icon: <CornerDownLeft size={12} />,
+        verb: 'post',
+        where: (
+          <>
+            to a thread
+            {chan ? (
+              <>
+                {' '}
+                in <B>#{chan}</B>
+              </>
+            ) : (
+              <> in another channel</>
+            )}
+          </>
+        ),
+      };
+    case 'dm_sender':
+      return {
+        icon: <AtSign size={12} />,
+        verb: 'send',
+        where: (
+          <>
+            as a DM to <B>{draft.senderName ?? 'the sender'}</B>
+          </>
+        ),
+      };
+    case 'dm':
+      return {
+        icon: <AtSign size={12} />,
+        verb: 'send',
+        where: (
+          <>
+            as a DM to <B>{draft.destinationUserName ?? 'them'}</B>
+          </>
+        ),
+      };
+    case 'origin_thread':
+    default:
+      return {
+        icon: <CornerDownLeft size={12} />,
+        verb: 'reply',
+        where: (
+          <>
+            in <B>this thread</B>
+          </>
+        ),
+      };
+  }
+}
+
+/** The one-line, clickable preview of the message this reply is drafted for — the
+ *  "who we're replying to" field. Borderless/inline (matches the original), a
+ *  single truncated line; clicking jumps to the source message in the thread. */
+function SourcePreview({ source }: { source: TwinSourceInfo }): ReactElement | null {
+  if (!source.text && !source.name) return null;
+  const clickable = !!source.onJump;
+  return (
+    <div
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onClick={clickable ? source.onJump : undefined}
+      onKeyDown={
+        clickable
+          ? e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                source.onJump?.();
+              }
+            }
+          : undefined
+      }
+      title={clickable ? 'Jump to message' : undefined}
+      data-track-category='twin-dock'
+      data-track-name='jump-to-source'
+      className={cn(
+        // w-full + min-w-0 so this fills (and can shrink to) the container width,
+        // letting the message text truncate to a single line responsively.
+        'group flex w-full min-w-0 items-center gap-1.5 py-0.5 text-[11px] text-muted-foreground/60',
+        clickable && 'cursor-pointer',
+      )}
+    >
+      <SourceAvatar name={source.name} size={14} />
+      {source.name && (
+        <span className='max-w-[45%] shrink-0 truncate font-medium text-muted-foreground/80'>
+          {source.name}
+        </span>
+      )}
+      <span className={cn('min-w-0 flex-1 truncate', clickable && 'group-hover:underline')}>
+        {source.text}
+      </span>
+    </div>
+  );
+}
+
+function ReplyCard({
+  draft,
+  source,
+  loading,
+  approve,
+  decline,
+  onPosted,
+  onOpenReasoning,
+  onBeginEdit,
+}: {
+  draft: TwinReplyDraftView;
+  source?: TwinSourceInfo | undefined;
+  loading: boolean;
+  approve: (edited?: string) => Promise<PostedTarget | null>;
+  decline: () => Promise<void>;
+  onPosted: (t: PostedTarget | null) => void;
+  onOpenReasoning: () => void;
+  /** Present ⇒ hand editing to the composer; absent ⇒ inline textarea fallback. */
+  onBeginEdit?: () => void;
+}): ReactElement {
+  // Inline-edit state is only used as the fallback when there's no composer to
+  // delegate to (the threads-page preview card). With a composer, Edit calls
+  // onBeginEdit and this stays dormant.
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState('');
+  const textRef = useRef<HTMLTextAreaElement>(null);
+
+  const hasReact = draft.action === 'react' || draft.action === 'react_and_reply';
+  const hasReply = draft.action === 'reply' || draft.action === 'react_and_reply';
+  const dest = destinationInfo(draft);
+  const emoji = <span className='text-sm leading-none'>{draft.emoji}</span>;
+
+  // One line that states the full intent: the reaction and/or where the reply
+  // lands, so react_and_reply reads as "React 👍 and reply in this thread".
+  let intent: ReactElement;
+  if (hasReact && hasReply) {
+    intent = (
+      <>
+        React {emoji} and {dest.verb} {dest.where}
+      </>
+    );
+  } else if (hasReact) {
+    intent = <>React {emoji} on the message</>;
+  } else {
+    intent = (
+      <>
+        {dest.verb.charAt(0).toUpperCase() + dest.verb.slice(1)} {dest.where}
+      </>
+    );
+  }
+
+  const beginEdit = (): void => {
+    if (onBeginEdit) {
+      onBeginEdit();
+      return;
+    }
+    setEditText(draft.message ?? '');
+    setEditing(true);
+    setTimeout(() => textRef.current?.focus(), 0);
+  };
+  const send = async (): Promise<void> => {
+    const posted = await approve(editing ? editText.trim() : undefined);
+    onPosted(posted);
+  };
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      {/* destination indicator (reaction + where) + private hint — kept faded so
+          focus stays on the draft body below. */}
+      <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground/60'>
+        {hasReply && dest.icon}
+        <span>{intent}</span>
+        <span className='ml-auto shrink-0'>Only you can see this</span>
+      </div>
+
+      {/* the message this reply is drafted for — inline, clickable, jumps to it.
+          Height reserved so paging to a draft whose source isn't loaded doesn't
+          change the card height. */}
+      <div className='flex min-h-[22px] items-center'>
+        {source ? <SourcePreview source={source} /> : null}
+      </div>
+
+      {/* draft body — dashed hairline marks it unsent; FIXED height so switching
+          drafts never changes the card size (long drafts scroll). */}
+      <div className='mt-0.5 h-[76px] overflow-y-auto rounded-md border border-dashed border-border bg-muted/30 px-3 py-2'>
+        {hasReact && !hasReply ? (
+          <div className='flex h-full items-center gap-2.5'>
+            <span className='flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-xl'>
+              {draft.emoji}
+            </span>
+            <span className='text-xs text-muted-foreground'>
+              Adds this reaction to the triggering message
+            </span>
+          </div>
+        ) : editing ? (
+          <textarea
+            ref={textRef}
+            value={editText}
+            onChange={e => setEditText(e.target.value)}
+            data-track-category='twin-dock'
+            data-track-name='edit-draft'
+            className='h-full w-full resize-none rounded bg-background px-2 py-1.5 text-sm text-foreground outline-none ring-1 ring-border focus:ring-foreground/40'
+          />
+        ) : (
+          <div className='whitespace-pre-wrap text-sm text-foreground'>{draft.message}</div>
+        )}
+      </div>
+
+      {/* actions: Why? on the left; Reject / Edit / Send right-aligned (Send is
+          the red primary, rightmost) — matches the reference. */}
+      <div className='flex items-center gap-1'>
+        {draft.reasoning && (
+          <button
+            onClick={onOpenReasoning}
+            aria-label='Why this reply'
+            data-track-category='twin-dock'
+            data-track-name='open-reasoning'
+            className='flex h-8 items-center gap-1 rounded-md px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+          >
+            Why?
+          </button>
+        )}
+        <div className='ml-auto flex items-center gap-1'>
+          {/* Reject + Edit are icon-only; Send is the red primary with an up
+              arrow — matching the reference. */}
+          <Button
+            size='iconSm'
+            variant='ghost'
+            onClick={() => void decline()}
+            disabled={loading}
+            aria-label='Reject'
+            className='text-muted-foreground hover:text-foreground'
+          >
+            <MessageSquareX size={17} />
+          </Button>
+          {hasReply && (
+            <Button
+              size='iconSm'
+              variant='ghost'
+              onClick={editing ? () => setEditing(false) : beginEdit}
+              disabled={loading}
+              aria-label={editing ? 'Cancel edit' : 'Edit'}
+              className='text-muted-foreground hover:text-foreground'
+            >
+              <Pencil size={16} />
+            </Button>
+          )}
+          <Button size='sm' onClick={() => void send()} disabled={loading} loading={loading}>
+            {!loading && <ArrowUp size={15} />}
+            {hasReact && !hasReply ? 'Send reaction' : editing ? 'Send edited' : 'Send'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinDraftBadgeContext.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinDraftBadgeContext.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { useSelector } from '@xstate/react';
+import { stateMachineActor } from '../../../machines/stateMachine';
+import type { TwinDraftAction } from './twinReplyDraftApi';
+
+/** Minimal marker that a thread has a pending Twin proposal (enough to render the
+ *  row indicator without the full draft). */
+export interface TwinDraftBadge {
+  conversationId: string;
+  action: TwinDraftAction;
+}
+
+/**
+ * Whether a thread has a pending Digital Twin proposal — derived straight from
+ * Zero-synced state (the `twinDrafts` slice → draft_messages rows with
+ * origin='twin'). No fetch, no socket, no provider: the same rows that drive the
+ * in-thread dock also drive the row indicator, so a badge appears and clears the
+ * instant the proposal does. Returns the NEWEST proposal's marker (a thread may
+ * hold several); undefined when there's none. Owner-only by construction — the
+ * twinDrafts query is scoped to the authenticated user.
+ */
+export function useTwinDraftBadge(conversationId?: string): TwinDraftBadge | undefined {
+  const all = useSelector(stateMachineActor, state => state.context.twinDrafts);
+  return useMemo(() => {
+    if (!conversationId) return undefined;
+    let newest: { createdAt: number; action: TwinDraftAction } | undefined;
+    for (const d of all) {
+      if (d.conversationId !== conversationId) continue;
+      // metadata is stringified JSON (TEXT column) — parse to read the action.
+      let action: TwinDraftAction = 'reply';
+      if (typeof d.metadata === 'string') {
+        try {
+          action = (JSON.parse(d.metadata) as { action?: TwinDraftAction }).action ?? 'reply';
+        } catch {
+          // malformed metadata → keep default 'reply'
+        }
+      }
+      if (!newest || d.createdAt > newest.createdAt) newest = { createdAt: d.createdAt, action };
+    }
+    return newest ? { conversationId, action: newest.action } : undefined;
+  }, [all, conversationId]);
+}

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinDraftIndicator.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinDraftIndicator.tsx
@@ -1,0 +1,35 @@
+import { Sparkles } from 'lucide-react';
+import type { ReactElement } from 'react';
+import { cn } from '../../../utils/classNames';
+import { useTwinDraftBadge } from './TwinDraftBadgeContext';
+
+/**
+ * A small, neutral "Twin draft" pill shown on a thread row when the caller has a
+ * pending Digital Twin draft for it. Reads the badge from context (no props to
+ * drill through the message list). Renders nothing when there's no draft. Theme
+ * tokens only — no accent colour.
+ */
+export function TwinDraftIndicator({
+  conversationId,
+  className,
+}: {
+  conversationId?: string | undefined;
+  className?: string;
+}): ReactElement | null {
+  const badge = useTwinDraftBadge(conversationId);
+  if (!badge) return null;
+
+  const label = badge.action === 'react' ? 'Twin reaction' : 'Twin draft';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground',
+        className,
+      )}
+      title='The Digital Twin drafted a response for you — open the thread to review it'
+    >
+      <Sparkles size={9} className='shrink-0' />
+      {label}
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinReasoningDrawer.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinReasoningDrawer.tsx
@@ -1,0 +1,187 @@
+import { ReactElement, useEffect, useMemo, useState } from 'react';
+import { Sparkles, Bug, X } from 'lucide-react';
+import { cn } from '../../../utils/classNames';
+import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
+import { createMarkdownComponents } from '../../../utils/markdownComponents';
+import {
+  buildClawCitationToolNumbers,
+  linkifyAndGroupClawCitations,
+  stripCitationMarks,
+} from '../../ui/TipTapExtensions/CitationMark';
+import { registerClawIcons } from '../XyneAISidebar/utils/clawCitationUrl';
+import type { ToolInvocation } from '../XyneAISidebar/utils/XyneAITypes';
+import { AskAIDebugPanel } from '../XyneAISidebar/components/AskAIDebugPanel';
+import type { TwinReplyDraftView } from './twinReplyDraftApi';
+
+const DIGITAL_TWIN_SLUG = 'digital-twin';
+
+type ReasoningTab = 'reasoning' | 'debug';
+
+interface TwinReasoningDrawerProps {
+  open: boolean;
+  /** The current draft (from the dock) — carries reasoning + the run identity. */
+  draft: TwinReplyDraftView | undefined;
+  /** Origin conversation — the debugger fetches the twin run's trace by this. */
+  conversationId: string;
+  onClose: () => void;
+}
+
+/**
+ * Right-side drawer explaining a Twin draft: a **Reasoning** tab (the twin's
+ * private rationale with clickable clf- citation chips) and a **Debug** tab
+ * (the reused AskAIDebugPanel — the full run trace: tool calls, thinking,
+ * timeline). Rendered as an overlay over the thread panel's right edge so it
+ * never displaces the thread; dismissible. The debugger is scoped to THIS twin
+ * run via (conversationId, agentSlug, sessionId) and owner-ACL'd server-side.
+ */
+export function TwinReasoningDrawer({
+  open,
+  draft,
+  conversationId,
+  onClose,
+}: TwinReasoningDrawerProps): ReactElement | null {
+  const [tab, setTab] = useState<ReasoningTab>('reasoning');
+
+  // Default to the Reasoning tab every time the drawer opens.
+  useEffect(() => {
+    if (open) setTab('reasoning');
+  }, [open]);
+
+  if (!open) return null;
+
+  const agentSlug = draft?.agentSlug ?? DIGITAL_TWIN_SLUG;
+
+  return (
+    <div className='absolute inset-y-0 right-0 z-20 flex w-full max-w-[480px] flex-col border-l border-border bg-background shadow-xl animate-slide-in-from-right'>
+      <div className='flex items-center gap-2 border-b border-border px-3 py-2'>
+        <div className='flex items-center gap-0.5 rounded-md bg-muted/60 p-0.5'>
+          <TabButton
+            active={tab === 'reasoning'}
+            onClick={() => setTab('reasoning')}
+            icon={<Sparkles size={13} />}
+            label='Reasoning'
+          />
+          <TabButton
+            active={tab === 'debug'}
+            onClick={() => setTab('debug')}
+            icon={<Bug size={13} />}
+            label='Debug'
+          />
+        </div>
+        <button
+          onClick={onClose}
+          aria-label='Close'
+          data-track-category='twin-reasoning'
+          data-track-name='close'
+          className='ml-auto flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {tab === 'reasoning' ? (
+        <div className='flex-1 overflow-y-auto p-4'>
+          {draft?.reasoning ? (
+            <ReasoningBody reasoning={draft.reasoning} draft={draft} />
+          ) : (
+            <p className='text-sm text-muted-foreground'>
+              No reasoning was captured for this draft.
+            </p>
+          )}
+        </div>
+      ) : (
+        // Reused run debugger — lazily mounted so it only fetches artifacts when
+        // the Debug tab is actually opened. Scoped to this twin run.
+        <div className='flex min-h-0 flex-1 flex-col'>
+          <AskAIDebugPanel
+            open
+            inline
+            agentSlug={agentSlug}
+            conversationId={conversationId}
+            onClose={onClose}
+            selectedSessionId={draft?.sessionId ?? null}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: ReactElement;
+  label: string;
+}): ReactElement {
+  return (
+    <button
+      onClick={onClick}
+      data-track-category='twin-reasoning'
+      data-track-name={`tab-${label.toLowerCase()}`}
+      className={cn(
+        'flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-semibold transition-colors',
+        active
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground',
+      )}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+/**
+ * The twin's rationale, rendered with the SAME clf- citation-chip pipeline as
+ * thread messages: register the baked icon bytes, number the cited tools,
+ * linkify `[clf-…#n]` tokens, then let createMarkdownComponents' `a`-override
+ * swap them for clickable chips.
+ */
+function ReasoningBody({
+  reasoning,
+  draft,
+}: {
+  reasoning: string;
+  draft: TwinReplyDraftView;
+}): ReactElement {
+  const clawCitationCtx = useMemo(() => {
+    const clawCitations = draft.clawCitations as ToolInvocation[] | undefined;
+    if (!clawCitations?.length) return undefined;
+    registerClawIcons(draft.clawCitationIcons);
+    const toolNumbers = buildClawCitationToolNumbers(reasoning);
+    if (toolNumbers.size === 0) return undefined;
+    return { toolInvocations: clawCitations, toolNumbers };
+  }, [draft.clawCitations, draft.clawCitationIcons, reasoning]);
+
+  const citationContent = useMemo(() => {
+    if (reasoning.indexOf('clf-') === -1) return reasoning;
+    const linkified = clawCitationCtx
+      ? linkifyAndGroupClawCitations(reasoning, clawCitationCtx.toolNumbers)
+      : reasoning;
+    return stripCitationMarks(linkified);
+  }, [reasoning, clawCitationCtx]);
+
+  const markdownComponents = useMemo(
+    () => createMarkdownComponents('twin-why', clawCitationCtx),
+    [clawCitationCtx],
+  );
+
+  return (
+    <>
+      <div className='mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground'>
+        <Sparkles size={12} /> Why this reply
+      </div>
+      <div className='text-sm leading-relaxed text-foreground'>
+        <MarkdownMessageRenderer
+          content={citationContent}
+          markdownComponents={markdownComponents}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/twinReplyDraftApi.ts
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/twinReplyDraftApi.ts
@@ -1,0 +1,131 @@
+import { apiInstance } from '../../../services/clients/apiClient';
+import type { ToolInvocation } from '../XyneAISidebar/utils/XyneAITypes';
+
+export type TwinDraftAction = 'react' | 'reply' | 'react_and_reply';
+
+/** A baked citation lookup entry (buildThreadCitationMeta.clawCitations) — the
+ *  toolCallId + its citations, exactly what ThreadCitationChip's resolvers need. */
+export interface TwinDraftClawCitation {
+  toolCallId: string;
+  citations: ToolInvocation['citations'];
+}
+
+/**
+ * Owner-facing view of a single Twin reply proposal, built from a `draft_messages`
+ * row (origin='twin') synced via Zero. `id` is the draft row id — the handle used
+ * to approve/decline this specific proposal (a thread may hold several).
+ */
+export interface TwinReplyDraftView {
+  /** draft_messages row id — the approve/decline handle. */
+  id: string;
+  conversationId: string;
+  action: TwinDraftAction;
+  message?: string;
+  emoji?: string;
+  /** Private rationale markdown; factual claims carry `[clf-…#n]` tokens. */
+  reasoning?: string;
+  clawCitations?: TwinDraftClawCitation[];
+  clawCitationIcons?: Record<string, string>;
+  destinationKind: string;
+  destinationChannelName?: string;
+  /** Human name of the DM recipient (dm / dm_sender), for the "sends a DM to …" label. */
+  destinationUserName?: string;
+  destinationReason?: string;
+  sourceMessageId?: string;
+  senderName?: string;
+  channelName?: string;
+  /** The claw agent + run behind this draft — used to point the run debugger at it. */
+  agentSlug?: string;
+  sessionId?: string;
+  createdAt: number;
+}
+
+/** The twin payload stored in the row's `metadata` JSON (the backend TwinReplyDraft). */
+type StoredTwinDraft = Omit<TwinReplyDraftView, 'id'> & Record<string, unknown>;
+
+/** The subset of a `draft_messages` (origin='twin') Zero row this mapper needs.
+ *  A structural type so callers pass `TwinDraftDB` without this module importing
+ *  the opaque Zero-derived alias. */
+export interface TwinDraftRow {
+  id: string;
+  conversationId?: string | null;
+  createdAt: number;
+  metadata?: unknown;
+}
+
+/** Parse the stringified-JSON twin payload from a row's `metadata` (TEXT column).
+ *  Tolerates an already-parsed object defensively. Returns null if absent/malformed. */
+function parseStoredTwinDraft(metadata: unknown): StoredTwinDraft | null {
+  if (!metadata) return null;
+  if (typeof metadata === 'string') {
+    try {
+      return JSON.parse(metadata) as StoredTwinDraft;
+    } catch {
+      return null;
+    }
+  }
+  return metadata as StoredTwinDraft;
+}
+
+/**
+ * Map a Zero-synced twin draft row to the owner-facing view. The rich payload
+ * lives in `metadata` (written by the S2S create route as stringified JSON);
+ * `id`/`createdAt` come from the row. Returns null if the row has no metadata.
+ */
+export function rowToTwinReplyDraftView(row: TwinDraftRow): TwinReplyDraftView | null {
+  const meta = parseStoredTwinDraft(row.metadata);
+  if (!meta) return null;
+  return {
+    ...meta,
+    id: row.id,
+    conversationId: row.conversationId ?? meta.conversationId,
+    createdAt: typeof meta.createdAt === 'number' ? meta.createdAt : row.createdAt,
+  };
+}
+
+/** Where an approved reply landed — used to redirect the user there. */
+export interface PostedTarget {
+  channelId: string;
+  conversationId?: string;
+}
+
+/**
+ * An in-progress "edit this Twin draft in the composer" session. The dock hands
+ * this to the ChatInput so the real message composer takes over editing: it loads
+ * the draft text, highlights the composer, and — crucially — routes Send through
+ * `onApprove` (the twin approve endpoint) rather than a plain thread post, since
+ * the draft's true destination lives server-side and approving is what records
+ * the twin's learning feedback. Leaving edit mode (the edit bar's Back button)
+ * restores the composer to the user's own draft without sending.
+ */
+export interface TwinEditSession {
+  /** The draft row id being edited — binds the session to one specific proposal. */
+  draftId: string;
+  /** The draft's current text, loaded into the composer when the session opens. */
+  message: string;
+  /** Sender of the message being replied to — shown in the edit bar for context. */
+  senderName?: string;
+  /** Approve with the user's edited text (empty ⇒ send the twin's original).
+   *  Owns the outcome: ends the session on success, keeps it (with a toast) on
+   *  failure so the user's edit survives for a retry. */
+  onApprove: (editedText: string) => void;
+}
+
+/** Approve a specific draft (by row id) — posts/reacts AS the user (optionally
+ *  with edited text). Returns where the reply posted (for redirect), or null for
+ *  a react-only delivery. Throws on failure so the caller can keep the draft. */
+export async function approveTwinReplyDraft(
+  draftId: string,
+  editedMessage?: string,
+): Promise<PostedTarget | null> {
+  const res = await apiInstance.post<{ success: boolean; posted?: PostedTarget }>(
+    `/conversations/reply-drafts/${draftId}/approve`,
+    { ...(editedMessage !== undefined ? { editedMessage } : {}) },
+  );
+  return res.data?.posted ?? null;
+}
+
+/** Decline a specific draft (by row id) — records the feedback and clears it. */
+export async function declineTwinReplyDraft(draftId: string): Promise<void> {
+  await apiInstance.post(`/conversations/reply-drafts/${draftId}/decline`, {});
+}

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/useThreadAssist.ts
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/useThreadAssist.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useThreadCatchupSummary } from '../ThreadCatchupSummary/useThreadCatchupSummary';
+import type { ThreadCatchupMessages } from '../ThreadCatchupSummary/ThreadCatchupSummary.utils';
+import { useTwinReplyDraft } from './useTwinReplyDraft';
+import type { TwinReplyDraftView, PostedTarget } from './twinReplyDraftApi';
+
+export type AssistTab = 'recap' | 'reply';
+
+export interface ThreadAssistState {
+  /** Whether the dock should render at all (recap enabled OR a draft exists). */
+  available: boolean;
+  /** Collapsed = the minimal one-line bar above the composer; expanded = full. */
+  collapsed: boolean;
+  toggleCollapse: () => void;
+  tab: AssistTab;
+  setTab: (t: AssistTab) => void;
+  hasRecap: boolean;
+  hasReply: boolean;
+  loading: boolean;
+  recap: { content: string | undefined; loading: boolean };
+  reply: {
+    /** This thread's pending Twin proposals, newest-first (may be several). */
+    drafts: TwinReplyDraftView[];
+    /** Draft ids with an approve/decline in flight (per-card spinners). */
+    pending: ReadonlySet<string>;
+    approve: (draftId: string, edited?: string) => Promise<PostedTarget | null>;
+    decline: (draftId: string) => Promise<void>;
+  };
+}
+
+/**
+ * Composes the thread catch-up summary (recap) and the Twin reply draft into ONE
+ * dock that lives ATTACHED to the message composer (not in the message list).
+ * Reuses both underlying hooks intact; adds only collapse/tab coordination:
+ *  - a reply draft (or a recommended recap) auto-expands the dock so the user
+ *    sees it the moment they open the thread they were tagged in;
+ *  - a recap that's merely enabled (not recommended) starts collapsed as a quiet
+ *    one-line bar the user can expand;
+ *  - the recap hook fetches on its own `expanded`, so we drive that to follow
+ *    "recap tab visible" (edge-triggered, so we never fight its own auto-open).
+ */
+export function useThreadAssist(
+  conversationId: string | undefined,
+  userId: string | undefined,
+  messages: ThreadCatchupMessages | undefined,
+  /** The user's lastReadAt for this thread (epoch ms; 0 if never read) — gates the
+   *  recap on unread-from-others rather than total thread length. */
+  lastReadAt: number,
+  isMessagesLoaded: boolean,
+  isThreadParticipant: boolean,
+): ThreadAssistState {
+  const recap = useThreadCatchupSummary(
+    conversationId,
+    userId,
+    messages,
+    lastReadAt,
+    isMessagesLoaded,
+    isThreadParticipant,
+  );
+  const reply = useTwinReplyDraft(conversationId);
+
+  const [collapsed, setCollapsed] = useState(true);
+  const [tab, setTab] = useState<AssistTab>('reply');
+
+  // Reset coordination state on conversation change (both hooks reset themselves).
+  const prevConv = useRef(conversationId);
+  if (prevConv.current !== conversationId) {
+    prevConv.current = conversationId;
+    setCollapsed(true);
+    setTab('reply');
+  }
+
+  const hasRecap = recap.isAvailable;
+  const hasReply = reply.hasDraft;
+
+  // Rising-edge: a reply draft appears → expand on the Reply tab.
+  const replyEdge = useRef(false);
+  useEffect(() => {
+    if (hasReply && !replyEdge.current) {
+      replyEdge.current = true;
+      setCollapsed(false);
+      setTab('reply');
+    } else if (!hasReply) {
+      replyEdge.current = false;
+    }
+  }, [hasReply]);
+
+  // Rising-edge: recap recommended → expand (Reply keeps priority if a draft waits).
+  const recapEdge = useRef(false);
+  useEffect(() => {
+    if (recap.isRecommended && !recapEdge.current) {
+      recapEdge.current = true;
+      setCollapsed(false);
+      setTab(hasReply ? 'reply' : 'recap');
+    } else if (!recap.isRecommended) {
+      recapEdge.current = false;
+    }
+  }, [recap.isRecommended, hasReply]);
+
+  // If the active tab's content is gone, fall back to what's available.
+  const effectiveTab: AssistTab =
+    tab === 'reply' && !hasReply ? 'recap' : tab === 'recap' && !hasRecap ? 'reply' : tab;
+
+  // Drive the recap hook's `expanded` to trigger its fetch. We PRE-GENERATE: as
+  // soon as the dock is open (regardless of which tab is active), so switching to
+  // the Recap tab shows a ready summary instead of a "Generating…" spinner. The
+  // recap fetches once per open and the server-side cache dedupes, so this is
+  // cheap. Edge-triggered on the derived boolean ONLY, so the recap hook's own
+  // auto-open is never fought back closed.
+  const recapVisible = hasRecap && !collapsed;
+  const lastRecapVisible = useRef(recapVisible);
+  useEffect(() => {
+    if (lastRecapVisible.current === recapVisible) return;
+    lastRecapVisible.current = recapVisible;
+    if (recapVisible && !recap.expanded) recap.toggleExpanded();
+    else if (!recapVisible && recap.expanded) recap.toggleExpanded();
+  }, [recapVisible, recap.expanded, recap.toggleExpanded]);
+
+  const toggleCollapse = useCallback(() => setCollapsed(c => !c), []);
+
+  return {
+    available: hasRecap || hasReply,
+    collapsed,
+    toggleCollapse,
+    tab: effectiveTab,
+    setTab,
+    hasRecap,
+    hasReply,
+    loading: recap.loading,
+    recap: { content: recap.content, loading: recap.loading },
+    reply: {
+      drafts: reply.drafts,
+      pending: reply.pending,
+      approve: reply.approve,
+      decline: reply.decline,
+    },
+  };
+}

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/useThreadAssist.ts
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/useThreadAssist.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useThreadCatchupSummary } from '../ThreadCatchupSummary/useThreadCatchupSummary';
 import type { ThreadCatchupMessages } from '../ThreadCatchupSummary/ThreadCatchupSummary.utils';
-import { useTwinReplyDraft } from './useTwinReplyDraft';
+import { useTwinReplyDraft } from '../../../hooks/useTwinReplyDraft';
 import type { TwinReplyDraftView, PostedTarget } from './twinReplyDraftApi';
 
 export type AssistTab = 'recap' | 'reply';

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/useTwinReplyDraft.ts
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/useTwinReplyDraft.ts
@@ -1,0 +1,86 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSelector } from '@xstate/react';
+import { stateMachineActor } from '../../../machines/stateMachine';
+import {
+  approveTwinReplyDraft,
+  declineTwinReplyDraft,
+  rowToTwinReplyDraftView,
+  type TwinReplyDraftView,
+  type PostedTarget,
+} from './twinReplyDraftApi';
+
+const EMPTY: TwinReplyDraftView[] = [];
+
+export interface TwinReplyDraftState {
+  /** This thread's pending Twin proposals, newest-first (may be empty). A thread
+   *  can hold several — one per @mention of the twin. */
+  drafts: TwinReplyDraftView[];
+  hasDraft: boolean;
+  /** Draft ids with an approve/decline currently in flight (per-card spinners). */
+  pending: ReadonlySet<string>;
+  /** Approve one draft (by id) — posts/reacts as the user, resolves with where it
+   *  landed (null for react-only). The row clears itself via Zero on success. */
+  approve: (draftId: string, editedMessage?: string) => Promise<PostedTarget | null>;
+  /** Decline one draft (by id) — records feedback, clears the row. */
+  decline: (draftId: string) => Promise<void>;
+}
+
+/**
+ * The caller's OWN pending Digital Twin reply proposals for a thread, read
+ * straight from Zero-synced state (the `twinDrafts` slice → draft_messages rows
+ * with origin='twin'). Proposals appear and clear LIVE via Zero replication — no
+ * bespoke fetch or socket. Owner-only: the twinDrafts query is scoped to the
+ * authenticated user, so only the owner's proposals are ever in state.
+ */
+export function useTwinReplyDraft(conversationId: string | undefined): TwinReplyDraftState {
+  // Subscribe to the whole slice (a stable ref that only changes when the set of
+  // proposals changes), then derive this thread's views with useMemo — avoids a
+  // new array on every unrelated state-machine event.
+  const allTwinDrafts = useSelector(stateMachineActor, state => state.context.twinDrafts);
+
+  const drafts = useMemo(() => {
+    if (!conversationId) return EMPTY;
+    const views = allTwinDrafts
+      .filter(d => d.conversationId === conversationId)
+      .map(rowToTwinReplyDraftView)
+      .filter((v): v is TwinReplyDraftView => v !== null)
+      .sort((a, b) => b.createdAt - a.createdAt);
+    return views.length > 0 ? views : EMPTY;
+  }, [allTwinDrafts, conversationId]);
+
+  const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set());
+  const mark = useCallback((id: string, on: boolean) => {
+    setPending(prev => {
+      const next = new Set(prev);
+      if (on) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const approve = useCallback(
+    async (draftId: string, editedMessage?: string): Promise<PostedTarget | null> => {
+      mark(draftId, true);
+      try {
+        return await approveTwinReplyDraft(draftId, editedMessage);
+      } finally {
+        mark(draftId, false);
+      }
+    },
+    [mark],
+  );
+
+  const decline = useCallback(
+    async (draftId: string): Promise<void> => {
+      mark(draftId, true);
+      try {
+        await declineTwinReplyDraft(draftId);
+      } finally {
+        mark(draftId, false);
+      }
+    },
+    [mark],
+  );
+
+  return { drafts, hasDraft: drafts.length > 0, pending, approve, decline };
+}

--- a/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
+++ b/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
@@ -20,6 +20,7 @@ import { useNavigate, useParams, Outlet } from 'react-router-dom';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { conversationService, ThreadListEntry } from '../../../services/Chat/conversationService';
 import { useUnreadThreadConversationIds } from '../../../hooks/useUnreadThreadsCount';
+import { TwinDraftIndicator } from '../TwinReplyDraft/TwinDraftIndicator';
 
 const PAGE_SIZE = 20;
 
@@ -64,6 +65,7 @@ const ThreadRow = memo(
             >
               {displayName}
             </button>
+            <TwinDraftIndicator conversationId={conversationId} />
           </div>
         </div>
         <div className='border border-border rounded-xl overflow-hidden bg-card shadow-sm'>

--- a/apps/dashboard/src/components/Markdown/D2Block/D2Block.tsx
+++ b/apps/dashboard/src/components/Markdown/D2Block/D2Block.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useRef, useState, memo, type ReactElement, type CSSProperties } from 'react';
+import { Code2, Image as ImageIcon, Download, Copy, Check, X } from 'lucide-react';
+import { Dialog } from '../../ui/Dialog/Dialog';
+import { type D2BlockProps, type ViewMode } from './D2Block.types';
+import {
+  renderD2Diagram,
+  isLikelyCompleteD2,
+  copyToClipboard,
+  downloadDiagramAsPng,
+} from './D2Block.utils';
+
+/**
+ * Tracks whether the app is in its dark theme by observing the `data-theme`
+ * attribute on <html> (Spaces sets data-theme="midnight" for dark). A plain
+ * useTheme() hook keeps per-component local state and would not react to a
+ * toggle made elsewhere, so we watch the attribute directly.
+ */
+function useIsDarkTheme(): boolean {
+  const [isDark, setIsDark] = useState<boolean>(
+    () =>
+      typeof document !== 'undefined' &&
+      document.documentElement.getAttribute('data-theme') === 'midnight',
+  );
+  useEffect(() => {
+    const el = document.documentElement;
+    const update = (): void => setIsDark(el.getAttribute('data-theme') === 'midnight');
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(el, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
+  return isDark;
+}
+
+/**
+ * Renders real D2-language diagrams (d2lang.com) via the @terrastruct/d2 WASM
+ * compiler, lazy-loaded on first use. Mirrors MermaidBlock's UX (diagram/code
+ * toggle, PNG download, fullscreen) but always surfaces errors instead of
+ * spinning forever. Debounced so streaming deltas don't recompile mid-stream.
+ * The diagram theme follows the app theme (light/dark) and re-renders on toggle.
+ */
+const D2BlockComponent = ({ source }: D2BlockProps): ReactElement => {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const isDark = useIsDarkTheme();
+  const [svg, setSvg] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [isRendering, setIsRendering] = useState<boolean>(false);
+  const [viewMode, setViewMode] = useState<ViewMode>('diagram');
+  const [copied, setCopied] = useState<boolean>(false);
+  const [showPreview, setShowPreview] = useState<boolean>(false);
+  const renderTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const lastRenderedRef = useRef<string>('');
+
+  useEffect(() => {
+    if (renderTimeoutRef.current) {
+      clearTimeout(renderTimeoutRef.current);
+    }
+
+    // Wait for the block to finish streaming (balanced braces) before we pay for
+    // a WASM compile — and skip if this exact source+theme already rendered.
+    const renderKey = `${isDark ? 'd' : 'l'}:${source}`;
+    if (!isLikelyCompleteD2(source) || lastRenderedRef.current === renderKey) {
+      return;
+    }
+
+    // Debounce to coalesce the final streaming deltas into one render.
+    renderTimeoutRef.current = setTimeout(() => {
+      void renderD2Diagram({
+        source,
+        isDark,
+        onSuccess: renderedSvg => {
+          setSvg(renderedSvg);
+          lastRenderedRef.current = renderKey;
+        },
+        onError: setError,
+        onLoading: setIsRendering,
+      });
+    }, 300);
+
+    return (): void => {
+      if (renderTimeoutRef.current) {
+        clearTimeout(renderTimeoutRef.current);
+      }
+    };
+  }, [source, isDark]);
+
+  const handleCopyCode = async (): Promise<void> => {
+    const success = await copyToClipboard(source);
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleDownloadImage = (): void => {
+    if (!svg || !elementRef.current) return;
+    const svgElement = elementRef.current.querySelector('svg');
+    if (!svgElement) return;
+    downloadDiagramAsPng(svgElement);
+  };
+
+  // Error — show the message plus the raw source (fail loud, never hang).
+  if (error) {
+    return (
+      <div className='my-4 rounded-2xl border border-red-200 bg-red-50 p-4'>
+        <p className='text-sm text-red-600'>Failed to render D2 diagram</p>
+        <p className='mt-1 text-xs text-red-500'>{error}</p>
+        <details className='mt-2'>
+          <summary className='text-xs text-red-500 cursor-pointer'>Show diagram code</summary>
+          <pre className='mt-2 text-xs text-foreground overflow-x-auto whitespace-pre-wrap break-words'>
+            {source}
+          </pre>
+        </details>
+      </div>
+    );
+  }
+
+  if (svg) {
+    const iconBtn = (active: boolean): string =>
+      `flex items-center justify-center rounded-md p-1 transition-colors ${
+        active
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground'
+      }`;
+    return (
+      <div className='group/d2 relative my-4 overflow-hidden rounded-xl border border-border/60 bg-muted/30'>
+        {/* Minimal control cluster — icon-only, reveals on hover */}
+        <div className='absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-lg border border-border/60 bg-background/70 p-0.5 opacity-0 shadow-sm backdrop-blur-sm transition-opacity focus-within:opacity-100 group-hover/d2:opacity-100'>
+          <button
+            onClick={() => setViewMode('diagram')}
+            className={iconBtn(viewMode === 'diagram')}
+            title='Diagram'
+            data-track-category='D2'
+            data-track-name='VIEW_DIAGRAM'
+          >
+            <ImageIcon className='h-3.5 w-3.5' />
+          </button>
+          <button
+            onClick={() => setViewMode('code')}
+            className={iconBtn(viewMode === 'code')}
+            title='Code'
+            data-track-category='D2'
+            data-track-name='VIEW_CODE'
+          >
+            <Code2 className='h-3.5 w-3.5' />
+          </button>
+
+          <span className='mx-0.5 h-4 w-px bg-border' />
+
+          {viewMode === 'diagram' ? (
+            <button
+              onClick={handleDownloadImage}
+              className='flex items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground'
+              title='Download as PNG'
+              data-track-category='D2'
+              data-track-name='DOWNLOAD_PNG'
+            >
+              <Download className='h-3.5 w-3.5' />
+            </button>
+          ) : (
+            <button
+              onClick={() => void handleCopyCode()}
+              className='flex items-center justify-center rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground'
+              title='Copy code'
+              data-track-category='D2'
+              data-track-name='COPY_CODE'
+            >
+              {copied ? (
+                <Check className='h-3.5 w-3.5 text-green-600' />
+              ) : (
+                <Copy className='h-3.5 w-3.5' />
+              )}
+            </button>
+          )}
+        </div>
+
+        {viewMode === 'diagram' ? (
+          <div
+            ref={elementRef}
+            className='d2-diagram flex cursor-zoom-in items-center justify-center p-4'
+            /* eslint-disable-next-line react/no-danger, @typescript-eslint/naming-convention */
+            dangerouslySetInnerHTML={{ __html: svg }}
+            onClick={() => setShowPreview(true)}
+            role='button'
+            tabIndex={0}
+            onKeyDown={(e): void => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setShowPreview(true);
+              }
+            }}
+            title='Click to preview'
+            data-track-category='D2'
+            data-track-name='OPEN_PREVIEW'
+          />
+        ) : (
+          <div className='p-3 pt-10'>
+            <pre className='overflow-x-auto whitespace-pre-wrap break-words rounded-lg bg-muted p-3 text-[12.5px] leading-relaxed text-foreground'>
+              {source}
+            </pre>
+          </div>
+        )}
+
+        {isRendering && (
+          <div className='absolute bottom-2 left-2 flex items-center gap-1 rounded-md bg-background/80 px-2 py-1 text-xs text-muted-foreground shadow-sm'>
+            <div className='h-3 w-3 animate-spin rounded-full border-2 border-blue-500 border-t-transparent' />
+            <span>Updating...</span>
+          </div>
+        )}
+
+        <Dialog
+          open={showPreview}
+          onOpenChange={setShowPreview}
+          title='D2 Diagram Preview'
+          description='Fullscreen preview of the D2 diagram'
+          className='w-[95vw] h-[95vh] max-w-[95vw] max-h-[95vh] p-0'
+        >
+          <button
+            onClick={() => setShowPreview(false)}
+            className='absolute top-4 right-4 z-10 p-2 rounded-full bg-muted hover:bg-secondary transition-colors'
+            aria-label='Close preview'
+            data-track-category='D2'
+            data-track-name='CLOSE_PREVIEW'
+          >
+            <X className='h-5 w-5 text-muted-foreground' />
+          </button>
+          <div className='h-full w-full flex items-center justify-center p-4 overflow-auto rounded-lg'>
+            <div
+              className='d2-diagram flex items-center justify-center w-[90vw] h-[85vh] bg-background rounded-lg m-10'
+              // Override the inline caps so the fullscreen preview scales the
+              // diagram up to fill the modal instead of the compact inline size.
+              style={
+                {
+                  maxWidth: '90vw',
+                  maxHeight: '85vh',
+                  ['--d2-max-w']: '88vw',
+                  ['--d2-max-h']: '82vh',
+                } as CSSProperties
+              }
+              /* eslint-disable-next-line react/no-danger, @typescript-eslint/naming-convention */
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </div>
+        </Dialog>
+      </div>
+    );
+  }
+
+  // No SVG yet: show a spinner while the block is finishing streaming or the
+  // WASM compile is in flight. Once complete, this resolves into a diagram or an
+  // error — it cannot get stuck, because renderD2Diagram always settles both.
+  if (isRendering || isLikelyCompleteD2(source)) {
+    return (
+      <div className='my-4 rounded-xl border border-border/60 bg-muted/30 p-8'>
+        <div className='flex items-center justify-center gap-2'>
+          <div className='animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full' />
+          <p className='text-sm text-muted-foreground'>Rendering diagram...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Still streaming (incomplete) — render nothing rather than a flash of error.
+  return <div className='my-2' />;
+};
+
+export const D2Block = memo(
+  D2BlockComponent,
+  (prev, next) => prev.source === next.source && prev.messageId === next.messageId,
+);

--- a/apps/dashboard/src/components/Markdown/D2Block/D2Block.types.ts
+++ b/apps/dashboard/src/components/Markdown/D2Block/D2Block.types.ts
@@ -1,0 +1,7 @@
+export interface D2BlockProps {
+  /** Raw D2-language source (d2lang.com), NOT the filesystem-tree JSON. */
+  source: string;
+  messageId?: string;
+}
+
+export type ViewMode = 'diagram' | 'code';

--- a/apps/dashboard/src/components/Markdown/D2Block/D2Block.utils.ts
+++ b/apps/dashboard/src/components/Markdown/D2Block/D2Block.utils.ts
@@ -1,0 +1,237 @@
+import type { D2, RenderOptions } from '@terrastruct/d2';
+
+// ─── Lazy WASM loader ─────────────────────────────────────────────────────────
+//
+// The browser build of @terrastruct/d2 is ~7.8MB (the D2 compiler + fonts are
+// embedded as base64 WASM, and the worker is spawned from a Blob — so there is
+// no external .wasm to serve and no Vite worker/wasm config required). We NEVER
+// want that in the initial bundle, so the module is pulled in via dynamic
+// import() the first time a D2 diagram actually renders. Vite code-splits it
+// into its own chunk. The instance (and its worker) is created once and reused.
+
+let d2Promise: Promise<D2> | null = null;
+
+async function getD2(): Promise<D2> {
+  if (!d2Promise) {
+    d2Promise = import('@terrastruct/d2').then(mod => new mod.D2());
+  }
+  return d2Promise;
+}
+
+// ─── Serialization ────────────────────────────────────────────────────────────
+//
+// The @terrastruct/d2 instance is NOT concurrency-safe: its worker keeps a
+// single `currentResolve`/`currentReject` slot (see dist/browser/index.js), so
+// two in-flight compile/render calls clobber each other's promise — one hangs
+// (→ 15s timeout) and responses cross (→ a render receives a compile object →
+// "[object Object]"). A page with N diagrams fires N calls at once and hits
+// exactly that. Funnel every worker op through a single-file queue so only one
+// runs at a time. The worker is single-threaded, so this costs no throughput.
+
+let d2Queue: Promise<unknown> = Promise.resolve();
+
+function runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  const result = d2Queue.then(fn, fn);
+  // Keep the chain alive regardless of this job's outcome so one failure/timeout
+  // doesn't wedge every subsequent diagram.
+  d2Queue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+// Cache rendered SVGs by source so re-renders (view toggles, scroll remounts,
+// identical diagrams) never recompile through the WASM worker. The key is
+// versioned: bump SVG_CACHE_VERSION whenever the compile options or the
+// post-processing in makeSvgResponsive change, so stale SVGs from an earlier
+// build are invalidated instead of being served from this long-lived Map.
+const SVG_CACHE_VERSION = 'v6-animated';
+const svgCache = new Map<string, string>();
+const cacheKey = (source: string, isDark: boolean): string =>
+  `${SVG_CACHE_VERSION}:${isDark ? 'd' : 'l'}:${source}`;
+
+// D2 theme IDs, forced at render time (overrides any theme-id in the source) so
+// the diagram matches the app theme. Light = Neutral default (near-black ink on
+// light). Dark = Dark Flagship Terrastruct — near-white ink #F4F6FA on very dark
+// #000410 (measured 18.9:1 contrast, higher than Dark Mauve's 11.3:1), so labels
+// stay crisp on the transparent dark card.
+const D2_THEME_LIGHT = 0;
+const D2_THEME_DARK = 201;
+
+// Frame interval (ms) for multi-board (steps/scenarios) animations. Matches the
+// D2 blog's default; long enough to read each frame before it transitions.
+const D2_ANIMATE_INTERVAL_MS = 1400;
+
+/**
+ * Heuristic for whether a D2 source looks complete enough to compile. During
+ * streaming, opening braces outrun closing ones; compiling a half-streamed
+ * block just produces noise. Balanced braces (and non-empty) is a cheap, stable
+ * signal that the block has finished streaming.
+ */
+export function isLikelyCompleteD2(source: string): boolean {
+  const trimmed = source.trim();
+  if (!trimmed) return false;
+  let balance = 0;
+  for (const ch of trimmed) {
+    if (ch === '{') balance++;
+    else if (ch === '}') balance--;
+    if (balance < 0) return false; // stray closer — malformed, but let it render+error
+  }
+  return balance === 0;
+}
+
+/**
+ * Cleans up D2's raw SVG for embedding in the Spaces-themed chat:
+ *
+ * 1. Strips D2's opaque full-canvas background rect (the first <rect> inside the
+ *    inner `d2-svg` group — the only one with stroke-width="0"). D2 paints a
+ *    solid theme background (e.g. white `fill-N7`) behind every diagram; removing
+ *    it makes the diagram transparent so it blends with the card instead of
+ *    showing a hard white/colored block.
+ *
+ * 2. Rewrites the outer <svg> to be responsive, centered, and bounded:
+ *    - width:100% up to --d2-max-w → small diagrams grow to a comfortable size,
+ *      wide ones fill the column; never past the cap.
+ *    - height:auto + the viewBox ratio → no distortion.
+ *    - max-height:--d2-max-h → tall diagrams are capped; preserveAspectRatio
+ *      ("meet", which D2 sets) scales the content to fit inside, centered.
+ *
+ * Both caps are CSS variables so the fullscreen preview can override them. Only
+ * the outer <svg> is restyled; the inner one scales along with it.
+ */
+export function makeSvgResponsive(svg: string): string {
+  // 1) Drop D2's opaque board-background rects → transparent diagram. Backgrounds
+  //    are uniquely `stroke-width="0"` + the `fill-N7` neutral class; real nodes
+  //    use B-scale fills, so this never removes a shape. Global (all matches)
+  //    because an animated multi-board SVG has one background per frame — strip
+  //    only the first and later frames flash white.
+  let out = svg.replace(/<rect\b[^>]*\bfill-N7\b[^>]*\sstroke-width="0"[^>]*>(?:<\/rect>)?/g, '');
+  // 2) Responsive + centered + bounded outer <svg>.
+  //    Force preserveAspectRatio to xMidYMid: D2 defaults the outer <svg> to
+  //    "xMinYMin meet", which LEFT-aligns the content whenever the diagram is
+  //    letterboxed (e.g. a tall diagram capped by max-height sitting in a wider
+  //    box). xMidYMid centers it both ways.
+  out = out.replace(/<svg\b([^>]*)>/, (_full, attrs: string) => {
+    const cleaned = attrs
+      .replace(/\s(width|height)="[^"]*"/g, '')
+      .replace(/\sstyle="[^"]*"/g, '')
+      .replace(/\spreserveAspectRatio="[^"]*"/g, '');
+    const style =
+      'width:100%;max-width:var(--d2-max-w,560px);height:auto;' +
+      'max-height:var(--d2-max-h,400px);display:block;margin:0 auto;';
+    return `<svg${cleaned} preserveAspectRatio="xMidYMid meet" style="${style}">`;
+  });
+  return out;
+}
+
+interface RenderD2Params {
+  source: string;
+  isDark: boolean;
+  onSuccess: (svg: string) => void;
+  onError: (error: string) => void;
+  onLoading: (isLoading: boolean) => void;
+}
+
+const RENDER_TIMEOUT_MS = 15000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      v => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      e => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      },
+    );
+  });
+}
+
+/**
+ * Compiles + renders D2-language source to an SVG string. Always resolves the
+ * loading state and always surfaces errors (never an infinite spinner) — the
+ * exact failure mode that made the old filesystem/d2 handler hang on non-JSON.
+ */
+export async function renderD2Diagram({
+  source,
+  isDark,
+  onSuccess,
+  onError,
+  onLoading,
+}: RenderD2Params): Promise<void> {
+  if (!source.trim()) return;
+
+  const cached = svgCache.get(cacheKey(source, isDark));
+  if (cached) {
+    onSuccess(cached);
+    onError('');
+    onLoading(false);
+    return;
+  }
+
+  onLoading(true);
+  try {
+    // One diagram at a time on the shared worker (see runExclusive). The timeout
+    // wraps only the actual worker calls, which start when it's this job's turn
+    // — queue-wait does not count against it.
+    const svg = await runExclusive(async () => {
+      const d2 = await getD2();
+      // Use the fully-typed CompileRequest form ({ fs, options }) — the string
+      // overload's option type is mistyped in @terrastruct/d2's .d.ts (it demands
+      // a nested `options`), so passing flat CompileOptions trips TS2353.
+      const result = await withTimeout(
+        d2.compile({
+          fs: { index: source },
+          options: { layout: 'dagre', pad: 20 },
+        }),
+        RENDER_TIMEOUT_MS,
+        'D2 compile',
+      );
+      // Force the theme at render time (overrides any theme-id in the source) so
+      // the diagram matches the app theme; the opaque background is stripped in
+      // makeSvgResponsive so it sits on the transparent, theme-aware card.
+      const renderOptions: RenderOptions = {
+        ...result.renderOptions,
+        themeID: isDark ? D2_THEME_DARK : D2_THEME_LIGHT,
+        noXMLTag: true,
+      };
+      // Multi-board animation: `steps` (progressive reveal) and `scenarios`
+      // (alternate states) are packaged into ONE animated SVG that cycles through
+      // the boards. This only happens when we render all boards (`target: '*'`)
+      // with a positive `animateInterval` — the default render would drop every
+      // board but the root. (Layers are for click-navigation, not animation, so
+      // they're intentionally left as the root board.)
+      const boardCount =
+        (result.diagram.steps?.length ?? 0) + (result.diagram.scenarios?.length ?? 0);
+      if (boardCount > 0) {
+        renderOptions.target = '*';
+        renderOptions.animateInterval = D2_ANIMATE_INTERVAL_MS;
+      }
+      const rendered = await withTimeout(
+        d2.render(result.diagram, renderOptions),
+        RENDER_TIMEOUT_MS,
+        'D2 render',
+      );
+      if (typeof rendered !== 'string') {
+        // Defensive: should never happen once serialized, but never feed a
+        // non-string to dangerouslySetInnerHTML (that's the "[object Object]").
+        throw new Error('D2 render returned a non-string result');
+      }
+      return makeSvgResponsive(rendered);
+    });
+    svgCache.set(cacheKey(source, isDark), svg);
+    onSuccess(svg);
+    onError('');
+  } catch (err) {
+    console.error('D2 rendering error:', err);
+    onError(err instanceof Error ? err.message : 'Failed to render D2 diagram');
+  } finally {
+    onLoading(false);
+  }
+}
+
+export { copyToClipboard, downloadDiagramAsPng } from '../MermaidBlock/MermaidBlock.utils';

--- a/apps/dashboard/src/components/Markdown/D2Block/index.ts
+++ b/apps/dashboard/src/components/Markdown/D2Block/index.ts
@@ -1,0 +1,2 @@
+export { D2Block } from './D2Block';
+export type { D2BlockProps, ViewMode } from './D2Block.types';

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -191,6 +191,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       sendDisabled = false,
       bottomLeftSlot,
       disableDraftUpload = false,
+      dockSlot,
     },
 
     ref,
@@ -1052,6 +1053,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
           editor?.commands.insertContent(content);
           editor?.commands.focus();
         },
+        getHtml: (): string => editor?.getHTML() ?? '',
         isSuggestionOpen: (): boolean => {
           if (!editor) return false;
           const state = editor.state;
@@ -1409,6 +1411,12 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
             {agentSlot}
           </div>
         </div>
+
+        {/* A detached dock (e.g. the Twin drafts tray) sits above the editor but
+            INSIDE this positioning root, so the activity bar above (which is
+            translated up off this root's top) floats over the whole unit rather
+            than colliding with the dock. */}
+        {dockSlot}
 
         <div
           className={isVoiceRecording ? 'xyne-voice-border-wrap' : undefined}

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
@@ -71,4 +71,9 @@ export interface InputBoxProps {
   /** Extra buttons rendered in the left side of the desktop bottom action bar, after the # button */
   bottomLeftSlot?: React.ReactNode;
   disableDraftUpload?: boolean;
+  /** A detached card rendered directly ABOVE the editor, inside the composer's
+   *  positioning root — e.g. the Twin drafts dock. Placing it here (rather than as
+   *  an outside sibling) lets the composer's single activity indicator float above
+   *  the whole unit instead of colliding with it. */
+  dockSlot?: React.ReactNode;
 }

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2708,6 +2708,22 @@ img.inline-emoji,
   padding-left: 6px !important;
 }
 
+/* When markdown is posted as a real chat message (e.g. a Digital Twin reply),
+   it renders in a MessageBubble alongside plain HTML messages. Strip the
+   standalone-answer spacing — the container's top/bottom margin, the last
+   paragraph's trailing margin, and the left indent — so it sits as tight as a
+   normal message. Inter-paragraph spacing (8px) is kept for multi-paragraph
+   replies; the AI-sidebar answer styling (outside any MessageBubble) is untouched. */
+[data-component="MessageBubble"] .bot-markdown-content {
+  margin: 0 !important;
+}
+[data-component="MessageBubble"] .bot-markdown-content p {
+  padding-left: 0 !important;
+}
+[data-component="MessageBubble"] .bot-markdown-content p:last-child {
+  margin-bottom: 0 !important;
+}
+
 .bot-markdown-content ol,
 .bot-markdown-content-call-summary ol {
   /* Enough inline space for 2–3 digit markers (10+) — default outside markers + narrow

--- a/apps/dashboard/src/hooks/useBoardTicketNav.ts
+++ b/apps/dashboard/src/hooks/useBoardTicketNav.ts
@@ -73,7 +73,11 @@ export function useBoardTicketNav(ticketId: string): BoardTicketNavState {
         }),
         { type: 'complete' },
       )) as KanbanTicketsPageRow[];
-      return rows.map(r => ({ id: r.id, conversationId: r.conversationId, createdAt: r.createdAt }));
+      return rows.map(r => ({
+        id: r.id,
+        conversationId: r.conversationId,
+        createdAt: r.createdAt,
+      }));
     },
     [baseArgs, columnType, zero],
   );

--- a/apps/dashboard/src/hooks/useDragAndDropAreaRef.ts
+++ b/apps/dashboard/src/hooks/useDragAndDropAreaRef.ts
@@ -9,6 +9,10 @@ export interface InputBoxHandle {
   insertContent: (content: string) => void;
   isSuggestionOpen: () => boolean;
   focus: () => void;
+  /** Current editor HTML — used to snapshot in-progress content before a
+   *  temporary takeover (e.g. editing a Twin draft in place) so it can be
+   *  restored losslessly, including keystrokes not yet flushed to the draft. */
+  getHtml?: () => string;
 }
 
 interface UseDragAndDropAreaRefReturn {

--- a/apps/dashboard/src/hooks/useTicketKeysetWindow.ts
+++ b/apps/dashboard/src/hooks/useTicketKeysetWindow.ts
@@ -22,14 +22,7 @@ export interface TicketKeysetWindow<Row> {
 export function useTicketKeysetWindow<Row, Cursor>(
   args: UseTicketKeysetWindowArgs<Row, Cursor>,
 ): TicketKeysetWindow<Row> {
-  const {
-    currentId,
-    currentRow,
-    seed,
-    radius = 5,
-    pageSize = 10,
-    enabled = true,
-  } = args;
+  const { currentId, currentRow, seed, radius = 5, pageSize = 10, enabled = true } = args;
 
   const fnRef = useRef(args);
   fnRef.current = args;
@@ -104,7 +97,7 @@ export function useTicketKeysetWindow<Row, Cursor>(
 
   if (idx === -1) return { prev: null, next: null };
   return {
-    prev: idx > 0 ? buffer[idx - 1] ?? null : null,
-    next: idx < buffer.length - 1 ? buffer[idx + 1] ?? null : null,
+    prev: idx > 0 ? (buffer[idx - 1] ?? null) : null,
+    next: idx < buffer.length - 1 ? (buffer[idx + 1] ?? null) : null,
   };
 }

--- a/apps/dashboard/src/hooks/useTwinReplyDraft.ts
+++ b/apps/dashboard/src/hooks/useTwinReplyDraft.ts
@@ -1,41 +1,25 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useSelector } from '@xstate/react';
-import { stateMachineActor } from '../../../machines/stateMachine';
+import { stateMachineActor } from '../machines/stateMachine';
 import {
   approveTwinReplyDraft,
   declineTwinReplyDraft,
   rowToTwinReplyDraftView,
   type TwinReplyDraftView,
   type PostedTarget,
-} from './twinReplyDraftApi';
+} from '../components/Chat/TwinReplyDraft/twinReplyDraftApi';
 
 const EMPTY: TwinReplyDraftView[] = [];
 
 export interface TwinReplyDraftState {
-  /** This thread's pending Twin proposals, newest-first (may be empty). A thread
-   *  can hold several — one per @mention of the twin. */
   drafts: TwinReplyDraftView[];
   hasDraft: boolean;
-  /** Draft ids with an approve/decline currently in flight (per-card spinners). */
   pending: ReadonlySet<string>;
-  /** Approve one draft (by id) — posts/reacts as the user, resolves with where it
-   *  landed (null for react-only). The row clears itself via Zero on success. */
   approve: (draftId: string, editedMessage?: string) => Promise<PostedTarget | null>;
-  /** Decline one draft (by id) — records feedback, clears the row. */
   decline: (draftId: string) => Promise<void>;
 }
 
-/**
- * The caller's OWN pending Digital Twin reply proposals for a thread, read
- * straight from Zero-synced state (the `twinDrafts` slice → draft_messages rows
- * with origin='twin'). Proposals appear and clear LIVE via Zero replication — no
- * bespoke fetch or socket. Owner-only: the twinDrafts query is scoped to the
- * authenticated user, so only the owner's proposals are ever in state.
- */
 export function useTwinReplyDraft(conversationId: string | undefined): TwinReplyDraftState {
-  // Subscribe to the whole slice (a stable ref that only changes when the set of
-  // proposals changes), then derive this thread's views with useMemo — avoids a
-  // new array on every unrelated state-machine event.
   const allTwinDrafts = useSelector(stateMachineActor, state => state.context.twinDrafts);
 
   const drafts = useMemo(() => {

--- a/apps/dashboard/src/machines/stateMachine.ts
+++ b/apps/dashboard/src/machines/stateMachine.ts
@@ -16,6 +16,7 @@ export {
 export type {
   DraftMessage,
   DraftMessages,
+  TwinDraftDB,
   User,
   Bookmarks,
   VisibleChannel,

--- a/apps/dashboard/src/pages/DraftsAndSentPage/DraftsAndSentPage.tsx
+++ b/apps/dashboard/src/pages/DraftsAndSentPage/DraftsAndSentPage.tsx
@@ -2,13 +2,14 @@ import { type ReactElement, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useSelector } from '@xstate/react';
 import DraftsPanel from '../../components/Chat/DraftsPanel/DraftsPanel';
+import TwinDraftsPanel from '../../components/Chat/DraftsPanel/TwinDraftsPanel';
 import SentPanel from '../../components/Chat/SentPanel/SentPanel';
 import DelayedMessagesPanel from '../../components/Chat/DelayedMessagesPanel/DelayedMessagesPanel';
 import { stateMachineActor } from '../../machines/stateMachine';
 import { usePendingDelayedMessagesCount } from '../../hooks/useUserDelayedMessages';
 import { cn } from '../../utils/classNames';
 
-type TabValue = 'drafts' | 'scheduled' | 'sent';
+type TabValue = 'drafts' | 'twin' | 'scheduled' | 'sent';
 
 const DraftsAndSentPage = (): ReactElement => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -22,10 +23,12 @@ const DraftsAndSentPage = (): ReactElement => {
   );
 
   const draftsCount = useSelector(stateMachineActor, state => state.context.draftMessages.length);
+  const twinDraftsCount = useSelector(stateMachineActor, state => state.context.twinDrafts.length);
   const pendingScheduledCount = usePendingDelayedMessagesCount();
 
   const tabOptions = [
     { value: 'drafts' as TabValue, label: 'Drafts', count: draftsCount },
+    { value: 'twin' as TabValue, label: 'Twin drafts', count: twinDraftsCount },
     { value: 'scheduled' as TabValue, label: 'Scheduled', count: pendingScheduledCount },
     { value: 'sent' as TabValue, label: 'Sent' },
   ];
@@ -68,6 +71,7 @@ const DraftsAndSentPage = (): ReactElement => {
 
       <div className='flex-1 min-h-0 overflow-hidden'>
         {activeTab === 'drafts' && <DraftsPanel />}
+        {activeTab === 'twin' && <TwinDraftsPanel />}
         {activeTab === 'scheduled' && <DelayedMessagesPanel />}
         {activeTab === 'sent' && <SentPanel />}
       </div>

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -380,6 +380,10 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
     queries.getUserGroupMappingsByUserId(),
   );
 
+  // One owner-scoped subscription for all of the user's drafts — composer drafts
+  // (origin='user') and Digital Twin proposals (origin='twin'). The stateMachine
+  // splits them by origin into draftMessages / twinDrafts, so pending proposals
+  // arrive/clear live via the same Zero replication — no bespoke fetch/socket.
   const [userDrafts, userDraftsDetails] = useCachedQuery(queries.userDrafts(), { ttl: '10m' });
   const [userDelayedMessages, userDelayedMessagesDetails] = useCachedQuery(
     queries.userDelayedMessages(),

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -6,6 +6,7 @@ import type { Element } from 'hast';
 import type { Components } from 'react-markdown';
 import { MermaidBlock } from '../components/Markdown/MermaidBlock';
 import { FilesystemBlock } from '../components/Markdown/FilesystemBlock';
+import { D2Block } from '../components/Markdown/D2Block';
 import { ClawCitationGroup } from '../components/Chat/XyneAISidebar/components/ClawCitationGroup';
 import { ThreadCitationChip } from '../components/ui/MessageBubble/ThreadCitationChip';
 import { parseCiteGroupHref } from '../components/ui/TipTapExtensions/CitationMark';
@@ -56,13 +57,31 @@ const CodeBlock = ({
     );
   }
 
-  // ── Filesystem interactive graph ──
-  if (language === 'filesystem' || language === 'd2') {
+  // ── Filesystem interactive graph (nested JSON tree) ──
+  if (language === 'filesystem') {
     return (
       <FilesystemBlock
         jsonSource={codeString}
         messageId={(props as { messageId: string }).messageId}
       />
+    );
+  }
+
+  // ── D2 fence ──
+  // The `d2` fence historically aliased the filesystem JSON renderer, but agents
+  // (esp. ask-ai v2) legitimately emit real D2-language source here. Route by
+  // content: a JSON object → the drillable FilesystemBlock (back-compat); any
+  // other D2 source → the real D2 (@terrastruct/d2 WASM) renderer. The sniff is
+  // on the first non-space char so it stays stable across streaming deltas.
+  if (language === 'd2') {
+    const looksLikeFilesystemJson = codeString.trimStart().startsWith('{');
+    return looksLikeFilesystemJson ? (
+      <FilesystemBlock
+        jsonSource={codeString}
+        messageId={(props as { messageId: string }).messageId}
+      />
+    ) : (
+      <D2Block source={codeString} messageId={(props as { messageId: string }).messageId} />
     );
   }
 

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -46,6 +46,12 @@ export default defineConfig({
   build: {
     manifest: true
   },
+  optimizeDeps: {
+    // @terrastruct/d2's browser build is a ~7.8MB self-contained bundle (base64
+    // WASM + a Blob-spawned worker). It's loaded lazily via dynamic import(), so
+    // keep esbuild's dev prebundler from trying to transform the whole blob.
+    exclude: ['@terrastruct/d2'],
+  },
   server: {
     port: 5173,
     host: true,

--- a/apps/xyne-claw-auth/backend/src/lib/twin-delivery.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/twin-delivery.ts
@@ -65,7 +65,14 @@ export async function executeTwinApprovalDelivery(
 
   const messageContent = ctx.messageContent ?? "";
   const edited = opts.editedContent?.trim();
-  const finalContent = willReply ? (edited && edited.length > 0 ? edited : messageContent) : "";
+  // Trim the model-generated draft too (not just the edited text) so leading/
+  // trailing whitespace/newlines never get posted — the composer path already
+  // trims, this makes the un-edited "Send" path match.
+  const finalContent = willReply
+    ? edited && edited.length > 0
+      ? edited
+      : messageContent.trim()
+    : "";
   const wasEdited = willReply && !!edited && edited.length > 0 && edited !== messageContent.trim();
 
   const s2sKey = process.env["INTERNAL_S2S_KEY"] ?? "";

--- a/packages/shared/src/machines/index.ts
+++ b/packages/shared/src/machines/index.ts
@@ -44,6 +44,7 @@ export {
 export type {
   DraftMessage,
   DraftMessages,
+  TwinDraftDB,
   User,
   Bookmarks,
   VisibleChannel,

--- a/packages/shared/src/machines/stateMachine.ts
+++ b/packages/shared/src/machines/stateMachine.ts
@@ -65,6 +65,12 @@ export type UserChannelStatus = QueryResultType<typeof queries.getAllChannelsUse
 export type Conversation = QueryResultType<typeof queries.channelConversationsPaginatedV3>[number];
 
 export type DraftMessageDB = QueryResultType<typeof queries.userDrafts>[number];
+/**
+ * A pending Digital Twin reply proposal (origin='twin' row in draft_messages).
+ * Same row shape as a composer draft — `userDrafts` fetches both origins in one
+ * subscription and the stateMachine partitions them by `origin`.
+ */
+export type TwinDraftDB = DraftMessageDB;
 export type DelayedMessageDB = QueryResultType<typeof queries.userDelayedMessages>[number];
 export type UnreadActivity = QueryResultType<typeof queries.userUnreadActivities>[number];
 export type UserPreference = QueryResultType<typeof queries.getCurrentUserPreference>;
@@ -197,6 +203,7 @@ interface StateMachineContext {
   savedRoutes: Record<string, string>;
   drafts: DraftMessages; // Draft messages per channel/conversation
   draftMessages: DraftMessageDB[];
+  twinDrafts: TwinDraftDB[]; // pending Digital Twin reply proposals (origin='twin')
   delayedMessages: DelayedMessageDB[];
   userPreference: UserPreference;
   allUserGroups: UserGroup[];
@@ -481,16 +488,27 @@ export const stateMachine = setup({
         return context.currentUserRoleIds;
       },
     }),
+    // Single `userDrafts` subscription carries both origins; split it here so the
+    // composer/Drafts UI (draftMessages) never sees twin proposals (twinDrafts).
+    // "twin is explicit, everything else is a user draft" — a null origin is a
+    // legacy (pre-migration) user draft and belongs in draftMessages.
     addUserDrafts: assign({
       draftMessages: ({ context, event }) => {
         if (event.type === 'ADD_USER_DRAFTS') {
           return event.draftMessages.filter(d => {
+            if (d.origin === 'twin') return false;
             const hasContent = d.content.trim() !== '';
             const hasAttachments = (d.attachments?.length ?? 0) > 0;
             return hasContent || hasAttachments;
           });
         }
         return context.draftMessages;
+      },
+      twinDrafts: ({ context, event }) => {
+        if (event.type === 'ADD_USER_DRAFTS') {
+          return event.draftMessages.filter(d => d.origin === 'twin');
+        }
+        return context.twinDrafts;
       },
     }),
     addUserDelayedMessages: assign({
@@ -689,6 +707,7 @@ export const stateMachine = setup({
       allUserGroups: [],
       userGroupMappings: [],
       draftMessages: [],
+      twinDrafts: [],
       delayedMessages: [],
       unreadActivities: [],
       filteredTicketIds: [],
@@ -741,6 +760,7 @@ export const stateMachine = setup({
     })(),
     drafts: JSON.parse(draftStorage().getItem(DRAFT_STORAGE_KEY) || '{}') as DraftMessages,
     draftMessages: [],
+    twinDrafts: [],
     delayedMessages: [],
     userPreference: undefined,
     allUserGroups: [],

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -909,6 +909,7 @@ export const mutators = defineMutators({
             userId: ctx.userID,
             content: draftMessage,
             hasAttachment: draft?.hasAttachment || false,
+            origin: 'user',
             updatedAt: timestamp,
             createdAt: draft?.createdAt || timestamp,
           });
@@ -2984,6 +2985,7 @@ export const mutators = defineMutators({
             userId: ctx.userID,
             content: content || '',
             hasAttachment: true,
+            origin: 'user',
             createdAt: timestamp,
             updatedAt: timestamp,
           });
@@ -3533,6 +3535,7 @@ export const mutators = defineMutators({
             userId: ctx.userID,
             content: draftMessage,
             hasAttachment: draft?.hasAttachment || false,
+            origin: 'user',
             updatedAt: timestamp,
             createdAt: draft?.createdAt || timestamp,
           });
@@ -10628,6 +10631,7 @@ export const mutators = defineMutators({
           userId: ctx.userID,
           content: scheduled.content,
           hasAttachment,
+          origin: 'user',
           createdAt: timestamp,
           updatedAt: timestamp,
         });

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -57,6 +57,7 @@ import {
   Status,
   OrgRole,
   DelayedMessageStatus,
+  DraftOrigin,
   Schema,
   CollectionRole,
   VCSProviderType,
@@ -909,7 +910,7 @@ export const mutators = defineMutators({
             userId: ctx.userID,
             content: draftMessage,
             hasAttachment: draft?.hasAttachment || false,
-            origin: 'user',
+            origin: DraftOrigin.user,
             updatedAt: timestamp,
             createdAt: draft?.createdAt || timestamp,
           });
@@ -2985,7 +2986,7 @@ export const mutators = defineMutators({
             userId: ctx.userID,
             content: content || '',
             hasAttachment: true,
-            origin: 'user',
+            origin: DraftOrigin.user,
             createdAt: timestamp,
             updatedAt: timestamp,
           });
@@ -3535,7 +3536,7 @@ export const mutators = defineMutators({
             userId: ctx.userID,
             content: draftMessage,
             hasAttachment: draft?.hasAttachment || false,
-            origin: 'user',
+            origin: DraftOrigin.user,
             updatedAt: timestamp,
             createdAt: draft?.createdAt || timestamp,
           });
@@ -10631,7 +10632,7 @@ export const mutators = defineMutators({
           userId: ctx.userID,
           content: scheduled.content,
           hasAttachment,
-          origin: 'user',
+          origin: DraftOrigin.user,
           createdAt: timestamp,
           updatedAt: timestamp,
         });

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2114,11 +2114,6 @@ export const queries = defineQueries({
     return zql.activities.where('isRead', false).orderBy('updatedAt', 'desc').related('channel');
   }),
   userDrafts: defineQuery(({ ctx }) => {
-    // All of the caller's OWN draft_messages rows, both origins: composer drafts
-    // (origin='user') and pending Digital Twin proposals (origin='twin', whose
-    // userId IS the mentioned owner). A single owner-scoped query keeps one Zero
-    // subscription; the stateMachine splits them into `draftMessages` (user) and
-    // `twinDrafts` (twin) so the composer/Drafts UI never sees twin rows.
     return zql.draft_messages.where('userId', ctx.userID).related('attachments');
   }),
   // Query for message with sender and channel info for activity display

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2114,6 +2114,11 @@ export const queries = defineQueries({
     return zql.activities.where('isRead', false).orderBy('updatedAt', 'desc').related('channel');
   }),
   userDrafts: defineQuery(({ ctx }) => {
+    // All of the caller's OWN draft_messages rows, both origins: composer drafts
+    // (origin='user') and pending Digital Twin proposals (origin='twin', whose
+    // userId IS the mentioned owner). A single owner-scoped query keeps one Zero
+    // subscription; the stateMachine splits them into `draftMessages` (user) and
+    // `twinDrafts` (twin) so the composer/Drafts UI never sees twin rows.
     return zql.draft_messages.where('userId', ctx.userID).related('attachments');
   }),
   // Query for message with sender and channel info for activity display

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1802,12 +1802,7 @@ export const messageAttachmentTable = table('message_attachments')
   })
   .primaryKey('id');
 
-/** Who authored a draft_messages row. Backed by a real Postgres enum
- *  (Prisma `DraftOrigin`). Declared as a string `enum` (not a bare union) so the
- *  Prisma↔Zero schema-sync check finds a matching `export enum`; the column below
- *  is typed via the `` `${DraftOrigin}` `` value-union so bare 'user'/'twin'
- *  literals stay assignable across the mutators/queries (a bare enum type would
- *  reject them). Extend by adding a member (and the Prisma enum + a migration). */
+// @ts-ignore TS1294
 export enum DraftOrigin {
   user = 'user',
   twin = 'twin',
@@ -1823,7 +1818,7 @@ export const draftMessageTable = table('draft_messages')
     userId: string(),
     content: string(),
     hasAttachment: boolean(),
-    origin: enumeration<`${DraftOrigin}`>().optional(), // 'user' | 'twin' | null (legacy = user)
+    origin: enumeration<DraftOrigin>().optional(),
     metadata: string().optional(), // twin-only: stringified JSON TwinReplyDraft payload
     createdAt: number(),
     updatedAt: number(),

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1802,6 +1802,17 @@ export const messageAttachmentTable = table('message_attachments')
   })
   .primaryKey('id');
 
+/** Who authored a draft_messages row. Backed by a real Postgres enum
+ *  (Prisma `DraftOrigin`). Declared as a string `enum` (not a bare union) so the
+ *  Prisma↔Zero schema-sync check finds a matching `export enum`; the column below
+ *  is typed via the `` `${DraftOrigin}` `` value-union so bare 'user'/'twin'
+ *  literals stay assignable across the mutators/queries (a bare enum type would
+ *  reject them). Extend by adding a member (and the Prisma enum + a migration). */
+export enum DraftOrigin {
+  user = 'user',
+  twin = 'twin',
+}
+
 export const draftMessageTable = table('draft_messages')
   .columns({
     workspaceId: string().optional(), // denormalized tenant key (nullable; stamped on insert)
@@ -1812,6 +1823,8 @@ export const draftMessageTable = table('draft_messages')
     userId: string(),
     content: string(),
     hasAttachment: boolean(),
+    origin: enumeration<`${DraftOrigin}`>().optional(), // 'user' | 'twin' | null (legacy = user)
+    metadata: string().optional(), // twin-only: stringified JSON TwinReplyDraft payload
     createdAt: number(),
     updatedAt: number(),
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,6 +760,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.2
         version: 3.14.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@terrastruct/d2':
+        specifier: ^0.1.33
+        version: 0.1.33
       '@tiptap/core':
         specifier: 3.29.2
         version: 3.29.2(@tiptap/pm@3.29.2)
@@ -8429,6 +8432,9 @@ packages:
   '@teppeis/multimaps@3.0.0':
     resolution: {integrity: sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==}
     engines: {node: '>=14'}
+
+  '@terrastruct/d2@0.1.33':
+    resolution: {integrity: sha512-eK5hyfGIJFolC7sUsiKvWdY9xGFctTe3d+PSijo09IYDso8psztC+A4SammizXtlwYZpnnW0AtDjfBYauceSeA==}
 
   '@tiptap/core@3.29.2':
     resolution: {integrity: sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==}
@@ -27623,6 +27629,8 @@ snapshots:
   '@tanstack/virtual-core@3.17.7': {}
 
   '@teppeis/multimaps@3.0.0': {}
+
+  '@terrastruct/d2@0.1.33': {}
 
   '@tiptap/core@3.29.2(@tiptap/pm@3.29.2)':
     dependencies:


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #59 (original author: @Pradeesh333).

## PR: Digital Twin reply drafts and thread catch-up recap

  Adds an in-thread Digital Twin assist dock for suggested replies and AI thread recaps.

  - Twin proposals are private, owner-only drafts synced through Zero.
  - Drafts appear in the relevant thread and as badges in thread lists.
  - Users can review, edit, send, reject, and inspect “Why?” reasoning.
  - Sending uses the approve flow, preserving the Twin’s intended destination and feedback loop.
  - Thread recaps are channel-gated, generated by the backend, cached in Redis, and suggested for newly added participants.
  - Adds D2 markdown diagram rendering.
  - Restores the rounded-composer layered dock effect.

  ### Draft dock behavior

  - A pending Twin draft creates a slim header above the composer.
  - The dock is tucked behind the composer; clicking its header expands it upward.
  - The composer stays rounded in the foreground.
  - Multiple proposals can be paged through.
  - Edit opens the real composer with the draft text; Send approves it, Reject removes it.
  - Recap and Reply share the same dock as tabs when both are available.
  
testing: https://drive.google.com/file/d/1JlJ9ccxeDcodQm1TUA-OuFrMGSBSo5PJ/view?usp=drive_link