### PR TITLE
fix: XYNE-55043 add accessible names to AuthScreen form inputs

### DIFF
--- a/apps/dashboard/src/routes/AuthScreen/AuthScreen.tsx
+++ b/apps/dashboard/src/routes/AuthScreen/AuthScreen.tsx
@@ -620,6 +620,7 @@ const AuthScreen = (): ReactElement => {
                       <input
                         type='text'
                         value={newEnterpriseWorkspaceName}
+                        aria-label='New workspace name'
                         onChange={e => setNewEnterpriseWorkspaceName(e.target.value)}
                         placeholder='Workspace name'
                         className='flex-1 px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-background text-foreground text-sm'
@@ -868,6 +869,7 @@ const AuthScreen = (): ReactElement => {
                               <input
                                 type='email'
                                 value={fpEmail}
+                                aria-label='Email address'
                                 onChange={e => setFpEmail(e.target.value)}
                                 placeholder='Email address'
                                 required
@@ -903,6 +905,7 @@ const AuthScreen = (): ReactElement => {
                               <input
                                 type='text'
                                 value={fpCode}
+                                aria-label='6-digit reset code'
                                 onChange={e =>
                                   setFpCode(e.target.value.replace(/\D/g, '').slice(0, 6))
                                 }
@@ -918,6 +921,7 @@ const AuthScreen = (): ReactElement => {
                               <input
                                 type='password'
                                 value={fpNewPassword}
+                                aria-label='New password'
                                 onChange={e => setFpNewPassword(e.target.value)}
                                 placeholder='New password (min 8 chars)'
                                 required
@@ -928,6 +932,7 @@ const AuthScreen = (): ReactElement => {
                               <input
                                 type='password'
                                 value={fpConfirmPassword}
+                                aria-label='Confirm new password'
                                 onChange={e => setFpConfirmPassword(e.target.value)}
                                 placeholder='Confirm new password'
                                 required
@@ -988,6 +993,7 @@ const AuthScreen = (): ReactElement => {
                           <input
                             type='email'
                             value={email}
+                            aria-label='Email address'
                             onChange={e => setEmail(e.target.value)}
                             placeholder='Email address'
                             required
@@ -998,6 +1004,7 @@ const AuthScreen = (): ReactElement => {
                           <input
                             type='password'
                             value={password}
+                            aria-label='Password'
                             onChange={e => setPassword(e.target.value)}
                             placeholder='Password'
                             required


### PR DESCRIPTION
Ticket: XYNE-55043 — [Epic] Accessibility remediation — icon buttons, form labels, focus, keyboard

This PR lands the first scoped slice of Batch B (programmatic labels for form controls) for the AuthScreen only. It is intentionally narrow; the remaining batches (shared IconButton/LabeledInput primitives, global :focus-visible, keyboard behavior) are follow-ups under the same epic.

1. Problem Description:
Several `<input>` elements on the login screen (`apps/dashboard/src/routes/AuthScreen/AuthScreen.tsx`) were labelled by `placeholder` only. `placeholder` is not a programmatic accessible name, so screen-reader users hear an unlabelled edit field. Affected: main login email/password, forgot-password email/code/new-password/confirm-password, and the enterprise "create workspace" name input.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Called out directly in the XYNE-55043 acceptance criteria ("AuthScreen fully labelled + focus-visible"). Verified in code — the listed inputs had `placeholder` but no `aria-label`, `<label htmlFor>`, or `aria-labelledby`.

3. Explain the solution implemented in the PR:
Added an explicit `aria-label` to the seven placeholder-only inputs so each exposes a programmatic accessible name. No visual change. The `orgName` and `workspaceName` inputs already have associated `<label htmlFor>` and were left untouched to avoid overriding their visible labels.

4. Documentation (link to confluence docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
Ran the dashboard locally and recorded a proof-of-test (PoT) video. A Playwright-driven in-page audit computes each visible input's programmatic accessible name (aria-label / label[for] / aria-labelledby — placeholder explicitly excluded) and reports PASS: both visible login controls now expose an accessible name. Keyboard tab walk-through confirms focus lands on each labelled field. PoT video is attached in the Spaces thread.

9. Services to which this change is to be deployed:
Dashboard (frontend) only.

10. Main PR link (if this PR is raised against a release branch):
N/A — targets main.