### PR TITLE
fix(XYNE-55037): sanitize email signature HTML before dangerouslySetInnerHTML preview

### DIFF
--- a/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
@@ -101,6 +101,7 @@ import {
   MAX_EMAIL_ATTACHMENT_FILES,
   MAX_EMAIL_ATTACHMENT_FILE_SIZE_BYTES,
   parseFromField,
+  sanitizeSignatureHtml,
   stripHtml,
 } from './helpers';
 
@@ -2030,7 +2031,7 @@ export const EmailComposer = ({
                     <p className='text-xs text-muted-foreground mb-1'>--</p>
                     <div
                       className='text-sm text-foreground/80 prose prose-sm dark:prose-invert max-w-none'
-                      dangerouslySetInnerHTML={{ __html: activeSig.content ?? '' }}
+                      dangerouslySetInnerHTML={{ __html: sanitizeSignatureHtml(activeSig.content) }}
                     />
                   </div>
                 </div>
@@ -2149,7 +2150,7 @@ export const EmailComposer = ({
                       <div
                         className='prose prose-sm dark:prose-invert mt-4 break-words border-t border-border pt-4 text-sm text-muted-foreground [overflow-wrap:anywhere]'
                         dangerouslySetInnerHTML={{
-                          __html: DOMPurify.sanitize(activeSig.content),
+                          __html: sanitizeSignatureHtml(activeSig.content),
                         }}
                       />
                     );

--- a/apps/dashboard/src/components/xyne-desk/EmailComposer/helpers.ts
+++ b/apps/dashboard/src/components/xyne-desk/EmailComposer/helpers.ts
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { parseSingleEmailAddress } from '../../../utils/emailAddress';
 
 // Match Gmail's 25MB per-message ceiling.
@@ -38,3 +39,7 @@ export const stripHtml = (html: string): string => {
   tmp.innerHTML = html;
   return tmp.textContent || tmp.innerText || '';
 };
+
+/** Sanitize signature HTML before rendering via dangerouslySetInnerHTML. */
+export const sanitizeSignatureHtml = (html: string | null | undefined): string =>
+  DOMPurify.sanitize(html ?? '');


### PR DESCRIPTION
Fixes stored/blind XSS in the email signature preview popover by routing all signature HTML through a single DOMPurify helper.

- Added sanitizeSignatureHtml() helper in EmailComposer/helpers.ts
- Applied helper to the vulnerable signature preview popover path
- Consolidated the existing DOMPurify.sanitize() call in the full-message preview to use the same helper

Closes XYNE-55037