### PR TITLE
fix: XYNE-55082 scope channel lookup by name to workspace

### DIFF
--- a/apps/backend/src/apps/controllers/channelController.ts
+++ b/apps/backend/src/apps/controllers/channelController.ts
@@ -49,10 +49,16 @@ export class ChannelController {
 
       const { channelId, channelName } = bodyResult.data;
 
-      // Find channel by ID or name
+      const workspaceId = req.user?.workspaceId;
+      if (!channelId && !workspaceId) {
+        res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+        return;
+      }
+
+      // Find channel by ID or name (name lookups are scoped to the caller's workspace)
       const channel = channelId
         ? await repositories.channels.findById(channelId)
-        : await repositories.channels.findByName(channelName!);
+        : await repositories.channels.findByName(channelName!, workspaceId!);
 
       if (!channel) {
         res.status(404).json({ 
@@ -105,9 +111,15 @@ export class ChannelController {
 
       const { channelId, channelName } = bodyResult.data;
 
+      const workspaceId = req.user?.workspaceId;
+      if (!channelId && !workspaceId) {
+        res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+        return;
+      }
+
       const channel = channelId
         ? await repositories.channels.findById(channelId)
-        : await repositories.channels.findByName(channelName!);
+        : await repositories.channels.findByName(channelName!, workspaceId!);
 
       if (!channel) {
         res.status(404).json({

--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -225,7 +225,7 @@ export class ChatController {
         return;
       }
 
-      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName);
+      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName, req.user?.workspaceId);
 
       let content: string;
       let isMarkdown = !!markdownText || contentFormat === ContentFormat.MARKDOWN;
@@ -504,7 +504,7 @@ export class ChatController {
       }
 
       const { channelId, channelName, conversationId, limit, cursor } = queryResult.data;
-      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName);
+      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName, req.user?.workspaceId);
       const response = await getChannelHistory(resolvedChannelId, limit, cursor);
 
       res.status(200).json(response);
@@ -550,7 +550,7 @@ export class ChatController {
       }
 
       const { channelId, channelName, conversationId, limit, cursor } = queryResult.data;
-      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName);
+      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName, req.user?.workspaceId);
       const response = await getConversationReplies(resolvedChannelId, conversationId, limit, cursor);
 
       res.status(200).json(response);

--- a/apps/backend/src/apps/controllers/emailController.ts
+++ b/apps/backend/src/apps/controllers/emailController.ts
@@ -32,7 +32,7 @@ export class EmailController {
 
       const { channelId, channelName, conversationId, limit, cursor } = queryResult.data;
 
-      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName);
+      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName, req.user?.workspaceId);
 
       const response = await getEmailReplies(resolvedChannelId, conversationId, limit, cursor);
 

--- a/apps/backend/src/apps/controllers/filesController.ts
+++ b/apps/backend/src/apps/controllers/filesController.ts
@@ -134,7 +134,7 @@ export class FilesController {
       const userId = req.user!.id; // bot's userId from the verified app token
 
       // Resolve channelId from channelName or conversationId if not provided
-      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName);
+      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName, req.user?.workspaceId);
 
       // Extract files from multer
       // uploadMultiple uses fields() so files are in object format

--- a/apps/backend/src/apps/controllers/ticketController.ts
+++ b/apps/backend/src/apps/controllers/ticketController.ts
@@ -607,7 +607,7 @@ export class TicketController {
       }
 
       // Resolve channelId from channelName if not provided
-      const resolvedChannelId = await resolveChannelId(channelId, undefined, channelName);
+      const resolvedChannelId = await resolveChannelId(channelId, undefined, channelName, req.user?.workspaceId);
 
       const channel = await repositories.channels.findById(resolvedChannelId);
       if (!channel) {

--- a/apps/backend/src/apps/middelware/channelValidation.ts
+++ b/apps/backend/src/apps/middelware/channelValidation.ts
@@ -31,13 +31,18 @@ async function resolveAndValidateChannel(
   channelName: string | undefined,
   conversationId: string | undefined,
   userId: string,
+  workspaceId: string | undefined,
   res: Response
 ): Promise<string | null> {
   let resolvedChannelId = channelId;
 
   // Resolve channelId from channelName if not provided
   if (!resolvedChannelId && channelName) {
-    const channel = await repositories.channels.findByName(channelName);
+    if (!workspaceId) {
+      sendError(res, 401, 'Unauthorized', 'Workspace not found');
+      return null;
+    }
+    const channel = await repositories.channels.findByName(channelName, workspaceId);
     if (!channel) {
       logger.warn(`[CHANNEL-VALIDATION] Channel with name "${channelName}" not found`);
       sendError(res, 404, 'Not Found', 'Channel not found');
@@ -159,6 +164,7 @@ export async function validateChannelAccessForGet(
     const channelName = req.query.channelName as string | undefined;
     const conversationId = req.query.conversationId as string | undefined;
     const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
 
     const validationResult = ChannelValidationSchema.safeParse({
       channelId,
@@ -178,6 +184,7 @@ export async function validateChannelAccessForGet(
       validated.channelName,
       validated.conversationId,
       validated.userId,
+      workspaceId,
       res
     );
 
@@ -207,6 +214,7 @@ export async function validateChannelAccessForPost(
     const channelName = req.body.channelName;
     const conversationId = req.body.conversationId;
     const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
 
     const validationResult = ChannelValidationSchema.safeParse({
       channelId,
@@ -226,6 +234,7 @@ export async function validateChannelAccessForPost(
       validated.channelName,
       validated.conversationId,
       validated.userId,
+      workspaceId,
       res
     );
 

--- a/apps/backend/src/apps/platform-adapters/slack/controller.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/controller.ts
@@ -568,7 +568,7 @@ export class SlackController {
 		}
 
 		if (parsed.data.channel) {
-			const channelId = await resolveSlackChannel(parsed.data.channel);
+			const channelId = await resolveSlackChannel(parsed.data.channel, botUser.workspaceId);
 			const isParticipant =
 				await repositories.channelParticipants.isParticipant(channelId, userId);
 			if (!isParticipant) {
@@ -677,8 +677,13 @@ export class SlackController {
 			return;
 		}
 
-		const channelId = await resolveSlackChannel(args.channelId);
 		const context = getSlackAuthContext(req);
+		if (!context.workspaceId) {
+			res.status(200).json({ ok: false, error: "workspace_not_found" });
+			return;
+		}
+
+		const channelId = await resolveSlackChannel(args.channelId, context.workspaceId);
 		const isParticipant = await repositories.channelParticipants.isParticipant(
 			channelId,
 			context.userId,
@@ -901,7 +906,7 @@ export class SlackController {
 
 			const { files, channel_id, channels, initial_comment, thread_ts } =
 				parsed.data;
-			const { userId } = getSlackAuthContext(req);
+			const { userId, workspaceId } = getSlackAuthContext(req);
 
 			const uploadedResults: UploadedFileResult[] = [];
 			const redisKeys: string[] = [];
@@ -956,7 +961,11 @@ export class SlackController {
 				return;
 			}
 
-			const channelId = await resolveSlackChannel(shareChannel);
+			if (!workspaceId) {
+				res.status(200).json({ ok: false, error: "workspace_not_found" });
+				return;
+			}
+			const channelId = await resolveSlackChannel(shareChannel, workspaceId);
 			const isParticipant =
 				await repositories.channelParticipants.isParticipant(channelId, userId);
 			if (!isParticipant) {

--- a/apps/backend/src/apps/platform-adapters/slack/middleware.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/middleware.ts
@@ -32,11 +32,14 @@ export function getResolvedChannelId(req: Request): string {
 	return channelId;
 }
 
-export async function resolveSlackChannel(channel: string): Promise<string> {
+export async function resolveSlackChannel(
+	channel: string,
+	workspaceId: string,
+): Promise<string> {
 	const existing = await repositories.channels.findById(channel);
 	if (existing) return existing.id;
 
-	const byName = await repositories.channels.findByName(channel);
+	const byName = await repositories.channels.findByName(channel, workspaceId);
 	if (byName) return byName.id;
 
 	throw new Error("Channel not found");
@@ -63,7 +66,7 @@ export async function resolveSlackChannelForUser(
 		return { channelId: dmChannel.id, isDM: true };
 	}
 
-	const channelId = await resolveSlackChannel(channel);
+	const channelId = await resolveSlackChannel(channel, workspaceId);
 	return { channelId, isDM: false };
 }
 

--- a/apps/backend/src/apps/utils/channelUtils.ts
+++ b/apps/backend/src/apps/utils/channelUtils.ts
@@ -7,13 +7,15 @@ import { logger } from '@/utils/logger';
  * @param channelId - Channel ID (optional)
  * @param conversationId - Conversation ID (optional)
  * @param channelName - Channel name (optional)
+ * @param workspaceId - Workspace ID (required when resolving by channelName)
  * @returns Resolved channel ID
  * @throws Error if no identifier is provided, or if the resource is not found
  */
 export async function resolveChannelId(
   channelId: string | undefined,
   conversationId: string | undefined,
-  channelName?: string | undefined
+  channelName?: string | undefined,
+  workspaceId?: string | undefined
 ): Promise<string> {
   if (channelId) {
     return channelId;
@@ -21,7 +23,10 @@ export async function resolveChannelId(
 
   if (channelName) {
     logger.info(`[CHANNEL-UTILS] Resolving channelId from channelName: ${channelName}`);
-    const channel = await repositories.channels.findByName(channelName);
+    if (!workspaceId) {
+      throw new Error('workspaceId is required to resolve a channel by name');
+    }
+    const channel = await repositories.channels.findByName(channelName, workspaceId);
     if (!channel) {
       logger.warn(`[CHANNEL-UTILS] Channel not found by name: ${channelName}`);
       throw new Error('Channel not found');

--- a/apps/backend/src/database/repositories/channelRepository.test.ts
+++ b/apps/backend/src/database/repositories/channelRepository.test.ts
@@ -1,0 +1,86 @@
+import { ChannelRepository } from './channelRepository';
+
+/**
+ * Regression test for XYNE-55082.
+ *
+ * Bug: `ChannelRepository.findByName` resolved a channel by name globally,
+ * ignoring the workspace. Because channel names are only unique *within* a
+ * workspace (see `checkDuplicateName`, scoped by `project.workspaceId`), two
+ * workspaces can both own a `#general`. The unscoped lookup returned whichever
+ * row the DB happened to hit first — e.g. `ensureUserInGeneralChannel` could add
+ * a brand-new user to another workspace's `#general`, breaking tenant isolation.
+ *
+ * Fix: `findByName(name, workspaceId)` filters on the denormalized
+ * `Channel.workspaceId` column. This test seeds two workspaces that share the
+ * channel name `general` and asserts the lookup is workspace-scoped.
+ */
+describe('ChannelRepository.findByName — workspace scoping (XYNE-55082)', () => {
+  const WS_A = 'ws_alpha';
+  const WS_B = 'ws_beta';
+
+  // Two workspaces, each with its own #general (plus an unrelated channel).
+  const rows = [
+    { id: 'chan_a_general', name: 'general', workspaceId: WS_A },
+    { id: 'chan_a_random', name: 'random', workspaceId: WS_A },
+    { id: 'chan_b_general', name: 'general', workspaceId: WS_B },
+  ];
+
+  // Faithful-enough emulation of the Prisma `findFirst` predicate the
+  // repository builds: AND of `workspaceId` (equality) and
+  // `name` (case-insensitive equality). Crucially, if `workspaceId` is
+  // undefined (the pre-fix behaviour), it is NOT applied — so the old code
+  // would match on name alone and return the first row, failing this test.
+  const makeRepo = () => {
+    const repo = new ChannelRepository();
+    (repo as unknown as { db: unknown }).db = {
+      channel: {
+        findFirst: async ({ where }: { where: any }) => {
+          const wantName: string | undefined = where?.name?.equals;
+          const insensitive = where?.name?.mode === 'insensitive';
+          const wantWs: string | undefined = where?.workspaceId;
+          const match = rows.find((r) => {
+            const nameOk =
+              wantName === undefined
+                ? true
+                : insensitive
+                  ? r.name.toLowerCase() === wantName.toLowerCase()
+                  : r.name === wantName;
+            const wsOk = wantWs === undefined ? true : r.workspaceId === wantWs;
+            return nameOk && wsOk;
+          });
+          return match ?? null;
+        },
+      },
+    };
+    return repo;
+  };
+
+  it('resolves #general within workspace A to workspace A\'s channel', async () => {
+    const channel = await makeRepo().findByName('general', WS_A);
+    expect(channel?.id).toBe('chan_a_general');
+    expect(channel?.workspaceId).toBe(WS_A);
+  });
+
+  it('resolves #general within workspace B to workspace B\'s channel', async () => {
+    const channel = await makeRepo().findByName('general', WS_B);
+    expect(channel?.id).toBe('chan_b_general');
+    expect(channel?.workspaceId).toBe(WS_B);
+  });
+
+  it('never returns another workspace\'s channel with the same name', async () => {
+    const a = await makeRepo().findByName('general', WS_A);
+    const b = await makeRepo().findByName('general', WS_B);
+    expect(a?.id).not.toBe(b?.id);
+  });
+
+  it('returns null when the name exists only in a different workspace', async () => {
+    // `random` exists only in workspace A; a lookup scoped to B must miss.
+    const channel = await makeRepo().findByName('random', WS_B);
+    expect(channel).toBeNull();
+  });
+
+  it('matches channel names case-insensitively but still within the workspace', async () => {
+    const channel = await makeRepo().findByName('GENERAL', WS_A);
+    expect(channel?.id).toBe('chan_a_general');
+  });
+});

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -290,9 +290,10 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
     return !!existingChannel;
   }
 
-  async findByName(name: string): Promise<Channel | null> {
+  async findByName(name: string, workspaceId: string): Promise<Channel | null> {
     return await this.db.channel.findFirst({
       where: {
+        workspaceId,
         name: {
           equals: name,
           mode: 'insensitive'

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -324,7 +324,7 @@ export class UserService {
 
       // Find the general channel by name
       logger.info(`[GENERAL_CHANNEL] Looking for channel with name 'general'`);
-      const generalChannel = await repositories.channels.findByName('general');
+      const generalChannel = await repositories.channels.findByName('general', user.workspaceId);
 
       if (generalChannel) {
         // Check if user is already a participant


### PR DESCRIPTION
## Summary
`channelRepository.findByName` resolved channels by name **globally**, ignoring the workspace. Channel names are only unique *within* a workspace (`checkDuplicateName` scopes by `project.workspaceId`), so two workspaces can both own a `#general`. The unscoped lookup returned whichever row the DB hit first — e.g. `ensureUserInGeneralChannel` could add a brand-new user to **another workspace's** `#general`, breaking tenant isolation. This is ticket XYNE-55082 (P1).

## Fix
- `findByName(name, workspaceId)` now filters on the denormalized `Channel.workspaceId` column. The schema already has a purpose-built index `@@index([workspaceId, name, id])`.
- `workspaceId` is a **required** parameter, so every caller must supply a workspace at compile time — an unscoped lookup can no longer silently exist.

## Call sites updated (all 6)
- `services/userService.ts` — `ensureUserInGeneralChannel` (uses `user.workspaceId`)
- `apps/middelware/channelValidation.ts` — `resolveAndValidateChannel` (uses `req.user.workspaceId`)
- `apps/utils/channelUtils.ts` — `resolveChannelId` + its callers in `chatController`, `filesController`, `emailController`, `ticketController`
- `apps/platform-adapters/slack/middleware.ts` — `resolveSlackChannel` + its callers in `slack/controller.ts`
- `apps/controllers/channelController.ts` — `getChannelByName` and `getDeskConfig`

Callers that could not establish a workspace now return 401/`workspace_not_found` instead of leaking a cross-workspace channel.

## Tests
Added `apps/backend/src/database/repositories/channelRepository.test.ts` — seeds two workspaces that both own a `#general` and asserts:
- lookups resolve to the correct workspace's channel
- a name that exists only in another workspace returns null
- case-insensitive matching stays workspace-scoped

Verified the test **fails on the pre-fix code** (3 cross-workspace assertions fail) and passes with the fix. `tsc --noEmit` passes clean.

## Risk / rollout
- Read-path only — no schema change, no migration, no backfill.
- Behavior change to watch: a caller that was accidentally resolving a channel from another workspace now gets "not found" (correct). Watch for `[CHANNEL-UTILS] Channel not found by name` and new 404/401s after rollout.