### PR TITLE
feat: XYNE-17952 TAG_GENERATED trigger, has_tag condition, AI priorit…

### DIFF
--- a/apps/backend/prisma/migrations/20260723000000_add_tag_generated_event_type/migration.sql
+++ b/apps/backend/prisma/migrations/20260723000000_add_tag_generated_event_type/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."WorkflowEventType" ADD VALUE IF NOT EXISTS 'TAG_GENERATED';

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -797,6 +797,7 @@ enum WorkflowEventType {
   WEBHOOK
   MESSAGE_RECEIVED
   CALL_EVENT
+  TAG_GENERATED
 
   @@schema("public")
 }

--- a/apps/backend/src/automations/engine/condition-evaluator.ts
+++ b/apps/backend/src/automations/engine/condition-evaluator.ts
@@ -2,6 +2,7 @@ import type { Condition, LeafCondition } from '../types/automation-config';
 import type { AutomationContext } from '../types/context';
 import { ConditionOperator } from '../types/operators';
 import { extractRefPath, isPureRef } from '../util/variable-ref';
+import { logger } from '@/utils/logger';
 
 const FORBIDDEN_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype']);
 
@@ -74,6 +75,42 @@ function applyOperator(
       return resolved !== undefined && resolved !== null && (resolved as number) < (refValue as number);
     case ConditionOperator.LTE:
       return resolved !== undefined && resolved !== null && (resolved as number) <= (refValue as number);
+
+    case ConditionOperator.HAS_TAG: {
+      if (!Array.isArray(resolved)) {
+        logger.info(`[CONDITION] has_tag — resolved is not an array (got ${typeof resolved}), result=false`);
+        return false;
+      }
+      const raw = String(refValue);
+      // value format: "category:match:tag1,tag2"  e.g. "priority:any:critical,high"
+      const firstColon = raw.indexOf(':');
+      const secondColon = raw.indexOf(':', firstColon + 1);
+      if (firstColon === -1 || secondColon === -1) {
+        logger.info(`[CONDITION] has_tag — malformed value="${raw}", result=false`);
+        return false;
+      }
+      const category = raw.slice(0, firstColon);
+      const match = raw.slice(firstColon + 1, secondColon);
+      const tags = raw.slice(secondColon + 1).split(',').filter(Boolean);
+      if (match !== 'any' && match !== 'all') {
+        logger.info(`[CONDITION] has_tag — invalid match="${match}", result=false`);
+        return false;
+      }
+      if (tags.length === 0) {
+        logger.info(`[CONDITION] has_tag — empty tag list, result=false`);
+        return false;
+      }
+      const tagEntries = resolved as Array<{ category: string; tag: string }>;
+      const presentTags = tagEntries.filter(t => t.category === category).map(t => t.tag);
+      const result = match === 'all'
+        ? tags.every(t => presentTags.includes(t))
+        : tags.some(t => presentTags.includes(t));
+      logger.debug(
+        `[CONDITION] has_tag category=${category} match=${match} want=[${tags.join(',')}] present=[${presentTags.join(',')}] result=${result}`,
+      );
+      return result;
+    }
+
     default:
       return assertNever(operator);
   }

--- a/apps/backend/src/automations/engine/config-validator.ts
+++ b/apps/backend/src/automations/engine/config-validator.ts
@@ -163,6 +163,10 @@ function isZodCompatible(upstream: z.ZodTypeAny, consumer: z.ZodTypeAny): boolea
 
   if (conType === 'ZodString') return true;
 
+  if (consumer instanceof z.ZodUnion) {
+    return (consumer._def.options as z.ZodTypeAny[]).some(branch => isZodCompatible(upstream, branch));
+  }
+
   return false;
 }
 

--- a/apps/backend/src/automations/index.ts
+++ b/apps/backend/src/automations/index.ts
@@ -10,6 +10,7 @@ import { ticketCommentedTrigger } from './triggers/ticket-commented.trigger';
 import { messageReceivedTrigger } from './triggers/message-received.trigger';
 import { callTrigger } from './triggers/call.trigger';
 import { webhookTrigger } from './triggers/webhook.trigger';
+import { tagGeneratedTrigger } from './triggers/tag-generated.trigger';
 
 import { conditionalStep } from './steps/conditional.step';
 import { switchStep } from './steps/switch.step';
@@ -55,6 +56,7 @@ export async function initializeAutomations(): Promise<void> {
   triggerRegistry.register(messageReceivedTrigger);
   triggerRegistry.register(callTrigger);
   triggerRegistry.register(webhookTrigger);
+  triggerRegistry.register(tagGeneratedTrigger);
 
   stepRegistry.register(conditionalStep);
   stepRegistry.register(switchStep);

--- a/apps/backend/src/automations/routes/automation.routes.ts
+++ b/apps/backend/src/automations/routes/automation.routes.ts
@@ -50,7 +50,7 @@ router.use((_req, res, next) => {
 
 const OPERATOR_METADATA: Record<
   ConditionOperator,
-  { label: string; valueType: 'string' | 'number' | 'boolean' | 'none' }
+  { label: string; valueType: 'string' | 'number' | 'boolean' | 'none' | 'tag' }
 > = {
   [ConditionOperator.EQ]: { label: 'equals', valueType: 'string' },
   [ConditionOperator.NEQ]: { label: 'does not equal', valueType: 'string' },
@@ -60,6 +60,7 @@ const OPERATOR_METADATA: Record<
   [ConditionOperator.LT]: { label: 'is less than', valueType: 'number' },
   [ConditionOperator.LTE]: { label: 'is less than or equal to', valueType: 'number' },
   [ConditionOperator.EXISTS]: { label: 'exists', valueType: 'none' },
+  [ConditionOperator.HAS_TAG]: { label: 'has tag', valueType: 'tag' },
 };
 
 const AutomationPayloadSchema = z.object({

--- a/apps/backend/src/automations/steps/assign-ticket-to-group.step.ts
+++ b/apps/backend/src/automations/steps/assign-ticket-to-group.step.ts
@@ -44,22 +44,44 @@ export class AssignTicketToGroupStep extends BaseActionStep<
     const groupId = config.groupId as string;
     const prisma = DatabaseClient.getInstance();
 
-    const prev = await prisma.ticket.findUnique({ where: { id: ticketId }, select: { userGroupId: true } });
+    const prev = await prisma.ticket.findUnique({
+      where: { id: ticketId },
+      select: { userGroupId: true, assignedTo: true },
+    });
+    const updatedBy = context.automation.createdById;
     const assignedUserId = await ticketAssignmentService.assignTicketToGroup({
       ticketId,
       groupId,
-      actorId: context.automation.createdById,
+      actorId: updatedBy,
     });
 
     await prisma.ticketActivity.create({
       data: {
         ticketId,
-        updatedBy: context.automation.createdById,
+        updatedBy,
         workspaceId: context.automation.workspaceId,
         activityType: ActivityType.USER_GROUP_ID,
         value: { field: 'userGroupId', oldValue: prev?.userGroupId ?? null, newValue: groupId, isAutomation: true },
       },
     });
+
+    if (assignedUserId && assignedUserId !== prev?.assignedTo) {
+      await prisma.ticketActivity.create({
+        data: {
+          ticketId,
+          updatedBy,
+          workspaceId: context.automation.workspaceId,
+          activityType: ActivityType.ASSIGNED_TO,
+          value: {
+            field: 'assignedTo',
+            oldValue: prev?.assignedTo ?? null,
+            newValue: assignedUserId,
+            reason: 'Automation group assignment',
+            isAutomation: true,
+          },
+        },
+      });
+    }
 
     return { ticketId, groupId, assignedUserId: assignedUserId ?? null };
   }

--- a/apps/backend/src/automations/steps/update-ticket.step.ts
+++ b/apps/backend/src/automations/steps/update-ticket.step.ts
@@ -14,7 +14,7 @@ const UpdateTicketConfigSchema = z.object({
   ticketId: variableRef(z.string().min(1)),
   title: variableRef(z.string()).optional(),
   description: variableRef(z.string()).optional(),
-  priority: z.nativeEnum(TicketPriority).optional(),
+  priority: variableRef(z.union([z.nativeEnum(TicketPriority), z.string()])).optional(),
   status: z.nativeEnum(TicketStatusV2).optional(),
   stageName: variableRef(z.string()).optional(),
   assignedTo: variableRef(z.string()).optional(),
@@ -88,7 +88,17 @@ export class UpdateTicketStep extends BaseActionStep<typeof UpdateTicketConfigSc
     const fields: Parameters<typeof repositories.tickets.updateTicketFields>[1] = {};
     if (config.title !== undefined) fields.title = config.title as string;
     if (config.description !== undefined) fields.description = config.description as string;
-    if (config.priority !== undefined) fields.priority = config.priority;
+    if (config.priority !== undefined) {
+      const normalized = (config.priority as string).toUpperCase();
+      if (Object.values(TicketPriority).includes(normalized as TicketPriority)) {
+        fields.priority = normalized as TicketPriority;
+      } else {
+        logger.warn(`[automations] UPDATE_TICKET skipping priority — "${config.priority}" is not a valid TicketPriority for ticket ${ticketId}`);
+      }
+      // Always stamp aiPriority — prevents AI retrigger from re-classifying this ticket.
+      // If enum was valid, mirrors priority. If invalid, raw value still blocks retrigger.
+      fields.aiPriority = fields.priority ?? normalized;
+    }
     if (config.status !== undefined) fields.statusV2 = config.status;
 
     if (Object.keys(fields).length > 0) {

--- a/apps/backend/src/automations/triggers/tag-generated.trigger.ts
+++ b/apps/backend/src/automations/triggers/tag-generated.trigger.ts
@@ -1,0 +1,201 @@
+import { z } from 'zod';
+import { BaseTrigger } from './base-trigger';
+import { TriggerCategory } from '../types/categories';
+import { eventRouter } from '../engine/event-router';
+import { repositories } from '@/database/repositories';
+import { logger } from '@/utils/logger';
+import { TicketContextSchema, buildTicketContext } from './ticket-context';
+import { DESK_EMAIL_SOURCE_TYPE } from '@/tags';
+import { TAG_FORMAT_REGEX } from '@xyne/shared';
+
+export const TAG_GENERATED_EVENT = 'TAG_GENERATED';
+
+const TagGeneratedConfigSchema = z.object({
+  channelIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Limit to specific email-inbox channels. At least one channel is required to scope this trigger.',
+    ),
+  categories: z
+    .array(z.string().regex(TAG_FORMAT_REGEX, 'Category must be lowercase hyphen-separated'))
+    .optional()
+    .describe(
+      'Only fire when tags were generated for at least one of these categories. Empty matches any category.',
+    ),
+});
+
+const GeneratedTagSchema = z.object({
+  category: z.string(),
+  tag: z.string(),
+  reason: z.string().nullable(),
+});
+
+const EmailContextSchema = z.object({
+  id: z.string(),
+  subject: z.string(),
+  from: z.string(),
+  to: z.array(z.string()),
+  conversationId: z.string(),
+  channelId: z.string(),
+});
+
+export const TagGeneratedOutputSchema = TicketContextSchema.partial().extend({
+  sourceId: z.string(),
+  sourceType: z.string(),
+  channelId: z.string(),
+  generatedTags: z.array(GeneratedTagSchema),
+  priorityTag: z.string().nullable(),
+  email: EmailContextSchema.nullable(),
+});
+
+type TagGeneratedConfig = z.infer<typeof TagGeneratedConfigSchema>;
+type TagGeneratedPayload = {
+  sourceId: string;
+  sourceType: string;
+  channelId: string;
+  tags: Array<{ category: string; tag: string; reason: string | null }>;
+};
+type TagGeneratedOutput = z.infer<typeof TagGeneratedOutputSchema>;
+
+function asStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+  }
+  if (typeof value === 'string' && value.trim().length > 0) return [value];
+  return [];
+}
+
+export class TagGeneratedTrigger extends BaseTrigger<typeof TagGeneratedConfigSchema> {
+  readonly type = TAG_GENERATED_EVENT;
+  readonly configSchema = TagGeneratedConfigSchema;
+  readonly outputSchema = TagGeneratedOutputSchema;
+  readonly name = 'When tags are generated';
+  readonly description =
+    'Fires after the AI tag pipeline writes tags for a desk email. Filter by channel or tag category to narrow when this trigger fires.';
+  readonly category = TriggerCategory.EVENT;
+  readonly icon = 'Tag';
+  readonly scopeFilterFields = ['channelIds'];
+
+  async hydratePayload(payload: TagGeneratedPayload): Promise<TagGeneratedOutput> {
+    const { sourceId, sourceType, channelId, tags } = payload;
+    if (sourceType !== DESK_EMAIL_SOURCE_TYPE) {
+      return { sourceId, sourceType, channelId, generatedTags: [], priorityTag: null, email: null };
+    }
+
+    const email = await repositories.emails.findById(sourceId);
+    if (!email) return { sourceId, sourceType, channelId, generatedTags: [], priorityTag: null, email: null };
+
+    const ticketRef = await repositories.tickets
+      .findFirstByConversationId(email.conversationId)
+      .catch(() => null);
+
+    const fullTicket = ticketRef
+      ? await repositories.tickets.getTicketById(ticketRef.id).catch(() => null)
+      : null;
+
+    const ticketContext =
+      fullTicket ? await buildTicketContext(fullTicket).catch(() => null) : null;
+
+    logger.info(
+      `[TAG-GENERATED] hydratePayload sourceId=${sourceId} generatedTags=${tags.length} categories=[${[...new Set(tags.map(t => t.category))].join(',')}]`,
+    );
+
+    const priorityTag = tags.find(t => t.category === 'priority')?.tag?.toUpperCase() ?? null;
+
+    return {
+      sourceId,
+      sourceType,
+      channelId,
+      ...(ticketContext ?? {}),
+      generatedTags: tags,
+      priorityTag,
+      email: {
+        id: email.id,
+        subject: email.subject,
+        from: email.from,
+        to: email.to,
+        conversationId: email.conversationId,
+        channelId: email.channelId,
+      },
+    };
+  }
+
+  matchFilters(filter: TagGeneratedConfig, payload: TagGeneratedOutput): boolean {
+    try {
+      return matchTagGenerated(filter, payload);
+    } catch (err) {
+      logger.error('[automations] TAG_GENERATED matchFilters threw — treating as no-match:', err);
+      return false;
+    }
+  }
+}
+
+export const tagGeneratedTrigger = new TagGeneratedTrigger();
+
+function matchTagGenerated(
+  cfg: TagGeneratedConfig,
+  payload: { channelId: string; generatedTags?: Array<{ category: string }> },
+): boolean {
+  const channelIds = asStringArray(cfg.channelIds);
+  if (channelIds.length > 0 && !channelIds.includes(payload.channelId)) return false;
+
+  const categories = asStringArray(cfg.categories);
+  if (categories.length > 0) {
+    const presentCategories = (payload.generatedTags ?? []).map(t => t.category);
+    if (!categories.some(c => presentCategories.includes(c))) return false;
+  }
+  return true;
+}
+
+export async function emitTagGenerated(result: {
+  sourceId: string;
+  sourceType: string;
+  tags: Array<{ category: string; tag: string; reason: string | null }>;
+}): Promise<void> {
+  try {
+    if (result.sourceType !== DESK_EMAIL_SOURCE_TYPE) {
+      logger.info('[automations] emitTagGenerated skipped — unsupported sourceType', {
+        sourceType: result.sourceType,
+      });
+      return;
+    }
+
+    const email = await repositories.emails.findById(result.sourceId);
+    if (!email) {
+      logger.warn('[automations] emitTagGenerated dropped — email not found', {
+        sourceId: result.sourceId,
+        sourceType: result.sourceType,
+      });
+      return;
+    }
+
+    const channel = await repositories.channels.findById(email.channelId).catch(() => null);
+    if (!channel?.workspaceId) {
+      logger.warn('[automations] emitTagGenerated dropped — could not resolve workspaceId', {
+        sourceId: result.sourceId,
+        channelId: email.channelId,
+      });
+      return;
+    }
+
+    await eventRouter.emit(
+      {
+        type: TAG_GENERATED_EVENT,
+        payload: {
+          sourceId: result.sourceId,
+          sourceType: result.sourceType,
+          channelId: email.channelId,
+          tags: result.tags,
+        },
+      },
+      channel.workspaceId,
+    );
+  } catch (err) {
+    logger.error('[automations] emitTagGenerated failed', {
+      sourceId: result.sourceId,
+      sourceType: result.sourceType,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/backend/src/automations/types/automation-config.ts
+++ b/apps/backend/src/automations/types/automation-config.ts
@@ -3,6 +3,21 @@ import type { TriggerType } from './trigger-types';
 import type { StepType } from './step-types';
 import { ControlFlowStepType } from './known-types';
 import { ConditionOperator, ConditionOperatorSchema } from './operators';
+import { TAG_FORMAT_REGEX } from '@xyne/shared';
+
+function isValidHasTagValue(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const firstColon = value.indexOf(':');
+  const secondColon = value.indexOf(':', firstColon + 1);
+  if (firstColon === -1 || secondColon === -1) return false;
+  const category = value.slice(0, firstColon);
+  const match = value.slice(firstColon + 1, secondColon);
+  const tags = value.slice(secondColon + 1).split(',').filter(Boolean);
+  if (!category || !TAG_FORMAT_REGEX.test(category)) return false;
+  if (match !== 'any' && match !== 'all') return false;
+  if (tags.length === 0) return false;
+  return tags.every(t => TAG_FORMAT_REGEX.test(t));
+}
 
 export {
   VARIABLE_REF_REGEX,
@@ -50,6 +65,14 @@ export const LeafConditionSchema: z.ZodType<LeafCondition> = z.object({
   variable: variableRefStringSchema,
   operator: ConditionOperatorSchema,
   value: z.unknown().optional(),
+}).superRefine((val, ctx) => {
+  if (val.operator === ConditionOperator.HAS_TAG && !isValidHasTagValue(val.value)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'has_tag value must be "category:any|all:tag1,tag2,..." with valid tag names',
+    });
+  }
 });
 
 export const ConditionSchema: z.ZodType<Condition> = z.lazy(() =>

--- a/apps/backend/src/automations/types/automation-events.ts
+++ b/apps/backend/src/automations/types/automation-events.ts
@@ -9,6 +9,7 @@ import {
 } from '../triggers/ticket-updated.trigger';
 import { MESSAGE_RECEIVED_EVENT } from '../triggers/message-received.trigger';
 import { CALL_EVENT, CALL_STARTED, CALL_ENDED } from '../triggers/call.trigger';
+import { TAG_GENERATED_EVENT } from '../triggers/tag-generated.trigger';
 import type { MessageType, CallType } from '@prisma/client';
 
 export interface TicketCreatedEventPayload {
@@ -57,6 +58,13 @@ export interface CallEventPayload {
   conversationId: string | null;
 }
 
+export interface TagGeneratedEventPayload {
+  sourceId: string;
+  sourceType: string;
+  channelId: string;
+  tags: Array<{ category: string; tag: string; reason: string | null }>;
+}
+
 export type AutomationEvent =
   | { type: typeof EMAIL_RECEIVED_EVENT; payload: EmailEventPayload }
   | { type: typeof EMAIL_SENT_EVENT; payload: EmailEventPayload }
@@ -64,6 +72,7 @@ export type AutomationEvent =
   | { type: typeof TICKET_CREATED_EVENT; payload: TicketCreatedEventPayload }
   | { type: typeof TICKET_UPDATED_EVENT; payload: TicketUpdatedEventPayload }
   | { type: typeof MESSAGE_RECEIVED_EVENT; payload: MessageReceivedEventPayload }
-  | { type: typeof CALL_EVENT; payload: CallEventPayload };
+  | { type: typeof CALL_EVENT; payload: CallEventPayload }
+  | { type: typeof TAG_GENERATED_EVENT; payload: TagGeneratedEventPayload };
 
 export type AutomationEventType = AutomationEvent['type'];

--- a/apps/backend/src/automations/types/operators.ts
+++ b/apps/backend/src/automations/types/operators.ts
@@ -9,6 +9,7 @@ export enum ConditionOperator {
   LT = 'lt',
   LTE = 'lte',
   EXISTS = 'exists',
+  HAS_TAG = 'has_tag',
 }
 
 export const ConditionOperatorSchema = z.nativeEnum(ConditionOperator);

--- a/apps/backend/src/database/repositories/ticketRepository.ts
+++ b/apps/backend/src/database/repositories/ticketRepository.ts
@@ -849,6 +849,7 @@ export class TicketRepository {
       isArchived?: boolean;
       closedAt?: Date | null;
       closedBy?: string | null;
+      aiPriority?: string;
     },
     updatedBy: string,
   ): Promise<void> {
@@ -862,6 +863,7 @@ export class TicketRepository {
     if (fields.isArchived !== undefined) data.isArchived = fields.isArchived;
     if (fields.closedAt !== undefined) data.closedAt = fields.closedAt;
     if (fields.closedBy !== undefined) data.closedBy = fields.closedBy;
+    if (fields.aiPriority !== undefined) data.aiPriority = fields.aiPriority;
 
     if (Object.keys(data).length <= 2) {
       return;

--- a/apps/backend/src/worker.ts
+++ b/apps/backend/src/worker.ts
@@ -38,6 +38,7 @@ import { emailClassificationWorker } from '@/workers/emailClassificationWorker';
 import { autoDraftWorker } from '@/workers/autoDraftWorker';
 import { entityExtractionWorker } from '@/workers/entityExtractionWorker';
 import { tagGenerationPipeline, registerDeskEmailTags, DESK_EMAIL_SOURCE_TYPE, enqueueTagVespaRefeed } from '@/tags';
+import { emitTagGenerated } from '@/automations/triggers/tag-generated.trigger';
 import { recoveryService } from './workflows/services/recovery-service'
 import { aiProvisioningWorker } from '@/workers/aiProvisioningWorker';
 config()
@@ -274,6 +275,12 @@ class WorkerService {
 
         tagGenerationPipeline.onCompleted(DESK_EMAIL_SOURCE_TYPE, (result) => {
           void enqueueTagVespaRefeed(DESK_EMAIL_SOURCE_TYPE, result.sourceId);
+          logger.info(`Tag generation completed for sourceId=${result.sourceId}, emitting tagGenerated event...`);
+          void emitTagGenerated({
+            sourceId: result.sourceId,
+            sourceType: result.sourceType,
+            tags: result.tags.map(t => ({ category: t.tagCategory, tag: t.tag, reason: t.reason ?? null })),
+          });
         });
       }
 

--- a/apps/dashboard/src/api/automationsApi.ts
+++ b/apps/dashboard/src/api/automationsApi.ts
@@ -64,7 +64,7 @@ export type StepKind = (typeof StepKindValues)[keyof typeof StepKindValues];
 export interface OperatorMeta {
   value: string;
   label: string;
-  valueType: 'string' | 'number' | 'boolean' | 'none';
+  valueType: 'string' | 'number' | 'boolean' | 'none' | 'tag';
 }
 
 export interface TriggerCatalogItem {

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.tsx
@@ -21,6 +21,7 @@ import { detectEntityKind, isVariableRefValue } from '../SchemaForm/SchemaForm.u
 import { ReferenceChip, UseVariableButton } from '../SchemaForm/VariableFieldParts';
 import type { ConditionEditorProps } from './ConditionEditor.types';
 import { isAndGroup, isLeaf, makeEmptyLeaf, resolveLeafSchema } from './ConditionEditor.utils';
+import { TagValueInput } from './TagValueInput';
 
 const MAX_DEPTH = 2;
 
@@ -114,7 +115,7 @@ interface LeafRowProps {
   operators: {
     value: string;
     label: string;
-    valueType: 'string' | 'number' | 'boolean' | 'none';
+    valueType: 'string' | 'number' | 'boolean' | 'none' | 'tag';
   }[];
   variableSources: VariablePickerSource[];
   onChange: (next: Condition) => void;
@@ -220,7 +221,7 @@ function ValueOperand({
   entityKind,
   variableSources,
 }: {
-  operator: { valueType: 'string' | 'number' | 'boolean' | 'none' } | undefined;
+  operator: { valueType: 'string' | 'number' | 'boolean' | 'none' | 'tag' } | undefined;
   value: unknown;
   onChange: (next: unknown) => void;
   enumValues: string[] | null;
@@ -248,7 +249,9 @@ function ValueOperand({
           entityKind={entityKind}
         />
       </div>
-      <UseVariableButton sources={variableSources} onPick={onChange} modal={true} />
+      {operator?.valueType !== 'tag' && (
+        <UseVariableButton sources={variableSources} onPick={onChange} modal={true} />
+      )}
     </div>
   );
 }
@@ -260,12 +263,15 @@ function ValueInput({
   enumValues,
   entityKind,
 }: {
-  operator: { valueType: 'string' | 'number' | 'boolean' | 'none' } | undefined;
+  operator: { valueType: 'string' | 'number' | 'boolean' | 'none' | 'tag' } | undefined;
   value: unknown;
   onChange: (next: unknown) => void;
   enumValues: string[] | null;
   entityKind: ReturnType<typeof detectEntityKind>;
 }): React.ReactElement {
+  if (operator?.valueType === 'tag') {
+    return <TagValueInput value={typeof value === 'string' ? value : ''} onChange={onChange} />;
+  }
   if (operator?.valueType === 'boolean') {
     return (
       <Checkbox

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.utils.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.utils.ts
@@ -3,6 +3,26 @@ import type { VariablePickerSource } from '../VariablePicker/VariablePicker.type
 import { parseReference } from '../VariablePicker/VariablePicker.utils';
 import { resolveSchema } from '../SchemaForm/SchemaForm.utils';
 
+export function hasInvalidTagCondition(condition: Condition): boolean {
+  if (isLeaf(condition)) {
+    if (condition.operator !== 'has_tag') return false;
+    const val = typeof condition.value === 'string' ? condition.value : '';
+    const firstColon = val.indexOf(':');
+    const secondColon = val.indexOf(':', firstColon + 1);
+    if (firstColon === -1 || secondColon === -1) return true;
+    const category = val.slice(0, firstColon);
+    if (!category) return true;
+    const tags = val
+      .slice(secondColon + 1)
+      .split(',')
+      .filter(Boolean);
+    return tags.length === 0;
+  }
+  if (isAndGroup(condition)) return condition.all.some(hasInvalidTagCondition);
+  if (isOrGroup(condition)) return condition.any.some(hasInvalidTagCondition);
+  return false;
+}
+
 export function makeEmptyLeaf(): LeafCondition {
   return { variable: '', operator: 'eq', value: '' };
 }
@@ -34,6 +54,7 @@ const OPERATOR_VERBS: Record<string, string> = {
   lt: '<',
   lte: '≤',
   exists: 'exists',
+  has_tag: 'has tag',
 };
 
 export function summarizeCondition(condition: Condition | undefined): string {

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/TagValueInput.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/TagValueInput.tsx
@@ -1,0 +1,173 @@
+import { useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import Input from '../../../ui/Input/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../../ui/Select/Select';
+import { useCategoryCatalog } from '../../../../hooks/useCategoryCatalog';
+import { normalizeTagName, TAG_FORMAT_REGEX } from '@xyne/shared';
+
+// Value format stored in LeafCondition.value: "category:match:tag1,tag2"
+// e.g. "priority:any:critical,high"
+
+function parseValue(raw: string): { category: string; match: string; tags: string[] } {
+  const firstColon = raw.indexOf(':');
+  const secondColon = raw.indexOf(':', firstColon + 1);
+  if (firstColon === -1 || secondColon === -1) {
+    return { category: raw, match: 'any', tags: [] };
+  }
+  return {
+    category: raw.slice(0, firstColon),
+    match: raw.slice(firstColon + 1, secondColon),
+    tags: raw
+      .slice(secondColon + 1)
+      .split(',')
+      .filter(Boolean),
+  };
+}
+
+function serializeValue(category: string, match: string, tags: string[]): string {
+  return `${category}:${match}:${tags.join(',')}`;
+}
+
+interface TagValueInputProps {
+  value: string;
+  onChange: (next: unknown) => void;
+}
+
+export function TagValueInput({ value, onChange }: TagValueInputProps): React.ReactElement {
+  const parsed = parseValue(value);
+  const [tagInput, setTagInput] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [tagError, setTagError] = useState<string | null>(null);
+  const { catalog } = useCategoryCatalog(true);
+
+  const update = (patch: Partial<{ category: string; match: string; tags: string[] }>): void => {
+    const next = { ...parsed, ...patch };
+    onChange(serializeValue(next.category, next.match, next.tags));
+  };
+
+  const addTag = (tag: string): void => {
+    const normalized = normalizeTagName(tag);
+    if (!normalized) {
+      setTagInput('');
+      setTagError('Tag must not be empty.');
+      return;
+    }
+    if (!TAG_FORMAT_REGEX.test(normalized)) {
+      setTagInput('');
+      setTagError('Tag must be lowercase and hyphen-separated (e.g. "high-priority").');
+      return;
+    }
+    if (parsed.tags.includes(normalized)) {
+      setTagInput('');
+      setTagError(`"${normalized}" is already added.`);
+      return;
+    }
+    setTagError(null);
+    update({ tags: [...parsed.tags, normalized] });
+    setTagInput('');
+  };
+
+  const removeTag = (tag: string): void => {
+    update({ tags: parsed.tags.filter(t => t !== tag) });
+  };
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <div className='flex items-center gap-2'>
+        {/* Category dropdown */}
+        <div className='w-[160px]'>
+          <Select value={parsed.category} onValueChange={cat => update({ category: cat })}>
+            <SelectTrigger className='w-full'>
+              <SelectValue placeholder='Category…' />
+            </SelectTrigger>
+            <SelectContent>
+              {catalog.map(c => (
+                <SelectItem key={c.name} value={c.name}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* any / all */}
+        <div className='w-[90px]'>
+          <Select value={parsed.match} onValueChange={m => update({ match: m })}>
+            <SelectTrigger className='w-full'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='any'>any of</SelectItem>
+              <SelectItem value='all'>all of</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Tag chips + input */}
+      <div
+        role='presentation'
+        className='flex min-h-9 flex-wrap items-center gap-1 rounded-md border border-input bg-background px-2 py-1.5 cursor-text'
+        onClick={() => inputRef.current?.focus()}
+        onKeyDown={() => inputRef.current?.focus()}
+        data-track-category='automation-builder'
+        data-track-name='tag-value-input-focus'
+      >
+        {parsed.tags.map(tag => (
+          <span
+            key={tag}
+            className='flex items-center gap-1 rounded bg-accent px-1.5 py-0.5 text-xs font-mono text-foreground'
+          >
+            {tag}
+            <button
+              type='button'
+              onClick={e => {
+                e.stopPropagation();
+                removeTag(tag);
+              }}
+              data-track-category='automation-builder'
+              data-track-name='tag-value-remove'
+              aria-label={`Remove tag ${tag}`}
+              className='text-muted-foreground hover:text-foreground'
+            >
+              <X className='size-3' />
+            </button>
+          </span>
+        ))}
+        <Input
+          ref={inputRef}
+          placeholder={parsed.tags.length === 0 ? 'Type a tag and press Enter…' : 'Add tag…'}
+          value={tagInput}
+          onChange={e => {
+            setTagInput(e.target.value);
+            setTagError(null);
+          }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              addTag(tagInput);
+            }
+            if (e.key === 'Backspace' && !tagInput && parsed.tags.length > 0) {
+              removeTag(parsed.tags[parsed.tags.length - 1]!);
+            }
+          }}
+          onBlur={() => {
+            if (tagInput.trim()) addTag(tagInput);
+          }}
+          className='h-auto min-w-[120px] flex-1 border-0 bg-transparent p-0 text-xs shadow-none focus-visible:ring-0'
+        />
+      </div>
+      {tagError && <p className='text-xs text-destructive px-1'>{tagError}</p>}
+      {!tagError && parsed.tags.length === 0 && (
+        <p className='text-xs text-destructive px-1'>At least one tag is required.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionalCard/ConditionalCard.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionalCard/ConditionalCard.tsx
@@ -15,7 +15,10 @@ import { Dialog } from '../../../ui/Dialog/Dialog';
 import { Button } from '../../../ui/Button/Button';
 import type { AutomationStepConfig, Condition, ValidationIssue } from '../../Automation.types';
 import { ConditionEditor } from '../ConditionEditor/ConditionEditor';
-import { summarizeCondition } from '../ConditionEditor/ConditionEditor.utils';
+import {
+  summarizeCondition,
+  hasInvalidTagCondition,
+} from '../ConditionEditor/ConditionEditor.utils';
 import { BranchSteps } from '../BranchSteps/BranchSteps';
 import type { ConditionalCardProps } from './ConditionalCard.types';
 
@@ -43,6 +46,7 @@ export function ConditionalCard({
   const [menuOpen, setMenuOpen] = useState(false);
   const [editorOpen, setEditorOpen] = useState(false);
   const [draftCondition, setDraftCondition] = useState<Condition>(step.config.condition);
+  const [tagConditionError, setTagConditionError] = useState<string | null>(null);
   useEffect(() => {
     if (editorOpen) setDraftCondition(step.config.condition);
   }, [editorOpen, step.config.condition]);
@@ -215,22 +219,39 @@ export function ConditionalCard({
                   variableSources={variableSources}
                 />
               </div>
-              <div className='flex justify-end gap-2 border-t border-border bg-background px-5 py-3'>
-                <Button variant='outline' size='sm' onClick={() => setEditorOpen(false)}>
-                  Cancel
-                </Button>
-                <Button
-                  size='sm'
-                  onClick={() => {
-                    onChange({
-                      ...step,
-                      config: { ...step.config, condition: draftCondition },
-                    });
-                    setEditorOpen(false);
-                  }}
-                >
-                  Save condition
-                </Button>
+              <div className='flex flex-col gap-2 border-t border-border bg-background px-5 py-3'>
+                {tagConditionError && <p className='text-xs text-red-500'>{tagConditionError}</p>}
+                <div className='flex justify-end gap-2'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => {
+                      setTagConditionError(null);
+                      setEditorOpen(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size='sm'
+                    onClick={() => {
+                      if (hasInvalidTagCondition(draftCondition)) {
+                        setTagConditionError(
+                          'One or more tag conditions are invalid — a category must be selected and at least one tag must be added.',
+                        );
+                        return;
+                      }
+                      setTagConditionError(null);
+                      onChange({
+                        ...step,
+                        config: { ...step.config, condition: draftCondition },
+                      });
+                      setEditorOpen(false);
+                    }}
+                  >
+                    Save condition
+                  </Button>
+                </div>
               </div>
             </div>
           </Dialog>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.utils.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.utils.ts
@@ -207,7 +207,13 @@ export function getVariableRefInner(schema: JsonSchema): JsonSchema | null {
         (s.pattern === VARIABLE_REF_REGEX.source || /context/.test(s.pattern ?? ''))
       ),
   );
-  return inner ?? null;
+  if (!inner) return null;
+  // If inner is itself a union (anyOf), prefer the enum branch so the UI renders a dropdown.
+  if (!inner.enum && Array.isArray(inner.anyOf)) {
+    const enumBranch = inner.anyOf.find(s => Array.isArray(s.enum) && s.enum.length > 0);
+    if (enumBranch) return enumBranch;
+  }
+  return inner;
 }
 
 export function isVariableRefValue(value: unknown): value is string {

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SwitchCard/SwitchCard.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SwitchCard/SwitchCard.tsx
@@ -22,7 +22,10 @@ import type {
   ValidationIssue,
 } from '../../Automation.types';
 import { ConditionEditor } from '../ConditionEditor/ConditionEditor';
-import { summarizeCondition } from '../ConditionEditor/ConditionEditor.utils';
+import {
+  summarizeCondition,
+  hasInvalidTagCondition,
+} from '../ConditionEditor/ConditionEditor.utils';
 import { BranchSteps } from '../BranchSteps/BranchSteps';
 import type { SwitchCardProps } from './SwitchCard.types';
 
@@ -49,6 +52,7 @@ export function SwitchCard({
   const [collapsed, setCollapsed] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [editingCaseIndex, setEditingCaseIndex] = useState<number | null>(null);
+  const [tagConditionError, setTagConditionError] = useState<string | null>(null);
   const [draftCondition, setDraftCondition] = useState<Condition>({
     variable: '',
     operator: 'eq',
@@ -88,6 +92,13 @@ export function SwitchCard({
 
   const handleCaseConditionSave = (): void => {
     if (editingCaseIndex === null) return;
+    if (hasInvalidTagCondition(draftCondition)) {
+      setTagConditionError(
+        'One or more tag conditions are invalid — a category must be selected and at least one tag must be added.',
+      );
+      return;
+    }
+    setTagConditionError(null);
     const cases = step.config.cases.slice();
     const existing = cases[editingCaseIndex];
     if (!existing) return;
@@ -352,13 +363,23 @@ export function SwitchCard({
               variableSources={variableSources}
             />
           </div>
-          <div className='flex justify-end gap-2 border-t border-border bg-background px-5 py-3'>
-            <Button variant='outline' size='sm' onClick={() => setEditingCaseIndex(null)}>
-              Cancel
-            </Button>
-            <Button size='sm' onClick={handleCaseConditionSave}>
-              Save condition
-            </Button>
+          <div className='flex flex-col gap-2 border-t border-border bg-background px-5 py-3'>
+            {tagConditionError && <p className='text-xs text-red-500'>{tagConditionError}</p>}
+            <div className='flex justify-end gap-2'>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => {
+                  setTagConditionError(null);
+                  setEditingCaseIndex(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button size='sm' onClick={handleCaseConditionSave}>
+                Save condition
+              </Button>
+            </div>
           </div>
         </div>
       </Dialog>


### PR DESCRIPTION
…y via automations

Migration-Changes:
  - Adds TAG_GENERATED as a new value to the existing WorkflowEventType enum in the database

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
