### PR TITLE
fix: XYNE-17378 init Vespa queue before bot user sync, skip no-op bot…

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -934,6 +934,19 @@ export class App {
     // Initialize unified bot framework
     logger.info('Initializing unified bot framework...');
     initializeBotRegistry(); // Register all bots (internal + external) with unified catalog
+
+    // Vespa queue MUST be initialized before syncing bot users below: each bot User
+    // upsert transparently fires the setupUserVespaSync Prisma middleware, which enqueues
+    // a user-index job on vespaQueue. If the queue isn't ready the enqueue is swallowed and
+    // logged ("Vespa queue not initialized Properly") — sync still succeeds, but the first
+    // bots' index jobs are silently dropped. The dependency is invisible at the sync call
+    // site (it lives in a Prisma $use hook), so keep these ordered explicitly.
+    logger.info('Initializing Vespa queue...');
+    const { vespaQueue, vespaBackfillQueue } = await import('@/queues/vespaQueue');
+    await vespaQueue.initialize();
+    // Backfill producer (backfill + migration) → isolated queues, drained by dedicated backfill worker pods
+    await vespaBackfillQueue.initialize();
+
     // Sync bots for all existing workspaces
     const dbClient = DatabaseClient.getInstance();
     const workspaces = await dbClient.workspace.findMany({ select: { id: true } });
@@ -942,12 +955,6 @@ export class App {
     }
     botCatalog.markInitialized();
     logger.info(`Unified bot framework initialized with ${botCatalog.count} bot(s)`);
-
-    logger.info('Initializing Vespa queue...');
-    const { vespaQueue, vespaBackfillQueue } = await import('@/queues/vespaQueue');
-    await vespaQueue.initialize();
-    // Backfill producer (backfill + migration) → isolated queues, drained by dedicated backfill worker pods
-    await vespaBackfillQueue.initialize();
 
     logger.info('Initializing conversation ingest queue (producer)...');
     await conversationIngestQueue.initialize();

--- a/apps/backend/src/bots/unified/services/unified-bot-user-service.ts
+++ b/apps/backend/src/bots/unified/services/unified-bot-user-service.ts
@@ -66,10 +66,21 @@ class UnifiedBotUserService {
    * Also ensures bot is added to the workspace's org as a member.
    */
   async ensureBotUserExists(definition: BotDefinition, workspaceId: string): Promise<User> {
-    // First, ensure bot is in org_member table
+    // First, ensure bot is in org_member table (idempotent: creates only when missing)
     await this.ensureBotInOrgMember(definition.email, workspaceId);
 
-    // Fetch the orgMember for the bot
+    // Read the current row first and only write when the code-defined bot has actually
+    // drifted from the DB. Skipping no-op writes avoids re-triggering the setupUserVespaSync
+    // Prisma middleware (a user-index enqueue) on every restart for unchanged bots.
+    const existing = await db.user.findUnique({
+      where: { email_workspaceId: { email: definition.email, workspaceId } },
+    });
+
+    if (existing && !this.botUserNeedsUpdate(existing, definition)) {
+      return existing;
+    }
+
+    // Fetch the orgMember for the bot (memberId is the FK the create branch needs)
     const orgMember = await db.orgMember.findUnique({
       where: { email: definition.email },
       select: { memberId: true }
@@ -81,6 +92,8 @@ class UnifiedBotUserService {
 
     const user = await db.user.upsert({
       where: { email_workspaceId: { email: definition.email, workspaceId } },
+      // Identity/FK fields in `create` (authProvider, providerUserId, orgMemberId) are set
+      // once and excluded from botUserNeedsUpdate; won't self-heal if a bot's id changes.
       create: {
         name: definition.name,
         email: definition.email,
@@ -109,6 +122,25 @@ class UnifiedBotUserService {
     });
 
     return user;
+  }
+
+  /**
+   * True when the DB row differs from the code-defined bot on any field the sync writes
+   * (name, picture, status, userType, and the metadata we own: botId + description).
+   * Only these fields are compared, so unrelated metadata keys don't force a rewrite.
+   */
+  private botUserNeedsUpdate(existing: User, definition: BotDefinition): boolean {
+    const desiredPicture = definition.picture || null;
+    const metadata = (existing.metadata as Record<string, unknown> | null) ?? {};
+
+    return (
+      existing.name !== definition.name ||
+      existing.picture !== desiredPicture ||
+      existing.status !== UserStatus.ACTIVE ||
+      existing.userType !== UserType.BOT ||
+      metadata.botId !== definition.id ||
+      metadata.description !== definition.description
+    );
   }
 
   /**


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
fix: XYNE-17378 init Vespa queue before bot user sync, skip no-op bot upserts
    
    Bot user sync fires the setupUserVespaSync Prisma $use middleware on every
    User create/upsert, which enqueues a user-index job on vespaQueue. Two fixes:
    
    - app.ts: initialize vespaQueue (and vespaBackfillQueue) before the bot-sync
      loop. Previously they were initialized after, so the enqueue triggered by each
      bot upsert ran against an uninitialized queue; the job was swallowed and logged
      ("Vespa queue not initialized Properly") and the first bots' index jobs were
      silently dropped. The dependency is invisible at the call site (it lives in a
      Prisma $use hook), so the ordering is now explicit.
    
    - unified-bot-user-service.ts: ensureBotUserExists reads the existing row first
      and returns early when the code-defined bot has not drifted (botUserNeedsUpdate),
      so unchanged bots no longer re-trigger the middleware enqueue on every restart.
      The write stays an upsert keyed on the (email, workspaceId) unique constraint,
      so the read-then-write is a fast path only and remains race-safe across
      concurrent boots.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
