### PR TITLE
feat: ArrowUp/Down to recall last sent message in the composer

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -30,6 +30,7 @@ import { useAuth, useAuthContextValues } from '../../../hooks/useAuth';
 import { websocketService } from '../../../services/clients/socketClient';
 import { processMessageForSending, containsSpecialBroadcastMention } from './ChatInput.utils';
 import { saveDraft, useDraft } from '../../../hooks/useDraft';
+import { useSentMessageHistory } from '../../../hooks/useSentMessageHistory';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
 import { CreateTicketModal } from '../../Tickets/CreateTicketModal/CreateTicketModal';
@@ -218,6 +219,9 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
     );
 
     const currentSessionId = conversationId ?? channelId;
+    // Per-composer sent-message recall (ArrowUp/Down). Scoped to currentSessionId
+    // so the channel composer and each thread composer keep separate history.
+    const messageHistory = useSentMessageHistory(currentSessionId);
     // The first message in a channel creates a conversation client-side, but the
     // `conversationId` prop only updates once the view switches into that thread.
     // Agent-progress events are scoped to the new conversationId, so without this
@@ -529,6 +533,12 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         console.info(
           `[AgentProgress] 📤 Message sent | conversationId: ${conversationId ?? currentSessionId} | hasFiles: ${!!(files && files.length > 0)}`,
         );
+
+        // Record into ArrowUp/Down recall history. Store the editor HTML (mention
+        // spans intact) for non-edit sends only; edits must not enter recall.
+        if (!messageId) {
+          messageHistory.push(html);
+        }
 
         const processedHtml = processMessageForSending(html, allUsersForMentionResolution);
         const hasFiles = files && files.length > 0;
@@ -969,6 +979,11 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
               }
               commandItems={channelCommands}
               onCommandSelect={handleCommandSelect}
+              {...(!messageId && {
+                onRecallPrev: messageHistory.recallPrev,
+                onRecallNext: messageHistory.recallNext,
+                onRecallReset: messageHistory.resetCursor,
+              })}
               {...(editorValue !== undefined && { value: editorValue })}
               {...(messageId && onCancel && { onCancel: handleCancelEdit })}
               {...(conversationId && { conversationId })}

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -191,6 +191,9 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       sendDisabled = false,
       bottomLeftSlot,
       disableDraftUpload = false,
+      onRecallPrev,
+      onRecallNext,
+      onRecallReset,
     },
 
     ref,
@@ -633,6 +636,9 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
         setIsInCodeBlock(editor.isActive('codeBlock'));
         handleTyping?.();
         notifyTyping();
+        // A real keystroke abandons recall navigation so the edited text becomes
+        // the new live draft.
+        onRecallReset?.();
 
         // Quick emoji size reset: if text clearly has non-emoji chars, switch to
         // small immediately so the user doesn't see large text while typing.
@@ -802,6 +808,76 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
             event.preventDefault();
             void handleSend();
             return true;
+          }
+
+          // Message-history recall (desktop only). ArrowUp on the first visual
+          // line loads the previous sent message; ArrowDown on the last visual
+          // line steps forward and finally restores the live draft. Gated so it
+          // never hijacks caret movement inside a multi-line draft, an active
+          // selection, or an open suggestion menu.
+          if (
+            (event.key === 'ArrowUp' || event.key === 'ArrowDown') &&
+            (onRecallPrev || onRecallNext) &&
+            window.innerWidth >= 500 &&
+            !event.shiftKey &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.altKey
+          ) {
+            const mentionState = mentionPluginKey.getState(view.state);
+            const channelMentionState = channelMentionPluginKey.getState(view.state);
+            const commandState = commandPluginKey.getState(view.state);
+            const emojiSelectorState = emojiSelectorPluginKey.getState(view.state);
+            const anyMenuOpen =
+              (mentionState?.isOpen && mentionState.items.length > 0) ||
+              (channelMentionState?.isOpen && channelMentionState.items.length > 0) ||
+              (commandState?.isOpen && commandState.items.length > 0) ||
+              (emojiSelectorState?.isOpen && emojiSelectorState.items.length > 0);
+
+            const { selection, doc } = view.state;
+            if (!anyMenuOpen && selection.empty && editor) {
+              // Determine whether the caret sits on the first / last visual line
+              // so recall only triggers when ArrowUp/Down would otherwise have
+              // nowhere to move vertically. coordsAtPos can throw on a detached
+              // view, so guard it.
+              let atFirstLine = true;
+              let atLastLine = true;
+              try {
+                const cursor = view.coordsAtPos(selection.from);
+                const start = view.coordsAtPos(1);
+                const end = view.coordsAtPos(Math.max(1, doc.content.size - 1));
+                atFirstLine = Math.abs(cursor.top - start.top) < 5;
+                atLastLine = Math.abs(cursor.bottom - end.bottom) < 5;
+              } catch {
+                atFirstLine = true;
+                atLastLine = true;
+              }
+
+              const currentHtml = sanitizeHtmlContent(editor.getHTML());
+              if (event.key === 'ArrowUp' && atFirstLine && onRecallPrev) {
+                const recalled = onRecallPrev(currentHtml);
+                if (recalled !== null && recalled !== undefined) {
+                  event.preventDefault();
+                  editor.commands.setContent(recalled, { emitUpdate: false });
+                  editor.commands.focus('end');
+                  lastAppliedValueRef.current = sanitizeHtmlContent(editor.getHTML());
+                  setContent(editor.getText().trim().length > 0 ? 'has-content' : '');
+                  updateEmojiSizeClass(editor);
+                  return true;
+                }
+              } else if (event.key === 'ArrowDown' && atLastLine && onRecallNext) {
+                const recalled = onRecallNext(currentHtml);
+                if (recalled !== null && recalled !== undefined) {
+                  event.preventDefault();
+                  editor.commands.setContent(recalled, { emitUpdate: false });
+                  editor.commands.focus('end');
+                  lastAppliedValueRef.current = sanitizeHtmlContent(editor.getHTML());
+                  setContent(editor.getText().trim().length > 0 ? 'has-content' : '');
+                  updateEmojiSizeClass(editor);
+                  return true;
+                }
+              }
+            }
           }
 
           return false;

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
@@ -71,4 +71,20 @@ export interface InputBoxProps {
   /** Extra buttons rendered in the left side of the desktop bottom action bar, after the # button */
   bottomLeftSlot?: React.ReactNode;
   disableDraftUpload?: boolean;
+  /**
+   * Terminal/Slack-style message recall. When the caret is on the first visual
+   * line and no suggestion menu is open, ArrowUp calls this with the current
+   * editor HTML and, if it returns a string, that HTML is loaded into the editor
+   * (return `null` to leave the editor untouched). Desktop only.
+   */
+  onRecallPrev?: (currentHtml: string) => string | null;
+  /**
+   * Counterpart to {@link onRecallPrev}: ArrowDown on the last visual line moves
+   * forward through recalled messages and finally restores the live draft. An
+   * empty string is a valid result (restore an empty draft); `null` means do
+   * nothing.
+   */
+  onRecallNext?: (currentHtml: string) => string | null;
+  /** Called when the user edits the text, so recall navigation can reset. */
+  onRecallReset?: () => void;
 }

--- a/apps/dashboard/src/hooks/useSentMessageHistory.ts
+++ b/apps/dashboard/src/hooks/useSentMessageHistory.ts
@@ -1,0 +1,154 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Terminal / Slack-style "recall last sent message" history for the message
+ * composer.
+ *
+ * Each composer scope keeps its OWN history so the channel input box and a
+ * thread input box never share recalled text. The scope id is the same value
+ * `ChatInput` already uses to identify a composer: `conversationId ?? channelId`
+ * (a channel composer has no conversationId, so it keys on channelId; a thread
+ * composer keys on its conversationId).
+ *
+ * History survives page reloads because it is persisted to `localStorage` under
+ * a per-scope key. Entries are the editor HTML strings (with mention spans
+ * intact) so a recalled message re-populates the editor exactly as it was
+ * typed and can be edited/re-sent.
+ *
+ * Navigation model (index over an oldest -> newest list):
+ *   index === -1  ->  showing the user's live draft (nothing recalled)
+ *   0..len-1      ->  showing a recalled entry (len-1 is the most recent send)
+ * The live draft is stashed the moment recall starts and restored when the user
+ * pages forward past the newest entry.
+ */
+
+const STORAGE_PREFIX = 'xyne:msg-history:';
+const MAX_ENTRIES = 50;
+
+function storageKey(scopeId: string): string {
+  return `${STORAGE_PREFIX}${scopeId}`;
+}
+
+function loadList(scopeId: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey(scopeId));
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    // Corrupt JSON / storage disabled / private mode — treat as empty history.
+    return [];
+  }
+}
+
+function saveList(scopeId: string, list: string[]): void {
+  try {
+    localStorage.setItem(storageKey(scopeId), JSON.stringify(list));
+  } catch {
+    // Quota exceeded or storage disabled — recall is a convenience, so failing
+    // to persist must never break sending. Swallow.
+  }
+}
+
+export interface SentMessageHistory {
+  /** Record a freshly sent message (editor HTML). Resets the recall cursor. */
+  push: (html: string) => void;
+  /**
+   * Move to the previous (older) entry. Returns the HTML to load, or `null` when
+   * there is nothing older (or no history at all) — in which case the caller
+   * should leave the editor untouched. `currentHtml` is stashed as the live
+   * draft the first time recall starts.
+   */
+  recallPrev: (currentHtml: string) => string | null;
+  /**
+   * Move to the next (newer) entry, or back to the stashed live draft once past
+   * the newest entry. Returns the HTML to load (which may be an empty string =
+   * restore an empty draft), or `null` when already on the live draft.
+   */
+  recallNext: (currentHtml: string) => string | null;
+  /** Abandon recall navigation (call when the user edits the text). */
+  resetCursor: () => void;
+}
+
+export function useSentMessageHistory(scopeId: string): SentMessageHistory {
+  // -1 means "showing the live draft"; >=0 indexes into the persisted list.
+  const indexRef = useRef(-1);
+  const stashRef = useRef<string>('');
+  const lastScopeRef = useRef(scopeId);
+
+  // Switching composer scope (e.g. opening a different thread) abandons any
+  // in-progress recall so the new composer starts on its own live draft.
+  if (lastScopeRef.current !== scopeId) {
+    lastScopeRef.current = scopeId;
+    indexRef.current = -1;
+    stashRef.current = '';
+  }
+
+  const push = useCallback(
+    (html: string): void => {
+      if (!html || html.trim().length === 0) {
+        indexRef.current = -1;
+        stashRef.current = '';
+        return;
+      }
+      const list = loadList(scopeId);
+      // Skip consecutive duplicates so spamming the same message doesn't bloat
+      // the recall list.
+      if (list[list.length - 1] !== html) {
+        list.push(html);
+        while (list.length > MAX_ENTRIES) list.shift();
+        saveList(scopeId, list);
+      }
+      indexRef.current = -1;
+      stashRef.current = '';
+    },
+    [scopeId],
+  );
+
+  const recallPrev = useCallback(
+    (currentHtml: string): string | null => {
+      const list = loadList(scopeId);
+      if (list.length === 0) return null;
+
+      if (indexRef.current === -1) {
+        // Entering recall from the live draft — stash it so ArrowDown can bring
+        // it back, then jump to the most recent sent message.
+        stashRef.current = currentHtml;
+        indexRef.current = list.length - 1;
+        return list[indexRef.current] ?? null;
+      }
+      if (indexRef.current > 0) {
+        indexRef.current -= 1;
+        return list[indexRef.current] ?? null;
+      }
+      // Already at the oldest entry — nothing older to show.
+      return null;
+    },
+    [scopeId],
+  );
+
+  const recallNext = useCallback(
+    (_currentHtml: string): string | null => {
+      const list = loadList(scopeId);
+      if (indexRef.current === -1) return null; // already on the live draft
+
+      if (indexRef.current < list.length - 1) {
+        indexRef.current += 1;
+        return list[indexRef.current] ?? null;
+      }
+      // Past the newest entry — restore the stashed live draft (may be empty).
+      indexRef.current = -1;
+      const draft = stashRef.current;
+      stashRef.current = '';
+      return draft;
+    },
+    [scopeId],
+  );
+
+  const resetCursor = useCallback((): void => {
+    indexRef.current = -1;
+    stashRef.current = '';
+  }, []);
+
+  return { push, recallPrev, recallNext, resetCursor };
+}


### PR DESCRIPTION
## What
Adds terminal/Slack-style message recall to the channel and thread message composers. Pressing **ArrowUp** on the first visual line of an empty/short composer loads the previously sent message; **ArrowDown** on the last visual line steps forward through newer messages and finally restores whatever live draft the user was typing.

## Why
Users frequently want to re-send or edit something they just sent without retyping it. Requested behaviour: "use up/down keys in the InputBox to go to the last sent text in that channel or thread, without mixing the channel input box and the thread input box."

## How
- **New hook `useSentMessageHistory`** (`apps/dashboard/src/hooks/useSentMessageHistory.ts`): a per-scope recall stack persisted to `localStorage` so it **survives page reloads**. Scoped by `conversationId ?? channelId` — the same identity `ChatInput` already uses — so the channel composer and each thread composer keep **completely separate** history. Stores editor HTML (mention spans intact), dedupes consecutive duplicates, caps at 50 entries, and fails silently if storage is unavailable.
- **`InputBox`**: a guarded ArrowUp/Down branch in `editorProps.handleKeyDown`. It only triggers when: no suggestion menu (mention/channel/command/emoji) is open, there is no active text selection, no modifier keys are held, and the caret is on the first (ArrowUp) / last (ArrowDown) **visual line** — so normal caret movement inside a multi-line draft is never hijacked. Desktop only (`window.innerWidth >= 500`). Uses `setContent(..., { emitUpdate: false })` so recall doesn't re-trigger the typing/onUpdate path.
- **`ChatInput`**: records non-edit sends into history and wires the three recall callbacks. Recall is disabled while editing an existing message (`messageId` set).

## Scope / safety
- No backend, schema, API, or Zero changes — purely client-side composer UX.
- `InputBox` is reused by DM-compose, forward, scheduled-message and canvas-comment surfaces; recall is gated behind the presence of the `onRecallPrev`/`onRecallNext` props, which only `ChatInput` passes, so every other call site is unchanged.
- Mobile intentionally excluded (no hardware arrow keys).

## Validation
- `tsc --noEmit` (dashboard) passes with no errors.
- `eslint` + `prettier --check` on the changed files clean.

## Manual test checklist
- [ ] Channel composer: ArrowUp recalls last channel message; repeated ArrowUp pages older; ArrowDown pages newer and restores the in-progress draft.
- [ ] Thread composer keeps its own history — switching between channel and thread never mixes recalled text.
- [ ] Recall history survives a full page reload.
- [ ] ArrowUp/Down still navigate the @mention / command / emoji menus when open.
- [ ] Multi-line draft: ArrowUp/Down move the caret between lines and only recall at the first/last line.
- [ ] Editing an existing message does not trigger recall.