### PR TITLE
fix(backend): scope DM/group-DM lookups by workspace and enforce uniq…

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -584,7 +584,6 @@ export enum NotificationType {
   EMAIL_FETCH_COMPLETED = "EMAIL_FETCH_COMPLETED",
   EMAIL_FETCH_FAILED = "EMAIL_FETCH_FAILED",
   CANVAS_SHARED = "CANVAS_SHARED",
-  RECORDING_SHARED = "RECORDING_SHARED",
   EMAIL_REPLY_RECEIVED = "EMAIL_REPLY_RECEIVED",
   MESSAGE_DELETED = "MESSAGE_DELETED",
   MESSAGE_EDITED = "MESSAGE_EDITED",
@@ -866,6 +865,20 @@ export enum TagMethod {
   MANUAL = "MANUAL",
   LLM = "LLM",
   AUTOMATED = "AUTOMATED",
+}
+
+export enum TelepresenceDeviceType {
+  TV = "TV",
+  CAMERA = "CAMERA",
+  MICROPHONE = "MICROPHONE",
+  SPEAKER = "SPEAKER",
+}
+
+export enum TelepresenceHealthStatus {
+  HEALTHY = "HEALTHY",
+  DEGRADED = "DEGRADED",
+  UNAVAILABLE = "UNAVAILABLE",
+  UNKNOWN = "UNKNOWN",
 }
 
 // Define tables
@@ -2472,39 +2485,6 @@ export const callTable = table("calls")
     callUpdatesChannel: string().optional(),
     participantCount: number().optional(),
     participantPreviewUserIds: string().optional(),
-    summaryTemplateId: string().optional(),
-    labels: json<string[]>(),
-    markedItems: json<any[]>(),
-  })
-  .primaryKey("id");
-
-export const entityAccessTable = table("entity_access")
-  .columns({
-    id: string(),
-    workspaceId: string(),
-    shareableEntityType: string(),
-    entityId: string(),
-    userId: string().optional(),
-    userGroupId: string().optional(),
-    channelId: string().optional(),
-    entityUserAccess: string(),
-    createdAt: number(),
-    updatedAt: number(),
-  })
-  .primaryKey("id");
-
-export const summaryTemplateTable = table("summary_templates")
-  .columns({
-    id: string(),
-    workspaceId: string(),
-    name: string(),
-    autoTriggerPrompt: string().optional(),
-    sections: json(),
-    version: number(),
-    systemPrompt: string(),
-    defaultOutlet: string(),
-    createdBy: string(),
-    createdAt: number(),
   })
   .primaryKey("id");
 
@@ -3610,6 +3590,38 @@ export const entityAliasTable = table("entity_aliases")
     surfaceForm: string(),
     normalizedForm: string(),
     count: number(),
+    createdAt: number(),
+  })
+  .primaryKey("id");
+
+export const telepresenceHealthViewTable = table("telepresence_health_view")
+  .columns({
+    id: string(),
+    userId: string(),
+    deviceType: enumeration<TelepresenceDeviceType>(),
+    name: string(),
+    status: enumeration<TelepresenceHealthStatus>(),
+    connected: number(),
+    detected: number(),
+    cpuTemperature: number(),
+    lastReportedAt: number(),
+    createdAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey("id");
+
+export const telepresenceHealthLogTable = table("telepresence_health_log")
+  .columns({
+    id: string(),
+    userId: string(),
+    deviceType: enumeration<TelepresenceDeviceType>(),
+    name: string().optional(),
+    status: enumeration<TelepresenceHealthStatus>(),
+    connected: number(),
+    detected: number(),
+    cpuTemperature: number(),
+    description: string().optional(),
+    reportedAt: number(),
     createdAt: number(),
   })
   .primaryKey("id");
@@ -5494,8 +5506,6 @@ export const schema = createSchema(
       notificationPreferenceTable,
       browserNotificationSubscriptionTable,
       callTable,
-      entityAccessTable,
-      summaryTemplateTable,
       callParticipantTable,
       callRecordingTable,
       recurringCallSeriesTable,
@@ -5568,6 +5578,8 @@ export const schema = createSchema(
       doclingAsyncPartTable,
       entityTable,
       entityAliasTable,
+      telepresenceHealthViewTable,
+      telepresenceHealthLogTable,
     ],
     relationships: [
       agentTableRelationships,
@@ -5774,8 +5786,6 @@ export type Notification = Row<typeof schema.tables.notifications>;
 export type NotificationPreference = Row<typeof schema.tables.notification_preferences>;
 export type BrowserNotificationSubscription = Row<typeof schema.tables.browser_notification_subscriptions>;
 export type Call = Row<typeof schema.tables.calls>;
-export type EntityAccess = Row<typeof schema.tables.entity_access>;
-export type SummaryTemplate = Row<typeof schema.tables.summary_templates>;
 export type CallParticipant = Row<typeof schema.tables.call_participants>;
 export type CallRecording = Row<typeof schema.tables.call_recordings>;
 export type RecurringCallSeries = Row<typeof schema.tables.recurring_call_series>;
@@ -5848,3 +5858,5 @@ export type DoclingAsyncFile = Row<typeof schema.tables.docling_async_files>;
 export type DoclingAsyncPart = Row<typeof schema.tables.docling_async_parts>;
 export type Entity = Row<typeof schema.tables.entities>;
 export type EntityAlias = Row<typeof schema.tables.entity_aliases>;
+export type TelepresenceHealthView = Row<typeof schema.tables.telepresence_health_view>;
+export type TelepresenceHealthLog = Row<typeof schema.tables.telepresence_health_log>;

--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -584,6 +584,7 @@ export enum NotificationType {
   EMAIL_FETCH_COMPLETED = "EMAIL_FETCH_COMPLETED",
   EMAIL_FETCH_FAILED = "EMAIL_FETCH_FAILED",
   CANVAS_SHARED = "CANVAS_SHARED",
+  RECORDING_SHARED = "RECORDING_SHARED",
   EMAIL_REPLY_RECEIVED = "EMAIL_REPLY_RECEIVED",
   MESSAGE_DELETED = "MESSAGE_DELETED",
   MESSAGE_EDITED = "MESSAGE_EDITED",
@@ -865,20 +866,6 @@ export enum TagMethod {
   MANUAL = "MANUAL",
   LLM = "LLM",
   AUTOMATED = "AUTOMATED",
-}
-
-export enum TelepresenceDeviceType {
-  TV = "TV",
-  CAMERA = "CAMERA",
-  MICROPHONE = "MICROPHONE",
-  SPEAKER = "SPEAKER",
-}
-
-export enum TelepresenceHealthStatus {
-  HEALTHY = "HEALTHY",
-  DEGRADED = "DEGRADED",
-  UNAVAILABLE = "UNAVAILABLE",
-  UNKNOWN = "UNKNOWN",
 }
 
 // Define tables
@@ -2485,6 +2472,39 @@ export const callTable = table("calls")
     callUpdatesChannel: string().optional(),
     participantCount: number().optional(),
     participantPreviewUserIds: string().optional(),
+    summaryTemplateId: string().optional(),
+    labels: json<string[]>(),
+    markedItems: json<any[]>(),
+  })
+  .primaryKey("id");
+
+export const entityAccessTable = table("entity_access")
+  .columns({
+    id: string(),
+    workspaceId: string(),
+    shareableEntityType: string(),
+    entityId: string(),
+    userId: string().optional(),
+    userGroupId: string().optional(),
+    channelId: string().optional(),
+    entityUserAccess: string(),
+    createdAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey("id");
+
+export const summaryTemplateTable = table("summary_templates")
+  .columns({
+    id: string(),
+    workspaceId: string(),
+    name: string(),
+    autoTriggerPrompt: string().optional(),
+    sections: json(),
+    version: number(),
+    systemPrompt: string(),
+    defaultOutlet: string(),
+    createdBy: string(),
+    createdAt: number(),
   })
   .primaryKey("id");
 
@@ -3590,38 +3610,6 @@ export const entityAliasTable = table("entity_aliases")
     surfaceForm: string(),
     normalizedForm: string(),
     count: number(),
-    createdAt: number(),
-  })
-  .primaryKey("id");
-
-export const telepresenceHealthViewTable = table("telepresence_health_view")
-  .columns({
-    id: string(),
-    userId: string(),
-    deviceType: enumeration<TelepresenceDeviceType>(),
-    name: string(),
-    status: enumeration<TelepresenceHealthStatus>(),
-    connected: number(),
-    detected: number(),
-    cpuTemperature: number(),
-    lastReportedAt: number(),
-    createdAt: number(),
-    updatedAt: number(),
-  })
-  .primaryKey("id");
-
-export const telepresenceHealthLogTable = table("telepresence_health_log")
-  .columns({
-    id: string(),
-    userId: string(),
-    deviceType: enumeration<TelepresenceDeviceType>(),
-    name: string().optional(),
-    status: enumeration<TelepresenceHealthStatus>(),
-    connected: number(),
-    detected: number(),
-    cpuTemperature: number(),
-    description: string().optional(),
-    reportedAt: number(),
     createdAt: number(),
   })
   .primaryKey("id");
@@ -5506,6 +5494,8 @@ export const schema = createSchema(
       notificationPreferenceTable,
       browserNotificationSubscriptionTable,
       callTable,
+      entityAccessTable,
+      summaryTemplateTable,
       callParticipantTable,
       callRecordingTable,
       recurringCallSeriesTable,
@@ -5578,8 +5568,6 @@ export const schema = createSchema(
       doclingAsyncPartTable,
       entityTable,
       entityAliasTable,
-      telepresenceHealthViewTable,
-      telepresenceHealthLogTable,
     ],
     relationships: [
       agentTableRelationships,
@@ -5786,6 +5774,8 @@ export type Notification = Row<typeof schema.tables.notifications>;
 export type NotificationPreference = Row<typeof schema.tables.notification_preferences>;
 export type BrowserNotificationSubscription = Row<typeof schema.tables.browser_notification_subscriptions>;
 export type Call = Row<typeof schema.tables.calls>;
+export type EntityAccess = Row<typeof schema.tables.entity_access>;
+export type SummaryTemplate = Row<typeof schema.tables.summary_templates>;
 export type CallParticipant = Row<typeof schema.tables.call_participants>;
 export type CallRecording = Row<typeof schema.tables.call_recordings>;
 export type RecurringCallSeries = Row<typeof schema.tables.recurring_call_series>;
@@ -5858,5 +5848,3 @@ export type DoclingAsyncFile = Row<typeof schema.tables.docling_async_files>;
 export type DoclingAsyncPart = Row<typeof schema.tables.docling_async_parts>;
 export type Entity = Row<typeof schema.tables.entities>;
 export type EntityAlias = Row<typeof schema.tables.entity_aliases>;
-export type TelepresenceHealthView = Row<typeof schema.tables.telepresence_health_view>;
-export type TelepresenceHealthLog = Row<typeof schema.tables.telepresence_health_log>;

--- a/apps/backend/prisma/migrations/20260731120000_add_unique_dm_channel_constraint/migration.sql
+++ b/apps/backend/prisma/migrations/20260731120000_add_unique_dm_channel_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- Add a unique constraint on (workspaceId, name, scopeType) for Channel to prevent duplicate DM / group-DM channels across a workspace.
+CREATE UNIQUE INDEX IF NOT EXISTS "Channel_workspaceId_name_scopeType_key" ON "channels"("workspaceId", "name", "scopeType");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2267,6 +2267,7 @@ model Channel {
 
   @@index([workspaceId, id])
   @@index([workspaceId, name, id])
+  @@unique([workspaceId, name, scopeType])
   @@map("channels")
   @@schema("public")
 }

--- a/apps/backend/src/bots/unified/services/unified-dm-service.ts
+++ b/apps/backend/src/bots/unified/services/unified-dm-service.ts
@@ -32,7 +32,7 @@ class UnifiedDMService {
    */
   async getOrCreateBotDM(userId: string, botUserId: string, workspaceId: string): Promise<Channel> {
     // Check for existing DM
-    const existingDM = await channelRepository.getDMChannel(userId, botUserId);
+    const existingDM = await channelRepository.getDMChannel(userId, botUserId, workspaceId);
     if (existingDM) {
       // Ensure participants exist (fix for channels created without participants)
       const participants = await channelParticipantRepository.getChannelParticipants(existingDM.id);

--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -953,7 +953,7 @@ export class ChannelController {
 
       // For DM channels, check if channel already exists
       if (scopeType === 'DM' && scopeId) {
-        const existingDM = await this.channelRepository.getDMChannel(userId, scopeId);
+        const existingDM = await this.channelRepository.getDMChannel(userId, scopeId, req.user!.workspaceId!);
         if (existingDM) {
           res.status(200).json({
             message: 'DM channel already exists',
@@ -2020,7 +2020,7 @@ export class ChannelController {
       // Handle self-DM case
       if (isSelfDm) {
         // Check if self-DM already exists
-        const existingSelfDm = await this.channelRepository.getDMChannel(currentUserId, currentUserId);
+        const existingSelfDm = await this.channelRepository.getDMChannel(currentUserId, currentUserId, workspaceId);
         if (existingSelfDm) {
           const conversations = await this.conversationRepository.getChannelConversations(existingSelfDm.id);
           const participants = await this.channelParticipantRepository.getChannelParticipants(existingSelfDm.id);
@@ -2137,7 +2137,7 @@ export class ChannelController {
         const targetUser = participantUsers[0];
 
         // Check if DM already exists
-        const existingDM = await this.channelRepository.getDMChannel(currentUserId, targetUserId);
+        const existingDM = await this.channelRepository.getDMChannel(currentUserId, targetUserId, workspaceId);
         if (existingDM) {
           const conversations = await this.conversationRepository.getChannelConversations(existingDM.id);
           const participants = await this.channelParticipantRepository.getChannelParticipants(existingDM.id);
@@ -2252,7 +2252,7 @@ export class ChannelController {
         const allMemberIds = [currentUserId, ...otherParticipantIds].sort();
 
         // Check for existing group DM with same members
-        const existingGroupDM = await this.channelRepository.getGroupChannelByMembers(allMemberIds);
+        const existingGroupDM = await this.channelRepository.getGroupChannelByMembers(allMemberIds, workspaceId);
         if (existingGroupDM) {
           const conversations = await this.conversationRepository.getChannelConversations(existingGroupDM.id);
           const participants = await this.channelParticipantRepository.getChannelParticipants(existingGroupDM.id);
@@ -2497,7 +2497,7 @@ export class ChannelController {
       }
 
       // 6. Check for existing GROUP_DM with same participants
-      const existingGroupDM = await this.channelRepository.getGroupChannelByMembers(allParticipantIds);
+      const existingGroupDM = await this.channelRepository.getGroupChannelByMembers(allParticipantIds, workspaceId);
 
       // 7. Handle different scenarios
       if (existingGroupDM) {

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -224,17 +224,17 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
     return await this.findMany({ projectId });
   }
 
-  async getDMChannel(userId1: string, userId2: string): Promise<Channel | null> {
+  async getDMChannel(userId1: string, userId2: string, workspaceId: string): Promise<Channel | null> {
     // Self-DM: channel name is stored as single userId, scopeType DM
     if (userId1 === userId2) {
       return await this.db.channel.findFirst({
-        where: { name: userId1, scopeType: ChannelScopeType.DM },
+        where: { name: userId1, scopeType: ChannelScopeType.DM, workspaceId },
       });
     }
     // For 1:1 DM channels, name is sorted user IDs joined by comma
     const name = [userId1, userId2].sort().join(",");
     return await this.db.channel.findFirst({
-      where: { name },
+      where: { name, workspaceId },
     });
   }
 
@@ -272,13 +272,14 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
     });
   }
 
-  async getGroupChannelByMembers(memberIds: string[]): Promise<Channel | null> {
+  async getGroupChannelByMembers(memberIds: string[], workspaceId: string): Promise<Channel | null> {
     // Get all GROUP_DM scope channels
     const name = memberIds.sort().join(",");
     return await this.db.channel.findFirst({
       where: {
         scopeType: 'GROUP_DM',
-        name: name
+        name: name,
+        workspaceId
       }
     });
   }
@@ -343,7 +344,7 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
       const targetUserId = invitedUserIds[0];
 
       // Check if DM channel exists
-      let dmChannel = await this.getDMChannel(userId, targetUserId);
+      let dmChannel = await this.getDMChannel(userId, targetUserId, workspaceId);
 
       if (dmChannel) {
         return dmChannel.id;
@@ -378,7 +379,7 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
 
     if (!isLargeGroup) {
       // Check if group DM already exists with these exact participants
-      const existingGroupDM = await this.getGroupChannelByMembers(allUserIds);
+      const existingGroupDM = await this.getGroupChannelByMembers(allUserIds, workspaceId);
 
       if (existingGroupDM) {
         return existingGroupDM.id;

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -48,7 +48,7 @@ router.get('/validate', authV2Middleware.authenticate, async (req, res) => {
   if (pendingInvitation) {
     logger.warn(`[DEBUG] [/validate] ⚠️ User already has a session but pending_invitation_id cookie exists (${pendingInvitation}). OAuth callback will be skipped — invitation will NOT be auto-accepted via callback flow.`);
   }
-  const selfDmChannelId = await channelService.getSelfDmId(req.user!.id);
+  const selfDmChannelId = await channelService.getSelfDmId(req.user!.id, req.user!.workspaceId!);
   const workspace = await prisma.workspace.findUnique({
     where: { id: req.user!.workspaceId },
     select: { landingChannelId: true },

--- a/apps/backend/src/services/channelService.ts
+++ b/apps/backend/src/services/channelService.ts
@@ -19,7 +19,7 @@ export class ChannelService {
   async ensureSelfDmExists(userId: string, workspaceId: string): Promise<string> {
     try {
 
-      const existingSelfDm = await this.channelRepository.getDMChannel(userId, userId);
+      const existingSelfDm = await this.channelRepository.getDMChannel(userId, userId, workspaceId);
 
       if (existingSelfDm) {
         logger.debug(`[ChannelService] Self-DM already exists for user ${userId}: ${existingSelfDm.id}`);
@@ -55,9 +55,9 @@ export class ChannelService {
     }
   }
 
-  async getSelfDmId(userId: string): Promise<string | null> {
+  async getSelfDmId(userId: string, workspaceId: string): Promise<string | null> {
     try {
-      const selfDm = await this.channelRepository.getDMChannel(userId, userId);
+      const selfDm = await this.channelRepository.getDMChannel(userId, userId, workspaceId);
       return selfDm?.id ?? null;
     } catch (error) {
       logger.error(`[ChannelService] Error getting self-DM for user ${userId}:`, error);


### PR DESCRIPTION
…ue constraint

- Add @@unique([workspaceId, name, scopeType]) on Channel model.
- Add manual migration creating unique index on (workspaceId, name, scopeType).
- Propagate workspaceId through getDMChannel, getGroupChannelByMembers, getSelfDmId.
- Update all callers in channelController, channelService, auth routes, and unified-dm-service.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
