### PR TITLE
fix: removed tokens from cookies

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -790,6 +790,10 @@ export const config = {
   session: {
     expiryDays: envVars.SESSION_EXPIRY_DAYS,
   },
+  pendingOAuthTokens: {
+    redisKeyPrefix: 'pendingauth:oauth:',
+    ttlSeconds: 10 * 60,
+  },
   pulse: {
     // Comma-separated channel IDs that have Pulse enabled (empty = disabled everywhere)
     enabledChannels: (envVars.PULSE_ENABLED_CHANNELS as string)

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -24,6 +24,11 @@ import {
   organizationDomainService,
 } from '@/services/organizationDomainService';
 import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper';
+import { redisService } from '@/services/redisService';
+import { randomUUID } from 'crypto';
+
+const PENDING_OAUTH_TOKEN_PREFIX = 'pendingauth:oauth:';
+const PENDING_OAUTH_TOKEN_TTL_SECONDS = 10 * 60;
 
 /**
  * Result type for single workspace auto-login
@@ -51,6 +56,24 @@ export class AuthV2Controller {
   private userSessionService: UserSessionService;
   private microsoftAuthController: MicrosoftAuthController;
   private prisma = DatabaseClient.getInstance();
+
+  private async storePendingOAuthTokens(
+    refreshToken?: string | null,
+    accessToken?: string | null,
+    accessTokenExpiry?: Date,
+  ): Promise<string> {
+    const tokenKey = randomUUID();
+    await redisService.set(
+      `${PENDING_OAUTH_TOKEN_PREFIX}${tokenKey}`,
+      JSON.stringify({
+        refreshToken: refreshToken ?? null,
+        accessToken: accessToken ?? null,
+        accessTokenExpiry: accessTokenExpiry?.toISOString() ?? null,
+      }),
+      PENDING_OAUTH_TOKEN_TTL_SECONDS,
+    );
+    return tokenKey;
+  }
 
   constructor() {
     const clientId = process.env.GOOGLE_CLIENT_ID;
@@ -505,15 +528,18 @@ export class AuthV2Controller {
       }
 
       const isProduction = process.env.NODE_ENV === 'production';
+      const tokenKey = await this.storePendingOAuthTokens(
+        refresh_token,
+        access_token,
+        accessTokenExpiry,
+      );
       res.cookie('google_access_token', jwt.sign({
         googleId: googleUserData.googleId,
         email: googleUserData.email,
         name: googleUserData.name,
         picture: googleUserData.picture,
         provider: AuthProvider.GOOGLE,
-        refreshToken: refresh_token,
-        accessToken: access_token,
-        accessTokenExpiry: accessTokenExpiry?.toISOString(),
+        tokenKey,
       }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
         httpOnly: true,
         secure: isProduction,
@@ -867,14 +893,18 @@ export class AuthV2Controller {
       const effectiveInvitationId = stateData.invitationId || invitationId;
       if (effectiveInvitationId) {
         logger.info(`[${requestId}] Invitation detected (${effectiveInvitationId}) — returning hasInvitation signal to Electron`);
+        const tokenKey = await this.storePendingOAuthTokens(
+          refresh_token,
+          access_token,
+          accessTokenExpiry,
+        );
         res.cookie('google_access_token', jwt.sign({
           googleId: googleUserData.googleId,
           email: googleUserData.email,
           name: googleUserData.name,
           picture: googleUserData.picture,
           provider: AuthProvider.GOOGLE,
-          refreshToken: refresh_token,
-          accessToken: access_token,
+          tokenKey,
         }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
           httpOnly: true,
           secure: isProduction,
@@ -949,15 +979,18 @@ export class AuthV2Controller {
       }
 
       // Store pending auth data for later loginWorkspace/createOrg call (multi-workspace case)
+      const tokenKey = await this.storePendingOAuthTokens(
+        refresh_token,
+        access_token,
+        accessTokenExpiry,
+      );
       res.cookie('google_access_token', jwt.sign({
         googleId: googleUserData.googleId,
         email: googleUserData.email,
         name: googleUserData.name,
         picture: googleUserData.picture,
         provider: AuthProvider.GOOGLE,
-        refreshToken: refresh_token,
-        accessToken: access_token,
-        accessTokenExpiry: accessTokenExpiry?.toISOString(),
+        tokenKey,
       }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
         httpOnly: true,
         secure: isProduction,
@@ -1046,6 +1079,7 @@ export class AuthV2Controller {
       });
 
       const { id_token, refresh_token, access_token } = tokens;
+      const accessTokenExpiry = tokens.expiry_date ? new Date(tokens.expiry_date) : undefined;
 
       if (!id_token) {
         logger.error(`[${requestId}] No ID token received`);
@@ -1112,15 +1146,19 @@ export class AuthV2Controller {
         maxAge: 10 * 60 * 1000, // 10 minutes
       };
 
-      // Store all Google auth data in one cookie (until workspace selection)
+      // Keep provider tokens in Redis; the cookie contains only the lookup key.
+      const tokenKey = await this.storePendingOAuthTokens(
+        refresh_token,
+        access_token,
+        accessTokenExpiry,
+      );
       res.cookie('google_access_token', jwt.sign({
         googleId: googleUserData.googleId,
         email: googleUserData.email,
         name: googleUserData.name,
         picture: googleUserData.picture,
         provider: AuthProvider.GOOGLE,
-        refreshToken: refresh_token || null,
-        accessToken: access_token || null,
+        tokenKey,
       }, process.env.JWT_SECRET!, { expiresIn: '10m' }), cookieOptions);
       logger.info(`[${requestId}] Stored pending auth data for workspace selection`);
 
@@ -1306,9 +1344,10 @@ export class AuthV2Controller {
       let pendingRefreshToken: string | undefined;
       let pendingAccessToken: string | undefined;
       let pendingAccessTokenExpiry: Date | undefined;
+      let pendingTokenKey: string | undefined;
 
       if (pendingAuthCookie) {
-        const parsed = this.parsePendingAuthCookie(pendingAuthCookie);
+        const parsed = await this.parsePendingAuthCookie(pendingAuthCookie);
         if (!parsed) {
           res.status(401).json({
             error: 'Invalid auth data',
@@ -1324,6 +1363,7 @@ export class AuthV2Controller {
           pendingRefreshToken = parsed.pendingRefreshToken;
           pendingAccessToken = parsed.pendingAccessToken;
           pendingAccessTokenExpiry = parsed.pendingAccessTokenExpiry;
+          pendingTokenKey = parsed.pendingTokenKey;
         } else {
           res.status(401).json({
             error: 'Invalid auth data',
@@ -1488,6 +1528,9 @@ export class AuthV2Controller {
         : '';
 
       // Clear pending auth cookie and return success
+      if (pendingTokenKey) {
+        await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingTokenKey}`);
+      }
       res.clearCookie('google_access_token', { path: '/' });
       res.status(200).json({
         success: true,
@@ -1534,7 +1577,7 @@ export class AuthV2Controller {
         return;
       }
 
-      const parsedAuth = this.parsePendingAuthCookie(pendingAuthCookie);
+      const parsedAuth = await this.parsePendingAuthCookie(pendingAuthCookie);
       if (!parsedAuth) {
         res.status(401).json({
           error: 'Invalid auth data',
@@ -1542,7 +1585,7 @@ export class AuthV2Controller {
         });
         return;
       }
-      const { oauthUserData, provider, pendingRefreshToken } = parsedAuth;
+      const { oauthUserData, provider, pendingRefreshToken, pendingTokenKey } = parsedAuth;
 
       if (!oauthUserData?.email) {
         res.status(401).json({
@@ -1663,6 +1706,9 @@ export class AuthV2Controller {
       });
 
       // Clear pending auth cookie
+      if (pendingTokenKey) {
+        await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingTokenKey}`);
+      }
       res.clearCookie('google_access_token', { path: '/' });
 
       logger.info(`[CREATE-ORG] Created org ${organization.orgId} with workspace ${workspace.id}`);
@@ -1847,7 +1893,7 @@ export class AuthV2Controller {
         return;
       }
 
-      const parsedAuth = this.parsePendingAuthCookie(pendingAuthCookie);
+      const parsedAuth = await this.parsePendingAuthCookie(pendingAuthCookie);
       if (!parsedAuth) {
         res.status(401).json({
           error: 'Invalid auth data',
@@ -1855,7 +1901,7 @@ export class AuthV2Controller {
         });
         return;
       }
-      const { oauthUserData, provider, pendingRefreshToken } = parsedAuth;
+      const { oauthUserData, provider, pendingRefreshToken, pendingTokenKey } = parsedAuth;
         if (!oauthUserData?.email) {
           res.status(401).json({
             error: 'Invalid auth data',
@@ -2003,6 +2049,9 @@ export class AuthV2Controller {
           maxAge: 24 * 60 * 60 * 1000,
         });
 
+        if (pendingTokenKey) {
+          await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingTokenKey}`);
+        }
         res.clearCookie('google_access_token', { path: '/' });
 
         logger.info(`[CREATE-WORKSPACE-PENDING] Created workspace "${workspaceName}" for ${oauthUserData.email} in org ${organization.orgId}`);
@@ -2170,13 +2219,14 @@ export class AuthV2Controller {
    * Parses and verifies the google_access_token pending-auth cookie (signed JWT).
    * Returns null if the token is invalid, expired, or cannot be verified.
    */
-  private parsePendingAuthCookie(cookie: string): {
+  private async parsePendingAuthCookie(cookie: string): Promise<{
     oauthUserData: { email: string; name: string; googleId?: string; providerUserId?: string; picture?: string };
     provider: string;
     pendingRefreshToken: string | undefined;
     pendingAccessToken: string | undefined;
     pendingAccessTokenExpiry: Date | undefined;
-  } | null {
+    pendingTokenKey: string | undefined;
+  } | null> {
     try {
       const decoded = jwt.verify(cookie, process.env.JWT_SECRET!) as {
         googleId?: string;
@@ -2188,10 +2238,28 @@ export class AuthV2Controller {
         refreshToken?: string | null;
         accessToken?: string | null;
         accessTokenExpiry?: string | null;
+        tokenKey?: string;
       };
       if (!decoded?.email) throw new Error('Invalid JWT payload');
-      const pendingAccessTokenExpiry = decoded.accessTokenExpiry
-        ? new Date(decoded.accessTokenExpiry)
+
+      let redisTokens: {
+        refreshToken?: string | null;
+        accessToken?: string | null;
+        accessTokenExpiry?: string | null;
+      } | null = null;
+      if (decoded.tokenKey) {
+        const storedTokens = await redisService.get(
+          `${PENDING_OAUTH_TOKEN_PREFIX}${decoded.tokenKey}`,
+        );
+        if (!storedTokens) return null;
+        redisTokens = JSON.parse(storedTokens);
+      }
+
+      const refreshToken = redisTokens?.refreshToken ?? decoded.refreshToken;
+      const accessToken = redisTokens?.accessToken ?? decoded.accessToken;
+      const accessTokenExpiry = redisTokens?.accessTokenExpiry ?? decoded.accessTokenExpiry;
+      const pendingAccessTokenExpiry = accessTokenExpiry
+        ? new Date(accessTokenExpiry)
         : undefined;
       return {
         oauthUserData: {
@@ -2202,12 +2270,13 @@ export class AuthV2Controller {
           picture: decoded.picture,
         },
         provider: decoded.provider || AuthProvider.GOOGLE,
-        pendingRefreshToken: decoded.refreshToken || undefined,
-        pendingAccessToken: decoded.accessToken || undefined,
+        pendingRefreshToken: refreshToken || undefined,
+        pendingAccessToken: accessToken || undefined,
         pendingAccessTokenExpiry:
           pendingAccessTokenExpiry && !Number.isNaN(pendingAccessTokenExpiry.getTime())
             ? pendingAccessTokenExpiry
             : undefined,
+        pendingTokenKey: decoded.tokenKey,
       };
     } catch {
       return null;

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -27,9 +27,6 @@ import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper'
 import { redisService } from '@/services/redisService';
 import { randomUUID } from 'crypto';
 
-const PENDING_OAUTH_TOKEN_PREFIX = 'pendingauth:oauth:';
-const PENDING_OAUTH_TOKEN_TTL_SECONDS = 10 * 60;
-
 /**
  * Result type for single workspace auto-login
  */
@@ -64,13 +61,13 @@ export class AuthV2Controller {
   ): Promise<string> {
     const tokenKey = randomUUID();
     await redisService.set(
-      `${PENDING_OAUTH_TOKEN_PREFIX}${tokenKey}`,
+      `${config.pendingOAuthTokens.redisKeyPrefix}${tokenKey}`,
       JSON.stringify({
         refreshToken: refreshToken ?? null,
         accessToken: accessToken ?? null,
         accessTokenExpiry: accessTokenExpiry?.toISOString() ?? null,
       }),
-      PENDING_OAUTH_TOKEN_TTL_SECONDS,
+      config.pendingOAuthTokens.ttlSeconds,
     );
     return tokenKey;
   }
@@ -1529,7 +1526,9 @@ export class AuthV2Controller {
 
       // Clear pending auth cookie and return success
       if (pendingTokenKey) {
-        await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingTokenKey}`);
+        await redisService.del(
+          `${config.pendingOAuthTokens.redisKeyPrefix}${pendingTokenKey}`,
+        );
       }
       res.clearCookie('google_access_token', { path: '/' });
       res.status(200).json({
@@ -1707,7 +1706,9 @@ export class AuthV2Controller {
 
       // Clear pending auth cookie
       if (pendingTokenKey) {
-        await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingTokenKey}`);
+        await redisService.del(
+          `${config.pendingOAuthTokens.redisKeyPrefix}${pendingTokenKey}`,
+        );
       }
       res.clearCookie('google_access_token', { path: '/' });
 
@@ -2050,7 +2051,9 @@ export class AuthV2Controller {
         });
 
         if (pendingTokenKey) {
-          await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingTokenKey}`);
+          await redisService.del(
+            `${config.pendingOAuthTokens.redisKeyPrefix}${pendingTokenKey}`,
+          );
         }
         res.clearCookie('google_access_token', { path: '/' });
 
@@ -2249,7 +2252,7 @@ export class AuthV2Controller {
       } | null = null;
       if (decoded.tokenKey) {
         const storedTokens = await redisService.get(
-          `${PENDING_OAUTH_TOKEN_PREFIX}${decoded.tokenKey}`,
+          `${config.pendingOAuthTokens.redisKeyPrefix}${decoded.tokenKey}`,
         );
         if (!storedTokens) return null;
         redisTokens = JSON.parse(storedTokens);

--- a/apps/backend/src/controllers/communityWorkspaceController.ts
+++ b/apps/backend/src/controllers/communityWorkspaceController.ts
@@ -17,8 +17,6 @@ import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 import { redisService } from '@/services/redisService';
 
-const PENDING_OAUTH_TOKEN_PREFIX = 'pendingauth:oauth:';
-
 type PendingAuth = {
   userData: {
     providerUserId: string;
@@ -145,7 +143,9 @@ export class CommunityWorkspaceController {
         });
       }
       if (pendingAuth.tokenKey) {
-        await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingAuth.tokenKey}`);
+        await redisService.del(
+          `${config.pendingOAuthTokens.redisKeyPrefix}${pendingAuth.tokenKey}`,
+        );
       }
       res.clearCookie('google_access_token', { path: '/' });
 
@@ -327,7 +327,7 @@ export class CommunityWorkspaceController {
 
       if (decoded.tokenKey) {
         const storedTokens = await redisService.get(
-          `${PENDING_OAUTH_TOKEN_PREFIX}${decoded.tokenKey}`,
+          `${config.pendingOAuthTokens.redisKeyPrefix}${decoded.tokenKey}`,
         );
         if (!storedTokens) return null;
         redisTokens = JSON.parse(storedTokens);

--- a/apps/backend/src/controllers/communityWorkspaceController.ts
+++ b/apps/backend/src/controllers/communityWorkspaceController.ts
@@ -15,6 +15,9 @@ import { jwtService } from '@/services/jwtService';
 import { channelService } from '@/services/channelService';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
+import { redisService } from '@/services/redisService';
+
+const PENDING_OAUTH_TOKEN_PREFIX = 'pendingauth:oauth:';
 
 type PendingAuth = {
   userData: {
@@ -27,6 +30,7 @@ type PendingAuth = {
   refreshToken?: string;
   accessToken?: string;
   accessTokenExpiry?: Date;
+  tokenKey?: string;
 };
 
 export class CommunityWorkspaceController {
@@ -139,6 +143,9 @@ export class CommunityWorkspaceController {
           path: '/',
           maxAge: 30 * 24 * 60 * 60 * 1000,
         });
+      }
+      if (pendingAuth.tokenKey) {
+        await redisService.del(`${PENDING_OAUTH_TOKEN_PREFIX}${pendingAuth.tokenKey}`);
       }
       res.clearCookie('google_access_token', { path: '/' });
 
@@ -295,7 +302,7 @@ export class CommunityWorkspaceController {
     };
   }
 
-  private parsePendingAuthCookie(cookie: string): PendingAuth | null {
+  private async parsePendingAuthCookie(cookie: string): Promise<PendingAuth | null> {
     try {
       const decoded = jwt.verify(cookie, process.env.JWT_SECRET!) as {
         googleId?: string;
@@ -307,12 +314,31 @@ export class CommunityWorkspaceController {
         refreshToken?: string | null;
         accessToken?: string | null;
         accessTokenExpiry?: string | null;
+        tokenKey?: string;
       };
       const providerUserId = decoded.providerUserId || decoded.googleId;
       if (!decoded.email || !providerUserId) return null;
 
-      const accessTokenExpiry = decoded.accessTokenExpiry
-        ? new Date(decoded.accessTokenExpiry)
+      let redisTokens: {
+        refreshToken?: string | null;
+        accessToken?: string | null;
+        accessTokenExpiry?: string | null;
+      } | null = null;
+
+      if (decoded.tokenKey) {
+        const storedTokens = await redisService.get(
+          `${PENDING_OAUTH_TOKEN_PREFIX}${decoded.tokenKey}`,
+        );
+        if (!storedTokens) return null;
+        redisTokens = JSON.parse(storedTokens);
+      }
+
+      const refreshToken = redisTokens?.refreshToken ?? decoded.refreshToken;
+      const accessToken = redisTokens?.accessToken ?? decoded.accessToken;
+      const accessTokenExpiryValue =
+        redisTokens?.accessTokenExpiry ?? decoded.accessTokenExpiry;
+      const accessTokenExpiry = accessTokenExpiryValue
+        ? new Date(accessTokenExpiryValue)
         : undefined;
       return {
         userData: {
@@ -322,12 +348,13 @@ export class CommunityWorkspaceController {
           picture: decoded.picture,
           authProvider: decoded.provider || AuthProvider.GOOGLE,
         },
-        refreshToken: decoded.refreshToken || undefined,
-        accessToken: decoded.accessToken || undefined,
+        refreshToken: refreshToken || undefined,
+        accessToken: accessToken || undefined,
         accessTokenExpiry:
           accessTokenExpiry && !Number.isNaN(accessTokenExpiry.getTime())
             ? accessTokenExpiry
             : undefined,
+        tokenKey: decoded.tokenKey,
       };
     } catch (_error) {
       return null;

--- a/apps/backend/src/controllers/microsoftAuthController.ts
+++ b/apps/backend/src/controllers/microsoftAuthController.ts
@@ -21,6 +21,11 @@ import {
 } from '@/services/organizationDomainService';
 import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper';
 import { signMicrosoftInvitationPendingAuthToken } from '@/utils/microsoftPendingAuth';
+import { redisService } from '@/services/redisService';
+import { randomUUID } from 'crypto';
+
+const PENDING_OAUTH_TOKEN_PREFIX = 'pendingauth:oauth:';
+const PENDING_OAUTH_TOKEN_TTL_SECONDS = 10 * 60;
 
 export class MicrosoftAuthController {
   private oauthClient: AuthorizationCode | undefined;
@@ -29,6 +34,24 @@ export class MicrosoftAuthController {
   private clientId: string | undefined;
   private tenantId: string = '';
   private msJwks!: ReturnType<typeof createRemoteJWKSet>;
+
+  private async storePendingOAuthTokens(
+    refreshToken?: string | null,
+    accessToken?: string | null,
+    accessTokenExpiry?: Date,
+  ): Promise<string> {
+    const tokenKey = randomUUID();
+    await redisService.set(
+      `${PENDING_OAUTH_TOKEN_PREFIX}${tokenKey}`,
+      JSON.stringify({
+        refreshToken: refreshToken ?? null,
+        accessToken: accessToken ?? null,
+        accessTokenExpiry: accessTokenExpiry?.toISOString() ?? null,
+      }),
+      PENDING_OAUTH_TOKEN_TTL_SECONDS,
+    );
+    return tokenKey;
+  }
 
   constructor() {
     const clientId = process.env.MICROSOFT_CLIENT_ID;
@@ -417,19 +440,21 @@ export class MicrosoftAuthController {
         const refreshToken = token.refresh_token as string | undefined;
         const isProduction = process.env.NODE_ENV === 'production';
 
-        // Microsoft access + refresh tokens can exceed the browser's per-cookie
-        // size limit when nested in our pending-auth JWT. Invitation acceptance
-        // only needs identity, and loginWorkspace can establish the target
-        // workspace session from the refresh token, so use the compact payload
-        // already used by the Microsoft Electron invitation flow.
+        // Keep Microsoft provider tokens in Redis; the cookie contains identity
+        // plus only the short-lived Redis lookup key.
         const cookieInvitationId = req.cookies?.pending_invitation_id as string | undefined;
         const pendingInvitationId = cookieInvitationId || peekedState?.invitationId;
         if (resolvedPlatform !== 'mobile' && pendingInvitationId) {
+          const tokenKey = await this.storePendingOAuthTokens(
+            refreshToken,
+            accessToken,
+            accessTokenExpiry,
+          );
           res.cookie(
             'google_access_token',
             signMicrosoftInvitationPendingAuthToken(
               microsoftUserData,
-              refreshToken,
+              tokenKey,
               process.env.JWT_SECRET!,
             ),
             {
@@ -485,13 +510,18 @@ export class MicrosoftAuthController {
             }
           }
 
+          const tokenKey = await this.storePendingOAuthTokens(
+            refreshToken,
+            accessToken,
+            accessTokenExpiry,
+          );
           res.cookie('google_access_token', jwt.sign({
             providerUserId: microsoftUserData.providerUserId,
             email: microsoftUserData.email,
             name: microsoftUserData.name,
             picture: microsoftUserData.picture,
             provider: AuthProvider.MICROSOFT,
-            refreshToken: refreshToken ?? null,
+            tokenKey,
           }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
             httpOnly: true,
             secure: isProduction,
@@ -610,20 +640,19 @@ export class MicrosoftAuthController {
           path: '/',
         };
 
-        // Set pending-auth cookie. This must be a pending-auth JWT (not the
-        // session customToken): loginWorkspace/createOrg read it via
-        // parsePendingAuthCookie, which needs providerUserId AND provider — the
-        // session token has neither, so it would mislabel the user as GOOGLE and
-        // drop the refresh token. Mirrors Google's web callback + MS electron.
+        // Keep provider identity in the signed cookie and provider tokens in Redis.
+        const tokenKey = await this.storePendingOAuthTokens(
+          refreshToken,
+          accessToken,
+          accessTokenExpiry,
+        );
         res.cookie('google_access_token', jwt.sign({
           providerUserId: microsoftUserData.providerUserId,
           email: microsoftUserData.email,
           name: microsoftUserData.name,
           picture: microsoftUserData.picture,
           provider: AuthProvider.MICROSOFT,
-          refreshToken: refreshToken ?? null,
-          accessToken: accessToken ?? null,
-          accessTokenExpiry: accessTokenExpiry?.toISOString(),
+          tokenKey,
         }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
           ...cookieOptions,
           maxAge: 10 * 60 * 1000, // 10 minutes pending auth window
@@ -870,13 +899,18 @@ export class MicrosoftAuthController {
       // This mirrors Google's exchangeElectronCode which always sets google_access_token (line 842).
       if (workspaces.length === 0 && !userExistsButRemoved && !stateData.invitationId && !bodyInvitationId) {
         logger.info(`[${requestId}] User has no workspaces and no invitation - setting google_access_token and returning no-access`);
+        const tokenKey = await this.storePendingOAuthTokens(
+          token.refresh_token as string | undefined,
+          accessToken,
+          accessTokenExpiry,
+        );
         res.cookie('google_access_token', jwt.sign({
           providerUserId: profile.id,
           email,
           name: profile.displayName,
           picture: undefined,
           provider: 'microsoft',
-          refreshToken: (token.refresh_token as string | undefined) ?? null,
+          tokenKey,
         }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
           httpOnly: true,
           secure: isProduction,
@@ -906,13 +940,18 @@ export class MicrosoftAuthController {
         logger.info(`[${requestId}] Invitation detected (${effectiveInvitationId}) — returning hasInvitation signal to Electron`);
         // Use sameSite: 'lax' for Electron invitation flow - cookies need to be sent
         // from the renderer (localhost:5173) to backend (localhost:3001)
+        const tokenKey = await this.storePendingOAuthTokens(
+          token.refresh_token as string | undefined,
+          accessToken,
+          accessTokenExpiry,
+        );
         res.cookie('google_access_token', jwt.sign({
           providerUserId: profile.id,
           email,
           name: profile.displayName,
           picture: undefined,
           provider: 'microsoft',
-          refreshToken: (token.refresh_token as string | undefined) ?? null,
+          tokenKey,
         }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
           httpOnly: true,
           secure: isProduction,
@@ -1031,15 +1070,18 @@ export class MicrosoftAuthController {
           });
         }
 
+        const tokenKey = await this.storePendingOAuthTokens(
+          refreshToken,
+          accessToken,
+          accessTokenExpiry,
+        );
         res.cookie('google_access_token', jwt.sign({
           providerUserId: profile.id,
           email,
           name: profile.displayName,
           picture: undefined,
           provider: 'microsoft',
-          refreshToken: refreshToken ?? null,
-          accessToken,
-          accessTokenExpiry: accessTokenExpiry?.toISOString(),
+          tokenKey,
         }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
           httpOnly: true,
           secure: isProduction,
@@ -1111,15 +1153,18 @@ export class MicrosoftAuthController {
       }
 
       // Store pending auth data for later loginWorkspace / acceptInvitation call
+      const tokenKey = await this.storePendingOAuthTokens(
+        refreshToken,
+        accessToken,
+        accessTokenExpiry,
+      );
       res.cookie('google_access_token', jwt.sign({
         providerUserId: profile.id,
         email,
         name: profile.displayName,
         picture: undefined,
         provider: 'microsoft',
-        refreshToken: refreshToken ?? null,
-        accessToken,
-        accessTokenExpiry: accessTokenExpiry?.toISOString(),
+        tokenKey,
       }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
         httpOnly: true,
         secure: isProduction,
@@ -1380,21 +1425,23 @@ export class MicrosoftAuthController {
         path: '/',
       };
 
-      // Pending-auth cookie must carry provider identity (providerUserId +
-      // provider) so a later loginWorkspace / createOrg / acceptInvitation call
-      // resolves the Microsoft user correctly. Mirrors Google's mobile exchange.
+      // Keep provider identity in the signed cookie and provider tokens in Redis.
       const mobileExpiresIn = token.expires_in as number | undefined;
+      const mobileAccessTokenExpiry = mobileExpiresIn
+        ? new Date(Date.now() + mobileExpiresIn * 1000)
+        : undefined;
+      const tokenKey = await this.storePendingOAuthTokens(
+        refreshToken,
+        accessToken,
+        mobileAccessTokenExpiry,
+      );
       res.cookie('google_access_token', jwt.sign({
         providerUserId: profile.id,
         email,
         name: profile.displayName,
         picture: undefined,
         provider: 'microsoft',
-        refreshToken: refreshToken ?? null,
-        accessToken: accessToken ?? null,
-        accessTokenExpiry: mobileExpiresIn
-          ? new Date(Date.now() + mobileExpiresIn * 1000).toISOString()
-          : undefined,
+        tokenKey,
       }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
         ...cookieOptions,
         maxAge: 10 * 60 * 1000, // 10 minutes pending auth window

--- a/apps/backend/src/controllers/microsoftAuthController.ts
+++ b/apps/backend/src/controllers/microsoftAuthController.ts
@@ -24,9 +24,6 @@ import { signMicrosoftInvitationPendingAuthToken } from '@/utils/microsoftPendin
 import { redisService } from '@/services/redisService';
 import { randomUUID } from 'crypto';
 
-const PENDING_OAUTH_TOKEN_PREFIX = 'pendingauth:oauth:';
-const PENDING_OAUTH_TOKEN_TTL_SECONDS = 10 * 60;
-
 export class MicrosoftAuthController {
   private oauthClient: AuthorizationCode | undefined;
   private userService: UserService | undefined;
@@ -42,13 +39,13 @@ export class MicrosoftAuthController {
   ): Promise<string> {
     const tokenKey = randomUUID();
     await redisService.set(
-      `${PENDING_OAUTH_TOKEN_PREFIX}${tokenKey}`,
+      `${config.pendingOAuthTokens.redisKeyPrefix}${tokenKey}`,
       JSON.stringify({
         refreshToken: refreshToken ?? null,
         accessToken: accessToken ?? null,
         accessTokenExpiry: accessTokenExpiry?.toISOString() ?? null,
       }),
-      PENDING_OAUTH_TOKEN_TTL_SECONDS,
+      config.pendingOAuthTokens.ttlSeconds,
     );
     return tokenKey;
   }

--- a/apps/backend/src/utils/microsoftPendingAuth.ts
+++ b/apps/backend/src/utils/microsoftPendingAuth.ts
@@ -8,21 +8,19 @@ export interface MicrosoftPendingAuthIdentity {
 }
 
 /**
- * Microsoft access tokens are large enough that embedding one alongside the
- * refresh token can exceed the browser's per-cookie size limit. Invitation
- * acceptance only needs the verified identity, while loginWorkspace can create
- * the new workspace session from the refresh token.
+ * Invitation acceptance needs the verified identity. Provider tokens remain in
+ * Redis and this JWT carries only their short-lived lookup key.
  */
 export function signMicrosoftInvitationPendingAuthToken(
   identity: MicrosoftPendingAuthIdentity,
-  refreshToken: string | undefined,
+  tokenKey: string,
   jwtSecret: string
 ): string {
   return jwt.sign(
     {
       ...identity,
       provider: 'MICROSOFT',
-      refreshToken: refreshToken ?? null,
+      tokenKey,
     },
     jwtSecret,
     { expiresIn: '10m' }


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [x] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [x] Google
- [x] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [x] Fresh signup / first-time user
- [x] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
