### PR TITLE
feat: XYNE-54995-Unify-call-share-link-functionality

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -867,6 +867,20 @@ export enum TagMethod {
   AUTOMATED = "AUTOMATED",
 }
 
+export enum TelepresenceDeviceType {
+  TV = "TV",
+  CAMERA = "CAMERA",
+  MICROPHONE = "MICROPHONE",
+  SPEAKER = "SPEAKER",
+}
+
+export enum TelepresenceHealthStatus {
+  HEALTHY = "HEALTHY",
+  DEGRADED = "DEGRADED",
+  UNAVAILABLE = "UNAVAILABLE",
+  UNKNOWN = "UNKNOWN",
+}
+
 // Define tables
 
 export const agentTable = table("agents")
@@ -3554,6 +3568,38 @@ export const doclingAsyncPartTable = table("docling_async_parts")
   })
   .primaryKey("fileId", "partIndex");
 
+export const telepresenceHealthViewTable = table("telepresence_health_view")
+  .columns({
+    id: string(),
+    userId: string(),
+    deviceType: enumeration<TelepresenceDeviceType>(),
+    name: string(),
+    status: enumeration<TelepresenceHealthStatus>(),
+    connected: number(),
+    detected: number(),
+    cpuTemperature: number(),
+    lastReportedAt: number(),
+    createdAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey("id");
+
+export const telepresenceHealthLogTable = table("telepresence_health_log")
+  .columns({
+    id: string(),
+    userId: string(),
+    deviceType: enumeration<TelepresenceDeviceType>(),
+    name: string().optional(),
+    status: enumeration<TelepresenceHealthStatus>(),
+    connected: number(),
+    detected: number(),
+    cpuTemperature: number(),
+    description: string().optional(),
+    reportedAt: number(),
+    createdAt: number(),
+  })
+  .primaryKey("id");
+
 
 // Define relationships
 
@@ -5488,6 +5534,8 @@ export const schema = createSchema(
       tagsConfigTable,
       doclingAsyncFileTable,
       doclingAsyncPartTable,
+      telepresenceHealthViewTable,
+      telepresenceHealthLogTable,
     ],
     relationships: [
       agentTableRelationships,
@@ -5762,3 +5810,5 @@ export type Tag = Row<typeof schema.tables.tags>;
 export type TagsConfig = Row<typeof schema.tables.tags_config>;
 export type DoclingAsyncFile = Row<typeof schema.tables.docling_async_files>;
 export type DoclingAsyncPart = Row<typeof schema.tables.docling_async_parts>;
+export type TelepresenceHealthView = Row<typeof schema.tables.telepresence_health_view>;
+export type TelepresenceHealthLog = Row<typeof schema.tables.telepresence_health_log>;

--- a/apps/backend/src/controllers/callInviteDetectionController.ts
+++ b/apps/backend/src/controllers/callInviteDetectionController.ts
@@ -1,0 +1,82 @@
+import type { Request, Response } from 'express';
+import { config } from '@/config/env';
+import { repositories } from '@/database/repositories';
+import { InternalCallInviteDetectionService } from '@/services/internalCallInviteDetectionService';
+import {
+  getCallInviteDetectionExternalReasons,
+  getCallInviteDetectionLatency,
+  getCallInviteDetectionRefreshes,
+  getCallInviteDetectionResults,
+} from '@/services/otel/callMetrics';
+import { targetWorkspaceSessionService } from '@/services/targetWorkspaceSessionService';
+import { buildInternalCallUrl } from '@/utils/urlUtils';
+import { logger } from '@/utils/logger';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const detectionService = new InternalCallInviteDetectionService(
+  repositories.calls,
+  targetWorkspaceSessionService
+);
+
+function getCookieString(req: Request, name: string): string | undefined {
+  const value = req.cookies?.[name] as unknown;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Public, privacy-neutral routing decision for the unified invite link. All
+ * expected misses deliberately collapse to 200 { result: 'external' }.
+ */
+export async function detectInternalCallInvite(req: Request, res: Response): Promise<void> {
+  const startedAt = Date.now();
+  res.set('Cache-Control', 'no-store');
+
+  try {
+    const outcome = await detectionService.detect({
+      externalId: req.params.externalId,
+      cookies: req.cookies as Record<string, unknown> | undefined,
+      sessionId: getCookieString(req, 'user_session_id'),
+    });
+
+    getCallInviteDetectionResults().add(1, { result: outcome.result });
+    if (outcome.result === 'external') {
+      getCallInviteDetectionExternalReasons().add(1, { reason: outcome.reason });
+    }
+    if (outcome.refresh !== 'not_attempted') {
+      getCallInviteDetectionRefreshes().add(1, { status: outcome.refresh });
+    }
+
+    logger.info('[call-lobby] unified invite detection completed', {
+      detect_internal_result: outcome.result,
+      ...(outcome.result === 'external' ? { detect_internal_external_reason: outcome.reason } : {}),
+      refresh: outcome.refresh,
+      latencyMs: Date.now() - startedAt,
+    });
+
+    if (outcome.result === 'external') {
+      res.status(200).json({ result: 'external' });
+      return;
+    }
+
+    if (outcome.refreshedToken) {
+      res.cookie(`xyne_ws_${outcome.workspaceId}_token`, outcome.refreshedToken, {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: 'strict',
+        path: '/',
+        maxAge: config.jwt.expirationSeconds * 1000,
+      });
+    }
+
+    res.status(200).json({
+      result: 'internal',
+      workspaceId: outcome.workspaceId,
+      redirectUrl: buildInternalCallUrl(outcome.externalId, outcome.callType),
+    });
+  } catch (error) {
+    logger.error('[call-lobby] unified invite detection failed unexpectedly', { error });
+    res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    getCallInviteDetectionLatency().record(Date.now() - startedAt);
+  }
+}

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -1586,6 +1586,30 @@ export class CallRepository {
   }
 
   /**
+   * Return the private routing fields needed by the unified invite detector.
+   * Unlike getPublicCallInfo, this result must never be returned directly from
+   * a public endpoint because it contains the owning workspace ID.
+   */
+  async getCallInviteRoutingInfo(externalId: string): Promise<{
+    id: string;
+    externalId: string;
+    callType: CallType;
+    status: CallStatus;
+    workspaceId: string | null;
+  } | null> {
+    return DatabaseClient.getInstance().call.findUnique({
+      where: { externalId },
+      select: {
+        id: true,
+        externalId: true,
+        callType: true,
+        status: true,
+        workspaceId: true,
+      },
+    });
+  }
+
+  /**
    * Create a CallParticipant row for an external lobby request.
    * userId is a random UUID (external users have no real account).
    */

--- a/apps/backend/src/routes/callLobby.ts
+++ b/apps/backend/src/routes/callLobby.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import { CallStatus } from '@prisma/client';
 import { callLobbyController } from '@/controllers/callLobbyController';
+import { detectInternalCallInvite } from '@/controllers/callInviteDetectionController';
 import { db } from '@/database/client';
 import { repositories } from '@/database/repositories';
 import { logger } from '@/utils/logger';
@@ -11,17 +11,12 @@ import {
   clearExtCallCookie,
 } from '@/services/externalCallTokenService';
 import type { CallLobbyRequest } from '@/types/express';
+import { isCallLobbyJoinable } from '@/services/callLobbyPolicy';
 
 // Statuses a call may be in when external users try to enter the lobby.
 // SCHEDULED is included so externals who click the invitation link before the
 // host starts the call land on the pre-join / waiting view instead of being
 // told "call ended".
-const JOINABLE_STATUSES: CallStatus[] = [
-  CallStatus.SCHEDULED,
-  CallStatus.ACTIVE,
-  CallStatus.IN_PROGRESS,
-];
-
 const router = Router();
 
 // ---------------------------------------------------------------------------
@@ -44,7 +39,7 @@ async function resolveCallSession(req: Request, res: Response, next: NextFunctio
       return;
     }
 
-    if (!JOINABLE_STATUSES.includes(call.status)) {
+    if (!isCallLobbyJoinable(call.status)) {
       clearExtCallCookie(res, externalId);
       res.json({ status: 'ended' });
       return;
@@ -118,9 +113,12 @@ async function requireCallParticipant(
 }
 
 // ---------------------------------------------------------------------------
-// Routes — ALL :externalId routes go through resolveCallSession
+// Routes — guest-lobby routes go through resolveCallSession
 // ---------------------------------------------------------------------------
 
+// Detection is intentionally outside resolveCallSession: expected misses must
+// stay privacy-neutral and must not read or mutate external participant state.
+router.post('/:externalId/detect-internal', detectInternalCallInvite);
 router.get('/:externalId', resolveCallSession, callLobbyController.getCallInfo);
 router.post('/:externalId/request', resolveCallSession, callLobbyController.requestToJoin);
 router.get('/:externalId/status', resolveCallSession, callLobbyController.getLobbyStatus);

--- a/apps/backend/src/services/callLobbyPolicy.ts
+++ b/apps/backend/src/services/callLobbyPolicy.ts
@@ -1,0 +1,13 @@
+import { CallStatus } from '@prisma/client';
+
+// Shared by the guest lobby and unified invite detector so routing cannot
+// silently drift from the statuses the lobby itself accepts.
+const JOINABLE_STATUSES = new Set<CallStatus>([
+  CallStatus.SCHEDULED,
+  CallStatus.ACTIVE,
+  CallStatus.IN_PROGRESS,
+]);
+
+export function isCallLobbyJoinable(status: CallStatus): boolean {
+  return JOINABLE_STATUSES.has(status);
+}

--- a/apps/backend/src/services/internalCallInviteDetectionService.test.ts
+++ b/apps/backend/src/services/internalCallInviteDetectionService.test.ts
@@ -1,0 +1,133 @@
+import { CallStatus, CallType } from '@prisma/client';
+import {
+  InternalCallInviteDetectionService,
+  type InternalCallInviteDetectionOutcome,
+} from './internalCallInviteDetectionService';
+import type { TargetWorkspaceSessionResult } from './targetWorkspaceSessionService';
+
+interface RoutingCall {
+  id: string;
+  externalId: string;
+  callType: CallType;
+  status: CallStatus;
+  workspaceId: string | null;
+}
+
+const ROUTABLE_CALL: RoutingCall = {
+  id: 'call-id',
+  externalId: 'public-call-id',
+  callType: CallType.VIDEO,
+  status: CallStatus.ACTIVE,
+  workspaceId: 'workspace-a',
+};
+
+function createSubject(params?: {
+  call?: RoutingCall | null;
+  authResult?: TargetWorkspaceSessionResult;
+}): {
+  subject: InternalCallInviteDetectionService;
+  authenticate: jest.Mock;
+} {
+  const getCallInviteRoutingInfo = jest
+    .fn()
+    .mockResolvedValue(params && 'call' in params ? params.call : ROUTABLE_CALL);
+  const authenticate = jest
+    .fn()
+    .mockResolvedValue(params?.authResult ?? ({ status: 'valid' } as const));
+
+  return {
+    subject: new InternalCallInviteDetectionService({ getCallInviteRoutingInfo }, { authenticate }),
+    authenticate,
+  };
+}
+
+describe('InternalCallInviteDetectionService', () => {
+  it.each([
+    ['not found', null, 'no_call'],
+    ['ended', { ...ROUTABLE_CALL, status: CallStatus.ENDED }, 'not_joinable'],
+    ['without workspace', { ...ROUTABLE_CALL, workspaceId: null }, 'no_workspace'],
+  ])('keeps a %s call external', async (_label, call, reason) => {
+    const { subject, authenticate } = createSubject({ call });
+
+    await expect(subject.detect({ externalId: 'public-call-id' })).resolves.toMatchObject({
+      result: 'external',
+      reason,
+    });
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  it('uses only the cookie named for the call workspace', async () => {
+    const { subject, authenticate } = createSubject();
+
+    await expect(
+      subject.detect({
+        externalId: 'public-call-id',
+        cookies: {
+          xyne_last_workspace: 'workspace-b',
+          'xyne_ws_workspace-b_token': 'valid-b-token',
+        },
+      })
+    ).resolves.toMatchObject({ result: 'external', reason: 'no_cookie' });
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  it('uses a matching token even when the last-workspace pointer differs', async () => {
+    const { subject, authenticate } = createSubject();
+
+    const outcome = await subject.detect({
+      externalId: 'public-call-id',
+      cookies: {
+        xyne_last_workspace: 'workspace-b',
+        'xyne_ws_workspace-b_token': 'workspace-b-token',
+        'xyne_ws_workspace-a_token': 'workspace-a-token',
+      },
+      sessionId: 'workspace-a-session',
+    });
+
+    expect(outcome).toMatchObject({
+      result: 'internal',
+      workspaceId: 'workspace-a',
+      externalId: 'public-call-id',
+    });
+    expect(authenticate).toHaveBeenCalledWith({
+      token: 'workspace-a-token',
+      targetWorkspaceId: 'workspace-a',
+      sessionId: 'workspace-a-session',
+    });
+  });
+
+  it.each<Extract<TargetWorkspaceSessionResult, { status: 'external' }>>([
+    { status: 'external', reason: 'invalid_token' },
+    { status: 'external', reason: 'inactive_user' },
+    { status: 'external', reason: 'refresh_failed', refreshAttempted: true },
+  ])('does not expose authentication misses for $reason', async (authResult) => {
+    const { subject } = createSubject({ authResult });
+
+    const outcome = await subject.detect({
+      externalId: 'public-call-id',
+      cookies: { 'xyne_ws_workspace-a_token': 'matching-token' },
+      sessionId: 'session-id',
+    });
+
+    expect(outcome).toMatchObject({ result: 'external', reason: authResult.reason });
+  });
+
+  it('returns only the matching refreshed token to its controller', async () => {
+    const { subject } = createSubject({
+      authResult: { status: 'refreshed', token: 'fresh-workspace-a-token' },
+    });
+
+    const outcome: InternalCallInviteDetectionOutcome = await subject.detect({
+      externalId: 'public-call-id',
+      cookies: { 'xyne_ws_workspace-a_token': 'expired-workspace-a-token' },
+      sessionId: 'workspace-a-session',
+    });
+
+    expect(outcome).toMatchObject({
+      result: 'internal',
+      workspaceId: 'workspace-a',
+      refresh: 'succeeded',
+      refreshedToken: 'fresh-workspace-a-token',
+    });
+  });
+});

--- a/apps/backend/src/services/internalCallInviteDetectionService.ts
+++ b/apps/backend/src/services/internalCallInviteDetectionService.ts
@@ -1,0 +1,97 @@
+import type { CallStatus, CallType } from '@prisma/client';
+import type { TargetWorkspaceSessionResult } from '@/services/targetWorkspaceSessionService';
+import { isCallLobbyJoinable } from '@/services/callLobbyPolicy';
+
+export type DetectInternalExternalReason =
+  | 'no_call'
+  | 'not_joinable'
+  | 'no_workspace'
+  | 'no_cookie'
+  | 'invalid_token'
+  | 'refresh_failed'
+  | 'inactive_user';
+
+export type InternalCallInviteDetectionOutcome =
+  | {
+      result: 'internal';
+      workspaceId: string;
+      externalId: string;
+      callType: CallType;
+      refresh: 'not_attempted' | 'succeeded';
+      refreshedToken?: string;
+    }
+  | {
+      result: 'external';
+      reason: DetectInternalExternalReason;
+      refresh: 'not_attempted' | 'failed';
+    };
+
+export interface CallInviteRoutingRepository {
+  getCallInviteRoutingInfo(externalId: string): Promise<{
+    id: string;
+    externalId: string;
+    callType: CallType;
+    status: CallStatus;
+    workspaceId: string | null;
+  } | null>;
+}
+
+export interface TargetWorkspaceAuthenticator {
+  authenticate(params: {
+    token: string;
+    targetWorkspaceId: string;
+    sessionId?: string;
+  }): Promise<TargetWorkspaceSessionResult>;
+}
+
+export class InternalCallInviteDetectionService {
+  constructor(
+    private readonly calls: CallInviteRoutingRepository,
+    private readonly sessionAuthenticator: TargetWorkspaceAuthenticator
+  ) {}
+
+  async detect(params: {
+    externalId: string;
+    cookies?: Record<string, unknown>;
+    sessionId?: string;
+  }): Promise<InternalCallInviteDetectionOutcome> {
+    const call = await this.calls.getCallInviteRoutingInfo(params.externalId);
+    if (!call) {
+      return { result: 'external', reason: 'no_call', refresh: 'not_attempted' };
+    }
+    if (!isCallLobbyJoinable(call.status)) {
+      return { result: 'external', reason: 'not_joinable', refresh: 'not_attempted' };
+    }
+    if (!call.workspaceId) {
+      return { result: 'external', reason: 'no_workspace', refresh: 'not_attempted' };
+    }
+
+    const cookieName = `xyne_ws_${call.workspaceId}_token`;
+    const cookieValue = params.cookies?.[cookieName];
+    if (typeof cookieValue !== 'string' || cookieValue.length === 0) {
+      return { result: 'external', reason: 'no_cookie', refresh: 'not_attempted' };
+    }
+
+    const authResult = await this.sessionAuthenticator.authenticate({
+      token: cookieValue,
+      targetWorkspaceId: call.workspaceId,
+      sessionId: params.sessionId,
+    });
+    if (authResult.status === 'external') {
+      return {
+        result: 'external',
+        reason: authResult.reason,
+        refresh: authResult.refreshAttempted ? 'failed' : 'not_attempted',
+      };
+    }
+
+    return {
+      result: 'internal',
+      workspaceId: call.workspaceId,
+      externalId: call.externalId,
+      callType: call.callType,
+      refresh: authResult.status === 'refreshed' ? 'succeeded' : 'not_attempted',
+      ...(authResult.status === 'refreshed' ? { refreshedToken: authResult.token } : {}),
+    };
+  }
+}

--- a/apps/backend/src/services/jwtService.ts
+++ b/apps/backend/src/services/jwtService.ts
@@ -91,6 +91,34 @@ export class JwtService {
   }
 
   /**
+   * Verify every JWT property except expiry. This is intentionally separate
+   * from decodeToken: callers may use the returned identity only to attempt a
+   * tightly-scoped refresh of an expired session.
+   */
+  verifyTokenIgnoringExpiration(token: string): JwtPayload {
+    try {
+      const decoded = jwt.verify(token, this.secret, {
+        issuer: this.issuer,
+        audience: this.audience,
+        ignoreExpiration: true,
+      }) as JwtPayload;
+
+      const forceLogoutBefore = config.jwt.forceLogoutBefore;
+      if (forceLogoutBefore && decoded.iat && decoded.iat < forceLogoutBefore) {
+        throw new Error('JWT token has expired');
+      }
+
+      return decoded;
+    } catch (error) {
+      if (error instanceof jwt.JsonWebTokenError) {
+        throw new Error('Invalid JWT token');
+      }
+      logger.error('Error verifying expired JWT token:', error);
+      throw new Error('Failed to verify JWT token');
+    }
+  }
+
+  /**
    * Decode a JWT token without verification (for debugging)
    */
   decodeToken(token: string): JwtPayload | null {

--- a/apps/backend/src/services/otel/callMetrics.ts
+++ b/apps/backend/src/services/otel/callMetrics.ts
@@ -1,5 +1,5 @@
 import { metrics } from '@opentelemetry/api';
-import type { Counter, Meter, Attributes } from '@opentelemetry/api';
+import type { Counter, Histogram, Meter, Attributes } from '@opentelemetry/api';
 import { config } from '@/config/env';
 
 // Define Attribute Types
@@ -41,4 +41,57 @@ export function getCallJobs(): Counter<CallJobAttributes> {
     });
   }
   return _callJobs;
+}
+
+let _callInviteDetectionResults: Counter | null = null;
+export function getCallInviteDetectionResults(): Counter {
+  if (!_callInviteDetectionResults) {
+    _callInviteDetectionResults = getMeter().createCounter('detect_internal_result_total', {
+      description: 'Unified call invite detections by internal/external result',
+      unit: '1',
+    });
+  }
+  return _callInviteDetectionResults;
+}
+
+let _callInviteDetectionExternalReasons: Counter | null = null;
+export function getCallInviteDetectionExternalReasons(): Counter {
+  if (!_callInviteDetectionExternalReasons) {
+    _callInviteDetectionExternalReasons = getMeter().createCounter(
+      'detect_internal_external_reason_total',
+      {
+        description: 'Internal-only reasons a unified call invite stayed external',
+        unit: '1',
+      },
+    );
+  }
+  return _callInviteDetectionExternalReasons;
+}
+
+let _callInviteDetectionRefreshes: Counter | null = null;
+export function getCallInviteDetectionRefreshes(): Counter {
+  if (!_callInviteDetectionRefreshes) {
+    _callInviteDetectionRefreshes = getMeter().createCounter(
+      'detect_internal_refresh_total',
+      {
+        description: 'Target-workspace refresh attempts for unified call invites',
+        unit: '1',
+      },
+    );
+  }
+  return _callInviteDetectionRefreshes;
+}
+
+let _callInviteDetectionLatency: Histogram | null = null;
+export function getCallInviteDetectionLatency(): Histogram {
+  if (!_callInviteDetectionLatency) {
+    _callInviteDetectionLatency = getMeter().createHistogram('detect_internal_latency_ms', {
+      description: 'Unified call invite detection latency',
+      unit: 'ms',
+      advice: {
+        explicitBucketBoundaries: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000],
+      },
+    });
+  }
+  return _callInviteDetectionLatency;
 }

--- a/apps/backend/src/services/sessionProviderValidationService.ts
+++ b/apps/backend/src/services/sessionProviderValidationService.ts
@@ -1,0 +1,106 @@
+import axios from 'axios';
+import { OAuth2Client, gaxios } from 'google-auth-library';
+import type { AuthProvider } from '@prisma/client';
+import { UserSessionService } from '@/services/userSessionService';
+
+export interface ProviderSession {
+  id: string;
+  refreshToken: string | null;
+  accessToken: string | null;
+  user: { authProvider: AuthProvider };
+}
+
+export interface SessionProviderValidator {
+  isValid(session: ProviderSession): Promise<boolean>;
+}
+
+/**
+ * Revalidates sessions against their external identity provider. A provider
+ * outage keeps an otherwise valid local session usable; explicit rejection
+ * from the provider invalidates it. This matches authV2's existing policy.
+ */
+export class SessionProviderValidationService implements SessionProviderValidator {
+  constructor(
+    private readonly userSessions: Pick<
+      UserSessionService,
+      'updateSession'
+    > = new UserSessionService()
+  ) {}
+
+  async isValid(session: ProviderSession): Promise<boolean> {
+    const { user } = session;
+
+    if (user.authProvider === 'GOOGLE' && session.refreshToken) {
+      return this.validateGoogleSession(session.refreshToken);
+    }
+
+    if (user.authProvider === 'MICROSOFT' && session.accessToken) {
+      return this.validateMicrosoftSession(session);
+    }
+
+    return true;
+  }
+
+  private async validateGoogleSession(refreshToken: string): Promise<boolean> {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    if (!clientId || !clientSecret) return false;
+
+    try {
+      const googleClient = new OAuth2Client(clientId, clientSecret);
+      googleClient.setCredentials({ refresh_token: refreshToken });
+      await googleClient.getAccessToken();
+      return true;
+    } catch (error) {
+      const googleError = error as gaxios.GaxiosError;
+      return googleError.response?.data?.error !== 'invalid_grant';
+    }
+  }
+
+  private async validateMicrosoftSession(session: ProviderSession): Promise<boolean> {
+    try {
+      const graphResponse = await axios.get('https://graph.microsoft.com/v1.0/me', {
+        headers: { Authorization: `Bearer ${session.accessToken}` },
+        validateStatus: () => true,
+      });
+
+      if (graphResponse.status === 200) return true;
+      if (graphResponse.status !== 401) return false;
+
+      return this.refreshMicrosoftAccessToken(session);
+    } catch {
+      return true;
+    }
+  }
+
+  private async refreshMicrosoftAccessToken(session: ProviderSession): Promise<boolean> {
+    const clientId = process.env.MICROSOFT_CLIENT_ID;
+    const clientSecret = process.env.MICROSOFT_CLIENT_SECRET;
+    if (!clientId || !clientSecret || !session.refreshToken) return false;
+
+    const tenantId = process.env.MICROSOFT_TENANT_ID || 'common';
+    const tokenResponse = await axios.post(
+      `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`,
+      new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: 'refresh_token',
+        refresh_token: session.refreshToken,
+        scope: 'openid email profile User.Read',
+      }),
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        validateStatus: () => true,
+      }
+    );
+
+    if (tokenResponse.status !== 200 || typeof tokenResponse.data?.access_token !== 'string') {
+      return false;
+    }
+
+    await this.userSessions.updateSession(session.id, {
+      accessToken: tokenResponse.data.access_token,
+    });
+    return true;
+  }
+}

--- a/apps/backend/src/services/targetWorkspaceSessionService.test.ts
+++ b/apps/backend/src/services/targetWorkspaceSessionService.test.ts
@@ -1,0 +1,168 @@
+import { db } from '@/database/client';
+import { jwtService, type JwtPayload } from '@/services/jwtService';
+import { UserSessionService } from '@/services/userSessionService';
+import { TargetWorkspaceSessionService } from './targetWorkspaceSessionService';
+
+const VALID_PAYLOAD: JwtPayload = {
+  sub: 'workspace-a-user',
+  email: 'user@example.test',
+  name: 'Test User',
+  workspaceId: 'workspace-a',
+  memberId: 'org-member',
+  exp: Math.floor(Date.now() / 1000) + 600,
+};
+
+const ACTIVE_SESSION = {
+  id: 'session-a',
+  userId: 'workspace-a-user',
+  workspaceId: 'workspace-a',
+  status: 'ACTIVE',
+  refreshToken: 'refresh-token',
+  refreshTokenExpiry: new Date(Date.now() + 60_000),
+  accessToken: null,
+  accessTokenExpiry: null,
+  deviceInfo: null,
+  deviceId: null,
+  fcmToken: null,
+  voipToken: null,
+  ipAddress: null,
+  lastActivity: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  user: {
+    id: 'workspace-a-user',
+    email: 'user@example.test',
+    name: 'Test User',
+    picture: null,
+    workspaceId: 'workspace-a',
+    orgMemberId: 'org-member',
+    providerUserId: 'provider-user',
+    authProvider: 'EMAIL',
+    status: 'ACTIVE',
+    leftAt: null,
+    orgMember: { leftAt: null },
+  },
+};
+
+describe('TargetWorkspaceSessionService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('accepts a signed matching token only for an active workspace user', async () => {
+    jest.spyOn(jwtService, 'verifyToken').mockReturnValue(VALID_PAYLOAD);
+    jest.spyOn(db.user, 'findFirst').mockResolvedValue({
+      orgMember: { leftAt: null },
+    } as never);
+
+    await expect(
+      new TargetWorkspaceSessionService().authenticate({
+        token: 'valid-token',
+        targetWorkspaceId: 'workspace-a',
+      })
+    ).resolves.toEqual({ status: 'valid' });
+  });
+
+  it('rejects a cookie whose signed workspace claim does not match its name', async () => {
+    jest.spyOn(jwtService, 'verifyToken').mockReturnValue({
+      ...VALID_PAYLOAD,
+      workspaceId: 'workspace-b',
+    });
+    const userLookup = jest.spyOn(db.user, 'findFirst');
+
+    await expect(
+      new TargetWorkspaceSessionService().authenticate({
+        token: 'workspace-b-token',
+        targetWorkspaceId: 'workspace-a',
+      })
+    ).resolves.toEqual({ status: 'external', reason: 'invalid_token' });
+    expect(userLookup).not.toHaveBeenCalled();
+  });
+
+  it('rejects inactive or removed users after token validation', async () => {
+    jest.spyOn(jwtService, 'verifyToken').mockReturnValue(VALID_PAYLOAD);
+    jest.spyOn(db.user, 'findFirst').mockResolvedValue(null);
+
+    await expect(
+      new TargetWorkspaceSessionService().authenticate({
+        token: 'valid-token',
+        targetWorkspaceId: 'workspace-a',
+      })
+    ).resolves.toEqual({ status: 'external', reason: 'inactive_user' });
+  });
+
+  it('does not refresh an invalid or tampered token', async () => {
+    jest.spyOn(jwtService, 'verifyToken').mockImplementation(() => {
+      throw new Error('Invalid JWT token');
+    });
+    const expiredVerification = jest.spyOn(jwtService, 'verifyTokenIgnoringExpiration');
+    const sessionLookup = jest.spyOn(UserSessionService.prototype, 'getSessionById');
+
+    await expect(
+      new TargetWorkspaceSessionService().authenticate({
+        token: 'tampered-token',
+        targetWorkspaceId: 'workspace-a',
+        sessionId: 'session-a',
+      })
+    ).resolves.toEqual({ status: 'external', reason: 'invalid_token' });
+    expect(expiredVerification).not.toHaveBeenCalled();
+    expect(sessionLookup).not.toHaveBeenCalled();
+  });
+
+  it('refreshes once when the signed expired token and global session bind to the target workspace', async () => {
+    jest.spyOn(jwtService, 'verifyToken').mockImplementation(() => {
+      throw new Error('JWT token has expired');
+    });
+    jest.spyOn(jwtService, 'verifyTokenIgnoringExpiration').mockReturnValue({
+      ...VALID_PAYLOAD,
+      exp: Math.floor(Date.now() / 1000) - 10,
+    });
+    const sessionLookup = jest
+      .spyOn(UserSessionService.prototype, 'getSessionById')
+      .mockResolvedValue(ACTIVE_SESSION as never);
+    const sessionUpdate = jest
+      .spyOn(UserSessionService.prototype, 'updateSession')
+      .mockResolvedValue(ACTIVE_SESSION as never);
+    jest.spyOn(jwtService, 'generateToken').mockReturnValue('fresh-workspace-a-token');
+
+    await expect(
+      new TargetWorkspaceSessionService().authenticate({
+        token: 'expired-workspace-a-token',
+        targetWorkspaceId: 'workspace-a',
+        sessionId: 'session-a',
+      })
+    ).resolves.toEqual({ status: 'refreshed', token: 'fresh-workspace-a-token' });
+    expect(sessionLookup).toHaveBeenCalledTimes(1);
+    expect(sessionLookup).toHaveBeenCalledWith('session-a');
+    expect(sessionUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh from a global session bound to another workspace', async () => {
+    jest.spyOn(jwtService, 'verifyToken').mockImplementation(() => {
+      throw new Error('JWT token has expired');
+    });
+    jest.spyOn(jwtService, 'verifyTokenIgnoringExpiration').mockReturnValue({
+      ...VALID_PAYLOAD,
+      exp: Math.floor(Date.now() / 1000) - 10,
+    });
+    jest.spyOn(UserSessionService.prototype, 'getSessionById').mockResolvedValue({
+      ...ACTIVE_SESSION,
+      workspaceId: 'workspace-b',
+      user: { ...ACTIVE_SESSION.user, workspaceId: 'workspace-b' },
+    } as never);
+    const generateToken = jest.spyOn(jwtService, 'generateToken');
+
+    await expect(
+      new TargetWorkspaceSessionService().authenticate({
+        token: 'expired-workspace-a-token',
+        targetWorkspaceId: 'workspace-a',
+        sessionId: 'session-b',
+      })
+    ).resolves.toEqual({
+      status: 'external',
+      reason: 'refresh_failed',
+      refreshAttempted: true,
+    });
+    expect(generateToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/services/targetWorkspaceSessionService.ts
+++ b/apps/backend/src/services/targetWorkspaceSessionService.ts
@@ -1,0 +1,176 @@
+import { UserStatus } from '@prisma/client';
+import { db } from '@/database/client';
+import { jwtService, type JwtPayload } from '@/services/jwtService';
+import { UserSessionService } from '@/services/userSessionService';
+import {
+  SessionProviderValidationService,
+  type SessionProviderValidator,
+} from '@/services/sessionProviderValidationService';
+
+export type TargetWorkspaceSessionResult =
+  | { status: 'valid' }
+  | { status: 'refreshed'; token: string }
+  | {
+      status: 'external';
+      reason: 'invalid_token' | 'inactive_user' | 'refresh_failed';
+      refreshAttempted?: boolean;
+    };
+
+function hasTargetWorkspaceClaims(
+  payload: JwtPayload,
+  targetWorkspaceId: string
+): payload is JwtPayload & { sub: string; memberId: string; workspaceId: string } {
+  return (
+    typeof payload.sub === 'string' &&
+    payload.sub.length > 0 &&
+    typeof payload.memberId === 'string' &&
+    payload.memberId.length > 0 &&
+    payload.workspaceId === targetWorkspaceId
+  );
+}
+
+/**
+ * Authenticates one explicitly selected workspace cookie. It deliberately has
+ * no request/header dependency, so it cannot fall back to x-workspace-id or
+ * xyne_last_workspace.
+ */
+export class TargetWorkspaceSessionService {
+  private readonly providerSessionValidator: SessionProviderValidator;
+
+  constructor(
+    private readonly userSessionService: UserSessionService = new UserSessionService(),
+    providerSessionValidator?: SessionProviderValidator
+  ) {
+    this.providerSessionValidator =
+      providerSessionValidator ?? new SessionProviderValidationService(userSessionService);
+  }
+
+  async authenticate(params: {
+    token: string;
+    targetWorkspaceId: string;
+    sessionId?: string;
+  }): Promise<TargetWorkspaceSessionResult> {
+    const { token, targetWorkspaceId, sessionId } = params;
+
+    let validPayload: JwtPayload | null = null;
+    try {
+      validPayload = jwtService.verifyToken(token);
+    } catch (error) {
+      const isExpired = error instanceof Error && error.message === 'JWT token has expired';
+      if (!isExpired) {
+        return { status: 'external', reason: 'invalid_token' };
+      }
+    }
+
+    if (validPayload) {
+      if (!hasTargetWorkspaceClaims(validPayload, targetWorkspaceId)) {
+        return { status: 'external', reason: 'invalid_token' };
+      }
+
+      const isActive = await this.isActiveWorkspaceUser(validPayload, targetWorkspaceId);
+      return isActive ? { status: 'valid' } : { status: 'external', reason: 'inactive_user' };
+    }
+
+    let expiredPayload: JwtPayload;
+    try {
+      expiredPayload = jwtService.verifyTokenIgnoringExpiration(token);
+    } catch {
+      return { status: 'external', reason: 'invalid_token' };
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (
+      !hasTargetWorkspaceClaims(expiredPayload, targetWorkspaceId) ||
+      typeof expiredPayload.exp !== 'number' ||
+      expiredPayload.exp > nowSeconds
+    ) {
+      return { status: 'external', reason: 'invalid_token' };
+    }
+
+    if (!sessionId) {
+      return { status: 'external', reason: 'refresh_failed', refreshAttempted: false };
+    }
+
+    try {
+      const refreshedToken = await this.refreshForTargetWorkspace({
+        sessionId,
+        targetWorkspaceId,
+        expectedUserId: expiredPayload.sub,
+        expectedMemberId: expiredPayload.memberId,
+      });
+
+      return refreshedToken
+        ? { status: 'refreshed', token: refreshedToken }
+        : { status: 'external', reason: 'refresh_failed', refreshAttempted: true };
+    } catch {
+      return { status: 'external', reason: 'refresh_failed', refreshAttempted: true };
+    }
+  }
+
+  private async isActiveWorkspaceUser(
+    payload: JwtPayload & { sub: string; memberId: string },
+    targetWorkspaceId: string
+  ): Promise<boolean> {
+    const user = await db.user.findFirst({
+      where: {
+        id: payload.sub,
+        workspaceId: targetWorkspaceId,
+        orgMemberId: payload.memberId,
+        status: UserStatus.ACTIVE,
+        leftAt: null,
+      },
+      select: {
+        orgMember: {
+          select: { leftAt: true },
+        },
+      },
+    });
+
+    return !!user && user.orgMember?.leftAt === null;
+  }
+
+  private async refreshForTargetWorkspace(params: {
+    sessionId: string;
+    targetWorkspaceId: string;
+    expectedUserId: string;
+    expectedMemberId: string;
+  }): Promise<string | null> {
+    const { sessionId, targetWorkspaceId, expectedUserId, expectedMemberId } = params;
+    const session = await this.userSessionService.getSessionById(sessionId);
+
+    if (
+      !session?.user ||
+      session.status !== 'ACTIVE' ||
+      session.refreshTokenExpiry <= new Date() ||
+      session.user.id !== expectedUserId ||
+      session.user.workspaceId !== targetWorkspaceId ||
+      session.user.orgMemberId !== expectedMemberId ||
+      (session.workspaceId !== null && session.workspaceId !== targetWorkspaceId) ||
+      session.user.status !== UserStatus.ACTIVE ||
+      session.user.leftAt !== null ||
+      !session.user.orgMember ||
+      session.user.orgMember.leftAt !== null
+    ) {
+      return null;
+    }
+
+    if (!(await this.providerSessionValidator.isValid(session))) {
+      return null;
+    }
+
+    const token = jwtService.generateToken({
+      sub: session.user.id,
+      email: session.user.email,
+      name: session.user.name,
+      picture: session.user.picture ?? undefined,
+      workspaceId: targetWorkspaceId,
+      memberId: session.user.orgMemberId,
+      providerUserId: session.user.providerUserId,
+    });
+
+    await this.userSessionService.updateSession(session.id, { lastActivity: new Date() });
+    return token;
+  }
+}
+
+export const targetWorkspaceSessionService = new TargetWorkspaceSessionService();

--- a/apps/backend/src/utils/callInviteUrl.test.ts
+++ b/apps/backend/src/utils/callInviteUrl.test.ts
@@ -1,0 +1,13 @@
+jest.mock('@/config/env', () => ({
+  config: { frontendUrl: 'http://dashboard:5173' },
+}));
+
+import { buildInternalCallUrl } from './urlUtils';
+
+describe('buildInternalCallUrl', () => {
+  it('uses the configured frontend origin and encodes path and query values', () => {
+    expect(buildInternalCallUrl('call/with spaces', 'VIDEO&admin=true')).toBe(
+      'http://dashboard:5173/call/call%2Fwith%20spaces?type=VIDEO%26admin%3Dtrue'
+    );
+  });
+});

--- a/apps/backend/src/utils/urlUtils.ts
+++ b/apps/backend/src/utils/urlUtils.ts
@@ -265,3 +265,11 @@ export function isValidUrl(url: string): boolean {
 export function buildCallInviteUrl(externalId: string): string {
   return `${config.externalCallInviteBaseUrl}/call/${externalId}`;
 }
+
+/** Build a trusted main-dashboard destination for unified call invite routing. */
+export function buildInternalCallUrl(externalId: string, callType: string): string {
+  const frontendOrigin = new URL(config.frontendUrl).origin;
+  const url = new URL(`/call/${encodeURIComponent(externalId)}`, frontendOrigin);
+  url.searchParams.set('type', callType);
+  return url.toString();
+}

--- a/apps/dashboard-external/.dependency-cruiser.cjs
+++ b/apps/dashboard-external/.dependency-cruiser.cjs
@@ -45,7 +45,8 @@ module.exports = {
       comment:
         'dashboard-external/src directly imported a dashboard/src module that is not ' +
         'on the approved entry-point list. ' +
-        'Approved entry points: roomMachine, FullCallView, callLobbyService, useHandRaise. ' +
+        'Approved entry points: roomMachine, FullCallView, callLobbyService, useHandRaise, ' +
+        'config, usePlatform, Tooltip. ' +
         'To add a new one, update this rule and get a code-review.',
       severity: 'error',
       from: {
@@ -60,6 +61,9 @@ module.exports = {
           'dashboard/src/components/Call/CallViews/FullCallView\\.tsx$',
           'dashboard/src/services/Call/callLobbyService\\.ts$',
           'dashboard/src/components/Call/hooks/useHandRaise\\.ts$',
+          'dashboard/src/config\\.ts$',
+          'dashboard/src/hooks/usePlatform\\.ts$',
+          'dashboard/src/components/ui/Tooltip/index\\.ts$',
         ],
       },
     },

--- a/apps/dashboard-external/eslint.config.js
+++ b/apps/dashboard-external/eslint.config.js
@@ -45,10 +45,12 @@ export default tseslint.config(
             '../dashboard/src/components/Call/CallViews/FullCallView.tsx',
             '../dashboard/src/services/Call/callLobbyService.ts',
             '../dashboard/src/components/Call/hooks/useHandRaise.ts',
+            '../dashboard/src/config.ts',
+            '../dashboard/src/hooks/usePlatform.ts',
           ],
           message:
             'dashboard-external may only import the approved entry points from dashboard/src ' +
-            '(roomMachine, FullCallView, callLobbyService, useHandRaise). ' +
+            '(roomMachine, FullCallView, callLobbyService, useHandRaise, config, usePlatform). ' +
             'To add a new one update .dependency-cruiser.cjs and get a review.',
         }],
       }],

--- a/apps/dashboard-external/src/main.tsx
+++ b/apps/dashboard-external/src/main.tsx
@@ -1,11 +1,18 @@
-import ReactDOM from 'react-dom/client';
-import './global.css';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { queryClient } from './services/clients/queryClient';
-import App from './App';
+import ReactDOM from "react-dom/client";
+import "./global.css";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { HttpClientProvider } from "@xyne/shared/hooks";
+import { TooltipProvider } from "@/components/ui/Tooltip";
+import { queryClient } from "./services/clients/queryClient";
+import { publicHttpClient } from "./services/clients/publicHttpClient";
+import App from "./App";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <QueryClientProvider client={queryClient}>
-    <App />
+    <HttpClientProvider client={publicHttpClient}>
+      <TooltipProvider delayDuration={0}>
+        <App />
+      </TooltipProvider>
+    </HttpClientProvider>
   </QueryClientProvider>,
 );

--- a/apps/dashboard-external/src/routes/ExternalLobby/ExternalCallView.tsx
+++ b/apps/dashboard-external/src/routes/ExternalLobby/ExternalCallView.tsx
@@ -18,6 +18,8 @@ interface ExternalCallViewProps {
   participantId: string;
   /** Called when the external user disconnects (room goes idle) */
   onDisconnected: () => void;
+  /** Called when the initial LiveKit connection cannot be established */
+  onConnectionFailed: (error?: string) => void;
 }
 
 /**
@@ -38,26 +40,11 @@ export function ExternalCallView({
   callType,
   participantId,
   onDisconnected,
+  onConnectionFailed,
 }: ExternalCallViewProps) {
   const wasConnectedRef = useRef(false);
-
-  // Connect to LiveKit room via the global XState machine
-  useEffect(() => {
-    if (token && serverUrl) {
-      roomActor.send({
-        type: 'CONNECT',
-        token,
-        serverUrl,
-        callType,
-        externalId,
-        zero: null,
-      });
-    }
-    return () => {
-      roomActor.send({ type: 'DISCONNECT', endForAll: false });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, serverUrl, callType, externalId]);
+  const connectionAttemptedRef = useRef(false);
+  const connectionFailureReportedRef = useRef(false);
 
   // Subscribe to room state
   const snapshot = useSelector(roomActor, s => s);
@@ -75,11 +62,44 @@ export function ExternalCallView({
   }, [isConnected]);
 
   useEffect(() => {
+    if (
+      isIdle &&
+      connectionAttemptedRef.current &&
+      !wasConnectedRef.current &&
+      snapshot.context.error &&
+      !connectionFailureReportedRef.current
+    ) {
+      connectionFailureReportedRef.current = true;
+      onConnectionFailed(snapshot.context.error);
+    }
+  }, [isIdle, onConnectionFailed, snapshot.context.error]);
+
+  useEffect(() => {
     if (isIdle && wasConnectedRef.current) {
       wasConnectedRef.current = false;
       onDisconnected();
     }
   }, [isIdle, onDisconnected]);
+
+  // Connect only after the lightweight connection screen has mounted. The
+  // shared dashboard call UI is intentionally rendered after this succeeds so
+  // a UI render error cannot interrupt LiveKit signalling.
+  useEffect(() => {
+    if (token && serverUrl) {
+      connectionAttemptedRef.current = true;
+      roomActor.send({
+        type: 'CONNECT',
+        token,
+        serverUrl,
+        callType,
+        externalId,
+        zero: null,
+      });
+    }
+    return () => {
+      roomActor.send({ type: 'DISCONNECT', endForAll: false });
+    };
+  }, [token, serverUrl, callType, externalId]);
 
   // Poll participants from the API so external users can see who's in the call
   const participantsQuery = useQuery({
@@ -151,6 +171,18 @@ export function ExternalCallView({
       roomActor.send({ type: 'INCREMENT_UNREAD_CALL_CHAT' });
     }
   }, [isCallChatOpen]);
+
+  if (!isConnected) {
+    return (
+      <div className='min-h-screen bg-gradient-to-br from-gray-900 to-gray-950 flex items-center justify-center p-4'>
+        <div className='flex flex-col items-center text-center'>
+          <div className='w-8 h-8 border-[3px] border-gray-700 border-t-blue-500 rounded-full animate-spin' />
+          <p className='text-white font-semibold mt-4'>Joining call...</p>
+          <p className='text-gray-400 text-sm mt-1'>Establishing a secure connection</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/dashboard-external/src/routes/ExternalLobby/ExternalLobbyPage.tsx
+++ b/apps/dashboard-external/src/routes/ExternalLobby/ExternalLobbyPage.tsx
@@ -1,4 +1,12 @@
-import { useRef, useState, useCallback, useEffect, useReducer } from 'react';
+import {
+  Component,
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  useReducer,
+  type ReactNode,
+} from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -16,6 +24,7 @@ import { CallType } from '@xyne/shared';
 import { callLobbyService, type CallInfo } from '@/services/Call/callLobbyService';
 import { usePlatform } from '@/hooks/usePlatform';
 import { ExternalCallView } from './ExternalCallView';
+import { useUnifiedCallInviteRouting } from './useUnifiedCallInviteRouting';
 
 // ---------------------------------------------------------------------------
 // State types
@@ -31,6 +40,7 @@ type LobbyStage =
   | 'JOINING'
   | 'IN_CALL'
   | 'REJECTED'
+  | 'CONNECTION_FAILED'
   | 'DISCONNECTED';
 
 interface LobbyState {
@@ -43,6 +53,7 @@ interface LobbyState {
   serverUrl?: string;
   externalId?: string;
   callType?: CallType;
+  connectionError?: string;
 }
 
 type LobbyAction =
@@ -62,7 +73,8 @@ type LobbyAction =
       callType: CallType;
       participantId: string;
     }
-  | { type: 'SET_DISCONNECTED' };
+  | { type: 'SET_DISCONNECTED' }
+  | { type: 'SET_CONNECTION_FAILED'; error?: string };
 
 const initialState: LobbyState = { stage: 'LOADING' };
 
@@ -106,6 +118,8 @@ function lobbyReducer(state: LobbyState, action: LobbyAction): LobbyState {
       };
     case 'SET_DISCONNECTED':
       return { ...state, stage: 'DISCONNECTED' };
+    case 'SET_CONNECTION_FAILED':
+      return { ...state, stage: 'CONNECTION_FAILED', connectionError: action.error };
     default:
       return state;
   }
@@ -132,13 +146,15 @@ export function ExternalLobbyPage() {
   const [micDenied, setMicDenied] = useState(false);
   const [camDenied, setCamDenied] = useState(false);
 
+  const { canLoadGuestLobby } = useUnifiedCallInviteRouting(externalId);
+
   // -------------------------------------------------------------------------
-  // 1. Load call info
+  // 1. Load call info after detection has failed open to the guest lobby
   // -------------------------------------------------------------------------
   const callInfoQuery = useQuery({
     queryKey: ['call-lobby-info', externalId],
     queryFn: () => callLobbyService.getCallInfo(externalId!),
-    enabled: !!externalId && state.stage === 'LOADING',
+    enabled: canLoadGuestLobby && state.stage === 'LOADING',
     retry: false,
   });
 
@@ -409,6 +425,10 @@ export function ExternalLobbyPage() {
     dispatch({ type: 'SET_DISCONNECTED' });
   }, []);
 
+  const handleConnectionFailed = useCallback((error?: string) => {
+    dispatch({ type: 'SET_CONNECTION_FAILED', error });
+  }, []);
+
   // Rejoin handler — cookie handles identity, no participantId needed
   const handleRejoin = useCallback(() => {
     rejoinMutation.mutate();
@@ -421,15 +441,18 @@ export function ExternalLobbyPage() {
   // Full-screen call
   if (state.stage === 'IN_CALL') {
     return (
-      <ExternalCallView
-        token={state.token!}
-        serverUrl={state.serverUrl!}
-        callId={state.externalId!}
-        externalId={state.externalId!}
-        callType={state.callType || CallType.AUDIO}
-        participantId={state.participantId!}
-        onDisconnected={handleDisconnected}
-      />
+      <ExternalCallErrorBoundary onError={handleConnectionFailed}>
+        <ExternalCallView
+          token={state.token!}
+          serverUrl={state.serverUrl!}
+          callId={state.externalId!}
+          externalId={state.externalId!}
+          callType={state.callType || CallType.AUDIO}
+          participantId={state.participantId!}
+          onDisconnected={handleDisconnected}
+          onConnectionFailed={handleConnectionFailed}
+        />
+      </ExternalCallErrorBoundary>
     );
   }
 
@@ -536,6 +559,45 @@ export function ExternalLobbyPage() {
         </button>
         {rejoinMutation.isError && (
           <p className='text-red-400 text-xs mt-3'>Failed to rejoin. The call may have ended.</p>
+        )}
+      </StatusScreen>
+    );
+  }
+
+  if (state.stage === 'CONNECTION_FAILED') {
+    return (
+      <StatusScreen>
+        <div className='w-16 h-16 rounded-full bg-red-900/30 flex items-center justify-center mb-4'>
+          <AlertTriangle size={28} className='text-red-400' />
+        </div>
+        <h2 className='text-xl font-semibold text-white mb-2'>Couldn’t connect to the call</h2>
+        <p className='text-gray-400 text-sm mb-6'>Check your connection and try joining again.</p>
+        {state.connectionError && (
+          <p className='text-red-300/80 text-xs mb-6 max-w-sm break-words'>
+            {state.connectionError}
+          </p>
+        )}
+        <button
+          onClick={handleRejoin}
+          disabled={rejoinMutation.isPending}
+          data-track-category='CALLS'
+          data-track-name='EXTERNAL_RETRY_CONNECTION'
+          className='inline-flex items-center gap-2 px-6 py-2.5 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+        >
+          {rejoinMutation.isPending ? (
+            <>
+              <LoadingSpinner size='sm' />
+              Retrying...
+            </>
+          ) : (
+            <>
+              <RotateCcw size={16} />
+              Retry connection
+            </>
+          )}
+        </button>
+        {rejoinMutation.isError && (
+          <p className='text-red-400 text-xs mt-3'>Unable to retry. The call may have ended.</p>
         )}
       </StatusScreen>
     );
@@ -679,4 +741,30 @@ function LoadingSpinner({ size = 'md' }: { size?: 'sm' | 'md' }) {
   return (
     <div className={`${sizeClasses} border-gray-700 border-t-blue-500 rounded-full animate-spin`} />
   );
+}
+
+interface ExternalCallErrorBoundaryProps {
+  children: ReactNode;
+  onError: (error: string) => void;
+}
+
+class ExternalCallErrorBoundary extends Component<
+  ExternalCallErrorBoundaryProps,
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    console.error('External call UI crashed after connecting', error);
+    this.props.onError(error.message);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
 }

--- a/apps/dashboard-external/src/routes/ExternalLobby/useUnifiedCallInviteRouting.ts
+++ b/apps/dashboard-external/src/routes/ExternalLobby/useUnifiedCallInviteRouting.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { callLobbyService } from "@/services/Call/callLobbyService";
+
+/**
+ * Resolves the unified invite before the guest lobby performs any work. The
+ * public lobby is the safe fallback when detection is disabled or fails.
+ */
+export function useUnifiedCallInviteRouting(externalId?: string): {
+  canLoadGuestLobby: boolean;
+} {
+  const detectionQuery = useQuery({
+    queryKey: ["call-detect-internal", externalId],
+    queryFn: () => callLobbyService.detectInternal(externalId!),
+    enabled: !!externalId,
+    retry: false,
+    staleTime: 0,
+  });
+
+  useEffect(() => {
+    if (detectionQuery.data?.result === "internal") {
+      window.location.replace(detectionQuery.data.redirectUrl);
+    }
+  }, [detectionQuery.data]);
+
+  const canLoadGuestLobby =
+    !!externalId &&
+    (detectionQuery.data?.result === "external" || detectionQuery.isError);
+
+  return { canLoadGuestLobby };
+}

--- a/apps/dashboard-external/src/services/clients/publicHttpClient.ts
+++ b/apps/dashboard-external/src/services/clients/publicHttpClient.ts
@@ -1,0 +1,94 @@
+import type { HttpClient } from "@xyne/shared/hooks";
+import { API_BASE_URL } from "@/config";
+
+const CAC_CONFIG_PATH_PREFIX = "/cac-config/";
+
+interface RequestOptions {
+  signal?: AbortSignal;
+  timeout?: number;
+}
+
+interface RequestSignal {
+  signal?: AbortSignal;
+  dispose: () => void;
+}
+
+function createRequestSignal(options?: RequestOptions): RequestSignal {
+  if (options?.timeout === undefined) {
+    return { signal: options?.signal, dispose: () => {} };
+  }
+
+  const controller = new AbortController();
+  const abortFromCaller = (): void => controller.abort(options.signal?.reason);
+
+  if (options.signal?.aborted) {
+    abortFromCaller();
+  } else {
+    options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+
+  const timeoutId = window.setTimeout(() => controller.abort(), options.timeout);
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      window.clearTimeout(timeoutId);
+      options.signal?.removeEventListener("abort", abortFromCaller);
+    },
+  };
+}
+
+function getPublicUrl(path: string): string {
+  return `${API_BASE_URL.replace(/\/$/, "")}/${path.replace(/^\//, "")}`;
+}
+
+function getUnavailableCacConfig<T>(path: string): T {
+  return {
+    key: path.slice(CAC_CONFIG_PATH_PREFIX.length),
+    config: null,
+  } as T;
+}
+
+async function request<T>(
+  method: "GET" | "POST",
+  path: string,
+  body?: unknown,
+  options?: RequestOptions,
+): Promise<T> {
+  // CAC is authenticated dashboard configuration. The public call app uses each
+  // hook's checked-in fallback instead of issuing a request that cannot succeed.
+  if (method === "GET" && path.startsWith(CAC_CONFIG_PATH_PREFIX)) {
+    return getUnavailableCacConfig<T>(path);
+  }
+
+  const requestSignal = createRequestSignal(options);
+  try {
+    const response = await fetch(getPublicUrl(path), {
+      method,
+      credentials: "include",
+      headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: requestSignal.signal,
+    });
+
+    if (!response.ok) {
+      const error = new Error(`Request failed with status ${response.status}`) as Error & {
+        status?: number;
+      };
+      error.status = response.status;
+      throw error;
+    }
+
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  } finally {
+    requestSignal.dispose();
+  }
+}
+
+export const publicHttpClient: HttpClient = {
+  get: <T>(path: string, options?: RequestOptions): Promise<T> =>
+    request<T>("GET", path, undefined, options),
+  post: <T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> =>
+    request<T>("POST", path, body, options),
+};

--- a/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
@@ -1,9 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { REACTION_EMOJIS } from '../hooks/useReactions';
 import {
   Users,
-  Share2,
   Mic,
   MicOff,
   Video,
@@ -38,9 +36,9 @@ import {
 import { DeviceSelector } from '../DeviceSelector/DeviceSelector';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useShortcutById, useShortcut } from '../../../shortcuts';
-import { callLobbyService } from '../../../services/Call/callLobbyService';
 import { InvitationResponse, type RecordingType } from '@xyne/shared';
 import { RecordingButton } from './RecordingButton';
+import { CallInviteControl } from './CallInviteControl';
 import {
   getAiButtonColorClass,
   getAiButtonDisabled,
@@ -127,7 +125,6 @@ export function CallControls({
   aiController,
   localParticipantId,
   callId: callId,
-  roomLink,
   onToggleMic,
   onToggleCamera,
   onToggleScreenShare,
@@ -158,22 +155,12 @@ export function CallControls({
   onTogglePresentationMode,
   isPresentationMode = false,
 }: CallControlsProps): React.ReactElement {
-  const [showCopied, setShowCopied] = useState(false);
   const [showCameraMenu, setShowCameraMenu] = useState(false);
   const [showMicMenu, setShowMicMenu] = useState(false);
   const [showReactionPicker, setShowReactionPicker] = useState(false);
-  const [showShareMenu, setShowShareMenu] = useState(false);
   const reactionPickerRef = useRef<HTMLDivElement>(null);
-  const shareMenuRef = useRef<HTMLDivElement>(null);
   const { isMobile, isMac } = usePlatform();
   const modKey = isMac ? '⌘' : 'Ctrl';
-
-  const inviteUrlQuery = useQuery({
-    queryKey: ['call-invite-url', callId],
-    queryFn: () => callLobbyService.getInviteUrl(callId),
-    staleTime: Infinity,
-    enabled: !!callId,
-  });
 
   const micMenuRef = useRef<HTMLDivElement>(null);
   const cameraMenuRef = useRef<HTMLDivElement>(null);
@@ -307,9 +294,6 @@ export function CallControls({
       if (reactionPickerRef.current && !reactionPickerRef.current.contains(event.target as Node)) {
         setShowReactionPicker(false);
       }
-      if (shareMenuRef.current && !shareMenuRef.current.contains(event.target as Node)) {
-        setShowShareMenu(false);
-      }
     };
 
     document.addEventListener('mousedown', handleClickOutside);
@@ -329,23 +313,6 @@ export function CallControls({
   const handleCameraDeviceChange = async (deviceId: string): Promise<void> => {
     await setActiveCameraDevice(deviceId);
     // Keep the main menu open so user can see the selection
-  };
-
-  const handleCopyInviteLink = (): void => {
-    const webUrl = inviteUrlQuery.data ?? '';
-    void navigator.clipboard.writeText(webUrl).then(() => {
-      setShowShareMenu(false);
-      setShowCopied(true);
-      setTimeout(() => setShowCopied(false), 2000);
-    });
-  };
-
-  const handleCopyAppLink = (): void => {
-    void navigator.clipboard.writeText(roomLink).then(() => {
-      setShowShareMenu(false);
-      setShowCopied(true);
-      setTimeout(() => setShowCopied(false), 2000);
-    });
   };
 
   // Determine if custom sizing is being used (for mini view with dynamic sizing)
@@ -856,94 +823,14 @@ export function CallControls({
           )}
         </button>
 
-        {/* Share Link Button */}
-        {isExternalUser ? (
-          <button
-            onClick={handleCopyInviteLink}
-            className={cn(buttonClasses, 'relative bg-gray-700 hover:bg-gray-600 text-white')}
-            style={hasCustomSizing ? { padding: `${buttonPadding}px` } : undefined}
-            title='Copy call link'
-            data-track-category='CALLS'
-            data-track-name='SHARE_CALL_LINK'
-            data-track-metadata={JSON.stringify({ callId })}
-          >
-            <Share2
-              className={hasCustomSizing ? '' : 'w-5 h-5 sm:w-6 sm:h-6'}
-              style={
-                hasCustomSizing ? { width: `${iconSize}px`, height: `${iconSize}px` } : undefined
-              }
-            />
-            {showCopied && (
-              <span className='absolute -top-8 sm:-top-10 left-1/2 transform -translate-x-1/2 bg-green-500 text-white text-xs sm:text-sm px-2 py-1 sm:px-3 sm:py-1.5 rounded-lg shadow-lg whitespace-nowrap'>
-                Copied!
-              </span>
-            )}
-          </button>
-        ) : (
-          <div className='relative' ref={shareMenuRef}>
-            <button
-              onClick={() => setShowShareMenu(prev => !prev)}
-              className={cn(
-                buttonClasses,
-                showShareMenu
-                  ? 'bg-blue-600 hover:bg-blue-700 text-white'
-                  : 'bg-gray-700 hover:bg-gray-600 text-white',
-              )}
-              style={hasCustomSizing ? { padding: `${buttonPadding}px` } : undefined}
-              title='Share call link'
-              data-track-category='CALLS'
-              data-track-name='SHARE_CALL_LINK'
-              data-track-metadata={JSON.stringify({ callId })}
-            >
-              <Share2
-                className={hasCustomSizing ? '' : 'w-5 h-5 sm:w-6 sm:h-6'}
-                style={
-                  hasCustomSizing ? { width: `${iconSize}px`, height: `${iconSize}px` } : undefined
-                }
-              />
-              {showCopied && (
-                <span className='absolute -top-8 sm:-top-10 left-1/2 transform -translate-x-1/2 bg-green-500 text-white text-xs sm:text-sm px-2 py-1 sm:px-3 sm:py-1.5 rounded-lg shadow-lg whitespace-nowrap'>
-                  Copied!
-                </span>
-              )}
-            </button>
-
-            {showShareMenu && (
-              <div className='absolute bottom-full mb-3 left-1/2 -translate-x-1/2 bg-gray-800 border border-gray-700 rounded-xl shadow-2xl overflow-hidden min-w-max'>
-                <div className='px-4 pt-2.5 pb-1.5 text-[10px] font-semibold uppercase tracking-widest text-gray-500'>
-                  Share call link
-                </div>
-                <button
-                  onClick={handleCopyInviteLink}
-                  className='flex items-center gap-3 w-full px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-700 transition-colors text-left'
-                  data-track-category='CALLS'
-                  data-track-name='COPY_INVITE_LINK'
-                >
-                  <Share2 className='w-4 h-4 text-blue-400 flex-shrink-0 mt-0.5' />
-                  <div>
-                    <div className='font-medium'>Invite external participants</div>
-                    <div className='text-xs text-gray-400'>Opens in browser — no app needed</div>
-                  </div>
-                </button>
-                <div className='h-px bg-gray-700/60 mx-3' />
-                <button
-                  onClick={handleCopyAppLink}
-                  className='flex items-center gap-3 w-full px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-700 transition-colors text-left'
-                  data-track-category='CALLS'
-                  data-track-name='COPY_APP_LINK'
-                >
-                  <Monitor className='w-4 h-4 text-purple-400 flex-shrink-0 mt-0.5' />
-                  <div>
-                    <div className='font-medium flex items-center gap-1.5'>
-                      Share with team members
-                    </div>
-                    <div className='text-xs text-gray-400'>Opens directly in Xyne app</div>
-                  </div>
-                </button>
-              </div>
-            )}
-          </div>
-        )}
+        <CallInviteControl
+          callId={callId}
+          isExternalUser={isExternalUser}
+          buttonClasses={buttonClasses}
+          hasCustomSizing={hasCustomSizing}
+          buttonPadding={buttonPadding}
+          iconSize={iconSize}
+        />
 
         {iconSize >= 16 && (
           <div className={cn('hidden sm:block w-px h-8 mx-0.5', midnightSeparatorClass)}></div>

--- a/apps/dashboard/src/components/Call/CallControls/CallInviteControl.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/CallInviteControl.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Share2 } from 'lucide-react';
+import { callLobbyService } from '../../../services/Call/callLobbyService';
+import { cn } from '../../../utils/classNames';
+
+interface CallInviteControlProps {
+  callId: string;
+  isExternalUser: boolean;
+  buttonClasses: string;
+  hasCustomSizing: boolean;
+  buttonPadding: number;
+  iconSize: number;
+}
+
+function CopiedBadge(): ReactElement {
+  return (
+    <span className='absolute -top-8 sm:-top-10 left-1/2 transform -translate-x-1/2 bg-green-500 text-white text-xs sm:text-sm px-2 py-1 sm:px-3 sm:py-1.5 rounded-lg shadow-lg whitespace-nowrap'>
+      Copied!
+    </span>
+  );
+}
+
+export function CallInviteControl({
+  callId,
+  isExternalUser,
+  buttonClasses,
+  hasCustomSizing,
+  buttonPadding,
+  iconSize,
+}: CallInviteControlProps): ReactElement {
+  const [showCopied, setShowCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const inviteUrlQuery = useQuery({
+    queryKey: ['call-invite-url', callId],
+    queryFn: () => callLobbyService.getInviteUrl(callId),
+    staleTime: Infinity,
+    enabled: !!callId,
+  });
+
+  useEffect(() => {
+    return (): void => clearTimeout(copiedTimerRef.current);
+  }, []);
+
+  const copyLink = (url: string | undefined): void => {
+    if (!url) return;
+
+    void navigator.clipboard.writeText(url).then(() => {
+      setShowCopied(true);
+      clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setShowCopied(false), 2000);
+    });
+  };
+
+  const customPadding = hasCustomSizing ? { padding: `${buttonPadding}px` } : undefined;
+  const iconClassName = hasCustomSizing ? '' : 'w-5 h-5 sm:w-6 sm:h-6';
+  const iconStyle = hasCustomSizing
+    ? { width: `${iconSize}px`, height: `${iconSize}px` }
+    : undefined;
+  const inviteUrl = inviteUrlQuery.data;
+  const buttonLabel = isExternalUser ? 'Copy call link' : 'Copy invite link';
+
+  return (
+    <button
+      onClick={() => copyLink(inviteUrl)}
+      disabled={!inviteUrl}
+      className={cn(
+        buttonClasses,
+        'relative bg-gray-700 text-white',
+        inviteUrl ? 'hover:bg-gray-600' : 'opacity-50 cursor-not-allowed hover:scale-100',
+      )}
+      style={customPadding}
+      title={
+        inviteUrl
+          ? buttonLabel
+          : inviteUrlQuery.isError
+            ? 'Invite link unavailable'
+            : 'Loading invite link'
+      }
+      aria-label={buttonLabel}
+      data-track-category='CALLS'
+      data-track-name='SHARE_CALL_LINK'
+      data-track-metadata={JSON.stringify({ callId })}
+    >
+      <Share2 className={iconClassName} style={iconStyle} />
+      {showCopied && <CopiedBadge />}
+    </button>
+  );
+}

--- a/apps/dashboard/src/services/Call/callLobbyService.ts
+++ b/apps/dashboard/src/services/Call/callLobbyService.ts
@@ -39,6 +39,10 @@ export interface CallLobbyRecordingStateResponse {
   activeRecording: CallLobbyActiveRecording | null;
 }
 
+export type DetectInternalResponse =
+  | { result: 'internal'; redirectUrl: string; workspaceId: string }
+  | { result: 'external' };
+
 // Re-export shared type for backward compatibility
 export type { CallChatMessage } from '@xyne/shared';
 
@@ -53,6 +57,14 @@ export interface ExternalJoinResponse {
 const BASE = '/call-lobby';
 
 export const callLobbyService = {
+  /** Decide whether a unified invite should enter through the authenticated app. */
+  async detectInternal(externalId: string): Promise<DetectInternalResponse> {
+    const response = await apiInstance.post<DetectInternalResponse>(
+      `${BASE}/${externalId}/detect-internal`,
+    );
+    return response.data;
+  },
+
   /**
    * Fetch public call info for the pre-join lobby page.
    * Returns null if the call has ended, throws on not-found.

--- a/apps/dashboard/src/services/clients/apiClient.ts
+++ b/apps/dashboard/src/services/clients/apiClient.ts
@@ -34,6 +34,11 @@ function sanitizeUrl(url: string): string {
   );
 }
 
+export function isPublicExternalAppPath(pathname: string): boolean {
+  const normalizedPath = pathname.replace(/\/+$/, '');
+  return normalizedPath === '/external' || normalizedPath.startsWith('/external/');
+}
+
 /**
  * Helper function to track API latency with mixpanel
  * @param config - The axios request config
@@ -248,7 +253,7 @@ apiConfig.interceptors.response.use(
       });
     });
 
-    if (axiosError.response?.status === 401) {
+    if (axiosError.response?.status === 401 && !isPublicExternalAppPath(window.location.pathname)) {
       logger.warn(Logger.Event.AUTH_SESSION_EXPIRED, {
         url: sanitizedUrl,
         message: 'Received 401 Unauthorized. Logging out.',


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
