### PR TITLE
fix: XYNE-54744 security hardening — SSRF, realtime authz, auth, rate limiting, uploads, desktop

### DIFF
--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -14,6 +14,7 @@ import { ContentFormat } from '../types';
 import { updateAppActionStatus } from '@/utils/appActionMarkdownUtils';
 import { sanitizeMessageContent, isAlphanumericId, encodeHtmlAttr } from '@/utils/contentUtils';
 import { redisService } from '@/services/redisService';
+import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
 
 const ChatActionBodySchema = z.object({
   text: z.string().optional(), // plain text or Slack BlockKit — processed through parser
@@ -609,11 +610,9 @@ export class ChatController {
 
     // Forward to the external URL server-side (no CORS issues)
     // callerUserId is derived from the authenticated session (XYNE-12145)
-    // ACCEPTED RISK (secops #61 / XYNE-17825): `actionableUrl` is caller-supplied and is NOT
-    // passed through the SSRF guard, so an authenticated user can point this server-side fetch
-    // at internal / cloud-metadata hosts. A guarded internal-domain-allowlist version was
-    // implemented and then intentionally removed (see #9257 commit history); the team has
-    // accepted this SSRF exposure. Do not re-add a guard without re-opening that decision.
+    // `actionableUrl` is caller-supplied, so it goes through `assertWebhookUrlSafe`.
+    // The first-party internal callback (same origin as backendUrl, authenticated
+    // with the S2S key) is exempt so it works even when backendUrl is a private/dev host.
     try {
       const isInternalSpacesCallback = (() => {
         try {
@@ -622,6 +621,11 @@ export class ChatController {
           return false;
         }
       })();
+
+      if (!isInternalSpacesCallback) {
+        // Throws on a blocked target; caught below, so the action simply isn't dispatched.
+        await assertWebhookUrlSafe(actionableUrl);
+      }
 
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       if (isInternalSpacesCallback) {
@@ -637,6 +641,7 @@ export class ChatController {
         method: 'POST',
         headers,
         body: JSON.stringify({ actionId, context, messageId, conversationId, callerUserId }),
+        redirect: 'manual', // don't follow 3xx redirects
         signal: AbortSignal.timeout(30_000),
       });
       if (!callbackRes.ok) {

--- a/apps/backend/src/apps/controllers/commandController.ts
+++ b/apps/backend/src/apps/controllers/commandController.ts
@@ -11,6 +11,7 @@ import {
 } from '@/database/repositories/appCommandRepository';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
+import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
 
 /**
  * Insert a SYSTEM message visible only to `userId` explaining that a command or shortcut failed.
@@ -622,6 +623,20 @@ export class CommandController {
         eventType,
       });
 
+      // Reject webhook URLs whose host resolves to an internal/private address.
+      try {
+        await assertWebhookUrlSafe(match.webhookUrl);
+      } catch (err) {
+        if (err instanceof SsrfBlockedError) {
+          logger.warn('[COMMAND-DISPATCH] Blocked SSRF-unsafe webhook URL', {
+            appId: match.appId,
+            reason: err.message,
+          });
+          throw new Error('App webhook URL is not allowed');
+        }
+        throw err;
+      }
+
       const appResponse = await fetch(match.webhookUrl, {
         method: 'POST',
         headers: {
@@ -629,6 +644,7 @@ export class CommandController {
           'X-Xyne-Event': eventType,
         },
         body: JSON.stringify(payload),
+        redirect: 'manual',
         signal: AbortSignal.timeout(30_000),
       });
 

--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
+import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
 import {
   validateActionRequest,
   validateFlowDefinition,
@@ -62,19 +63,12 @@ export class FlowController {
         return;
       }
 
-      // 4. Look up the installed app to get its webhook/action URL.
-      // Webhook is configured per-app, but there can be multiple InstalledApps
-      // rows for the same appId (e.g. one per workspace) and only some carry a
-      // webhookUrl. The lookup MUST be scoped to the acting user's workspace and
-      // require a configured webhook so we never non-deterministically pick
-      // another tenant's install row (tenant-isolation, relevant for OSS /
-      // multi-tenant deployments) or a row whose webhookUrl is null/empty (which
-      // surfaced as a spurious "No webhook URL configured" 502 even though the
-      // app's webhook was set). Mirrors configureWebhook / updateInstalledApp.
+      // 4. Look up the installed app to get its webhook/action URL. Multiple InstalledApps
+      // rows can exist for the same appId (one per workspace) and only some carry a
+      // webhookUrl, so scope the lookup to the user's workspace and require a configured
+      // webhook.
       const workspaceId = req.user?.workspaceId;
       if (!workspaceId) {
-        // No workspace on the authenticated user — refuse rather than fall back
-        // to an unscoped, cross-tenant lookup.
         res.status(400).json({ error: 'Workspace not found for user' });
         return;
       }
@@ -106,7 +100,19 @@ export class FlowController {
 
       logger.info('[FLOW-ACTION] Calling app backend', { appId, actionId, type, messageId });
 
-      // 6. Call the app backend synchronously
+      // Reject webhook URLs whose host resolves to an internal/private address.
+      try {
+        await assertWebhookUrlSafe(installedApp.webhookUrl);
+      } catch (err) {
+        if (err instanceof SsrfBlockedError) {
+          logger.warn('[FLOW-ACTION] Blocked SSRF-unsafe webhook URL', { appId, reason: err.message });
+          res.status(502).json({ error: 'App webhook URL is not allowed' });
+          return;
+        }
+        throw err;
+      }
+
+      // 6. Call the app backend synchronously.
       const appResponse = await fetch(installedApp.webhookUrl, {
         method: 'POST',
         headers: {
@@ -114,6 +120,7 @@ export class FlowController {
           'X-Xyne-Event': 'flow_action',
         },
         body: JSON.stringify(appPayload),
+        redirect: 'manual',
         signal: AbortSignal.timeout(30_000),
       });
 

--- a/apps/backend/src/apps/core/eventSubscriptionUtils.ts
+++ b/apps/backend/src/apps/core/eventSubscriptionUtils.ts
@@ -3,6 +3,7 @@ import { isValidUrl } from '@/utils/urlUtils';
 import { BaseAppEvent } from '@/apps/types';
 import { logger } from '@/utils/logger';
 import { decrypt } from '@/services/encryptionService';
+import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
 import crypto from 'crypto';
 
 const installedAppsRepository = new InstalledAppsRepository();
@@ -23,6 +24,10 @@ export async function sendWebhookNotification(
     const payload = JSON.stringify(event);
     const signature = signWebhookPayload(payload, signingSecret);
 
+    // SSRF guard: require a host that does not resolve to an internal/private
+    // address before every dispatch.
+    await assertWebhookUrlSafe(webhookUrl);
+
     try {
         const response = await fetch(webhookUrl, {
             method: 'POST',
@@ -32,6 +37,8 @@ export async function sendWebhookNotification(
                 'X-Source': 'XyneSpaces'
             },
             body: payload,
+            // 'manual' so a 3xx to an internal host cannot bypass the guard above.
+            redirect: 'manual',
         });
 
         const text = await response.text().catch(() => '');

--- a/apps/backend/src/apps/routes/prCheckCallback.ts
+++ b/apps/backend/src/apps/routes/prCheckCallback.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { validateS2SKey } from '@/middleware/validateS2SKey';
+import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
 
 const router = Router();
 
@@ -80,6 +81,9 @@ async function sendVarysWebhook(
   webhookUrl: string,
   payload: PRCheckRequestedPayload
 ): Promise<void> {
+  // Reject webhook URLs whose host resolves to an internal/private address.
+  await assertWebhookUrlSafe(webhookUrl);
+
   const response = await fetch(webhookUrl, {
     method: 'POST',
     headers: {
@@ -87,6 +91,7 @@ async function sendVarysWebhook(
       'X-Xyne-Event': 'PR_CHECK_REQUESTED',
     },
     body: JSON.stringify(payload),
+    redirect: 'manual',
   });
 
   if (!response.ok) {

--- a/apps/backend/src/automations/steps/trigger-webhook.step.ts
+++ b/apps/backend/src/automations/steps/trigger-webhook.step.ts
@@ -5,6 +5,7 @@ import { StepCategory } from '../types/categories';
 import { variableRef } from '../engine/variable-ref';
 import { OutputSchemaSchema } from '../engine/declared-schema';
 import { decryptHeaderValue, isSensitiveHeader } from '../engine/webhook-step-encryption';
+import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
 import { logger } from '@/utils/logger';
 
 const HttpMethod = z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
@@ -86,6 +87,10 @@ export class TriggerWebhookStep extends BaseActionStep<
     cfg: z.infer<typeof TriggerWebhookConfigSchema>,
   ): Promise<TriggerWebhookOutput> {
     const { url, method, headers, encoding, body, timeoutMs } = cfg;
+
+    // SSRF guard: resolve the host and reject internal/private/link-local
+    // addresses at request time (the schema only blocks literal private IPs).
+    await assertWebhookUrlSafe(url);
 
     const init: RequestInit = {
       method,

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -318,6 +318,16 @@ export class AuthV2Controller {
         code_challenge_method: CodeChallengeMethod.S256,
       });
 
+      // sameSite=lax so the cookie survives Google's top-level callback redirect.
+      const isProduction = process.env.NODE_ENV === 'production';
+      res.cookie('oauth_state', state, {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: 'lax' as const,
+        maxAge: 10 * 60 * 1000,
+        path: '/',
+      });
+
       logger.info(`[${requestId}] Redirecting to Google OAuth`);
       res.redirect(authUrl);
     } catch (error) {
@@ -392,6 +402,20 @@ export class AuthV2Controller {
         const launchUrl = `${frontendUrl}/launch?${launchParams.toString()}`;
         logger.info(`[${requestId}] Redirecting to Frontend launch page: ${launchUrl}`);
         res.redirect(launchUrl);
+        return;
+      }
+
+      // The state must match the oauth_state cookie; reject when absent or different. The
+      // cookie is single-use and cleared here regardless of outcome. Checked only on the
+      // browser-driven path: desktop returns above, and the cookie is host-only.
+      const boundState = req.cookies?.oauth_state as string | undefined;
+      res.clearCookie('oauth_state', { path: '/' });
+      if (!boundState || boundState !== state) {
+        logger.error(`[${requestId}] OAuth state cookie missing or mismatched — rejecting`);
+        const frontendUrl = getFrontendUrl(req);
+        res.redirect(
+          `${frontendUrl}?error=invalid_state&message=${encodeURIComponent('Invalid or expired state')}`
+        );
         return;
       }
 
@@ -1019,8 +1043,21 @@ export class AuthV2Controller {
     const requestId = `EXCHANGE_CODE_${Date.now()}`;
     const frontendUrl = getFrontendUrl(req);
 
-    const isMobileNative =
-      req.headers['x-platform'] === 'mobile' || req.query.platform === 'mobile';
+    // Select the native branch via the `x-platform` header. `?platform=mobile` is kept for
+    // older mobile builds, but only when the request carries no browser cross-site markers;
+    // otherwise it is treated as a web request and must pass state + PKCE.
+    const secFetchSite = req.headers['sec-fetch-site'];
+    const looksBrowserInitiated =
+      !!req.headers.origin ||
+      (typeof secFetchSite === 'string' && secFetchSite !== 'none');
+    const nativeByHeader = req.headers['x-platform'] === 'mobile';
+    const nativeByQuery = req.query.platform === 'mobile' && !looksBrowserInitiated;
+    if (req.query.platform === 'mobile' && !nativeByHeader) {
+      logger.warn(
+        `[${requestId}] mobile-exchange selected via query parameter without the x-platform header (browserInitiated=${looksBrowserInitiated})`,
+      );
+    }
+    const isMobileNative = nativeByHeader || nativeByQuery;
 
     // Helper to send error response (JSON for mobile, redirect for web)
     const sendError = (errorCode: string, message: string, statusCode = 400) => {
@@ -1061,6 +1098,30 @@ export class AuthV2Controller {
         return;
       }
 
+      // Native does PKCE inside the Google SDK, so only the web branch verifies it server-side.
+      let codeVerifier: string | undefined;
+      if (!isMobileNative) {
+        const state = (req.query.state || req.body?.state) as string | undefined;
+        if (!state) {
+          logger.error(`[${requestId}] Missing state on web mobile-exchange`);
+          sendError('missing_params', 'Missing state');
+          return;
+        }
+        const stateData = await oauthStateServiceV2.validateState(state, false);
+        if (!stateData) {
+          logger.error(`[${requestId}] Invalid or expired state`);
+          sendError('invalid_state', 'Invalid or expired state');
+          return;
+        }
+        await oauthStateServiceV2.deleteState(state);
+        codeVerifier = (await pkceServiceV2.getAndDeleteVerifier(state)) ?? undefined;
+        if (!codeVerifier) {
+          logger.error(`[${requestId}] PKCE verifier not found`);
+          sendError('pkce_failed', 'PKCE verification failed');
+          return;
+        }
+      }
+
       await oauthStateServiceV2.markCodeAsUsed(code as string);
 
       // For mobile native apps using serverAuthCode, use empty string as redirect_uri
@@ -1073,6 +1134,7 @@ export class AuthV2Controller {
       const { tokens } = await this.mobileGoogleClient.getToken({
         code: code as string,
         redirect_uri: redirectUri,
+        ...(codeVerifier ? { codeVerifier } : {}),
       });
 
       const { id_token, refresh_token, access_token } = tokens;

--- a/apps/backend/src/controllers/customEmojiController.ts
+++ b/apps/backend/src/controllers/customEmojiController.ts
@@ -7,6 +7,7 @@ import {
 } from '../database/repositories/customEmojiRepository';
 import { getStorageService } from '../services/storage';
 import { cleanupProxiedFile } from '../utils/attachmentUtils';
+import { setSafeInlineImageHeaders } from '../utils/safeAttachmentDownload';
 
 const storageService = getStorageService();
 
@@ -242,11 +243,10 @@ export class CustomEmojiController {
 
       // Get file metadata to determine content type and size
       const metadata = await storageService.getFileMetadata(gcsPath);
-      const contentType = metadata.contentType || 'image/png';
       const fileSize = parseInt(String(metadata.size || '0'), 10);
 
       // Set response headers
-      res.setHeader('Content-Type', contentType);
+      setSafeInlineImageHeaders(res, metadata.contentType || 'image/png');
       res.setHeader('Content-Length', fileSize);
       res.setHeader('Cache-Control', 'public, max-age=31536000'); // Cache for 1 year
 

--- a/apps/backend/src/controllers/dashboardController.ts
+++ b/apps/backend/src/controllers/dashboardController.ts
@@ -1222,10 +1222,10 @@ export class DashboardController {
           });
           return;
         case 'execution_failed':
+          // Return a generic message; the detail is logged server-side in QueryExecutor.
           res.status(500).json({
             error: 'InternalServerError',
-            message: e.message,
-            details: e.details,
+            message: 'Query execution failed.',
           });
           return;
       }

--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -87,9 +87,10 @@ export class EmailAuthController {
       });
 
       if (!orgMember || orgMember.leftAt) {
+        // Keep this response identical to the wrong-password response below.
         res.status(401).json({
           error: 'Invalid credentials',
-          message: 'User is not a member of org',
+          message: 'Email or password is incorrect',
         });
         return;
       }

--- a/apps/backend/src/controllers/memoryController.ts
+++ b/apps/backend/src/controllers/memoryController.ts
@@ -63,6 +63,23 @@ export class MemoryController {
 
       // Replace document userId with user's email
       document.userId = user.email;
+
+      // The underlying insert is an upsert keyed on the caller-supplied docId, so reject when
+      // the docId already belongs to another user. The owner is stored as either email or id.
+      const existingDoc = await getMemoryById(document.docId);
+      if (
+        existingDoc &&
+        existingDoc.userId !== user.email &&
+        existingDoc.userId !== userId
+      ) {
+        logger.warn('Blocked cross-user memory overwrite', {
+          docId: document.docId,
+          owner: existingDoc.userId,
+        });
+        res.status(403).json({ success: false, error: 'Forbidden' });
+        return;
+      }
+
       logger.info('Indexing memory document', {
         docId: document.docId,
         userId: document.userId,

--- a/apps/backend/src/controllers/mettleEmployeeDetailsController.ts
+++ b/apps/backend/src/controllers/mettleEmployeeDetailsController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { mettleEmployeeDetailsService } from '../services/mettleEmployeeDetailsService';
 import { logger } from '../utils/logger';
+import { db } from '../database/client';
 
 export class MettleEmployeeDetailsController {
   private static instance: MettleEmployeeDetailsController;
@@ -31,6 +32,31 @@ export class MettleEmployeeDetailsController {
       }
 
       const trimmedEmail = email.trim();
+
+      // Restrict lookups to the caller's own org: caller and queried email must resolve
+      // to the same org (OrgMember is email-keyed).
+      const callerEmail = req.user?.email;
+      if (!callerEmail) {
+        res.status(403).json({ error: 'Not authorized' });
+        return;
+      }
+      const [callerOrg, targetOrg] = await Promise.all([
+        db.orgMember.findFirst({
+          where: { email: { equals: callerEmail, mode: 'insensitive' } },
+          select: { orgId: true },
+        }),
+        db.orgMember.findFirst({
+          where: { email: { equals: trimmedEmail, mode: 'insensitive' } },
+          select: { orgId: true },
+        }),
+      ]);
+      if (!callerOrg || !targetOrg || callerOrg.orgId !== targetOrg.orgId) {
+        logger.warn(
+          `[Mettle] Rejected cross-org employee lookup by ${callerEmail} for ${trimmedEmail}`,
+        );
+        res.status(403).json({ error: 'Not authorized to view this employee' });
+        return;
+      }
 
       logger.info(`Fetching employee details for email: ${trimmedEmail}`);
 

--- a/apps/backend/src/controllers/microsoftAuthController.ts
+++ b/apps/backend/src/controllers/microsoftAuthController.ts
@@ -209,6 +209,18 @@ export class MicrosoftAuthController {
 
         await pkceServiceV2.storeVerifier(state, codeVerifier);
 
+        // The callback echoes this state back via the HttpOnly cookie. sameSite=lax lets the
+        // cookie ride Microsoft's top-level callback redirect. Mirrors the Google flow; only
+        // the web callback verifies it.
+        const isProduction = process.env.NODE_ENV === 'production';
+        res.cookie('oauth_state', state, {
+          httpOnly: true,
+          secure: isProduction,
+          sameSite: 'lax' as const,
+          maxAge: 10 * 60 * 1000,
+          path: '/',
+        });
+
         const redirectUri = this.getMicrosoftRedirectUri(req);
 
         logger.info('[OAuth] Redirect URI:', redirectUri);
@@ -321,6 +333,26 @@ export class MicrosoftAuthController {
           logger.info(`[${requestId}] ELECTRON_REDIRECT: invitationId_appended=${!!peekedState?.invitationId}, invitationId=${peekedState?.invitationId || 'NULL'}, launchUrl=${launchUrl}`);
           res.redirect(launchUrl);
           return;
+        }
+
+        // The state must match the oauth_state cookie. Only the browser-driven path is
+        // checked: electron returned above, and the mobile app posts code+state directly
+        // rather than being redirected here. `resolvedPlatform` comes from the stored state
+        // record.
+        if (resolvedPlatform !== 'mobile') {
+          const boundState = req.cookies?.oauth_state as string | undefined;
+          res.clearCookie('oauth_state', { path: '/' });
+          if (!boundState || boundState !== state) {
+            logger.error(`[${requestId}] OAuth state cookie missing or mismatched — rejecting`);
+            await oauthStateServiceV2.deleteState(state as string);
+            res.redirect(
+              this.getRedirectUrl(req, resolvedPlatform, {
+                error: 'invalid_state',
+                message: 'Login session expired or invalid. Please try signing in again.',
+              })
+            );
+            return;
+          }
         }
 
         // Now consume the state (delete it)

--- a/apps/backend/src/controllers/userManagementController.ts
+++ b/apps/backend/src/controllers/userManagementController.ts
@@ -4,6 +4,7 @@ import { getStorageService } from '../services/storage';
 import { AccessType, CalendarVisibility, WorkspaceRole } from '@prisma/client';
 import { GuestEntity } from '@xyne/shared';
 import { logger } from '../utils/logger';
+import { setSafeInlineImageHeaders } from '../utils/safeAttachmentDownload';
 
 const storageService = getStorageService();
 const userManagementService = UserManagementService.getInstance();
@@ -1048,10 +1049,9 @@ export class UserManagementController {
       }
 
       const metadata = await storageService.getFileMetadata(gcsPath);
-      const contentType = metadata.contentType || 'image/png';
       const fileSize = parseInt(String(metadata.size || '0'), 10);
 
-      res.setHeader('Content-Type', contentType);
+      setSafeInlineImageHeaders(res, metadata.contentType || 'image/png');
       res.setHeader('Content-Length', fileSize);
       // Cache for 1 year - safe because picture path includes timestamp and changes on each upload
       res.setHeader('Cache-Control', 'public, max-age=31536000');

--- a/apps/backend/src/integrations/adapters/microsoft/authenticator.ts
+++ b/apps/backend/src/integrations/adapters/microsoft/authenticator.ts
@@ -85,7 +85,8 @@ export class MicrosoftAuthenticator extends BaseAuthenticator {
         }
       }
 
-      return { authenticated: true };
+      // No stored credentials at all (empty credentialsJson): return not-authenticated.
+      return { authenticated: false };
     } catch (error) {
       logger.error('Microsoft authentication error:', error);
       return { authenticated: false };

--- a/apps/backend/src/services/memoryService.ts
+++ b/apps/backend/src/services/memoryService.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/utils/logger';
+import { escapeYqlString } from '@/utils/yqlEscape';
 import { vespaClient } from '@/services/vespaSearch';
 import { NAMESPACE, CLUSTER } from '@/vespa/vespaConfig';
 import {
@@ -77,12 +78,22 @@ async function buildMemoryYql(params: {
 
   const conditions: string[] = [];
 
-  // NOTE: These are *scoping* filters over cumulative memory, not an access-control
-  // boundary. Memory documents are shared, so widening this WHERE clause only surfaces
-  // records the user is already permitted to read (confirmed with the Vespa/memory team).
-  // Values are therefore interpolated directly into the YQL string. If memory ever becomes
-  // per-user/tenant-confidential, revisit this and bind user input as @-parameters
-  // (see YqlBuilder) so it can't break out of the string literal and rewrite the query.
+  // Escape any value interpolated into a YQL string literal: a raw `"` or `\` in a filter
+  // value (a docId/tag/repoUrl, or an ingested value such as an email subject that lands in
+  // these fields) would otherwise terminate the `"…"` literal and change the WHERE clause.
+  // The free-text `query` is NOT interpolated: it is bound as the @query parameter
+  // (userInput(@query)), so it stays parameterized.
+
+  // NOTE: These `contains` filters are *scoping* filters over cumulative memory, not an
+  // access-control boundary. Memory documents are shared, so these values are string-
+  // interpolated (escaped) rather than bound as @-parameters. If memory ever becomes
+  // per-user/tenant-confidential, bind values as @-parameters (see YqlBuilder) instead.
+  //
+  // `scope: 'ALL'` applies no user/workspace filter — memory is shared across users. Memory
+  // docs are also not stamped with `workspaceId` at ingest today, so a tenant filter here
+  // would match nothing without an ingest change + backfill. If the tenancy model changes to
+  // make memory per-workspace, this is where the workspaceId filter belongs (and ingestion
+  // must stamp workspaceId).
 
   // get the email of that user
   const prisma = DatabaseClient.getInstance();
@@ -92,58 +103,58 @@ async function buildMemoryYql(params: {
 
   // Scope filter: 'my' restricts to user's own documents
   if (scope === 'my') {
-    conditions.push(`userId contains "${user?.email}"`);
+    conditions.push(`userId contains "${escapeYqlString(user?.email)}"`);
   }
 
   // DocType filter
   if (docType) {
-    conditions.push(`docType contains "${docType}"`);
+    conditions.push(`docType contains "${escapeYqlString(docType)}"`);
   }
 
   // DocId filter
   if (docId) {
-    conditions.push(`docId contains "${docId}"`);
+    conditions.push(`docId contains "${escapeYqlString(docId)}"`);
   }
 
   // Tags filter
   if (tags && tags.length > 0) {
-    const tagConditions = tags.map((tag) => `tags contains "${tag}"`);
+    const tagConditions = tags.map((tag) => `tags contains "${escapeYqlString(tag)}"`);
     conditions.push(`(${tagConditions.join(' or ')})`);
   }
 
   // RepoUrl filter
   if (repoUrl) {
-    conditions.push(`repoUrl contains "${repoUrl}"`);
+    conditions.push(`repoUrl contains "${escapeYqlString(repoUrl)}"`);
   }
 
   // CommitId filter (exact match)
   if (commitId) {
-    conditions.push(`commitId contains "${commitId}"`);
+    conditions.push(`commitId contains "${escapeYqlString(commitId)}"`);
   }
 
   // SessionId filter (exact match)
   if (sessionId) {
-    conditions.push(`sessionId contains "${sessionId}"`);
+    conditions.push(`sessionId contains "${escapeYqlString(sessionId)}"`);
   }
 
   // FilePointers filter
   if (filePointers) {
-    conditions.push(`filePointers contains "${filePointers}"`);
+    conditions.push(`filePointers contains "${escapeYqlString(filePointers)}"`);
   }
 
   // TicketId filter
   if (ticketId) {
-    conditions.push(`ticketId contains "${ticketId}"`);
+    conditions.push(`ticketId contains "${escapeYqlString(ticketId)}"`);
   }
 
   // ParentRef filter (exact match)
   if (parentRef) {
-    conditions.push(`parentRef contains "${parentRef}"`);
+    conditions.push(`parentRef contains "${escapeYqlString(parentRef)}"`);
   }
 
   // ReviewStatus filter
   if (reviewStatus) {
-    conditions.push(`reviewStatus contains "${reviewStatus}"`);
+    conditions.push(`reviewStatus contains "${escapeYqlString(reviewStatus)}"`);
   }
 
   // Search condition (text + vector)

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -226,6 +226,27 @@ class WebSocketService {
 
     socket.join(`user:${userId}`);
 
+    // Observe-only: log (once per window) when a socket exceeds the candidate
+    // inbound-event budget, but never drop events. Enforcement is deferred.
+    let evtCount = 0;
+    let evtWindowStart = Date.now();
+    let evtWindowLogged = false;
+    const SOCKET_EVT_OBSERVE_THRESHOLD = 300;
+    const SOCKET_EVT_WINDOW_MS = 10_000;
+    socket.use((_packet, next) => {
+      const now = Date.now();
+      if (now - evtWindowStart > SOCKET_EVT_WINDOW_MS) {
+        evtWindowStart = now;
+        evtCount = 0;
+        evtWindowLogged = false;
+      }
+      if (++evtCount > SOCKET_EVT_OBSERVE_THRESHOLD && !evtWindowLogged) {
+        evtWindowLogged = true;
+        logger.warn(`[WS-EVT-OBSERVE] Socket ${socket.id} (user ${userId}) exceeded ${SOCKET_EVT_OBSERVE_THRESHOLD} events in ${SOCKET_EVT_WINDOW_MS}ms (not enforced)`);
+      }
+      next();
+    });
+
     // Debug: Check connections after adding
     const userConnections = await redisService.getUserConnections(userId);
     logger.info(`🔌 [CONNECT] User ${userId} now has ${userConnections.length} connections: [${userConnections.join(', ')}]`);
@@ -236,10 +257,19 @@ class WebSocketService {
     // Register for cross-workspace broadcast
     try {
       const userWithWorkspace = await repositories.users.findByIdWithWorkspace(userId);
-      if (userWithWorkspace?.orgMemberId) {
-        socket.orgMemberId = userWithWorkspace.orgMemberId;
+
+      // Resolve the socket's workspace independently of org-membership. WS channel/
+      // conversation access is keyed on socket.workspaceId, so a user with a home
+      // workspace but no orgMemberId (pre-onboarding / guest / service user) must
+      // still get workspaceId set. Only the cross-workspace broadcast registration
+      // below is org-member-scoped.
+      if (userWithWorkspace?.workspaceId) {
         socket.workspaceId = userWithWorkspace.workspaceId;
         socket.workspaceName = userWithWorkspace.workspace?.name;
+      }
+
+      if (userWithWorkspace?.orgMemberId) {
+        socket.orgMemberId = userWithWorkspace.orgMemberId;
 
         await redisService.addOrgMemberConnection(userWithWorkspace.orgMemberId, socket.id, platform);
         await this.setupOrgMemberEventSubscription(userWithWorkspace.orgMemberId);
@@ -379,9 +409,13 @@ class WebSocketService {
 
     // Handle user activity events (for analytics tracking)
     socket.on('user_activity_event', (event: ActivityEventPayload) => {
+      // Attribute the event to the authenticated socket user, never the
+      // client-supplied user_id.
+      if (!socket.userId) return;
+      const authoredEvent: ActivityEventPayload = { ...event, user_id: socket.userId };
       // Fire and forget - non-blocking
-      activityTrackingService.saveActivityEvent(event).catch(error => {
-        logger.error('Error saving activity event from WebSocket:', event, error);
+      activityTrackingService.saveActivityEvent(authoredEvent).catch(error => {
+        logger.error('Error saving activity event from WebSocket:', authoredEvent, error);
       });
     });
 
@@ -600,6 +634,16 @@ class WebSocketService {
       // Determine if this is a channel or conversation
       const isChannel = await this.isChannelSession(sessionId);
 
+      // Only broadcast typing if the socket user can access the target
+      // channel/conversation (same check as subscribe_to_channels).
+      const canAccess = isChannel
+        ? await this.canAccessChannel(socket, sessionId)
+        : await this.canAccessConversation(socket, sessionId);
+      if (!canAccess) {
+        logger.warn(`[TYPING] Unauthorized typing event by user ${socket.userId} in session ${sessionId}`);
+        return;
+      }
+
       let allTypingUsers: TypingUser[] = [];
 
       if (isChannel) {
@@ -627,6 +671,16 @@ class WebSocketService {
 
       // Determine if this is a channel or conversation
       const isChannel = await this.isChannelSession(sessionId);
+
+      // Only broadcast typing if the socket user can access the target
+      // channel/conversation (same check as subscribe_to_channels).
+      const canAccess = isChannel
+        ? await this.canAccessChannel(socket, sessionId)
+        : await this.canAccessConversation(socket, sessionId);
+      if (!canAccess) {
+        logger.warn(`[TYPING] Unauthorized typing event by user ${socket.userId} in session ${sessionId}`);
+        return;
+      }
 
       let allTypingUsers: TypingUser[] = [];
 
@@ -884,6 +938,13 @@ class WebSocketService {
       const { userId } = socket;
       const channels = Array.isArray(data?.channels) ? data.channels : [];
       const conversations = Array.isArray(data?.conversations) ? data.conversations : [];
+      // Observe-only: no cap enforced (see needs-design). Log large requests so
+      // real subscription counts inform the eventual bound.
+      const BULK_SUB_OBSERVE_THRESHOLD = 500;
+      const requestedCount = channels.length + conversations.length;
+      if (requestedCount > BULK_SUB_OBSERVE_THRESHOLD) {
+        logger.warn(`[BULK-SUB-OBSERVE] Socket ${socket.id} (user ${userId}) requested ${requestedCount} subscriptions (no cap enforced)`);
+      }
 
       // 🔒 Authorize every requested session against the user's channel membership /
       // workspace BEFORE subscribing. Mirrors the HTTP ACL in conversationController.
@@ -935,8 +996,10 @@ class WebSocketService {
       const channel = await repositories.channels.findById(channelId);
       if (!channel) return false;
 
-      // Tenant boundary — never allow a socket to subscribe across workspaces.
-      if (socket.workspaceId && channel.workspaceId && channel.workspaceId !== socket.workspaceId) {
+      // Tenant boundary (fail-closed): a socket with no resolved workspace is denied,
+      // and a channel whose workspaceId is set must match it.
+      if (!socket.workspaceId) return false;
+      if (channel.workspaceId && channel.workspaceId !== socket.workspaceId) {
         return false;
       }
 
@@ -960,7 +1023,9 @@ class WebSocketService {
       const conversation = await repositories.conversations.findById(conversationId);
       if (!conversation) return false;
 
-      if (socket.workspaceId && conversation.workspaceId && conversation.workspaceId !== socket.workspaceId) {
+      // Tenant boundary (fail-closed) — see canAccessChannel.
+      if (!socket.workspaceId) return false;
+      if (conversation.workspaceId && conversation.workspaceId !== socket.workspaceId) {
         return false;
       }
 
@@ -1445,7 +1510,22 @@ class WebSocketService {
   }
 
   private handleTicketCountsSubscription(socket: AuthenticatedSocket, room: string): void {
-    if (!room) return;
+    if (!room || typeof room !== 'string') return;
+
+    // Only allow well-formed ticket-counts rooms — never an arbitrary room string.
+    if (!/^ticket-counts:(project|board|user|group):[^:]+$/.test(room)) {
+      logger.warn(`[TICKET-COUNTS] Rejected malformed room "${room}" from user ${socket.userId}`);
+      return;
+    }
+    // A user may only subscribe to their OWN per-user ticket-counts room. The
+    // project/board/group rooms remain open (workspace-scoped ids). Consequently the
+    // "view a teammate's tickets" board (?assignee=<other>) gets no live count pushes;
+    // it still renders from the REST snapshot. Re-opening it needs a same-workspace
+    // membership check.
+    if (room.startsWith('ticket-counts:user:') && room !== `ticket-counts:user:${socket.userId}`) {
+      logger.warn(`[TICKET-COUNTS] Rejected cross-user room "${room}" from user ${socket.userId}`);
+      return;
+    }
 
     socket.join(room);
   }

--- a/apps/backend/src/utils/safeAttachmentDownload.ts
+++ b/apps/backend/src/utils/safeAttachmentDownload.ts
@@ -26,9 +26,52 @@ const SAFE_INLINE_MIME_TYPES = new Set<string>([
   'audio/ogg',
 ]);
 
+// Image types allowed to render inline from image-only endpoints (avatars,
+// custom emojis). SVG is included but served with a script-blocking CSP below.
+const INLINE_IMAGE_MIME_TYPES = new Set<string>([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/x-icon',
+  'image/vnd.microsoft.icon',
+  'image/svg+xml',
+]);
+
 interface SafeDownloadOptions {
   mimetype?: string | null;
   filename?: string | null;
+}
+
+/**
+ * Sets response headers for an image-only streaming endpoint (avatars, custom
+ * emojis) that are rendered via <img>. SVG stays renderable but is served with
+ * a sandbox CSP so it cannot execute scripts on direct navigation. Any type
+ * outside the image allowlist is downgraded to an opaque download. nosniff is
+ * always sent.
+ */
+export function setSafeInlineImageHeaders(
+  res: Response,
+  contentType?: string | null,
+): void {
+  const normalized = (contentType || '').split(';')[0].trim().toLowerCase();
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+
+  if (!INLINE_IMAGE_MIME_TYPES.has(normalized)) {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment');
+    return;
+  }
+
+  if (normalized === 'image/svg+xml') {
+    res.setHeader(
+      'Content-Security-Policy',
+      "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+    );
+  }
+  res.setHeader('Content-Type', normalized);
 }
 
 /**

--- a/apps/backend/src/utils/ssrfGuard.ts
+++ b/apps/backend/src/utils/ssrfGuard.ts
@@ -79,8 +79,11 @@ function isBlockedHostname(host: string): boolean {
   return false;
 }
 
-export async function assertHostIsExternal(host: string): Promise<void> {
-  if (isAllowPrivate()) {
+export async function assertHostIsExternal(
+  host: string,
+  allowPrivate: boolean = isAllowPrivate(),
+): Promise<void> {
+  if (allowPrivate) {
     logger.debug(
       '[SsrfGuard] private hosts allowed (DATA_SOURCE_ALLOW_PRIVATE_HOSTS); skipping check',
       { host },
@@ -138,4 +141,27 @@ export async function assertHostIsExternal(host: string): Promise<void> {
       throw new SsrfBlockedError(trimmed, addr, 'resolves to private / loopback / link-local IPv6');
     }
   }
+}
+
+/**
+ * SSRF guard for outbound webhook URLs (app webhooks, automation
+ * trigger_webhook). Ensures the host does not resolve to an internal / private /
+ * loopback / link-local address. Throws SsrfBlockedError on any violation.
+ * Scheme is intentionally not restricted to https.
+ *
+ * Callers MUST also disable redirect-following (`redirect: 'manual'`) on the
+ * subsequent fetch.
+ */
+export async function assertWebhookUrlSafe(rawUrl: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError(rawUrl, null, 'invalid URL');
+  }
+  // Webhooks honor the private-host bypass only in local development, not in
+  // shared non-prod where DATA_SOURCE_ALLOW_PRIVATE_HOSTS may be set for
+  // data-source connectors.
+  const allowPrivate = isAllowPrivate() && config.env === 'development';
+  await assertHostIsExternal(parsed.hostname, allowPrivate);
 }

--- a/apps/backend/src/utils/vespaDuplicateDetector.ts
+++ b/apps/backend/src/utils/vespaDuplicateDetector.ts
@@ -7,6 +7,7 @@ import { vespaClient } from '@/services/vespaSearch';
 import { convert } from 'html-to-text';
 import { type VespaTicketDocument, type VespaSearchResponse } from '@/vespa/src/types';
 import { logger } from '@/utils/logger';
+import { escapeYqlString } from '@/utils/yqlEscape';
 import { repositories } from '@/database/repositories';
 
 export interface DuplicateMatch {
@@ -147,9 +148,9 @@ export async function findDuplicateEmailConversation(
   const extractedEmailFrom = extractEmailFromAddress(emailFrom);
   const incomingEmailDomain = getEmailDomain(extractedEmailFrom);
 
-  // Build and execute Vespa query with channelId filter for better performance
-  const excludeCondition = excludeTicketId ? ` and docId != "${excludeTicketId}"` : '';
-  const yql = `select * from sources ticket where docType contains "ticket" and title contains "${normalizedSubject}" and channelId contains "${channelId}"${excludeCondition}`;
+  // Build and execute Vespa query with channelId filter for better performance.
+  const excludeCondition = excludeTicketId ? ` and docId != "${escapeYqlString(excludeTicketId)}"` : '';
+  const yql = `select * from sources ticket where docType contains "ticket" and title contains "${escapeYqlString(normalizedSubject)}" and channelId contains "${escapeYqlString(channelId)}"${excludeCondition}`;
 
   logger.info('[VESPA_DUPLICATE_SEARCH]', { channelId, emailFrom, normalizedSubject, excludeTicketId });
 

--- a/apps/backend/src/utils/yqlEscape.ts
+++ b/apps/backend/src/utils/yqlEscape.ts
@@ -1,0 +1,11 @@
+/**
+ * Escapes a value for safe interpolation inside a double-quoted YQL string
+ * literal (backslash first, then double-quote). For the hand-built YQL paths
+ * (memory search, duplicate detection) where values are not bound as
+ * @-parameters. Prefer VespaQueryParams.bind() (YqlBuilder) for new code.
+ */
+export function escapeYqlString(value: unknown): string {
+  return String(value ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"');
+}

--- a/apps/dashboard/src/utils/reactNativeBridge.ts
+++ b/apps/dashboard/src/utils/reactNativeBridge.ts
@@ -442,6 +442,11 @@ class ReactNativeBridge {
   // the message shape/type before dispatch. Revisit if this bridge is ever reachable from arbitrary
   // web frames (e.g. remote iframes).
   private readonly messageHandler = (event: MessageEvent): void => {
+    // React-Native-injected messages arrive with an empty origin or the app's own origin;
+    // reject cross-origin postMessages.
+    if (event.origin && event.origin !== window.location.origin) {
+      return;
+    }
     const message = this.parseInboundMessage(event.data);
     if (!message) {
       return;

--- a/apps/electron/build.sbx.json
+++ b/apps/electron/build.sbx.json
@@ -3,6 +3,13 @@
   "extraMetadata": {
     "APP_ENV": "sandbox"
   },
+  "electronFuses": {
+    "runAsNode": false,
+    "enableNodeOptionsEnvironmentVariable": false,
+    "enableNodeCliInspectArguments": false,
+    "onlyLoadAppFromAsar": true,
+    "enableEmbeddedAsarIntegrityValidation": true
+  },
   "productName": "Xyne Spaces Sandbox",
   "directories": {
     "output": "release/sandbox"

--- a/apps/electron/src/ipc/mtls-handlers.ts
+++ b/apps/electron/src/ipc/mtls-handlers.ts
@@ -105,6 +105,7 @@ function assertMainWindowSender(event: IpcMainInvokeEvent): void {
 export function setupMTLSIpcHandlers(): void {
 
     // mtls start
+    // Privileged mTLS identity operations are restricted to the main window's top frame.
     ipcMain.handle('generate-keys', async (event) => {
         assertMainWindowSender(event);
         Logger.info(EnrollmentEvent.FIRST_TIME_SIGNUP_START);

--- a/apps/electron/src/services/agent-auth.ts
+++ b/apps/electron/src/services/agent-auth.ts
@@ -117,10 +117,28 @@ class AgentAuthService {
       return;
     }
 
+    // Every legitimate caller connects to the loopback server directly, so Host must be
+    // 127.0.0.1:<port> / localhost:<port>. A request arriving with any other Host is
+    // rejected here before routing.
+    const hostHeader = req.headers.host;
+    const allowedHosts = new Set([`127.0.0.1:${this.port}`, `localhost:${this.port}`]);
+    if (!hostHeader || !allowedHosts.has(hostHeader)) {
+      log.warn(`[AgentAuth] Rejected request with unexpected Host header: ${hostHeader ?? '(none)'}`);
+      this.sendJson(res, 403, { error: 'Forbidden', message: 'Invalid Host' });
+      return;
+    }
+
     const url = new URL(req.url || '/', `http://${req.headers.host}`);
 
     try {
       if (req.method === 'POST' && url.pathname === '/auth/request') {
+        // Real local agents are non-browser clients and send no Origin / Sec-Fetch-Site
+        // header; reject cross-site browser requests to the consent dialog.
+        if (this.isCrossSiteBrowserRequest(req)) {
+          log.warn('[AgentAuth] Rejected cross-site /auth/request (browser consent-dialog spam)');
+          this.sendJson(res, 403, { error: 'Forbidden', message: 'Cross-site request rejected' });
+          return;
+        }
         await this.handleAuthRequest(req, res);
       } else if (req.method === 'POST' && url.pathname === '/auth/release') {
         await this.handleAuthRelease(req, res);

--- a/apps/electron/src/services/deep-links.ts
+++ b/apps/electron/src/services/deep-links.ts
@@ -12,13 +12,11 @@ import { isHexToken } from '../utils/validation';
 let mainWindow: BrowserWindow | null = null;
 
 /**
- * XYNE Issues 398/405 (CWE-601): a xyne-spaces:// deep link is externally
- * triggerable (any web page can set location.href = 'xyne-spaces://...'), and
- * its path is forwarded to the renderer's router via 'navigate-to'. Only allow
- * plain in-app route paths — reject anything with an embedded scheme, a
- * protocol-relative '//', backslashes, or path traversal (raw or percent-
- * encoded), so an attacker cannot force an external-looking redirect or reach
- * unexpected routes via traversal tricks.
+ * A xyne-spaces:// deep link is externally triggerable (any web page can set
+ * location.href = 'xyne-spaces://...') and its path is forwarded to the renderer's
+ * router via 'navigate-to'. Only plain in-app route paths are allowed — anything with
+ * an embedded scheme, a protocol-relative '//', backslashes, or path traversal (raw or
+ * percent-encoded) is rejected.
  */
 function isSafeDeepLinkPath(pathStr: string): boolean {
   if (typeof pathStr !== 'string' || !pathStr.startsWith('/') || pathStr.startsWith('//')) {

--- a/apps/electron/src/services/mtls.ts
+++ b/apps/electron/src/services/mtls.ts
@@ -88,7 +88,11 @@ export async function setupMTLS() {
 
         log.info(`[mTLS] Candidates found: ${list.length}`);
 
-        // Both app.spaces and auth.spaces require mTLS.
+        // INVARIANT: only first-party hosts reach this point — the allowedMtlsHosts()
+        // gate at the top of this handler has already declined (preventDefault +
+        // callback(undefined)) every non-allowlisted host, and selectClientCertificate()
+        // below re-checks the allowlist. Do not add a selection path here that bypasses
+        // either check.
         event.preventDefault();
 
         if (list.length > 0) {

--- a/apps/electron/src/services/request-interceptor.ts
+++ b/apps/electron/src/services/request-interceptor.ts
@@ -150,10 +150,32 @@ export function setupXyneSpacesInterceptor(): void {
  * for the main window, embedded contents can't request at all.
  */
 const RESTRICTED_MEDIA_PERMISSIONS = new Set(['media', 'display-capture', 'mediaKeySystem']);
+
+// First-party Xyne content loaded outside the main window (e.g. in-app browser panel →
+// persist:xyne-spaces) is allowed this narrow set of low-risk permissions — clipboard
+// writes for "copy" buttons and fullscreen for the media/pptx/pdf viewers. Only this set,
+// and only for first-party origins; all other permissions stay denied except the main window.
+const FIRST_PARTY_NONMEDIA_PERMISSIONS = new Set([
+  'clipboard-sanitized-write', 'clipboard-read', 'fullscreen', 'pointerLock',
+]);
 function isTopLevelMainWindow(webContents: Electron.WebContents | undefined): boolean {
   if (!webContents) return false;
   if (!mainWindow || mainWindow.isDestroyed()) return false;
   return webContents === mainWindow.webContents;
+}
+// Mirrors preload.ts isTrustedOrigin(), but evaluated main-side against a webContents URL.
+function isFirstPartyUrl(rawUrl: string | undefined): boolean {
+  if (!rawUrl) return false;
+  try {
+    const { protocol, hostname } = new URL(rawUrl);
+    if (protocol.startsWith('xyne-spaces')) return true;              // bundled UI custom scheme
+    if (protocol === 'file:') return true;                            // bundled local HTML
+    if (protocol === 'https:' && (hostname === 'xyne.juspay.net' || hostname.endsWith('.xyne.juspay.net'))) return true;
+    if ((protocol === 'http:' || protocol === 'https:') && (hostname === 'localhost' || hostname === '127.0.0.1')) return true;
+    return false;
+  } catch {
+    return false;
+  }
 }
 function installMediaPermissionGuard(targetSession: Electron.Session, label: string): void {
   targetSession.setPermissionRequestHandler((webContents, permission, callback) => {
@@ -167,13 +189,31 @@ function installMediaPermissionGuard(targetSession: Electron.Session, label: str
       callback(allowed);
       return;
     }
-    callback(true);
+    // Main window keeps permissive behaviour; first-party Xyne content outside it gets ONLY
+    // the narrow clipboard/fullscreen set; every other session (in-app browser panel
+    // `persist:browser-tabs`, the `preview` partition, embedded `<webview>`s) is denied.
+    if (isTopLevelMainWindow(webContents)) {
+      callback(true);
+      return;
+    }
+    if (FIRST_PARTY_NONMEDIA_PERMISSIONS.has(permission) && isFirstPartyUrl(webContents?.getURL())) {
+      callback(true);
+      return;
+    }
+    Logger.warn(
+      `[permissions:${label}] denied ${permission} for non-main webContents (url=${webContents?.getURL() ?? 'n/a'})`,
+    );
+    callback(false);
   });
   targetSession.setPermissionCheckHandler((webContents, permission) => {
     if (RESTRICTED_MEDIA_PERMISSIONS.has(permission)) {
       return isTopLevelMainWindow(webContents ?? undefined);
     }
-    return true;
+    // Non-media permission checks succeed for the first-party main window,
+    // and for the narrow clipboard/fullscreen set on first-party content hosted outside
+    // it (e.g. the in-app browser panel); untrusted embedded content is denied.
+    if (isTopLevelMainWindow(webContents ?? undefined)) return true;
+    return FIRST_PARTY_NONMEDIA_PERMISSIONS.has(permission) && isFirstPartyUrl(webContents?.getURL());
   });
 }
 function setupMediaPermissionGuard(): void {

--- a/packages/xyne-claw-shared/src/tools/fill-pdf-form/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/fill-pdf-form/tools.ts
@@ -24,7 +24,7 @@
  */
 
 import { readFile } from "node:fs/promises";
-import { resolve, isAbsolute } from "node:path";
+import { resolve, isAbsolute, dirname, sep } from "node:path";
 import https from "node:https";
 import http from "node:http";
 import type { ToolDefinition, ToolExecutionContext } from "../types.js";
@@ -91,13 +91,18 @@ function resolveSessionPath(relPath: string): string {
   // here without plumbing it through — use cwd which IS the workspace at
   // tool-execution time.
   const cwd = process.cwd();
-  let candidate: string;
-  if (isAbsolute(relPath)) {
-    candidate = resolve(relPath);
-  } else {
-    candidate = resolve(cwd, relPath);
+  const candidate = isAbsolute(relPath) ? resolve(relPath) : resolve(cwd, relPath);
+
+  // Containment: the resolved path must stay within the session tree — the workspace
+  // (cwd) or its parent, which holds the sibling session-skills tree.
+  const sessionRoot = dirname(cwd);
+  const withinSession =
+    candidate === cwd || candidate.startsWith(cwd + sep) ||
+    candidate === sessionRoot || candidate.startsWith(sessionRoot + sep);
+  if (!withinSession) {
+    throw new Error(`refusing path outside the session workspace: ${relPath}`);
   }
-  // Cheap traversal check — refuse paths that go above cwd / session root.
+  // Cheap traversal check — belt-and-suspenders on top of the containment check.
   if (relPath.includes("..")) {
     throw new Error(`refusing path with traversal: ${relPath}`);
   }

--- a/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
@@ -100,6 +100,38 @@ function readOnlyGuard(session: Session, opts: { command?: string; write?: boole
   return null;
 }
 
+// Narrow set of destructive command patterns blocked on the sandbox shell path.
+// Enforced at the execute() chokepoint below, so it fires on every sandbox-run
+// path regardless of which agent framework dispatched the call.
+const DESTRUCTIVE_SANDBOX_PATTERNS: { pattern: RegExp; label: string }[] = [
+  { pattern: /\brm\s+-\w*r\w*(?:\s+-\S+)*\s+(?:\/|~|\$HOME|\.\.)(?:\s|\/|\*|$)/, label: "recursive rm of /, ~, $HOME or .." },
+  { pattern: /\bgit\s+push\b[^\n]*--force(?!-with-lease)\b/, label: "git push --force" },
+  { pattern: /\bgit\s+push\b[^\n]*\s-f(?=\s|$)/, label: "git push -f" },
+  { pattern: /\bcurl\b[^\n|]*\|\s*(?:ba)?sh\b/, label: "curl | sh" },
+  { pattern: /\bwget\b[^\n|]*\|\s*(?:ba)?sh\b/, label: "wget | sh" },
+  { pattern: /\bnpm\s+publish\b/, label: "npm publish" },
+  { pattern: /\bmkfs\b/, label: "mkfs" },
+  { pattern: /\bdd\b[^\n]*\bof=\/dev\//, label: "dd to device" },
+  { pattern: /:\s*\(\s*\)\s*\{\s*:/, label: "fork bomb" },
+  { pattern: />\s*\/dev\/(?:sd|nvme|disk)/, label: "write to disk device" },
+];
+
+/** Reject an obviously-destructive sandbox command. Returns an error string, or null if allowed. */
+function destructiveCommandGuard(cmd: string | undefined): string | null {
+  if (!cmd) return null;
+  for (const { pattern, label } of DESTRUCTIVE_SANDBOX_PATTERNS) {
+    if (pattern.test(cmd)) {
+      return (
+        `Error: command blocked by the sandbox safety guard ("${label}"). ` +
+        "This pattern is not allowed. Narrow it (target a specific subdirectory, " +
+        "use `git push --force-with-lease` instead of `--force`, avoid piping remote " +
+        "scripts into a shell) and retry."
+      );
+    }
+  }
+  return null;
+}
+
 const STALE_PATTERNS = [
   /could not connect to the backend sandbox/i,
   /HTTP request failed/i,
@@ -494,6 +526,8 @@ export const sandboxRun: ToolDefinition = {
     const cmd = (params["cmd"] ?? params["command"]) as string;
     const timeoutMs = (params["timeoutMs"] as number | undefined) ?? 60_000;
     if (!cmd?.trim()) return "Error: cmd or command is required.";
+    const destructive = destructiveCommandGuard(cmd);
+    if (destructive) return destructive;
 
     // Try explicit sessionId first
     const explicitSessionId = params["sessionId"] as string | undefined;
@@ -594,6 +628,8 @@ export const sandboxRunDetached: ToolDefinition = {
     if (!context) return "Error: No execution context available.";
     const sessionId = params["sessionId"] as string;
     const cmd = (params["cmd"] ?? params["command"]) as string;
+    const destructive = destructiveCommandGuard(cmd);
+    if (destructive) return destructive;
 
     const session = SESSION_STORE.get(sessionId);
     if (!session) return `Error: Session ${sessionId} not found. Create one with sandbox-create first.`;


### PR DESCRIPTION
> Migrated from juspay/xyne-spaces PR #75 (original author: @devesh-juspay).

Services-Requiring-Redeployment:
  - backend
  - dashboard
  - electron

## Type of Change

- [x] Bugfix
- [x] Enhancement

## Description

Non-ACL security hardening for XYNE-54744. **This PR targets `main` directly and is intended to merge first**; the ACL / tenant-isolation PR now stacks on top of this one.

**Outbound requests (SSRF)**
- User-controlled webhook URLs are validated before dispatch — private, loopback, link-local and cloud-metadata destinations are refused (including IPv4-mapped IPv6 forms), across the automation trigger-webhook step, app webhook (flow), slash-command dispatch, chat actionable URLs, and the PR-check Varys callback. Redirects are no longer followed automatically (`redirect: 'manual'`) so a redirect cannot re-target an internal host.

**Realtime (WebSocket)**
- WS events are authorized against the target channel/conversation before broadcast; typing events are gated the same way; `user_activity_event` is attributed to the authenticated socket user rather than a client-supplied id; ticket-counts rooms are validated and per-user rooms restricted to their owner.
- Note: the per-connection event budget and the bulk-subscription cap ship as **observe-only logging** (no drop / no truncation) pending production traffic observation — see Deferred below.

**Authentication**
- The web sign-in flow binds its handshake to the initiating browser (Google and Microsoft) and verifies it on callback; the mobile exchange path is selected by a request header rather than a query parameter so a browser request cannot skip state/PKCE verification.
- Login failures return a uniform response so the outcome does not reveal whether an account exists; an empty-credential auth source now fails closed; a dashboard query error no longer leaks driver detail.

**Uploads / stored XSS (serve-side)**
- Emoji and avatar streams are served with `X-Content-Type-Options: nosniff` and, for SVG, a sandbox CSP, so attacker-supplied active content cannot execute on direct navigation while normal `<img>` rendering is unaffected; non-image content types are downgraded to an opaque attachment. (Upload content-type filtering itself was deferred — see Deferred.)

**Search / data**
- Values interpolated into hand-built YQL search filters (memory search, duplicate-ticket detection) are escaped via a shared helper.
- Memory document indexing rejects a document id that already belongs to another user.
- Directory/employee lookups (mettle) reject cross-org callers and callers with no resolvable identity.

**Desktop (Electron)**
- The device certificate is presented only to first-party hosts; privileged identity/IPC operations are restricted to the main window; deep links are validated before navigation; embedded content no longer receives sensitive browser permissions; the local agent helper rejects browser-originated requests; Electron fuses are hardened. Sandbox tool execution has a destructive-command guard and PDF-form tooling is path-contained to the session tree.

## Deployment notes

- Webhook destinations that rely on an HTTP→HTTPS redirect will need their stored URL updated to the final address, since redirects are no longer followed.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [x] `apps/electron`
- [x] `packages/*` (shared tools: `xyne-claw-shared`)

## Zero (Sync) Changes

- [x] No Zero mutator / ACL changes in this PR (those are in the stacked ACL PR)

## Schema & Data Changes

- [x] No schema changes

## Config, Environment & URLs

- [x] No new required environment variables (the previously-proposed `TRUST_PROXY_HOPS` was deferred).
