### PR TITLE
feat: GENIUS-5429 update MergeTicketsDialog to disable archived ticke…

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -4274,11 +4274,10 @@ const ChannelCommandMenu = ({
             ? new Date(result.metadata.timestamp).getTime()
             : null,
         }))}
-        onMerge={async parentTicketId => {
+        onMerge={async (parentTicketId, ticketIds) => {
           try {
-            const ticketsToMerge = Array.from(selectedMergeTickets.keys()).filter(
-              id => id !== parentTicketId,
-            );
+            // ticketIds comes pre-filtered from the dialog (archived tickets excluded).
+            const ticketsToMerge = ticketIds.filter(id => id !== parentTicketId);
             await Promise.all(
               ticketsToMerge.map(ticketId =>
                 apiInstance.post(`/tickets/${ticketId}/merge`, { targetTicketId: parentTicketId }),

--- a/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -7,6 +7,8 @@ import Avatar from '../../ui/Avatar/Avatar';
 import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
 import { useUser } from '../../../hooks/useUsers';
 import { useUserGroupById } from '../../../hooks/useUserGroup';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { queries } from '../../../zero/queries';
 import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
 import { cn } from '../../../utils/classNames';
@@ -27,7 +29,8 @@ interface MergeTicketsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tickets: MergeTicket[];
-  onMerge: (parentTicketId: string) => void | Promise<void>;
+  /** ticketIds is the eligible (non-archived) subset of `tickets` that should actually be merged. */
+  onMerge: (parentTicketId: string, ticketIds: string[]) => void | Promise<void>;
 }
 
 const formatTicketDate = (timestamp?: number | null): string =>
@@ -98,6 +101,27 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
     [tickets],
   );
 
+  // Selection can go stale: a ticket picked before opening this dialog may have been
+  // archived in the meantime (merged elsewhere, archived by another agent, etc). Re-check
+  // live status for every candidate so an already-archived ticket can't be picked again —
+  // showing it disabled here is clearer than silently dropping it from the list.
+  const ticketIds = useMemo(() => tickets.map(t => t.id), [tickets]);
+  const [liveTickets] = useCachedQuery(queries.ticketsByIds({ ticketIds }), {
+    enabled: open && ticketIds.length > 0,
+  });
+  const archivedIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const t of liveTickets ?? []) {
+      if (t.isArchived) ids.add(t.id);
+    }
+    return ids;
+  }, [liveTickets]);
+
+  const eligibleTickets = useMemo(
+    () => sortedTickets.filter(t => !archivedIds.has(t.id)),
+    [sortedTickets, archivedIds],
+  );
+
   useEffect(() => {
     if (!open) {
       setSelectedParentTicketId(null);
@@ -105,16 +129,21 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   }, [open]);
 
   useEffect(() => {
-    if (open && selectedParentTicketId === null && sortedTickets.length > 0) {
-      setSelectedParentTicketId(sortedTickets[0]?.id ?? null);
+    if (!open) return;
+    // Pick (or fix up) a default parent among tickets that aren't archived.
+    if (selectedParentTicketId === null || archivedIds.has(selectedParentTicketId)) {
+      setSelectedParentTicketId(eligibleTickets[0]?.id ?? null);
     }
-  }, [open, sortedTickets, selectedParentTicketId]);
+  }, [open, eligibleTickets, archivedIds, selectedParentTicketId]);
 
   const handleMerge = async (): Promise<void> => {
-    if (!selectedParentTicketId) return;
+    if (!selectedParentTicketId || archivedIds.has(selectedParentTicketId)) return;
     setIsMerging(true);
     try {
-      await onMerge(selectedParentTicketId);
+      await onMerge(
+        selectedParentTicketId,
+        eligibleTickets.map(t => t.id),
+      );
     } finally {
       setIsMerging(false);
     }
@@ -143,7 +172,8 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
               className='space-y-1.5 max-h-[360px] overflow-y-auto -mx-1 px-1 py-0.5'
             >
               {sortedTickets.map(ticket => {
-                const isParent = ticket.id === selectedParentTicketId;
+                const isArchived = archivedIds.has(ticket.id);
+                const isParent = !isArchived && ticket.id === selectedParentTicketId;
                 const priority = ticket.priority as TicketPriority | undefined;
                 const priorityIcon = priority ? getPriorityIcon(priority) : null;
 
@@ -151,13 +181,16 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
                   <RadioGroupPrimitive.Item
                     key={ticket.id}
                     value={ticket.id}
+                    disabled={isArchived}
                     className={cn(
                       'relative flex w-full flex-col gap-1.5 rounded-md border py-2.5 pl-4 pr-3 text-left',
                       'shadow-sm transition-all outline-none',
                       'focus-visible:ring-2 focus-visible:ring-ring/50',
-                      isParent
-                        ? 'border-primary/40 bg-primary/[0.04]'
-                        : 'border-border bg-card hover:border-input hover:shadow',
+                      isArchived
+                        ? 'border-border bg-muted/40 opacity-60 cursor-not-allowed'
+                        : isParent
+                          ? 'border-primary/40 bg-primary/[0.04]'
+                          : 'border-border bg-card hover:border-input hover:shadow',
                     )}
                     data-track-category='Support'
                     data-track-name='SelectMergeParent'
@@ -171,19 +204,26 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
                         {ticket.xyneId || ticket.id.slice(0, 8)}
                       </span>
                       <TruncatedTooltip content={ticket.title || 'No subject'}>
-                        <h3 className='flex-1 min-w-0 truncate text-[15px] font-semibold text-foreground'>
+                        <h3
+                          className={cn(
+                            'flex-1 min-w-0 truncate text-[15px] font-semibold',
+                            isArchived ? 'text-muted-foreground' : 'text-foreground',
+                          )}
+                        >
                           {ticket.title || 'No subject'}
                         </h3>
                       </TruncatedTooltip>
                       <span
                         className={cn(
                           'shrink-0 inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium whitespace-nowrap',
-                          isParent
-                            ? 'border-primary/30 bg-primary/10 text-primary'
-                            : 'border-border text-muted-foreground',
+                          isArchived
+                            ? 'border-border text-muted-foreground'
+                            : isParent
+                              ? 'border-primary/30 bg-primary/10 text-primary'
+                              : 'border-border text-muted-foreground',
                         )}
                       >
-                        {isParent ? 'Parent' : 'Merges in'}
+                        {isArchived ? 'Already archived' : isParent ? 'Parent' : 'Merges in'}
                       </span>
                     </div>
 
@@ -230,7 +270,12 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </Button>
           <Button
             onClick={() => void handleMerge()}
-            disabled={isMerging || !selectedParentTicketId || sortedTickets.length === 0}
+            disabled={
+              isMerging ||
+              !selectedParentTicketId ||
+              archivedIds.has(selectedParentTicketId) ||
+              eligibleTickets.length < 2
+            }
             data-track-category='Support'
             data-track-name='ConfirmMergeTickets'
           >

--- a/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
-import { User } from 'lucide-react';
+import { User, X } from 'lucide-react';
 import { Dialog } from '../../ui/Dialog';
 import Button from '../../ui/Button';
 import Avatar from '../../ui/Avatar/Avatar';
@@ -12,6 +12,7 @@ import { queries } from '../../../zero/queries';
 import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
 import { cn } from '../../../utils/classNames';
+import { htmlToPlainText } from '../../../utils/sanitizer';
 import type { TicketPriority } from '@xyne/shared';
 
 interface MergeTicket {
@@ -29,7 +30,6 @@ interface MergeTicketsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tickets: MergeTicket[];
-  /** ticketIds is the eligible (non-archived) subset of `tickets` that should actually be merged. */
   onMerge: (parentTicketId: string, ticketIds: string[]) => void | Promise<void>;
 }
 
@@ -95,16 +95,13 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 }) => {
   const [isMerging, setIsMerging] = useState(false);
   const [selectedParentTicketId, setSelectedParentTicketId] = useState<string | null>(null);
+  const [removedIds, setRemovedIds] = useState<Set<string>>(() => new Set());
 
   const sortedTickets = useMemo(
     () => [...tickets].sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0)),
     [tickets],
   );
 
-  // Selection can go stale: a ticket picked before opening this dialog may have been
-  // archived in the meantime (merged elsewhere, archived by another agent, etc). Re-check
-  // live status for every candidate so an already-archived ticket can't be picked again —
-  // showing it disabled here is clearer than silently dropping it from the list.
   const ticketIds = useMemo(() => tickets.map(t => t.id), [tickets]);
   const [liveTickets] = useCachedQuery(queries.ticketsByIds({ ticketIds }), {
     enabled: open && ticketIds.length > 0,
@@ -117,32 +114,36 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
     return ids;
   }, [liveTickets]);
 
-  const eligibleTickets = useMemo(
-    () => sortedTickets.filter(t => !archivedIds.has(t.id)),
-    [sortedTickets, archivedIds],
+  const excludedTickets = sortedTickets.filter(t => archivedIds.has(t.id));
+  const visibleTickets = useMemo(
+    () => sortedTickets.filter(t => !archivedIds.has(t.id) && !removedIds.has(t.id)),
+    [sortedTickets, archivedIds, removedIds],
   );
 
   useEffect(() => {
     if (!open) {
       setSelectedParentTicketId(null);
+      setRemovedIds(new Set());
     }
   }, [open]);
 
   useEffect(() => {
     if (!open) return;
-    // Pick (or fix up) a default parent among tickets that aren't archived.
-    if (selectedParentTicketId === null || archivedIds.has(selectedParentTicketId)) {
-      setSelectedParentTicketId(eligibleTickets[0]?.id ?? null);
-    }
-  }, [open, eligibleTickets, archivedIds, selectedParentTicketId]);
+    if (selectedParentTicketId && visibleTickets.some(t => t.id === selectedParentTicketId)) return;
+    setSelectedParentTicketId(visibleTickets[0]?.id ?? null);
+  }, [open, visibleTickets, selectedParentTicketId]);
+
+  const handleRemoveTicket = (ticketId: string): void => {
+    setRemovedIds(prev => new Set(prev).add(ticketId));
+  };
 
   const handleMerge = async (): Promise<void> => {
-    if (!selectedParentTicketId || archivedIds.has(selectedParentTicketId)) return;
+    if (!selectedParentTicketId) return;
     setIsMerging(true);
     try {
       await onMerge(
         selectedParentTicketId,
-        eligibleTickets.map(t => t.id),
+        visibleTickets.map(t => t.id),
       );
     } finally {
       setIsMerging(false);
@@ -150,7 +151,11 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange} title={`Merge ${sortedTickets.length} Tickets`}>
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Merge ${visibleTickets.length} Tickets`}
+    >
       <div className='p-6 space-y-4'>
         <p className='text-sm text-muted-foreground'>
           Pick the ticket that stays open. The rest will be archived and linked as merged into it —
@@ -160,6 +165,14 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 
         {sortedTickets.length === 0 ? (
           <p className='text-sm text-destructive'>Could not load ticket details.</p>
+        ) : visibleTickets.length === 0 ? (
+          <p className='text-sm text-muted-foreground'>
+            All selected tickets are already archived. Cancel and reselect to start over.
+          </p>
+        ) : visibleTickets.length < 2 ? (
+          <p className='text-sm text-muted-foreground'>
+            Only one ticket left to merge. Cancel and reselect at least two.
+          </p>
         ) : (
           <>
             <div className='text-xs font-medium text-muted-foreground uppercase tracking-wide'>
@@ -171,26 +184,24 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
               aria-label='Parent ticket'
               className='space-y-1.5 max-h-[360px] overflow-y-auto -mx-1 px-1 py-0.5'
             >
-              {sortedTickets.map(ticket => {
-                const isArchived = archivedIds.has(ticket.id);
-                const isParent = !isArchived && ticket.id === selectedParentTicketId;
+              {visibleTickets.map(ticket => {
+                const isParent = ticket.id === selectedParentTicketId;
                 const priority = ticket.priority as TicketPriority | undefined;
                 const priorityIcon = priority ? getPriorityIcon(priority) : null;
+
+                const plainTitle = ticket.title ? htmlToPlainText(ticket.title) : '';
 
                 return (
                   <RadioGroupPrimitive.Item
                     key={ticket.id}
                     value={ticket.id}
-                    disabled={isArchived}
                     className={cn(
                       'relative flex w-full flex-col gap-1.5 rounded-md border py-2.5 pl-4 pr-3 text-left',
                       'shadow-sm transition-all outline-none',
                       'focus-visible:ring-2 focus-visible:ring-ring/50',
-                      isArchived
-                        ? 'border-border bg-muted/40 opacity-60 cursor-not-allowed'
-                        : isParent
-                          ? 'border-primary/40 bg-primary/[0.04]'
-                          : 'border-border bg-card hover:border-input hover:shadow',
+                      isParent
+                        ? 'border-primary/40 bg-primary/[0.04]'
+                        : 'border-border bg-card hover:border-input hover:shadow',
                     )}
                     data-track-category='Support'
                     data-track-name='SelectMergeParent'
@@ -199,31 +210,38 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
                       <span className='absolute inset-y-1.5 left-1 w-[3px] rounded-full bg-primary' />
                     )}
 
+                    <button
+                      type='button'
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleRemoveTicket(ticket.id);
+                      }}
+                      className='absolute -left-1.5 -top-1.5 flex size-4 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-sm hover:text-foreground hover:border-input'
+                      aria-label={`Remove ${plainTitle || 'ticket'} from merge`}
+                      data-track-category='Support'
+                      data-track-name='RemoveTicketFromMerge'
+                    >
+                      <X className='size-2.5' strokeWidth={2.5} />
+                    </button>
+
                     <div className='flex items-center gap-2 min-w-0'>
                       <span className='font-mono text-xs text-muted-foreground shrink-0'>
                         {ticket.xyneId || ticket.id.slice(0, 8)}
                       </span>
-                      <TruncatedTooltip content={ticket.title || 'No subject'}>
-                        <h3
-                          className={cn(
-                            'flex-1 min-w-0 truncate text-[15px] font-semibold',
-                            isArchived ? 'text-muted-foreground' : 'text-foreground',
-                          )}
-                        >
-                          {ticket.title || 'No subject'}
+                      <TruncatedTooltip content={plainTitle || 'No subject'}>
+                        <h3 className='flex-1 min-w-0 truncate text-[15px] font-semibold text-foreground'>
+                          {plainTitle || 'No subject'}
                         </h3>
                       </TruncatedTooltip>
                       <span
                         className={cn(
                           'shrink-0 inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium whitespace-nowrap',
-                          isArchived
-                            ? 'border-border text-muted-foreground'
-                            : isParent
-                              ? 'border-primary/30 bg-primary/10 text-primary'
-                              : 'border-border text-muted-foreground',
+                          isParent
+                            ? 'border-primary/30 bg-primary/10 text-primary'
+                            : 'border-border text-muted-foreground',
                         )}
                       >
-                        {isArchived ? 'Already archived' : isParent ? 'Parent' : 'Merges in'}
+                        {isParent ? 'Parent' : 'Merges in'}
                       </span>
                     </div>
 
@@ -259,6 +277,13 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </>
         )}
 
+        {excludedTickets.length > 0 && (
+          <p className='text-xs text-muted-foreground'>
+            Already archived, excluded from this merge:{' '}
+            {excludedTickets.map(t => t.xyneId || t.id.slice(0, 8)).join(', ')}
+          </p>
+        )}
+
         <div className='flex justify-end gap-3 pt-2'>
           <Button
             variant='secondary'
@@ -270,12 +295,7 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </Button>
           <Button
             onClick={() => void handleMerge()}
-            disabled={
-              isMerging ||
-              !selectedParentTicketId ||
-              archivedIds.has(selectedParentTicketId) ||
-              eligibleTickets.length < 2
-            }
+            disabled={isMerging || !selectedParentTicketId || visibleTickets.length < 2}
             data-track-category='Support'
             data-track-name='ConfirmMergeTickets'
           >

--- a/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -7,7 +7,7 @@ import Avatar from '../../ui/Avatar/Avatar';
 import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
 import { useUser } from '../../../hooks/useUsers';
 import { useUserGroupById } from '../../../hooks/useUserGroup';
-import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useQuery } from '../../../hooks/useQuery';
 import { queries } from '../../../zero/queries';
 import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
@@ -103,21 +103,28 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   );
 
   const ticketIds = useMemo(() => tickets.map(t => t.id), [tickets]);
-  const [liveTickets] = useCachedQuery(queries.ticketsByIds({ ticketIds }), {
+  // useQuery, not useCachedQuery — the latter can replay a stale "complete" snapshot from its cross-mount cache.
+  const [liveTickets, liveTicketsDetails] = useQuery(queries.ticketsByIds({ ticketIds }), {
     enabled: open && ticketIds.length > 0,
   });
+  // Fail closed until the live archived check has actually resolved, not just "no data yet".
+  const archivedStateLoaded = ticketIds.length === 0 || liveTicketsDetails.type === 'complete';
   const archivedIds = useMemo(() => {
     const ids = new Set<string>();
+    if (!archivedStateLoaded) return ids;
     for (const t of liveTickets ?? []) {
       if (t.isArchived) ids.add(t.id);
     }
     return ids;
-  }, [liveTickets]);
+  }, [liveTickets, archivedStateLoaded]);
 
   const excludedTickets = sortedTickets.filter(t => archivedIds.has(t.id));
   const visibleTickets = useMemo(
-    () => sortedTickets.filter(t => !archivedIds.has(t.id) && !removedIds.has(t.id)),
-    [sortedTickets, archivedIds, removedIds],
+    () =>
+      archivedStateLoaded
+        ? sortedTickets.filter(t => !archivedIds.has(t.id) && !removedIds.has(t.id))
+        : [],
+    [sortedTickets, archivedIds, removedIds, archivedStateLoaded],
   );
 
   useEffect(() => {
@@ -128,17 +135,17 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   }, [open]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !archivedStateLoaded) return;
     if (selectedParentTicketId && visibleTickets.some(t => t.id === selectedParentTicketId)) return;
     setSelectedParentTicketId(visibleTickets[0]?.id ?? null);
-  }, [open, visibleTickets, selectedParentTicketId]);
+  }, [open, archivedStateLoaded, visibleTickets, selectedParentTicketId]);
 
   const handleRemoveTicket = (ticketId: string): void => {
     setRemovedIds(prev => new Set(prev).add(ticketId));
   };
 
   const handleMerge = async (): Promise<void> => {
-    if (!selectedParentTicketId) return;
+    if (!selectedParentTicketId || !archivedStateLoaded) return;
     setIsMerging(true);
     try {
       await onMerge(
@@ -165,6 +172,8 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 
         {sortedTickets.length === 0 ? (
           <p className='text-sm text-destructive'>Could not load ticket details.</p>
+        ) : !archivedStateLoaded ? (
+          <p className='text-sm text-muted-foreground'>Checking ticket status…</p>
         ) : visibleTickets.length === 0 ? (
           <p className='text-sm text-muted-foreground'>
             All selected tickets are already archived. Cancel and reselect to start over.
@@ -295,7 +304,12 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </Button>
           <Button
             onClick={() => void handleMerge()}
-            disabled={isMerging || !selectedParentTicketId || visibleTickets.length < 2}
+            disabled={
+              isMerging ||
+              !archivedStateLoaded ||
+              !selectedParentTicketId ||
+              visibleTickets.length < 2
+            }
             data-track-category='Support'
             data-track-name='ConfirmMergeTickets'
           >

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1547,10 +1547,9 @@ const SupportScreen = (): ReactElement => {
   }, []);
 
   const handleMergeSelectedTickets = useCallback(
-    async (parentTicketId: string): Promise<void> => {
-      if (selectedTickets.size < 2) return;
+    async (parentTicketId: string, ticketIds: string[]): Promise<void> => {
+      if (ticketIds.length < 2) return;
       try {
-        const ticketIds = Array.from(selectedTickets.keys());
         await Promise.all(
           ticketIds
             .filter(id => id !== parentTicketId)


### PR DESCRIPTION
POT:-

https://github.com/user-attachments/assets/2566c538-7510-41e5-9a27-862b74d18b94




…ts before merging

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
