### PR TITLE
feat: stabilize shared useZero proxy

### DIFF
--- a/packages/shared/src/hooks/useZero.ts
+++ b/packages/shared/src/hooks/useZero.ts
@@ -8,7 +8,7 @@ import type {
   Query,
   HumanReadable,
 } from '@rocicorp/zero';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import type { Logger, MetricsRecorder } from '../logger/index.js';
 import { noopLogger, noopMetrics } from '../logger/index.js';
 import { Event } from '../logger/events.js';
@@ -45,175 +45,175 @@ export function useZero(): Zero {
   const originalZero = useOriginalZero();
   const { logger, metrics } = useInstrumentation();
 
-  const handler: ProxyHandler<Zero> = {
-    get(target, prop) {
-      if (prop === 'mutate') {
-        return <TArgs extends ReadonlyJSONValue | undefined>(
-          mutationRequest: MutateRequest<TArgs>,
-        ): PromiseWithServerResult => {
-          const startTime = performance.now();
-          const mutationName = mutationRequest.mutator.mutatorName;
+  return useMemo(() => {
+    const instrumentedMutate = <TArgs extends ReadonlyJSONValue | undefined>(
+      mutationRequest: MutateRequest<TArgs>,
+    ): PromiseWithServerResult => {
+      const startTime = performance.now();
+      const mutationName = mutationRequest.mutator.mutatorName;
 
-          logger.info(Event.ZERO_MUTATION_CALLED, { mutation: mutationName });
-          metrics.incrementCounter('zero.mutation.operations', {
-            mutation: mutationName,
-            stage: 'start',
-          });
+      logger.info(Event.ZERO_MUTATION_CALLED, { mutation: mutationName });
+      metrics.incrementCounter('zero.mutation.operations', {
+        mutation: mutationName,
+        stage: 'start',
+      });
 
-          trackMutationStart();
-          const result = target.mutate(mutationRequest as Parameters<Zero['mutate']>[0]);
+      trackMutationStart();
+      const result = originalZero.mutate(mutationRequest as Parameters<Zero['mutate']>[0]);
 
-          Promise.all([result.client, result.server])
-            .then(([_clientResult, serverResult]) => {
-              const duration = performance.now() - startTime;
-              const skewed = wasInterrupted(startTime);
-              let hasError = false;
-              let errorMessage = '';
+      Promise.all([result.client, result.server])
+        .then(([_clientResult, serverResult]) => {
+          const duration = performance.now() - startTime;
+          const skewed = wasInterrupted(startTime);
+          let hasError = false;
+          let errorMessage = '';
 
-              if (serverResult && typeof serverResult === 'object') {
-                const sr = serverResult as Record<string, unknown>;
-                if (sr.type === 'error' && sr.error) {
-                  hasError = true;
-                  const err = sr.error as Record<string, unknown>;
-                  errorMessage =
-                    (err.message as string) || (err.type as string) || 'Unknown error';
-                }
-              }
-
-              if (hasError) {
-                logger.error(Event.ZERO_MUTATION_ERROR, {
-                  mutation: mutationName,
-                  error: errorMessage,
-                  duration,
-                  skewed,
-                });
-                if (!skewed) {
-                  metrics.recordLatency('zero.mutation.latency', duration, {
-                    mutation: mutationName,
-                  });
-                }
-                metrics.incrementCounter('zero.mutation.operations', {
-                  mutation: mutationName,
-                  stage: 'error',
-                });
-              } else {
-                logger.info(Event.ZERO_MUTATION_COMPLETE, {
-                  mutation: mutationName,
-                  duration,
-                  skewed,
-                });
-                if (!skewed) {
-                  metrics.recordLatency('zero.mutation.latency', duration, {
-                    mutation: mutationName,
-                  });
-                }
-                metrics.incrementCounter('zero.mutation.operations', {
-                  mutation: mutationName,
-                  stage: 'success',
-                });
-              }
-            })
-            .catch(error => {
-              const duration = performance.now() - startTime;
-              const skewed = wasInterrupted(startTime);
-              const errorMessage = error instanceof Error ? error.message : String(error);
-              logger.error(Event.ZERO_MUTATION_ERROR, {
-                mutation: mutationName,
-                error: errorMessage,
-                skewed,
-              });
-              if (!skewed) {
-                metrics.recordLatency('zero.mutation.latency', duration, {
-                  mutation: mutationName,
-                });
-              }
-              metrics.incrementCounter('zero.mutation.operations', {
-                mutation: mutationName,
-                stage: 'error',
-              });
-            })
-            .finally(() => {
-              trackMutationSettled();
-            });
-
-          return result;
-        };
-      }
-
-      if (prop === 'run') {
-        return async <
-          TTable extends keyof Zero['schema']['tables'],
-          TInput extends ReadonlyJSONValue | undefined,
-          TOutput extends ReadonlyJSONValue | undefined,
-          TReturn,
-        >(
-          query:
-            | QueryRequest<TTable, TInput, TOutput, Zero['schema'], TReturn, Zero['context']>
-            | Query<TTable, Zero['schema'], TReturn>,
-          runOptions?: RunOptionsWithName,
-        ): Promise<HumanReadable<TReturn>> => {
-          const startTime = performance.now();
-
-          let queryName: string;
-          let queryArgs: unknown = undefined;
-
-          if ('query' in query && 'args' in query) {
-            queryName = query.query.queryName || 'unknown';
-            queryArgs = query.args;
-          } else {
-            queryName = runOptions?.queryName || 'unknown';
+          if (serverResult && typeof serverResult === 'object') {
+            const sr = serverResult as Record<string, unknown>;
+            if (sr.type === 'error' && sr.error) {
+              hasError = true;
+              const err = sr.error as Record<string, unknown>;
+              errorMessage = (err.message as string) || (err.type as string) || 'Unknown error';
+            }
           }
 
-          logger.info(Event.ZERO_RUN_CALLED, { query: queryName, args: queryArgs });
-          metrics.incrementCounter('zero.run.operations', { query: queryName, stage: 'start' });
-
-          try {
-            const result = (await target.run(
-              query as Parameters<Zero['run']>[0],
-              runOptions as Parameters<Zero['run']>[1],
-            )) as Promise<HumanReadable<TReturn>>;
-
-            const duration = performance.now() - startTime;
-            const skewed = wasInterrupted(startTime);
-            logger.info(Event.ZERO_RUN_COMPLETE, {
-              query: queryName,
-              duration,
-              args: queryArgs,
-              skewed,
-            });
-            if (!skewed) {
-              metrics.recordLatency('zero.run.latency', duration, { query: queryName });
-            }
-            metrics.incrementCounter('zero.run.operations', {
-              query: queryName,
-              stage: 'success',
-            });
-
-            return result;
-          } catch (error) {
-            const duration = performance.now() - startTime;
-            const skewed = wasInterrupted(startTime);
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            logger.error(Event.ZERO_RUN_ERROR, {
-              query: queryName,
+          if (hasError) {
+            logger.error(Event.ZERO_MUTATION_ERROR, {
+              mutation: mutationName,
               error: errorMessage,
-              args: queryArgs,
+              duration,
               skewed,
             });
             if (!skewed) {
-              metrics.recordLatency('zero.run.latency', duration, { query: queryName });
+              metrics.recordLatency('zero.mutation.latency', duration, {
+                mutation: mutationName,
+              });
             }
-            metrics.incrementCounter('zero.run.operations', {
-              query: queryName,
+            metrics.incrementCounter('zero.mutation.operations', {
+              mutation: mutationName,
               stage: 'error',
             });
-            throw error;
+          } else {
+            logger.info(Event.ZERO_MUTATION_COMPLETE, {
+              mutation: mutationName,
+              duration,
+              skewed,
+            });
+            if (!skewed) {
+              metrics.recordLatency('zero.mutation.latency', duration, {
+                mutation: mutationName,
+              });
+            }
+            metrics.incrementCounter('zero.mutation.operations', {
+              mutation: mutationName,
+              stage: 'success',
+            });
           }
-        };
-      }
-      return Reflect.get(target, prop) as never;
-    },
-  };
+        })
+        .catch(error => {
+          const duration = performance.now() - startTime;
+          const skewed = wasInterrupted(startTime);
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          logger.error(Event.ZERO_MUTATION_ERROR, {
+            mutation: mutationName,
+            error: errorMessage,
+            skewed,
+          });
+          if (!skewed) {
+            metrics.recordLatency('zero.mutation.latency', duration, {
+              mutation: mutationName,
+            });
+          }
+          metrics.incrementCounter('zero.mutation.operations', {
+            mutation: mutationName,
+            stage: 'error',
+          });
+        })
+        .finally(() => {
+          trackMutationSettled();
+        });
 
-  return new Proxy(originalZero, handler);
+      return result;
+    };
+
+    const instrumentedRun = async <
+      TTable extends keyof Zero['schema']['tables'],
+      TInput extends ReadonlyJSONValue | undefined,
+      TOutput extends ReadonlyJSONValue | undefined,
+      TReturn,
+    >(
+      query:
+        | QueryRequest<TTable, TInput, TOutput, Zero['schema'], TReturn, Zero['context']>
+        | Query<TTable, Zero['schema'], TReturn>,
+      runOptions?: RunOptionsWithName,
+    ): Promise<HumanReadable<TReturn>> => {
+      const startTime = performance.now();
+
+      let queryName: string;
+      let queryArgs: unknown = undefined;
+
+      if ('query' in query && 'args' in query) {
+        queryName = query.query.queryName || 'unknown';
+        queryArgs = query.args;
+      } else {
+        queryName = runOptions?.queryName || 'unknown';
+      }
+
+      logger.info(Event.ZERO_RUN_CALLED, { query: queryName, args: queryArgs });
+      metrics.incrementCounter('zero.run.operations', { query: queryName, stage: 'start' });
+
+      try {
+        const result = (await originalZero.run(
+          query as Parameters<Zero['run']>[0],
+          runOptions as Parameters<Zero['run']>[1],
+        )) as Promise<HumanReadable<TReturn>>;
+
+        const duration = performance.now() - startTime;
+        const skewed = wasInterrupted(startTime);
+        logger.info(Event.ZERO_RUN_COMPLETE, {
+          query: queryName,
+          duration,
+          args: queryArgs,
+          skewed,
+        });
+        if (!skewed) {
+          metrics.recordLatency('zero.run.latency', duration, { query: queryName });
+        }
+        metrics.incrementCounter('zero.run.operations', {
+          query: queryName,
+          stage: 'success',
+        });
+
+        return result;
+      } catch (error) {
+        const duration = performance.now() - startTime;
+        const skewed = wasInterrupted(startTime);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(Event.ZERO_RUN_ERROR, {
+          query: queryName,
+          error: errorMessage,
+          args: queryArgs,
+          skewed,
+        });
+        if (!skewed) {
+          metrics.recordLatency('zero.run.latency', duration, { query: queryName });
+        }
+        metrics.incrementCounter('zero.run.operations', {
+          query: queryName,
+          stage: 'error',
+        });
+        throw error;
+      }
+    };
+
+    const handler: ProxyHandler<Zero> = {
+      get(target, prop, receiver) {
+        if (prop === 'mutate') return instrumentedMutate;
+        if (prop === 'run') return instrumentedRun;
+        return Reflect.get(target, prop, target) as never;
+      },
+    };
+
+    return new Proxy(originalZero, handler);
+  }, [originalZero, logger, metrics]);
 }


### PR DESCRIPTION
## Summary
- Stabilizes the shared `useZero()` instrumentation proxy by memoizing the proxy and intercepted methods for the lifetime of the underlying Zero instance/instrumentation context.
- Preserves native/private-field accessors by forwarding non-intercepted properties with the original Zero object as the receiver (`Reflect.get(target, prop, target)`).
- Keeps existing mutate/run logging and metrics behaviour unchanged.

## Verification
- `pnpm --filter @xyne/shared run build` — PASS
- `cd apps/dashboard && npx tsc --noEmit --project tsconfig.app.json` — PASS
- `cd apps/backend && NODE_OPTIONS=--max-old-space-size=4096 npx tsc --noEmit` — PASS
- POT TC1 — PASS: authenticated chat route loads `Inbox`, `# general`, and `Send a message` without the prior `Cannot read private member #rep` proxy error. Evidence: `packages/shared/src/hooks/useZero.ts:48`, `packages/shared/src/hooks/useZero.ts:209`.

## Proof artifacts
- Screenshot: `/workspace/xyne-spaces/screenshots/usezero-proxy/TC1-usezero-proxy-stable.png`
- Walkthrough video recorded in sandbox: `/tmp/videos/page@10c825266eb8deb119c8e23e1d433fce.webm` (489984 bytes)