### PR TITLE
Fix canvas note sorting and editor spacing

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.utils.ts
+++ b/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.utils.ts
@@ -53,7 +53,10 @@ export function sortByName<T>(items: T[], getName: (item: T) => string): T[] {
 }
 
 export function sortCanvases(canvases: Canvas[]): Canvas[] {
-  return sortByName(canvases, canvas => canvas.title || 'Untitled');
+  return [...canvases].sort(
+    (a, b) =>
+      b.updatedAt - a.updatedAt || (a.title || 'Untitled').localeCompare(b.title || 'Untitled'),
+  );
 }
 
 export function matchesGroupedCanvasSearch(

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -209,6 +209,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
   const latestContentRef = useRef<PartialBlock[] | undefined>(undefined);
   const lastSavedContentRef = useRef<string>(''); // Stringify to compare deep equality easily
   const latestHtmlRef = useRef<string>('');
+  const hasPendingCollaborativeTimestampRef = useRef(false);
   const titleRef = useRef(currentTitle);
   const selectedCanvasRef = useRef(selectedCanvas);
   const isCreatingRef = useRef(isCreating);
@@ -707,15 +708,32 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     void handleSave(blocks, html);
   };
 
+  const flushCollaborativeCanvasTimestamp = useCallback((): void => {
+    if (!hasPendingCollaborativeTimestampRef.current) return;
+
+    const canvasToUpdate = selectedCanvasRef.current;
+    hasPendingCollaborativeTimestampRef.current = false;
+    if (!canvasToUpdate?.id || !canEditRef.current) return;
+
+    z.mutate(
+      mutators.canvas.update({
+        id: canvasToUpdate.id,
+        timestamp: Date.now(),
+      }),
+    );
+  }, [z]);
+
   const handleCollaborativeContentChange = useCallback((blocks: PartialBlock[]): void => {
     latestContentRef.current = blocks;
+    hasPendingCollaborativeTimestampRef.current = true;
   }, []);
 
   useEffect(() => {
     return (): void => {
+      flushCollaborativeCanvasTimestamp();
       saveCanvasExitSnapshotRef.current?.();
     };
-  }, [selectedCanvas?.id]);
+  }, [selectedCanvas?.id, flushCollaborativeCanvasTimestamp]);
 
   useEffect(() => {
     const handlePointerDown = (event: PointerEvent): void => {
@@ -725,6 +743,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
       if (!contentElement || !(target instanceof Node)) return;
       if (contentElement.contains(target)) return;
 
+      flushCollaborativeCanvasTimestamp();
       saveCanvasExitSnapshotRef.current?.();
     };
 
@@ -732,7 +751,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     return (): void => {
       document.removeEventListener('pointerdown', handlePointerDown, true);
     };
-  }, []);
+  }, [flushCollaborativeCanvasTimestamp]);
 
   const handlePreviewVersion = useCallback((version: CanvasVersionRecord): void => {
     if (!previewVersionRef.current) {

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2406,7 +2406,7 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   margin: 3.5px 0;
 }
 
-/* Lists — 8px above / 4px below, 24px marker box with a 12px gutter. The marker
+/* Lists — 8px above / 4px below, 16px marker box with a 4px gutter. The marker
    is pinned to the first line (BlockNote centres it across the whole block). */
 .canvas-surface .bn-editor .bn-block-content[data-content-type="bulletListItem"],
 .canvas-surface .bn-editor .bn-block-content[data-content-type="numberedListItem"] {
@@ -2422,11 +2422,11 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   .bn-block
   .bn-block-content[data-content-type="bulletListItem"]::before {
   content: "";
-  min-width: 24px;
+  min-width: 16px;
   height: 1.55em;
   align-self: flex-start;
   padding-right: 0;
-  margin-right: 12px;
+  margin-right: 4px;
   background-image: radial-gradient(circle at center, currentColor 3px, transparent 3px);
 }
 
@@ -2498,6 +2498,7 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
 .canvas-surface .bn-editor [data-content-type="table"] td,
 .canvas-surface .bn-editor [data-content-type="table"] th {
   border-color: hsl(var(--border));
+  padding: 4px 8px;
 }
 .canvas-surface .bn-editor [data-content-type="table"] th {
   background-color: hsl(var(--muted));


### PR DESCRIPTION
Services-Requiring-Redeployment:
- dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes canvas ordering and editor spacing polish:
- Sorts canvases by most recently updated first, with title as a stable fallback.
- Updates the selected canvas timestamp when editable collaborative content changes.
- Tightens canvas list marker spacing and table cell padding for better editor layout.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed**
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests

Ran:
- `pnpm --filter @xyne/shared run build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter xyne-spaces-dashboard run build`
- `pnpm run test`

Result:
- 71 passed, 0 failed, 0 skipped

Report:
- `tools/xyne-automation/reports/9f26d3f5c-runner/html-report/index.html`

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

POT https://drive.google.com/file/d/1N_m1-OJx1t6WdaKCFEvVp3x9OxoF6SNC/view?usp=sharing

Context:
Changed this from per-keystroke/debounced mutation to a dirty-flag flush. `onChange` only marks the canvas timestamp as pending, and we mutate once on editor exit/canvas switch/unmount. This keeps body edits reflected in `updatedAt` without repeatedly calling the mutator while the user types.