### PR TITLE
fix: index draft message lookups

### DIFF
--- a/apps/dashboard/src/hooks/useDraft.ts
+++ b/apps/dashboard/src/hooks/useDraft.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from '@xstate/react';
-import { stateMachineActor } from '../machines/stateMachine';
+import { getDraftMessageLookupId, stateMachineActor } from '../machines/stateMachine';
 import { useZero } from './useZero';
 import { mutators } from '../zero/mutators';
 import { apiInstance } from '../services/clients/apiClient';
@@ -58,11 +58,8 @@ export function removeDraft(lookupId: string): void {
 }
 
 export function useDraftFromDB(channelId: string, conversationId: string | null) {
-  return useSelector(stateMachineActor, state =>
-    state.context.draftMessages.find(
-      draft => draft.channelId === channelId && draft.conversationId === conversationId,
-    ),
-  );
+  const lookupId = getDraftMessageLookupId(channelId, conversationId);
+  return useSelector(stateMachineActor, state => state.context.draftMessagesByLookupId[lookupId]);
 }
 
 export function useDraft(channelId: string, conversationId: string | null) {
@@ -70,10 +67,10 @@ export function useDraft(channelId: string, conversationId: string | null) {
     stateMachineActor,
     state => state.context.drafts[conversationId ?? channelId],
   );
-  const draftFromDB = useSelector(stateMachineActor, state =>
-    state.context.draftMessages.find(
-      draft => draft.channelId === channelId && draft.conversationId === conversationId,
-    ),
+  const lookupId = getDraftMessageLookupId(channelId, conversationId);
+  const draftFromDB = useSelector(
+    stateMachineActor,
+    state => state.context.draftMessagesByLookupId[lookupId],
   );
 
   return useMemo(() => {
@@ -91,9 +88,8 @@ export function getDraft(channelId: string, conversationId: string | null) {
 
   const draftFromLocal = state.context.drafts[conversationId ?? channelId];
 
-  const draftFromDB = state.context.draftMessages.find(
-    draft => draft.channelId === channelId && draft.conversationId === conversationId,
-  );
+  const draftFromDB =
+    state.context.draftMessagesByLookupId[getDraftMessageLookupId(channelId, conversationId)];
 
   return draftFromDB && draftFromLocal && draftFromDB.updatedAt > draftFromLocal.updatedAt
     ? draftFromDB.content
@@ -102,7 +98,10 @@ export function getDraft(channelId: string, conversationId: string | null) {
 
 export function useDraftAttachments() {
   const zero = useZero();
-  const draftMessages = useSelector(stateMachineActor, state => state.context.draftMessages);
+  const draftMessagesByLookupId = useSelector(
+    stateMachineActor,
+    state => state.context.draftMessagesByLookupId,
+  );
 
   const addDroppedFiles = useCallback(
     async (files: File | File[], channelId: string, conversationId?: string) => {
@@ -348,9 +347,7 @@ export function useDraftAttachments() {
     // eslint-disable-next-line @typescript-eslint/require-await
     async (channelId: string, conversationId: string | null) => {
       // Find the draft message matching the channelId and conversationId
-      const draftMessage = draftMessages.find(
-        d => d.channelId === channelId && d.conversationId === conversationId,
-      );
+      const draftMessage = draftMessagesByLookupId[getDraftMessageLookupId(channelId, conversationId)];
 
       if (!draftMessage || !draftMessage.attachments) return;
 
@@ -364,7 +361,7 @@ export function useDraftAttachments() {
         delete filesMapRef[attachment.id];
       });
     },
-    [zero, draftMessages],
+    [zero, draftMessagesByLookupId],
   );
 
   const getDroppedFilesForEntity = useCallback(
@@ -375,9 +372,7 @@ export function useDraftAttachments() {
       }
 
       // Find the draft message matching the channelId and conversationId
-      const draftMessage = draftMessages.find(
-        d => d.channelId === channelId && d.conversationId === conversationId,
-      );
+      const draftMessage = draftMessagesByLookupId[getDraftMessageLookupId(channelId, conversationId)];
 
       if (!draftMessage || !draftMessage.attachments) {
         return new Map();
@@ -423,7 +418,7 @@ export function useDraftAttachments() {
 
       return result;
     },
-    [draftMessages],
+    [draftMessagesByLookupId],
   );
 
   return useMemo(

--- a/apps/dashboard/src/machines/stateMachine.ts
+++ b/apps/dashboard/src/machines/stateMachine.ts
@@ -9,6 +9,7 @@ export {
   useHasOverlay,
   useOverlayEffect,
   getThreadTrackingSnapshot,
+  getDraftMessageLookupId,
   setThreadLastRead,
   setThreadScroll,
 } from '@xyne/shared/machines';
@@ -25,6 +26,7 @@ export type {
   UserChannelStatus,
   Conversation,
   DraftMessageDB,
+  DraftMessagesByLookupId,
   DelayedMessageDB,
   UserPreference,
   PeriodMetrics,

--- a/packages/shared/src/machines/index.ts
+++ b/packages/shared/src/machines/index.ts
@@ -37,6 +37,7 @@ export {
   useHasOverlay,
   useOverlayEffect,
   getThreadTrackingSnapshot,
+  getDraftMessageLookupId,
   setThreadLastRead,
   setThreadScroll,
 } from './stateMachine.js';
@@ -53,6 +54,7 @@ export type {
   UserChannelStatus,
   Conversation,
   DraftMessageDB,
+  DraftMessagesByLookupId,
   DelayedMessageDB,
   UserPreference,
   PeriodMetrics,

--- a/packages/shared/src/machines/stateMachine.ts
+++ b/packages/shared/src/machines/stateMachine.ts
@@ -49,6 +49,10 @@ export interface DraftMessages {
   [lookupId: string]: DraftMessage | undefined;
 }
 
+export interface DraftMessagesByLookupId {
+  [lookupId: string]: DraftMessageDB | undefined;
+}
+
 const DRAFT_STORAGE_KEY = 'channel-draft-message';
 
 export type User = QueryResultType<typeof queries.getUsersV2>[number];
@@ -65,6 +69,15 @@ export type UserChannelStatus = QueryResultType<typeof queries.getAllChannelsUse
 export type Conversation = QueryResultType<typeof queries.channelConversationsPaginatedV3>[number];
 
 export type DraftMessageDB = QueryResultType<typeof queries.userDrafts>[number];
+
+export const getDraftMessageLookupId = (channelId: string, conversationId: string | null): string =>
+  `${channelId}::${conversationId === null ? 'channel' : `conversation:${conversationId}`}`;
+
+const indexDraftMessages = (draftMessages: DraftMessageDB[]): DraftMessagesByLookupId =>
+  draftMessages.reduce<DraftMessagesByLookupId>((acc, draftMessage) => {
+    acc[getDraftMessageLookupId(draftMessage.channelId, draftMessage.conversationId)] = draftMessage;
+    return acc;
+  }, {});
 export type DelayedMessageDB = QueryResultType<typeof queries.userDelayedMessages>[number];
 export type UnreadActivity = QueryResultType<typeof queries.userUnreadActivities>[number];
 export type UserPreference = QueryResultType<typeof queries.getCurrentUserPreference>;
@@ -197,6 +210,7 @@ interface StateMachineContext {
   savedRoutes: Record<string, string>;
   drafts: DraftMessages; // Draft messages per channel/conversation
   draftMessages: DraftMessageDB[];
+  draftMessagesByLookupId: DraftMessagesByLookupId;
   delayedMessages: DelayedMessageDB[];
   userPreference: UserPreference;
   allUserGroups: UserGroup[];
@@ -481,17 +495,24 @@ export const stateMachine = setup({
         return context.currentUserRoleIds;
       },
     }),
-    addUserDrafts: assign({
-      draftMessages: ({ context, event }) => {
-        if (event.type === 'ADD_USER_DRAFTS') {
-          return event.draftMessages.filter(d => {
-            const hasContent = d.content.trim() !== '';
-            const hasAttachments = (d.attachments?.length ?? 0) > 0;
-            return hasContent || hasAttachments;
-          });
-        }
-        return context.draftMessages;
-      },
+    addUserDrafts: assign(({ context, event }) => {
+      if (event.type !== 'ADD_USER_DRAFTS') {
+        return {
+          draftMessages: context.draftMessages,
+          draftMessagesByLookupId: context.draftMessagesByLookupId,
+        };
+      }
+
+      const draftMessages = event.draftMessages.filter(d => {
+        const hasContent = d.content.trim() !== '';
+        const hasAttachments = (d.attachments?.length ?? 0) > 0;
+        return hasContent || hasAttachments;
+      });
+
+      return {
+        draftMessages,
+        draftMessagesByLookupId: indexDraftMessages(draftMessages),
+      };
     }),
     addUserDelayedMessages: assign({
       delayedMessages: ({ context, event }) => {
@@ -689,6 +710,7 @@ export const stateMachine = setup({
       allUserGroups: [],
       userGroupMappings: [],
       draftMessages: [],
+      draftMessagesByLookupId: {},
       delayedMessages: [],
       unreadActivities: [],
       filteredTicketIds: [],
@@ -741,6 +763,7 @@ export const stateMachine = setup({
     })(),
     drafts: JSON.parse(draftStorage().getItem(DRAFT_STORAGE_KEY) || '{}') as DraftMessages,
     draftMessages: [],
+    draftMessagesByLookupId: {},
     delayedMessages: [],
     userPreference: undefined,
     allUserGroups: [],


### PR DESCRIPTION
## Summary
- Adds a `draftMessagesByLookupId` index to the shared state machine so hydrated draft messages are indexed once when `ADD_USER_DRAFTS` arrives.
- Replaces repeated `draftMessages.find(...)` lookups in draft hooks/attachment helpers with keyed reads.
- Re-exports the lookup helper/type through shared and dashboard machine barrels.

## Proof of testing
| TC | Result | Evidence |
| --- | --- | --- |
| TC1 Indexed draft lookup implementation | PASS | `packages/shared/src/machines/stateMachine.ts:73`, `packages/shared/src/machines/stateMachine.ts:213`, `packages/shared/src/machines/stateMachine.ts:498`, `apps/dashboard/src/hooks/useDraft.ts:60`, `apps/dashboard/src/hooks/useDraft.ts:86` |
| TC2 Repeated array scans removed | PASS | grep found no `draftMessages.find` references under `apps/dashboard/src` or `packages/shared/src`; keyed reads at `apps/dashboard/src/hooks/useDraft.ts:62`, `:73`, `:92`, `:350`, `:375` |
| TC3 Typecheck shared/dashboard/backend | PASS | `pnpm --filter @xyne/shared run build`, `pnpm --filter xyne-spaces-dashboard run typecheck`, `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter xyne-spaces-backend run typecheck` exited 0 |

Branch push verified by `git ls-remote --heads origin fix/draft-indexed-lookups` returning `56750d9673cabd5e7e1b5f608da3323819565539 refs/heads/fix/draft-indexed-lookups`.