### PR TITLE
fix: XYNE-55195 xyne scribe ux bugs resolve

### DIFF
--- a/apps/dashboard/src/components/xyne-desk/RecipientSuggestionsDropdown/RecipientSuggestionsDropdown.tsx
+++ b/apps/dashboard/src/components/xyne-desk/RecipientSuggestionsDropdown/RecipientSuggestionsDropdown.tsx
@@ -77,6 +77,7 @@ export const RecipientSuggestionsDropdown = ({
         top: pos.top,
         width: pos.width,
         maxHeight: DROPDOWN_MAX_HEIGHT,
+        pointerEvents: 'auto',
       }}
       className='z-50 overflow-y-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md recipient-suggestions-dropdown'
     >

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -1,5 +1,5 @@
 /**
-  The Xyne Oats Details Screen 
+  The Xyne Scribe Details Screen 
  */
 
 import { type ReactElement, useState, useEffect, useCallback, useMemo, useRef } from 'react';
@@ -47,6 +47,7 @@ import {
   DropdownMenuTrigger,
 } from '../../components/ui/dropdown-menu';
 import { RecordingDetailV2Header } from './components/RecordingDetailV2Header';
+import { RecordingDetailV2Skeleton } from './components/RecordingDetailV2Skeleton';
 import { LiveRecordingControlBar } from './components/LiveRecordingControlBar';
 import { LiveTranscriptSection } from './components/LiveTranscriptSection';
 import { ResumeRecordingButton } from './components/ResumeRecordingButton';
@@ -94,8 +95,19 @@ const AUDIO_POLL_MAX_ATTEMPTS = 30;
 const POST_SPLIT_BUTTON_CLASS =
   'text-background hover:bg-foreground/90 hover:text-background dark:hover:bg-foreground/90 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-background';
 
+const CANVAS_POPOVER_LAYER_CLASS = '[&_[style*="--bn-ui-base-z-index"]]:!z-[15]';
+
 function isRecordingLive(recording: RecordingDetail): boolean {
   return recording.status === 'ACTIVE' || recording.status === 'IN_PROGRESS';
+}
+
+function isSameRecordingSnapshot(a: RecordingDetail, b: RecordingDetail): boolean {
+  if (a === b) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
 }
 
 export default function RecordingDetailV2Screen(): ReactElement {
@@ -306,7 +318,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
       if (recordingRow.status) {
         next.status = recordingRow.status as NonNullable<RecordingDetail['status']>;
       }
-      return next;
+      return isSameRecordingSnapshot(prev, next) ? prev : next;
     });
   }, [recordingRow]);
 
@@ -415,6 +427,12 @@ export default function RecordingDetailV2Screen(): ReactElement {
     summaryTemplateId: BuiltinRecordingSummaryTemplateId,
   ): Promise<void> => {
     if (!recording || isRegeneratingSummary) return;
+
+    // Picking the template the existing summary was already written with is a no-op
+    if (recording.detailedSummaryCanvasId && summaryTemplateId === recording.summaryTemplateId) {
+      handleTabSelect('summary');
+      return;
+    }
 
     setPendingSummaryTemplateId(summaryTemplateId);
     handleTabSelect('summary');
@@ -525,16 +543,15 @@ export default function RecordingDetailV2Screen(): ReactElement {
   }, [recordingId, transcriptText]);
 
   if (loading) {
-    return (
-      <div className='flex h-full w-full items-center justify-center'>
-        <Spinner size={28} className='animate-spin text-muted-foreground' />
-      </div>
-    );
+    return <RecordingDetailV2Skeleton />;
   }
 
   if (error || !recording) {
     return (
-      <div className='flex h-full w-full items-center justify-center'>
+      <div
+        data-testid='recording-detail-v2-page'
+        className='relative flex h-full w-full flex-col items-center justify-center overflow-hidden bg-background shadow-md md:rounded-2xl'
+      >
         <div className='flex max-w-md flex-col items-center gap-3 text-center'>
           <AlertCircle className='size-12 text-destructive' />
           <p className='text-sm text-muted-foreground'>{error ?? 'Recording not found'}</p>
@@ -607,7 +624,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
           .join(' ')}
       >
         <div className='mx-auto flex min-h-full w-full max-w-[860px] flex-col px-4 py-6'>
-          <div className='sticky top-0 z-10 -mx-4 -mt-6 flex flex-col bg-background px-4 pt-6'>
+          <div className='sticky top-0 z-20 -mx-4 -mt-6 flex flex-col bg-background px-4 pt-6'>
             <RecordingDetailV2Header
               recording={recording}
               isLive={isLive}
@@ -730,7 +747,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                         data-track-name='open_post_to_email_modal'
                       >
                         <EnvelopeDefault className='size-4 text-muted-foreground' />
-                        Post to email
+                        Draft follow-up email
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
@@ -872,7 +889,7 @@ function NotesCanvas({ canvasId }: { canvasId: string }): ReactElement {
       title={canvas.title}
       editable={true}
       placeholder='Start typing your notes…'
-      className='min-h-0 w-full flex-1
+      className={`min-h-0 w-full flex-1 ${CANVAS_POPOVER_LAYER_CLASS}
         [&_.bn-side-menu]:!hidden
         [&_.thin-scrollbar]:!pt-2
         [&_.bn-editor]:!px-0
@@ -882,7 +899,7 @@ function NotesCanvas({ canvasId }: { canvasId: string }): ReactElement {
         [&_.bn-mt-suggestion-menu-item-title]:!text-sm [&_.bn-mt-suggestion-menu-item-title]:!leading-4
         [&_.bn-mt-suggestion-menu-item-title]:!whitespace-nowrap [&_.bn-mt-suggestion-menu-item-title]:!overflow-hidden [&_.bn-mt-suggestion-menu-item-title]:!text-ellipsis
         [&_.bn-mt-suggestion-menu-item-section_svg]:!size-4
-        '
+        `}
       autoFocus={true}
     />
   );
@@ -909,7 +926,7 @@ function DetailedSummaryCanvas({ canvasId }: { canvasId: string }): ReactElement
       editable={true}
       placeholder='Detailed summary'
       autoFocus={false}
-      className='min-h-0 w-full flex-1
+      className={`min-h-0 w-full flex-1 ${CANVAS_POPOVER_LAYER_CLASS}
         detailed-summary-canvas-editor
         [&_.bn-side-menu]:!hidden
         [&_.thin-scrollbar]:!pt-0
@@ -918,9 +935,9 @@ function DetailedSummaryCanvas({ canvasId }: { canvasId: string }): ReactElement
         [&_.bn-suggestion-menu]:!w-auto [&_.bn-suggestion-menu]:!no-scrollbar [&_.bn-suggestion-menu]:!max-h-60 [&_.bn-suggestion-menu]:!max-w-[calc(100vw-2rem)]
         [&_.bn-suggestion-menu-item]:!h-8 [&_.bn-suggestion-menu-item]:!px-2 [&_.bn-suggestion-menu-item]:!py-1
         [&_.bn-mt-suggestion-menu-item-title]:!text-sm [&_.bn-mt-suggestion-menu-item-title]:!leading-4
-        [&_.bn-mt-suggestion-menu-item-title]:!whitespace-nowrap [&_.bn-mt-suggestion-menu-item-title]:!overflow-hidden [&_.bn-mt-suggestion-menu-item-title]:!text-ellipsis
+        [&_.bn-mt-suggestion-menu-item-title]:!whitespace-nowrap [&_.bn-mt-suggestion-menu-item-title]:!text-ellipsis
         [&_.bn-mt-suggestion-menu-item-section_svg]:!size-4
-        '
+        `}
     />
   );
 }

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
@@ -180,7 +180,7 @@ export const LiveRecordingControlBar = ({
       <span
         className={[
           'shrink-0 font-mono text-xs font-medium uppercase tracking-wide w-12',
-          isPaused ? 'text-muted-foreground' : 'text-destructive',
+          isPaused ? 'text-muted-foreground' : 'text-primary',
         ].join(' ')}
       >
         {isPaused ? 'Paused' : 'Live'}
@@ -326,10 +326,8 @@ const LiveRecordingTimeline = ({
           className='absolute top-1/2 size-3.5 -translate-x-1/2 -translate-y-1/2'
           style={{ left: `${progressPercent}%` }}
         >
-          {!isPaused && (
-            <span className='absolute inset-0 animate-ping rounded-full bg-destructive opacity-40' />
-          )}
-          <span className='absolute inset-0 rounded-full border-2 border-background bg-destructive shadow-sm' />
+          {!isPaused && <span className='absolute inset-0 animate-ping rounded-full bg-primary' />}
+          <span className='absolute inset-0 rounded-full border-2 border-background bg-primary shadow-sm' />
         </div>
       </div>
     </div>
@@ -560,7 +558,10 @@ const RecordingVisualizer = ({ isPaused }: { isPaused: boolean }): ReactElement 
       };
       return (
         <div key={i} className='flex h-4 items-center'>
-          <div className='rec-overlay-waveform-bar w-1 rounded-full bg-destructive' style={style} />
+          <div
+            className='rec-overlay-waveform-bar w-1 rounded-full bg-primary !opacity-100'
+            style={style}
+          />
         </div>
       );
     })}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToEmailModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToEmailModal.tsx
@@ -181,6 +181,7 @@ const RecipientLine = ({
           onChange={event => {
             setInputValue(event.target.value);
             setHighlightedIndex(0);
+            setSuggestionsOpen(true);
           }}
           onFocus={() => setSuggestionsOpen(true)}
           onBlur={() => window.setTimeout(() => setSuggestionsOpen(false), 100)}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingContentTabs.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingContentTabs.tsx
@@ -49,6 +49,13 @@ interface RecordingContentTabsProps {
 
 const TAB_INDICATOR_ID = 'recording-content-tab-indicator';
 
+const MIDNIGHT_LISTBOX_RESET =
+  '[[data-theme=midnight]_&[role=listbox]:not([cmdk-list])]:!bg-transparent';
+
+const MIDNIGHT_OPTION_RESET = cn(
+  '[[data-theme=midnight]_&[role=option]:not([cmdk-item])]:!text-foreground',
+);
+
 export const RecordingContentTabs = ({
   visibleTab,
   secondTab,
@@ -230,7 +237,11 @@ export const RecordingContentTabs = ({
           </button>
         }
       >
-        <div role='listbox' aria-label='Summary templates' className='thin-scrollbar'>
+        <div
+          role='listbox'
+          aria-label='Summary templates'
+          className={cn('thin-scrollbar', MIDNIGHT_LISTBOX_RESET)}
+        >
           {templates.map(template => {
             const isSelected = template.id === selectedTemplate?.id;
 
@@ -243,6 +254,7 @@ export const RecordingContentTabs = ({
                 onClick={() => handleTemplateSelect(template.id)}
                 className={cn(
                   'flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-accent',
+                  MIDNIGHT_OPTION_RESET,
                   isSelected && 'bg-accent',
                 )}
                 data-track-category='RecordingDetailV2'

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -1,6 +1,5 @@
 import { type ReactElement, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import * as Popover from '@radix-ui/react-popover';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 import { MinimizeLineArrow, Share02, Spinner, UturnLeft } from '@xyne/icons';
@@ -74,7 +73,6 @@ export const RecordingDetailV2Header = ({
   const [editedTitle, setEditedTitle] = useState(recording.title);
   const [isSavingTitle, setIsSavingTitle] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
-  const [showLiveAskAIHint, setShowLiveAskAIHint] = useState(false);
   const [isUpdatingTicketLink, setIsUpdatingTicketLink] = useState(false);
 
   // Only the creator can rename or relabel; a recording shared with you is read-only.
@@ -189,14 +187,6 @@ export const RecordingDetailV2Header = ({
       event.preventDefault();
       handleCancelEdit();
     }
-  };
-
-  const handleAskAIClick = (): void => {
-    if (isLive) {
-      setShowLiveAskAIHint(true);
-      return;
-    }
-    onAskAI();
   };
 
   const handleStartEdit = (): void => {
@@ -378,43 +368,22 @@ export const RecordingDetailV2Header = ({
             />
           </Dialog>
         )}
-
-        <Popover.Root open={showLiveAskAIHint} onOpenChange={setShowLiveAskAIHint}>
+        {!isLive && (
           <Tooltip content='Ask AI about this recording' side='top'>
-            <Popover.Anchor asChild>
-              <Button
-                type='button'
-                variant='outline'
-                size='sm'
-                onClick={handleAskAIClick}
-                className='h-8 gap-2 rounded-xl w-24 text-[13px] font-medium border-muted-foreground/20'
-                data-track-category='RecordingDetailV2'
-                data-track-name={isLive ? 'ask_ai_live_hint' : 'ask_ai_recording'}
-              >
-                <XyneAIStar />
-                Ask AI
-              </Button>
-            </Popover.Anchor>
-          </Tooltip>
-
-          <Popover.Portal>
-            <Popover.Content
-              side='bottom'
-              align='end'
-              sideOffset={8}
-              className='z-50 w-64 rounded-xl border border-border bg-popover p-3.5 shadow-2xl'
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              onClick={onAskAI}
+              className='h-8 gap-2 rounded-xl w-24 text-[13px] font-medium border-muted-foreground/20'
+              data-track-category='RecordingDetailV2'
+              data-track-name='ask_ai_recording'
             >
-              <div className='mb-2 flex items-center gap-1.5'>
-                <XyneAIStar size={14} />
-                <h3 className='text-sm font-semibold text-foreground'>Ask AI</h3>
-              </div>
-              <p className='text-pretty text-xs leading-relaxed text-muted-foreground/70'>
-                Ask about decisions, action items, and anything said. Available on the full
-                recording once you stop.
-              </p>
-            </Popover.Content>
-          </Popover.Portal>
-        </Popover.Root>
+              <XyneAIStar />
+              Ask AI
+            </Button>
+          </Tooltip>
+        )}
       </div>
     </header>
   );

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Skeleton.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Skeleton.tsx
@@ -1,0 +1,99 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../../components/ui/Skeleton';
+
+/** Paragraph shapes for the summary body — ragged widths, like real prose. */
+const SUMMARY_LINES = ['w-full', 'w-[94%]', 'w-[88%]', 'w-[62%]'] as const;
+
+export function RecordingDetailV2Skeleton(): ReactElement {
+  return (
+    <div
+      data-testid='recording-detail-v2-page'
+      role='status'
+      aria-live='polite'
+      aria-busy='true'
+      aria-label='Loading recording'
+      className='relative flex h-full w-full flex-col overflow-hidden bg-background shadow-md md:rounded-2xl'
+    >
+      <span className='sr-only'>Loading recording</span>
+      <div aria-hidden='true' className='h-full w-full overflow-y-scroll'>
+        <div className='mx-auto flex min-h-full w-full max-w-[860px] flex-col px-4 py-6'>
+          <div className='-mx-4 -mt-6 flex flex-col bg-background px-4 pt-6'>
+            <header className='mb-6'>
+              <div className='mb-3 flex h-5 items-center gap-1.5'>
+                <Skeleton className='h-3 w-24' />
+                <Skeleton className='h-3 w-1' />
+                <Skeleton className='h-3 w-44' />
+              </div>
+
+              <div className='mb-4'>
+                <div className='flex h-9 items-center'>
+                  <Skeleton className='h-7 w-[24rem] max-w-full !rounded-lg' />
+                </div>
+                {/* The date · duration line */}
+                <div className='mt-2.5 flex h-5 items-center'>
+                  <Skeleton className='h-3 w-52' />
+                </div>
+              </div>
+
+              {/* Chips on the left, Ask AI on the right */}
+              <div className='flex flex-wrap items-center justify-between gap-3'>
+                <div className='flex flex-wrap items-center gap-2'>
+                  <Skeleton className='h-7 w-16 !rounded-lg' />
+                  <Skeleton className='h-7 w-32 !rounded-lg' />
+                  <Skeleton className='h-7 w-8 !rounded-lg' />
+                </div>
+                <Skeleton className='h-8 w-24 rounded-xl' />
+              </div>
+            </header>
+
+            <div className='flex flex-col pt-2'>
+              {/* Control bar: the real card, with the transport stood in inside it */}
+              <div className='mb-6 rounded-2xl border border-border bg-card px-5 py-4'>
+                <div className='flex min-h-11 items-center gap-4'>
+                  <Skeleton className='size-8 shrink-0 !rounded-full' />
+                  <Skeleton className='h-3 w-12 shrink-0' />
+                  <Skeleton className='h-1.5 flex-1 !rounded-full' />
+                  <Skeleton className='h-3 w-12 shrink-0' />
+                  {/* The visualizer's own bordered well, with its bars at rest */}
+                  <div className='inline-flex h-7 w-14 shrink-0 items-center justify-center gap-0.5 rounded-lg border border-border'>
+                    {Array.from({ length: 4 }, (_, index) => (
+                      <Skeleton key={index} className='size-1 !rounded-full' />
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* Tab strip: the segmented control is one filled pill, so it stands in
+                  as one shape; the post/share action sits opposite it. */}
+              <div className='mb-4 flex items-center justify-between border-b border-border/70 pb-2'>
+                <Skeleton className='h-10 w-[19rem] max-w-full !rounded-full' />
+                <Skeleton className='h-8 w-40 !rounded-lg' />
+              </div>
+            </div>
+          </div>
+
+          {/* Summary pane: heading and the transcript toggle, then the body */}
+          <section className='mb-8 max-w-full'>
+            <div className='flex items-center justify-between'>
+              <Skeleton className='h-4 w-24' />
+              <Skeleton className='size-8 !rounded-lg' />
+            </div>
+
+            <div className='mt-6 flex flex-col gap-3'>
+              {SUMMARY_LINES.map(width => (
+                <Skeleton key={width} className={`h-3 ${width}`} />
+              ))}
+            </div>
+
+            <div className='mt-8 flex flex-col gap-3'>
+              <Skeleton className='h-3.5 w-40' />
+              {SUMMARY_LINES.slice(0, 3).map(width => (
+                <Skeleton key={width} className={`h-3 ${width}`} />
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -18,7 +18,7 @@ export interface RecordingLabelPickerProps {
 const MAX_VISIBLE_LABELS = 3;
 
 const CHIP_CLASS_NAME =
-  'inline-flex items-center gap-1.5 rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-foreground';
+  'inline-flex shrink-0 items-center gap-1.5 rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-foreground whitespace-nowrap scrollbar-none data-[theme=midnight]:bg-muted/50';
 
 const READ_ONLY_TRIGGER_CLASS_NAME =
   'inline-flex h-7 items-center gap-1.5 rounded-lg border bg-background px-2 text-xs font-normal text-foreground shadow-xs';
@@ -30,7 +30,7 @@ function LabelChip({ label }: { label: string }): ReactElement {
         className={cn('size-1.5 shrink-0 rounded-full', getRecordingTagDotColor(label))}
         aria-hidden='true'
       />
-      <span className='max-w-24 truncate'>{label}</span>
+      <span>{label}</span>
     </span>
   );
 }
@@ -73,7 +73,7 @@ export function RecordingLabelPicker({
   };
 
   const appliedLabels = (
-    <>
+    <span className='flex max-w-76 w-full items-center gap-1.5 overflow-x-scroll scrollbar-none'>
       {visibleLabels.map(label => (
         <LabelChip key={label} label={resolveLabel(label)} />
       ))}
@@ -85,7 +85,7 @@ export function RecordingLabelPicker({
           +{overflowCount}
         </span>
       )}
-    </>
+    </span>
   );
 
   if (!canEdit) {

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
@@ -223,7 +223,7 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
               const label = share.userGroupId
                 ? (share.userGroup?.name ?? share.userGroupId)
                 : share.channelId
-                  ? `#${share.channel?.name ?? share.channelId}`
+                  ? `${share.channel?.name ?? share.channelId}`
                   : share.user
                     ? getUserDisplayName(share.user)
                     : share.userId;

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPanel.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPanel.tsx
@@ -79,7 +79,7 @@ export const SummaryGenerationPanel = ({
               </p>
               <p className='mt-1 text-sm text-muted-foreground'>
                 {canGenerate
-                  ? 'Transcript’s ready. Oats takes up to 2 minutes to write the recap, decisions and action items — often less.'
+                  ? 'Transcript ready. Scribe takes up to 2 minutes to write the recap, decisions and action items — often less.'
                   : 'A summary needs a transcript. This recording doesn’t have one yet.'}
               </p>
             </motion.div>
@@ -91,7 +91,7 @@ export const SummaryGenerationPanel = ({
             >
               <p className='text-sm font-medium text-foreground'>Writing your summary…</p>
               <p className='mt-1 text-sm text-muted-foreground'>
-                The recap, decisions and action items land here as soon as Oats is done.
+                The recap, decisions and action items land here as soon as Scribe is done.
               </p>
             </motion.div>
           </div>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -228,15 +228,15 @@ const RecordingsV2Screen = (): ReactElement => {
     <div
       data-testid='recordings-v2-page'
       className='relative flex h-full w-full flex-col overflow-hidden bg-background shadow-md md:rounded-2xl'
-      aria-labelledby='xyne-oats-heading'
+      aria-labelledby='xyne-scribe-heading'
     >
       <div ref={setScrollContainer} className='h-full w-full overflow-y-scroll'>
         <div className='flex min-h-full w-full flex-col items-center px-4'>
           <header className='max-w-[860px] w-full sticky top-0 bg-background z-20 pt-6 pb-6 sm:pb-3'>
             <div className='grid grid-cols-[minmax(0,1fr)_auto] items-center gap-y-6'>
               <div className='col-start-1 row-start-1 min-w-0'>
-                <h1 id='xyne-oats-heading' className='text-3xl font-semibold text-foreground'>
-                  Xyne Oats
+                <h1 id='xyne-scribe-heading' className='text-3xl font-semibold text-foreground'>
+                  Xyne Scribe
                 </h1>
                 <p className='mt-1 text-sm text-muted-foreground/70'>
                   {ownershipFilteredRecordings.length} recordings · {recordingsCapturedThisWeek}{' '}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
@@ -49,6 +49,7 @@ interface RecordingPanelHeaderProps {
 interface RecordingControlBarProps {
   elapsed: number;
   isPaused: boolean;
+  markedCount: number;
   onPause: () => void;
   onResume: () => void;
   onStop: () => void;
@@ -66,6 +67,8 @@ interface NotesTabProps {
 const TRACK_CATEGORY = 'NoteTakerOverlay';
 /** Matches the `h-8` inner row; needed as a number so the bar can animate open. */
 const OFFLINE_BAR_HEIGHT_PX = 32;
+
+const MARK_FEEDBACK_MS = 1400;
 
 // ─── Sub-components ─────────────────────────────────────────────────────────
 
@@ -140,9 +143,84 @@ const OfflineStatusBar = (): ReactElement => {
   );
 };
 
+const MarkMomentButton = ({
+  markedCount,
+  onMarkMoment,
+}: {
+  markedCount: number;
+  onMarkMoment: () => void;
+}): ReactElement => {
+  const shouldReduceMotion = useReducedMotion();
+  const [justMarked, setJustMarked] = useState(false);
+  const previousCount = useRef(markedCount);
+
+  useEffect(() => {
+    const grew = markedCount > previousCount.current;
+    previousCount.current = markedCount;
+    if (!grew) return;
+
+    setJustMarked(true);
+    const timer = window.setTimeout(() => setJustMarked(false), MARK_FEEDBACK_MS);
+    return (): void => window.clearTimeout(timer);
+  }, [markedCount]);
+
+  return (
+    <>
+      <Button
+        type='button'
+        variant='ghost'
+        size='iconSm'
+        onClick={onMarkMoment}
+        className={cn(
+          'relative rounded-xl border transition-colors',
+          justMarked
+            ? 'border-status-success text-status-success hover:bg-transparent hover:text-status-success'
+            : 'border-transparent text-muted-foreground hover:bg-muted hover:text-foreground',
+        )}
+        aria-label='Mark moment'
+        title={justMarked ? 'Moment marked' : 'Mark moment'}
+        data-track-category={TRACK_CATEGORY}
+        data-track-name='mark_moment'
+      >
+        {justMarked && (
+          <span
+            className='pointer-events-none absolute inset-0 rounded-xl bg-status-success opacity-10'
+            aria-hidden='true'
+          />
+        )}
+        <AnimatePresence>
+          {justMarked && !shouldReduceMotion && (
+            <motion.span
+              className='pointer-events-none absolute inset-0 rounded-xl ring-2 ring-status-success'
+              initial={{ opacity: 0.8, scale: 0.92 }}
+              animate={{ opacity: 0, scale: 1.5 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.5, ease: 'easeOut' }}
+              aria-hidden='true'
+            />
+          )}
+        </AnimatePresence>
+
+        <motion.span
+          className='flex items-center justify-center'
+          animate={shouldReduceMotion || !justMarked ? { scale: 1 } : { scale: [1, 1.28, 1] }}
+          transition={{ duration: 0.36, ease: [0.22, 1, 0.36, 1], times: [0, 0.4, 1] }}
+        >
+          <Flag size={17} strokeWidth={2} {...(justMarked ? { variant: 'Solid' as const } : {})} />
+        </motion.span>
+      </Button>
+
+      <span className='sr-only' role='status'>
+        {justMarked ? 'Moment marked' : ''}
+      </span>
+    </>
+  );
+};
+
 const RecordingControlBar = ({
   elapsed,
   isPaused,
+  markedCount,
   onPause,
   onResume,
   onStop,
@@ -161,19 +239,7 @@ const RecordingControlBar = ({
       {formatElapsedTime(elapsed)}
     </span>
     <div className='flex flex-1 shrink-0 items-center justify-end gap-1.5'>
-      <Button
-        type='button'
-        variant='ghost'
-        size='iconSm'
-        onClick={onMarkMoment}
-        className='rounded-xl text-muted-foreground hover:bg-muted hover:text-foreground'
-        aria-label='Mark moment'
-        title='Mark moment'
-        data-track-category={TRACK_CATEGORY}
-        data-track-name='mark_moment'
-      >
-        <Flag size={17} strokeWidth={2} />
-      </Button>
+      <MarkMomentButton markedCount={markedCount} onMarkMoment={onMarkMoment} />
       {onMinimize && (
         <Button
           type='button'
@@ -441,6 +507,7 @@ export function NoteTakerOverlay({
           <RecordingControlBar
             elapsed={elapsed}
             isPaused={isPaused}
+            markedCount={markedMoments.length}
             onPause={onPause}
             onResume={onResume}
             onStop={onStop}

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -176,11 +176,6 @@ export const recordingStore = createStore({
             startTime: session.startTime,
             defaultLayout,
           });
-
-          toast.success('Recording started', {
-            description: 'Your voice is being recorded and transcribed',
-            duration: 3000,
-          });
         })
         .catch(error => {
           logger.error(Event.RECORDING_ERROR, {


### PR DESCRIPTION
## Xyne Scribe feature dashboard resolved changes:

- Snack Bar Remove ✅
- Mark moment feedback@ on small UI not present ✅
- Wave color ✅
- Width overflow in label
- Ask AI Remove it in ongoing ✅
- Rename Oats to scribe ✅
- double # in share UI for channel ✅
- regenerating the summary on clicking on same template ✅
- Canvas action item overflow z index ✅


POT: [https://drive.google.com/file/d/1KgTlOGT5mOFEUgs4o8yAynSbLW4PrzvI/view?usp=sharing](https://drive.google.com/file/d/1KgTlOGT5mOFEUgs4o8yAynSbLW4PrzvI/view?usp=sharing)

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
