### PR TITLE
fix(dashboard): remove lowlight auto-detection from chat rendering

### DIFF
--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/utils.ts
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/utils.ts
@@ -3,20 +3,55 @@
  * - Single DOMParser usage
  * - Safer injection of highlighted HTML
  * - No double parsing
- * - Faster language detection
- * - Avoids unnecessary work
+ * - Curated, commonly-used language set
+ * - No auto-detection (avoid main-thread stalls)
  */
 
 import { toHtml } from 'hast-util-to-html';
-import { all, createLowlight } from 'lowlight';
+import { createLowlight } from 'lowlight';
 
-const lowlight = createLowlight(all);
+import bash from 'highlight.js/lib/languages/bash';
+import css from 'highlight.js/lib/languages/css';
+import go from 'highlight.js/lib/languages/go';
+import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import python from 'highlight.js/lib/languages/python';
+import rust from 'highlight.js/lib/languages/rust';
+import sql from 'highlight.js/lib/languages/sql';
+import typescript from 'highlight.js/lib/languages/typescript';
+import xml from 'highlight.js/lib/languages/xml';
+
+const lowlight = createLowlight({
+  javascript,
+  js: javascript,
+  typescript,
+  ts: typescript,
+  python,
+  py: python,
+  bash,
+  sh: bash,
+  shell: bash,
+  json,
+  sql,
+  html: xml,
+  xml,
+  css,
+  go,
+  golang: go,
+  rust,
+  rs: rust,
+});
 
 // Regex to detect language-xxxxx class quickly
 const LANG_CLASS_REGEX = /language-([\w-]+)/;
 
 /**
  * Highlight code blocks within an HTML string.
+ *
+ * Only code blocks with a language class in the curated registry above
+ * are highlighted. Unknown or missing language hints are left as plain
+ * text; auto-detection is intentionally disabled because it scans every
+ * registered grammar and blocks the main thread.
  */
 export const highlightCodeBlocks = (html: string): string => {
   if (!html || html.indexOf('<code') === -1) return html; // cheap fast-path
@@ -42,17 +77,18 @@ export const highlightCodeBlocks = (html: string): string => {
       const match = LANG_CLASS_REGEX.exec(className);
       const lang = match?.[1];
 
-      if (lang) {
-        // Specific language highlight
-        try {
-          tree = lowlight.highlight(lang, raw);
-        } catch {
-          // Fallback to auto-language
-          tree = lowlight.highlightAuto(raw);
-        }
-      } else {
-        // Auto-detect
-        tree = lowlight.highlightAuto(raw);
+      if (!lang) {
+        // No language hint: leave as plain text (no auto-detect).
+        return;
+      }
+
+      // Specific language highlight. If the language is not in our
+      // curated registry, `lowlight.highlight` throws; leave the block
+      // as plain text instead of falling back to expensive auto-detection.
+      try {
+        tree = lowlight.highlight(lang, raw);
+      } catch {
+        return;
       }
 
       // Convert to HTML string (safe)


### PR DESCRIPTION
## Problem
Chat message rendering was importing `all` from `lowlight` and falling back to `lowlight.highlightAuto(raw)` for code blocks without a recognized language class. Auto-detection scans every registered highlight.js grammar and stalls the main thread, causing the ~71× slowdown reported in XYNE-55035 / XYNE-55048.

## Change
- Replace `createLowlight(all)` with a curated registry covering the most common languages in chat messages:
  - JavaScript/TypeScript (`javascript`, `js`, `typescript`, `ts`)
  - Python (`python`, `py`)
  - Bash/Shell (`bash`, `sh`, `shell`)
  - JSON, SQL, HTML/XML, CSS
  - Go, Rust (`rust`, `rs`)
- Unknown or missing language hints are now left as plain text instead of calling `highlightAuto`.
- Keeps the existing fast-path and DOM-injection logic intact.

## POT
Verified with a Vite-served utility test that imports `highlightCodeBlocks` directly:
- TC1: Unclassified code block stays plain text — PASS
- TC2: `language-javascript` is highlighted — PASS
- TC3: `language-ruby` (not curated) stays plain text — PASS
- TC4: `language-ts` alias is highlighted — PASS
Walkthrough video recorded and passed the @pot-verifier gate.

Resolves XYNE-55035 / XYNE-55048.