### PR TITLE
fix: XYNE-55187 recoinciling back issue

### DIFF
--- a/apps/electron/assets/recording-pill.html
+++ b/apps/electron/assets/recording-pill.html
@@ -323,6 +323,9 @@
 
     function hide() {
       card.classList.add('hiding');
+      card.classList.remove('expanded');
+      if (collapseTimer) { clearTimeout(collapseTimer); collapseTimer = null; }
+      lastIgnoreMouse = null;
       stopTimer();
     }
 

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -12,11 +12,11 @@ export interface RecordingSnapshot {
 
 const RENDERER_READY_TIMEOUT_MS = 10_000;
 const EXTERNAL_START_TIMEOUT_MS = 5 * 60_000;
-/** Long enough to outlast a Space-switch animation's focus churn, short enough
- * that the pill still feels like it responds to leaving the app. */
 const PILL_SYNC_DEBOUNCE_MS = 150;
+const FOCUS_REQUEST_GRACE_MS = 2_000;
 
 let pillSyncTimer: ReturnType<typeof setTimeout> | null = null;
+let focusRequestTimer: ReturnType<typeof setTimeout> | null = null;
 
 let active = false;
 let startTime: number | null = null;
@@ -91,9 +91,24 @@ function waitForRenderer(): Promise<void> {
   });
 }
 
+function markFocusRequested(): void {
+  clearFocusRequested();
+  focusRequestTimer = setTimeout(() => {
+    focusRequestTimer = null;
+    syncPillVisibility();
+  }, FOCUS_REQUEST_GRACE_MS);
+}
+
+function clearFocusRequested(): void {
+  if (!focusRequestTimer) return;
+  clearTimeout(focusRequestTimer);
+  focusRequestTimer = null;
+}
+
 export function focusMainWindow(pathname?: string): BrowserWindow | null {
   const mainWindow = getMainWindow();
   if (!mainWindow || mainWindow.isDestroyed()) return null;
+  markFocusRequested();
   mainWindow.show();
   mainWindow.focus();
   if (pathname) mainWindow.webContents.send('navigate-to', pathname);
@@ -101,6 +116,7 @@ export function focusMainWindow(pathname?: string): BrowserWindow | null {
 }
 
 function isMainWindowFocused(): boolean {
+  if (focusRequestTimer) return true;
   const mainWindow = getMainWindow();
   return !!mainWindow && !mainWindow.isDestroyed() && mainWindow.isFocused();
 }
@@ -142,6 +158,7 @@ export function setOverlayMinimized(next: boolean): void {
 export function initRecordingPillVisibility(): void {
   const handleWindowFocus = (_event: Electron.Event, window: BrowserWindow): void => {
     if (isPillWindow(window)) return;
+    if (window === getMainWindow()) clearFocusRequested();
     scheduleSyncPillVisibility();
   };
   const handleWindowBlur = (_event: Electron.Event, window: BrowserWindow): void => {
@@ -154,6 +171,7 @@ export function initRecordingPillVisibility(): void {
 
   app.once('will-quit', () => {
     cancelPendingPillSync();
+    clearFocusRequested();
     app.removeListener('browser-window-focus', handleWindowFocus);
     app.removeListener('browser-window-blur', handleWindowBlur);
   });

--- a/apps/electron/src/services/recording-pill-window.ts
+++ b/apps/electron/src/services/recording-pill-window.ts
@@ -8,6 +8,7 @@ const POSITION_KEY = 'pillPosition';
 
 let pillWindow: BrowserWindow | null = null;
 let hideTimer: ReturnType<typeof setTimeout> | null = null;
+let pillRequested = false;
 let ignoreMouseHandler: ((event: Electron.IpcMainEvent, ignore: boolean) => void) | null = null;
 let dragStartHandler: ((event: Electron.IpcMainEvent) => void) | null = null;
 let dragEndHandler: ((event: Electron.IpcMainEvent) => void) | null = null;
@@ -171,9 +172,13 @@ export function showRecordingPill(recordingStartTime?: number): void {
   }
 
   currentStartTime = recordingStartTime ?? Date.now();
+  pillRequested = true;
 
   if (pillWindow && !pillWindow.isDestroyed()) {
+    applyIgnoreMouseEvents(true);
+    pillWindow.webContents.send('recording-pill:theme-changed', currentTheme);
     pillWindow.webContents.send('recording-pill:show', currentStartTime);
+    if (!pillWindow.isVisible()) pillWindow.showInactive();
     return;
   }
 
@@ -251,7 +256,7 @@ export function showRecordingPill(recordingStartTime?: number): void {
       )
       .catch((error) => log.warn('[RecordingPill] Failed to inject layout CSS', error));
     applyIgnoreMouseEvents(true);
-    if (hideTimer) return;
+    if (!pillRequested) return;
     pillWindow.webContents.send('recording-pill:theme-changed', currentTheme);
     pillWindow.webContents.send('recording-pill:show', currentStartTime ?? Date.now());
     pillWindow.showInactive();
@@ -267,7 +272,6 @@ export function showRecordingPill(recordingStartTime?: number): void {
     stopDrag();
     if (!pillWindow || pillWindow.isDestroyed()) return;
     applyIgnoreMouseEvents(true);
-    if (hideTimer) return;
     pillWindow.reload();
   });
 
@@ -302,19 +306,16 @@ export function showRecordingPill(recordingStartTime?: number): void {
 }
 
 export function hideRecordingPill(): void {
+  pillRequested = false;
   if (!pillWindow || pillWindow.isDestroyed()) return;
-  if (hideTimer) return;
+  if (hideTimer || !pillWindow.isVisible()) return;
 
   stopDrag();
 
-  pillWindow.blur();
   pillWindow.webContents.send('recording-pill:hide');
   hideTimer = setTimeout(() => {
     hideTimer = null;
-    if (pillWindow && !pillWindow.isDestroyed()) {
-      pillWindow.close();
-      pillWindow = null;
-    }
+    if (pillWindow && !pillWindow.isDestroyed()) pillWindow.hide();
   }, 300);
 
   log.info('[RecordingPill] Hiding recording pill');


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1fMaAaqhNdVbZf6r8J4PfI53ElWEuWGzR/view?usp=sharing
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-55187 — fixes the black flash / whole-app-sliding-left glitch when the floating recording pill hands back to the in-app recording UI.

**Symptom.** Clicking the pill's Open (or Stop) blanked the screen — including the macOS menu bar — and slid the app off to the left before it settled.

**Root cause.** The menu bar going black rules out an app repaint; that is the macOS **Space-switch animation**. When the Xyne window is in fullscreen it lives on its own Space, so `focusMainWindow()` (`show()` + `focus()`) makes macOS animate the switch. That part is expected. What made it look broken was the pill thrashing right through that ~0.5–1s animation, for three reasons:

1. **The pill was resurrected mid-transition.** `recording-pill:open-app` calls `focusMainWindow()` and then `setOverlayMinimized(false)`, which re-evaluates `syncPillVisibility()` *synchronously*. macOS activation is async — during a Space slide `mainWindow.isFocused()` stays `false` for the whole animation — so the controller concluded the app was not focused and re-showed the pill it was midway through hiding.
2. **`hideRecordingPill()` called `pillWindow.blur()`.** Electron implements macOS blur as `orderOut:` followed by `orderFront:`, which re-asserts a `screen-saver`-level, `canJoinAllSpaces` panel's Space membership — during an activation, the worst possible moment.
3. **The pill window was destroyed and rebuilt on every hide/show** — `close()` on hide, then `new BrowserWindow` + `setAlwaysOnTop` + `setVisibleOnAllWorkspaces` + `loadFile` + `showInactive()` on show, all landing while the window server was still animating.

**What regressed it.** (2) and (3) predate this feature, but the old pill was one-shot — shown once when a recording started, hidden once when it stopped. #48 (`Feature/xyne oats final`) introduced `recording-controller.ts`, which makes pill visibility a derived function of window focus and re-runs it on every `browser-window-focus` / `browser-window-blur`. A teardown that used to run twice per recording now runs on every focus change, on the same path as an activation that can trigger a Space switch.

**Fix.**

- `recording-pill-window.ts` — the pill window is built once and hidden/shown thereafter; `blur()` and `close()` are gone from the hide path. Added a `pillRequested` flag so `did-finish-load` (including after a crash-reload) only reveals the pill when it is actually wanted.
- `recording-controller.ts` — `focusMainWindow()` marks the activation as requested, and `isMainWindowFocused()` honours that until focus really lands (cleared on the main window's `browser-window-focus`) or a 2s grace expires. Nothing re-shows the pill mid-slide.
- `recording-pill.html` — `hide()` now collapses the card and clears its `lastIgnoreMouse` cache. Required by the lifecycle change: the window survives a hide, so a pill hidden while hovered would otherwise return expanded, and the stale `false` would dedupe the re-enable and leave it **permanently click-through**.

The Space switch itself is unchanged — if the window is fullscreen, activating it from the pill has to take you there, and macOS animates that. What is gone is the pill teardown/rebuild layered on top.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [x] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
