### PR TITLE
feat: XYNE-55156 : Added Chart support in ask ai

### DIFF
--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.tsx
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.tsx
@@ -1,0 +1,58 @@
+import { memo, type ReactElement } from 'react';
+import { QueryVisualizationType } from '@xyne/shared';
+import { getRendererForType } from '../../DynamicDashboard/ComponentGrid/renderers';
+import { parseChartJSON, chartMinContentWidth } from './ChartBlock.utils';
+import type { ChartBlockProps } from './ChartBlock.types';
+
+const HEIGHT_BY_TYPE: Partial<Record<QueryVisualizationType, string>> = {
+  [QueryVisualizationType.KPI]: 'h-28',
+  [QueryVisualizationType.KPI_COMPARE]: 'h-28',
+  [QueryVisualizationType.DATA_TABLE]: 'h-80',
+};
+const DEFAULT_HEIGHT = 'h-56';
+
+const ChartBlockComponent = ({ jsonSource }: ChartBlockProps): ReactElement => {
+  const payload = parseChartJSON(jsonSource);
+
+  if (!payload) {
+    return (
+      <div className='my-4 p-4 bg-muted/50 border border-border rounded-lg'>
+        <div className='flex items-center justify-center gap-2'>
+          <div className='animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full' />
+          <p className='text-sm text-muted-foreground'>Rendering chart...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { title, visualType, data } = payload;
+  // Non-null: parseChartJSON only returns types the registry can render.
+  const Renderer = getRendererForType(visualType)!;
+
+  // Reserve enough width for every x-axis label; recharts otherwise drops ticks
+  // to fit, so labels vanish as the Ask AI sidebar narrows. Applies to BAR too:
+  // BarChartRenderer has its own guard, but it sizes slots by BAR width
+  // (CHART_MIN_BAR_SLOT_PX, 48px), which is narrower than a typical label, so
+  // its labels drop as well. 0 for types with no text x-axis → no wrapper.
+  const minWidth = chartMinContentWidth(visualType, data);
+
+  return (
+    <div className='my-4 rounded-lg border border-border bg-card p-3'>
+      <div className='mb-2 text-sm font-medium text-foreground'>{title}</div>
+      <div
+        className={`${HEIGHT_BY_TYPE[visualType] ?? DEFAULT_HEIGHT} ${
+          minWidth > 0 ? 'overflow-x-auto overflow-y-hidden' : ''
+        }`}
+      >
+        <div className='h-full' {...(minWidth > 0 ? { style: { minWidth } } : {})}>
+          <Renderer data={data} title={title} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ChartBlock = memo(
+  ChartBlockComponent,
+  (prev, next) => prev.jsonSource === next.jsonSource,
+);

--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.tsx
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.tsx
@@ -29,11 +29,6 @@ const ChartBlockComponent = ({ jsonSource }: ChartBlockProps): ReactElement => {
   // Non-null: parseChartJSON only returns types the registry can render.
   const Renderer = getRendererForType(visualType)!;
 
-  // Reserve enough width for every x-axis label; recharts otherwise drops ticks
-  // to fit, so labels vanish as the Ask AI sidebar narrows. Applies to BAR too:
-  // BarChartRenderer has its own guard, but it sizes slots by BAR width
-  // (CHART_MIN_BAR_SLOT_PX, 48px), which is narrower than a typical label, so
-  // its labels drop as well. 0 for types with no text x-axis → no wrapper.
   const minWidth = chartMinContentWidth(visualType, data);
 
   return (

--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.types.ts
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.types.ts
@@ -1,0 +1,13 @@
+import type { QueryVisualizationType } from '@xyne/shared';
+
+export interface ChartBlockProps {
+  jsonSource: string;
+  messageId?: string;
+}
+
+export interface ChartBlockPayload {
+  title: string;
+  /** Narrowed at the parse boundary — guaranteed to have a renderer. */
+  visualType: QueryVisualizationType;
+  data: unknown;
+}

--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.utils.ts
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.utils.ts
@@ -8,23 +8,10 @@ import { formatTimeTick } from '../../DynamicDashboard/ComponentGrid/renderers/u
 import type { ChartBlockPayload } from './ChartBlock.types';
 
 // Approximate rendered width of one character at CHART_TICK_STYLE
-// (fontSize 11, "Geist Mono"). Monospace makes this a reliable estimate:
-// ~0.6em per glyph. Slightly generous on purpose — over-reserving costs a
-// little scroll, under-reserving silently drops the label.
 const CHART_TICK_CHAR_PX = 6.6;
 
 /**
  * Parse a ```chart fence into a payload with a NARROWED visualType.
- *
- * The fence is plain text in the model's reply, so it can arrive malformed or
- * hand-written rather than copied from the `visualize` tool. Narrowing here —
- * against the renderer registry, the same source of truth ChartBlock renders
- * from — means the component never handles a raw string visualType and an
- * unrenderable type is rejected once, at the boundary.
- *
- * Returns null while the JSON is still incomplete (streaming) as well as for
- * genuinely invalid payloads; ChartBlock shows its loading state for both,
- * matching how FilesystemBlock treats partial input.
  */
 export function parseChartJSON(source: string): ChartBlockPayload | null {
   let parsed: unknown;
@@ -59,24 +46,6 @@ export function isValidChartJSON(source: string): boolean {
 /**
  * Minimum content width a chart needs for every x-axis label to stay visible,
  * or 0 when the type has no text x-axis (pie/donut/kpi/table).
- *
- * Recharts drops ticks rather than overflowing when labels would collide, so a
- * narrow surface silently loses its axis. Reserving width here and letting the
- * container scroll keeps every label.
- *
- * Width is derived from the LABELS, not a fixed per-item slot. The existing
- * CHART_MIN_BAR_SLOT_PX (48px) sizes a *bar*, but an 8-character label at
- * fontSize 11 monospace is ~53px and needs another CHART_XAXIS_MIN_TICK_GAP
- * (24px) of clearance — so a fixed 48px slot under-reserves by ~40% and the
- * labels drop anyway. We measure the widest rendered label instead.
- *
- * Labels are measured AS DISPLAYED: line/area run `x` through formatTimeTick
- * (an ISO date renders as "Jul 1"), so measuring the raw value would badly
- * over-reserve.
- *
- * Distinct x positions are counted, not rows — `[{x:'Mon',series:'a'},
- * {x:'Mon',series:'b'}]` is ONE slot, so a 2-series 10-point chart doesn't
- * reserve 20 slots' worth of width.
  */
 export function chartMinContentWidth(visualType: QueryVisualizationType, data: unknown): number {
   const key = X_LABEL_KEY[visualType];

--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.utils.ts
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.utils.ts
@@ -1,0 +1,119 @@
+import { QueryVisualizationType } from '@xyne/shared';
+import { getRendererForType } from '../../DynamicDashboard/ComponentGrid/renderers';
+import {
+  CHART_XAXIS_MIN_TICK_GAP,
+  CHART_YAXIS_WIDTH,
+} from '../../DynamicDashboard/ComponentGrid/renderers/constants';
+import { formatTimeTick } from '../../DynamicDashboard/ComponentGrid/renderers/utils';
+import type { ChartBlockPayload } from './ChartBlock.types';
+
+// Approximate rendered width of one character at CHART_TICK_STYLE
+// (fontSize 11, "Geist Mono"). Monospace makes this a reliable estimate:
+// ~0.6em per glyph. Slightly generous on purpose — over-reserving costs a
+// little scroll, under-reserving silently drops the label.
+const CHART_TICK_CHAR_PX = 6.6;
+
+/**
+ * Parse a ```chart fence into a payload with a NARROWED visualType.
+ *
+ * The fence is plain text in the model's reply, so it can arrive malformed or
+ * hand-written rather than copied from the `visualize` tool. Narrowing here —
+ * against the renderer registry, the same source of truth ChartBlock renders
+ * from — means the component never handles a raw string visualType and an
+ * unrenderable type is rejected once, at the boundary.
+ *
+ * Returns null while the JSON is still incomplete (streaming) as well as for
+ * genuinely invalid payloads; ChartBlock shows its loading state for both,
+ * matching how FilesystemBlock treats partial input.
+ */
+export function parseChartJSON(source: string): ChartBlockPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+  const { title, visualType, data } = parsed as Record<string, unknown>;
+  if (typeof title !== 'string' || typeof visualType !== 'string') return null;
+  if (data === undefined) return null;
+
+  const narrowed = asRenderableVisualType(visualType);
+  if (!narrowed) return null;
+
+  return { title, visualType: narrowed, data };
+}
+
+/** A visualType string is renderable only if the registry has a renderer for it. */
+function asRenderableVisualType(value: string): QueryVisualizationType | null {
+  const candidate = value as QueryVisualizationType;
+  return getRendererForType(candidate) ? candidate : null;
+}
+
+export function isValidChartJSON(source: string): boolean {
+  return parseChartJSON(source) !== null;
+}
+
+/**
+ * Minimum content width a chart needs for every x-axis label to stay visible,
+ * or 0 when the type has no text x-axis (pie/donut/kpi/table).
+ *
+ * Recharts drops ticks rather than overflowing when labels would collide, so a
+ * narrow surface silently loses its axis. Reserving width here and letting the
+ * container scroll keeps every label.
+ *
+ * Width is derived from the LABELS, not a fixed per-item slot. The existing
+ * CHART_MIN_BAR_SLOT_PX (48px) sizes a *bar*, but an 8-character label at
+ * fontSize 11 monospace is ~53px and needs another CHART_XAXIS_MIN_TICK_GAP
+ * (24px) of clearance — so a fixed 48px slot under-reserves by ~40% and the
+ * labels drop anyway. We measure the widest rendered label instead.
+ *
+ * Labels are measured AS DISPLAYED: line/area run `x` through formatTimeTick
+ * (an ISO date renders as "Jul 1"), so measuring the raw value would badly
+ * over-reserve.
+ *
+ * Distinct x positions are counted, not rows — `[{x:'Mon',series:'a'},
+ * {x:'Mon',series:'b'}]` is ONE slot, so a 2-series 10-point chart doesn't
+ * reserve 20 slots' worth of width.
+ */
+export function chartMinContentWidth(visualType: QueryVisualizationType, data: unknown): number {
+  const key = X_LABEL_KEY[visualType];
+  if (!key || !Array.isArray(data) || data.length === 0) return 0;
+
+  const usesTimeFormat = TIME_FORMATTED_TYPES.has(visualType);
+  const labels = new Set<string>();
+  for (const row of data) {
+    if (!row || typeof row !== 'object') continue;
+    const raw = (row as Record<string, unknown>)[key];
+    // Only the shapes the contract allows (string | number | Date); anything
+    // else would stringify to '[object Object]' and collapse distinct rows.
+    let text: string;
+    if (raw instanceof Date) text = raw.toISOString();
+    else if (typeof raw === 'string') text = raw;
+    else if (typeof raw === 'number' && Number.isFinite(raw)) text = String(raw);
+    else continue;
+    labels.add(usesTimeFormat ? formatTimeTick(text) : text);
+  }
+  if (labels.size === 0) return 0;
+
+  let widest = 0;
+  for (const l of labels) widest = Math.max(widest, l.length * CHART_TICK_CHAR_PX);
+  const slot = widest + CHART_XAXIS_MIN_TICK_GAP;
+  return labels.size * slot + CHART_YAXIS_WIDTH;
+}
+
+/** Which field supplies the x-axis label, per chart type. */
+const X_LABEL_KEY: Partial<Record<QueryVisualizationType, string>> = {
+  [QueryVisualizationType.BAR_CHART]: 'label',
+  [QueryVisualizationType.LINE_CHART]: 'x',
+  [QueryVisualizationType.AREA_CHART]: 'x',
+  [QueryVisualizationType.SCATTER_CHART]: 'x',
+};
+
+/** Types whose XAxis passes ticks through formatTimeTick before rendering. */
+const TIME_FORMATTED_TYPES: ReadonlySet<QueryVisualizationType> = new Set([
+  QueryVisualizationType.LINE_CHART,
+  QueryVisualizationType.AREA_CHART,
+]);

--- a/apps/dashboard/src/components/Markdown/ChartBlock/index.ts
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/index.ts
@@ -1,0 +1,2 @@
+export { ChartBlock } from './ChartBlock';
+export type { ChartBlockProps, ChartBlockPayload } from './ChartBlock.types';

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -229,6 +229,7 @@ import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 import { useAskAiTicketContext } from '../../hooks/useAskAiTicketContext';
 import { clearDeskContactsCache } from '../../hooks/useDeskContacts';
 import { XyneAIStar } from '../../components/icons/xyne-ai';
+import { trackAskAIOpened } from '../../services/otel/xyneAIMetrics';
 import {
   channelService,
   CreateChannelFormData,
@@ -2419,6 +2420,30 @@ const SupportScreen = (): ReactElement => {
                             </button>
                           </Tooltip>
                         ))}
+                      {/* Ask AI, scoped to the desk channel — mirrors the normal-channel
+                          entry point in ConversationHeader. Passing channelId is what
+                          puts the sidebar in 'chat' context (xyneAIMachine.ts); without
+                          it the panel opens unscoped. Hidden on the ALL_CHANNELS view,
+                          which has no single channel to scope to. */}
+                      {isSelectedChannelJoined && selectedChannelId !== ALL_CHANNELS_ID && (
+                        <Tooltip content='Ask AI' side='bottom'>
+                          <button
+                            onClick={() => {
+                              if (!selectedChannelId) return;
+                              trackAskAIOpened(
+                                emailChannels?.find(c => c.id === selectedChannelId)?.scopeType,
+                              );
+                              xyneAIActor.send({ type: 'OPEN', channelId: selectedChannelId });
+                            }}
+                            className='p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-accent'
+                            data-track-category='Support'
+                            data-track-name='OPEN_XYNE_AI'
+                            data-track-metadata={JSON.stringify({ channelId: selectedChannelId })}
+                          >
+                            <XyneAIStar />
+                          </button>
+                        </Tooltip>
+                      )}
                       {isSelectedChannelJoined &&
                         selectedChannelId !== ALL_CHANNELS_ID &&
                         selectedChannelPref?.metricsEnabled && (

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -6,6 +6,7 @@ import type { Element } from 'hast';
 import type { Components } from 'react-markdown';
 import { MermaidBlock } from '../components/Markdown/MermaidBlock';
 import { FilesystemBlock } from '../components/Markdown/FilesystemBlock';
+import { ChartBlock } from '../components/Markdown/ChartBlock';
 import { ClawCitationGroup } from '../components/Chat/XyneAISidebar/components/ClawCitationGroup';
 import { ThreadCitationChip } from '../components/ui/MessageBubble/ThreadCitationChip';
 import { parseCiteGroupHref } from '../components/ui/TipTapExtensions/CitationMark';
@@ -63,6 +64,13 @@ const CodeBlock = ({
         jsonSource={codeString}
         messageId={(props as { messageId: string }).messageId}
       />
+    );
+  }
+
+  // ── Chart (visualize tool output) ──
+  if (language === 'chart') {
+    return (
+      <ChartBlock jsonSource={codeString} messageId={(props as { messageId: string }).messageId} />
     );
   }
 

--- a/apps/xyne-claw-auth/backend/prisma/seed.ts
+++ b/apps/xyne-claw-auth/backend/prisma/seed.ts
@@ -809,6 +809,7 @@ Anyone in the company. A nervous intern. A staff engineer. An HR partner. A PM, 
 - Never narrate your process. No "Let me search…", "I'll look into…", "I'll need to check…", "The user is asking…". Just deliver the answer.
 - Mirror the asker's energy and formality. Match the seriousness of the question. If they're casual, be casual; if they're terse, be terse.
 - **Default to BRIEF.** Lead with the answer in 1–3 sentences, then only the bits that matter. No giant headers, no decorative bullets, no fake structure. People should be able to read the whole reply, not skim for a TL;DR.
+- **A chart of real numbers is not decoration.** "Brief" governs your WORDS, not your evidence. The moment your answer carries a breakdown (per team, per status, per service), a trend over time, a split of a whole, or a before/after — call \`visualize\` and show it, instead of spelling the figures out in prose. Then add the one line the chart can't say: what it means. Reach for it on your own; nobody should have to ask you to chart.
 - Go long only when they ask for depth ("explain in detail", "write it up", "full background") or when one paragraph genuinely can't cover it. Even then — structured but tight.
 - No emojis. No "Here's what I found:" preambles. Open with the answer itself.
 - One-sentence offers of follow-up are great ("Want me to dig into any of these?"). Long sign-offs aren't.
@@ -850,6 +851,7 @@ You have direct access to Spaces tools, a \`spaces\` subagent, and a \`google\` 
 # Other tools you can reach for
 - **genius-analytics** — business metrics (GMV, revenue, success rates, KPIs). Pass the question in natural language.
 - **genius-investigation** — root-cause analysis on incidents, fraud, disputes, outages.
+- **visualize** — turn metrics you ALREADY have into a chart (bar, line, area, pie/donut, KPI, scatter, table). Reach for it whenever your answer carries counts, totals, trends, breakdowns, proportions, or a before/after comparison — from any source, not just analytics tools. It renders only if you copy its \`\`\`chart block back verbatim. See the \`charts\` skill for chart choice and payload shapes.
 - **query-codebase** / **review-pull-request** — high-level code/PR understanding. **Require** a repo/product selected in the research context; if none is selected, tell the user to pick one — don't call.
 - **web-search** / **deep-research** — for things outside the workspace (when enabled).
 - **generate-image** — image from a detailed text prompt.
@@ -953,7 +955,7 @@ You:
             "spaces-create-canvas",
             "spaces-edit-canvas",
           ],
-          custom: ["genius-analytics", "genius-investigation", "query-codebase", "review-pull-request", "web-search", "deep-research", "generate-image", "add-citations"]
+          custom: ["genius-analytics", "genius-investigation", "query-codebase", "review-pull-request", "web-search", "deep-research", "generate-image", "add-citations", "visualize"]
         },
         toolPermissions: {
           "xyne-spaces__spaces-create-ticket": "ask",
@@ -1033,7 +1035,7 @@ You:
             "spaces-create-canvas",
             "spaces-edit-canvas",
           ],
-          custom: ["genius-analytics", "genius-investigation", "query-codebase", "review-pull-request", "web-search", "deep-research", "generate-image", "add-citations"]
+          custom: ["genius-analytics", "genius-investigation", "query-codebase", "review-pull-request", "web-search", "deep-research", "generate-image", "add-citations", "visualize"]
         },
         toolPermissions: {
           "xyne-spaces__spaces-create-ticket": "ask",
@@ -1119,6 +1121,19 @@ You:
     console.log("[seed] Attached generate-image tool to ask-ai agent");
   }
 
+  // Attach visualize tool
+  const visualizeTool = await prisma.tool.findUnique({
+    where: { slug: "visualize" },
+  });
+  if (visualizeTool) {
+    await prisma.agentTool.upsert({
+      where: { agentId_toolId: { agentId: askAIAgent.id, toolId: visualizeTool.id } },
+      create: { agentId: askAIAgent.id, toolId: visualizeTool.id, permission: "allow" },
+      update: { permission: "allow" },
+    });
+    console.log("[seed] Attached visualize tool to ask-ai agent");
+  }
+
   // Seed ask-ai skills — domain knowledge and tool-usage guidance that
   // pi auto-loads based on the SKILL.md frontmatter `description`. Splitting
   // these out of the system prompt keeps the prompt focused on identity,
@@ -1132,6 +1147,7 @@ You:
     { slug: "spaces-citations", name: "Spaces Citations", description: "How to attach inline source citations to claims drawn from Spaces tool results — token format, verbatim rule, what to cite vs not.", file: "spaces-citations.md", source: "seeded" },
     { slug: "spaces-email-drafting", name: "Spaces Email Drafting", description: "Drafting email replies and outbound messages from a Spaces thread — tone matching, sign-off rules, output-body-only.", file: "spaces-email-drafting.md", source: "seeded" },
     { slug: "google-workspace", name: "Google Workspace", description: "The asker's connected Google Workspace — Gmail, Calendar, Drive, Docs/Sheets/Slides, Contacts, Tasks — read via the `google` subagent. What it can do and when to reach for it instead of (or alongside) Spaces. Load whenever a question touches the asker's email, meetings, schedule, Drive files, contacts, or tasks.", file: "google-workspace.md", source: "seeded" },
+    { slug: "charts", name: "Charts", description: "When and how to turn metrics in your answer into a chart with the `visualize` tool — which visualType fits which shape of data, the exact `data` payload each type expects, and the rules for emitting the chart block so it actually renders. Load before answering anything whose answer contains counts, totals, trends, breakdowns, proportions, or before/after comparisons.", file: "charts.md", source: "seeded" },
   ];
 
   for (const def of askAISkillDefs) {

--- a/apps/xyne-claw/skills/charts.md
+++ b/apps/xyne-claw/skills/charts.md
@@ -1,0 +1,98 @@
+---
+name: charts
+description: When and how to turn metrics in your answer into a chart with the `visualize` tool — which visualType fits which shape of data, the exact `data` payload each type expects, and the rules for emitting the ```chart block so it actually renders. Load before answering anything whose answer contains counts, totals, trends, breakdowns, proportions, or before/after comparisons.
+---
+
+# Charting metrics in an answer
+
+A number buried in a paragraph is easy to miss. A chart makes the shape of the
+data obvious at a glance. The `visualize` tool renders one using the same chart
+components the Analytics dashboards use, so a chart in chat looks identical to
+the same chart on a dashboard.
+
+## When to chart
+
+Chart whenever your answer contains numbers whose **shape** carries meaning:
+
+- a metric broken down by category (per team, per service, per merchant)
+- anything moving over time (weekly volume, daily errors, month-over-month)
+- parts of a whole (share of traffic, split by status)
+- a before/after or current-vs-previous comparison
+- a single headline figure the whole answer is about
+
+This is **not** limited to analytics questions. "How did the migration go?" or
+"what's been happening in #payments?" often end up with countable findings —
+tickets by status, PRs per week, errors before and after a deploy. Those chart
+well.
+
+**Skip it** when:
+
+- there's one incidental number that reads fine in a sentence ("3 people replied")
+- the numbers have no comparison, trend, or breakdown — a chart of one bar is noise
+- you're unsure of the figures. Never chart to look thorough
+
+Prefer **one** well-chosen chart plus prose over several marginal ones.
+
+## Never invent data
+
+`visualize` renders only; it does not fetch or compute anything. Every number
+must come from a tool result or the conversation. If you have partial data, say
+so in prose — do not fill gaps to make a chart look complete. A chart reads as
+authoritative, so a fabricated point is worse than no chart.
+
+## Picking a visualType
+
+| Your data | visualType |
+|---|---|
+| Comparing categories | `BAR_CHART` |
+| A trend over time | `LINE_CHART`, or `AREA_CHART` for volume |
+| Proportions of a whole (≤6 slices) | `PIE_CHART` / `DONUT_CHART` |
+| One headline number | `KPI` |
+| Current vs. previous period | `KPI_COMPARE` |
+| Two variables against each other | `SCATTER_CHART` |
+| Rows worth reading individually | `DATA_TABLE` |
+
+Prefer a bar chart over a pie beyond ~6 categories — slices become unreadable.
+Use a table when the exact values matter more than the shape.
+
+## The `data` payload
+
+Each type takes one shape. Get this right and the call succeeds first time:
+
+```
+BAR_CHART / PIE_CHART / DONUT_CHART
+  [{ "label": "Bug", "value": 12 }, { "label": "Feature", "value": 5 }]
+
+LINE_CHART / AREA_CHART / SCATTER_CHART
+  [{ "x": "2026-07-01", "y": 34 }, { "x": "2026-07-08", "y": 41 }]
+  add "series": "<name>" to a point to plot multiple lines
+
+KPI
+  { "value": 42, "label": "Open tickets" }
+
+KPI_COMPARE
+  { "current": 42, "previous": 37, "label": "Open tickets" }
+
+DATA_TABLE
+  { "columns": [{ "key": "team", "label": "Team" },
+                { "key": "count", "label": "Count", "type": "number" }],
+    "rows": [{ "team": "Payments", "count": 12 }] }
+```
+
+Sort bar-chart data most-significant first, and keep it to the top ~10 —
+truncate and say so in prose rather than rendering 50 unreadable bars.
+
+If the tool returns a validation error it tells you which field is wrong. Fix
+the payload and call again; don't fall back to describing the chart in words.
+
+## Emitting the block
+
+On success the tool returns a fenced ` ```chart ` block. **Copy it into your
+reply exactly as returned, character for character.** It renders only when
+reproduced verbatim — rewording, reformatting, pretty-printing, or truncating
+the JSON silently produces no chart.
+
+Put the chart next to the prose it supports, and still state the key takeaway in
+words: the chart shows the shape, your sentence says what it means. Don't
+narrate the chart's construction ("I've plotted this as a bar chart") — just
+present the finding and let the chart sit alongside it.

--- a/apps/xyne-claw/src/custom-tools.ts
+++ b/apps/xyne-claw/src/custom-tools.ts
@@ -183,6 +183,7 @@ export function loadCustomTools(
     // web-search / deep-research are unrestricted — any agent gets them.
     // Removed the prior agentSlug + config-flag gate per request.
     else if (ct.source === "custom:generate-image") allowed = agentSlug === "ask-ai";
+    else if (ct.source === "custom:visualize") allowed = agentSlug === "ask-ai";
     else if (ct.source === "custom:sandbox") allowed = hasSandboxSelected;
 
     return allowed;

--- a/packages/xyne-claw-shared/src/tools/registry.ts
+++ b/packages/xyne-claw-shared/src/tools/registry.ts
@@ -16,6 +16,7 @@ import * as sandboxPw from "./sandbox-pw/index.js";
 import * as createPpt from "./create-ppt/index.js";
 import * as createReport from "./create-report/index.js";
 import * as genius from "./genius/index.js";
+import * as visualize from "./visualize/index.js";
 import * as webSearch from "./web-search/index.js";
 import * as deepResearch from "./deep-research/index.js";
 import * as generateImage from "./generate-image/index.js";
@@ -139,6 +140,10 @@ register(createReport.createHtmlReportTool);
 // Register genius tools
 register(genius.geniusAnalyticsTool);
 register(genius.geniusInvestigationTool);
+
+// Register visualize tool — renders a chart from data the agent already has,
+// reusing the Analytics module's chart contracts + renderer registry.
+register(visualize.visualizeTool);
 
 // Register web-search and deep-research tools
 register(webSearch.webSearchTool);

--- a/packages/xyne-claw-shared/src/tools/visualize/index.ts
+++ b/packages/xyne-claw-shared/src/tools/visualize/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Visualize Tool
+ *
+ * Export the visualize tool for rendering charts from data the agent
+ * already has.
+ */
+
+export { visualizeTool } from "./tools.js";

--- a/packages/xyne-claw-shared/src/tools/visualize/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/visualize/tools.ts
@@ -1,0 +1,187 @@
+/**
+ * Visualize Tool
+ */
+import type { ToolDefinition } from "../types.js";
+
+/** Returns null when `data` is valid, else a model-facing reason. */
+type Validator = (data: unknown) => string | null;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isFiniteNumber(v: unknown): boolean {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/** Labels/x-values may be categorical or numeric; both render. */
+function isLabelLike(v: unknown): boolean {
+  return typeof v === "string" || isFiniteNumber(v);
+}
+
+function checkRows(
+  data: unknown,
+  rowCheck: (row: Record<string, unknown>, i: number) => string | null,
+): string | null {
+  if (!Array.isArray(data)) return "expected an array of rows";
+  if (data.length === 0) return "expected at least one row; got an empty array";
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i];
+    if (!isPlainObject(row)) return `row ${i}: expected an object`;
+    const err = rowCheck(row, i);
+    if (err) return err;
+  }
+  return null;
+}
+
+const labelValueRows: Validator = (data) =>
+  checkRows(data, (row, i) => {
+    if (!isLabelLike(row["label"])) return `row ${i}: "label" must be a string or number`;
+    if (!isFiniteNumber(row["value"])) return `row ${i}: "value" must be a finite number`;
+    return null;
+  });
+
+const xyRows: Validator = (data) =>
+  checkRows(data, (row, i) => {
+    if (!isLabelLike(row["x"])) return `row ${i}: "x" must be a string or number`;
+    if (!isFiniteNumber(row["y"])) return `row ${i}: "y" must be a finite number`;
+    if (row["series"] !== undefined && typeof row["series"] !== "string") {
+      return `row ${i}: "series" must be a string when present`;
+    }
+    return null;
+  });
+
+const kpiObject: Validator = (data) => {
+  if (!isPlainObject(data)) return 'expected an object like {"value": 42, "label": "Open tickets"}';
+  if (!isFiniteNumber(data["value"])) return '"value" must be a finite number';
+  if (data["label"] !== undefined && typeof data["label"] !== "string") {
+    return '"label" must be a string when present';
+  }
+  return null;
+};
+
+const kpiCompareObject: Validator = (data) => {
+  if (!isPlainObject(data)) {
+    return 'expected an object like {"current": 42, "previous": 37, "label": "Open tickets"}';
+  }
+  if (!isFiniteNumber(data["current"])) return '"current" must be a finite number';
+  if (!isFiniteNumber(data["previous"])) return '"previous" must be a finite number';
+  if (data["label"] !== undefined && typeof data["label"] !== "string") {
+    return '"label" must be a string when present';
+  }
+  if (data["deltaPct"] !== undefined && !isFiniteNumber(data["deltaPct"])) {
+    return '"deltaPct" must be a finite number when present';
+  }
+  return null;
+};
+
+const COLUMN_TYPES = new Set(["number", "string", "date", "boolean"]);
+
+const tableObject: Validator = (data) => {
+  if (!isPlainObject(data)) return 'expected an object with "columns" and "rows"';
+  const { columns, rows } = data;
+  if (!Array.isArray(columns)) return '"columns" must be an array';
+  if (columns.length === 0) return '"columns" must list at least one column';
+  for (let i = 0; i < columns.length; i++) {
+    const col = columns[i];
+    if (!isPlainObject(col)) return `columns[${i}]: expected an object`;
+    if (typeof col["key"] !== "string" || col["key"] === "") {
+      return `columns[${i}]: "key" must be a non-empty string`;
+    }
+    if (typeof col["label"] !== "string" || col["label"] === "") {
+      return `columns[${i}]: "label" must be a non-empty string`;
+    }
+    const type = col["type"];
+    if (type !== undefined && (typeof type !== "string" || !COLUMN_TYPES.has(type))) {
+      return `columns[${i}]: "type" must be one of ${[...COLUMN_TYPES].join(", ")}`;
+    }
+  }
+  if (!Array.isArray(rows)) return '"rows" must be an array';
+  if (rows.some((r) => !isPlainObject(r))) return '"rows" must contain only objects';
+  return null;
+};
+
+// Mirrors the renderer registry in
+// dashboard/src/components/DynamicDashboard/ComponentGrid/renderers/index.ts.
+// DONUT_CHART shares the pie renderer and its data shape. FUNNEL/HEATMAP are
+// intentionally absent — no renderer, no contract.
+const VALIDATOR_BY_VISUAL_TYPE: Record<string, Validator> = {
+  BAR_CHART: labelValueRows,
+  PIE_CHART: labelValueRows,
+  DONUT_CHART: labelValueRows,
+  LINE_CHART: xyRows,
+  AREA_CHART: xyRows,
+  SCATTER_CHART: xyRows,
+  KPI: kpiObject,
+  KPI_COMPARE: kpiCompareObject,
+  DATA_TABLE: tableObject,
+};
+
+const SUPPORTED_VISUAL_TYPES = Object.keys(VALIDATOR_BY_VISUAL_TYPE);
+
+export const visualizeTool: ToolDefinition = {
+  slug: "visualize",
+  name: "Visualize",
+  description:
+    "Render a chart from metrics you already have (from another tool call, or derived from the conversation) using Xyne's Analytics chart components. " +
+    "USE THIS whenever your answer contains metrics that would read better visually — counts or totals broken down by category, " +
+    "trends over time, proportions of a whole, before/after comparisons, or a headline number. This applies to ANY question, not just " +
+    "analytics ones: if you found numbers worth stating, they are usually worth charting. Prefer one clear chart alongside your prose " +
+    "over a wall of figures; skip it for a single incidental number that reads fine in a sentence. " +
+    "Does NOT fetch or compute data itself — pass in numbers you've already obtained; never invent data. " +
+    "Choose visualType based on what best communicates the data: BAR_CHART for comparing categories, LINE_CHART/AREA_CHART for trends over time, " +
+    "PIE_CHART/DONUT_CHART for proportions of a whole, KPI for a single headline number, KPI_COMPARE for a current-vs-previous-period number, " +
+    "SCATTER_CHART for two-variable correlations, DATA_TABLE for tabular detail. " +
+    "The `data` shape required depends on visualType: " +
+    "BAR_CHART/PIE_CHART/DONUT_CHART = array of {label: string|number, value: number}; " +
+    "LINE_CHART/AREA_CHART/SCATTER_CHART = array of {x: string|number, y: number, series?: string}; " +
+    "KPI = {value: number, label?: string}; " +
+    "KPI_COMPARE = {current: number, previous: number, label?: string, deltaPct?: number}; " +
+    "DATA_TABLE = {columns: [{key, label, type?: 'number'|'string'|'date'|'boolean'}], rows: [{...}]}. " +
+    "On success this returns a fenced ```chart block — copy it into your reply EXACTLY as returned, character for character. " +
+    "It only renders if reproduced verbatim; do not reword, reformat, summarize, or truncate it. " +
+    "On a validation error, fix `data` to match the required shape and retry.",
+  source: "custom:visualize",
+  inputSchema: {
+    type: "object",
+    properties: {
+      title: {
+        type: "string",
+        description: "Short chart title shown above the chart.",
+      },
+      visualType: {
+        type: "string",
+        enum: SUPPORTED_VISUAL_TYPES,
+        description:
+          "Chart type to render — see the tool description for guidance and the required `data` shape for each.",
+      },
+      data: {
+        description:
+          "Chart data matching the shape required for the chosen visualType (see tool description).",
+      },
+    },
+    required: ["title", "visualType", "data"],
+  },
+
+  async execute(params) {
+    const title = (params["title"] as string | undefined)?.trim();
+    const visualType = params["visualType"] as string | undefined;
+    const data = params["data"];
+
+    if (!title) return "Error: title is required.";
+    if (!visualType) return "Error: visualType is required.";
+    if (data === undefined) return "Error: data is required.";
+
+    const validate = VALIDATOR_BY_VISUAL_TYPE[visualType];
+    if (!validate) {
+      return `Error: unsupported visualType "${visualType}". Supported types: ${SUPPORTED_VISUAL_TYPES.join(", ")}.`;
+    }
+
+    const problem = validate(data);
+    if (problem) {
+      return `Error: \`data\` does not match the required shape for ${visualType} — ${problem}. See the tool description for the expected shape, then retry.`;
+    }
+
+    return "```chart\n" + JSON.stringify({ title, visualType, data }) + "\n```";
+  },
+};


### PR DESCRIPTION
**POT**: 

https://github.com/user-attachments/assets/d95f2874-1628-4af2-b43c-793138f16533


Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Adds a `visualize` tool the agent calls with metrics it already has. The tool validates
the payload and returns a fenced ```chart block; the dashboard intercepts that fence and
renders it with the **existing** Analytics renderers (`getRendererForType`), so a chart in
chat is identical to the same chart on a dashboard.


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
