### PR TITLE
fix: repair xyne-automation test pnpm and other fixes 

### DIFF
--- a/apps/backend/.env.test
+++ b/apps/backend/.env.test
@@ -13,7 +13,7 @@ PORT=3001
 
 # Database - Docker PostgreSQL (use container hostname 'postgres')
 DATABASE_URL=postgresql://xyne:xyne123@postgres:5432/xyne_dev_db?schema=public
-COMMON_DATABASE_URL=postgresql://xyne:xyne123@common-postgres:5432/xyne_common?schema=common
+COMMON_DATABASE_URL=postgresql://xyne:xyne123@postgres:5432/xyne_common?schema=common
 ENABLE_COMMON_DB_TICKET_SEQUENCE=true
 ZERO_UPSTREAM_DB=postgresql://xyne:xyne123@postgres:5432/xyne_dev_db
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,8 +13,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      common-postgres:
-        condition: service_healthy
 
   # Backend API for testing - builds from Dockerfile.test
   # Loads .env.local as base, then .env.test overrides container-specific values

--- a/tools/xyne-automation/Dockerfile
+++ b/tools/xyne-automation/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /app
 
 COPY package*.json ./
 RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --no-frozen-lockfile
+
+# pnpm v10 blocks @getgauge/cli's install script; run it explicitly to fetch the gauge binary.
+RUN cd node_modules/@getgauge/cli && node src/index.js
+RUN pnpm exec gauge install ts && pnpm exec gauge install html-report
 
 COPY . .
 

--- a/tools/xyne-automation/scripts/collect-ci-artifacts.sh
+++ b/tools/xyne-automation/scripts/collect-ci-artifacts.sh
@@ -26,9 +26,7 @@ mkdir -p "$OUTPUT_DIR"
 # Keep this list in sync with the services defined under docker-compose.{dev,test}.yml.
 SERVICES=(
   postgres
-  common-postgres
   backend-migrate
-  claw-auth-postgres
   redis
   livekit
   fake-gcs

--- a/tools/xyne-automation/scripts/run-ci-tests.sh
+++ b/tools/xyne-automation/scripts/run-ci-tests.sh
@@ -12,7 +12,10 @@ if [ -s "$NVM_DIR/nvm.sh" ]; then
   [ -f .nvmrc ] && nvm use
 fi
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+AUTOMATION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# cwd = tools/ (parent of the package), which the runner uses to place artifacts.
+# ts-node by path (not `pnpm exec`): it's a package dep, not a root one.
+cd "$AUTOMATION_DIR/.."
 
-exec pnpm exec ts-node --project tools/xyne-automation/tsconfig.json \
-  tools/xyne-automation/scripts/runner/index.ts --mode=ci --plain "$@"
+exec "$AUTOMATION_DIR/node_modules/.bin/ts-node" --project "$AUTOMATION_DIR/tsconfig.json" \
+  "$AUTOMATION_DIR/scripts/runner/index.ts" --mode=ci --plain "$@"

--- a/tools/xyne-automation/scripts/run-test.sh
+++ b/tools/xyne-automation/scripts/run-test.sh
@@ -12,4 +12,5 @@ if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
   export OUTPUT_MODE=plain
 fi
 
-exec pnpm exec ts-node --project "$AUTOMATION_DIR/tsconfig.json" "$AUTOMATION_DIR/scripts/runner/index.ts" "$@"
+# ts-node by path (not `pnpm exec`): keeps cwd at PROJECT_ROOT, which the runner uses to place artifacts.
+exec "$AUTOMATION_DIR/node_modules/.bin/ts-node" --project "$AUTOMATION_DIR/tsconfig.json" "$AUTOMATION_DIR/scripts/runner/index.ts" "$@"

--- a/tools/xyne-automation/scripts/runner/index.ts
+++ b/tools/xyne-automation/scripts/runner/index.ts
@@ -237,6 +237,19 @@ function prepareArtifactDirectory(artifactDir: string): void {
   fs.mkdirSync(artifactDir, { recursive: true });
 }
 
+// Walk up to the monorepo root (where the compose files live) instead of assuming a fixed depth.
+function findMonorepoRoot(start: string): string {
+  let dir = start;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'docker-compose.dev.yml'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not find monorepo root (docker-compose.dev.yml) above ${start}`);
+    }
+    dir = parent;
+  }
+}
+
 const MAX_DOCKER_START_ATTEMPTS = 3;
 const PORT_BIND_CONFLICT_REGEX =
   /address already in use|failed to bind host port|port is already allocated/i;
@@ -259,10 +272,7 @@ async function main(): Promise<void> {
   let portMap = await buildPortMap(mode);
   const projectRoot = await resolveProjectRoot(mode, originalRoot, !cliArgs.plain);
 
-  // Docker compose files are in the monorepo root
-  // Resolve monorepo root: if running from xyne-automation, go up one level
-  const monorepoRoot =
-    path.basename(projectRoot) === 'xyne-automation' ? path.dirname(projectRoot) : projectRoot;
+  const monorepoRoot = findMonorepoRoot(projectRoot);
 
   const composeFiles = [
     path.join(monorepoRoot, 'docker-compose.dev.yml'),


### PR DESCRIPTION
…to postgres

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
