### PR TITLE
feature: user-configurable keyboard shortcuts synced via user_preferences

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1375,6 +1375,7 @@ export const userPreferenceTable = table("user_preferences")
     threadReplyNotificationsEnabled: boolean(),
     channelWideMentionsEnabled: boolean(),
     notificationKeywords: string().optional(),
+    keyboardShortcuts: string().optional(), // Per-user shortcut overrides (stringified JSON map)
     createdAt: number(),
     updatedAt: number(),
   })

--- a/apps/backend/prisma/migrations/20260801120000_add_user_preference_keyboard_shortcuts/migration.sql
+++ b/apps/backend/prisma/migrations/20260801120000_add_user_preference_keyboard_shortcuts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: per-user keyboard shortcut overrides (stringified JSON map, sparse)
+ALTER TABLE "public"."user_preferences" ADD COLUMN "keyboardShortcuts" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1334,6 +1334,7 @@ model UserPreference {
   threadReplyNotificationsEnabled Boolean           @default(true) // Receive thread reply notifications globally
   channelWideMentionsEnabled      Boolean           @default(true) // Receive @channel and @here mention notifications
   notificationKeywords            String?             // Global keyword-notification list (max 50, each <= 80 chars)
+  keyboardShortcuts               String?             // Per-user keyboard shortcut overrides: stringified JSON map { [shortcutId]: string[] }. Sparse — only remapped shortcuts.
   createdAt               DateTime @default(now())
   updatedAt               DateTime @updatedAt
 

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -13871,6 +13871,42 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           }
         },
       ),
+      setKeyboardShortcuts: defineMutator(
+        z.object({
+          id: z.string(),
+          keyboardShortcuts: z.string(),
+          timestamp: z.number(),
+        }),
+        async ({ tx, args: { id, keyboardShortcuts, timestamp } }) => {
+          const existing = await tx.run(
+            zql.user_preferences.where('userId', authData.sub).one(),
+          );
+          if (existing) {
+            await tx.mutate.user_preferences.update({
+              id: existing.id,
+              keyboardShortcuts,
+              updatedAt: timestamp,
+            });
+          } else {
+            await tx.mutate.user_preferences.insert({
+              workspaceId: authData.workspaceId,
+              id,
+              userId: authData.sub,
+              channelSortOrder: ChannelSortOrder.RECENCY,
+              enterSendsMessage: true,
+              allowThreadBroadcastMentions: false,
+              globalDesktopNotificationLevel: NotificationLevel.MENTIONS_ONLY,
+              globalMobileNotificationLevel: NotificationLevel.MENTIONS_ONLY,
+              threadReplyNotificationsEnabled: true,
+              channelWideMentionsEnabled: true,
+              notificationKeywords: '[]',
+              keyboardShortcuts,
+              createdAt: timestamp,
+              updatedAt: timestamp,
+            });
+          }
+        },
+      ),
       setEnterSendsMessage: defineMutator(
         z.object({
           id: z.string(),

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -1138,9 +1138,9 @@ const ShortcutRow: FC<{
             {isUnbound ? (
               <span className='text-xs text-muted-foreground'>Unbound</span>
             ) : (
-              resolvedKeys.slice(0, 1).map(combo => (
-                <KeyCap key={combo}>{formatCombo(combo, isMac)}</KeyCap>
-              ))
+              resolvedKeys
+                .slice(0, 1)
+                .map(combo => <KeyCap key={combo}>{formatCombo(combo, isMac)}</KeyCap>)
             )}
           </button>
         )}
@@ -1284,7 +1284,6 @@ const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
     </div>
   );
 };
-
 
 const SECTIONS: Record<PreferenceSection, FC<{ state: PreferencesState }>> = {
   appearance: AppearanceSection,

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -55,12 +55,7 @@ import { Badge } from '../../ui/Badge/Badge';
 
 import { usePreferencesState, type PreferencesState } from '../../../hooks/usePreferencesState';
 import { useShortcutConfig } from '../../../hooks/useShortcutConfig';
-import {
-  getShortcutsByCategory,
-  shortcuts,
-  scopesOverlap,
-  findActionsForCombo,
-} from '../../../shortcuts';
+import { getShortcutsByCategory, shortcuts, scopesOverlap } from '../../../shortcuts';
 import type { ShortcutId, ShortcutDefinition } from '../../../shortcuts';
 import {
   CALL_MEDIA_QUALITY_OPTIONS,
@@ -1062,10 +1057,10 @@ const formatCombo = (combo: string, isMac: boolean): string =>
 // Categories intentionally hidden from the user-facing configurator.
 const HIDDEN_SHORTCUT_CATEGORIES = new Set(['Viewer']);
 
-// Combos the browser or OS usually claim before the page ever sees them. In the
-// browser the playground can only warn about these; it cannot actually test
-// them (the keydown never reaches Xyne). Stored in the platform-neutral
-// `mod+...` form produced by serializeKeyEvent.
+// Combos the browser or OS usually claim before the page ever sees them. The
+// settings page can only warn about these on the row that binds them; it cannot
+// reliably rebind them (the keydown never reaches Xyne). Stored in the
+// platform-neutral `mod+...` form produced by serializeKeyEvent.
 const BROWSER_RESERVED_COMBOS = new Set<string>([
   'mod+w',
   'mod+t',
@@ -1123,6 +1118,9 @@ const ShortcutRow: FC<{
   onReset,
 }) => {
   const isUnbound = resolvedKeys.length === 0;
+  // Browser/OS-reserved combos (e.g. ⌘W) are usually intercepted before the
+  // page ever receives the keydown, so warn right on the row that binds them.
+  const reservedCombo = resolvedKeys.find(combo => BROWSER_RESERVED_COMBOS.has(combo));
   return (
     <div className='flex items-center justify-between gap-4 py-2'>
       <div className='min-w-0'>
@@ -1137,6 +1135,12 @@ const ShortcutRow: FC<{
         {isCapturing && conflictLabel && (
           <p className='text-xs text-destructive mt-0.5'>
             Already used by “{conflictLabel}”. Try another combination.
+          </p>
+        )}
+        {reservedCombo && !isCapturing && (
+          <p className='text-xs text-amber-600 dark:text-amber-500 mt-0.5'>
+            {formatCombo(reservedCombo, isMac)} may be intercepted by your browser or OS before Xyne
+            receives it.
           </p>
         )}
       </div>
@@ -1181,13 +1185,10 @@ const ShortcutRow: FC<{
 };
 
 const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
-  const { isMac, isElectron } = usePlatform();
+  const { isMac } = usePlatform();
   const { overrides, setOverride, resetOverride, resetAll, isCustomized } = useShortcutConfig();
   const [capturingId, setCapturingId] = useState<ShortcutId | null>(null);
   const [conflictLabel, setConflictLabel] = useState<string | null>(null);
-  // Playground: press any combo to see what it maps to, without assigning it.
-  const [isTesting, setIsTesting] = useState(false);
-  const [testCombo, setTestCombo] = useState<string | null>(null);
 
   const grouped = useMemo(() => getShortcutsByCategory(), []);
 
@@ -1245,60 +1246,6 @@ const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [capturingId, overrides]);
 
-  // Playground capture: listen for a single combo, then show what it maps to.
-  // Kept separate from the row-capture listener above so testing never writes
-  // an override.
-  useEffect(() => {
-    if (!isTesting) return;
-
-    const onKeyDown = (event: KeyboardEvent): void => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (event.key === 'Escape') {
-        setIsTesting(false);
-        return;
-      }
-
-      const combo = serializeKeyEvent(event);
-      if (!combo) return; // still holding only modifiers
-
-      setTestCombo(combo);
-      setIsTesting(false);
-    };
-
-    window.addEventListener('keydown', onKeyDown, true);
-    return () => window.removeEventListener('keydown', onKeyDown, true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isTesting]);
-
-  // Override-aware reverse lookup for the combo under test.
-  const testMatches = useMemo(
-    () => (testCombo ? findActionsForCombo(testCombo, resolveKeys) : []),
-    // resolveKeys reads `overrides`, so re-run when either changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [testCombo, overrides],
-  );
-
-  // A hard collision is two actions bound to this combo in the *same* scope
-  // where at least one is unconditional (no `when` guard) — only then can both
-  // fire in the same context. Cross-scope matches are disambiguated by scope
-  // precedence and are reported as context-dependent, not as errors.
-  const testHardCollision = useMemo(() => {
-    for (let i = 0; i < testMatches.length; i += 1) {
-      for (let j = i + 1; j < testMatches.length; j += 1) {
-        const a = testMatches[i];
-        const b = testMatches[j];
-        if (!a || !b) continue;
-        if (a.scope === b.scope && !(a.hasWhen && b.hasWhen)) return true;
-      }
-    }
-    return false;
-  }, [testMatches]);
-
-  const testCrossScope = testMatches.length > 1 && !testHardCollision;
-  const testReserved = testCombo ? BROWSER_RESERVED_COMBOS.has(testCombo) : false;
-
   const hasAnyCustom = Object.keys(overrides).length > 0;
 
   return (
@@ -1322,81 +1269,6 @@ const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
           >
             Reset all
           </Button>
-        )}
-      </div>
-
-      <div className='rounded-lg border border-border bg-muted/20 p-3 space-y-2'>
-        <div className='flex items-center justify-between gap-4'>
-          <div className='min-w-0'>
-            <p className='text-sm font-medium text-foreground'>Test a shortcut</p>
-            <p className='text-xs text-muted-foreground'>
-              Press any combination to see what it does in Xyne — nothing is saved.
-            </p>
-          </div>
-          <button
-            type='button'
-            onClick={() => {
-              setTestCombo(null);
-              setIsTesting(true);
-            }}
-            className='inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 hover:bg-muted transition-colors shrink-0'
-            aria-label='Test a shortcut'
-            data-track-category='PREFERENCES'
-            data-track-name='TestShortcut'
-          >
-            {isTesting ? (
-              <span className='text-xs text-primary animate-pulse'>
-                Press keys… (Esc to cancel)
-              </span>
-            ) : testCombo ? (
-              <KeyCap>{formatCombo(testCombo, isMac)}</KeyCap>
-            ) : (
-              <span className='text-xs text-muted-foreground'>Press a shortcut</span>
-            )}
-          </button>
-        </div>
-
-        {testCombo && !isTesting && (
-          <div className='space-y-1 text-xs'>
-            {testMatches.length === 0 ? (
-              <p className='text-muted-foreground'>
-                No Xyne action uses this combination — it’s free to assign.
-              </p>
-            ) : (
-              <ul className='space-y-0.5'>
-                {testMatches.map(match => (
-                  <li key={match.id} className='text-foreground'>
-                    Triggers <span className='font-medium'>{match.description}</span>
-                    <span className='text-muted-foreground'> · {match.scope}</span>
-                  </li>
-                ))}
-              </ul>
-            )}
-
-            {testHardCollision && (
-              <p className='text-destructive'>
-                Conflict: more than one action is bound to this combination in the same scope.
-              </p>
-            )}
-
-            {testCrossScope && (
-              <p className='text-muted-foreground'>
-                Context-dependent — Xyne runs the action for whichever surface is active.
-              </p>
-            )}
-
-            {testReserved && (
-              <p className='text-amber-600 dark:text-amber-500'>
-                Your browser or OS may intercept this combination before Xyne receives it.
-              </p>
-            )}
-
-            {isElectron && (
-              <p className='text-muted-foreground'>
-                Desktop system-level shortcut detection is not enabled yet.
-              </p>
-            )}
-          </div>
         )}
       </div>
 

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -20,6 +20,7 @@ import {
   Shield,
   Eye,
   EyeOff,
+  Keyboard,
 } from 'lucide-react';
 import {
   NotificationLevel,
@@ -53,6 +54,9 @@ import { useNotificationKeywords } from '../../../hooks/useNotificationKeywords'
 import { Badge } from '../../ui/Badge/Badge';
 
 import { usePreferencesState, type PreferencesState } from '../../../hooks/usePreferencesState';
+import { useShortcutConfig } from '../../../hooks/useShortcutConfig';
+import { getShortcutsByCategory, shortcuts } from '../../../shortcuts';
+import type { ShortcutId, ShortcutDefinition } from '../../../shortcuts';
 import {
   CALL_MEDIA_QUALITY_OPTIONS,
   type CallMediaQuality,
@@ -87,6 +91,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'calendar', label: 'Calendar', icon: <Calendar className='size-4' /> },
   { id: 'password', label: 'Password', icon: <Shield className='size-4' /> },
   { id: 'developer', label: 'Developer', icon: <Code2 className='size-4' /> },
+  { id: 'shortcuts', label: 'Shortcuts', icon: <Keyboard className='size-4' /> },
 ];
 
 const THEMES: Array<{ id: Theme; label: string; bg: string }> = [
@@ -1035,6 +1040,252 @@ const ToolbarSection: FC<{ state: PreferencesState }> = () => {
 };
 
 // ─── Section registry ───────────────────────────────────────────────────────
+// ─── Shortcuts ──────────────────────────────────────────────────────────────
+
+// Human-readable rendering of a platform-neutral combo (e.g. 'mod+shift+space').
+const formatCombo = (combo: string, isMac: boolean): string =>
+  combo
+    .replace('mod+', isMac ? '⌘' : 'Ctrl+')
+    .replace('shift+', isMac ? '⇧' : 'Shift+')
+    .replace('alt+', isMac ? '⌥' : 'Alt+')
+    .replace('ctrl+', isMac ? '⌃' : 'Ctrl+')
+    .split('+')
+    .map(part => part.trim())
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(isMac ? ' ' : ' + ');
+
+// Categories intentionally hidden from the user-facing configurator.
+const HIDDEN_SHORTCUT_CATEGORIES = new Set(['Viewer']);
+
+// Turn a raw keydown into a platform-neutral combo string, ordered
+// mod → shift → alt → key to match the catalog convention. Returns null while
+// only modifier keys are held (so the capture waits for a real key).
+const serializeKeyEvent = (event: KeyboardEvent): string | null => {
+  const { key, code } = event;
+  if (['Meta', 'Control', 'Shift', 'Alt', 'OS'].includes(key)) return null;
+
+  const tokens: string[] = [];
+  if (event.metaKey || event.ctrlKey) tokens.push('mod');
+  if (event.shiftKey) tokens.push('shift');
+  if (event.altKey) tokens.push('alt');
+
+  let main = '';
+  if (code === 'Space' || key === ' ') main = 'space';
+  else if (/^Key[A-Z]$/.test(code)) main = code.slice(3).toLowerCase();
+  else if (/^Digit[0-9]$/.test(code)) main = code.slice(5);
+  else if (key.startsWith('Arrow')) main = key.slice(5).toLowerCase();
+  else if (key.length === 1) main = key.toLowerCase();
+  else main = key.toLowerCase();
+
+  if (!main) return null;
+  tokens.push(main);
+  return tokens.join('+');
+};
+
+const ShortcutRow: FC<{
+  id: ShortcutId;
+  description: string;
+  resolvedKeys: string[];
+  isMac: boolean;
+  isCustomized: boolean;
+  isCapturing: boolean;
+  conflictLabel: string | null;
+  onStartCapture: () => void;
+  onReset: () => void;
+}> = ({
+  id,
+  description,
+  resolvedKeys,
+  isMac,
+  isCustomized,
+  isCapturing,
+  conflictLabel,
+  onStartCapture,
+  onReset,
+}) => {
+  const isUnbound = resolvedKeys.length === 0;
+  return (
+    <div className='flex items-center justify-between gap-4 py-2'>
+      <div className='min-w-0'>
+        <div className='flex items-center gap-2'>
+          <p className='text-sm text-foreground truncate'>{description}</p>
+          {isCustomized && (
+            <Badge variant='secondary' className='text-[10px] px-1.5 py-0'>
+              Custom
+            </Badge>
+          )}
+        </div>
+        {isCapturing && conflictLabel && (
+          <p className='text-xs text-destructive mt-0.5'>
+            Already used by “{conflictLabel}”. Try another combination.
+          </p>
+        )}
+      </div>
+
+      <div className='flex items-center gap-2 shrink-0'>
+        {isCapturing ? (
+          <span className='text-xs text-primary animate-pulse'>Press keys… (Esc to cancel)</span>
+        ) : (
+          <button
+            type='button'
+            onClick={onStartCapture}
+            className='inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 hover:bg-muted transition-colors'
+            data-track-category='PREFERENCES'
+            data-track-name='EditShortcut'
+            data-track-metadata={JSON.stringify({ shortcutId: id })}
+            aria-label={`Edit shortcut: ${description}`}
+          >
+            {isUnbound ? (
+              <span className='text-xs text-muted-foreground'>Unbound</span>
+            ) : (
+              resolvedKeys.slice(0, 1).map(combo => (
+                <KeyCap key={combo}>{formatCombo(combo, isMac)}</KeyCap>
+              ))
+            )}
+          </button>
+        )}
+        {isCustomized && !isCapturing && (
+          <button
+            type='button'
+            onClick={onReset}
+            className='text-xs text-muted-foreground hover:text-foreground transition-colors'
+            data-track-category='PREFERENCES'
+            data-track-name='ResetShortcut'
+            data-track-metadata={JSON.stringify({ shortcutId: id })}
+          >
+            Reset
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
+  const { isMac } = usePlatform();
+  const { overrides, setOverride, resetOverride, resetAll, isCustomized } = useShortcutConfig();
+  const [capturingId, setCapturingId] = useState<ShortcutId | null>(null);
+  const [conflictLabel, setConflictLabel] = useState<string | null>(null);
+
+  const grouped = useMemo(() => getShortcutsByCategory(), []);
+
+  // Effective binding for a shortcut: user override wins over the catalog default.
+  const resolveKeys = (id: ShortcutId): string[] => {
+    const override = overrides[id];
+    if (override) return override;
+    const defKeys = shortcuts[id]?.keys ?? [];
+    return Array.isArray(defKeys) ? defKeys : [defKeys];
+  };
+
+  // Return the description of a conflicting shortcut in an overlapping scope, else null.
+  const findConflict = (combo: string, targetId: ShortcutId): string | null => {
+    const targetScope = shortcuts[targetId]?.scope ?? 'global';
+    for (const rawId of Object.keys(shortcuts) as ShortcutId[]) {
+      if (rawId === targetId) continue;
+      const definition = shortcuts[rawId] as ShortcutDefinition;
+      const scope = definition.scope ?? 'global';
+      const overlaps = scope === targetScope || scope === 'global' || targetScope === 'global';
+      if (!overlaps) continue;
+      if (resolveKeys(rawId).includes(combo)) return definition.description ?? rawId;
+    }
+    return null;
+  };
+
+  useEffect(() => {
+    if (!capturingId) return;
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (event.key === 'Escape') {
+        setCapturingId(null);
+        setConflictLabel(null);
+        return;
+      }
+
+      const combo = serializeKeyEvent(event);
+      if (!combo) return; // still holding only modifiers
+
+      const conflict = findConflict(combo, capturingId);
+      if (conflict) {
+        setConflictLabel(conflict);
+        return; // block save on conflict; user tries another combo
+      }
+
+      setOverride(capturingId, [combo]);
+      setCapturingId(null);
+      setConflictLabel(null);
+    };
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [capturingId, overrides]);
+
+  const hasAnyCustom = Object.keys(overrides).length > 0;
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-start justify-between gap-4'>
+        <SectionHeader
+          title='Shortcuts'
+          subtitle='Customize keyboard shortcuts. Changes sync across your devices.'
+        />
+        {hasAnyCustom && (
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={() => {
+              resetAll();
+              setCapturingId(null);
+              setConflictLabel(null);
+            }}
+            data-track-category='PREFERENCES'
+            data-track-name='ResetAllShortcuts'
+          >
+            Reset all
+          </Button>
+        )}
+      </div>
+
+      {Object.entries(grouped)
+        .filter(([category]) => !HIDDEN_SHORTCUT_CATEGORIES.has(category))
+        .map(([category, items]) => {
+          const rows = items.filter(item => item.description);
+          if (rows.length === 0) return null;
+          return (
+            <div key={category} className='rounded-lg border border-border bg-muted/20 px-3'>
+              <p className='text-xs font-semibold uppercase tracking-wide text-muted-foreground pt-3 pb-1'>
+                {category}
+              </p>
+              <div className='divide-y divide-border/60'>
+                {rows.map(item => (
+                  <ShortcutRow
+                    key={item.id}
+                    id={item.id}
+                    description={item.description ?? item.id}
+                    resolvedKeys={resolveKeys(item.id)}
+                    isMac={isMac}
+                    isCustomized={isCustomized(item.id)}
+                    isCapturing={capturingId === item.id}
+                    conflictLabel={capturingId === item.id ? conflictLabel : null}
+                    onStartCapture={() => {
+                      setConflictLabel(null);
+                      setCapturingId(item.id);
+                    }}
+                    onReset={() => resetOverride(item.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+    </div>
+  );
+};
+
+
 const SECTIONS: Record<PreferenceSection, FC<{ state: PreferencesState }>> = {
   appearance: AppearanceSection,
   notifications: NotificationsSection,
@@ -1048,6 +1299,7 @@ const SECTIONS: Record<PreferenceSection, FC<{ state: PreferencesState }>> = {
   calendar: CalendarSection,
   password: PasswordSection as FC<{ state: PreferencesState }>,
   developer: DeveloperSection,
+  shortcuts: ShortcutsSection,
 };
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -55,7 +55,12 @@ import { Badge } from '../../ui/Badge/Badge';
 
 import { usePreferencesState, type PreferencesState } from '../../../hooks/usePreferencesState';
 import { useShortcutConfig } from '../../../hooks/useShortcutConfig';
-import { getShortcutsByCategory, shortcuts } from '../../../shortcuts';
+import {
+  getShortcutsByCategory,
+  shortcuts,
+  scopesOverlap,
+  findActionsForCombo,
+} from '../../../shortcuts';
 import type { ShortcutId, ShortcutDefinition } from '../../../shortcuts';
 import {
   CALL_MEDIA_QUALITY_OPTIONS,
@@ -1057,6 +1062,20 @@ const formatCombo = (combo: string, isMac: boolean): string =>
 // Categories intentionally hidden from the user-facing configurator.
 const HIDDEN_SHORTCUT_CATEGORIES = new Set(['Viewer']);
 
+// Combos the browser or OS usually claim before the page ever sees them. In the
+// browser the playground can only warn about these; it cannot actually test
+// them (the keydown never reaches Xyne). Stored in the platform-neutral
+// `mod+...` form produced by serializeKeyEvent.
+const BROWSER_RESERVED_COMBOS = new Set<string>([
+  'mod+w',
+  'mod+t',
+  'mod+n',
+  'mod+shift+n',
+  'mod+shift+t',
+  'mod+shift+w',
+  'mod+q',
+]);
+
 // Turn a raw keydown into a platform-neutral combo string, ordered
 // mod → shift → alt → key to match the catalog convention. Returns null while
 // only modifier keys are held (so the capture waits for a real key).
@@ -1162,10 +1181,13 @@ const ShortcutRow: FC<{
 };
 
 const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
-  const { isMac } = usePlatform();
+  const { isMac, isElectron } = usePlatform();
   const { overrides, setOverride, resetOverride, resetAll, isCustomized } = useShortcutConfig();
   const [capturingId, setCapturingId] = useState<ShortcutId | null>(null);
   const [conflictLabel, setConflictLabel] = useState<string | null>(null);
+  // Playground: press any combo to see what it maps to, without assigning it.
+  const [isTesting, setIsTesting] = useState(false);
+  const [testCombo, setTestCombo] = useState<string | null>(null);
 
   const grouped = useMemo(() => getShortcutsByCategory(), []);
 
@@ -1184,7 +1206,7 @@ const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
       if (rawId === targetId) continue;
       const definition = shortcuts[rawId] as ShortcutDefinition;
       const scope = definition.scope ?? 'global';
-      const overlaps = scope === targetScope || scope === 'global' || targetScope === 'global';
+      const overlaps = scopesOverlap(scope, targetScope);
       if (!overlaps) continue;
       if (resolveKeys(rawId).includes(combo)) return definition.description ?? rawId;
     }
@@ -1223,6 +1245,60 @@ const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [capturingId, overrides]);
 
+  // Playground capture: listen for a single combo, then show what it maps to.
+  // Kept separate from the row-capture listener above so testing never writes
+  // an override.
+  useEffect(() => {
+    if (!isTesting) return;
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (event.key === 'Escape') {
+        setIsTesting(false);
+        return;
+      }
+
+      const combo = serializeKeyEvent(event);
+      if (!combo) return; // still holding only modifiers
+
+      setTestCombo(combo);
+      setIsTesting(false);
+    };
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isTesting]);
+
+  // Override-aware reverse lookup for the combo under test.
+  const testMatches = useMemo(
+    () => (testCombo ? findActionsForCombo(testCombo, resolveKeys) : []),
+    // resolveKeys reads `overrides`, so re-run when either changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [testCombo, overrides],
+  );
+
+  // A hard collision is two actions bound to this combo in the *same* scope
+  // where at least one is unconditional (no `when` guard) — only then can both
+  // fire in the same context. Cross-scope matches are disambiguated by scope
+  // precedence and are reported as context-dependent, not as errors.
+  const testHardCollision = useMemo(() => {
+    for (let i = 0; i < testMatches.length; i += 1) {
+      for (let j = i + 1; j < testMatches.length; j += 1) {
+        const a = testMatches[i];
+        const b = testMatches[j];
+        if (!a || !b) continue;
+        if (a.scope === b.scope && !(a.hasWhen && b.hasWhen)) return true;
+      }
+    }
+    return false;
+  }, [testMatches]);
+
+  const testCrossScope = testMatches.length > 1 && !testHardCollision;
+  const testReserved = testCombo ? BROWSER_RESERVED_COMBOS.has(testCombo) : false;
+
   const hasAnyCustom = Object.keys(overrides).length > 0;
 
   return (
@@ -1246,6 +1322,81 @@ const ShortcutsSection: FC<{ state: PreferencesState }> = () => {
           >
             Reset all
           </Button>
+        )}
+      </div>
+
+      <div className='rounded-lg border border-border bg-muted/20 p-3 space-y-2'>
+        <div className='flex items-center justify-between gap-4'>
+          <div className='min-w-0'>
+            <p className='text-sm font-medium text-foreground'>Test a shortcut</p>
+            <p className='text-xs text-muted-foreground'>
+              Press any combination to see what it does in Xyne — nothing is saved.
+            </p>
+          </div>
+          <button
+            type='button'
+            onClick={() => {
+              setTestCombo(null);
+              setIsTesting(true);
+            }}
+            className='inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-1 hover:bg-muted transition-colors shrink-0'
+            aria-label='Test a shortcut'
+            data-track-category='PREFERENCES'
+            data-track-name='TestShortcut'
+          >
+            {isTesting ? (
+              <span className='text-xs text-primary animate-pulse'>
+                Press keys… (Esc to cancel)
+              </span>
+            ) : testCombo ? (
+              <KeyCap>{formatCombo(testCombo, isMac)}</KeyCap>
+            ) : (
+              <span className='text-xs text-muted-foreground'>Press a shortcut</span>
+            )}
+          </button>
+        </div>
+
+        {testCombo && !isTesting && (
+          <div className='space-y-1 text-xs'>
+            {testMatches.length === 0 ? (
+              <p className='text-muted-foreground'>
+                No Xyne action uses this combination — it’s free to assign.
+              </p>
+            ) : (
+              <ul className='space-y-0.5'>
+                {testMatches.map(match => (
+                  <li key={match.id} className='text-foreground'>
+                    Triggers <span className='font-medium'>{match.description}</span>
+                    <span className='text-muted-foreground'> · {match.scope}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {testHardCollision && (
+              <p className='text-destructive'>
+                Conflict: more than one action is bound to this combination in the same scope.
+              </p>
+            )}
+
+            {testCrossScope && (
+              <p className='text-muted-foreground'>
+                Context-dependent — Xyne runs the action for whichever surface is active.
+              </p>
+            )}
+
+            {testReserved && (
+              <p className='text-amber-600 dark:text-amber-500'>
+                Your browser or OS may intercept this combination before Xyne receives it.
+              </p>
+            )}
+
+            {isElectron && (
+              <p className='text-muted-foreground'>
+                Desktop system-level shortcut detection is not enabled yet.
+              </p>
+            )}
+          </div>
         )}
       </div>
 

--- a/apps/dashboard/src/components/Settings/Preferences/index.ts
+++ b/apps/dashboard/src/components/Settings/Preferences/index.ts
@@ -12,7 +12,8 @@ export type PreferenceSection =
   | 'toolbar'
   | 'calendar'
   | 'password'
-  | 'developer';
+  | 'developer'
+  | 'shortcuts';
 
 export interface PreferencesProps {
   open: boolean;

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -362,8 +362,20 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
         .split('+')
         .map(part => part.trim())
         .filter(Boolean);
-      const MODIFIER_TOKENS = ['mod', 'meta', 'cmd', 'command', 'ctrl', 'control', 'shift', 'alt', 'option'];
-      const needMod = parts.some(p => ['mod', 'meta', 'cmd', 'command', 'ctrl', 'control'].includes(p));
+      const MODIFIER_TOKENS = [
+        'mod',
+        'meta',
+        'cmd',
+        'command',
+        'ctrl',
+        'control',
+        'shift',
+        'alt',
+        'option',
+      ];
+      const needMod = parts.some(p =>
+        ['mod', 'meta', 'cmd', 'command', 'ctrl', 'control'].includes(p),
+      );
       const needShift = parts.includes('shift');
       const needAlt = parts.some(p => ['alt', 'option'].includes(p));
       const mainKey = parts.find(p => !MODIFIER_TOKENS.includes(p)) ?? '';

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -67,7 +67,7 @@ import { usePlatform } from '../../../hooks/usePlatform';
 import { MobileEditor } from './MobileEditor';
 import { useTypingState } from '../../../contexts/TypingStateContext';
 import { validateFile } from '../utils/files';
-import { useScope, useShortcutById } from '../../../shortcuts';
+import { useScope, useShortcutById, useResolvedShortcutCombo } from '../../../shortcuts';
 import { useEnterSendsMessage } from '../../../hooks/useEnterSendsMessage';
 import { Preferences } from '../../Settings/Preferences';
 import { Dialog } from '../Dialog';
@@ -336,6 +336,10 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
 
     useShortcutById('composer.voiceInput', () => voiceInputRef.current?.toggle());
 
+    // Override-aware push-to-talk combo (default mod+shift+space). Reading it from
+    // the registry means a user remap in Settings rebinds this hold gesture live.
+    const voiceHoldCombo = useResolvedShortcutCombo('composer.voiceInputHold');
+
     useEffect(() => {
       if (!isVoiceRecording) return;
       const onKeyDown = (e: KeyboardEvent): void => {
@@ -351,11 +355,34 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
     useEffect(() => {
       if (disabled) return;
 
+      // Parse the (possibly user-remapped) combo, e.g. 'mod+shift+space'. `mod`
+      // maps to Meta OR Control so the same binding works on macOS and Windows.
+      const parts = voiceHoldCombo
+        .toLowerCase()
+        .split('+')
+        .map(part => part.trim())
+        .filter(Boolean);
+      const MODIFIER_TOKENS = ['mod', 'meta', 'cmd', 'command', 'ctrl', 'control', 'shift', 'alt', 'option'];
+      const needMod = parts.some(p => ['mod', 'meta', 'cmd', 'command', 'ctrl', 'control'].includes(p));
+      const needShift = parts.includes('shift');
+      const needAlt = parts.some(p => ['alt', 'option'].includes(p));
+      const mainKey = parts.find(p => !MODIFIER_TOKENS.includes(p)) ?? '';
+      if (!mainKey) return; // no non-modifier key → nothing to hold
+
+      const isMainKey = (e: KeyboardEvent): boolean =>
+        mainKey === 'space'
+          ? e.code === 'Space'
+          : e.key.toLowerCase() === mainKey || e.code === `Key${mainKey.toUpperCase()}`;
+
       const HOLD_TO_TALK_MS = 700;
       let armTimer: number | null = null;
       let gestureActive = false; // this gesture is the one that started recording
-      const pressed = { mod: false, shift: false, space: false };
-      const comboHeld = (): boolean => pressed.mod && pressed.shift && pressed.space;
+      const pressed = { mod: false, shift: false, alt: false, main: false };
+      const comboHeld = (): boolean =>
+        (!needMod || pressed.mod) &&
+        (!needShift || pressed.shift) &&
+        (!needAlt || pressed.alt) &&
+        pressed.main;
 
       const clearArm = (): void => {
         if (armTimer !== null) {
@@ -375,10 +402,13 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       const onKeyDown = (e: KeyboardEvent): void => {
         if (e.key === 'Meta' || e.key === 'Control') pressed.mod = true;
         if (e.key === 'Shift') pressed.shift = true;
-        if (e.code === 'Space') pressed.space = true;
+        if (e.key === 'Alt') pressed.alt = true;
+        if (isMainKey(e)) pressed.main = true;
 
-        if (e.code !== 'Space') return;
-        if (!(e.metaKey || e.ctrlKey) || !e.shiftKey) return;
+        if (!isMainKey(e)) return;
+        if (needMod && !(e.metaKey || e.ctrlKey)) return;
+        if (needShift && !e.shiftKey) return;
+        if (needAlt && !e.altKey) return;
         if (e.isComposing) return; // don't fight IME composition
         e.preventDefault();
         if (e.repeat) return; // ignore auto-repeat — arm once per physical press
@@ -395,14 +425,16 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       const onKeyUp = (e: KeyboardEvent): void => {
         if (e.key === 'Meta' || e.key === 'Control') pressed.mod = false;
         if (e.key === 'Shift') pressed.shift = false;
-        if (e.code === 'Space') pressed.space = false;
+        if (e.key === 'Alt') pressed.alt = false;
+        if (isMainKey(e)) pressed.main = false;
         if (!comboHeld()) endGesture();
       };
 
       const onInterrupt = (): void => {
         pressed.mod = false;
         pressed.shift = false;
-        pressed.space = false;
+        pressed.alt = false;
+        pressed.main = false;
         endGesture();
       };
 
@@ -418,7 +450,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
         window.removeEventListener('blur', onInterrupt);
         document.removeEventListener('visibilitychange', onInterrupt);
       };
-    }, [disabled]);
+    }, [disabled, voiceHoldCombo]);
 
     const handleTyping = onTyping;
 

--- a/apps/dashboard/src/hooks/useShortcutConfig.ts
+++ b/apps/dashboard/src/hooks/useShortcutConfig.ts
@@ -33,7 +33,7 @@ export interface UseShortcutConfig {
 export const useShortcutConfig = (): UseShortcutConfig => {
   const zero = useZero();
   const userPreference = useSelector(stateMachineActor, state => state.context.userPreference);
-  const raw = (userPreference?.keyboardShortcuts) ?? null;
+  const raw = userPreference?.keyboardShortcuts ?? null;
 
   const overrides = useMemo(() => parseShortcutOverrides(raw), [raw]);
 

--- a/apps/dashboard/src/hooks/useShortcutConfig.ts
+++ b/apps/dashboard/src/hooks/useShortcutConfig.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { useSelector } from '@xstate/react';
+
+import { useZero } from './useZero';
+import { mutators } from '../zero/mutators';
+import { stateMachineActor } from '../machines/stateMachine';
+import { parseShortcutOverrides } from '../shortcuts/overridesStore';
+import type { ShortcutOverrideMap } from '../shortcuts/overridesStore';
+import type { ShortcutId } from '../shortcuts/catalog';
+
+/**
+ * Read/write hook for the user's keyboard-shortcut overrides, backed by
+ * `user_preferences.keyboardShortcuts` (a stringified JSON map) via the
+ * `userPreference.setKeyboardShortcuts` Zero mutator.
+ *
+ * The whole sparse map is persisted on every change — it is tiny and always read
+ * as a unit — mirroring the existing single-column preference mutators. Writes
+ * propagate through Zero → stateMachine → ShortcutsProvider, which is what makes
+ * a remap take effect live and sync across the user's devices.
+ */
+export interface UseShortcutConfig {
+  overrides: ShortcutOverrideMap;
+  /** Set (or replace) the binding for a shortcut. Pass `[]` to unbind it. */
+  setOverride: (id: ShortcutId, keys: string[]) => void;
+  /** Remove the override so the shortcut falls back to its catalog default. */
+  resetOverride: (id: ShortcutId) => void;
+  /** Clear every override (restore all defaults). */
+  resetAll: () => void;
+  /** True when the shortcut currently has a user override. */
+  isCustomized: (id: ShortcutId) => boolean;
+}
+
+export const useShortcutConfig = (): UseShortcutConfig => {
+  const zero = useZero();
+  const userPreference = useSelector(stateMachineActor, state => state.context.userPreference);
+  const raw = (userPreference?.keyboardShortcuts) ?? null;
+
+  const overrides = useMemo(() => parseShortcutOverrides(raw), [raw]);
+
+  const persist = (next: ShortcutOverrideMap): void => {
+    void zero.mutate(
+      mutators.userPreference.setKeyboardShortcuts({
+        id: userPreference?.id ?? crypto.randomUUID(),
+        keyboardShortcuts: JSON.stringify(next),
+        timestamp: Date.now(),
+      }),
+    );
+  };
+
+  const setOverride = (id: ShortcutId, keys: string[]): void => {
+    persist({ ...overrides, [id]: keys });
+  };
+
+  const resetOverride = (id: ShortcutId): void => {
+    const next = { ...overrides };
+    delete next[id];
+    persist(next);
+  };
+
+  const resetAll = (): void => {
+    persist({});
+  };
+
+  const isCustomized = (id: ShortcutId): boolean => overrides[id] !== undefined;
+
+  return { overrides, setOverride, resetOverride, resetAll, isCustomized };
+};

--- a/apps/dashboard/src/providers/ShortcutsProvider.tsx
+++ b/apps/dashboard/src/providers/ShortcutsProvider.tsx
@@ -1,9 +1,11 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { HotkeysProvider, useHotkeys } from 'react-hotkeys-hook';
 import { useSelector } from '@xstate/react';
 import { shortcutsActor } from '../machines/shortcutsMachine';
 import { getUseKeyForShortcut, resolveShortcut } from '../shortcuts/shortcutsRegistry';
 import { usePlatform } from '../hooks/usePlatform';
+import { stateMachineActor } from '../machines/stateMachine';
+import { parseShortcutOverrides, setShortcutOverrides } from '../shortcuts/overridesStore';
 
 const APP_SCOPE = 'app';
 
@@ -92,6 +94,18 @@ export const ShortcutsProvider = ({
     (a, b) => a === b || (a.length === b.length && a.every((k, i) => k === b[i])),
   );
   const { isMobile, isMac } = usePlatform();
+
+  // Mirror the user's persisted keyboard-shortcut overrides into the live
+  // registry store. Runs once here (the provider wraps the whole app), so a
+  // remap made on any client — or synced from another device via Zero — takes
+  // effect immediately without a reload.
+  const persistedShortcutOverrides = useSelector(
+    stateMachineActor,
+    state => state.context.userPreference?.keyboardShortcuts,
+  );
+  useEffect(() => {
+    setShortcutOverrides(parseShortcutOverrides(persistedShortcutOverrides ?? null));
+  }, [persistedShortcutOverrides]);
 
   if (isMobile) {
     return <>{children}</>;

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -491,41 +491,7 @@ export const findConflicts = (): Array<{ key: string; scope: string; ids: Shortc
 /**
  * Two scopes "overlap" (can be active at the same time) when they are the same
  * scope, or when either is `global` — global shortcuts are live in every scope.
- * Single source of truth for collision checks, shared by the settings
- * configurator and the shortcut playground so the two never drift.
+ * Single source of truth for the settings configurator's collision check.
  */
 export const scopesOverlap = (a: ShortcutScope, b: ShortcutScope): boolean =>
   a === b || a === 'global' || b === 'global';
-
-export interface ComboMatch {
-  id: ShortcutId;
-  description: string;
-  scope: ShortcutScope;
-  hasWhen: boolean;
-}
-
-/**
- * Reverse lookup for the shortcut playground: every catalog action whose
- * *effective* binding (override-aware, via the supplied resolver) includes
- * `combo`. `hasWhen` reports whether the action is guarded by a runtime
- * predicate, which lets the playground tell a genuine ambiguity apart from a
- * context-disambiguated binding.
- */
-export const findActionsForCombo = (
-  combo: string,
-  resolveKeys: (id: ShortcutId) => string[],
-): ComboMatch[] => {
-  const matches: ComboMatch[] = [];
-  (Object.keys(shortcuts) as ShortcutId[]).forEach(id => {
-    if (resolveKeys(id).includes(combo)) {
-      const def = shortcuts[id] as ShortcutDefinition;
-      matches.push({
-        id,
-        description: def.description ?? id,
-        scope: def.scope ?? 'global',
-        hasWhen: typeof def.when === 'function',
-      });
-    }
-  });
-  return matches;
-};

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -139,6 +139,19 @@ export const shortcuts = {
     category: 'Composer',
     preventDefault: true,
   },
+  // Push-to-talk: HOLD this combo to dictate, release to stop. Handled by a raw
+  // key listener in the composer (a hold gesture, not a keydown dispatch), so it
+  // is NOT registered via useShortcutById — but it lives in the catalog so it is
+  // listed in the shortcut configurator and remappable like any other binding.
+  'composer.voiceInputHold': {
+    keys: 'mod+shift+space',
+    scope: 'composer',
+    allowInInputs: true,
+    priority: 100,
+    description: 'Hold to talk (push-to-talk voice input)',
+    category: 'Composer',
+    preventDefault: true,
+  },
   'global.toggleBrowser': {
     keys: 'mod+shift+b',
     scope: 'global',

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -485,3 +485,47 @@ export const findConflicts = (): Array<{ key: string; scope: string; ids: Shortc
 
   return conflicts;
 };
+
+// ─── Playground / collision helpers ─────────────────────────────────────────
+
+/**
+ * Two scopes "overlap" (can be active at the same time) when they are the same
+ * scope, or when either is `global` — global shortcuts are live in every scope.
+ * Single source of truth for collision checks, shared by the settings
+ * configurator and the shortcut playground so the two never drift.
+ */
+export const scopesOverlap = (a: ShortcutScope, b: ShortcutScope): boolean =>
+  a === b || a === 'global' || b === 'global';
+
+export interface ComboMatch {
+  id: ShortcutId;
+  description: string;
+  scope: ShortcutScope;
+  hasWhen: boolean;
+}
+
+/**
+ * Reverse lookup for the shortcut playground: every catalog action whose
+ * *effective* binding (override-aware, via the supplied resolver) includes
+ * `combo`. `hasWhen` reports whether the action is guarded by a runtime
+ * predicate, which lets the playground tell a genuine ambiguity apart from a
+ * context-disambiguated binding.
+ */
+export const findActionsForCombo = (
+  combo: string,
+  resolveKeys: (id: ShortcutId) => string[],
+): ComboMatch[] => {
+  const matches: ComboMatch[] = [];
+  (Object.keys(shortcuts) as ShortcutId[]).forEach(id => {
+    if (resolveKeys(id).includes(combo)) {
+      const def = shortcuts[id] as ShortcutDefinition;
+      matches.push({
+        id,
+        description: def.description ?? id,
+        scope: def.scope ?? 'global',
+        hasWhen: typeof def.when === 'function',
+      });
+    }
+  });
+  return matches;
+};

--- a/apps/dashboard/src/shortcuts/hooks.ts
+++ b/apps/dashboard/src/shortcuts/hooks.ts
@@ -1,9 +1,18 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
 import { shortcutsActor } from '../machines/shortcutsMachine';
 import { registerShortcut } from './shortcutsRegistry';
 import type { ShortcutScope, ShortcutRegistration } from './shortcutsRegistry';
 import { shortcuts } from './catalog';
 import type { ShortcutDefinition, ShortcutId } from './catalog';
+import { getShortcutOverrides, subscribeShortcutOverrides } from './overridesStore';
+
+/**
+ * Subscribe to the live per-user override map. Returns a stable snapshot whose
+ * identity only changes when the user remaps a shortcut, so downstream `keys`
+ * references stay referentially stable between renders.
+ */
+const useShortcutOverrideMap = (): ReturnType<typeof getShortcutOverrides> =>
+  useSyncExternalStore(subscribeShortcutOverrides, getShortcutOverrides, getShortcutOverrides);
 
 export const useShortcut = (
   keys: ShortcutRegistration['keys'],
@@ -80,12 +89,36 @@ export const useShortcutById = (
   handler: (event: KeyboardEvent) => void,
   overrides: ShortcutOverrides = {},
 ): void => {
+  const overrideMap = useShortcutOverrideMap();
   const definition = shortcuts[id];
-  const { keys, ...baseConfig } = definition || { keys: '' };
+  const { keys: catalogKeys, ...baseConfig } = definition || { keys: '' };
 
-  useShortcut(keys, handler, {
+  // Resolve the effective key binding: a user override (if present) wins over the
+  // catalog default. Both branches return referentially stable arrays/strings, so
+  // useShortcut only re-registers when the binding actually changes.
+  const userKeys = overrideMap[id];
+  const resolvedKeys = userKeys ?? catalogKeys;
+
+  // An override set to an empty array means the user intentionally unbound it.
+  const isUnbound = Array.isArray(userKeys) && userKeys.length === 0;
+
+  useShortcut(resolvedKeys, handler, {
     ...baseConfig,
     ...overrides,
-    enabled: definition ? (overrides.enabled ?? true) : false,
+    enabled: definition && !isUnbound ? (overrides.enabled ?? true) : false,
   });
+};
+
+/**
+ * Resolve the effective primary combo string for a shortcut (override-aware).
+ * Used by non-registry gesture handlers (e.g. composer push-to-talk) that need to
+ * read the current binding without registering a react-hotkeys handler. Returns a
+ * primitive string so it is safe to place directly in effect dependency arrays.
+ */
+export const useResolvedShortcutCombo = (id: ShortcutId): string => {
+  const overrideMap = useShortcutOverrideMap();
+  const userKeys = overrideMap[id];
+  const catalogKeys = shortcuts[id]?.keys ?? '';
+  const keys = userKeys ?? catalogKeys;
+  return Array.isArray(keys) ? (keys[0] ?? '') : keys;
 };

--- a/apps/dashboard/src/shortcuts/index.ts
+++ b/apps/dashboard/src/shortcuts/index.ts
@@ -1,6 +1,13 @@
 export { ShortcutsProvider } from '../providers/ShortcutsProvider';
-export { useShortcut, useScope, useShortcutById } from './hooks';
+export { useShortcut, useScope, useShortcutById, useResolvedShortcutCombo } from './hooks';
 export { shortcuts, getShortcut, getShortcutsByCategory, findConflicts } from './catalog';
 export { invokeShortcut } from './shortcutsRegistry';
 export type { ShortcutConfig, ShortcutRegistration, ShortcutScope } from './shortcutsRegistry';
 export type { ShortcutDefinition, ShortcutId } from './catalog';
+export {
+  getShortcutOverrides,
+  setShortcutOverrides,
+  subscribeShortcutOverrides,
+  parseShortcutOverrides,
+} from './overridesStore';
+export type { ShortcutOverrideMap } from './overridesStore';

--- a/apps/dashboard/src/shortcuts/index.ts
+++ b/apps/dashboard/src/shortcuts/index.ts
@@ -6,11 +6,10 @@ export {
   getShortcutsByCategory,
   findConflicts,
   scopesOverlap,
-  findActionsForCombo,
 } from './catalog';
 export { invokeShortcut } from './shortcutsRegistry';
 export type { ShortcutConfig, ShortcutRegistration, ShortcutScope } from './shortcutsRegistry';
-export type { ShortcutDefinition, ShortcutId, ComboMatch } from './catalog';
+export type { ShortcutDefinition, ShortcutId } from './catalog';
 export {
   getShortcutOverrides,
   setShortcutOverrides,

--- a/apps/dashboard/src/shortcuts/index.ts
+++ b/apps/dashboard/src/shortcuts/index.ts
@@ -1,9 +1,16 @@
 export { ShortcutsProvider } from '../providers/ShortcutsProvider';
 export { useShortcut, useScope, useShortcutById, useResolvedShortcutCombo } from './hooks';
-export { shortcuts, getShortcut, getShortcutsByCategory, findConflicts } from './catalog';
+export {
+  shortcuts,
+  getShortcut,
+  getShortcutsByCategory,
+  findConflicts,
+  scopesOverlap,
+  findActionsForCombo,
+} from './catalog';
 export { invokeShortcut } from './shortcutsRegistry';
 export type { ShortcutConfig, ShortcutRegistration, ShortcutScope } from './shortcutsRegistry';
-export type { ShortcutDefinition, ShortcutId } from './catalog';
+export type { ShortcutDefinition, ShortcutId, ComboMatch } from './catalog';
 export {
   getShortcutOverrides,
   setShortcutOverrides,

--- a/apps/dashboard/src/shortcuts/overridesStore.ts
+++ b/apps/dashboard/src/shortcuts/overridesStore.ts
@@ -1,0 +1,59 @@
+import type { ShortcutId } from './catalog';
+
+/**
+ * Per-user keyboard-shortcut overrides.
+ *
+ * This is a small module-level pub/sub store that mirrors the user's persisted
+ * `user_preferences.keyboardShortcuts` value (a stringified JSON map). It is the
+ * single source of truth the live shortcut registry reads from via
+ * `useSyncExternalStore`, so a remap re-registers bindings immediately with no
+ * reload.
+ *
+ * Data flow (unidirectional):
+ *   Settings UI → setKeyboardShortcuts mutator → Zero → stateMachine
+ *     → ShortcutsProvider sync effect → setShortcutOverrides() → registry
+ *
+ * The map is sparse: only remapped shortcuts appear. An entry mapped to an empty
+ * array (`[]`) means the shortcut is intentionally unbound. A missing entry means
+ * "use the catalog default".
+ */
+export type ShortcutOverrideMap = Partial<Record<ShortcutId, string[]>>;
+
+let overrides: ShortcutOverrideMap = {};
+const listeners = new Set<() => void>();
+
+/** Stable snapshot getter for useSyncExternalStore. Identity only changes on set. */
+export const getShortcutOverrides = (): ShortcutOverrideMap => overrides;
+
+export const subscribeShortcutOverrides = (cb: () => void): (() => void) => {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+};
+
+export const setShortcutOverrides = (next: ShortcutOverrideMap): void => {
+  overrides = next ?? {};
+  listeners.forEach(listener => listener());
+};
+
+/**
+ * Parse the persisted stringified JSON map into a validated override map.
+ * Any malformed input degrades safely to `{}` (i.e. all catalog defaults).
+ */
+export const parseShortcutOverrides = (raw: string | null | undefined): ShortcutOverrideMap => {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: ShortcutOverrideMap = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (Array.isArray(value) && value.every(item => typeof item === 'string')) {
+        out[key as ShortcutId] = value;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+};

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -8692,6 +8692,42 @@ export const mutators = defineMutators({
         }
       },
     ),
+    setKeyboardShortcuts: defineMutator(
+      z.object({
+        id: z.string(),
+        keyboardShortcuts: z.string(),
+        timestamp: z.number(),
+      }),
+      async ({ tx, ctx, args: { id, keyboardShortcuts, timestamp } }) => {
+        const existing = await tx.run(
+          zql.user_preferences.where('userId', ctx.userID).one(),
+        );
+        if (existing) {
+          await tx.mutate.user_preferences.update({
+            id: existing.id,
+            keyboardShortcuts,
+            updatedAt: timestamp,
+          });
+        } else {
+          await tx.mutate.user_preferences.insert({
+            workspaceId: ctx.workspaceId,
+            id,
+            userId: ctx.userID,
+            channelSortOrder: ChannelSortOrder.RECENCY,
+            enterSendsMessage: true,
+            allowThreadBroadcastMentions: false,
+            globalDesktopNotificationLevel: NotificationLevel.MENTIONS_ONLY,
+            globalMobileNotificationLevel: NotificationLevel.MENTIONS_ONLY,
+            threadReplyNotificationsEnabled: true,
+            channelWideMentionsEnabled: true,
+            notificationKeywords: '[]',
+            keyboardShortcuts,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          });
+        }
+      },
+    ),
     setEnterSendsMessage: defineMutator(
       z.object({
         id: z.string(),

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1487,6 +1487,7 @@ export const userPreferenceTable = table('user_preferences')
     threadReplyNotificationsEnabled: boolean(), // Receive thread reply notifications globally
     channelWideMentionsEnabled: boolean(),      // Receive @channel and @here notifications
     notificationKeywords: string().optional(), // Stringified JSON array of keywords (max 50, each <= 80 chars)
+    keyboardShortcuts: string().optional(), // Per-user shortcut overrides (stringified JSON map)
     createdAt: number(),
     updatedAt: number(),
   })


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #91 (original author: @XyneSpaces).

## What
Adds a **Shortcuts** section to Preferences that lets each user remap keyboard shortcuts. Overrides are stored per-user and sync across web/electron and devices through Zero.

This PR is stacked on `feature/composer-voice-hold-to-talk` (the push-to-talk work), so it targets that branch, not `main`.

## Why
The push-to-talk hold gesture (and every other shortcut) was hardcoded. This makes the shortcut catalog user-configurable and routes the voice hold-to-talk keybinding through the same registry.

## How
**Storage (additive, low-risk)**
- New nullable `user_preferences.keyboardShortcuts` (`TEXT`) holding a sparse stringified-JSON map `{ [shortcutId]: string[] }` — present = custom, `[]` = unbound, missing = default. No backfill.
- Migration `20260801120000_add_user_preference_keyboard_shortcuts`.
- Column hand-added to the generated + shared Zero `schema.ts`; `setKeyboardShortcuts` mutator added to both the shared and backend Zero mutator files.

**Frontend**
- `overridesStore` — singleton override registry via `useSyncExternalStore`.
- `ShortcutsProvider` syncs `userPreference.keyboardShortcuts` → registry (unidirectional: UI → `setKeyboardShortcuts` mutator → Zero → stateMachine → sync effect → registry).
- `useShortcutById` / `useResolvedShortcutCombo` resolve overrides over catalog defaults.
- Preferences **Shortcuts** section reuses existing components: capture mode, conflict detection, reset-to-default.

**Voice through the registry**
- New catalog entry `composer.voiceInputHold` (default `mod+shift+space`).
- `InputBox` sources the hold-to-talk keybinding from `useResolvedShortcutCombo('composer.voiceInputHold')`; arm/release stays raw keydown/keyup, only the binding comes from the catalog, and it re-registers when the binding changes.

## Testing
- Backend, shared, and dashboard typecheck: 0 errors. ESLint: clean.
- Migration applies cleanly; zero-cache picks up the DDL.
- Verified in a running dev stack: Preferences → Shortcuts renders the full catalog (incl. the new "Hold to talk" entry under COMPOSER), and capture mode records a new combo. Screenshots attached in the thread.

## Notes / follow-ups
- End-to-end persistence (mutator → Zero → KeyCap echo) could not be filmed in the CI sandbox because its headless-browser Zero WebSocket doesn't connect (read-only HTTP fallback only); the write path is unchanged-standard Zero mutator plumbing and typechecks against the schema.