### PR TITLE
fix: XYNE-55174 added retry for redis and db connections

### DIFF
--- a/apps/backend/src/database/client.ts
+++ b/apps/backend/src/database/client.ts
@@ -1,6 +1,8 @@
 import { PrismaClient } from '@prisma/client';
 import { logger } from '@/utils/logger';
 import { config } from '@/config/env';
+import { retryForever } from '@/utils/retry';
+import { installPrismaRetryMiddleware } from './retryMiddleware';
 import { setupUserSessionLogging } from './middleware/userSessionLogging';
 import { setupMessageMetadataSync } from './middleware/messageMetadataSync';
 import { setupTicketActivityChannelSync } from './middleware/ticketActivityChannelSync';
@@ -26,6 +28,8 @@ export class DatabaseClient {
           },
         },
       });
+
+      installPrismaRetryMiddleware(DatabaseClient.readReplicaInstance, 'prisma.replica');
     }
     return DatabaseClient.readReplicaInstance;
   }
@@ -57,6 +61,9 @@ export class DatabaseClient {
       setupTicketCreatedActivity(DatabaseClient.instance);
       setupUserVespaSync(DatabaseClient.instance);
 
+      // Registered last on purpose — see installPrismaRetryMiddleware.
+      installPrismaRetryMiddleware(DatabaseClient.instance);
+
       (DatabaseClient.instance as any).$on('error', (e: any) => {
         logger.error('Database error:', e);
       });
@@ -79,15 +86,11 @@ export class DatabaseClient {
       return;
     }
 
-    try {
-      const client = DatabaseClient.getInstance();
-      await client.$connect();
-      DatabaseClient.isConnected = true;
-      logger.info('Database connected successfully');
-    } catch (error) {
-      logger.error('Failed to connect to database:', error);
-      throw error;
-    }
+    const client = DatabaseClient.getInstance();
+    await retryForever(() => client.$connect(), 'prisma.connect');
+
+    DatabaseClient.isConnected = true;
+    logger.info('Database connected successfully');
   }
 
   static async disconnect(): Promise<void> {

--- a/apps/backend/src/database/commonClient.ts
+++ b/apps/backend/src/database/commonClient.ts
@@ -1,6 +1,8 @@
 import { PrismaClient as CommonPrismaClient } from '../../prisma-common/generated/client';
 import { logger } from '@/utils/logger';
 import { config } from '@/config/env';
+import { withRetry } from '@/utils/retry';
+import { installPrismaRetryMiddleware } from './retryMiddleware';
 
 /**
  * Builds the common DB connection URL with pool settings from env config.
@@ -50,6 +52,8 @@ export class CommonDatabaseClient {
         },
       });
 
+      installPrismaRetryMiddleware(CommonDatabaseClient.instance, 'prisma.common');
+
       (CommonDatabaseClient.instance as any).$on('error', (e: any) => {
         logger.error('Common database error:', e);
       });
@@ -76,7 +80,7 @@ export class CommonDatabaseClient {
 
     try {
       const client = CommonDatabaseClient.getInstance();
-      await client.$connect();
+      await withRetry(() => client.$connect(), 'prisma.common.connect');
       CommonDatabaseClient.isConnected = true;
       logger.info('Common database connected successfully');
       return true;

--- a/apps/backend/src/database/retryMiddleware.ts
+++ b/apps/backend/src/database/retryMiddleware.ts
@@ -1,0 +1,14 @@
+import { withRetry } from '@/utils/retry';
+interface MiddlewareCapableClient {
+  $use(middleware: (params: any, next: (params: any) => Promise<any>) => Promise<any>): void;
+}
+
+export function installPrismaRetryMiddleware(
+  prisma: MiddlewareCapableClient,
+  prefix = 'prisma'
+): void {
+  prisma.$use(
+    async (params: { model?: string; action: string }, next: (p: unknown) => Promise<unknown>) =>
+      withRetry(() => next(params), `${prefix}.${params.model ?? 'raw'}.${params.action}`)
+  );
+}

--- a/apps/backend/src/notification-service/config/redis.ts
+++ b/apps/backend/src/notification-service/config/redis.ts
@@ -1,5 +1,6 @@
 import Redis from 'ioredis';
 import { logger } from '@/utils/logger';
+import { createRedisClient, connectWithRetryForever } from '@/services/redisFactory';
 
 class NotificationRedisService {
   private redis: Redis | null = null;
@@ -12,43 +13,25 @@ class NotificationRedisService {
 
   private initializeRedis(): void {
     try {
-      const config = {
-        host: process.env.REDIS_HOST || 'localhost',
-        port: parseInt(process.env.REDIS_PORT || '6379', 10),
-        maxRetriesPerRequest: 3,
-        lazyConnect: true,
-        ...(process.env.REDIS_PASSWORD && { password: process.env.REDIS_PASSWORD }),
-        ...(process.env.REDIS_TLS === 'true' && {
-          tls: { rejectUnauthorized: false }
-        })
-      };
-
-      this.redis = new Redis(config);
-      this.publisher = new Redis(config);
-      this.subscriber = new Redis(config);
-
-      this.redis.on('connect', () => {
-        logger.info('Notification Redis connected successfully');
-      });
-
-      this.redis.on('error', (error) => {
-        logger.error('Notification Redis connection error:', error);
-      });
-
+      this.redis = createRedisClient('notification');
+      this.publisher = createRedisClient('notification-publisher');
+      this.subscriber = createRedisClient('notification-subscriber');
     } catch (error) {
       logger.error('Failed to initialize Notification Redis:', error);
     }
   }
 
   async connect(): Promise<void> {
-    try {
-      if (this.redis) await this.redis.connect();
-      if (this.publisher) await this.publisher.connect();
-      if (this.subscriber) await this.subscriber.connect();
-      logger.info('All Notification Redis connections established');
-    } catch (error) {
-      logger.error('Failed to connect to Notification Redis:', error);
-    }
+    await Promise.all([
+      this.redis ? connectWithRetryForever(this.redis, 'notification') : Promise.resolve(),
+      this.publisher
+        ? connectWithRetryForever(this.publisher, 'notification-publisher')
+        : Promise.resolve(),
+      this.subscriber
+        ? connectWithRetryForever(this.subscriber, 'notification-subscriber')
+        : Promise.resolve(),
+    ]);
+    logger.info('All Notification Redis connections established');
   }
 
   async disconnect(): Promise<void> {

--- a/apps/backend/src/services/redisFactory.ts
+++ b/apps/backend/src/services/redisFactory.ts
@@ -1,0 +1,39 @@
+import Redis, { RedisOptions } from 'ioredis';
+import { logger } from '@/utils/logger';
+import { config } from '@/config/env';
+import { retryForever } from '@/utils/retry';
+
+export function getBaseRedisOptions(role: 'default' | 'bullmq' = 'default'): RedisOptions {
+  return {
+    host: config.redis.host,
+    port: config.redis.port,
+    ...(config.redis.password && { password: config.redis.password }),
+    ...(config.redis.tls && { tls: { rejectUnauthorized: false } }),
+    lazyConnect: true,
+    // BullMQ requires null and manages its own retries.
+    maxRetriesPerRequest: role === 'bullmq' ? null : 3,
+    retryStrategy: (times: number) => Math.min(times * 200, 5_000),
+    enableOfflineQueue: true,
+  };
+}
+
+export function createRedisClient(name: string, overrides: RedisOptions = {}): Redis {
+  const client = new Redis({ ...getBaseRedisOptions(), ...overrides });
+
+  client.on('connect', () => logger.info(`[redis:${name}] connected`));
+  client.on('error', (error: Error) =>
+    logger.error(`[redis:${name}] connection error`, { message: error.message })
+  );
+  client.on('reconnecting', (delayMs: number) =>
+    logger.warn(`[redis:${name}] reconnecting`, { delayMs })
+  );
+
+  return client;
+}
+
+export async function connectWithRetryForever(client: Redis, name: string): Promise<void> {
+  if (client.status === 'ready' || client.status === 'connecting' || client.status === 'connect') {
+    return;
+  }
+  await retryForever(() => client.connect(), `redis.${name}.connect`);
+}

--- a/apps/backend/src/services/redisService.ts
+++ b/apps/backend/src/services/redisService.ts
@@ -1,5 +1,6 @@
 import Redis from 'ioredis';
 import { logger } from '@/utils/logger';
+import { createRedisClient, getBaseRedisOptions, connectWithRetryForever } from './redisFactory';
 
 export interface ChatMessage {
   messageId: string;
@@ -65,57 +66,26 @@ class RedisService {
   }
 
   public getRedisConfig() {
-    return {
-      maxRetriesPerRequest: 3,
-      lazyConnect: true,
-      host: process.env.REDIS_HOST || 'localhost',
-      port: parseInt(process.env.REDIS_PORT || '6379', 10),
-      ...(process.env.REDIS_PASSWORD && { password: process.env.REDIS_PASSWORD }),
-      ...(process.env.REDIS_TLS === 'true' && {
-        tls: {
-          rejectUnauthorized: false
-        }
-      })
-    };
+    return getBaseRedisOptions('default');
   }
 
   private initializeRedis(): void {
     try {
-      const config = this.getRedisConfig();
-
-      // Main Redis instance for data operations
-      this.redis = new Redis(config);
-
-      // Publisher instance for broadcasting messages
-      this.publisher = new Redis(config);
-
-      // Subscriber instance for listening to messages
-      this.subscriber = new Redis(config);
-
-      this.redis.on('connect', () => {
-        logger.info('🔴 [REDIS-CONNECTION] Redis connected successfully');
-        logger.info('Redis connected successfully');
-      });
-
-      this.redis.on('error', (error) => {
-        logger.info('❌ [REDIS-CONNECTION] Redis connection error:', error);
-        logger.error('Redis connection error:', error);
-      });
-
+      this.redis = createRedisClient('main');
+      this.publisher = createRedisClient('publisher');
+      this.subscriber = createRedisClient('subscriber');
     } catch (error) {
       logger.error('Failed to initialize Redis:', error);
     }
   }
 
   async connect(): Promise<void> {
-    try {
-      if (this.redis) await this.redis.connect();
-      if (this.publisher) await this.publisher.connect();
-      if (this.subscriber) await this.subscriber.connect();
-      logger.info('All Redis connections established');
-    } catch (error) {
-      logger.error('Failed to connect to Redis:', error);
-    }
+    await Promise.all([
+      this.redis ? connectWithRetryForever(this.redis, 'main') : Promise.resolve(),
+      this.publisher ? connectWithRetryForever(this.publisher, 'publisher') : Promise.resolve(),
+      this.subscriber ? connectWithRetryForever(this.subscriber, 'subscriber') : Promise.resolve(),
+    ]);
+    logger.info('All Redis connections established');
   }
 
   async disconnect(): Promise<void> {

--- a/apps/backend/src/services/workspaceEventService.ts
+++ b/apps/backend/src/services/workspaceEventService.ts
@@ -8,6 +8,7 @@
 
 import Redis from 'ioredis';
 import { logger } from '@/utils/logger';
+import { createRedisClient } from './redisFactory';
 
 // File tree node structure (matches frontend FileTreeNode)
 export interface FileTreeNode {
@@ -94,29 +95,9 @@ class WorkspaceEventService {
 
   private initializeRedis(): void {
     try {
-      const config = {
-        host: process.env.REDIS_HOST || 'localhost',
-        port: parseInt(process.env.REDIS_PORT || '6379', 10),
-        maxRetriesPerRequest: 3,
-        lazyConnect: true,
-        ...(process.env.REDIS_PASSWORD && { password: process.env.REDIS_PASSWORD }),
-        ...(process.env.REDIS_TLS === 'true' && {
-          tls: { rejectUnauthorized: false }
-        })
-      };
-
-      this.redis = new Redis(config);
-      this.publisher = new Redis(config);
-      this.subscriber = new Redis(config);
-
-      this.redis.on('connect', () => {
-        logger.info('📁 [WORKSPACE-REDIS] Redis connected');
-      });
-
-      this.redis.on('error', (error) => {
-        logger.error('❌ [WORKSPACE-REDIS] Redis error:', error);
-      });
-
+      this.redis = createRedisClient('workspace');
+      this.publisher = createRedisClient('workspace-publisher');
+      this.subscriber = createRedisClient('workspace-subscriber');
     } catch (error) {
       logger.error('Failed to initialize workspace Redis:', error);
     }

--- a/apps/backend/src/utils/retry.ts
+++ b/apps/backend/src/utils/retry.ts
@@ -1,0 +1,92 @@
+import { logger } from '@/utils/logger';
+
+const CONNECTION_ERROR_CODES = new Set([
+  'P1001',
+  'P1002',
+  'P1008',
+  'P1017',
+  'P2024',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENOTFOUND',
+  'EPIPE',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+]);
+
+const CONNECTION_ERROR_MESSAGES = ["Connection is closed", "Stream isn't writeable", 'READONLY'];
+
+export function isConnectionError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { code?: unknown; errorCode?: unknown; name?: unknown; message?: unknown };
+
+  const code =
+    typeof e.code === 'string' ? e.code : typeof e.errorCode === 'string' ? e.errorCode : '';
+  if (CONNECTION_ERROR_CODES.has(code)) return true;
+
+  if (e.name === 'MaxRetriesPerRequestError') return true;
+
+  const message = typeof e.message === 'string' ? e.message : '';
+  if (CONNECTION_ERROR_MESSAGES.some(m => message.includes(m))) return true;
+  for (const c of CONNECTION_ERROR_CODES) {
+    if (message.includes(c)) return true;
+  }
+  return false;
+}
+
+function envInt(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function computeBackoffMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const ceiling = Math.min(maxDelayMs, baseDelayMs * Math.pow(2, Math.max(0, attempt - 1)));
+  return Math.floor(Math.random() * ceiling);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+export async function withRetry<T>(fn: () => Promise<T>, label: string): Promise<T> {
+  const attempts = envInt('RETRY_ATTEMPTS', 3);
+  const baseDelayMs = envInt('RETRY_BASE_DELAY_MS', 200);
+  const maxDelayMs = envInt('RETRY_MAX_DELAY_MS', 5_000);
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= attempts || !isConnectionError(err)) throw err;
+
+      const delayMs = computeBackoffMs(attempt, baseDelayMs, maxDelayMs);
+      logger.warn('Retrying after connection error', {
+        label,
+        attempt,
+        delayMs,
+        message: (err as { message?: string })?.message,
+      });
+      await sleep(delayMs);
+    }
+  }
+}
+
+export async function retryForever<T>(fn: () => Promise<T>, label: string): Promise<T> {
+  const baseDelayMs = envInt('RETRY_BASE_DELAY_MS', 200);
+  const maxDelayMs = envInt('CONNECT_RETRY_MAX_DELAY_MS', 30_000);
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const delayMs = computeBackoffMs(attempt, baseDelayMs, maxDelayMs);
+      const detail = { label, attempt, delayMs, message: (err as { message?: string })?.message };
+      if (attempt % 10 === 0) {
+        logger.error('Still unable to connect; retrying indefinitely', detail);
+      } else {
+        logger.warn('Connection failed, retrying', detail);
+      }
+      await sleep(delayMs);
+    }
+  }
+}

--- a/apps/dashboard/src/services/clients/socketClient.ts
+++ b/apps/dashboard/src/services/clients/socketClient.ts
@@ -38,7 +38,6 @@ class WebSocketService {
   private socket: Socket | null = null;
   private isConnected = false;
   private reconnectAttempts = 0;
-  private maxReconnectAttempts = 5;
   private connectionStartTime: number | null = null;
   private reconnectionStartTime: number | null = null;
   private connectionPromise: Promise<void> | null = null;
@@ -78,6 +77,18 @@ class WebSocketService {
         path: '/api/socket.io/',
         withCredentials: true, // Important: send cookies with socket connection
         transports: ['websocket', 'polling'],
+        reconnection: true,
+        reconnectionAttempts: Infinity,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 30000,
+        randomizationFactor: 0.5,
+      });
+
+      this.socket.io.on('reconnect_attempt', (attempt: number) => {
+        this.reconnectAttempts = attempt;
+        safeRecordMetric(() => {
+          socketEventsTotal.add(1, { event: 'retry', reason: `attempt_${attempt}` });
+        });
       });
 
       this.socket.on('connect', () => {
@@ -165,13 +176,9 @@ class WebSocketService {
           });
         });
 
-        // Auto-reconnect on unexpected disconnection
         if (reason === 'io server disconnect') {
-          // Server initiated disconnect, don't reconnect
-          return;
+          this.socket?.connect();
         }
-
-        this.attemptReconnect();
       });
 
       this.socket.on('connect_error', error => {
@@ -229,32 +236,6 @@ class WebSocketService {
     return this.connectionPromise;
   }
 
-  private attemptReconnect(): void {
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      return;
-    }
-
-    this.reconnectAttempts++;
-    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000); // Exponential backoff
-
-    safeRecordMetric(() => {
-      socketEventsTotal.add(1, {
-        event: 'retry',
-        reason: `attempt_${this.reconnectAttempts}`,
-      });
-    });
-
-    setTimeout(() => {
-      if (!this.isConnected && this.socket) {
-        // Force a fresh connection by disconnecting first
-        this.socket.disconnect();
-
-        // Reconnect (this will trigger our connect event handler with rejoin logic)
-        this.socket.connect();
-      }
-    }, delay);
-  }
-
   disconnect(): void {
     if (this.socket) {
       safeRecordMetric(() => {
@@ -276,7 +257,7 @@ class WebSocketService {
   }
 
   reconnect(): void {
-    void this.attemptReconnect();
+    this.forceReconnect();
   }
 
   forceReconnect(): void {

--- a/apps/xyne-claw-auth/backend/src/db.ts
+++ b/apps/xyne-claw-auth/backend/src/db.ts
@@ -1,3 +1,27 @@
 import { PrismaClient } from "@prisma/client";
+import { withRetry, retryForever } from "./retry.js";
+import { createLogger } from "./logger.js";
 
-export const prisma = new PrismaClient();
+const log = createLogger("db");
+
+const basePrisma = new PrismaClient();
+
+export const prisma = basePrisma.$extends({
+  query: {
+    $allOperations({ operation, model, args, query }) {
+      return withRetry(() => query(args), `prisma.${model ?? "raw"}.${operation}`);
+    },
+  },
+});
+
+export type AppPrismaClient = typeof prisma;
+
+export type AppTransactionClient = Omit<
+  AppPrismaClient,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$extends"
+>;
+
+export async function connectDb(): Promise<void> {
+  await retryForever(() => basePrisma.$connect(), "prisma.connect");
+  log.info("[db] Connected successfully");
+}

--- a/apps/xyne-claw-auth/backend/src/lib/callable-agent-resolver.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/callable-agent-resolver.ts
@@ -17,7 +17,8 @@
  * The resolved specs are forwarded to xyne-claw as `callableAgents` in the /run
  * body, where buildCallableAgentTools() turns each into a governed tool.
  */
-import type { Prisma, PrismaClient } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
+import type { AppPrismaClient } from "../db.js";
 import { parseToolsConfig, stripPlatformConfigKeys } from "xyne-claw-shared";
 import { resolveAgentProviderConfigs, type ProviderConfig } from "./agent-provider-config.js";
 import { resolveCustomSubagentsForRun, type CustomSubagentSpec } from "./subagent-resolver.js";
@@ -96,7 +97,7 @@ export function toLightweightCallableAgentSpec(
 }
 
 export async function hydrateCallableAgentSpec(
-  prisma: PrismaClient,
+  prisma: AppPrismaClient,
   callee: AgentRowWithSkills,
   identityMode: DelegationIdentityMode,
 ): Promise<CallableAgentSpec> {
@@ -153,7 +154,7 @@ export async function hydrateCallableAgentSpec(
  * enabled callee agents are returned.
  */
 export async function resolveCallableAgentsForRun(
-  prisma: PrismaClient,
+  prisma: AppPrismaClient,
   callerAgentId: string,
   requestedCalleeSlugs: string[],
   callerOrgId?: string,
@@ -227,7 +228,7 @@ export async function resolveCallableAgentsForRun(
  * forwarded; xyne-claw hydrates a selected callee at execute time.
  */
 export async function resolveOrchestratorCallableAgentsForRun(
-  prisma: PrismaClient,
+  prisma: AppPrismaClient,
   callerAgentId: string,
   callerOrgId: string,
   opts: { runningUserId?: string; isAdmin?: boolean } = {},
@@ -281,7 +282,7 @@ export async function resolveOrchestratorCallableAgentsForRun(
 }
 
 export async function resolveCallableAgentSpecForOrchestratorCall(
-  prisma: PrismaClient,
+  prisma: AppPrismaClient,
   args: {
     callerSlug: string;
     calleeSlug: string;

--- a/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
@@ -23,6 +23,7 @@
 import { PrismaClient } from "@prisma/client";
 import { CONFIG } from "../config.js";
 import { prisma } from "../db.js";
+import { withRetry } from "../retry.js";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("spaces-db");
@@ -108,7 +109,22 @@ async function refreshSpacesAccessToken(sessionId: string, workspaceId: string):
   }
 }
 
-let _client: PrismaClient | null = null;
+function buildClient() {
+  return new PrismaClient({
+    datasourceUrl: CONFIG.spacesDbUrl,
+    log: ["error"],
+  }).$extends({
+    query: {
+      $allOperations({ operation, model, args, query }) {
+        return withRetry(() => query(args), `spaces-db.${model ?? "raw"}.${operation}`);
+      },
+    },
+  });
+}
+
+type SpacesDbClient = ReturnType<typeof buildClient>;
+
+let _client: SpacesDbClient | null = null;
 let _initFailed = false;
 
 /**
@@ -117,16 +133,13 @@ let _initFailed = false;
  * unreachable DB) we mark it so subsequent calls short-circuit without
  * thrashing on retries; the operator can fix env + restart.
  */
-function getClient(): PrismaClient | null {
+function getClient(): SpacesDbClient | null {
   if (_initFailed) return null;
   if (_client) return _client;
   if (!CONFIG.spacesDbUrl) return null;
 
   try {
-    _client = new PrismaClient({
-      datasourceUrl: CONFIG.spacesDbUrl,
-      log: ["error"],
-    });
+    _client = buildClient();
     log.info("[spaces-db] Read-only client initialized");
     return _client;
   } catch (err) {

--- a/apps/xyne-claw-auth/backend/src/lib/subagent-resolver.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/subagent-resolver.ts
@@ -12,7 +12,8 @@
  * gets sent to xyne-claw as part of the run payload.
  */
 
-import type { PrismaClient, SubagentDefinition, Skill, SkillFile } from "@prisma/client";
+import type { SubagentDefinition, Skill, SkillFile } from "@prisma/client";
+import type { AppPrismaClient } from "../db.js";
 import { SUBAGENT_DEFINITIONS, type SubagentDefinition as BuiltinDef } from "xyne-claw-shared";
 
 import { createLogger } from "../logger.js";
@@ -183,7 +184,7 @@ function validateToolsConfig(raw: unknown): SubagentToolsConfig {
   return out;
 }
 
-async function validateSkillIds(prisma: PrismaClient, raw: unknown): Promise<string[]> {
+async function validateSkillIds(prisma: AppPrismaClient, raw: unknown): Promise<string[]> {
   if (raw === undefined || raw === null) return [];
   if (!Array.isArray(raw)) throw new ValidationError("skillIds", "must be an array of skill IDs");
   const ids = raw.map((x, i) => {
@@ -232,7 +233,7 @@ function validateMcpInstanceMap(raw: unknown): Record<string, string> {
 }
 
 export async function validateSubagentInput(
-  prisma: PrismaClient,
+  prisma: AppPrismaClient,
   input: SubagentInput,
   options: { isCreate: boolean; orgId?: string | null },
 ): Promise<ValidatedSubagentInput> {
@@ -334,7 +335,7 @@ export interface ResolvedSubagent {
  * crash the /run handler.
  */
 export async function resolveSubagentsForRun(
-  prisma: PrismaClient,
+  prisma: AppPrismaClient,
   requestedNames: string[],
   orgId?: string,
 ): Promise<ResolvedSubagent[]> {
@@ -374,7 +375,7 @@ export async function resolveSubagentsForRun(
  * bundled code and don't need to be sent.
  */
 export async function resolveCustomSubagentsForRun(
-  prisma: PrismaClient,
+  prisma: AppPrismaClient,
   requestedNames: string[],
   orgId?: string,
 ): Promise<CustomSubagentSpec[]> {

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -98,6 +98,7 @@ import {
 import { requireAuth, requireS2S, requireStrictS2S, requireInternalS2S, requireUserAuth, s2sKeyMatches } from "./middleware/require-auth.js";
 import { requireClawAdmin, requireSearchEvalAccess } from "./middleware/agent-acl.js";
 import { redisService } from "./redis.js";
+import { connectDb } from "./db.js";
 
 const app = express();
 // Capture the raw request body so verify-spaces-signature middleware can
@@ -284,6 +285,10 @@ app.use(`${BASE}/gateway`, mcpGatewayRouter);
 const server = app.
 listen(CONFIG.port, () => {
   log.info(`[xyne-claw-auth] Server listening on port ${CONFIG.port}`);
+
+  void connectDb().catch(err => {
+    log.error('[xyne-claw-auth] Database warmup failed:', err);
+  });
   // npx cache scrub: prior deploys left half-installed package trees in
   // ~/.npm/_npx (e.g. node-fetch present, data-uri-to-buffer missing),
   // which made every stdio MCP spawn (github, etc.) die with

--- a/apps/xyne-claw-auth/backend/src/redis.ts
+++ b/apps/xyne-claw-auth/backend/src/redis.ts
@@ -11,6 +11,7 @@
 
 import { Redis } from "ioredis";
 import { CONFIG } from "./config.js";
+import { retryForever } from "./retry.js";
 
 import { createLogger } from "./logger.js";
 const log = createLogger("redis");
@@ -26,26 +27,36 @@ class RedisService {
       ...(CONFIG.redisTls ? { tls: { rejectUnauthorized: false } } : {}),
       maxRetriesPerRequest: null as null, // required by BullMQ
       lazyConnect: true,
+      retryStrategy: (times: number) => Math.min(times * 200, 5_000),
+      enableOfflineQueue: true,
+      reconnectOnError: (err: Error) => /READONLY/.test(err.message),
+      connectTimeout: 10_000,
+      keepAlive: 30_000,
     };
+  }
+
+  private attachHandlers(client: Redis): void {
+    client.on("connect", () => {
+      log.info("[redis] Connected successfully");
+    });
+
+    client.on("error", (err: Error) => {
+      log.error("[redis] Connection error:", err.message);
+    });
+
+    client.on("reconnecting", (delayMs: number) => {
+      log.warn(`[redis] reconnecting in ${delayMs}ms`);
+    });
   }
 
   async connect(): Promise<void> {
     if (this.redis) return;
-    try {
-      this.redis = new Redis(this.getRedisConfig());
 
-      this.redis.on("connect", () => {
-        log.info("[redis] Connected successfully");
-      });
+    this.redis = new Redis(this.getRedisConfig());
+    this.attachHandlers(this.redis);
 
-      this.redis.on("error", (err: Error) => {
-        log.error("[redis] Connection error:", err.message);
-      });
-
-      await this.redis.connect();
-    } catch (err) {
-      log.error("[redis] Failed to initialize:", err);
-    }
+    const client = this.redis;
+    await retryForever(() => client.connect(), "redis.connect");
   }
 
   async disconnect(): Promise<void> {
@@ -60,9 +71,7 @@ class RedisService {
   getConnection(): Redis {
     if (!this.redis) {
       this.redis = new Redis(this.getRedisConfig());
-      this.redis.on("error", (err: Error) => {
-        log.error("[redis] Connection error:", err.message);
-      });
+      this.attachHandlers(this.redis);
     }
     return this.redis;
   }

--- a/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
@@ -1,5 +1,5 @@
 import { Prisma } from "@prisma/client";
-import { prisma } from "../db.js";
+import { prisma, type AppTransactionClient } from "../db.js";
 import { formatDayIST } from "../lib/ist-time.js";
 import { createLogger } from "../logger.js";
 
@@ -61,7 +61,7 @@ const LOCK_NAMESPACE = "agent_run";
 
 async function withSessionWriteLock<T>(
   sessionId: string,
-  fn: (tx: Prisma.TransactionClient) => Promise<T>,
+  fn: (tx: AppTransactionClient) => Promise<T>,
 ): Promise<T> {
   return prisma.$transaction(
     async (tx) => {

--- a/apps/xyne-claw-auth/backend/src/retry.ts
+++ b/apps/xyne-claw-auth/backend/src/retry.ts
@@ -1,0 +1,95 @@
+import { createLogger } from "./logger.js";
+
+const log = createLogger("retry");
+
+
+const CONNECTION_ERROR_CODES = new Set([
+  "P1001",
+  "P1002",
+  "P1008",
+  "P1017",
+  "P2024",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+]);
+
+const CONNECTION_ERROR_MESSAGES = ["Connection is closed", "Stream isn't writeable", "READONLY"];
+
+export function isConnectionError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: unknown; errorCode?: unknown; name?: unknown; message?: unknown };
+
+  const code =
+    typeof e.code === "string" ? e.code : typeof e.errorCode === "string" ? e.errorCode : "";
+  if (CONNECTION_ERROR_CODES.has(code)) return true;
+
+  if (e.name === "MaxRetriesPerRequestError") return true;
+
+  const message = typeof e.message === "string" ? e.message : "";
+  if (CONNECTION_ERROR_MESSAGES.some((m) => message.includes(m))) return true;
+  for (const c of CONNECTION_ERROR_CODES) {
+    if (message.includes(c)) return true;
+  }
+  return false;
+}
+
+function envInt(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+
+export function computeBackoffMs(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const ceiling = Math.min(maxDelayMs, baseDelayMs * Math.pow(2, Math.max(0, attempt - 1)));
+  return Math.floor(Math.random() * ceiling);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function withRetry<T>(fn: () => Promise<T>, label: string): Promise<T> {
+  const attempts = envInt("RETRY_ATTEMPTS", 3);
+  const baseDelayMs = envInt("RETRY_BASE_DELAY_MS", 200);
+  const maxDelayMs = envInt("RETRY_MAX_DELAY_MS", 5_000);
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= attempts || !isConnectionError(err)) throw err;
+
+      const delayMs = computeBackoffMs(attempt, baseDelayMs, maxDelayMs);
+      log.warn(
+        `[retry] ${label} failed on a connection error (attempt ${attempt}, retrying in ${delayMs}ms): ${
+          (err as { message?: string })?.message ?? "unknown error"
+        }`,
+      );
+      await sleep(delayMs);
+    }
+  }
+}
+
+export async function retryForever<T>(fn: () => Promise<T>, label: string): Promise<T> {
+  const baseDelayMs = envInt("RETRY_BASE_DELAY_MS", 200);
+  const maxDelayMs = envInt("CONNECT_RETRY_MAX_DELAY_MS", 30_000);
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const delayMs = computeBackoffMs(attempt, baseDelayMs, maxDelayMs);
+      const message = (err as { message?: string })?.message ?? "unknown error";
+      if (attempt % 10 === 0) {
+        log.error(`[retry] ${label} still failing after ${attempt} attempts: ${message}`);
+      } else {
+        log.warn(`[retry] ${label} failed, retrying in ${delayMs}ms: ${message}`);
+      }
+      await sleep(delayMs);
+    }
+  }
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
