### PR TITLE
fix: XYNE-55192 ask ai recording context fixes

### DIFF
--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -78,6 +78,7 @@ import {
   type ThreadInfo,
   type CanvasInfo,
   type XyneAIContext,
+  type AskAIInitialContextSelections,
   type SelectionInfo,
   flattenCanvasContexts,
 } from '../../../machines/xyneAIMachine';
@@ -107,6 +108,10 @@ interface XyneAISidebarProps {
   threadInfo?: ThreadInfo | null;
   startFreshChat?: boolean;
   canvasInfo?: CanvasInfo | null;
+  /** Context supplied by the surface that opened this Ask AI conversation. */
+  initialContextSelections?: AskAIInitialContextSelections | null;
+  /** Re-applies the supplied context on every explicit Ask AI open. */
+  contextOpenNonce?: number;
   variant?: 'sidebar' | 'fullscreen';
   onClose?: () => void;
   onDebuggerOpenChange?: (open: boolean) => void;
@@ -135,6 +140,8 @@ const XyneAISidebar = ({
   channelId,
   threadInfo,
   canvasInfo,
+  initialContextSelections,
+  contextOpenNonce,
   startFreshChat = false,
   variant = 'sidebar',
   onClose,
@@ -264,6 +271,15 @@ const XyneAISidebar = ({
     timestamp: number;
   } | null>(null);
   const [activeSelectionInfos, setActiveSelectionInfos] = useState<SelectionInfo[]>([]);
+
+  // A recording page already knows the exact call and notes canvas that should
+  // scope the conversation. Seed the normal picker state so its visible pills
+  // and the request payload use the same source of truth.
+  useEffect(() => {
+    if (!initialContextSelections) return;
+    setSelectedCanvases(initialContextSelections.canvases);
+    setSelectedRecordings(initialContextSelections.recordings);
+  }, [initialContextSelections, contextOpenNonce]);
   // Track the original channel where the current conversation was started
   // This prevents duplicate history entries when user switches channels during a query
   const [conversationChannelId, setConversationChannelId] = useState<string | null>(null);

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPickerPanel.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPickerPanel.tsx
@@ -108,6 +108,7 @@ export function toAttachedContext(selections: ContextSelections): AttachedContex
       type: 'call',
       id: transcript.id,
       title: transcript.title,
+      ...(transcript.conversationId ? { threadId: transcript.conversationId } : {}),
     });
   }
 
@@ -116,6 +117,7 @@ export function toAttachedContext(selections: ContextSelections): AttachedContex
       type: 'call',
       id: recording.id,
       title: recording.title,
+      ...(recording.conversationId ? { threadId: recording.conversationId } : {}),
     });
   }
 
@@ -127,7 +129,7 @@ import { toast } from 'sonner';
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const MAX_CHANNELS = 5;
-const MAX_CONTEXT_ITEMS = 5;
+const MAX_CONTEXT_ITEMS = 20;
 
 const ENABLED_TABS: TabType[] = [
   TabType.CHANNELS,

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
@@ -1591,8 +1591,8 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
           selectedCanvases.length +
           selectedTranscripts.length +
           selectedRecordings.length;
-        if (nonChannelCount >= 5) {
-          toast.error('Maximum 5 context items can be selected', { duration: 2000 });
+        if (nonChannelCount >= 20) {
+          toast.error('Maximum 20 context items can be selected', { duration: 2000 });
           return null;
         }
         return [...list, make()];

--- a/apps/dashboard/src/machines/xyneAIMachine.ts
+++ b/apps/dashboard/src/machines/xyneAIMachine.ts
@@ -57,6 +57,23 @@ export interface CanvasSelectionContext {
   selections: SelectionInfo[];
 }
 
+/**
+ * Context pills to seed when Ask AI is opened from a surface that already knows
+ * exactly which records the question is about. Keeping this in the machine
+ * means the global sidebar, rather than an ad-hoc query string, owns the same
+ * context that it sends to the Claw API.
+ */
+export interface AskAIInitialContextSelections {
+  canvases: Array<{ id: string; title: string; canvasId?: string }>;
+  recordings: Array<{
+    id: string;
+    title: string;
+    channelId?: string;
+    conversationId?: string;
+    externalId?: string;
+  }>;
+}
+
 // Context interface for the XyneAI machine
 export interface XyneAIContext {
   xyneAIState: XyneAIState;
@@ -72,6 +89,10 @@ export interface XyneAIContext {
   canvasInfo: CanvasInfo | null;
   // Canvas selection context - groups canvas with its selections
   canvasContexts: CanvasSelectionContext[];
+  /** Context pills supplied by the surface that opened Ask AI. */
+  initialContextSelections: AskAIInitialContextSelections | null;
+  /** Re-seeds context even when a user clicks Ask AI on the same item twice. */
+  contextOpenNonce: number;
   /** Session to focus when opening from a background completion toast */
   focusSessionId: string | null;
   // Knowledge Base context
@@ -104,6 +125,7 @@ export type XyneAIEvent =
       kbChannelId?: string | null;
       kbDocId?: string | null;
       kbDocName?: string | null;
+      initialContextSelections?: AskAIInitialContextSelections | null;
     }
   | { type: 'CLOSE' }
   | { type: 'SET_FOCUS_SESSION'; sessionId: string | null }
@@ -426,6 +448,11 @@ export const xyneAIMachine = setup({
           startFreshChat,
           canvasInfo: event.canvasInfo ?? null,
           canvasContexts: newCanvasContexts,
+          initialContextSelections: event.initialContextSelections ?? null,
+          contextOpenNonce:
+            event.initialContextSelections !== undefined
+              ? context.contextOpenNonce + 1
+              : context.contextOpenNonce,
           focusSessionId:
             'focusSessionId' in event && event.focusSessionId !== undefined
               ? event.focusSessionId
@@ -492,6 +519,14 @@ export const xyneAIMachine = setup({
           startFreshChat,
           canvasInfo: event.canvasInfo ?? null,
           canvasContexts: newCanvasContexts,
+          initialContextSelections:
+            event.initialContextSelections !== undefined
+              ? event.initialContextSelections
+              : context.initialContextSelections,
+          contextOpenNonce:
+            event.initialContextSelections !== undefined
+              ? context.contextOpenNonce + 1
+              : context.contextOpenNonce,
           focusSessionId:
             'focusSessionId' in event && event.focusSessionId !== undefined
               ? event.focusSessionId
@@ -544,6 +579,8 @@ export const xyneAIMachine = setup({
         startFreshChat: false,
         canvasInfo: null,
         canvasContexts: [] as CanvasSelectionContext[],
+        initialContextSelections: null,
+        contextOpenNonce: context.contextOpenNonce,
         focusSessionId: null,
         kbCollectionId: null,
         kbChannelId: null,
@@ -686,6 +723,8 @@ export const xyneAIMachine = setup({
     startFreshChat: false,
     canvasInfo: null,
     canvasContexts: [],
+    initialContextSelections: null,
+    contextOpenNonce: 0,
     focusSessionId: null,
     kbCollectionId: null,
     kbChannelId: null,
@@ -783,6 +822,9 @@ const initializeActor = async (): Promise<void> => {
           }),
         ...(persistedContext.threadInfo !== undefined && {
           threadInfo: persistedContext.threadInfo,
+        }),
+        ...(persistedContext.initialContextSelections !== undefined && {
+          initialContextSelections: persistedContext.initialContextSelections,
         }),
       });
     }

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -373,6 +373,11 @@ const AppRoot = (): ReactElement => {
   const xyneAICanvasInfo = useSelector(xyneAIActor, state => state.context.canvasInfo);
   const xyneAIThreadInfo = useSelector(xyneAIActor, state => state.context.threadInfo);
   const xyneAIStartFreshChat = useSelector(xyneAIActor, state => state.context.startFreshChat);
+  const xyneAIInitialContextSelections = useSelector(
+    xyneAIActor,
+    state => state.context.initialContextSelections,
+  );
+  const xyneAIContextOpenNonce = useSelector(xyneAIActor, state => state.context.contextOpenNonce);
   const xyneAIKbCollectionId = useSelector(xyneAIActor, state => state.context.kbCollectionId);
   const xyneAIKbChannelId = useSelector(xyneAIActor, state => state.context.kbChannelId);
   const xyneAIKbDocId = useSelector(xyneAIActor, state => state.context.kbDocId);
@@ -598,6 +603,8 @@ const AppRoot = (): ReactElement => {
                             threadInfo={xyneAIThreadInfo}
                             startFreshChat={xyneAIStartFreshChat}
                             canvasInfo={xyneAICanvasInfo}
+                            initialContextSelections={xyneAIInitialContextSelections}
+                            contextOpenNonce={xyneAIContextOpenNonce}
                             kbCollectionId={xyneAIKbCollectionId ?? ''}
                             kbChannelId={xyneAIKbChannelId ?? ''}
                             kbDocId={xyneAIKbDocId ?? ''}
@@ -743,6 +750,8 @@ const AppRoot = (): ReactElement => {
                       threadInfo={xyneAIThreadInfo}
                       startFreshChat={xyneAIStartFreshChat}
                       canvasInfo={xyneAICanvasInfo}
+                      initialContextSelections={xyneAIInitialContextSelections}
+                      contextOpenNonce={xyneAIContextOpenNonce}
                       kbCollectionId={xyneAIKbCollectionId ?? ''}
                       kbChannelId={xyneAIKbChannelId ?? ''}
                       kbDocId={xyneAIKbDocId ?? ''}
@@ -770,6 +779,8 @@ const AppRoot = (): ReactElement => {
                       threadInfo={xyneAIThreadInfo}
                       startFreshChat={xyneAIStartFreshChat}
                       canvasInfo={xyneAICanvasInfo}
+                      initialContextSelections={xyneAIInitialContextSelections}
+                      contextOpenNonce={xyneAIContextOpenNonce}
                       kbCollectionId={xyneAIKbCollectionId ?? ''}
                       kbChannelId={xyneAIKbChannelId ?? ''}
                       kbDocId={xyneAIKbDocId ?? ''}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -466,6 +466,13 @@ export default function RecordingDetailV2Screen(): ReactElement {
     { enabled: !!recording?.messageId },
   );
 
+  // While live the notes canvas is created by NoteTakerOverlayHost, so its id only
+  // reaches this screen through the store until the detail is refetched.
+  const notesCanvasId =
+    (isLive && recording?.externalId === activeRecordingId ? liveNotesCanvasId : null) ??
+    recording?.notesCanvasId ??
+    null;
+
   /**
    * A note-taker recording has no channel, message or conversation — it is created
    * from a LiveKit webhook rather than posted anywhere — so none of those can gate
@@ -474,23 +481,58 @@ export default function RecordingDetailV2Screen(): ReactElement {
    * as the recordings list does.
    */
   const handleAskAI = useCallback((): void => {
+    if (!recording) return;
     const attachmentIds = (message?.attachments ?? []).map((att: { id: string }) => att.id);
-    const hasThreadContext = !!recording?.conversationId || attachmentIds.length > 0;
+    const hasThreadContext = !!recording.conversationId || attachmentIds.length > 0;
+    const canvasSelections = [
+      ...(recording.detailedSummaryCanvasId
+        ? [
+            {
+              id: recording.detailedSummaryCanvasId,
+              canvasId: recording.detailedSummaryCanvasId,
+              title: `${recording.title || 'Recording'} summary`,
+            },
+          ]
+        : []),
+      ...(notesCanvasId && notesCanvasId !== recording.detailedSummaryCanvasId
+        ? [
+            {
+              id: notesCanvasId,
+              canvasId: notesCanvasId,
+              title: `${recording.title || 'Recording'} notes`,
+            },
+          ]
+        : []),
+    ];
 
     xyneAIActor.send({
       type: 'OPEN',
       startFreshChat: true,
       contextType: 'general',
-      ...(recording?.channelId ? { channelId: recording.channelId } : {}),
+      initialContextSelections: {
+        recordings: [
+          {
+            // `id` is the canonical Call id. `externalId` is only the public
+            // recording-route id, so using it here would make Claw fail to
+            // resolve the attached call.
+            id: recording.id,
+            title: recording.title || 'Recording',
+            ...(recording.channelId ? { channelId: recording.channelId } : {}),
+            ...(recording.conversationId ? { conversationId: recording.conversationId } : {}),
+            externalId: recording.externalId,
+          },
+        ],
+        canvases: canvasSelections,
+      },
       threadInfo: hasThreadContext
         ? {
-            conversationId: recording?.conversationId ?? '',
-            previewText: recording?.title || 'Recording Transcript',
+            conversationId: recording.conversationId ?? '',
+            previewText: recording.title || 'Recording Transcript',
             ...(attachmentIds.length > 0 ? { attachmentIds } : {}),
           }
         : null,
     });
-  }, [recording, message]);
+  }, [recording, message, notesCanvasId]);
 
   const transcriptText =
     speakerIdentificationEnabled && recording?.hasIdentifiedTranscript
@@ -546,11 +588,6 @@ export default function RecordingDetailV2Screen(): ReactElement {
     );
   }
 
-  // While live the notes canvas is created by NoteTakerOverlayHost, so its id only
-  // reaches this screen through the store until the detail is refetched.
-  const notesCanvasId =
-    (isLive && recording.externalId === activeRecordingId ? liveNotesCanvasId : null) ??
-    recording.notesCanvasId;
   // The player replaces the read-only timeline once there is audio to scrub.
   const showAudioPlayer = !isLive && !!recording.hasRecording;
   const hasDetailedSummary = !!recording.detailedSummaryCanvasId;

--- a/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
+++ b/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
@@ -99,7 +99,7 @@ interface ResolvedContextSection {
 }
 
 const MAX_CONTEXT_TOTAL = 20;
-const PER_TYPE_LIMIT = 5;
+const PER_TYPE_LIMIT = 20;
 const INLINE_THRESHOLD = 2_000;
 const TICKET_MESSAGE_LIMIT = 12;
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
