### PR TITLE
fix(claw-auth): reject CLI/service access tokens on non-/run routes

### DIFF
--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -98,7 +98,7 @@ import {
   stopBitbucketStatsBackgroundRefresh,
 } from "./services/bitbucket-stats.js";
 
-import { requireAuth, requireS2S, requireStrictS2S, requireInternalS2S, requireUserAuth, s2sKeyMatches } from "./middleware/require-auth.js";
+import { requireAuth, requireNoAccessToken, requireS2S, requireStrictS2S, requireInternalS2S, requireUserAuth, s2sKeyMatches } from "./middleware/require-auth.js";
 import { requireClawAdmin, requireSearchEvalAccess } from "./middleware/agent-acl.js";
 import { redisService } from "./redis.js";
 import { connectDb } from "./db.js";
@@ -165,28 +165,28 @@ const BASE = "/claw/api/v1";
 // can't be forged. Was previously fully unauthenticated: anyone could POST a
 // stdio connector whose launch command the gateway then spawned (RCE).
 app.use(`${BASE}/servers`, requireUserAuth, serversRouter);
-app.use(`${BASE}/users`, requireAuth, usersRouter);
-app.use(`${BASE}/users`, requireAuth, connectionsRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, usersRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, connectionsRouter);
 app.use(`${BASE}/sessions`, mcpRouter);
-app.use(`${BASE}/gateways`, requireAuth, requireClawAdmin, gatewaysRouter);
-app.use(`${BASE}/agents`, requireAuth, agentsRouter);
+app.use(`${BASE}/gateways`, requireAuth, requireNoAccessToken, requireClawAdmin, gatewaysRouter);
+app.use(`${BASE}/agents`, requireAuth, requireNoAccessToken, agentsRouter);
 app.use(`${BASE}/cli`, cliAuthRouter);
 // Public Slack ingress; authenticates itself with the per-install HMAC secret.
 app.use(`${BASE}/surfaces/slack`, slackRouter);
-app.use(`${BASE}/chain-workflows`, requireAuth, chainWorkflowsRouter);
-app.use(`${BASE}/spaces`, requireAuth, spacesRouter);
-app.use(`${BASE}/tools`, requireAuth, toolsRouter);
-app.use(`${BASE}/skills`, requireAuth, skillsRouter);
-app.use(`${BASE}/knowledge-base`, requireAuth, knowledgeBaseRouter);
-app.use(`${BASE}/subagents`, requireAuth, subagentsRouter);
-app.use(`${BASE}/sandbox`, requireAuth, sandboxRouter);
-app.use(`${BASE}/organizations`, requireAuth, organizationsRouter);
-app.use(`${BASE}/admin`, requireAuth, adminRouter);
+app.use(`${BASE}/chain-workflows`, requireAuth, requireNoAccessToken, chainWorkflowsRouter);
+app.use(`${BASE}/spaces`, requireAuth, requireNoAccessToken, spacesRouter);
+app.use(`${BASE}/tools`, requireAuth, requireNoAccessToken, toolsRouter);
+app.use(`${BASE}/skills`, requireAuth, requireNoAccessToken, skillsRouter);
+app.use(`${BASE}/knowledge-base`, requireAuth, requireNoAccessToken, knowledgeBaseRouter);
+app.use(`${BASE}/subagents`, requireAuth, requireNoAccessToken, subagentsRouter);
+app.use(`${BASE}/sandbox`, requireAuth, requireNoAccessToken, sandboxRouter);
+app.use(`${BASE}/organizations`, requireAuth, requireNoAccessToken, organizationsRouter);
+app.use(`${BASE}/admin`, requireAuth, requireNoAccessToken, adminRouter);
 // TEMPORARY — delete this mount + the import above + the file after backfill.
-app.use(`${BASE}/admin`, requireAuth, adminBackfillSigningSecretsRouter);
-app.use(`${BASE}/dashboard`, requireAuth, dashboardRouter);
-app.use(`${BASE}/agent-chat`, requireAuth, agentChatRouter);
-app.use(`${BASE}/daily-brief`, requireAuth, dailyBriefRouter);
+app.use(`${BASE}/admin`, requireAuth, requireNoAccessToken, adminBackfillSigningSecretsRouter);
+app.use(`${BASE}/dashboard`, requireAuth, requireNoAccessToken, dashboardRouter);
+app.use(`${BASE}/agent-chat`, requireAuth, requireNoAccessToken, agentChatRouter);
+app.use(`${BASE}/daily-brief`, requireAuth, requireNoAccessToken, dailyBriefRouter);
 app.use(`${BASE}/internal/agent-chat`, requireStrictS2S, agentChatInternalRouter); // progress/callback from xyne-claw
 app.use(`${BASE}/internal/twin-draft`, requireInternalS2S, twinDraftInternalRouter);  // Spaces → approve/decline an in-thread Twin reply draft (INTERNAL_S2S_KEY)
 app.use(`${BASE}/internal/attachments`, requireInternalS2S, attachmentsInternalRouter); // Spaces → extract document text via claw's converters (INTERNAL_S2S_KEY)
@@ -199,18 +199,18 @@ app.use(`${BASE}/internal/tts`, requireStrictS2S, ttsRouter);
 // Mounted before the per-provider routers (which now only serve authorize/callback)
 // so it owns the `/token` path. Same requireAuth guard; the handler additionally
 // requires the run's HMAC session token. See routes/oauth-token.ts.
-app.use(`${BASE}/users`, requireAuth, oauthTokenRouter);
-app.use(`${BASE}/users`, requireAuth, googleOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, oauthTokenRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, googleOAuthRouter);
 app.use(BASE, googleCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, microsoftOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, microsoftOAuthRouter);
 app.use(BASE, microsoftCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, calendlyOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, calendlyOAuthRouter);
 app.use(BASE, calendlyCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, jotformOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, jotformOAuthRouter);
 app.use(BASE, jotformCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, docusignOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, docusignOAuthRouter);
 app.use(BASE, docusignCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, egnyteOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, egnyteOAuthRouter);
 app.use(BASE, egnyteCallbackRouter);
 // requireAuth on every `/users/...` OAuth initiation router so an
 // unauthenticated request can't enumerate userIds and either start an
@@ -220,21 +220,21 @@ app.use(BASE, egnyteCallbackRouter);
 // routers stay unauthenticated because the OAuth provider hits them
 // directly with no session cookie — they self-protect by verifying the
 // `state` parameter against the in-flight session.
-app.use(`${BASE}/users`, requireAuth, miroOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, miroOAuthRouter);
 app.use(BASE, miroCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, webflowOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, webflowOAuthRouter);
 app.use(BASE, webflowCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, wixOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, wixOAuthRouter);
 app.use(BASE, wixCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, attioOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, attioOAuthRouter);
 app.use(BASE, attioCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, mailerliteOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, mailerliteOAuthRouter);
 app.use(BASE, mailerliteCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, honeycombOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, honeycombOAuthRouter);
 app.use(BASE, honeycombCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, customerioOAuthRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, customerioOAuthRouter);
 app.use(BASE, customerioCallbackRouter);
-app.use(`${BASE}/users`, requireAuth, rapidApiLinkedInRouter);
+app.use(`${BASE}/users`, requireAuth, requireNoAccessToken, rapidApiLinkedInRouter);
 app.use(`${BASE}/internal`, requireStrictS2S, runRouter);
 // IMPORTANT: more-specific runStreamRouter MUST be mounted BEFORE the broader
 // runRouter at BASE. runRouter has `POST /run/:sessionId/cancel`, which would
@@ -260,29 +260,29 @@ app.use(`${BASE}/flow`, requireStrictS2S, flowActionRouter);
 // require a real user session (requireAuth derives x-user-id from the Spaces
 // cookie). The handler treats that authenticated id as the caller identity
 // instead of the spoofable body field.
-app.use(`${BASE}/app`, requireAuth, appCallbackRouter);
-app.use(`${BASE}/scheduled-jobs`, requireAuth, scheduledJobsRouter);
+app.use(`${BASE}/app`, requireAuth, requireNoAccessToken, appCallbackRouter);
+app.use(`${BASE}/scheduled-jobs`, requireAuth, requireNoAccessToken, scheduledJobsRouter);
 // Strict S2S: the only callers are services (ask-question tool POSTs with the
 // S2S key; flow-action/app-callback import the helpers directly, not HTTP).
 // The previous per-route requireS2S cookie fallback let any logged-in user
 // read other users' pending questions by ID.
 app.use(`${BASE}/pending-questions`, requireStrictS2S, pendingQuestionsRouter);
-app.use(`${BASE}/settings`, requireAuth, settingsRouter);
-app.use(`${BASE}/runs`, requireAuth, runsRouter);
-app.use(`${BASE}/metrics`, requireAuth, metricsRouter);
+app.use(`${BASE}/settings`, requireAuth, requireNoAccessToken, settingsRouter);
+app.use(`${BASE}/runs`, requireAuth, requireNoAccessToken, runsRouter);
+app.use(`${BASE}/metrics`, requireAuth, requireNoAccessToken, metricsRouter);
 // Mount-level baseline auth (defense-in-depth): every memory route also has
 // stricter per-route middleware (requireUserAuth / requireClawAdmin), but a
 // future route that forgets it must still fail closed at the mount. requireAuth
 // (not requireUserAuth) because /recall-hits is an S2S callback from xyne-claw.
 // The per-request memoization in require-auth.ts makes the second layer free.
-app.use(`${BASE}/memory`, requireAuth, memoryRouter);
+app.use(`${BASE}/memory`, requireAuth, requireNoAccessToken, memoryRouter);
 app.use(`${BASE}/digital-twin`, requireUserAuth, digitalTwinRouter);
-app.use(`${BASE}/control-center`, requireAuth, controlCenterRouter);
-app.use(`${BASE}/research-agent`, requireAuth, researchAgentRouter);
-app.use(`${BASE}/evals`, requireAuth, requireClawAdmin, evalsRouter);
-app.use(`${BASE}/search-evals`, requireAuth, requireSearchEvalAccess, searchEvalsRouter);
+app.use(`${BASE}/control-center`, requireAuth, requireNoAccessToken, controlCenterRouter);
+app.use(`${BASE}/research-agent`, requireAuth, requireNoAccessToken, researchAgentRouter);
+app.use(`${BASE}/evals`, requireAuth, requireNoAccessToken, requireClawAdmin, evalsRouter);
+app.use(`${BASE}/search-evals`, requireAuth, requireNoAccessToken, requireSearchEvalAccess, searchEvalsRouter);
 // A run reads a whole channel with no per-user ACL guard — operator action only.
-app.use(`${BASE}/entity-extraction`, requireAuth, requireClawAdmin, entityExtractionRouter);
+app.use(`${BASE}/entity-extraction`, requireAuth, requireNoAccessToken, requireClawAdmin, entityExtractionRouter);
 
 // MCP Gateway routes (for backend service registration)
 app.use(`${BASE}/gateway`, mcpGatewayRouter);

--- a/apps/xyne-claw-auth/backend/src/middleware/require-auth.test.ts
+++ b/apps/xyne-claw-auth/backend/src/middleware/require-auth.test.ts
@@ -112,3 +112,59 @@ describe("requireAuth CLI bearer branch", () => {
     expect(res.status).toHaveBeenCalledWith(401);
   });
 });
+
+describe("requireNoAccessToken barrier", () => {
+  beforeEach(() => {
+    state.rawToken = "";
+    state.verifyCalls = 0;
+    state.config.cliTokensEnabled = true;
+  });
+
+  it("rejects requests authenticated via a CLI/service access token", async () => {
+    const { requireAuth, requireNoAccessToken } = await import("./require-auth.js");
+    const req = {
+      headers: {
+        authorization: "Bearer xyne_cli_real",
+      },
+    } as unknown as Request;
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+    const authNext: NextFunction = vi.fn();
+
+    await requireAuth(req, res, authNext);
+    expect(authNext).toHaveBeenCalledOnce();
+    expect(state.rawToken).toBe("xyne_cli_real");
+
+    const barrierNext: NextFunction = vi.fn();
+    requireNoAccessToken(req, res, barrierNext);
+
+    expect(barrierNext).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      error: "Access tokens are not authorized for this endpoint",
+    });
+  });
+
+  it("allows requests that are not access-token authenticated", async () => {
+    const { requireNoAccessToken } = await import("./require-auth.js");
+    const req = {
+      headers: {
+        "x-s2s-key": "s2s-secret",
+        "x-user-id": "service-account",
+      },
+    } as unknown as Request;
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+    const next: NextFunction = vi.fn();
+
+    requireNoAccessToken(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/middleware/require-auth.ts
+++ b/apps/xyne-claw-auth/backend/src/middleware/require-auth.ts
@@ -4,10 +4,16 @@ import { CONFIG } from "../config.js";
 import { ensureUserExists } from "../lib/users-jit.js";
 import { checkResultCallbackToken } from "../lib/session-tokens.js";
 import { verify as verifyCliToken } from "../lib/cli-tokens.js";
+import type { VerifiedCliToken } from "../lib/cli-tokens.js";
 import { prisma } from "../db.js";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("require-auth");
+
+// Track which Response objects were authenticated via a CLI/service access token.
+// Used by requireNoAccessToken to reject access-token callers from routes that
+// do not enforce scopes. Intentionally NOT exposed outside this module.
+const accessTokenRegistry = new WeakMap<Response, VerifiedCliToken>();
 
 /**
  * Attach phase-1 org context to the request as headers, right after `x-user-id`
@@ -174,6 +180,7 @@ export async function requireAuth(
       // (locals always exists under Express; test doubles may omit it.)
       res.locals = res.locals ?? {};
       res.locals["accessToken"] = token;
+      accessTokenRegistry.set(res, token);
       next();
       return;
     }
@@ -332,5 +339,23 @@ export async function requireUserAuth(
   });
   req.headers["x-user-id"] = userId;
   await attachOrgContext(req, userId);
+  next();
+}
+
+/**
+ * Barrier middleware: reject requests whose identity came from a CLI/service
+ * access token. Mount this AFTER requireAuth on routes that should only be
+ * reachable by a browser session or a validated S2S key.
+ *
+ * This closes the bearer-token scope-enforcement gap: requireAuth accepts
+ * xyne_cli_* / xyne_svc_* tokens, but most routes do not enforce scopes.
+ * Only endpoints that explicitly understand scopes (currently /run) should
+ * omit this barrier.
+ */
+export function requireNoAccessToken(_req: Request, res: Response, next: NextFunction): void {
+  if (accessTokenRegistry.has(res)) {
+    res.status(403).json({ success: false, error: "Access tokens are not authorized for this endpoint" });
+    return;
+  }
   next();
 }

--- a/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response } from "express";
 import { randomUUID } from "node:crypto";
 import { CONFIG } from "../config.js";
-import { requireAuth, requireResultToken } from "../middleware/require-auth.js";
+import { requireAuth, requireNoAccessToken, requireResultToken } from "../middleware/require-auth.js";
 import { getRequesterId } from "../middleware/agent-acl.js";
 import { prisma } from "../db.js";
 import { chatMessageRepository, agentRunRepository, chatAttachmentRepository } from "../repositories/index.js";
@@ -312,7 +312,7 @@ export async function persistRunStreamResult(args: {
  * Spaces backend connects via SSE, and we internally handle the webhook callbacks
  * from xyne-claw, proxying them as SSE events.
  */
-publicRouter.post("/", requireAuth, async (req: Request, res: Response) => {
+publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, res: Response) => {
   const streamId = randomUUID();
   // Periodic keepalive on the frontend leg (Spaces backend ← claw-auth).
   // Started once the SSE response is open, stopped on disconnect and in the
@@ -1079,7 +1079,7 @@ publicRouter.post("/", requireAuth, async (req: Request, res: Response) => {
  * claw is what actually persists partial state — this endpoint just
  * triggers it.
  */
-publicRouter.post("/cancel", requireAuth, async (req: Request, res: Response): Promise<void> => {
+publicRouter.post("/cancel", requireAuth, requireNoAccessToken, async (req: Request, res: Response): Promise<void> => {
   try {
     const userId = getRequesterId(req) ?? (req.body as { userId?: string }).userId;
     if (!userId) {


### PR DESCRIPTION
requireAuth accepts xyne_cli_* / xyne_svc_* bearer tokens and stores them in res.locals, but only /run enforced scopes. This PR adds a WeakMap-backed requireNoAccessToken barrier and mounts it after every requireAuth route except /run (which already has service-token scope checks). It also protects the public run-stream POST endpoints. Adds tests for the barrier.