### PR TITLE
email flow

### DIFF
--- a/backend/src/controllers/emailAuthController.ts
+++ b/backend/src/controllers/emailAuthController.ts
@@ -11,10 +11,24 @@ import {
 import { DatabaseClient } from '@/database/client';
 import { emailService } from '@/services/email/factory';
 import { redisService } from '@/services/redisService';
+import {
+  organizationDomainService,
+  OrganizationDomainConflictError,
+  PublicEmailDomainError,
+} from '@/services/organizationDomainService';
+import { UserService } from '@/services/userService';
 import '../types/express';
 
 interface ResetCodePayload {
   code: string;
+}
+
+interface RegistrationPendingPayload {
+  code: string;
+  email: string;
+  passwordHash: string;
+  name: string;
+  workspaceId?: string;
 }
 
 const LOGIN_MAX_FAILED_ATTEMPTS = 5;
@@ -22,12 +36,19 @@ const LOGIN_LOCKOUT_SECONDS = 5 * 60;
 const LOGIN_FAILED_ATTEMPT_WINDOW_SECONDS = 5 * 60;
 const PASSWORD_RESET_REQUEST_MESSAGE = 'If an account exists, a reset code has been sent.';
 
+const REGISTER_RATE_LIMIT_SECONDS = 60;
+const REGISTER_CODE_TTL_SECONDS = 15 * 60;
+const REGISTER_MAX_VERIFY_ATTEMPTS = 3;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export class EmailAuthController {
   private userSessionService: UserSessionService;
+  private userService: UserService;
   private prisma = DatabaseClient.getInstance();
 
   constructor() {
     this.userSessionService = new UserSessionService();
+    this.userService = new UserService();
   }
 
   /**
@@ -159,6 +180,138 @@ export class EmailAuthController {
         : null;
 
       if (workspaceUsers.length === 0 && !pendingInvitation) {
+        // Check if user has approved community workspace join request(s).
+        const approvedJoinRequests = await this.prisma.workspaceJoinRequest.findMany({
+          where: { email: normalizedEmail, status: 'APPROVED' },
+          orderBy: { updatedAt: 'desc' },
+          select: { id: true, workspaceId: true },
+        });
+
+        if (approvedJoinRequests.length === 1) {
+          // Exactly one approved request — issue pending-auth cookie and
+          // signal the frontend to complete the join for this workspace.
+          const approvedJoinRequest = approvedJoinRequests[0];
+          const userName = normalizedEmail.split('@')[0];
+          const pendingAuthJwtId = crypto.randomUUID();
+
+          await redisService.set(
+            `pendingauth:jwtid:${pendingAuthJwtId}`,
+            normalizedEmail,
+            10 * 60,
+          );
+
+          const isProduction = process.env.NODE_ENV === 'production';
+          const cookieBase = {
+            httpOnly: true,
+            secure: isProduction,
+            sameSite: 'strict' as const,
+            path: '/',
+          };
+
+          res.cookie(
+            'google_access_token',
+            jwt.sign(
+              {
+                email: normalizedEmail,
+                name: userName,
+                providerUserId: `email-${normalizedEmail}`,
+                provider: 'EMAIL',
+                refreshToken: null,
+                accessToken: null,
+                jwtId: pendingAuthJwtId,
+              },
+              process.env.JWT_SECRET!,
+              { expiresIn: '10m' },
+            ),
+            {
+              ...cookieBase,
+              maxAge: 10 * 60 * 1000,
+            },
+          );
+
+          res.status(200).json({
+            success: true,
+            workspaces: [],
+            pendingUserData: { email: normalizedEmail, name: userName },
+            userExistsButRemoved: false,
+            autoLoginWorkspace: approvedJoinRequest.workspaceId,
+          });
+          return;
+        }
+
+        if (approvedJoinRequests.length > 1) {
+          // Multiple approved requests — let the user pick which workspace to join.
+          const workspaceIds = approvedJoinRequests.map(r => r.workspaceId);
+          const workspaces = await this.prisma.workspace.findMany({
+            where: { id: { in: workspaceIds } },
+            select: { id: true, name: true },
+          });
+          const workspaceMap = new Map(workspaces.map(w => [w.id, w.name]));
+          const userName = normalizedEmail.split('@')[0];
+          const pendingAuthJwtId = crypto.randomUUID();
+
+          await redisService.set(
+            `pendingauth:jwtid:${pendingAuthJwtId}`,
+            normalizedEmail,
+            10 * 60,
+          );
+
+          const isProduction = process.env.NODE_ENV === 'production';
+          const cookieBase = {
+            httpOnly: true,
+            secure: isProduction,
+            sameSite: 'strict' as const,
+            path: '/',
+          };
+
+          res.cookie(
+            'google_access_token',
+            jwt.sign(
+              {
+                email: normalizedEmail,
+                name: userName,
+                providerUserId: `email-${normalizedEmail}`,
+                provider: 'EMAIL',
+                refreshToken: null,
+                accessToken: null,
+                jwtId: pendingAuthJwtId,
+              },
+              process.env.JWT_SECRET!,
+              { expiresIn: '10m' },
+            ),
+            {
+              ...cookieBase,
+              maxAge: 10 * 60 * 1000,
+            },
+          );
+
+          res.status(200).json({
+            success: true,
+            workspaces: approvedJoinRequests.map(r => ({
+              id: r.workspaceId,
+              name: workspaceMap.get(r.workspaceId) || r.workspaceId,
+              role: 'COMMUNITY_MEMBER',
+            })),
+            pendingUserData: { email: normalizedEmail, name: userName },
+            userExistsButRemoved: false,
+          });
+          return;
+        }
+
+        // Check if user has a pending join request
+        const pendingJoinRequest = await this.prisma.workspaceJoinRequest.findFirst({
+          where: { email: normalizedEmail, status: 'PENDING' },
+          orderBy: { updatedAt: 'desc' },
+        });
+
+        if (pendingJoinRequest) {
+          res.status(403).json({
+            error: 'Join request pending',
+            message: 'Your request to join the community workspace is pending approval.',
+          });
+          return;
+        }
+
         res.status(403).json({
           error: 'No workspace access',
           message: 'You do not have access to any workspace. Please contact your administrator.',
@@ -568,6 +721,475 @@ export class EmailAuthController {
       ]);
 
       res.status(200).json({ success: true, message: 'Password reset successful. You can now log in.' });
+    } catch (error) {
+      res.status(500).json({ error: 'An unexpected error occurred' });
+    }
+  };
+
+  /**
+   * Register a new account with email + password
+   * POST /v2/auth/email/register
+   *
+   * Validates email + password, hashes the password, stores pending
+   * registration data in Redis, and sends a 6-digit verification code.
+   * The OrgMember is NOT created until the code is verified.
+   *
+   * If workspaceId is provided, the user is registering to join a specific
+   * workspace (community or enterprise). If not provided, the post-verification
+   * flow mirrors OAuth — domain checking determines if an org exists, and
+   * the user can join existing workspaces or create a new org.
+   */
+  register = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { email, password, name } = req.body;
+      const workspaceId: string | undefined = req.body.workspaceId;
+
+      if (!email || !password || !name) {
+        res.status(400).json({
+          error: 'Missing required fields',
+          message: 'email, password, and name are required',
+        });
+        return;
+      }
+
+      const normalizedEmail = email.toLowerCase().trim();
+      const trimmedName = name.trim();
+
+      if (!EMAIL_REGEX.test(normalizedEmail)) {
+        res.status(400).json({ error: 'Invalid email address' });
+        return;
+      }
+
+      const passwordValidationError = validatePasswordComplexity(password);
+      if (passwordValidationError) {
+        res.status(400).json({ error: passwordValidationError });
+        return;
+      }
+
+      // Rate-limit: 60s between registration attempts for the same email
+      const rateLimitKey = `emailreg:ratelimit:${normalizedEmail}`;
+      const rateLimited = await redisService.get(rateLimitKey);
+      if (rateLimited) {
+        res.status(429).json({
+          error: 'Rate limited',
+          message: 'Please wait before requesting another verification code.',
+        });
+        return;
+      }
+
+      // If workspaceId is provided, verify the workspace exists and is active
+      let workspaceName: string | null = null;
+      if (workspaceId) {
+        const workspace = await this.prisma.workspace.findUnique({
+          where: { id: workspaceId },
+          select: { id: true, name: true, status: true },
+        });
+
+        if (!workspace || workspace.status !== 'ACTIVE') {
+          res.status(404).json({ error: 'Workspace not found' });
+          return;
+        }
+        workspaceName = workspace.name;
+      }
+
+      // Check if OrgMember already exists with a password (already registered)
+      const existingOrgMember = await this.prisma.orgMember.findUnique({
+        where: { email: normalizedEmail },
+        select: { memberId: true, passwordHash: true, leftAt: true },
+      });
+
+      if (existingOrgMember && existingOrgMember.passwordHash && !existingOrgMember.leftAt) {
+        res.status(409).json({
+          error: 'Already registered',
+          message: 'An account with this email already exists. Please log in instead.',
+        });
+        return;
+      }
+
+      // Hash the password now so we don't store plaintext in Redis
+      const passwordHash = await hashPassword(password);
+
+      // Generate 6-digit verification code
+      const code = crypto.randomInt(100000, 1000000).toString().padStart(6, '0');
+      const redisKey = `emailreg:code:${normalizedEmail}`;
+      const attemptsKey = `emailreg:attempts:${normalizedEmail}`;
+
+      const payload: RegistrationPendingPayload = {
+        code,
+        email: normalizedEmail,
+        passwordHash,
+        name: trimmedName,
+        ...(workspaceId ? { workspaceId } : {}),
+      };
+
+      await Promise.all([
+        redisService.set(redisKey, JSON.stringify(payload), REGISTER_CODE_TTL_SECONDS),
+        redisService.del(attemptsKey),
+        redisService.set(rateLimitKey, '1', REGISTER_RATE_LIMIT_SECONDS),
+      ]);
+
+      // Send verification email
+      const emailResult = await emailService.sendEmail({
+        to: normalizedEmail,
+        subject: 'Xyne Spaces — Verify Your Email',
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 480px; margin: 0 auto;">
+            <h2>Verify Your Email</h2>
+            ${workspaceName
+              ? `<p>You're registering for <strong>${workspaceName}</strong> on Xyne Spaces.</p>`
+              : '<p>Welcome to Xyne Spaces!</p>'
+            }
+            <p>Enter the following code to complete your registration:</p>
+            <p style="font-size: 28px; font-weight: bold; letter-spacing: 4px; padding: 16px; background: #f5f5f5; border-radius: 8px; text-align: center;">${code}</p>
+            <p>This code expires in 15 minutes.</p>
+            <p>If you didn't request this, you can safely ignore this email.</p>
+          </div>
+        `,
+        text: `Your Xyne Spaces verification code is: ${code}\n\nThis code expires in 15 minutes.\n`,
+      });
+
+      if (!emailResult.success) {
+        await Promise.all([
+          redisService.del(redisKey),
+          redisService.del(attemptsKey),
+          redisService.del(rateLimitKey),
+        ]);
+        res.status(500).json({ error: 'Failed to send verification email. Please try again.' });
+        return;
+      }
+
+      res.status(200).json({
+        success: true,
+        message: 'Verification code sent to your email.',
+        email: normalizedEmail,
+      });
+    } catch (error) {
+      res.status(500).json({
+        error: 'Registration failed',
+        message: `An unexpected error occurred. Error: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  };
+
+  /**
+   * Verify email and complete registration
+   * POST /v2/auth/email/verify
+   *
+   * Verifies the 6-digit code, creates the OrgMember with passwordHash,
+   * and issues a pending-auth cookie (same as OAuth flow). The frontend
+   * auth machine then handles the workspace join — community OPEN joins
+   * immediately, REQUEST_TO_JOIN creates a join request, and enterprise
+   * goes through the domain-check + join-request flow. All identical to
+   * what happens after Google/Microsoft SSO authentication.
+   */
+  verifyEmail = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { email, code } = req.body;
+
+      if (!email || !code) {
+        res.status(400).json({ error: 'Email and verification code are required' });
+        return;
+      }
+
+      const normalizedEmail = email.toLowerCase().trim();
+      const redisKey = `emailreg:code:${normalizedEmail}`;
+      const attemptsKey = `emailreg:attempts:${normalizedEmail}`;
+
+      const raw = await redisService.get(redisKey);
+      if (!raw) {
+        res.status(400).json({ error: 'Invalid or expired code. Please register again.' });
+        return;
+      }
+
+      let payload: RegistrationPendingPayload;
+      try {
+        payload = JSON.parse(raw) as RegistrationPendingPayload;
+      } catch {
+        res.status(400).json({ error: 'Invalid or expired code. Please register again.' });
+        return;
+      }
+
+      if (payload.code !== code) {
+        const redis = redisService.getClient();
+        const attempts = await redis.incr(attemptsKey);
+        if (attempts === 1) {
+          await redis.expire(attemptsKey, REGISTER_CODE_TTL_SECONDS);
+        }
+
+        if (attempts >= REGISTER_MAX_VERIFY_ATTEMPTS) {
+          await Promise.all([
+            redisService.del(redisKey),
+            redisService.del(attemptsKey),
+          ]);
+          res.status(400).json({ error: 'Too many failed attempts. Please register again.' });
+          return;
+        }
+
+        res.status(400).json({ error: 'Invalid code' });
+        return;
+      }
+
+      // Code verified — retrieve pending data
+      const { passwordHash, name, workspaceId } = payload;
+
+      // Clean up Redis
+      await Promise.all([
+        redisService.del(redisKey),
+        redisService.del(attemptsKey),
+      ]);
+
+      // Determine the orgId for the OrgMember:
+      // - If workspaceId is provided, use that workspace's org
+      // - If not, try to find an existing org by email domain
+      // - If neither, don't create OrgMember yet — defer to create-org flow
+      let orgId: string | null = null;
+
+      if (workspaceId) {
+        const workspace = await this.prisma.workspace.findUnique({
+          where: { id: workspaceId },
+          select: { orgId: true, status: true },
+        });
+        if (!workspace || workspace.status !== 'ACTIVE') {
+          res.status(404).json({ error: 'Workspace not found' });
+          return;
+        }
+        orgId = workspace.orgId;
+      } else {
+        // No workspaceId — check if the email domain maps to an existing org
+        const existingOrg = await organizationDomainService.findExistingOrgByEmailDomain(normalizedEmail);
+        if (existingOrg) {
+          orgId = existingOrg.orgId;
+        }
+      }
+
+      // Create or update OrgMember with passwordHash.
+      // If we have an orgId, create/update the OrgMember now.
+      // If not, store the passwordHash in Redis so the create-org flow can
+      // pick it up when creating the OrgMember.
+      const existingOrgMember = await this.prisma.orgMember.findUnique({
+        where: { email: normalizedEmail },
+        select: { memberId: true },
+      });
+
+      if (existingOrgMember) {
+        await this.prisma.orgMember.update({
+          where: { email: normalizedEmail },
+          data: {
+            passwordHash,
+            leftAt: null,
+            ...(orgId ? { orgId } : {}),
+          },
+        });
+      } else if (orgId) {
+        await this.prisma.orgMember.create({
+          data: {
+            orgId,
+            email: normalizedEmail,
+            role: 'COMMUNITY_MEMBER',
+            passwordHash,
+          },
+        });
+      } else {
+        // No orgId and no existing OrgMember — store passwordHash in Redis
+        // so createOrganizationWithUser can set it on the OrgMember later.
+        await redisService.set(
+          `emailreg:verified:${normalizedEmail}`,
+          JSON.stringify({ passwordHash, name }),
+          10 * 60, // 10 minutes
+        );
+      }
+
+      // Issue pending-auth cookie — same mechanism as OAuth callback.
+      const userName = name || normalizedEmail.split('@')[0];
+      const pendingAuthJwtId = crypto.randomUUID();
+
+      await redisService.set(
+        `pendingauth:jwtid:${pendingAuthJwtId}`,
+        normalizedEmail,
+        10 * 60,
+      );
+
+      const isProduction = process.env.NODE_ENV === 'production';
+      const cookieBase = {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: 'strict' as const,
+        path: '/',
+      };
+
+      res.cookie(
+        'google_access_token',
+        jwt.sign(
+          {
+            email: normalizedEmail,
+            name: userName,
+            providerUserId: `email-${normalizedEmail}`,
+            provider: 'EMAIL',
+            refreshToken: null,
+            accessToken: null,
+            jwtId: pendingAuthJwtId,
+          },
+          process.env.JWT_SECRET!,
+          { expiresIn: '10m' },
+        ),
+        {
+          ...cookieBase,
+          maxAge: 10 * 60 * 1000,
+        },
+      );
+
+      // Build response — mirrors OAuth callback structure.
+      // If workspaceId was provided, return empty workspaces so the frontend
+      // triggers the joinWorkspace actor (handles community/enterprise join).
+      // If not, return existing workspaces + domain conflict info (same as OAuth).
+      if (workspaceId) {
+        res.status(200).json({
+          success: true,
+          workspaces: [],
+          pendingUserData: { email: normalizedEmail, name: userName },
+          userExistsButRemoved: false,
+        });
+        return;
+      }
+
+      // No workspaceId — same domain-checking logic as OAuth callback
+      const workspaces = await this.userService.getWorkspacesByEmail(normalizedEmail);
+
+      let domainConflictError: string | null = null;
+      let publicEmailDomainError: string | null = null;
+      let enterpriseJoinOrgName: string | null = null;
+      let enterpriseJoinWorkspaces: string | null = null;
+
+      if (workspaces.length === 0) {
+        try {
+          await organizationDomainService.assertCanCreateOrgForEmail(normalizedEmail);
+        } catch (error) {
+          if (error instanceof PublicEmailDomainError) {
+            publicEmailDomainError = error.message;
+          } else if (error instanceof OrganizationDomainConflictError) {
+            domainConflictError = error.message;
+          }
+        }
+
+        if (!domainConflictError && !publicEmailDomainError) {
+          const domainConflict = await organizationDomainService.findEnterpriseWorkspaceByEmailDomain(normalizedEmail);
+          if (domainConflict) {
+            domainConflictError = new OrganizationDomainConflictError(domainConflict.domain, domainConflict).message;
+            enterpriseJoinOrgName = domainConflict.name;
+            enterpriseJoinWorkspaces = JSON.stringify(domainConflict.workspaces);
+          }
+        }
+      }
+
+      res.status(200).json({
+        success: true,
+        workspaces: workspaces.map(w => ({ id: w.id, name: w.name, role: w.role })),
+        pendingUserData: { email: normalizedEmail, name: userName },
+        userExistsButRemoved: false,
+        ...(domainConflictError ? { domainConflictError } : {}),
+        ...(enterpriseJoinOrgName ? { enterpriseJoinOrgName } : {}),
+        ...(enterpriseJoinWorkspaces ? { enterpriseJoinWorkspaces } : {}),
+        ...(publicEmailDomainError ? { publicEmailDomainError } : {}),
+      });
+    } catch (error) {
+      res.status(500).json({
+        error: 'Verification failed',
+        message: `An unexpected error occurred. Error: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  };
+
+  /**
+   * Resend verification code
+   * POST /v2/auth/email/resend-code
+   *
+   * Resends a new 6-digit code using the pending registration data in Redis.
+   */
+  resendVerificationCode = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { email } = req.body;
+
+      if (!email) {
+        res.status(400).json({ error: 'Email is required' });
+        return;
+      }
+
+      const normalizedEmail = email.toLowerCase().trim();
+
+      const rateLimitKey = `emailreg:ratelimit:${normalizedEmail}`;
+      const rateLimited = await redisService.get(rateLimitKey);
+      if (rateLimited) {
+        res.status(429).json({
+          error: 'Rate limited',
+          message: 'Please wait before requesting another verification code.',
+        });
+        return;
+      }
+
+      const redisKey = `emailreg:code:${normalizedEmail}`;
+      const raw = await redisService.get(redisKey);
+      if (!raw) {
+        res.status(400).json({
+          error: 'No pending registration found',
+          message: 'Please register again.',
+        });
+        return;
+      }
+
+      let payload: RegistrationPendingPayload;
+      try {
+        payload = JSON.parse(raw) as RegistrationPendingPayload;
+      } catch {
+        res.status(400).json({
+          error: 'No pending registration found',
+          message: 'Please register again.',
+        });
+        return;
+      }
+
+      // Generate new code
+      const newCode = crypto.randomInt(100000, 1000000).toString().padStart(6, '0');
+      payload.code = newCode;
+
+      const attemptsKey = `emailreg:attempts:${normalizedEmail}`;
+
+      await Promise.all([
+        redisService.set(redisKey, JSON.stringify(payload), REGISTER_CODE_TTL_SECONDS),
+        redisService.del(attemptsKey),
+        redisService.set(rateLimitKey, '1', REGISTER_RATE_LIMIT_SECONDS),
+      ]);
+
+      // Fetch workspace name for the email
+      const workspace = await this.prisma.workspace.findUnique({
+        where: { id: payload.workspaceId },
+        select: { name: true },
+      });
+
+      const emailResult = await emailService.sendEmail({
+        to: normalizedEmail,
+        subject: 'Xyne Spaces — Verify Your Email',
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 480px; margin: 0 auto;">
+            <h2>Verify Your Email</h2>
+            <p>You're registering for <strong>${workspace?.name || 'Xyne Spaces'}</strong> on Xyne Spaces.</p>
+            <p>Enter the following code to complete your registration:</p>
+            <p style="font-size: 28px; font-weight: bold; letter-spacing: 4px; padding: 16px; background: #f5f5f5; border-radius: 8px; text-align: center;">${newCode}</p>
+            <p>This code expires in 15 minutes.</p>
+            <p>If you didn't request this, you can safely ignore this email.</p>
+          </div>
+        `,
+        text: `Your Xyne Spaces verification code is: ${newCode}\n\nThis code expires in 15 minutes.\n`,
+      });
+
+      if (!emailResult.success) {
+        res.status(500).json({ error: 'Failed to send verification email. Please try again.' });
+        return;
+      }
+
+      res.status(200).json({
+        success: true,
+        message: 'A new verification code has been sent to your email.',
+      });
     } catch (error) {
       res.status(500).json({ error: 'An unexpected error occurred' });
     }

--- a/backend/src/routes/authV2.ts
+++ b/backend/src/routes/authV2.ts
@@ -35,6 +35,12 @@ router.get('/refresh-session', authV2Controller.refreshSession);
 
 router.post('/email/login', emailAuthController.login);
 
+router.post('/email/register', emailAuthController.register);
+
+router.post('/email/verify', emailAuthController.verifyEmail);
+
+router.post('/email/resend-code', emailAuthController.resendVerificationCode);
+
 router.post('/email/forgot-password', emailAuthController.requestResetCode);
 
 router.post('/email/reset-password', emailAuthController.resetPassword);

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -13,6 +13,7 @@ import { isOrganizationPolicyError, organizationDomainService } from '@/services
 import { createCommunityWorkspaceDefaults } from '@/utils/communityWorkspaceDefaults';
 import { ensureGeneralChannelForWorkspace } from '@/utils/workspaceGeneralChannel';
 import { ensureUserInGeneralChannel as joinUserToGeneralChannel } from '@/utils/workspaceGeneralChannel';
+import { redisService } from '@/services/redisService';
 
 interface OAuthUserData {
   provider: AuthProvider;
@@ -847,6 +848,23 @@ export class UserService {
   }
 
   /**
+   * Check Redis for a verified email-password registration's passwordHash.
+   * Returns { passwordHash } if found, so it can be set on the OrgMember
+   * during org creation. Cleans up the Redis key after reading.
+   */
+  private async getVerifiedPasswordHash(email: string): Promise<{ passwordHash?: string }> {
+    try {
+      const raw = await redisService.get(`emailreg:verified:${email.toLowerCase().trim()}`);
+      if (!raw) return {};
+      const data = JSON.parse(raw) as { passwordHash?: string };
+      await redisService.del(`emailreg:verified:${email.toLowerCase().trim()}`);
+      return data.passwordHash ? { passwordHash: data.passwordHash } : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
    * Create organization with default workspace and user
    * Called after temp token is verified
    */
@@ -921,6 +939,7 @@ export class UserService {
               orgId: organization.orgId,
               role: 'OWNER',
               leftAt: null,
+              ...(existingOrgMember.passwordHash ? {} : await this.getVerifiedPasswordHash(userData.email)),
             },
           })
         : await this.prisma.orgMember.create({
@@ -928,6 +947,7 @@ export class UserService {
               orgId: organization.orgId,
               email: userData.email,
               role: 'OWNER',
+              ...(await this.getVerifiedPasswordHash(userData.email)),
             }
           });
 

--- a/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
+++ b/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
@@ -25,6 +25,7 @@ import type { MentionData } from '../Chat/ChatDirectory/ChannelCommandMenu.types
 import { formatElapsedTime } from '../../utils/recordingUtils';
 import { queries } from '../../zero/queries';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { WorkspaceJoinPolicy } from '@xyne/shared';
 
 interface GlobalTopBarProps {
   onOpenErrorReport?: () => void;
@@ -267,6 +268,11 @@ const WorkspaceInviteButton = (): ReactElement | null => {
   });
 
   if (!workspaceId) {
+    return null;
+  }
+
+  const joinPolicy = workspace?.joinPolicy ?? WorkspaceJoinPolicy.INVITE_ONLY;
+  if (joinPolicy === WorkspaceJoinPolicy.INVITE_ONLY) {
     return null;
   }
 

--- a/dashboard/src/hooks/useAuth.ts
+++ b/dashboard/src/hooks/useAuth.ts
@@ -35,6 +35,17 @@ export interface UseAuthReturn {
   signInWithGoogle: () => void;
   signInWithMicrosoft: () => void;
   signInWithEmail: (email: string, password: string, invitationId?: string) => Promise<void>;
+  registerWithEmail: (
+    email: string,
+    password: string,
+    name: string,
+    workspaceId?: string,
+  ) => Promise<{ success: boolean; message?: string; error?: string }>;
+  verifyEmailCode: (
+    email: string,
+    code: string,
+  ) => Promise<{ success: boolean; status?: string; error?: string }>;
+  resendVerificationCode: (email: string) => Promise<{ success: boolean; message?: string; error?: string }>;
   logout: () => void;
   clearError: () => void;
   startEnterpriseLogin: () => void;
@@ -150,6 +161,116 @@ export const useAuth = (): UseAuthReturn => {
     [send],
   );
 
+  const registerWithEmail = useCallback(
+    async (
+      email: string,
+      password: string,
+      name: string,
+      workspaceId?: string,
+    ): Promise<{ success: boolean; message?: string; error?: string }> => {
+      try {
+        const response = await apiInstance.post(
+          '/v2/auth/email/register',
+          { email, password, name, ...(workspaceId ? { workspaceId } : {}) },
+          { timeout: 30000 },
+        );
+        const data = response.data as { success: boolean; message?: string };
+        return { success: true, message: data.message ?? 'Verification code sent.' };
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const data = err.response?.data as { error?: string; message?: string } | undefined;
+          return { success: false, error: data?.message ?? data?.error ?? 'Registration failed' };
+        }
+        return { success: false, error: 'Registration failed. Please try again.' };
+      }
+    },
+    [],
+  );
+
+  const verifyEmailCode = useCallback(
+    async (
+      email: string,
+      code: string,
+    ): Promise<{ success: boolean; status?: string; error?: string }> => {
+      try {
+        const response = await apiInstance.post(
+          '/v2/auth/email/verify',
+          { email, code },
+          { timeout: 15000 },
+        );
+        const data = response.data as {
+          success: boolean;
+          status?: string;
+          user?: User;
+          workspaces?: Workspace[];
+          pendingUserData?: { email: string; name: string; picture?: string };
+          userExistsButRemoved?: boolean;
+          autoLoginWorkspace?: string;
+          domainConflictError?: string;
+          publicEmailDomainError?: string;
+          enterpriseJoinOrgName?: string;
+          enterpriseJoinWorkspaces?: string;
+        };
+
+        if (!data.success) {
+          return { success: false, error: 'Verification failed' };
+        }
+
+        // Dispatch to auth machine — same as OAuth callback.
+        // The auth machine will check hasPendingWorkspace (from localStorage)
+        // and trigger the joinWorkspace actor, which handles community OPEN,
+        // community REQUEST_TO_JOIN, and enterprise join flows identically
+        // to Google/Microsoft SSO. If no workspaceId is pending, the auth
+        // machine shows the create-org / workspace-selection / domain-conflict
+        // UI — exactly like the OAuth callback flow.
+        authActor.send({
+          type: 'OAUTH_CALLBACK_COMPLETE',
+          output: {
+            ...(data.user ? { user: data.user } : {}),
+            workspaces: data.workspaces ?? [],
+            pendingUserData: data.pendingUserData ?? { email, name: '' },
+            userExistsButRemoved: data.userExistsButRemoved ?? false,
+            autoLoginWorkspace: data.autoLoginWorkspace,
+            domainConflictError: data.domainConflictError,
+            publicEmailDomainError: data.publicEmailDomainError,
+            enterpriseJoinOrgName: data.enterpriseJoinOrgName,
+            enterpriseJoinWorkspaces: data.enterpriseJoinWorkspaces,
+          } as OAuthCallbackOutput,
+        });
+
+        return { success: true, status: data.status ?? 'JOINED' };
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const data = err.response?.data as { error?: string; message?: string } | undefined;
+          return { success: false, error: data?.message ?? data?.error ?? 'Verification failed' };
+        }
+        return { success: false, error: 'Verification failed. Please try again.' };
+      }
+    },
+    [],
+  );
+
+  const resendVerificationCode = useCallback(
+    async (email: string): Promise<{ success: boolean; message?: string; error?: string }> => {
+      try {
+        const response = await apiInstance.post(
+          '/v2/auth/email/resend-code',
+          { email },
+          { timeout: 30000 },
+        );
+        const data = response.data as { success: boolean; message?: string };
+        return { success: true, message: data.message ?? 'A new verification code has been sent.' };
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const data = err.response?.data as { error?: string; message?: string } | undefined;
+          return { success: false, error: data?.message ?? data?.error ?? 'Failed to resend code' };
+        }
+        return { success: false, error: 'Failed to resend code. Please try again.' };
+      }
+    },
+    [],
+  );
+
   return {
     // State
     user: state.context.user,
@@ -181,6 +302,9 @@ export const useAuth = (): UseAuthReturn => {
     signInWithGoogle,
     signInWithMicrosoft,
     signInWithEmail,
+    registerWithEmail,
+    verifyEmailCode,
+    resendVerificationCode,
     logout,
     clearError,
     startEnterpriseLogin,

--- a/dashboard/src/machines/authMachine.ts
+++ b/dashboard/src/machines/authMachine.ts
@@ -69,6 +69,7 @@ type AuthEvent =
   | { type: 'GOOGLE_SIGNIN' }
   | { type: 'MICROSOFT_SIGNIN' }
   | { type: 'EMAIL_SIGNIN' }
+  | { type: 'EMAIL_REGISTER' }
   | { type: 'LOGOUT' }
   | { type: 'SESSION_VALIDATED'; user: User; isNewUser?: boolean }
   | { type: 'OAUTH_CALLBACK_COMPLETE'; output: OAuthCallbackOutput }
@@ -86,6 +87,7 @@ export type AuthState =
   | 'authenticated'
   | 'unauthenticated'
   | 'authenticating'
+  | 'registering'
   | 'loggingOut'
   | 'validatingSession'
   | 'processingOAuthCallback'
@@ -786,6 +788,9 @@ export const authMachine = createMachine(
           EMAIL_SIGNIN: {
             target: 'authenticating',
           },
+          EMAIL_REGISTER: {
+            target: 'registering',
+          },
           SESSION_VALIDATED: {
             target: 'authenticated',
             actions: {
@@ -955,6 +960,90 @@ export const authMachine = createMachine(
             actions: [
               'clearSessionCookies',
               { type: 'notifySignOut', params: { reason: 'User canceled sign-in' } },
+              assign(() => createClearedContext()),
+            ],
+          },
+        },
+      },
+      registering: {
+        on: {
+          OAUTH_CALLBACK_COMPLETE: [
+            {
+              guard: 'hasPendingWorkspace',
+              target: 'joiningWorkspace',
+              actions: assign(({ context, event }) => {
+                const output = (event as XStateEvent).output;
+                return {
+                  ...context,
+                  workspaces: getWorkspaces(output),
+                  pendingUserData: output?.pendingUserData || null,
+                  selectedWorkspaceId: localStorage.getItem(PENDING_WORKSPACE_ID_KEY),
+                  userExistsButRemoved: output?.userExistsButRemoved || false,
+                  error: null,
+                };
+              }),
+            },
+            {
+              guard: 'hasLastActiveWorkspace',
+              target: 'loggingInToWorkspace',
+              actions: assign(({ context, event }) => {
+                const output = (event as XStateEvent).output;
+                const email = output?.pendingUserData?.email;
+                const lastWorkspaceId = email ? getLastActiveWorkspaceId(email) : null;
+                return {
+                  ...context,
+                  workspaces: getWorkspaces(output),
+                  pendingUserData: output?.pendingUserData || null,
+                  selectedWorkspaceId: lastWorkspaceId,
+                  userExistsButRemoved: output?.userExistsButRemoved || false,
+                  error: null,
+                };
+              }),
+            },
+            {
+              guard: 'hasWorkspaces',
+              target: 'selectingWorkspace',
+              actions: assign(({ context, event }) => {
+                const output = (event as XStateEvent).output;
+                return {
+                  ...context,
+                  workspaces: getWorkspaces(output),
+                  pendingUserData: output?.pendingUserData || null,
+                  userExistsButRemoved: output?.userExistsButRemoved || false,
+                  error: null,
+                };
+              }),
+            },
+            {
+              target: 'creatingOrg',
+              actions: assign(({ context, event }) => {
+                const output = (event as XStateEvent).output;
+                return {
+                  ...context,
+                  workspaces: [],
+                  pendingUserData: output?.pendingUserData || null,
+                  userExistsButRemoved: output?.userExistsButRemoved || false,
+                  error: null,
+                };
+              }),
+            },
+          ],
+          AUTH_ERROR: {
+            target: 'unauthenticated',
+            actions: {
+              type: 'setError',
+            },
+          },
+          CLEAR_ERROR: {
+            actions: {
+              type: 'clearError',
+            },
+          },
+          LOGOUT: {
+            target: 'unauthenticated',
+            actions: [
+              'clearSessionCookies',
+              { type: 'notifySignOut', params: { reason: 'User canceled registration' } },
               assign(() => createClearedContext()),
             ],
           },

--- a/dashboard/src/routes/AuthScreen/AuthScreen.tsx
+++ b/dashboard/src/routes/AuthScreen/AuthScreen.tsx
@@ -60,6 +60,9 @@ const AuthScreen = (): ReactElement | null => {
     signInWithMicrosoft,
     logout,
     signInWithEmail,
+    registerWithEmail,
+    verifyEmailCode,
+    resendVerificationCode,
     communityJoinRequest,
     enterpriseJoinTarget,
   } = useAuth();
@@ -103,6 +106,19 @@ const AuthScreen = (): ReactElement | null => {
   const [fpMessage, setFpMessage] = useState('');
   const [fpLoading, setFpLoading] = useState(false);
   const fpSubmitLockRef = useRef(false);
+
+  // Registration flow
+  const [showRegisterForm, setShowRegisterForm] = useState(false);
+  const [regName, setRegName] = useState('');
+  const [regEmail, setRegEmail] = useState('');
+  const [regPassword, setRegPassword] = useState('');
+  const [regConfirmPassword, setRegConfirmPassword] = useState('');
+  const [regStep, setRegStep] = useState<'register' | 'verify'>('register');
+  const [regError, setRegError] = useState('');
+  const [regMessage, setRegMessage] = useState('');
+  const [regLoading, setRegLoading] = useState(false);
+  const [regCode, setRegCode] = useState('');
+  const regSubmitLockRef = useRef(false);
 
   useEffect(() => {
     const param = searchParams.get('enrollment_success');
@@ -385,6 +401,110 @@ const AuthScreen = (): ReactElement | null => {
       fpSubmitLockRef.current = false;
       setFpLoading(false);
     }
+  };
+
+  const handleRegisterSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (regSubmitLockRef.current) return;
+
+    setRegError('');
+    setRegMessage('');
+
+    if (!regName.trim()) {
+      setRegError('Name is required');
+      return;
+    }
+    if (!regEmail.trim()) {
+      setRegError('Email is required');
+      return;
+    }
+    if (regPassword.length < 8) {
+      setRegError('Password must be at least 8 characters');
+      return;
+    }
+    if (!/[A-Z]/.test(regPassword) || !/\d/.test(regPassword) || !/[^A-Za-z0-9]/.test(regPassword)) {
+      setRegError('Password must include at least one uppercase letter, one number, and one special character');
+      return;
+    }
+    if (regPassword !== regConfirmPassword) {
+      setRegError('Passwords do not match');
+      return;
+    }
+
+    const pendingWorkspaceId =
+      searchParams.get('workspaceId')?.trim() ||
+      localStorage.getItem(PENDING_WORKSPACE_ID_KEY)?.trim() ||
+      undefined;
+
+    regSubmitLockRef.current = true;
+    setRegLoading(true);
+    try {
+      const result = await registerWithEmail(regEmail.trim(), regPassword, regName.trim(), pendingWorkspaceId);
+      if (result.success) {
+        setRegMessage(result.message || 'Verification code sent to your email.');
+        setRegStep('verify');
+      } else {
+        setRegError(result.error || 'Registration failed');
+      }
+    } finally {
+      regSubmitLockRef.current = false;
+      setRegLoading(false);
+    }
+  };
+
+  const handleRegVerify = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (regSubmitLockRef.current) return;
+
+    setRegError('');
+    const normalizedCode = regCode.replace(/\D/g, '');
+    if (!/^\d{6}$/.test(normalizedCode)) {
+      setRegError('Enter a valid 6-digit code');
+      return;
+    }
+
+    regSubmitLockRef.current = true;
+    setRegLoading(true);
+    try {
+      const result = await verifyEmailCode(regEmail.trim(), normalizedCode);
+      // On success, OAUTH_CALLBACK_COMPLETE is dispatched to the auth machine,
+      // which takes over navigation — joining the workspace (community OPEN,
+      // community REQUEST_TO_JOIN, or enterprise) just like Google/Microsoft SSO.
+      // No local step change needed; the auth machine will redirect.
+      if (!result.success) {
+        setRegError(result.error || 'Verification failed');
+      }
+    } finally {
+      regSubmitLockRef.current = false;
+      setRegLoading(false);
+    }
+  };
+
+  const handleRegResendCode = async (): Promise<void> => {
+    setRegError('');
+    setRegMessage('');
+    try {
+      const result = await resendVerificationCode(regEmail.trim());
+      if (result.success) {
+        setRegMessage(result.message || 'A new verification code has been sent.');
+      } else {
+        setRegError(result.error || 'Failed to resend code');
+      }
+    } catch {
+      setRegError('Failed to resend code. Please try again.');
+    }
+  };
+
+  const resetRegistrationState = (): void => {
+    setShowRegisterForm(false);
+    setRegName('');
+    setRegEmail('');
+    setRegPassword('');
+    setRegConfirmPassword('');
+    setRegCode('');
+    setRegStep('register');
+    setRegError('');
+    setRegMessage('');
   };
 
   if (isAuthenticated) {
@@ -836,9 +956,9 @@ const AuthScreen = (): ReactElement | null => {
                         <div className='flex-1 h-px bg-border' />
                       </div>
 
-                      {/* Email Sign In Toggle */}
-                      {!showEmailForm ? (
-                        <div className='w-full max-w-[280px] md:max-w-[320px]'>
+                      {/* Email Sign In / Sign Up Toggle */}
+                      {!showEmailForm && !showRegisterForm ? (
+                        <div className='w-full max-w-[280px] md:max-w-[320px] flex flex-col gap-3'>
                           <button
                             onClick={() => {
                               clearError();
@@ -852,9 +972,160 @@ const AuthScreen = (): ReactElement | null => {
                               Sign in with Email
                             </span>
                           </button>
+                          <button
+                            onClick={() => {
+                              clearError();
+                              setShowEmailForm(true);
+                              setShowRegisterForm(true);
+                            }}
+                            className='appearance-none outline-none font-inherit cursor-pointer opacity-100 flex items-center justify-center gap-4 px-4 py-[9px] w-full relative bg-transparent text-foreground border border-border rounded-[10px] overflow-hidden h-12 hover:bg-accent'
+                            data-track-category='Auth'
+                            data-track-name='EmailRegisterToggle'
+                          >
+                            <span className='text-sm font-semibold text-center'>
+                              Sign up with Email
+                            </span>
+                          </button>
+                        </div>
+                      ) : showRegisterForm ? (
+                        /* Registration Flow */
+                        <div className='w-full max-w-[280px] md:max-w-[320px] flex flex-col gap-3'>
+                          {regStep === 'register' && (
+                            <form
+                              onSubmit={e => {
+                                void handleRegisterSubmit(e);
+                              }}
+                              className='flex flex-col gap-3'
+                            >
+                              <p className='text-sm font-medium text-foreground'>
+                                {pendingCommunityWorkspaceName
+                                  ? `Join ${pendingCommunityWorkspaceName}`
+                                  : 'Create Account'}
+                              </p>
+                              <p className='text-xs text-muted-foreground'>
+                                Register with your email to join the community.
+                              </p>
+                              <input
+                                type='text'
+                                value={regName}
+                                onChange={e => setRegName(e.target.value)}
+                                placeholder='Full name'
+                                required
+                                className='w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-background text-foreground text-sm'
+                                data-track-category='Auth'
+                                data-track-name='RegisterNameInput'
+                              />
+                              <input
+                                type='email'
+                                value={regEmail}
+                                onChange={e => setRegEmail(e.target.value)}
+                                placeholder='Email address'
+                                required
+                                className='w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-background text-foreground text-sm'
+                                data-track-category='Auth'
+                                data-track-name='RegisterEmailInput'
+                              />
+                              <input
+                                type='password'
+                                value={regPassword}
+                                onChange={e => setRegPassword(e.target.value)}
+                                placeholder='Password (min 8 chars, 1 uppercase, 1 number, 1 special)'
+                                required
+                                className='w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-background text-foreground text-sm'
+                                data-track-category='Auth'
+                                data-track-name='RegisterPasswordInput'
+                              />
+                              <input
+                                type='password'
+                                value={regConfirmPassword}
+                                onChange={e => setRegConfirmPassword(e.target.value)}
+                                placeholder='Confirm password'
+                                required
+                                className='w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-background text-foreground text-sm'
+                                data-track-category='Auth'
+                                data-track-name='RegisterConfirmPasswordInput'
+                              />
+                              {regError && <p className='text-xs text-red-600'>{regError}</p>}
+                              <button
+                                type='submit'
+                                disabled={regLoading}
+                                className='w-full py-2.5 bg-black text-white font-medium rounded-lg hover:bg-neutral-800 disabled:opacity-50 text-sm'
+                                data-track-category='Auth'
+                                data-track-name='RegisterSubmit'
+                              >
+                                {regLoading ? 'Sending...' : 'Send Verification Code'}
+                              </button>
+                            </form>
+                          )}
+
+                          {regStep === 'verify' && (
+                            <form
+                              onSubmit={e => {
+                                void handleRegVerify(e);
+                              }}
+                              className='flex flex-col gap-3'
+                            >
+                              <p className='text-sm font-medium text-foreground'>
+                                Verify Your Email
+                              </p>
+                              <p className='text-xs text-muted-foreground'>
+                                We sent a 6-digit code to {regEmail}
+                              </p>
+                              <input
+                                type='text'
+                                value={regCode}
+                                onChange={e =>
+                                  setRegCode(e.target.value.replace(/\D/g, '').slice(0, 6))
+                                }
+                                placeholder='6-digit code'
+                                maxLength={6}
+                                pattern='[0-9]{6}'
+                                inputMode='numeric'
+                                required
+                                className='w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-background text-foreground text-sm tracking-widest text-center'
+                                data-track-category='Auth'
+                                data-track-name='RegisterVerifyCodeInput'
+                              />
+                              {regError && <p className='text-xs text-red-600'>{regError}</p>}
+                              {regMessage && <p className='text-xs text-green-600'>{regMessage}</p>}
+                              <button
+                                type='submit'
+                                disabled={regLoading}
+                                className='w-full py-2.5 bg-black text-white font-medium rounded-lg hover:bg-neutral-800 disabled:opacity-50 text-sm'
+                                data-track-category='Auth'
+                                data-track-name='RegisterVerifySubmit'
+                              >
+                                {regLoading ? 'Verifying...' : 'Verify & Continue'}
+                              </button>
+                              <button
+                                type='button'
+                                onClick={() => {
+                                  void handleRegResendCode();
+                                }}
+                                disabled={regLoading}
+                                className='text-xs text-muted-foreground hover:text-foreground text-center'
+                                data-track-category='Auth'
+                                data-track-name='RegisterResendCode'
+                              >
+                                Resend code
+                              </button>
+                            </form>
+                          )}
+
+                          <button
+                            type='button'
+                            onClick={() => {
+                              clearError();
+                              resetRegistrationState();
+                            }}
+                            className='text-xs text-muted-foreground hover:text-foreground text-center'
+                            data-track-category='Auth'
+                            data-track-name='BackToSignIn'
+                          >
+                            Back to sign in
+                          </button>
                         </div>
                       ) : showForgotPassword ? (
-                        /* Forgot Password Flow */
                         <div className='w-full max-w-[280px] md:max-w-[320px] flex flex-col gap-3'>
                           {fpStep === 'email' && (
                             <form
@@ -1032,7 +1303,21 @@ const AuthScreen = (): ReactElement | null => {
                             type='button'
                             onClick={() => {
                               clearError();
+                              setShowRegisterForm(true);
+                              setShowForgotPassword(false);
+                            }}
+                            className='text-xs text-muted-foreground hover:text-foreground text-center'
+                            data-track-category='Auth'
+                            data-track-name='SwitchToRegister'
+                          >
+                            Don&apos;t have an account? Sign up
+                          </button>
+                          <button
+                            type='button'
+                            onClick={() => {
+                              clearError();
                               setShowEmailForm(false);
+                              setShowRegisterForm(false);
                               setEmail('');
                               setPassword('');
                             }}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
