### PR TITLE
fix: XYNE-55052 reduce long-thread ChatBubble re-render + layout cost

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -133,7 +133,7 @@ interface ChatBubbleProps {
   isThreadTicketSubTicket?: boolean;
 }
 
-export const ChatBubble: React.FC<ChatBubbleProps> = ({
+const ChatBubbleComponent: React.FC<ChatBubbleProps> = ({
   message,
   channelId,
   projectId,
@@ -1650,3 +1650,14 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
     </div>
   );
 };
+
+ChatBubbleComponent.displayName = 'ChatBubble';
+
+/**
+ * Memoized to stop a single new message in a long thread from re-rendering every
+ * ChatBubble in the list (XYNE-55052). Default shallow prop comparison is safe:
+ * Zero returns stable row identities for unchanged messages, and the only array
+ * prop (`allThreadAttachments`) is identity-stabilized by ThreadList, so unchanged
+ * bubbles compare equal and skip re-render while edited/reacted rows still update.
+ */
+export const ChatBubble = React.memo(ChatBubbleComponent);

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -82,9 +82,14 @@ const ThreadList = ({
     [conversationId],
   );
 
-  // Pre-compute all thread attachments for gallery navigation
+  // Pre-compute all thread attachments for gallery navigation.
+  // Identity is stabilized (XYNE-55052): a new array is only returned when the
+  // attachment set actually changes. Text-only message arrivals — the common case
+  // that previously re-rendered every ChatBubble in the thread — keep the same
+  // reference, so the memoized ChatBubble can skip re-rendering.
+  const prevAttachmentsRef = useRef<AttachmentRef[]>([]);
   const allThreadAttachments: AttachmentRef[] = useMemo(() => {
-    if (!threadMessages) return [];
+    if (!threadMessages) return prevAttachmentsRef.current;
 
     const result = threadMessages.flatMap(msg => {
       if (!msg.hasAttachment || !msg.attachments?.length) return [];
@@ -102,6 +107,21 @@ const ThreadList = ({
       }));
     });
 
+    const prev = prevAttachmentsRef.current;
+    const unchanged =
+      prev.length === result.length &&
+      prev.every((p, i) => {
+        const n = result[i]!;
+        return (
+          p.attachmentId === n.attachmentId &&
+          p.conversationId === n.conversationId &&
+          p.channelId === n.channelId &&
+          p.replyCount === n.replyCount
+        );
+      });
+    if (unchanged) return prev;
+
+    prevAttachmentsRef.current = result;
     return result;
   }, [threadMessages, channelId, conversation?.replyCount]);
 
@@ -476,7 +496,13 @@ const ThreadList = ({
 
               return (
                 <div key={threadMessage.messageId}>
-                  <div id={`thread-message-${conversationId}-${threadMessage.messageId}`}>
+                  <div
+                    id={`thread-message-${conversationId}-${threadMessage.messageId}`}
+                    // content-visibility skips layout/paint for off-screen bubbles (XYNE-55052).
+                    // contain-intrinsic-size:auto lets the browser remember each row's last
+                    // measured height, so scroll position and deep-link jumps stay stable.
+                    style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 80px' }}
+                  >
                     <ChatBubble
                       message={threadMessage}
                       channelId={channelId}
@@ -574,7 +600,13 @@ const ThreadList = ({
                     </div>
                   </div>
                 )}
-                <div id={`thread-message-${conversationId}-${threadMessage.messageId}`}>
+                <div
+                  id={`thread-message-${conversationId}-${threadMessage.messageId}`}
+                  // content-visibility skips layout/paint for off-screen bubbles (XYNE-55052).
+                  // contain-intrinsic-size:auto lets the browser remember each row's last
+                  // measured height, so scroll position and deep-link jumps stay stable.
+                  style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 80px' }}
+                >
                   <ChatBubble
                     message={threadMessage}
                     channelId={channelId}


### PR DESCRIPTION
## What & why
XYNE-55052 [FE-Perf][P1]: long thread message lists (`ThreadList`) render every message with `.map()` and no virtualization, and `ChatBubble` was not memoized. On a long thread, a single new message re-rendered every `ChatBubble` (measured ~0.237ms/bubble → ~47ms at 200 msgs, ~237ms at 1000). This PR ships the **interim safeguard (stage 1)** from the ticket. Full TanStack virtualization is the follow-up (stage 2).

## Changes
- **Memoize `ChatBubble`** (`React.memo`) so unchanged bubbles skip re-render when a new message arrives. Default shallow comparison is safe: Zero returns stable row identities for unchanged messages; edited/reacted rows still get a new identity and re-render correctly.
- **Stabilize `allThreadAttachments`** in `ThreadList` — return the same array reference when the attachment set is unchanged, so text-only arrivals (the common case) don't defeat the memo.
- **`content-visibility:auto` + `contain-intrinsic-size:auto 80px`** on each message wrapper div (both the ticket-thread date-separator path and the default path) to skip layout/paint for off-screen bubbles. `contain-intrinsic-size:auto` preserves the last measured height so scroll position and deep-link jumps stay stable.

## Risk / compatibility
- No API/schema/query changes. Pure client render optimization.
- Behavior preserved: unread markers, date separators, deep-link ids (`thread-message-...`), avatar grouping, scroll restoration.
- `tsc --noEmit` passes; eslint reports 0 errors on both files (only pre-existing warnings).

## Follow-up (stage 2, separate ticket/PR)
- Virtualize both render paths with TanStack `useVirtualizer`, mirroring `ChatListV4` (`directDomUpdates`, `anchorTo:'end'`, `useFlushSync:false`), switching deep-link/jump logic from `getElementById` to `virtualizer.scrollToIndex`.
- Note: `conversationMessagesV2` is a Zero/IVM query; a naive `.orderBy('createdAt','asc').limit(N)` keeps the OLDEST N — handle via windowed pagination, not a raw limit.