### PR TITLE
fix: centralize safe external window opening

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
@@ -49,6 +49,7 @@ import { usePath } from '../../../hooks/usePath';
 import { useDebouncedValue } from '../../../hooks/useDebouncedValue';
 import { canvasService } from '../../../services/Canvas/canvasService';
 import { usePersistedCanvasPreferences } from '../../../hooks/usePersistedCanvasPreferences';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 
 const CanvasPanel = (): ReactElement => {
   const { isMobile } = usePlatform();
@@ -141,7 +142,7 @@ const CanvasPanel = (): ReactElement => {
       const canvasUrl = `/chat/canvas/${canvas.id}`;
       // Only open in new tab on desktop when Cmd/Ctrl+Click is pressed
       if (!isMobile && isCmdClick) {
-        window.open(canvasUrl, '_blank');
+        openSafeWindow(canvasUrl);
       } else {
         void navigate(canvasUrl);
       }

--- a/apps/dashboard/src/components/Canvas/CanvasPreview/CanvasPreview.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasPreview/CanvasPreview.tsx
@@ -16,6 +16,7 @@ import { useRouteContext } from '../../../hooks/useRouteContext';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useTheme } from '../../../hooks/useTheme';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 
 interface CanvasPreviewProps {
   canvasId?: string;
@@ -81,7 +82,7 @@ export const CanvasPreview: React.FC<CanvasPreviewProps> = ({
     const isCmdClick = event?.metaKey || event?.ctrlKey;
     if (!isMobile && isCmdClick && canvasId) {
       const canvasUrl = `${shareableOrigin}/chat/canvas/${canvasId}`;
-      window.open(canvasUrl, '_blank');
+      openSafeWindow(canvasUrl);
       return;
     }
 

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -81,6 +81,7 @@ import { useAllVisibleChannels } from '@xyne/shared/hooks';
 import { usePersistedCanvasPreferences } from '../../../hooks/usePersistedCanvasPreferences';
 import { useCanvasExitTitleGuard } from '../../../hooks/useCanvasExitTitleGuard';
 import { CanvasExitTitleDialog } from '../CanvasExitTitleDialog';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 import {
   createCanvasContentTextDiff,
   isVisibleCanvasContentDiffPart,
@@ -1521,7 +1522,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
 
                 // Only open in new tab on desktop when Cmd/Ctrl+Click is pressed
                 if (!isMobile && isCmdClick) {
-                  window.open(canvasRoute, '_blank');
+                  openSafeWindow(canvasRoute);
                 } else {
                   void navigate(canvasRoute);
                 }

--- a/apps/dashboard/src/components/Chat/BotBubble/BotBubble.tsx
+++ b/apps/dashboard/src/components/Chat/BotBubble/BotBubble.tsx
@@ -12,6 +12,7 @@ import { standaloneNavigate } from '../../../utils/electronApp';
 import { useLocation } from 'react-router-dom';
 import { SearchResultsContext } from '../SearchResults/SearchResultsContext';
 import { useNavigate } from '../../../hooks/useWorkspaceNavigate';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 
 interface BotBubbleProps {
   messageId?: string;
@@ -79,7 +80,7 @@ const TicketDisplayModeV2: React.FC<{
     if (!isMobile && isCmdClick) {
       const ws = window.location.pathname.split('/').find(s => s.length > 0) ?? '';
       const ticketUrl = `${ws ? `/${ws}` : ''}/chat/dir/${resolvedChannelId}?tab=tickets&ticketId=${ticket.id}&conversationId=${resolvedConversationId}`;
-      window.open(ticketUrl, '_blank');
+      openSafeWindow(ticketUrl);
       return;
     }
 

--- a/apps/dashboard/src/components/Chat/LinkPreview/InternalMessagePreview.tsx
+++ b/apps/dashboard/src/components/Chat/LinkPreview/InternalMessagePreview.tsx
@@ -17,6 +17,7 @@ import { MessageAttachment } from '../MessageAttachment/MessageAttachment';
 import { TicketCard } from '../../Tickets/TicketCard/TicketCard';
 import { queries } from '../../../zero/queries';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 interface InternalMessagePreviewProps {
   metadata: InternalMessageLinkMetadata;
   onClose?: () => void;
@@ -370,7 +371,7 @@ const InternalMessagePreviewComponent: React.FC<InternalMessagePreviewProps> = (
       !!event && 'metaKey' in event && !isMobile && (event.metaKey || event.ctrlKey);
 
     if (isModifiedClick) {
-      window.open(url, '_blank');
+      openSafeWindow(url);
       return;
     }
 

--- a/apps/dashboard/src/components/Chat/LinksTab/LinksTab.tsx
+++ b/apps/dashboard/src/components/Chat/LinksTab/LinksTab.tsx
@@ -14,6 +14,7 @@ import { useRouteContext } from '../../../hooks/useRouteContext';
 import { useAuthContextValues } from '../../../hooks/useAuth';
 import { isElectronApp } from '../../../utils/electronApp';
 import { openLink, getLinkOpenExternalDefault } from '../../../utils/openLink';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 
 interface LinksTabProps {
   channelId: string;
@@ -46,7 +47,7 @@ const LinksTab: React.FC<LinksTabProps> = ({ channelId }) => {
         xyneAIActor.send({ type: 'CLOSE' });
         browserPanelActor.send({ type: 'OPEN', urls });
       } else {
-        urls.forEach(url => window.open(url, '_blank'));
+        urls.forEach(url => openSafeWindow(url));
       }
 
       void navigate(`${baseRoute}/${channelId}?tab=links`, { replace: true });

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -46,6 +46,7 @@ import { FlowScreenManager } from '../../flowUI/FlowScreenManager';
 import { ChannelScopeType, type FlowDefinition } from '@xyne/shared';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import { formatChannelLabel } from '../ChatDirectory/ChatDirectory.utils';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 
 interface RenderMessageWithHTMLProps {
   message: string;
@@ -242,7 +243,7 @@ const CanvasLink = ({
     const isCmdClick = event.metaKey || event.ctrlKey;
     if (!isMobile && isCmdClick) {
       event.preventDefault();
-      window.open(resolvedHref, '_blank');
+      openSafeWindow(resolvedHref);
       return;
     }
 
@@ -1301,7 +1302,7 @@ const parseNode = (
             } else if (e.metaKey || e.ctrlKey) {
               e.preventDefault();
               const newWindowPath = `/newWindow${urlObj.pathname}${urlObj.search}${urlObj.hash}`;
-              const newWindow = window.open(newWindowPath, '_blank');
+              const newWindow = openSafeWindow(newWindowPath);
               if (newWindow) {
                 newWindow.focus();
               }

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -82,6 +82,7 @@ import { CallParticipantsSelectionModal } from '../Call/CallParticipantsSelectio
 import { ScheduleCallModal } from '../Call/ScheduleCallModal/ScheduleCallModal';
 import { ThreadCallButton } from '../Call/ThreadCallButton/ThreadCallButton';
 import { ConversationTabContext } from './ConversationTabContext';
+import { openSafeWindow } from '../../utils/safeWindowOpen';
 
 type TabType = 'thread' | 'details' | 'files' | 'workflows' | 'rca';
 type UnderTicketTabType = 'replies' | 'workflows' | 'rca';
@@ -733,9 +734,8 @@ export const ThreadMessages = ({
     );
   };
   const openInNewWindow = (): void => {
-    const newWindow = window.open(
+    const newWindow = openSafeWindow(
       `/newWindow/chat/dir/${derivedChannelId}/${derivedConversationId}`,
-      '_blank',
     );
     if (!newWindow) {
       console.warn('Failed to open new window - popup may be blocked');

--- a/apps/dashboard/src/components/ErrorReportModal/ErrorReportModal.tsx
+++ b/apps/dashboard/src/components/ErrorReportModal/ErrorReportModal.tsx
@@ -35,6 +35,7 @@ import {
 import type { ErrorReportModalProps } from './ErrorReportModal.types';
 import { MACOS_PRIVACY_URLS } from '../../constants/permissions';
 import type { ScreenSource } from '../../types/electron';
+import { openSafeWindow } from '../../utils/safeWindowOpen';
 
 type ErrorReportCacConfig = {
   channelId: string;
@@ -579,7 +580,7 @@ export const ErrorReportModal = ({
                           onRemove={() => handleRemoveAttachment(index)}
                           onPreview={() => {
                             const url = URL.createObjectURL(file);
-                            window.open(url, '_blank');
+                            openSafeWindow(url);
                             setTimeout(() => URL.revokeObjectURL(url), 30_000);
                           }}
                         />

--- a/apps/dashboard/src/components/FileViewer/ImageViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/ImageViewer.tsx
@@ -9,6 +9,7 @@ import { BaseViewerProps } from './utils';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useMobileZoom } from '../../hooks/useMobileZoom';
 import { useScope, useShortcutById } from '../../shortcuts';
+import { openSafeWindow } from '../../utils/safeWindowOpen';
 
 const ImageViewer: React.FC<BaseViewerProps> = ({
   source,
@@ -84,7 +85,7 @@ const ImageViewer: React.FC<BaseViewerProps> = ({
 
   const handleOpenInNewWindow = useCallback(() => {
     if (imageUrl) {
-      window.open(imageUrl, '_blank');
+      openSafeWindow(imageUrl);
     }
   }, [imageUrl]);
 

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -94,6 +94,7 @@ const getFileExtension = (name: string): string => {
   return dotIndex > 0 ? name.slice(dotIndex).toLowerCase() : '';
 };
 import { preloadEmojiData } from '../../../utils/emojiLookup';
+import { openSafeWindow } from '../../../utils/safeWindowOpen';
 
 const lowlight = createLowlight(all);
 
@@ -1217,7 +1218,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
 
         // Open canvas editor in new tab for editing
         const canvasUrl = `${shareableOrigin}/chat/canvas/${newCanvasId}`;
-        window.open(canvasUrl, '_blank');
+        openSafeWindow(canvasUrl);
       } catch (error) {
         logger.error(Event.CANVAS_CREATE_FAILED, {
           canvasId: newCanvasId,

--- a/apps/dashboard/src/routes/BrowserTabsScreen/BrowserTabsScreen.tsx
+++ b/apps/dashboard/src/routes/BrowserTabsScreen/BrowserTabsScreen.tsx
@@ -25,6 +25,7 @@ import { logger, Event } from '../../utils/logger';
 import { xyneAIActor } from '../../machines/xyneAIMachine';
 import { BrowserSettingsMenu } from '../../components/BrowserPanel/BrowserSettingsMenu';
 import { usePlatform } from '../../hooks/usePlatform';
+import { openSafeWindow } from '../../utils/safeWindowOpen';
 
 // Define WebviewTag interface locally since Electron types may not be available in renderer
 interface WebviewTag extends HTMLElement {
@@ -491,7 +492,7 @@ export function BrowserTabsScreen({
   const handleOpenExternal = () => {
     if (activeTab?.url) {
       void (
-        window.electronAPI?.openExternal?.(activeTab.url) ?? window.open(activeTab.url, '_blank')
+        window.electronAPI?.openExternal?.(activeTab.url) ?? openSafeWindow(activeTab.url)
       );
     }
   };

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -119,6 +119,7 @@ import { useZero } from '../../hooks/useZero';
 import { useBoardsSlaPolicies } from '../../hooks/useChannelSlaPolicy';
 import { useKanbanCounts } from './useKanbanCounts';
 import { valuesToFilters } from '../../utils/savedViewSerialization';
+import { openSafeWindow } from '../../utils/safeWindowOpen';
 
 type SavedConfigValue = {
   id: string;
@@ -1895,7 +1896,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       if (isDeskChannelType(ticketChannel?.type) && ticket.xyneId) {
         const supportUrl = `/support/${ticket.channelId}/${ticket.xyneId}`;
         if (!isMobile && isCmdClick) {
-          window.open(`${ws ? `/${ws}` : ''}${supportUrl}`, '_blank');
+          openSafeWindow(`${ws ? `/${ws}` : ''}${supportUrl}`);
           return;
         }
         void navigate(supportUrl, {
@@ -1921,7 +1922,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         const relativeUrl = isDeskTicket
           ? supportRoute
           : `/chat/dir/${ticket.channelId}?tab=tickets&ticketId=${ticket.id}&conversationId=${ticket.conversationId}`;
-        window.open(`${ws ? `/${ws}` : ''}${relativeUrl}`, '_blank');
+        openSafeWindow(`${ws ? `/${ws}` : ''}${relativeUrl}`);
         return;
       }
 

--- a/apps/dashboard/src/routes/ReleaseDetailScreen/ReleaseDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ReleaseDetailScreen/ReleaseDetailScreen.tsx
@@ -33,6 +33,7 @@ import {
   downloadCsvFile,
 } from './releaseReport.utils';
 import { usePublishReleaseReport } from './usePublishReleaseReport';
+import { openSafeWindow } from '../../utils/safeWindowOpen';
 
 type TabValue = 'testing' | 'envs' | 'migrations';
 
@@ -324,7 +325,7 @@ const ReleaseDetailScreen = (): ReactElement => {
               <button
                 type='button'
                 onClick={() => {
-                  const w = window.open(window.location.href, '_blank');
+                  const w = openSafeWindow(window.location.href);
                   w?.focus();
                 }}
                 className='shrink-0 p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -240,6 +240,7 @@ import { ScheduleCallModal } from '../../components/Call/ScheduleCallModal/Sched
 import { ThreadCallButton } from '../../components/Call/ThreadCallButton/ThreadCallButton';
 import { WorkspaceDeskEmailCard } from '../../components/xyne-desk/WorkspaceDeskEmailCard/WorkspaceDeskEmailCard';
 import { WorkspaceOzonetelCard } from '../../components/xyne-desk/WorkspaceOzonetelCard/WorkspaceOzonetelCard';
+import { openSafeWindow } from '../../utils/safeWindowOpen';
 
 // Unified type for tickets from the supportTicketsFiltered query
 type SupportTicket = QueryResultType<typeof queries.supportTicketsFilteredV3>[number];
@@ -1797,7 +1798,7 @@ const SupportScreen = (): ReactElement => {
 
       // Only open in new tab on desktop when Cmd/Ctrl+Click is pressed
       if (!isMobile && isCmdClick) {
-        window.open(ticketUrl, '_blank');
+        openSafeWindow(ticketUrl);
         return;
       }
 

--- a/apps/dashboard/src/utils/canvasExport.ts
+++ b/apps/dashboard/src/utils/canvasExport.ts
@@ -1,6 +1,7 @@
 import type { PartialBlock } from '@blocknote/core';
 import DOMPurify from 'dompurify';
 import { blobToBase64, createPreviewUrl } from '../services/clients/fileFetchService';
+import { openSafeWindow } from './safeWindowOpen';
 
 /**
  * Minimal shape of a BlockNote editor instance required to export a canvas.
@@ -315,7 +316,7 @@ export async function exportCanvasAsPDF(
     return window.electronAPI.exportCanvasPdf(filename, html);
   }
 
-  const printWindow = window.open('', '_blank', 'width=900,height=1200');
+  const printWindow = openSafeWindow('', '_blank', 'width=900,height=1200');
   if (!printWindow) {
     throw new Error('Unable to open the print window — please allow pop-ups for this site.');
   }

--- a/apps/dashboard/src/utils/electronApp.ts
+++ b/apps/dashboard/src/utils/electronApp.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react';
 import type { ElectronAPI } from '../types/electron';
 import type { NavigateFunction } from 'react-router-dom';
+import { openSafeWindow } from './safeWindowOpen';
 
 interface ElectronWindow extends Window {
   electronAPI?: ElectronAPI;
@@ -121,7 +122,7 @@ export const standaloneNavigate = (
 
   if (isElectronApp() && isCmdOrCtrlClick && isStandaloneSupportedPath(normalizedPath)) {
     const newWindowPath = toStandalonePath(normalizedPath);
-    const newWindow = window.open(newWindowPath, '_blank');
+    const newWindow = openSafeWindow(newWindowPath);
     if (newWindow) {
       newWindow.focus();
     } else {
@@ -188,10 +189,10 @@ export const openCreateTicketWindow = (draft: CreateTicketPopoutDraft): boolean 
   if (draft.tab) search.set('tab', draft.tab);
 
   const path = toStandalonePath(`/create-ticket?${search.toString()}`);
-  const newWindow = window.open(
+  const newWindow = openSafeWindow(
     path,
     '_blank',
-    isElectronApp() ? '' : 'popup=yes,width=960,height=900',
+    isElectronApp() ? undefined : 'popup=yes,width=960,height=900',
   );
   if (newWindow) {
     newWindow.focus();

--- a/apps/dashboard/src/utils/openLink.ts
+++ b/apps/dashboard/src/utils/openLink.ts
@@ -2,6 +2,7 @@ import { toast } from 'sonner';
 import { isElectronApp } from './electronApp';
 import { detectReactNativeWebView, reactNativeBridge } from './reactNativeBridge';
 import { browserPanelActor } from '../machines/browserPanelMachine';
+import { openSafeWindow } from './safeWindowOpen';
 
 const LINK_OPEN_EXTERNAL_KEY = 'xyne:link-open-external-default';
 const LINK_OPEN_HINT_DISMISSED_KEY = 'xyne:link-open-hint-dismissed';
@@ -73,7 +74,7 @@ const openExternal = (url: string): void => {
   if (detectReactNativeWebView() && reactNativeBridge.isAvailable()) {
     if (reactNativeBridge.openExternalUrl(url)) return;
   }
-  window.open(url, '_blank', 'noopener,noreferrer');
+  openSafeWindow(url);
 };
 
 const openInApp = (url: string): void => {
@@ -86,7 +87,7 @@ const openInApp = (url: string): void => {
     }
     return;
   }
-  window.open(url, '_blank', 'noopener,noreferrer');
+  openSafeWindow(url);
 };
 
 const maybeShowHint = (): void => {

--- a/apps/dashboard/src/utils/safeWindowOpen.ts
+++ b/apps/dashboard/src/utils/safeWindowOpen.ts
@@ -1,0 +1,21 @@
+export const SAFE_WINDOW_OPEN_FEATURES = 'noopener,noreferrer';
+
+const mergeWindowFeatures = (features?: string): string => {
+  const tokens = new Set(
+    features
+      ?.split(',')
+      .map(feature => feature.trim())
+      .filter(Boolean) ?? [],
+  );
+
+  tokens.add('noopener');
+  tokens.add('noreferrer');
+
+  return Array.from(tokens).join(',');
+};
+
+export const openSafeWindow = (
+  url?: string | URL,
+  target = '_blank',
+  features?: string,
+): Window | null => window.open(url, target, mergeWindowFeatures(features));

--- a/apps/dashboard/src/utils/searchNavigation.ts
+++ b/apps/dashboard/src/utils/searchNavigation.ts
@@ -13,6 +13,7 @@ import { browserPanelActor } from '../machines/browserPanelMachine';
 import { xyneAIActor } from '../machines/xyneAIMachine';
 import { isXyneOrigin } from './browserPanelPartition';
 import { toStandalonePath } from './electronApp';
+import { openSafeWindow } from './safeWindowOpen';
 
 /**
  * Channel data interface for navigation
@@ -255,7 +256,7 @@ export const navigateToAttachment = (
 ): void => {
   const attachmentId = result.searchContext?.attachmentId || result.id;
   if (result.searchContext?.originalUrl) {
-    window.open(result.searchContext.originalUrl, '_blank', 'noopener,noreferrer');
+    openSafeWindow(result.searchContext.originalUrl);
   } else if (result.searchContext?.channelId) {
     void navigate(`/chat/dir/${result.searchContext.channelId}`, {
       state: {
@@ -558,7 +559,7 @@ export const openSearchResult = async (
       // Use target.path (no workspace prefix) so it matches /newWindow/chat/dir/:id routes.
       const basePath = target.kind === 'external' ? target.url : target.path;
       const standalonePath = toStandalonePath(basePath);
-      const newWin = window.open(standalonePath, '_blank');
+      const newWin = openSafeWindow(standalonePath);
       newWin?.focus();
     } else {
       // External URLs go to the browser panel.
@@ -575,7 +576,7 @@ export const openSearchResult = async (
 
   // Web: open the regular route in a new browser tab (full app chrome).
   // No theme param needed — same origin = same localStorage = same theme.
-  window.open(url, '_blank', 'noopener,noreferrer');
+  openSafeWindow(url);
 };
 
 /**


### PR DESCRIPTION
Root cause: dashboard had multiple direct window.open(..., '_blank') call sites without centralized noopener,noreferrer protection, e.g. apps/dashboard/src/components/FileViewer/ImageViewer.tsx:87 and apps/dashboard/src/components/Chat/LinksTab/LinksTab.tsx:49 before the fix.

Fix: add apps/dashboard/src/utils/safeWindowOpen.ts and route dashboard external-window openings through openSafeWindow, preserving popup/window features while always adding noopener,noreferrer.

Verification:
- Dashboard tsc passed via `cd /workspace/xyne-spaces/apps/dashboard && npx tsc --noEmit --project tsconfig.app.json`
- Backend tsc passed via `cd /workspace/xyne-spaces/apps/backend && NODE_OPTIONS=--max-old-space-size=4096 npx tsc --noEmit`
- Grep confirmed no remaining dashboard `window.open` call sites lacking `noopener/noreferrer` outside the centralized helper
- POT TC1 PASS with visible features `width=100,height=100,noopener,noreferrer`, evidence `apps/dashboard/src/utils/safeWindowOpen.ts:17`
- Branch push verified by `git ls-remote` showing `f4e3708214044d7de1e99d69e677dfe24130f2a7 refs/heads/fix/centralize-safe-window-open`