### PR TITLE
fix: scope flow-action webhook lookup to a configured install row

### DIFF
--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -65,18 +65,25 @@ export class FlowController {
       // 4. Look up the installed app to get its webhook/action URL.
       // Webhook is configured per-app, but there can be multiple InstalledApps
       // rows for the same appId (e.g. one per workspace) and only some carry a
-      // webhookUrl. Scope to the acting user's workspace and require a configured
-      // webhook so we don't non-deterministically pick a row whose webhookUrl is
-      // null/empty (which surfaced as a spurious "No webhook URL configured" 502
-      // even though the app's webhook was set). Mirrors the scoping used by
-      // configureWebhook / updateInstalledApp.
+      // webhookUrl. The lookup MUST be scoped to the acting user's workspace and
+      // require a configured webhook so we never non-deterministically pick
+      // another tenant's install row (tenant-isolation, relevant for OSS /
+      // multi-tenant deployments) or a row whose webhookUrl is null/empty (which
+      // surfaced as a spurious "No webhook URL configured" 502 even though the
+      // app's webhook was set). Mirrors configureWebhook / updateInstalledApp.
       const workspaceId = req.user?.workspaceId;
+      if (!workspaceId) {
+        // No workspace on the authenticated user — refuse rather than fall back
+        // to an unscoped, cross-tenant lookup.
+        res.status(400).json({ error: 'Workspace not found for user' });
+        return;
+      }
       const installedApp = await repositories.installedApps.findFirst({
         where: {
           appId,
           webhookUrl: { not: null },
           AND: [{ webhookUrl: { not: '' } }],
-          ...(workspaceId ? { user: { workspaceId } } : {}),
+          user: { workspaceId },
         },
       });
       if (!installedApp?.webhookUrl) {

--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -62,10 +62,22 @@ export class FlowController {
         return;
       }
 
-      // 4. Look up the installed app to get its webhook/action URL
-      // Note: Webhook is configured per-app, not per-user
+      // 4. Look up the installed app to get its webhook/action URL.
+      // Webhook is configured per-app, but there can be multiple InstalledApps
+      // rows for the same appId (e.g. one per workspace) and only some carry a
+      // webhookUrl. Scope to the acting user's workspace and require a configured
+      // webhook so we don't non-deterministically pick a row whose webhookUrl is
+      // null/empty (which surfaced as a spurious "No webhook URL configured" 502
+      // even though the app's webhook was set). Mirrors the scoping used by
+      // configureWebhook / updateInstalledApp.
+      const workspaceId = req.user?.workspaceId;
       const installedApp = await repositories.installedApps.findFirst({
-        where: { appId },
+        where: {
+          appId,
+          webhookUrl: { not: null },
+          AND: [{ webhookUrl: { not: '' } }],
+          ...(workspaceId ? { user: { workspaceId } } : {}),
+        },
       });
       if (!installedApp?.webhookUrl) {
         res.status(502).json({ error: `No webhook URL configured for app: ${appId}` });


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #31 (original author: @XyneSpaces).

1. Problem Description:
Clicking "Approve" on an installed-app HITL flow card (e.g. reg-watch-v2's `spaces-upload-to-kb`) returns HTTP 502 `No webhook URL configured for app: <appId>`, even though the app's webhook is configured and the agent's normal chat/mention replies work fine.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Production logs: `POST /api/apps/flow/action` -> 502 with `serverError: No webhook URL configured for app: cmr22edbs0ckvclp745wpqvhj` for multiple users, while the same app's mention webhook (`.../claw/api/v1/webhook/app/<appId>`) returned 200 in the same window. Root cause traced to `FlowController.executeAction`.

3. Explain the solution implemented in the PR:
`FlowController.executeAction` resolved the app webhook via an unscoped `repositories.installedApps.findFirst({ where: { appId } })`. There can be multiple `InstalledApps` rows for one `appId` (e.g. one per workspace / per install) and only some carry a `webhookUrl`; the unscoped lookup could non-deterministically return a row whose `webhookUrl` is null/empty, producing the spurious 502. The app-mention path never hit this because it scopes to the bot user + non-null webhookUrl (`findWithWebhooksByUserIds`).

Fix: scope the lookup to the acting user's workspace and require a non-null, non-empty `webhookUrl`, mirroring the scoping already used by `configureWebhook` and `updateInstalledApp` (`user: { workspaceId }`). File: `apps/backend/src/apps/controllers/flowController.ts`.

4. Documentation: N/A

5. DB Alter Details (if any): N/A

6. Data fix Details (if any):
Optional immediate mitigation without deploy: set/re-save the app's webhook on the affected install row(s) via `POST /api/apps/configureWebhook/:appId` or `PATCH /api/apps/installed/:installedAppId` so the null rows get backfilled. Not required once this code fix ships.

7. Environment variable Changes (if any): N/A

8. Testing (how it was tested; screenshots/links):
Local: patched file passes esbuild syntax check. Recommend adding an integration test: an app with >=2 InstalledApps rows where only the bot/workspace row has a webhookUrl, assert `/api/apps/flow/action` resolves the row with the webhook (200) instead of 502. Full backend typecheck was not run in-sandbox due to an unrelated prebake issue (missing generated prisma-common client).

9. Services to which this change is to be deployed:
xyne-backend (Spaces backend / apps API).

10. Main PR link (if this PR is raised against a release branch): N/A (targets main)