### PR TITLE
fix: XYNE-54744 tenant-scope workflow execution endpoints; uniform login failure

### DIFF
--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -96,10 +96,9 @@ export class EmailAuthController {
       }
 
       if (!orgMember.passwordHash) {
-        // EMAIL user who was invited but password isn't set yet
-        res.status(403).json({
-          error: 'Password not set',
-          message: 'Please use forgot password to set your password.',
+        res.status(401).json({
+          error: 'Invalid credentials',
+          message: 'Email or password is incorrect',
         });
         return;
       }

--- a/apps/backend/src/controllers/workflowController.ts
+++ b/apps/backend/src/controllers/workflowController.ts
@@ -30,6 +30,72 @@ export class WorkflowController {
     this.workflowRepository = new WorkflowRepository();
   }
 
+  private async authorizeExecution(
+    req: Request,
+    res: Response,
+    executionId: string
+  ): Promise<boolean> {
+    const callerWorkspaceId = req.user?.workspaceId;
+    if (!callerWorkspaceId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return false;
+    }
+
+    const prisma = DatabaseClient.getInstance();
+    const execution = await prisma.workflowExecution.findUnique({
+      where: { id: executionId },
+      select: { id: true, workspaceId: true, workflow: { select: { workspaceId: true } } },
+    });
+
+    const ownerWorkspaceId = execution?.workflow?.workspaceId ?? execution?.workspaceId ?? null;
+    if (!execution || !ownerWorkspaceId || ownerWorkspaceId !== callerWorkspaceId) {
+      if (execution) {
+        logger.warn(
+          `[WorkflowController] Cross-workspace execution access blocked: ${executionId} (${ownerWorkspaceId}) by user ${req.user?.id} (${callerWorkspaceId})`
+        );
+      }
+      res.status(404).json({ error: 'Workflow execution not found' });
+      return false;
+    }
+    return true;
+  }
+
+  private async authorizeStep(req: Request, res: Response, stepId: string): Promise<boolean> {
+    const callerWorkspaceId = req.user?.workspaceId;
+    if (!callerWorkspaceId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return false;
+    }
+
+    const prisma = DatabaseClient.getInstance();
+    const step = await prisma.workflowStep.findUnique({
+      where: { id: stepId },
+      select: {
+        id: true,
+        workspaceId: true,
+        workflowExecution: {
+          select: { workspaceId: true, workflow: { select: { workspaceId: true } } },
+        },
+      },
+    });
+
+    const ownerWorkspaceId =
+      step?.workflowExecution?.workflow?.workspaceId ??
+      step?.workflowExecution?.workspaceId ??
+      step?.workspaceId ??
+      null;
+    if (!step || !ownerWorkspaceId || ownerWorkspaceId !== callerWorkspaceId) {
+      if (step) {
+        logger.warn(
+          `[WorkflowController] Cross-workspace step access blocked: ${stepId} (${ownerWorkspaceId}) by user ${req.user?.id} (${callerWorkspaceId})`
+        );
+      }
+      res.status(404).json({ error: 'Workflow step not found' });
+      return false;
+    }
+    return true;
+  }
+
   /**
    * Copy parent execution's agentic step data to new execution for rerun scenarios.
    * Loads from parent's Redis/GCS storage and copies to new execution's storage.
@@ -657,6 +723,7 @@ export class WorkflowController {
   updateWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { id } = req.params;
+      if (!(await this.authorizeExecution(req, res, id))) return;
       const updateData = req.body;
 
       const execution = await this.workflowRepository.updateWorkflowExecution(id, updateData);
@@ -791,6 +858,7 @@ export class WorkflowController {
   updateWorkflowStep = async (req: Request, res: Response): Promise<void> => {
     try {
       const { id } = req.params;
+      if (!(await this.authorizeStep(req, res, id))) return;
       const updateData = req.body;
 
       // Convert data to JSON string if it's an object
@@ -826,11 +894,21 @@ export class WorkflowController {
   restoreWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
       const { stepId } = req.body;
 
       // Validate required fields
       if (!stepId) {
         res.status(400).json({ error: 'stepId is required (DB ID of INPUT step)' });
+        return;
+      }
+
+      const restoreStep = await this.workflowRepository.getWorkflowStepById(stepId);
+      if (!restoreStep || restoreStep.workflowExecutionId !== executionId) {
+        logger.warn(
+          `[WorkflowController] Restore step ${stepId} does not belong to execution ${executionId}; rejecting restore`
+        );
+        res.status(404).json({ error: 'Step not found' });
         return;
       }
 
@@ -864,6 +942,7 @@ export class WorkflowController {
   rerunWorkflowFromStart = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Use workflow rerun service
       const result = await workflowRerunService.rerunFromExecution(executionId);
@@ -895,6 +974,7 @@ export class WorkflowController {
   continueAgenticStep = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
       const { stepId, message } = req.body;
 
       // Validate required fields
@@ -906,6 +986,14 @@ export class WorkflowController {
       // Get the step to find its stepName for the Redis channel
       const step = await this.workflowRepository.getWorkflowStepById(stepId);
       if (!step) {
+        res.status(404).json({ error: 'Step not found' });
+        return;
+      }
+
+      if (step.workflowExecutionId !== executionId) {
+        logger.warn(
+          `[WorkflowController] Step ${stepId} does not belong to execution ${executionId}; rejecting continue`
+        );
         res.status(404).json({ error: 'Step not found' });
         return;
       }
@@ -1155,6 +1243,7 @@ export class WorkflowController {
   pauseWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Import workflowManager dynamically to avoid circular dependencies
       const { workflowManager } = await import('../workflows/services/workflowManager');
@@ -1201,6 +1290,7 @@ export class WorkflowController {
   resumeWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Import workflowManager dynamically to avoid circular dependencies
       const { workflowManager } = await import('../workflows/services/workflowManager');
@@ -1247,6 +1337,7 @@ export class WorkflowController {
   cancelWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Import workflowManager dynamically to avoid circular dependencies
       const { workflowManager } = await import('../workflows/services/workflowManager');
@@ -1528,6 +1619,7 @@ export class WorkflowController {
   setExecutionMode = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
       const { mode } = req.body;
 
       // Validate required fields


### PR DESCRIPTION
Follow-up to PR #47. Closes two controller authorization findings left open by the tenant-ACL work — both the same shape: a caller-supplied id resolved with no tenant predicate.

## What changed

**Workflow executions and steps (#56)** — nine handlers took `executionId`/`stepId` straight from `req.params` into `findUnique`-by-id finders, so a wrong-tenant id resolved and mutated. Two guards resolve ownership through `workflow.workspaceId` (non-null; the denormalized execution/step columns are nullable and used only as a fallback for rows predating stamping). They answer 404 rather than 403 so a response never confirms an id exists in another tenant.

`continueAgenticStep` and `restoreWorkflowExecution` additionally require the body-supplied `stepId` to belong to the authorized execution. Guarding the execution alone would have left the inverse open — driving another tenant's step from an execution of your own.

**Email login (#377)** — the distinct `403 "Password not set"` now answers exactly like a wrong password and an unknown address, closing the unauthenticated enumeration oracle. Verified no client keys off those strings.

## Scope reduced after review

Fixes for **email demerge (#96, #104)** and **ticket `updateFormField` (#51)** were drafted here and then dropped: **PR #19 already carries equivalent guards for both**, and neither is on `main`, so keeping a second version would have conflicted on merge. PR #19's versions are the ones to keep.

One thing PR #19 does not have, worth porting there separately: `updateFormField`'s route gate authorizes a channel supplied in the request body while the handler mutates a ticket reached by a different id. Tying the two together needs `validateChannelAccessForPost` to expose the channel it authorized.

## Verified already fixed on main, no code needed

Eight findings originally scoped here were closed already, each checked against the tree: **#81, #84, #147, #170, #184** (`join_session` and `add_channel_subscription` are commented out entirely; `subscribe_to_channels` authorizes every id; the `session:<id>` bypass via `subscribe_to_ticket_counts` is regex-closed), **#203** (`requireAdminOrOwner` on `/provision-org`), **#210** (`authorize('DATA_SOURCES', READ)` on `/query/preview`), and **#152** (the system-prompt concatenation no longer exists anywhere in the monorepo).

## Residuals

- #377 still has a timing difference: the passwordless branch skips the bcrypt compare.
- #84's DoS half (unbounded bulk subscription arrays) remains instrumented observe-only at threshold 500 — a separate needs-design item.

## Testing

Backend typecheck, backend build, gitleaks on staged changes, and schema-migration validation all pass. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)