### PR TITLE
fix(claw-auth): replay-protected signed write-action cards with bound identity fields

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/write-action-signature.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/write-action-signature.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env["ENCRYPTION_KEY"] = "00".repeat(32);
+
+const state = vi.hoisted(() => ({
+  consumedNonces: new Set<string>(),
+  config: {
+    encryptionKey: Buffer.from("00".repeat(32), "hex"),
+  },
+}));
+
+vi.mock("../config.js", () => ({
+  CONFIG: state.config,
+}));
+
+vi.mock("../redis.js", () => ({
+  redisService: {
+    markNonceConsumed: vi.fn(async (nonce: string) => {
+      if (state.consumedNonces.has(nonce)) {
+        return false;
+      }
+      state.consumedNonces.add(nonce);
+      return true;
+    }),
+    isNonceConsumed: vi.fn(async (nonce: string) => state.consumedNonces.has(nonce)),
+  },
+}));
+
+describe("signWriteAction / verifyWriteActionSignature", () => {
+  beforeEach(() => {
+    state.consumedNonces.clear();
+  });
+
+  it("accepts a freshly signed action and rejects replays", async () => {
+    const { signWriteAction, verifyWriteActionSignature } = await import("./write-action-signature.js");
+    const action = await signWriteAction({
+      serverType: "spaces",
+      tool: "spaces-create-ticket",
+      params: { title: "x" },
+      userId: "u1",
+      agentSlug: "agent-a",
+      spacesAppId: "app-1",
+    });
+
+    expect(action.signature).toBeTruthy();
+    expect(action.nonce).toHaveLength(36);
+    expect(action.issuedAt).toBeGreaterThan(Date.now() - 5000);
+
+    expect(await verifyWriteActionSignature(action, action.signature)).toBe(true);
+    expect(await verifyWriteActionSignature(action, action.signature)).toBe(false);
+  });
+
+  it("rejects tampered fields", async () => {
+    const { signWriteAction, verifyWriteActionSignature } = await import("./write-action-signature.js");
+    const action = await signWriteAction({
+      serverType: "spaces",
+      tool: "spaces-create-ticket",
+      params: { title: "x" },
+      userId: "u1",
+      agentSlug: "agent-a",
+      spacesAppId: "app-1",
+    });
+
+    expect(await verifyWriteActionSignature({ ...action, tool: "spaces-delete-ticket" }, action.signature)).toBe(false);
+    expect(await verifyWriteActionSignature({ ...action, params: { title: "y" } }, action.signature)).toBe(false);
+    expect(await verifyWriteActionSignature({ ...action, userId: "u2" }, action.signature)).toBe(false);
+    expect(await verifyWriteActionSignature({ ...action, agentSlug: "agent-b" }, action.signature)).toBe(false);
+    expect(await verifyWriteActionSignature({ ...action, spacesAppId: "app-2" }, action.signature)).toBe(false);
+  });
+
+  it("rejects expired actions", async () => {
+    const { signWriteAction, verifyWriteActionSignature } = await import("./write-action-signature.js");
+    const action = await signWriteAction({
+      serverType: "spaces",
+      tool: "spaces-create-ticket",
+      params: { title: "x" },
+      userId: "u1",
+      issuedAt: Date.now() - 11 * 60 * 1000,
+    });
+
+    expect(await verifyWriteActionSignature(action, action.signature)).toBe(false);
+  });
+
+  it("rejects actions from the future", async () => {
+    const { signWriteAction, verifyWriteActionSignature } = await import("./write-action-signature.js");
+    const action = await signWriteAction({
+      serverType: "spaces",
+      tool: "spaces-create-ticket",
+      params: { title: "x" },
+      userId: "u1",
+      issuedAt: Date.now() + 5 * 60 * 1000,
+    });
+
+    expect(await verifyWriteActionSignature(action, action.signature)).toBe(false);
+  });
+
+  it("rejects invalid signatures", async () => {
+    const { signWriteAction, verifyWriteActionSignature } = await import("./write-action-signature.js");
+    const action = await signWriteAction({
+      serverType: "spaces",
+      tool: "spaces-create-ticket",
+      params: { title: "x" },
+      userId: "u1",
+    });
+
+    expect(await verifyWriteActionSignature(action, action.signature.replace(/^.{4}/, "dead"))).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/write-action-signature.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/write-action-signature.ts
@@ -1,0 +1,100 @@
+import crypto from "node:crypto";
+import { CONFIG } from "../config.js";
+import { redisService } from "../redis.js";
+
+export interface WriteActionSignaturePayload {
+  serverType: string;
+  tool: string;
+  params: Record<string, unknown>;
+  userId: string;
+  agentSlug?: string | undefined;
+  spacesAppId?: string | undefined;
+  issuedAt: number;
+  nonce: string;
+}
+
+export interface SignWriteActionInput {
+  serverType: string;
+  tool: string;
+  params: Record<string, unknown>;
+  userId: string;
+  agentSlug?: string | undefined;
+  spacesAppId?: string | undefined;
+  issuedAt?: number;
+  nonce?: string;
+}
+
+export const WRITE_ACTION_MAX_AGE_MS = 10 * 60 * 1000;
+
+function canonicalize(payload: WriteActionSignaturePayload): string {
+  return JSON.stringify({
+    serverType: payload.serverType,
+    tool: payload.tool,
+    params: payload.params,
+    userId: payload.userId,
+    agentSlug: payload.agentSlug,
+    spacesAppId: payload.spacesAppId,
+    issuedAt: payload.issuedAt,
+    nonce: payload.nonce,
+  });
+}
+
+function hmac(payload: string): string {
+  return crypto.createHmac("sha256", CONFIG.encryptionKey).update(payload).digest("hex");
+}
+
+export async function signWriteAction(
+  input: SignWriteActionInput,
+): Promise<WriteActionSignaturePayload & { signature: string }> {
+  const issuedAt = input.issuedAt ?? Date.now();
+  const nonce = input.nonce ?? crypto.randomUUID();
+  const payload: WriteActionSignaturePayload = {
+    serverType: input.serverType,
+    tool: input.tool,
+    params: input.params,
+    userId: input.userId,
+    agentSlug: input.agentSlug,
+    spacesAppId: input.spacesAppId,
+    issuedAt,
+    nonce,
+  };
+  const signature = hmac(canonicalize(payload));
+  return { ...payload, signature };
+}
+
+export async function verifyWriteActionSignature(
+  payload: WriteActionSignaturePayload,
+  signature: string,
+): Promise<boolean> {
+  const now = Date.now();
+  if (
+    typeof payload.issuedAt !== "number" ||
+    Number.isNaN(payload.issuedAt) ||
+    now - payload.issuedAt > WRITE_ACTION_MAX_AGE_MS ||
+    payload.issuedAt > now + 60_000
+  ) {
+    return false;
+  }
+
+  const expected = hmac(canonicalize(payload));
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(signature, "hex"))) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const consumed = await redisService.isNonceConsumed(payload.nonce);
+  if (consumed) {
+    return false;
+  }
+
+  const ttl = Math.max(1, Math.ceil((WRITE_ACTION_MAX_AGE_MS - (now - payload.issuedAt)) / 1000));
+  const marked = await redisService.markNonceConsumed(payload.nonce, ttl);
+  if (!marked) {
+    return false;
+  }
+
+  return true;
+}

--- a/apps/xyne-claw-auth/backend/src/lib/write-actions.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/write-actions.ts
@@ -32,6 +32,10 @@ export interface SignedWriteAction {
   params: Record<string, unknown>;
   userId: string;
   signature: string;
+  agentSlug?: string | undefined;
+  spacesAppId?: string | undefined;
+  issuedAt: number;
+  nonce: string;
 }
 
 export interface WriteActionResult {
@@ -61,13 +65,13 @@ function parseGatewayActionTarget(serverType: string): { serviceName: string; ba
  * approver.
  */
 export async function executeWriteAction(action: SignedWriteAction): Promise<WriteActionResult> {
-  const { serverType, tool, params, userId, signature } = action;
+  const { serverType, tool, params, userId, signature, agentSlug, spacesAppId, issuedAt, nonce } = action;
 
   // 1. Signature verification — prevents tampered params sneaking through.
-  const { verifyActionSignature } = await import("../routes/mcp.js");
-  const actionCore = { serverType, tool, params, userId };
-  if (!verifyActionSignature(actionCore, signature)) {
-    return { ok: false, content: "", error: "Signature verification failed — action may have been tampered with." };
+  const { verifyWriteActionSignature } = await import("../routes/mcp.js");
+  const actionCore = { serverType, tool, params, userId, agentSlug, spacesAppId, issuedAt, nonce };
+  if (!(await verifyWriteActionSignature(actionCore, signature))) {
+    return { ok: false, content: "", error: "Signature verification failed — action may have been tampered with or replayed." };
   }
 
   try {

--- a/apps/xyne-claw-auth/backend/src/redis.ts
+++ b/apps/xyne-claw-auth/backend/src/redis.ts
@@ -56,6 +56,34 @@ class RedisService {
     }
   }
 
+
+  /**
+   * Mark a nonce as consumed with a TTL. Returns true if the nonce was newly
+   * consumed, false if it was already present or on Redis error.
+   */
+  async markNonceConsumed(nonce: string, ttlSeconds: number): Promise<boolean> {
+    const redis = this.getConnection();
+    try {
+      const result = await redis.set(`nonce:${nonce}`, "1", "EX", ttlSeconds, "NX");
+      return result === "OK";
+    } catch (err) {
+      log.error("[redis] markNonceConsumed failed:", err);
+      return false;
+    }
+  }
+
+  /** Check whether a nonce has already been consumed. */
+  async isNonceConsumed(nonce: string): Promise<boolean> {
+    const redis = this.getConnection();
+    try {
+      const result = await redis.exists(`nonce:${nonce}`);
+      return result === 1;
+    } catch (err) {
+      log.error("[redis] isNonceConsumed failed:", err);
+      return false;
+    }
+  }
+
   /** Get the shared connection (creates lazily if needed). */
   getConnection(): Redis {
     if (!this.redis) {

--- a/apps/xyne-claw-auth/backend/src/routes/app-callback.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/app-callback.ts
@@ -511,10 +511,19 @@ router.post("/callback", async (req: Request, res: Response) => {
 
     const params = JSON.parse(paramsStr) as Record<string, unknown>;
 
-    // Verify HMAC signature
-    const { verifyActionSignature } = await import("./mcp.js");
-    const action = { serverType, tool, params, userId: writeUserId };
-    if (!verifyActionSignature(action, signature)) {
+    // Verify HMAC signature + replay/identity binding
+    const { verifyWriteActionSignature } = await import("./mcp.js");
+    const action = {
+      serverType,
+      tool,
+      params,
+      userId: writeUserId,
+      agentSlug,
+      spacesAppId,
+      issuedAt: Number(context["issuedAt"]),
+      nonce: String(context["nonce"] ?? ""),
+    };
+    if (!(await verifyWriteActionSignature(action, signature))) {
       log.error("[app-callback] HMAC verification failed — action may have been tampered with");
       return;
     }

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -442,6 +442,8 @@ async function finishWriteSuccess(opts: {
   signature: string;
   agentSlug: string | undefined;
   spacesAppId: string | undefined;
+  issuedAt: number;
+  nonce: string;
   messageId: string;
   conversationId?: string | undefined;
   channelId?: string | undefined;
@@ -472,6 +474,8 @@ async function finishWriteFailure(opts: {
   signature: string;
   agentSlug: string | undefined;
   spacesAppId: string | undefined;
+  issuedAt: number;
+  nonce: string;
   messageId: string;
   conversationId?: string | undefined;
   channelId?: string | undefined;
@@ -489,6 +493,8 @@ async function finishWriteFailure(opts: {
       userId: opts.writeUserId,
       signature: opts.signature,
       agentSlug: opts.agentSlug ?? "",
+      issuedAt: opts.issuedAt,
+      nonce: opts.nonce,
       ...(opts.channelId !== undefined ? { channelId: opts.channelId } : {}),
       ...(opts.conversationId !== undefined ? { conversationId: opts.conversationId } : {}),
       ...(opts.spacesAppId !== undefined ? { spacesAppId: opts.spacesAppId } : {}),
@@ -518,6 +524,8 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       const signature = data["signature"] as string;
       const agentSlug = data["agentSlug"] as string | undefined;
       const spacesAppId = data["spacesAppId"] as string | undefined;
+      const issuedAt = Number(data["issuedAt"]);
+      const nonce = String(data["nonce"] ?? "");
 
       const continueChannelId = data["channelId"] as string | undefined;
 
@@ -544,10 +552,19 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       // actionId === "approve-write"
       const params = JSON.parse(paramsStr) as Record<string, unknown>;
 
-      // Verify HMAC signature
-      const { verifyActionSignature } = await import("./mcp.js");
-      const actionPayload = { serverType, tool, params, userId: writeUserId };
-      if (!verifyActionSignature(actionPayload, signature)) {
+      // Verify HMAC signature + replay/identity binding
+      const { verifyWriteActionSignature } = await import("./mcp.js");
+      const actionPayload = {
+        serverType,
+        tool,
+        params,
+        userId: writeUserId,
+        agentSlug,
+        spacesAppId,
+        issuedAt,
+        nonce,
+      };
+      if (!(await verifyWriteActionSignature(actionPayload, signature))) {
         log.error("[flow-action] HMAC verification failed");
         res.json({ type: "error", message: "HMAC verification failed — action may have been tampered with" } satisfies AppActionResponse);
         return;
@@ -658,7 +675,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
             message: userMessage,
           } satisfies AppActionResponse);
           await finishWriteFailure({
-            tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId,
+            tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId, issuedAt, nonce,
             messageId, conversationId, channelId: continueChannelId, errorText: userMessage,
           });
           return;
@@ -670,7 +687,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         resp = { type: "close_screen", finalMessage: `✅ ${tool} executed successfully.` };
         res.json(resp);
         await finishWriteSuccess({
-          actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId,
+          actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId, issuedAt, nonce,
           messageId, conversationId, channelId: continueChannelId, resultText: safeResultString(execution.result),
         });
         return;
@@ -723,7 +740,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         resp = { type: "close_screen", finalMessage: `✅ ${tool} executed successfully.` };
         res.json(resp);
         await finishWriteSuccess({
-          actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId,
+          actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId, issuedAt, nonce,
           messageId, conversationId, channelId: continueChannelId, resultText: safeResultString(result),
         });
         return;
@@ -777,7 +794,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         resp = { type: "close_screen", finalMessage: `✅ ${tool} executed successfully.` };
         res.json(resp);
         await finishWriteSuccess({
-          actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId,
+          actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId, issuedAt, nonce,
           messageId, conversationId, channelId: continueChannelId, resultText: safeResultString(result),
         });
         return;
@@ -866,7 +883,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
           message: userMessage,
         } satisfies AppActionResponse);
         await finishWriteFailure({
-          tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId,
+          tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId, issuedAt, nonce,
           messageId, conversationId, channelId: continueChannelId, errorText: userMessage,
         });
         return;
@@ -875,7 +892,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       resp = { type: "close_screen", finalMessage: `✅ ${tool} executed successfully.` };
       res.json(resp);
       await finishWriteSuccess({
-        actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId,
+        actionId, tool, serverType, params, writeUserId, signature, agentSlug, spacesAppId, issuedAt, nonce,
         messageId, conversationId, channelId: continueChannelId, resultText: toolResult.content,
       });
       return;

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -34,6 +34,12 @@ import {
   type KbHandlerResult,
 } from "../mcp/kb-handlers.js";
 import { createLogger } from "../logger.js";
+import {
+  signWriteAction,
+  verifyWriteActionSignature,
+  type WriteActionSignaturePayload,
+  WRITE_ACTION_MAX_AGE_MS,
+} from "../lib/write-action-signature.js";
 import { executeTool as executeGatewayTool } from "../mcpgateway/services/execution.js";
 import {
   GATEWAY_KEY_PREFIX,
@@ -639,6 +645,9 @@ export function verifyActionSignature(action: Record<string, unknown>, signature
   }
 }
 
+export { signWriteAction, verifyWriteActionSignature, WRITE_ACTION_MAX_AGE_MS };
+export type { WriteActionSignaturePayload };
+
 const router = Router();
 
 // Scope the Bearer gate to the subpaths this router actually serves
@@ -1174,9 +1183,8 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
       );
 
       if (effectivePermission === "ask") {
-        const action = { serverType, tool, params: params ?? {}, userId };
-        const signature = signAction(action);
-        res.json({ success: true, data: { content: `Action queued for approval: ${tool}`, pendingAction: { ...action, signature } } });
+        const pendingAction = await signWriteAction({ serverType, tool, params: params ?? {}, userId, agentSlug, spacesAppId });
+        res.json({ success: true, data: { content: `Action queued for approval: ${tool}`, pendingAction } });
         return;
       }
 
@@ -1274,9 +1282,8 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
         res.json({ success: true, data: { content: `Cannot ${tool}: ${validationError}` } });
         return;
       }
-      const action = { serverType, tool, params: effectiveParams, userId };
-      const signature = signAction(action);
-      res.json({ success: true, data: { content: `Action queued for approval: ${tool}`, pendingAction: { ...action, signature } } });
+      const pendingAction = await signWriteAction({ serverType, tool, params: effectiveParams, userId, agentSlug, spacesAppId });
+      res.json({ success: true, data: { content: `Action queued for approval: ${tool}`, pendingAction } });
       return;
     }
 
@@ -1545,6 +1552,10 @@ router.post("/:sessionId/actions/sign", async (req: Request<{ sessionId: string 
         params?: Record<string, unknown>;
         userId?: string;
         signature?: string;
+        issuedAt?: number;
+        nonce?: string;
+        agentSlug?: string;
+        spacesAppId?: string;
       };
       // Initial-signing shape (2026-07-15): claw's custom-tool write wrapper
       // (custom-tools.ts signWriteAction) sends the bare action — it CANNOT
@@ -1566,7 +1577,7 @@ router.post("/:sessionId/actions/sign", async (req: Request<{ sessionId: string 
 
     if (body.pendingAction && typeof body.pendingAction === "object") {
       // Re-sign shape: verify the existing signature before re-issuing.
-      const { serverType: st, tool: t, params, userId: pendingUserId, signature } = body.pendingAction;
+      const { serverType: st, tool: t, params, userId: pendingUserId, signature, issuedAt, nonce, agentSlug: pendingAgentSlug, spacesAppId: pendingSpacesAppId } = body.pendingAction;
       if (!st || !t || !pendingUserId || !signature) {
         res.status(400).json({ success: false, error: "pendingAction must include serverType, tool, userId, signature" });
         return;
@@ -1576,8 +1587,12 @@ router.post("/:sessionId/actions/sign", async (req: Request<{ sessionId: string 
         return;
       }
       actionParams = params ?? {};
-      const action = { serverType: st, tool: t, params: actionParams, userId: pendingUserId };
-      if (!verifyActionSignature(action, signature)) {
+      // Support legacy four-field signatures (backward compat during rollout).
+      const hasNewFields = typeof issuedAt === "number" && typeof nonce === "string";
+      const verified = hasNewFields
+        ? await verifyWriteActionSignature({ serverType: st, tool: t, params: actionParams, userId: pendingUserId, agentSlug: pendingAgentSlug, spacesAppId: pendingSpacesAppId, issuedAt, nonce }, signature)
+        : verifyActionSignature({ serverType: st, tool: t, params: actionParams, userId: pendingUserId }, signature);
+      if (!verified) {
         res.status(400).json({ success: false, error: "Invalid pendingAction signature" });
         return;
       }
@@ -1687,12 +1702,11 @@ router.post("/:sessionId/actions/sign", async (req: Request<{ sessionId: string 
       }
     }
 
-    const signedAction = { serverType, tool, params: actionParams, userId };
-    const signedSignature = signAction(signedAction);
+    const signedAction = await signWriteAction({ serverType, tool, params: actionParams, userId, agentSlug, spacesAppId });
 
     log.info(`[actions/sign] Signed write action: user=${userId} server=${serverType} tool=${tool}`);
 
-    res.json({ success: true, data: { ...signedAction, signature: signedSignature } });
+    res.json({ success: true, data: signedAction });
   } catch (err) {
     log.error("[actions/sign] error:", err);
     res.status(500).json({ success: false, error: "Internal server error" });

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -4565,9 +4565,11 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             params: action["params"] as Record<string, unknown>,
             userId: action["userId"] as string,
             signature: action["signature"] as string,
-            agentSlug: ctx.agentSlug ?? "",
+            agentSlug: (action["agentSlug"] as string | undefined) ?? ctx.agentSlug ?? "",
             channelId: ctx.channelId,
             conversationId: ctx.conversationId,
+            issuedAt: Number(action["issuedAt"]),
+            nonce: String(action["nonce"] ?? ""),
           }), ctx.spacesAppId);
 
           if (action["tool"] === "spaces-memory-create" && (action["params"] as Record<string, unknown>)?.["content"]) {
@@ -4978,9 +4980,11 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
           params: action["params"] as Record<string, unknown>,
           userId: action["userId"] as string,
           signature: action["signature"] as string,
-          agentSlug: ctx.agentSlug ?? "",
+          agentSlug: (action["agentSlug"] as string | undefined) ?? ctx.agentSlug ?? "",
           channelId: ctx.channelId,
           conversationId: ctx.conversationId,
+          issuedAt: Number(action["issuedAt"]),
+          nonce: String(action["nonce"] ?? ""),
         }), ctx.spacesAppId);
 
         // Post in the same thread where the conversation happened

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -328,6 +328,8 @@ export function buildWriteApprovalFlow(
     agentSlug: string;
     channelId?: string;
     conversationId?: string;
+    issuedAt: number;
+    nonce: string;
   },
 ): FlowDefinition {
   return new FlowBuilder(`write-approval-${crypto.randomUUID()}`)
@@ -381,6 +383,8 @@ export function buildWriteResultFlow(opts: {
     channelId?: string;
     conversationId?: string;
     spacesAppId?: string;
+    issuedAt: number;
+    nonce: string;
   };
 }): FlowDefinition {
   const b = new FlowBuilder(`write-result-${crypto.randomUUID()}`)


### PR DESCRIPTION
Adds issuedAt + random nonce to signed write-action envelopes, stores consumed nonces in Redis, and binds agentSlug/spacesAppId into the HMAC. Surfaces updated: /mcp/call ask paths, /actions/sign, flow-action, app-callback, write-actions, webhook, shared flow builder. Includes backward-compat fallback for legacy 4-field signatures and unit tests.