### PR TITLE
fix: memoize FlowRenderer validation

### DIFF
--- a/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
@@ -31,9 +31,28 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
   onStateChange,
   compact = false,
 }) => {
-  const [validationError, setValidationError] = useState<string | null>(null);
-  const [validatedFlow, setValidatedFlow] = useState<FlowDefinition | null>(null);
   const [state, setState] = useState<FlowState>(flow.state);
+
+  const flowKey = useMemo(() => JSON.stringify(flow), [flow]);
+  const validation = useMemo(() => {
+    const result = validateFlowDefinition(flow);
+    if (!result.success) {
+      return {
+        error: formatValidationErrors(result).join('; '),
+        flow: null,
+      };
+    }
+    return {
+      error: null,
+      flow: result.data as FlowDefinition,
+    };
+    // validateFlowDefinition is intentionally keyed by serialized flow content so
+    // re-parsed objects with identical payloads do not re-run zod validation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flowKey]);
+
+  const validationError = validation.error;
+  const validatedFlow = validation.flow;
 
   // Always-current ref so executeAction closures never read stale values.
   // Synced synchronously inside updateFieldValue (not via useEffect) so debounced
@@ -45,24 +64,18 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
   // we must NOT reset form values in that case, only update the flow definition.
   const initializedScreenIdRef = useRef<string | null>(null);
 
-  // Validate flow whenever the prop changes
   useEffect(() => {
-    const result = validateFlowDefinition(flow);
-    if (!result.success) {
-      const errors = formatValidationErrors(result);
-      setValidationError(errors.join('; '));
-      setValidatedFlow(null);
-    } else {
-      setValidationError(null);
-      setValidatedFlow(result.data as FlowDefinition);
-      // Only reset form state when this is genuinely a new screen
-      if (initializedScreenIdRef.current !== result.data.screenId) {
-        initializedScreenIdRef.current = result.data.screenId;
-        // Always start with submitting=false so a remounted screen isn't frozen
-        setState({ ...result.data.state, submitting: false });
-      }
+    if (!validatedFlow) return;
+
+    // Only reset form state when this is genuinely a new screen.
+    if (initializedScreenIdRef.current !== validatedFlow.screenId) {
+      initializedScreenIdRef.current = validatedFlow.screenId;
+      // Always start with submitting=false so a remounted screen isn't frozen.
+      const next = { ...validatedFlow.state, submitting: false };
+      stateRef.current = next;
+      setState(next);
     }
-  }, [flow]);
+  }, [validatedFlow]);
 
   useEffect(() => {
     onStateChange?.(state);
@@ -299,11 +312,7 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
     );
   }
 
-  // The node registry is populated synchronously at module load (see NodeRegistry.ts),
-  // so the only thing we wait for here is the one-tick flow validation below.
-  if (!validatedFlow) {
-    return <div className='animate-pulse bg-muted h-32 rounded-lg' />;
-  }
+  if (!validatedFlow) return null;
 
   return (
     <FlowContext.Provider value={contextValue}>

--- a/apps/dashboard/src/components/flowUI/FlowScreenManager.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowScreenManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X, ChevronLeft } from 'lucide-react';
 import { FlowRenderer } from './FlowRenderer';
@@ -47,7 +47,7 @@ export const FlowScreenManager: React.FC<FlowScreenManagerProps> = ({
   // avoid an update loop. Only the inline base [0] is replaced; any open popup
   // stack (screenStack[1+]) is preserved. FlowRenderer reseeds its own
   // validated flow from the new prop (same screenId ⇒ user form values kept).
-  const flowKey = JSON.stringify(flow);
+  const flowKey = useMemo(() => JSON.stringify(flow), [flow]);
   const flowRef = useRef(flow);
   flowRef.current = flow;
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Memoizes FlowRenderer validation by serialized flow content so re-parsed but identical flow payloads do not rerun Zod validation.
- Keeps same-screen state preservation intact and syncs stateRef when a genuinely new screen seeds state.
- Memoizes FlowScreenManager's flow serialization with useMemo.

## Testing
- PASS: pnpm --filter xyne-spaces-dashboard typecheck
- PASS: Browser POT harness on authenticated dashboard at /flowrenderer-pot.html showed valid flow rendering, same-screen update preserving input value, invalid flow definition error rendering, and recorded walkthrough video.

## Evidence
- apps/dashboard/src/components/flowUI/FlowRenderer.tsx:36 memoized flowKey
- apps/dashboard/src/components/flowUI/FlowRenderer.tsx:37 memoized validation
- apps/dashboard/src/components/flowUI/FlowRenderer.tsx:67 same-screen state reseed guard
- apps/dashboard/src/components/flowUI/FlowScreenManager.tsx:50 memoized serialization

Commit: fd99c98679bb6cc0f088e04f160e70b2f09cf608