### PR TITLE
feat: XYNE-55170 Paginate ticket table

### DIFF
--- a/apps/backend/src/controllers/kanbanTicketController.ts
+++ b/apps/backend/src/controllers/kanbanTicketController.ts
@@ -56,6 +56,7 @@ const kanbanCountsBodySchema = z.object({
     ])
     .optional(),
   showOverdueOnly: z.boolean().optional(),
+  includeColumnCounts: z.boolean().optional(),
 });
 
 export class KanbanTicketController {

--- a/apps/backend/src/services/tickets/kanbanCountsService.ts
+++ b/apps/backend/src/services/tickets/kanbanCountsService.ts
@@ -210,6 +210,7 @@ const addTicketToGroup = (
   displayName: string,
   columnType: KanbanCountColumnType,
   columnValue: string,
+  includeColumnCounts: boolean,
 ): void => {
   const group = groupsByKey.get(groupKey) ?? {
     groupKey,
@@ -220,10 +221,12 @@ const addTicketToGroup = (
   };
 
   group.totalCount += 1;
-  if (columnType === 'status') {
-    group.statuses[columnValue] = (group.statuses[columnValue] ?? 0) + 1;
-  } else {
-    group.stages[columnValue] = (group.stages[columnValue] ?? 0) + 1;
+  if (includeColumnCounts) {
+    if (columnType === 'status') {
+      group.statuses[columnValue] = (group.statuses[columnValue] ?? 0) + 1;
+    } else {
+      group.stages[columnValue] = (group.stages[columnValue] ?? 0) + 1;
+    }
   }
   groupsByKey.set(groupKey, group);
 };
@@ -235,6 +238,7 @@ const addAggregateRowToGroup = (
   columnType: KanbanCountColumnType,
   columnValue: string,
   count: number,
+  includeColumnCounts: boolean,
 ): void => {
   const group = groupsByKey.get(groupKey) ?? {
     groupKey,
@@ -245,10 +249,12 @@ const addAggregateRowToGroup = (
   };
 
   group.totalCount += count;
-  if (columnType === 'status') {
-    group.statuses[columnValue] = (group.statuses[columnValue] ?? 0) + count;
-  } else {
-    group.stages[columnValue] = (group.stages[columnValue] ?? 0) + count;
+  if (includeColumnCounts) {
+    if (columnType === 'status') {
+      group.statuses[columnValue] = (group.statuses[columnValue] ?? 0) + count;
+    } else {
+      group.stages[columnValue] = (group.stages[columnValue] ?? 0) + count;
+    }
   }
   groupsByKey.set(groupKey, group);
 };
@@ -277,6 +283,7 @@ export const getKanbanCounts = async (
   const where = buildKanbanTicketWhere(context);
   const dynamicFieldIds = Object.keys(context.filters?.dynamicFields ?? {});
   const groupBy = context.groupBy ?? 'none';
+  const includeColumnCounts = context.includeColumnCounts ?? true;
   const countColumnType = getCountColumnType(context);
   const countField = getCountField(countColumnType);
   const groupsByKey = new Map<string, KanbanCountGroup>();
@@ -289,13 +296,31 @@ export const getKanbanCounts = async (
     groupId: context.groupId ?? null,
     groupBy,
     countColumnType,
+    includeColumnCounts,
     hasDynamicFields: dynamicFieldIds.length > 0,
     where,
   });
 
+  if (!includeColumnCounts && groupBy === 'none' && dynamicFieldIds.length === 0) {
+    const totalCount = await db.ticket.count({ where });
+    return {
+      groups: [
+        {
+          groupKey: ALL_TICKETS_GROUP,
+          displayName: ALL_TICKETS_GROUP,
+          totalCount,
+          stages: {},
+          statuses: {},
+        },
+      ],
+    };
+  }
+
   if (!isFormFieldGroup(groupBy) && dynamicFieldIds.length === 0) {
     const groupFields = getBuiltInGroupByFields(groupBy);
-    const aggregateGroupFields = [...new Set([...groupFields, countField])] as Array<
+    const aggregateGroupFields = [
+      ...new Set(includeColumnCounts ? [...groupFields, countField] : groupFields),
+    ] as Array<
       'assignedTo' | 'stageName' | 'statusV2' | 'priority'
     >;
 
@@ -329,6 +354,7 @@ export const getKanbanCounts = async (
         countColumnType,
         row[countField] ?? '',
         row._count._all,
+        includeColumnCounts,
       );
     }
 
@@ -340,7 +366,9 @@ export const getKanbanCounts = async (
   const fallbackGroupFields = isFormFieldGroup(groupBy)
     ? []
     : getBuiltInGroupByFields(groupBy);
-  const fallbackFields = [...new Set(['id', countField, ...fallbackGroupFields])] as Array<
+  const fallbackFields = [
+    ...new Set(includeColumnCounts ? ['id', countField, ...fallbackGroupFields] : ['id', ...fallbackGroupFields]),
+  ] as Array<
     'id' | 'assignedTo' | 'stageName' | 'statusV2' | 'priority'
   >;
 
@@ -399,6 +427,7 @@ export const getKanbanCounts = async (
         group.displayName,
         countColumnType,
         ticket[countField] ?? '',
+        includeColumnCounts,
       );
     }
   }

--- a/apps/backend/src/services/tickets/kanbanQueryBuilder.ts
+++ b/apps/backend/src/services/tickets/kanbanQueryBuilder.ts
@@ -58,6 +58,7 @@ export type KanbanTicketQueryContext = {
   filters?: KanbanTicketFilters;
   groupBy?: KanbanGroupBy;
   showOverdueOnly?: boolean;
+  includeColumnCounts?: boolean;
 };
 
 const hasItems = <T>(value: readonly T[] | undefined): value is readonly T[] =>

--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
@@ -18,7 +18,7 @@ import { useZero } from '../../../hooks/useZero';
 import { queries } from '../../../zero/queries';
 import { useUser, useUsers } from '../../../hooks/useUsers';
 import { useUserGroupById, useUserGroups } from '../../../hooks/useUserGroup';
-import { Calendar, Check, User } from 'lucide-react';
+import { Calendar, Check, ChevronLeft, ChevronRight, User } from 'lucide-react';
 import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
 import { formatStatusLabel, getPriorityIcon, isEtaUrgent } from '../TicketCard/TicketCard.utils';
 import { mutators } from '../../../zero/mutators';
@@ -52,7 +52,33 @@ interface TicketTableProps {
   extraColumns?: ColDef<Ticket>[];
   selectedIds?: ReadonlySet<string>;
   onSelectionChange?: (tickets: Ticket[]) => void;
+  onPaginationBoundaryReached?: () => void;
+  onFirstPageRequested?: () => void;
+  onLastPageRequested?: () => void;
+  totalRowCount?: number;
+  hasMoreRows?: boolean;
+  isLoadingMoreRows?: boolean;
 }
+
+const TABLE_PAGE_SIZE = 25;
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+type PaginationSummary = {
+  currentPage: number;
+  loadedPageCount: number;
+  loadedRowCount: number;
+  pageSize: number;
+};
+
+type TicketTableGridContext = {
+  rowNumberOffset?: number;
+};
+
+const getRowNumberOffset = (context: unknown): number => {
+  if (!context || typeof context !== 'object' || !('rowNumberOffset' in context)) return 0;
+  const offset = (context as TicketTableGridContext).rowNumberOffset;
+  return typeof offset === 'number' ? offset : 0;
+};
 
 // Index header renderer component
 const IndexHeaderRenderer = (params: IHeaderParams) => {
@@ -100,7 +126,7 @@ const IndexHeaderRenderer = (params: IHeaderParams) => {
 const IndexCellRenderer = (params: ICellRendererParams<Ticket>) => {
   const [isHovered, setIsHovered] = useState(false);
   const [isSelected, setIsSelected] = useState(params.node.isSelected());
-  const rowIndex = (params.node.rowIndex ?? 0) + 1;
+  const rowIndex = getRowNumberOffset(params.context) + (params.node.rowIndex ?? 0) + 1;
   useEffect(() => {
     const onSelectionChanged = () => {
       setIsSelected(params.node.isSelected());
@@ -160,6 +186,12 @@ export const TicketTable: React.FC<TicketTableProps> = ({
   extraColumns,
   selectedIds,
   onSelectionChange,
+  onPaginationBoundaryReached,
+  onFirstPageRequested,
+  onLastPageRequested,
+  totalRowCount,
+  hasMoreRows = false,
+  isLoadingMoreRows = false,
 }) => {
   const zero = useZero();
   const users = useUsers();
@@ -213,6 +245,34 @@ export const TicketTable: React.FC<TicketTableProps> = ({
 
   const [gridApi, setGridApi] = useState<GridApi | null>(null);
   const [selectedCount, setSelectedCount] = useState(0);
+  const [paginationSummary, setPaginationSummary] = useState<PaginationSummary>({
+    currentPage: 0,
+    loadedPageCount: 0,
+    loadedRowCount: tickets.length,
+    pageSize: TABLE_PAGE_SIZE,
+  });
+  const [pendingPageAfterLoad, setPendingPageAfterLoad] = useState<number | null>(null);
+  const [serverPageIndex, setServerPageIndex] = useState(0);
+
+  const refreshPaginationSummary = useCallback((api: GridApi): void => {
+    const nextSummary = {
+      currentPage: api.paginationGetCurrentPage(),
+      loadedPageCount: api.paginationGetTotalPages(),
+      loadedRowCount: api.paginationGetRowCount(),
+      pageSize: api.paginationGetPageSize() || TABLE_PAGE_SIZE,
+    };
+    setPaginationSummary(prev => {
+      if (
+        prev.currentPage === nextSummary.currentPage &&
+        prev.loadedPageCount === nextSummary.loadedPageCount &&
+        prev.loadedRowCount === nextSummary.loadedRowCount &&
+        prev.pageSize === nextSummary.pageSize
+      ) {
+        return prev;
+      }
+      return nextSummary;
+    });
+  }, []);
 
   useEffect(() => {
     if (!gridApi || selectedIds === undefined) return;
@@ -222,6 +282,23 @@ export const TicketTable: React.FC<TicketTableProps> = ({
       if (node.isSelected() !== shouldBeSelected) node.setSelected(shouldBeSelected);
     });
   }, [gridApi, selectedIds, tickets]);
+
+  useEffect(() => {
+    if (!gridApi) return;
+    refreshPaginationSummary(gridApi);
+  }, [gridApi, refreshPaginationSummary, tickets.length]);
+
+  useEffect(() => {
+    if (!gridApi || pendingPageAfterLoad === null) return;
+    if (pendingPageAfterLoad >= gridApi.paginationGetTotalPages()) return;
+    gridApi.paginationGoToPage(pendingPageAfterLoad);
+    refreshPaginationSummary(gridApi);
+    setPendingPageAfterLoad(null);
+  }, [gridApi, pendingPageAfterLoad, refreshPaginationSummary, tickets.length]);
+
+  useEffect(() => {
+    setServerPageIndex(0);
+  }, [totalRowCount]);
 
   const userGroups = useUserGroups();
 
@@ -703,6 +780,87 @@ export const TicketTable: React.FC<TicketTableProps> = ({
     [gridApi, zero, ticketTags],
   );
 
+  const usesServerTotal = totalRowCount !== undefined;
+  const effectiveTotalRows = totalRowCount ?? paginationSummary.loadedRowCount;
+  const totalPageCount =
+    effectiveTotalRows > 0 ? Math.ceil(effectiveTotalRows / paginationSummary.pageSize) : 0;
+  const currentPage =
+    totalPageCount === 0
+      ? 0
+      : usesServerTotal
+        ? Math.min(serverPageIndex, totalPageCount - 1)
+        : Math.min(paginationSummary.currentPage, totalPageCount - 1);
+  const firstRowOnPage =
+    effectiveTotalRows === 0 ? 0 : currentPage * paginationSummary.pageSize + 1;
+  const lastRowOnPage =
+    effectiveTotalRows === 0
+      ? 0
+      : Math.min((currentPage + 1) * paginationSummary.pageSize, effectiveTotalRows);
+  const canGoFirst = !!gridApi && currentPage > 0;
+  const hasLoadedPreviousPage =
+    !usesServerTotal ||
+    serverPageIndex === paginationSummary.currentPage ||
+    currentPage <= paginationSummary.loadedPageCount - 1;
+  const rowNumberOffset =
+    usesServerTotal && currentPage >= paginationSummary.loadedPageCount
+      ? currentPage * paginationSummary.pageSize
+      : 0;
+  const gridContext = useMemo<TicketTableGridContext>(
+    () => ({ rowNumberOffset }),
+    [rowNumberOffset],
+  );
+  const canGoPrevious = !!gridApi && currentPage > 0 && hasLoadedPreviousPage;
+  const hasLoadedNextPage = currentPage + 1 < paginationSummary.loadedPageCount;
+  const canGoNext =
+    !!gridApi && currentPage + 1 < totalPageCount && (hasLoadedNextPage || hasMoreRows);
+
+  const goToPreviousPage = useCallback(() => {
+    if (!gridApi || currentPage === 0) return;
+    gridApi.paginationGoToPreviousPage();
+    refreshPaginationSummary(gridApi);
+    setServerPageIndex(prev => Math.max(0, prev - 1));
+  }, [currentPage, gridApi, refreshPaginationSummary]);
+
+  const goToFirstPage = useCallback(() => {
+    if (!gridApi || !canGoFirst) return;
+    onFirstPageRequested?.();
+    gridApi.paginationGoToFirstPage();
+    refreshPaginationSummary(gridApi);
+    setServerPageIndex(0);
+  }, [canGoFirst, gridApi, onFirstPageRequested, refreshPaginationSummary]);
+
+  const goToNextPage = useCallback(() => {
+    if (!gridApi || !canGoNext) return;
+    const nextPage = currentPage + 1;
+    if (nextPage < gridApi.paginationGetTotalPages()) {
+      gridApi.paginationGoToNextPage();
+      refreshPaginationSummary(gridApi);
+      setServerPageIndex(nextPage);
+      return;
+    }
+    if (!onPaginationBoundaryReached || isLoadingMoreRows) return;
+    setPendingPageAfterLoad(nextPage);
+    setServerPageIndex(nextPage);
+    onPaginationBoundaryReached();
+  }, [
+    canGoNext,
+    currentPage,
+    gridApi,
+    isLoadingMoreRows,
+    onPaginationBoundaryReached,
+    refreshPaginationSummary,
+  ]);
+  const canGoLastPage =
+    !!gridApi && !!onLastPageRequested && currentPage + 1 < totalPageCount && !isLoadingMoreRows;
+
+  const goToLastPage = useCallback(() => {
+    if (!gridApi || !canGoLastPage) return;
+    setPendingPageAfterLoad(0);
+    setServerPageIndex(Math.max(0, totalPageCount - 1));
+    onLastPageRequested?.();
+    refreshPaginationSummary(gridApi);
+  }, [canGoLastPage, gridApi, onLastPageRequested, refreshPaginationSummary, totalPageCount]);
+
   return (
     <>
       <div className='flex flex-col'>
@@ -730,6 +888,7 @@ export const TicketTable: React.FC<TicketTableProps> = ({
               onSelectionChange?.(selectedRows);
             }}
             rowData={tickets}
+            context={gridContext}
             columnDefs={columnDefs}
             rowHeight={44}
             headerHeight={44}
@@ -740,17 +899,93 @@ export const TicketTable: React.FC<TicketTableProps> = ({
             }}
             onGridReady={(params: GridReadyEvent) => {
               setGridApi(params.api);
+              refreshPaginationSummary(params.api);
               setTimeout(() => {
                 params.api.setFocusedCell(0, 'title');
               }, 100);
+            }}
+            onPaginationChanged={params => {
+              refreshPaginationSummary(params.api);
+              if (!onPaginationBoundaryReached) return;
+              if (usesServerTotal) return;
+              const currentPage = params.api.paginationGetCurrentPage();
+              const totalPages = params.api.paginationGetTotalPages();
+              if (totalPages > 0 && currentPage >= totalPages - 1) {
+                onPaginationBoundaryReached();
+              }
             }}
             suppressCellFocus={false}
             suppressNoRowsOverlay={true}
             alwaysShowHorizontalScroll
             pagination={true}
-            paginationPageSize={25}
+            paginationPageSize={TABLE_PAGE_SIZE}
             paginationPageSizeSelector={false}
+            suppressPaginationPanel={usesServerTotal}
           />
+          {usesServerTotal && (
+            <div className='flex h-12 items-center justify-end gap-8 border-t border-border px-4 text-sm text-foreground'>
+              <span className='whitespace-nowrap'>
+                {numberFormatter.format(firstRowOnPage)} to {numberFormatter.format(lastRowOnPage)}{' '}
+                of {numberFormatter.format(effectiveTotalRows)}
+              </span>
+              <span className='flex items-center gap-3 whitespace-nowrap'>
+                <button
+                  type='button'
+                  className='inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-35'
+                  disabled={!canGoFirst}
+                  onClick={goToFirstPage}
+                  aria-label='First page'
+                  data-track-category='Tickets'
+                  data-track-name='TablePaginationFirst'
+                >
+                  <span className='relative inline-flex h-5 w-5 items-center justify-center'>
+                    <span className='absolute left-1 h-4 w-0.5 rounded-full bg-current' />
+                    <ChevronLeft className='h-5 w-5 translate-x-0.5' />
+                  </span>
+                </button>
+                <button
+                  type='button'
+                  className='inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-35'
+                  disabled={!canGoPrevious}
+                  onClick={goToPreviousPage}
+                  aria-label='Previous page'
+                  data-track-category='Tickets'
+                  data-track-name='TablePaginationPrevious'
+                >
+                  <ChevronLeft className='h-5 w-5' />
+                </button>
+                <span className='px-2 text-foreground'>
+                  Page {numberFormatter.format(totalPageCount === 0 ? 0 : currentPage + 1)} of{' '}
+                  {numberFormatter.format(totalPageCount)}
+                </span>
+                <button
+                  type='button'
+                  className='inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground hover:bg-muted disabled:pointer-events-none disabled:opacity-35'
+                  disabled={!canGoNext || isLoadingMoreRows}
+                  onClick={goToNextPage}
+                  aria-label='Next page'
+                  data-track-category='Tickets'
+                  data-track-name='TablePaginationNext'
+                >
+                  <ChevronRight className='h-5 w-5' />
+                </button>
+                <button
+                  type='button'
+                  className='inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground hover:bg-muted disabled:pointer-events-none disabled:opacity-35'
+                  disabled={!canGoLastPage}
+                  onClick={goToLastPage}
+                  aria-label='Last page'
+                  data-track-category='Tickets'
+                  data-track-name='TablePaginationLast'
+                >
+                  <span className='relative inline-flex h-5 w-5 items-center justify-center'>
+                    <ChevronRight className='h-5 w-5 -translate-x-0.5' />
+                    <span className='absolute right-1 h-4 w-0.5 rounded-full bg-current' />
+                  </span>
+                </button>
+              </span>
+            </div>
+          )}
         </div>
 
         <div>

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -49,7 +49,7 @@ import { StageFormModal } from '../../components/Tickets/StageFormModal/StageFor
 import { useMachine } from '@xstate/react';
 import { ticketFiltersMachine } from '../../machines/ticketFiltersMachine';
 import { setBoardNavParams } from '../../components/Tickets/boardNavStore';
-import type { KanbanTicketsPageBaseArgs } from './useKanbanTicketsPage';
+import { useKanbanTicketsPage, type KanbanTicketsPageBaseArgs } from './useKanbanTicketsPage';
 import type { TicketFilters } from '../../components/Tickets/TicketFilters/types';
 import { KanbanColumns } from '../../components/Tickets/KanbanColumns/KanbanColumns';
 import { ViewBoardPicker } from '../../components/Project/ViewBoardPicker/ViewBoardPicker';
@@ -126,6 +126,8 @@ type SavedConfigValue = {
   fieldName: string;
   fieldValue: string;
 };
+
+const TABLE_TICKETS_PAGE_SIZE = 25;
 
 // Serialize filters (incl. boards) + groupBy into saved-config value rows.
 const WORKSPACE_VIEW_ARRAY_KEYS = [
@@ -244,6 +246,104 @@ function uniqueProjectIds(boards: readonly { projectId?: string | null }[]): str
   });
   return Array.from(ids);
 }
+
+type TableTicketGroupProps = {
+  groupKey: string;
+  totalCount: number;
+  fallbackTickets: Ticket[];
+  paginationArgs: KanbanTicketsPageBaseArgs | null;
+  enabled: boolean;
+  ticketTags: React.ComponentProps<typeof TicketTable>['ticketTags'];
+  availableTags: string[];
+  visibleColumns: Set<string>;
+  isComfortView: boolean;
+};
+
+const TableTicketGroup: React.FC<TableTicketGroupProps> = ({
+  groupKey,
+  totalCount,
+  fallbackTickets,
+  paginationArgs,
+  enabled,
+  ticketTags,
+  availableTags,
+  visibleColumns,
+  isComfortView,
+}) => {
+  const effectivePaginationArgs = useMemo<KanbanTicketsPageBaseArgs>(
+    () =>
+      paginationArgs
+        ? {
+            ...paginationArgs,
+            ...(groupKey !== 'All Tickets' ? { groupKey } : {}),
+          }
+        : {
+            viewMode: 'project',
+          },
+    [paginationArgs, groupKey],
+  );
+  const page = useKanbanTicketsPage({
+    ...effectivePaginationArgs,
+    stageName: '',
+    pageSize: TABLE_TICKETS_PAGE_SIZE,
+    enabled: enabled && paginationArgs !== null,
+  });
+
+  const tickets = paginationArgs && enabled ? page.tickets : fallbackTickets;
+  const mergedTicketTags = useMemo(() => {
+    const next = new Map(ticketTags ?? []);
+    tickets.forEach(ticket => {
+      const tagMappings = (ticket as KanbanLocalTicket).tagMappings;
+      if (!tagMappings?.length || next.has(ticket.id)) return;
+      next.set(
+        ticket.id,
+        tagMappings.map(tag => ({
+          workspaceId: ticket.workspaceId,
+          id: tag.id,
+          name: tag.tagName,
+          ticketId: tag.ticketId,
+        })),
+      );
+    });
+    return next;
+  }, [ticketTags, tickets]);
+
+  const handlePaginationBoundaryReached = useCallback(() => {
+    if (!page.hasMore || page.isLoadingMore) return;
+    page.loadMore();
+  }, [page.hasMore, page.isLoadingMore, page.loadMore]);
+
+  const handleFirstPageRequested = useCallback(() => {
+    page.reset();
+  }, [page.reset]);
+
+  const handleLastPageRequested = useCallback(() => {
+    const lastPageSize = totalCount % TABLE_TICKETS_PAGE_SIZE || TABLE_TICKETS_PAGE_SIZE;
+    page.loadLast(lastPageSize);
+  }, [page.loadLast, totalCount]);
+
+  const paginationBoundaryProps = paginationArgs
+    ? {
+        onPaginationBoundaryReached: handlePaginationBoundaryReached,
+        onFirstPageRequested: handleFirstPageRequested,
+        onLastPageRequested: handleLastPageRequested,
+        totalRowCount: totalCount,
+        hasMoreRows: page.hasMore,
+        isLoadingMoreRows: page.isLoadingMore,
+      }
+    : {};
+
+  return (
+    <TicketTable
+      tickets={tickets}
+      ticketTags={mergedTicketTags}
+      availableTags={availableTags}
+      visibleColumns={visibleColumns}
+      isComfortView={isComfortView}
+      {...paginationBoundaryProps}
+    />
+  );
+};
 
 const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   viewMode: viewModeProp,
@@ -477,11 +577,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const [state, send] = useMachine(ticketFiltersMachine);
   const layoutView = searchParams.get('layout') ?? 'kanban';
   const isKanbanLayout = layoutView === 'kanban';
+  const isTableLayout = layoutView === 'table';
   const groupBy: GroupByType = useMemo(
     () => parseGroupBy(state.context.groupBy),
     [state.context.groupBy],
   );
-  const shouldUseLegacyTicketsQuery = !isKanbanLayout;
   const [selectedViewId, setSelectedViewId] = useState<string | null>(null);
   const activeViewKey = `active-view-${state.context.storageKey}`;
   const hasRestoredActiveView = useRef<string | null>(null);
@@ -614,6 +714,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   // Don't query a workspace view until a board is picked (else it fans out across the workspace).
   const workspaceViewReady = !isWorkspaceView || (filters.boards?.length ?? 0) > 0;
+  const shouldUsePagedTicketData = (isKanbanLayout || isTableLayout) && workspaceViewReady;
+  const shouldUseLegacyTicketsQuery = !shouldUsePagedTicketData;
   const showSubStatus = state.context.showSubStatus;
 
   const setShowOverdueOnly = useCallback(
@@ -1269,7 +1371,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     queries.ticketsQueryV2(ticketsQueryParams),
     {
       enabled:
-        !isKanbanLayout &&
+        shouldUseLegacyTicketsQuery &&
         ((viewMode === 'board' && !!boardId) ||
           (viewMode === 'project' && !!effectiveProjectId) ||
           viewMode === 'my-tickets' ||
@@ -1282,12 +1384,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   }
 
   const kanbanSourceTickets = useMemo(() => {
-    if (!isKanbanLayout) {
+    if (!shouldUsePagedTicketData) {
       return allProjectTickets ?? undefined;
     }
 
     return localTickets ?? [];
-  }, [allProjectTickets, isKanbanLayout, localTickets]);
+  }, [allProjectTickets, shouldUsePagedTicketData, localTickets]);
 
   // Collect the unique board IDs visible on screen.
   //
@@ -1735,6 +1837,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   }, [filteredTickets, isKanbanLayout, kanbanTicketsByColumn, localTickets]);
 
   useEffect(() => {
+    if (!isTableLayout || !shouldUsePagedTicketData || localTickets === null) return;
+    setLocalTickets(null);
+  }, [isTableLayout, shouldUsePagedTicketData, localTickets]);
+
+  useEffect(() => {
     if (!isKanbanLayout) {
       setKanbanTicketsByColumn({});
     }
@@ -1998,13 +2105,15 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   const hasSearchTerm = searchTerm.trim().length > 0;
   const canUseKanbanColumnPagination = isKanbanLayout && workspaceViewReady;
-  const shouldFetchKanbanCounts = canUseKanbanColumnPagination && !hasSearchTerm;
+  const canUseTicketCounts = shouldUsePagedTicketData;
+  const shouldFetchKanbanCounts = canUseTicketCounts && !hasSearchTerm;
   const kanbanCounts = useKanbanCounts({
     ...ticketsQueryParams,
     columnType: shouldUseStatusColumns ? 'status' : 'stage',
     filters: deferredFilters,
     groupBy,
     showOverdueOnly,
+    includeColumnCounts: isKanbanLayout,
     ...(user?.id ? { currentUserId: user.id } : {}),
     enabled: shouldFetchKanbanCounts,
   });
@@ -2017,7 +2126,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   } | null>(null);
 
   useEffect(() => {
-    if (!isKanbanLayout) return;
+    if (!canUseTicketCounts) return;
     if (hasSearchTerm) return;
     if (lastKnownKanbanGroupsQueryKeyRef.current !== kanbanColumnQueryKey) {
       lastKnownKanbanGroupsRef.current = null;
@@ -2030,22 +2139,22 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     lastKnownKanbanGroupsRef.current = {
       groups: kanbanCounts.groups,
     };
-  }, [hasSearchTerm, isKanbanLayout, kanbanCounts.groups, kanbanColumnQueryKey]);
+  }, [hasSearchTerm, canUseTicketCounts, kanbanCounts.groups, kanbanColumnQueryKey]);
 
   useEffect(() => {
-    if (!isKanbanLayout) return;
+    if (!canUseTicketCounts) return;
     if (!localTickets || localTickets.length === 0) return;
 
     lastKnownKanbanTicketsRef.current = {
       tickets: localTickets,
     };
-  }, [isKanbanLayout, localTickets]);
+  }, [canUseTicketCounts, localTickets]);
 
   const hasMatchingLastKnownKanbanGroups =
     lastKnownKanbanGroupsQueryKeyRef.current === kanbanColumnQueryKey &&
     (lastKnownKanbanGroupsRef.current?.groups.length ?? 0) > 0;
 
-  const isTicketsSyncing = isKanbanLayout
+  const isTicketsSyncing = shouldUsePagedTicketData
     ? !hasSearchTerm && kanbanCounts.isLoading
     : ticketsDetails.type !== 'complete';
 
@@ -2065,7 +2174,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const processedGroups = useMemo(() => {
     const groupedRows = groupTickets(kanbanTicketsForGrouping, groupBy);
     const localEntries = Object.entries(groupedRows);
-    const serverGroups = isKanbanLayout
+    const serverGroups = shouldUsePagedTicketData
       ? hasSearchTerm
         ? groupBy === 'status'
           ? getStatusColumns().map(column => ({
@@ -2095,7 +2204,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         : localEntries;
 
     const mapped = entries.map(([groupName, groupTickets]) => {
-      const serverCountGroup = isKanbanLayout ? kanbanCounts.groupsByKey.get(groupName) : undefined;
+      const serverCountGroup = shouldUsePagedTicketData
+        ? kanbanCounts.groupsByKey.get(groupName)
+        : undefined;
       const serverColumnCounts = shouldUseStatusColumns
         ? (serverCountGroup?.statuses ?? {})
         : (serverCountGroup?.stages ?? {});
@@ -2174,7 +2285,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     groupNamesById,
     canReorder,
     shouldUseStatusColumns,
-    isKanbanLayout,
+    shouldUsePagedTicketData,
     hasSearchTerm,
     searchTerm,
     kanbanCounts.groups,
@@ -2869,8 +2980,26 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
                 {(isExpanded || !showGroupHeader) && (
                   <div>
-                    <TicketTable
-                      tickets={group.allTickets}
+                    <TableTicketGroup
+                      groupKey={group.key}
+                      totalCount={group.count}
+                      fallbackTickets={group.allTickets}
+                      paginationArgs={
+                        shouldUsePagedTicketData
+                          ? {
+                              ...ticketsQueryParams,
+                              searchTerm,
+                              filters: deferredFilters,
+                              formEntityValueFieldIds: fevFieldIds,
+                              dynamicFieldVespaTokens,
+                              dynamicFieldDateRanges,
+                              zeroOnlyDynamicFieldIds,
+                              showOverdueOnly,
+                              groupBy,
+                            }
+                          : null
+                      }
+                      enabled={isExpanded || !showGroupHeader}
                       ticketTags={tagsByTicketId}
                       availableTags={availableTags || []}
                       visibleColumns={tableVisibleColumns}

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanCounts.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanCounts.ts
@@ -24,6 +24,7 @@ interface UseKanbanCountsOptions {
   filters?: TicketFilters;
   groupBy?: KanbanCountsGroupBy;
   showOverdueOnly?: boolean;
+  includeColumnCounts?: boolean;
   enabled?: boolean;
   currentUserId?: string;
 }
@@ -359,6 +360,7 @@ const applyGroupDelta = (
   statusKeys: string[],
   delta: number,
   columnType: 'stage' | 'status',
+  includeColumnCounts: boolean,
 ): KanbanCountGroup[] => {
   const nextGroups = groups.map(cloneGroup);
   for (const groupKey of groupKeys) {
@@ -380,10 +382,12 @@ const applyGroupDelta = (
     }
 
     group.totalCount += delta;
-    if (columnType === 'status') {
-      applyCountDelta(group, statusKeys, delta, 'statuses');
-    } else {
-      applyCountDelta(group, stageKeys, delta, 'stages');
+    if (includeColumnCounts) {
+      if (columnType === 'status') {
+        applyCountDelta(group, statusKeys, delta, 'statuses');
+      } else {
+        applyCountDelta(group, stageKeys, delta, 'stages');
+      }
     }
 
     if (group.totalCount <= 0) {
@@ -422,6 +426,7 @@ const applyTicketCountsUpdate = (
 
   let nextGroups = current.groups;
   const columnType = request.columnType ?? 'stage';
+  const includeColumnCounts = request.includeColumnCounts ?? true;
 
   if (previousMatches && event.previousTicket) {
     const previousGroupKeys = getGroupKeys(event.previousTicket, request.groupBy);
@@ -435,6 +440,7 @@ const applyTicketCountsUpdate = (
         previousStatusKeys,
         -1,
         columnType,
+        includeColumnCounts,
       );
     }
   }
@@ -451,6 +457,7 @@ const applyTicketCountsUpdate = (
         currentStatusKeys,
         1,
         columnType,
+        includeColumnCounts,
       );
     }
   }
@@ -564,6 +571,8 @@ const toRequest = (options: UseKanbanCountsOptions): KanbanCountsRequest => {
 
   if (options.groupBy !== undefined) request.groupBy = options.groupBy;
   if (options.showOverdueOnly !== undefined) request.showOverdueOnly = options.showOverdueOnly;
+  if (options.includeColumnCounts !== undefined)
+    request.includeColumnCounts = options.includeColumnCounts;
 
   return request;
 };

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -83,6 +83,7 @@ type UseKanbanTicketsPageResult = {
   hasMore: boolean;
   isLoadingMore: boolean;
   loadMore: () => void;
+  loadLast: (limit?: number) => void;
   reset: () => void;
 };
 
@@ -100,7 +101,10 @@ type TicketsState = {
 
 type FetchCursorState = {
   queryKey: string;
-  cursor: KanbanCursor;
+  cursor: KanbanCursor | null;
+  dir?: 'forward' | 'backward';
+  replace?: boolean;
+  limit?: number;
 };
 
 const hasZeroOnlyFilters = (
@@ -443,8 +447,17 @@ export const useKanbanTicketsPage = (
   const { start: _start, ...queryKeyArgs } = basePageArgs;
   const queryKey = JSON.stringify(queryKeyArgs);
   const fetchCursor = fetchCursorState?.queryKey === queryKey ? fetchCursorState.cursor : null;
+  const fetchDir = fetchCursorState?.queryKey === queryKey ? fetchCursorState.dir : undefined;
+  const shouldReplacePage =
+    shouldUseDirectVespaRows || fetchCursor === null || fetchCursorState?.replace === true;
   const tickets = ticketsState.queryKey === queryKey ? ticketsState.tickets : [];
-  const pageArgs = buildKanbanTicketsPageArgs(pageOptions, fetchCursor);
+  const pageArgs = {
+    ...buildKanbanTicketsPageArgs(pageOptions, fetchCursor),
+    ...(fetchCursorState?.queryKey === queryKey && fetchCursorState.limit
+      ? { limit: fetchCursorState.limit }
+      : {}),
+    ...(fetchDir ? { dir: fetchDir } : {}),
+  };
   const [page, pageDetails] = useCachedQuery(
     queries.kanbanTicketsPageV2(pageArgs as Parameters<typeof queries.kanbanTicketsPageV2>[0]),
     {
@@ -502,7 +515,7 @@ export const useKanbanTicketsPage = (
     }
 
     setTicketsState(prev => {
-      if (shouldUseDirectVespaRows || fetchCursor === null) {
+      if (shouldReplacePage) {
         return { queryKey, tickets: pageRows };
       }
 
@@ -518,7 +531,9 @@ export const useKanbanTicketsPage = (
       return;
     }
 
-    setHasMore(pageRows.length >= (options.pageSize ?? DEFAULT_PAGE_SIZE));
+    setHasMore(
+      fetchDir === 'backward' ? false : pageRows.length >= (options.pageSize ?? DEFAULT_PAGE_SIZE),
+    );
 
     const lastItemOfPage = rawPageRows.at(-1);
     if (lastItemOfPage) {
@@ -531,18 +546,36 @@ export const useKanbanTicketsPage = (
     }
   }, [
     fetchCursor,
+    fetchCursorState?.replace,
+    fetchDir,
     queryKey,
     options.pageSize,
     effectivePage,
     effectivePageDetailsType,
     shouldUseDirectVespaRows,
+    shouldReplacePage,
   ]);
 
   const loadMore = useCallback(() => {
     if (isLoadingMoreRef.current || !hasMore || !nextCursor) return;
     isLoadingMoreRef.current = true;
-    setFetchCursorState({ queryKey, cursor: nextCursor });
+    setFetchCursorState({ queryKey, cursor: nextCursor, dir: 'forward' });
   }, [hasMore, nextCursor, queryKey]);
+
+  const loadLast = useCallback(
+    (limit?: number) => {
+      if (isLoadingMoreRef.current || shouldUseDirectVespaRows) return;
+      isLoadingMoreRef.current = true;
+      setFetchCursorState({
+        queryKey,
+        cursor: null,
+        dir: 'backward',
+        replace: true,
+        ...(limit ? { limit } : {}),
+      });
+    },
+    [queryKey, shouldUseDirectVespaRows],
+  );
 
   const reset = useCallback(() => {
     setTicketsState({ queryKey, tickets: [] });
@@ -554,13 +587,19 @@ export const useKanbanTicketsPage = (
 
   const isLoadingMore =
     !shouldUseDirectVespaRows && fetchCursor !== null && pageDetails.type !== 'complete';
+  const isLoadingLast =
+    !shouldUseDirectVespaRows &&
+    fetchCursorState?.queryKey === queryKey &&
+    fetchCursorState.dir === 'backward' &&
+    pageDetails.type !== 'complete';
 
   return {
     tickets,
     detailsType: effectivePageDetailsType,
     hasMore,
-    isLoadingMore,
+    isLoadingMore: isLoadingMore || isLoadingLast,
     loadMore,
+    loadLast,
     reset,
   };
 };

--- a/apps/dashboard/src/services/ticketService.ts
+++ b/apps/dashboard/src/services/ticketService.ts
@@ -72,6 +72,7 @@ export interface KanbanCountsRequest {
   filters?: KanbanCountsFilters;
   groupBy?: KanbanCountsGroupBy;
   showOverdueOnly?: boolean;
+  includeColumnCounts?: boolean;
 }
 
 export interface KanbanCountGroup {


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
