### PR TITLE
Feature/eval custom rank profile v2

### DIFF
--- a/apps/xyne-claw-auth/backend/src/config.ts
+++ b/apps/xyne-claw-auth/backend/src/config.ts
@@ -186,6 +186,33 @@ export const CONFIG = {
   vespaNamespace: process.env["VESPA_NAMESPACE"] ?? "namespace",
   vespaCluster: process.env["VESPA_CLUSTER"] ?? "my_content",
   /**
+   * Vespa CONFIG SERVER endpoint (port 19071, distinct from the query port
+   * above) — used only to fetch each schema's deployed .sd text
+   * (GET .../content/schemas/<schema>.sd) so rank-profile names can be read
+   * live off the running deployment instead of hand-maintained in code (see
+   * vespa-schema-profiles.ts). Defaults to VESPA_QUERY_ENDPOINT's host on
+   * port 19071 — query and config server are normally the same pod.
+   * Tenant/application/environment/region/instance default to "default",
+   * matching this app's own deployed session scripts (reindex.sh) for a
+   * plain single-node `vespa deploy`.
+   */
+  vespaConfigEndpoint: (() => {
+    const explicit = process.env["VESPA_CONFIG_ENDPOINT"];
+    if (explicit) return explicit.replace(/\/+$/, "");
+    try {
+      const u = new URL(process.env["VESPA_QUERY_ENDPOINT"] ?? "http://localhost:8081");
+      u.port = "19071";
+      return u.toString().replace(/\/+$/, "");
+    } catch {
+      return "http://localhost:19071";
+    }
+  })(),
+  vespaConfigTenant: process.env["VESPA_CONFIG_TENANT"] ?? "default",
+  vespaConfigApplication: process.env["VESPA_CONFIG_APPLICATION"] ?? "default",
+  vespaConfigEnvironment: process.env["VESPA_CONFIG_ENVIRONMENT"] ?? "default",
+  vespaConfigRegion: process.env["VESPA_CONFIG_REGION"] ?? "default",
+  vespaConfigInstance: process.env["VESPA_CONFIG_INSTANCE"] ?? "default",
+  /**
    * Pause (ms) the search-eval-run-worker inserts after each row's Vespa
    * query, in BOTH permission modes — a large sheet (hundreds/thousands of
    * rows) run at full QUERY_CONCURRENCY would otherwise hammer the Vespa

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/search-eval-vespa.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/search-eval-vespa.ts
@@ -55,7 +55,10 @@ import { CONFIG } from "../../config.js";
 import { buildYqlFromParams, buildFederatedYqlFromParams, type StructuredQueryParams } from "./vespa-search-areas.js";
 import { convertDateLiteralsToMs, defaultNativeInputs, callVespa, transformHit, type SearchResult } from "./vespa-direct.js";
 
-const TYPE_TO_AREA: Record<string, string> = {
+// Exported for the rank-profiles route (vespa-schema-profiles.ts +
+// routes/search-evals/rank-profiles.ts) to map a UI entity type to the
+// SearchArea whose .sd schema it should list live rank-profiles from.
+export const TYPE_TO_AREA: Record<string, string> = {
   messages: "message",
   files: "file",
   tickets: "ticket",
@@ -63,7 +66,7 @@ const TYPE_TO_AREA: Record<string, string> = {
   emails: "mail",
 };
 
-const ALL_AREAS = Object.values(TYPE_TO_AREA);
+export const ALL_AREAS = Object.values(TYPE_TO_AREA);
 
 // Mirrors vespa-direct.ts's (unexported) IST_OFFSET_MS — kept in lockstep so
 // the literal this produces round-trips through convertDateLiteralsToMs back
@@ -95,10 +98,12 @@ export interface SearchEvalVespaParams {
   type?: string;
   /** datetime-local string ("YYYY-MM-DDTHH:MM") — results must be at/before this. */
   before?: string;
-  /** Explicit rank profile ("default_native" | "unranked"), validated per-area
-   *  via rankProfilesForArea(). Undefined/"" → buildYqlFromParams auto-picks
-   *  (default_native for scored text). Only these two are safe across every
-   *  area — no SEARCH_AREA declares a wider allowedRankProfiles list. */
+  /** Explicit rank profile name, passed through to Vespa as-is — not
+   *  allow-listed (see buildYqlFromParams in vespa-search-areas.ts). The eval
+   *  UI's dropdown sources valid names live from vespa-schema-profiles.ts, or
+   *  a free-typed "Custom…" name — either way a name that doesn't exist on
+   *  the queried schema just fails at Vespa. Undefined/"" → buildYqlFromParams
+   *  auto-picks (default_native for scored text). */
   rankProfile?: string;
   workspaceId: string;
   limit?: number;

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/search-eval-vespa.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/search-eval-vespa.ts
@@ -98,12 +98,13 @@ export interface SearchEvalVespaParams {
   type?: string;
   /** datetime-local string ("YYYY-MM-DDTHH:MM") — results must be at/before this. */
   before?: string;
-  /** Explicit rank profile name, passed through to Vespa as-is — not
-   *  allow-listed (see buildYqlFromParams in vespa-search-areas.ts). The eval
-   *  UI's dropdown sources valid names live from vespa-schema-profiles.ts, or
-   *  a free-typed "Custom…" name — either way a name that doesn't exist on
-   *  the queried schema just fails at Vespa. Undefined/"" → buildYqlFromParams
-   *  auto-picks (default_native for scored text). */
+  /** Explicit rank profile name, passed through to Vespa as-is — this caller
+   *  opts out of buildYqlFromParams' allow-list (skipRankProfileValidation;
+   *  see vespa-search-areas.ts) since the eval UI's dropdown sources valid
+   *  names live from vespa-schema-profiles.ts, or a free-typed "Custom…"
+   *  name — either way a name that doesn't exist on the queried schema just
+   *  fails at Vespa. Undefined/"" → buildYqlFromParams auto-picks
+   *  (default_native for scored text). */
   rankProfile?: string;
   workspaceId: string;
   limit?: number;
@@ -171,11 +172,11 @@ export async function searchEvalVespa(
   const built =
     areas.length === 1
       ? params.permissionMode === "with"
-        ? buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, params.userId!, params.workspaceId)
-        : buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, "search-eval-public-only", params.workspaceId, { publicOnly: true })
+        ? buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, params.userId!, params.workspaceId, { skipRankProfileValidation: true })
+        : buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, "search-eval-public-only", params.workspaceId, { publicOnly: true, skipRankProfileValidation: true })
       : params.permissionMode === "with"
-        ? buildFederatedYqlFromParams(areas, commonParams, params.userId!, params.workspaceId)
-        : buildFederatedYqlFromParams(areas, commonParams, "search-eval-public-only", params.workspaceId, { publicOnly: true });
+        ? buildFederatedYqlFromParams(areas, commonParams, params.userId!, params.workspaceId, { skipRankProfileValidation: true })
+        : buildFederatedYqlFromParams(areas, commonParams, "search-eval-public-only", params.workspaceId, { publicOnly: true, skipRankProfileValidation: true });
 
   const datedYql = convertDateLiteralsToMs(built.yql);
   const stageLabel = areas.length === 1 ? areas[0]! : `federated (${areas.join(", ")})`;

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/search-eval-vespa.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/search-eval-vespa.ts
@@ -98,13 +98,13 @@ export interface SearchEvalVespaParams {
   type?: string;
   /** datetime-local string ("YYYY-MM-DDTHH:MM") — results must be at/before this. */
   before?: string;
-  /** Explicit rank profile name, passed through to Vespa as-is — this caller
-   *  opts out of buildYqlFromParams' allow-list (skipRankProfileValidation;
-   *  see vespa-search-areas.ts) since the eval UI's dropdown sources valid
-   *  names live from vespa-schema-profiles.ts, or a free-typed "Custom…"
-   *  name — either way a name that doesn't exist on the queried schema just
-   *  fails at Vespa. Undefined/"" → buildYqlFromParams auto-picks
-   *  (default_native for scored text). */
+  /** Explicit rank profile name, applied to the built query as-is (see the
+   *  searchEvalVespa comment above) rather than through buildYqlFromParams'
+   *  allow-list, since the eval UI's dropdown sources valid names live from
+   *  vespa-schema-profiles.ts, or a free-typed "Custom…" name — either way a
+   *  name that doesn't exist on the queried schema just fails at Vespa.
+   *  Undefined/"" → buildYqlFromParams auto-picks (default_native for scored
+   *  text). */
   rankProfile?: string;
   workspaceId: string;
   limit?: number;
@@ -162,21 +162,40 @@ export async function searchEvalVespa(
   const areas = requestedTypes.length > 0 ? requestedTypes.map(t => TYPE_TO_AREA[t]!) : ALL_AREAS;
   const limit = params.limit ?? 10;
 
+  // buildYqlFromParams/buildFederatedYqlFromParams (vespa-search-areas.ts) allow-list
+  // params.rankProfile against a hardcoded per-area list — deliberately NOT bypassed
+  // here (that validation also guards the production agent-facing search MCP tool,
+  // xyne-spaces-tools.ts, which shares these builders). Instead: only forward
+  // rankProfile through when it's "unranked" — always allow-listed everywhere, and
+  // the one value buildAreaClauses' `scored` flag treats specially (it decides
+  // whether to add the nearestNeighbor/embedding clause off `rankProfile !==
+  // "unranked"`, read from `params`, so an actually-unranked custom profile needs to
+  // reach that check as literally "unranked" to skip the vector clause correctly).
+  // Any OTHER custom/live-discovered name is withheld from the builder call — it
+  // auto-picks its own default_native/unranked (always allow-listed, and `scored`
+  // still resolves correctly since "not unranked" holds either way) — and is applied
+  // to the built query's `rankProfile` field directly below, post-validation.
   const commonParams: Omit<StructuredQueryParams, "searchArea"> = {
     query: params.q,
     hits: limit,
     ...(params.before ? { filters: { createdDate: { lte: toDateLiteral(params.before) } } } : {}),
-    ...(params.rankProfile ? { rankProfile: params.rankProfile } : {}),
+    ...(params.rankProfile === "unranked" ? { rankProfile: "unranked" as const } : {}),
   };
 
   const built =
     areas.length === 1
       ? params.permissionMode === "with"
-        ? buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, params.userId!, params.workspaceId, { skipRankProfileValidation: true })
-        : buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, "search-eval-public-only", params.workspaceId, { publicOnly: true, skipRankProfileValidation: true })
+        ? buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, params.userId!, params.workspaceId)
+        : buildYqlFromParams({ ...commonParams, searchArea: areas[0]! }, "search-eval-public-only", params.workspaceId, { publicOnly: true })
       : params.permissionMode === "with"
-        ? buildFederatedYqlFromParams(areas, commonParams, params.userId!, params.workspaceId, { skipRankProfileValidation: true })
-        : buildFederatedYqlFromParams(areas, commonParams, "search-eval-public-only", params.workspaceId, { publicOnly: true, skipRankProfileValidation: true });
+        ? buildFederatedYqlFromParams(areas, commonParams, params.userId!, params.workspaceId)
+        : buildFederatedYqlFromParams(areas, commonParams, "search-eval-public-only", params.workspaceId, { publicOnly: true });
+
+  // The actual rank profile to send to Vespa is always the eval caller's raw choice
+  // when one was given (not allow-listed — see the comment above); a name that
+  // doesn't exist on the queried schema just fails at Vespa (400), surfaced
+  // per-query in the eval UI.
+  if (params.rankProfile) built.rankProfile = params.rankProfile;
 
   const datedYql = convertDateLiteralsToMs(built.yql);
   const stageLabel = areas.length === 1 ? areas[0]! : `federated (${areas.join(", ")})`;

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-schema-profiles.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-schema-profiles.ts
@@ -1,0 +1,92 @@
+/**
+ * Live rank-profile discovery — fetches each schema's actually-deployed .sd
+ * text straight from Vespa's config server and regexes out `rank-profile
+ * <name>` declarations, instead of hand-maintaining a list that drifts (the
+ * old MESSAGE_RANK_PROFILES-style arrays in vespa-search-areas.ts — kept
+ * there as inert reference, no longer used to validate/populate anything).
+ * A profile added to a .sd and redeployed shows up here immediately, no code
+ * change needed.
+ *
+ * Cached in-memory per schema (CACHE_TTL_MS) so a burst of requests (e.g. the
+ * eval UI's "Entity type" switcher) doesn't hammer the config server, while
+ * still picking up a redeploy without restarting this service.
+ */
+import { CONFIG } from "../../config.js";
+import { createLogger } from "../../logger.js";
+
+const log = createLogger("vespa-schema-profiles");
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<string, { profiles: string[]; fetchedAt: number }>();
+
+function schemaContentUrl(schema: string): string {
+  return `${CONFIG.vespaConfigEndpoint}/application/v2/tenant/${CONFIG.vespaConfigTenant}` +
+    `/application/${CONFIG.vespaConfigApplication}/environment/${CONFIG.vespaConfigEnvironment}` +
+    `/region/${CONFIG.vespaConfigRegion}/instance/${CONFIG.vespaConfigInstance}` +
+    `/content/schemas/${schema}.sd`;
+}
+
+/**
+ * Parses `rank-profile <name>` declarations out of raw .sd text — skips
+ * commented-out lines (e.g. ticket.sd has a `# rank-profile global_sorted
+ * inherits initial {` left in as a note) and dedupes/sorts for a stable list.
+ * Exported standalone so it's testable without a live Vespa config server.
+ */
+export function parseRankProfileNames(sdText: string): string[] {
+  const names = new Set<string>();
+  for (const rawLine of sdText.split("\n")) {
+    const line = rawLine.trim();
+    if (line.startsWith("#")) continue;
+    const m = line.match(/^rank-profile\s+([A-Za-z0-9_]+)/);
+    if (m && m[1]) names.add(m[1]);
+  }
+  return Array.from(names).sort();
+}
+
+/**
+ * Live rank-profile names declared on `schema` (the .sd base name — matches
+ * SearchArea.source, e.g. "mail", "ticket", "file"). Throws if the config
+ * server is unreachable or the schema doesn't exist there; callers decide
+ * how to degrade (the route below falls back to BASE_RANK_PROFILES).
+ */
+export async function getSchemaRankProfiles(schema: string): Promise<string[]> {
+  const cached = cache.get(schema);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.profiles;
+
+  const url = schemaContentUrl(schema);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Vespa config server returned ${res.status} for schema "${schema}" (${url})`);
+  }
+  const text = await res.text();
+  const profiles = parseRankProfileNames(text);
+  cache.set(schema, { profiles, fetchedAt: Date.now() });
+  log.info(`[vespa-schema-profiles] ${schema}: ${profiles.join(", ")}`);
+  return profiles;
+}
+
+/** Rank profiles common to every one of `schemas` — the only ones safe to
+ *  pick for a federated ("All types") query, since Vespa applies exactly ONE
+ *  ranking.profile across all merged sources. Schemas that fail to fetch are
+ *  logged and excluded from the intersection (rather than failing the whole
+ *  call) so one bad/renamed schema doesn't blank out the entire list. */
+export async function getCommonRankProfiles(schemas: string[]): Promise<string[]> {
+  const perSchema = await Promise.all(
+    schemas.map(async (schema) => {
+      try {
+        return await getSchemaRankProfiles(schema);
+      } catch (err) {
+        log.error(`[vespa-schema-profiles] failed to fetch "${schema}":`, err instanceof Error ? err.message : err);
+        return null;
+      }
+    }),
+  );
+  const lists = perSchema.filter((p): p is string[] => p !== null);
+  if (lists.length === 0) return [];
+  return lists.reduce((common, list) => common.filter((p) => list.includes(p)));
+}
+
+/** Clears the cache — call after a known Vespa redeploy, or from a test. */
+export function clearSchemaRankProfilesCache(): void {
+  cache.clear();
+}

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
@@ -842,15 +842,14 @@ export function buildYqlFromParams(
     })}`;
   }
 
-  // 8. Validate an agent-supplied rank profile early, against the profiles that
-  //    actually exist on this area's source — fail with the allowed list rather
-  //    than let Vespa 400 or silently fall back.
+  // 8. An agent/eval-supplied rank profile is passed through as-is. The eval
+  //    UI sources its dropdown live from Vespa's deployed schema (see
+  //    vespa-schema-profiles.ts), or a free-typed "Custom…" name, rather than
+  //    a hardcoded allow-list, so this no longer pre-validates — a name that
+  //    doesn't exist on this area's source just fails at Vespa (400),
+  //    surfaced per-query in the eval UI.
   let rankProfile: string | undefined;
   if (params.rankProfile != null && params.rankProfile !== "") {
-    const allowed = rankProfilesForArea(area);
-    if (!allowed.includes(params.rankProfile)) {
-      throw new Error(`rankProfile "${params.rankProfile}" is not available for area "${params.searchArea}". Allowed: ${allowed.join(", ")}.`);
-    }
     rankProfile = params.rankProfile;
   } else if (query) {
     // A text query always scores (hybrid retrieval), EVEN when grouping — pin
@@ -887,9 +886,13 @@ export interface FederatedBuiltQuery {
  * single-schema queries and merging results client-side.
  *
  * Vespa applies exactly ONE ranking.profile to the whole query, so it must be
- * a profile that exists on every involved source — only "default_native"
- * (present on message/file/ticket/channel/mail) and "unranked" qualify;
- * anything else throws. No sort/groupBy here — federating differing schemas'
+ * a profile that exists on every involved source to work cleanly — passed
+ * through as-is (not allow-listed, see buildYqlFromParams above); the eval
+ * UI's dropdown restricts "All types" to the live intersection
+ * (getCommonRankProfiles, vespa-schema-profiles.ts) unless a free-typed
+ * "Custom…" name is used, so a profile missing from one of the merged
+ * schemas here just fails that query at Vespa. No
+ * sort/groupBy here — federating differing schemas'
  * field vocabularies under one sort/group key isn't well-defined, and no
  * caller currently needs it (search-eval-vespa.ts's only use is a plain
  * "All types" query+date-filter, never sort/groupBy).
@@ -922,9 +925,6 @@ export function buildFederatedYqlFromParams(
 
   let rankProfile: string | undefined;
   if (params.rankProfile != null && params.rankProfile !== "") {
-    if (!BASE_RANK_PROFILES.includes(params.rankProfile)) {
-      throw new Error(`rankProfile "${params.rankProfile}" is not valid for a federated ("All types") query — it must exist on every involved source. Allowed: ${BASE_RANK_PROFILES.join(", ")}.`);
-    }
     rankProfile = params.rankProfile;
   } else if (query) {
     rankProfile = "default_native";

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
@@ -793,7 +793,7 @@ export function buildYqlFromParams(
   params: StructuredQueryParams,
   userId: string,
   workspaceId: string,
-  opts?: { publicOnly?: boolean; skipRankProfileValidation?: boolean },
+  opts?: { publicOnly?: boolean },
 ): BuiltQuery {
   const area = resolveArea(params.searchArea);
   if (!area) {
@@ -844,19 +844,12 @@ export function buildYqlFromParams(
 
   // 8. Validate an agent-supplied rank profile early, against the profiles that
   //    actually exist on this area's source — fail with the allowed list rather
-  //    than let Vespa 400 or silently fall back. The search-eval caller opts out
-  //    (skipRankProfileValidation) since its UI sources options live from Vespa's
-  //    deployed schema (see vespa-schema-profiles.ts) or a free-typed "Custom…"
-  //    name, rather than this hardcoded allow-list — a name that doesn't exist
-  //    on this area's source there just fails at Vespa (400), surfaced per-query
-  //    in the eval UI.
+  //    than let Vespa 400 or silently fall back.
   let rankProfile: string | undefined;
   if (params.rankProfile != null && params.rankProfile !== "") {
-    if (!opts?.skipRankProfileValidation) {
-      const allowed = rankProfilesForArea(area);
-      if (!allowed.includes(params.rankProfile)) {
-        throw new Error(`rankProfile "${params.rankProfile}" is not available for area "${params.searchArea}". Allowed: ${allowed.join(", ")}.`);
-      }
+    const allowed = rankProfilesForArea(area);
+    if (!allowed.includes(params.rankProfile)) {
+      throw new Error(`rankProfile "${params.rankProfile}" is not available for area "${params.searchArea}". Allowed: ${allowed.join(", ")}.`);
     }
     rankProfile = params.rankProfile;
   } else if (query) {
@@ -896,12 +889,7 @@ export interface FederatedBuiltQuery {
  * Vespa applies exactly ONE ranking.profile to the whole query, so it must be
  * a profile that exists on every involved source — only "default_native"
  * (present on message/file/ticket/channel/mail) and "unranked" qualify;
- * anything else throws, UNLESS the caller opts out (skipRankProfileValidation
- * — the search-eval caller's UI already restricts "All types" to the live
- * intersection across schemas, getCommonRankProfiles in
- * vespa-schema-profiles.ts, or a free-typed "Custom…" name, so a profile
- * missing from one of the merged schemas there just fails that query at
- * Vespa instead). No sort/groupBy here — federating differing schemas'
+ * anything else throws. No sort/groupBy here — federating differing schemas'
  * field vocabularies under one sort/group key isn't well-defined, and no
  * caller currently needs it (search-eval-vespa.ts's only use is a plain
  * "All types" query+date-filter, never sort/groupBy).
@@ -911,7 +899,7 @@ export function buildFederatedYqlFromParams(
   params: Omit<StructuredQueryParams, "searchArea">,
   userId: string,
   workspaceId: string,
-  opts?: { publicOnly?: boolean; skipRankProfileValidation?: boolean },
+  opts?: { publicOnly?: boolean },
 ): FederatedBuiltQuery {
   if (areaNames.length === 0) {
     throw new Error("buildFederatedYqlFromParams: at least one area is required.");
@@ -934,7 +922,7 @@ export function buildFederatedYqlFromParams(
 
   let rankProfile: string | undefined;
   if (params.rankProfile != null && params.rankProfile !== "") {
-    if (!opts?.skipRankProfileValidation && !BASE_RANK_PROFILES.includes(params.rankProfile)) {
+    if (!BASE_RANK_PROFILES.includes(params.rankProfile)) {
       throw new Error(`rankProfile "${params.rankProfile}" is not valid for a federated ("All types") query — it must exist on every involved source. Allowed: ${BASE_RANK_PROFILES.join(", ")}.`);
     }
     rankProfile = params.rankProfile;

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
@@ -793,7 +793,7 @@ export function buildYqlFromParams(
   params: StructuredQueryParams,
   userId: string,
   workspaceId: string,
-  opts?: { publicOnly?: boolean },
+  opts?: { publicOnly?: boolean; skipRankProfileValidation?: boolean },
 ): BuiltQuery {
   const area = resolveArea(params.searchArea);
   if (!area) {
@@ -842,14 +842,22 @@ export function buildYqlFromParams(
     })}`;
   }
 
-  // 8. An agent/eval-supplied rank profile is passed through as-is. The eval
-  //    UI sources its dropdown live from Vespa's deployed schema (see
-  //    vespa-schema-profiles.ts), or a free-typed "Custom…" name, rather than
-  //    a hardcoded allow-list, so this no longer pre-validates — a name that
-  //    doesn't exist on this area's source just fails at Vespa (400),
-  //    surfaced per-query in the eval UI.
+  // 8. Validate an agent-supplied rank profile early, against the profiles that
+  //    actually exist on this area's source — fail with the allowed list rather
+  //    than let Vespa 400 or silently fall back. The search-eval caller opts out
+  //    (skipRankProfileValidation) since its UI sources options live from Vespa's
+  //    deployed schema (see vespa-schema-profiles.ts) or a free-typed "Custom…"
+  //    name, rather than this hardcoded allow-list — a name that doesn't exist
+  //    on this area's source there just fails at Vespa (400), surfaced per-query
+  //    in the eval UI.
   let rankProfile: string | undefined;
   if (params.rankProfile != null && params.rankProfile !== "") {
+    if (!opts?.skipRankProfileValidation) {
+      const allowed = rankProfilesForArea(area);
+      if (!allowed.includes(params.rankProfile)) {
+        throw new Error(`rankProfile "${params.rankProfile}" is not available for area "${params.searchArea}". Allowed: ${allowed.join(", ")}.`);
+      }
+    }
     rankProfile = params.rankProfile;
   } else if (query) {
     // A text query always scores (hybrid retrieval), EVEN when grouping — pin
@@ -886,13 +894,14 @@ export interface FederatedBuiltQuery {
  * single-schema queries and merging results client-side.
  *
  * Vespa applies exactly ONE ranking.profile to the whole query, so it must be
- * a profile that exists on every involved source to work cleanly — passed
- * through as-is (not allow-listed, see buildYqlFromParams above); the eval
- * UI's dropdown restricts "All types" to the live intersection
- * (getCommonRankProfiles, vespa-schema-profiles.ts) unless a free-typed
- * "Custom…" name is used, so a profile missing from one of the merged
- * schemas here just fails that query at Vespa. No
- * sort/groupBy here — federating differing schemas'
+ * a profile that exists on every involved source — only "default_native"
+ * (present on message/file/ticket/channel/mail) and "unranked" qualify;
+ * anything else throws, UNLESS the caller opts out (skipRankProfileValidation
+ * — the search-eval caller's UI already restricts "All types" to the live
+ * intersection across schemas, getCommonRankProfiles in
+ * vespa-schema-profiles.ts, or a free-typed "Custom…" name, so a profile
+ * missing from one of the merged schemas there just fails that query at
+ * Vespa instead). No sort/groupBy here — federating differing schemas'
  * field vocabularies under one sort/group key isn't well-defined, and no
  * caller currently needs it (search-eval-vespa.ts's only use is a plain
  * "All types" query+date-filter, never sort/groupBy).
@@ -902,7 +911,7 @@ export function buildFederatedYqlFromParams(
   params: Omit<StructuredQueryParams, "searchArea">,
   userId: string,
   workspaceId: string,
-  opts?: { publicOnly?: boolean },
+  opts?: { publicOnly?: boolean; skipRankProfileValidation?: boolean },
 ): FederatedBuiltQuery {
   if (areaNames.length === 0) {
     throw new Error("buildFederatedYqlFromParams: at least one area is required.");
@@ -925,6 +934,9 @@ export function buildFederatedYqlFromParams(
 
   let rankProfile: string | undefined;
   if (params.rankProfile != null && params.rankProfile !== "") {
+    if (!opts?.skipRankProfileValidation && !BASE_RANK_PROFILES.includes(params.rankProfile)) {
+      throw new Error(`rankProfile "${params.rankProfile}" is not valid for a federated ("All types") query — it must exist on every involved source. Allowed: ${BASE_RANK_PROFILES.join(", ")}.`);
+    }
     rankProfile = params.rankProfile;
   } else if (query) {
     rankProfile = "default_native";

--- a/apps/xyne-claw-auth/backend/src/routes/search-evals/index.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/search-evals/index.ts
@@ -7,10 +7,12 @@ import { Router } from "express";
 import { searchEvalSheetsRouter } from "./sheets.js";
 import { searchEvalRunsRouter } from "./runs.js";
 import { searchEvalExportRouter } from "./export.js";
+import { searchEvalRankProfilesRouter } from "./rank-profiles.js";
 
 const router = Router();
 router.use(searchEvalSheetsRouter);
 router.use(searchEvalRunsRouter);
 router.use(searchEvalExportRouter);
+router.use(searchEvalRankProfilesRouter);
 
 export { router as searchEvalsRouter };

--- a/apps/xyne-claw-auth/backend/src/routes/search-evals/rank-profiles.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/search-evals/rank-profiles.ts
@@ -1,0 +1,51 @@
+/**
+ * Search Evals — live rank-profile listing per entity type, read straight
+ * off Vespa's deployed .sd schema (see vespa-schema-profiles.ts) instead of
+ * a hand-maintained list, so a profile added to a schema and redeployed
+ * shows up in the eval UI's "Rank profile" dropdown immediately.
+ */
+import { Router, type Request, type Response } from "express";
+import { resolveArea } from "../../mcp/servers/vespa-search-areas.js";
+import { TYPE_TO_AREA, ALL_AREAS } from "../../mcp/servers/search-eval-vespa.js";
+import { getSchemaRankProfiles, getCommonRankProfiles } from "../../mcp/servers/vespa-schema-profiles.js";
+
+import { createLogger } from "../../logger.js";
+const log = createLogger("search-evals/rank-profiles");
+
+const router = Router();
+
+// GET /search-evals/rank-profiles?type=messages|tickets|files|emails|channels
+// Omitted/"" type = "All types" — returns the intersection across every
+// area's schema, since Vespa applies exactly ONE ranking.profile to a
+// federated query (see buildFederatedYqlFromParams).
+router.get("/rank-profiles", async (req: Request, res: Response) => {
+  const type = typeof req.query["type"] === "string" ? req.query["type"] : "";
+  try {
+    if (!type) {
+      const sources = ALL_AREAS
+        .map((areaName) => resolveArea(areaName)?.source)
+        .filter((s): s is string => Boolean(s));
+      const profiles = await getCommonRankProfiles(sources);
+      res.json({ success: true, profiles });
+      return;
+    }
+
+    const areaName = TYPE_TO_AREA[type];
+    const area = areaName ? resolveArea(areaName) : null;
+    if (!area) {
+      res.status(400).json({ success: false, error: `Unsupported entity type "${type}".` });
+      return;
+    }
+
+    const profiles = await getSchemaRankProfiles(area.source);
+    res.json({ success: true, profiles });
+  } catch (err) {
+    log.error(`[search-evals/rank-profiles] failed for type "${type}":`, err instanceof Error ? err.message : err);
+    res.status(502).json({
+      success: false,
+      error: err instanceof Error ? err.message : "Failed to fetch rank profiles from Vespa's config server.",
+    });
+  }
+});
+
+export { router as searchEvalRankProfilesRouter };

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -5946,6 +5946,18 @@ export async function startSearchEvalRun(
   );
 }
 
+/** Live rank-profile names for a UI entity type ("messages"/"tickets"/
+ *  "files"/"emails"/"channels"), or the common-to-every-schema set when
+ *  `queryType` is "" ("All types") — read straight off Vespa's deployed .sd
+ *  schema (see rank-profiles.ts), not a hardcoded list. */
+export async function getSearchEvalRankProfiles(queryType: string, userId: string): Promise<string[]> {
+  const data = await request<{ success: boolean; profiles: string[] }>(
+    `${AUTH_API_URL}/api/v1/search-evals/rank-profiles?type=${encodeURIComponent(queryType)}`,
+    { headers: { "x-user-id": userId } },
+  );
+  return data.profiles ?? [];
+}
+
 interface SearchEvalTopKStat {
   count: number;
   pct: number | null;

--- a/apps/xyne-claw-auth/frontend/src/v3/components/SearchEvalsPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/SearchEvalsPageV3.tsx
@@ -755,9 +755,10 @@ function QueryDebugDialog({ row, onClose }: { row: SearchEvalResultRow; onClose:
       leftOffset={100}
       maxWidth={1560}
       maxHeight="85vh"
+      bodyClassName="flex-1 overflow-hidden p-[var(--comp-dialog-padding)]"
       footer={<Button variant="secondary" size="sm" onClick={onClose}>Close</Button>}
     >
-      <div className="max-h-[calc(85vh-140px)] w-full space-y-[20px] overflow-y-auto">
+      <div className="max-h-[calc(85vh-140px)] min-w-0 w-full space-y-[20px] overflow-y-auto pr-[4px]">
         {(!row.debug || row.debug.length === 0) && (
           <p className="text-[12px] text-xyne-fg-tertiary">No YQL/debug info captured for this row.</p>
         )}
@@ -771,7 +772,7 @@ function QueryDebugDialog({ row, onClose }: { row: SearchEvalResultRow; onClose:
               </p>
               {/* Side by side once there's room — inputs table stays a fixed
                   readable width, YQL takes the rest, instead of stacking. */}
-              <div className="flex flex-col gap-[12px] lg:flex-row">
+              <div className="flex min-w-0 flex-col gap-[12px] lg:flex-row">
                 {inputs.length > 0 && (
                   <table className="w-full shrink-0 self-start text-[11px] lg:w-[340px]">
                     <tbody>
@@ -784,7 +785,7 @@ function QueryDebugDialog({ row, onClose }: { row: SearchEvalResultRow; onClose:
                     </tbody>
                   </table>
                 )}
-                <pre className="max-h-[220px] min-w-0 flex-1 overflow-auto rounded-lg bg-xyne-surface-sunken p-[8px] text-[10.5px] leading-[1.4] text-xyne-fg-secondary whitespace-pre-wrap">
+                <pre className="max-h-[220px] min-w-0 flex-1 overflow-auto break-words rounded-lg bg-xyne-surface-sunken p-[8px] text-[10.5px] leading-[1.4] text-xyne-fg-secondary whitespace-pre-wrap">
                   {stage.yql}
                 </pre>
               </div>
@@ -796,8 +797,8 @@ function QueryDebugDialog({ row, onClose }: { row: SearchEvalResultRow; onClose:
           <p className="mb-[8px] text-[11px] font-medium uppercase tracking-[0.06em] text-xyne-fg-tertiary">
             Top {results.length} results — click a row to inspect its full values
           </p>
-          <div className="grid grid-cols-1 gap-[12px] lg:grid-cols-[380px_1fr]">
-            <div className="max-h-[420px] overflow-y-auto rounded-xl border border-xyne-border">
+          <div className="grid min-w-0 grid-cols-1 gap-[12px] lg:grid-cols-[minmax(280px,420px)_minmax(0,1fr)]">
+            <div className="min-w-0 max-h-[420px] overflow-auto rounded-xl border border-xyne-border">
               <table className="w-full text-[11.5px]">
                 <thead className="sticky top-0">
                   <tr className="border-b border-xyne-border bg-xyne-surface-subtle text-left text-xyne-fg-tertiary">
@@ -838,13 +839,13 @@ function QueryDebugDialog({ row, onClose }: { row: SearchEvalResultRow; onClose:
               </table>
             </div>
 
-            <div className="max-h-[420px] overflow-y-auto rounded-xl border border-xyne-border bg-xyne-surface-sunken p-[10px]">
+            <div className="min-w-0 max-h-[420px] overflow-auto rounded-xl border border-xyne-border bg-xyne-surface-sunken p-[10px]">
               {selected ? (
                 <>
                   <p className="mb-[6px] text-[11px] font-medium text-xyne-fg-tertiary">
                     #{selectedIdx + 1} — all values
                   </p>
-                  <pre className="text-[10.5px] leading-[1.4] text-xyne-fg-secondary whitespace-pre-wrap">
+                  <pre className="break-words text-[10.5px] leading-[1.4] text-xyne-fg-secondary whitespace-pre-wrap">
                     {JSON.stringify(selected.raw ?? selected, null, 2)}
                   </pre>
                 </>
@@ -879,7 +880,7 @@ function MatchFeaturesTable({ results, goldId }: { results: SearchEvalTopResult[
       <p className="mb-[8px] text-[11px] font-medium uppercase tracking-[0.06em] text-xyne-fg-tertiary">
         Match features
       </p>
-      <div className="overflow-x-auto rounded-xl border border-xyne-border">
+      <div className="min-w-0 overflow-x-auto rounded-xl border border-xyne-border">
         <table className="w-full text-[11px]">
           <thead>
             <tr className="border-b border-xyne-border bg-xyne-surface-subtle text-left text-xyne-fg-tertiary">

--- a/apps/xyne-claw-auth/frontend/src/v3/components/SearchEvalsPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/SearchEvalsPageV3.tsx
@@ -25,10 +25,12 @@ import { Button } from "./ui/Button";
 import { Badge } from "./ui/Badge";
 import { Dialog } from "./ui/Dialog";
 import { SelectField, type SelectOption } from "./ui/SelectField";
+import { TextField } from "./ui/TextField";
 import {
   listSearchEvalSheets,
   uploadSearchEvalSheet,
   startSearchEvalRun,
+  getSearchEvalRankProfiles,
   getSearchEvalRun,
   listSearchEvalRuns,
   downloadSearchEvalRunExport,
@@ -85,67 +87,40 @@ const PERMISSION_OPTIONS: SelectOption[] = [
   { value: "with", label: "With permission (private + public, as you)" },
 ];
 
-// Both permission modes run entirely through search-eval-vespa.ts's own YQL
-// builder (see the architecture note at the top of that file) — neither
-// calls the real main backend — but each SEARCH_AREA in vespa-search-areas.ts
-// now declares its own `allowedRankProfiles`, read directly off the deployed
-// .sd schemas (see the ground-truth comment there, cross-checked against
-// /Users/priyanshu.c/Desktop/codeeee/vespa-core/vespa/common/schemas/*.sd), so
-// the options here are genuinely per-entity-type, matching what's really
-// declared in Vespa — not a client-invented generic list. "tunable" is a
-// REAL rank-profile name declared per-schema. When picked, its sliders use
-// that entity type's real `inputs {}` block (see TUNABLE_INPUTS_BY_AREA).
-const BASE_RANK_PROFILE_OPTIONS: SelectOption[] = [
-  { value: "", label: "default_native (default)" },
-];
+// Rank-profile choices are fetched live per entity type from
+// getSearchEvalRankProfiles() (rank-profiles.ts on the backend), which reads
+// Vespa's actually-deployed .sd schema and regexes out `rank-profile <name>`
+// — not a hardcoded list here, so a profile added to a schema and redeployed
+// (e.g. "unified") shows up without a frontend change. "" always means "let
+// the backend auto-pick default_native" (see buildYqlFromParams) rather than
+// sending an explicit name. "All types" gets the intersection across every
+// area's schema, since Vespa applies exactly ONE ranking.profile to a
+// federated query (see buildFederatedYqlFromParams).
+const DEFAULT_RANK_PROFILE_OPTION: SelectOption = { value: "", label: "default_native (default)" };
 
-const MESSAGE_RANK_PROFILE_OPTIONS: SelectOption[] = [
-  ...BASE_RANK_PROFILE_OPTIONS,
-  { value: "tunable", label: "tunable (custom weights)" },
-  { value: "personalized", label: "personalized" },
-  { value: "default_random", label: "default_random" },
-  { value: "default_fuzzy", label: "default_fuzzy" },
-  { value: "default_native_tb", label: "default_native_tb" },
-  { value: "default_native_tb2", label: "default_native_tb2" },
-  ...Array.from({ length: 23 }, (_, i) => ({ value: `default_native_${i}`, label: `default_native_${i}` })),
-];
+/** A couple of well-known profiles get a friendlier label; anything else
+ *  (a brand-new profile) just shows its own name as-is. */
+const RANK_PROFILE_LABELS: Record<string, string> = {
+  tunable: "tunable (custom weights)",
+};
 
-const TICKET_RANK_PROFILE_OPTIONS: SelectOption[] = [
-  ...BASE_RANK_PROFILE_OPTIONS,
-  { value: "tunable", label: "tunable (custom weights)" },
-  { value: "semantic_ranking", label: "semantic_ranking" },
-  { value: "default_fuzzy", label: "default_fuzzy" },
-];
+/** Covers a profile added to (or renamed in) the .sd schema after the live
+ *  fetch ran, or one that getSearchEvalRankProfiles() otherwise doesn't
+ *  return — the name is passed straight through to Vespa unvalidated (see
+ *  buildYqlFromParams in vespa-search-areas.ts), so a typo or a profile
+ *  missing from the queried schema just fails that run with Vespa's own
+ *  error, shown in the results. */
+const CUSTOM_RANK_PROFILE_VALUE = "__custom__";
+const CUSTOM_RANK_PROFILE_OPTION: SelectOption = { value: CUSTOM_RANK_PROFILE_VALUE, label: "Custom..." };
 
-const FILE_RANK_PROFILE_OPTIONS: SelectOption[] = [
-  ...BASE_RANK_PROFILE_OPTIONS,
-  { value: "tunable", label: "tunable (custom weights)" },
-  { value: "default_fuzzy", label: "default_fuzzy" },
-];
-
-const MAIL_RANK_PROFILE_OPTIONS: SelectOption[] = [
-  ...BASE_RANK_PROFILE_OPTIONS,
-  { value: "tunable", label: "tunable (custom weights)" },
-  { value: "global_sorted", label: "global_sorted" },
-  { value: "default_bm25", label: "default_bm25" },
-  { value: "default_ai", label: "default_ai" },
-  { value: "default_fuzzy", label: "default_fuzzy" },
-  { value: "default_native_best_chunk_025", label: "default_native_best_chunk_025" },
-  { value: "default_native_top_chunk_lexical_025", label: "default_native_top_chunk_lexical_025" },
-];
-
-/** "All types" merges N single-schema queries (see search-eval-vespa.ts) each
- *  against a different schema — only default_native (every schema's base
- *  profile) is safe to pick there. Pick a single entity type to unlock its
- *  full, real profile list (including tunable). */
-function rankProfileOptionsForType(queryType: string): SelectOption[] {
-  switch (queryType) {
-    case "messages": return MESSAGE_RANK_PROFILE_OPTIONS;
-    case "tickets": return TICKET_RANK_PROFILE_OPTIONS;
-    case "files": return FILE_RANK_PROFILE_OPTIONS;
-    case "emails": return MAIL_RANK_PROFILE_OPTIONS;
-    default: return BASE_RANK_PROFILE_OPTIONS;
-  }
+function rankProfileOptionsFromNames(names: string[]): SelectOption[] {
+  return [
+    DEFAULT_RANK_PROFILE_OPTION,
+    ...names
+      .filter((name) => name !== "default_native")
+      .map((name) => ({ value: name, label: RANK_PROFILE_LABELS[name] ?? name })),
+    CUSTOM_RANK_PROFILE_OPTION,
+  ];
 }
 
 interface TunableField {
@@ -551,23 +526,52 @@ function RunConfigDialog({
 }) {
   const [queryType, setQueryType] = useState<string>("");
   const [rankProfile, setRankProfile] = useState<string>("");
+  const [customRankProfile, setCustomRankProfile] = useState<string>("");
   const [tunableInputs, setTunableInputs] = useState<Record<string, number>>({});
   const [starting, setStarting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  const rankProfileOptions = rankProfileOptionsForType(queryType);
+  // Fetched live from Vespa's deployed schema per queryType (see
+  // getSearchEvalRankProfiles) rather than a hardcoded per-type list.
+  const [rankProfileOptions, setRankProfileOptions] = useState<SelectOption[]>([DEFAULT_RANK_PROFILE_OPTION]);
+  const [rankProfilesLoading, setRankProfilesLoading] = useState(false);
+  const [rankProfilesErr, setRankProfilesErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setRankProfilesLoading(true);
+    setRankProfilesErr(null);
+    getSearchEvalRankProfiles(queryType, userId)
+      .then((names) => {
+        if (cancelled) return;
+        setRankProfileOptions(rankProfileOptionsFromNames(names));
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setRankProfilesErr(e instanceof Error ? e.message : String(e));
+        setRankProfileOptions([DEFAULT_RANK_PROFILE_OPTION]);
+      })
+      .finally(() => { if (!cancelled) setRankProfilesLoading(false); });
+    return () => { cancelled = true; };
+  }, [queryType, userId]);
+
   const tunableFields = TUNABLE_INPUTS_BY_AREA[queryType] ?? [];
   const isTunable = rankProfile === "tunable" && tunableFields.length > 0;
+  const isCustomRankProfile = rankProfile === CUSTOM_RANK_PROFILE_VALUE;
+  // The name actually sent to the backend — the sentinel is a UI-only pick.
+  const effectiveRankProfile = isCustomRankProfile ? customRankProfile.trim() : rankProfile;
 
   function handleQueryTypeChange(v: string) {
     setQueryType(v);
     setRankProfile("");
+    setCustomRankProfile("");
     setTunableInputs(defaultTunableInputs(TUNABLE_INPUTS_BY_AREA[v] ?? []));
   }
 
   function handleRankProfileChange(v: string) {
     setRankProfile(v);
     if (v === "tunable") setTunableInputs(defaultTunableInputs(tunableFields));
+    if (v !== CUSTOM_RANK_PROFILE_VALUE) setCustomRankProfile("");
   }
 
   async function submit() {
@@ -578,7 +582,7 @@ function RunConfigDialog({
         sheet.id,
         {
           queryType: queryType ? [queryType] : [],
-          ...(rankProfile ? { rankProfile } : {}),
+          ...(effectiveRankProfile ? { rankProfile: effectiveRankProfile } : {}),
           ...(isTunable ? { rankProfileInputs: tunableInputs } : {}),
         },
         userId,
@@ -605,7 +609,13 @@ function RunConfigDialog({
       footer={
         <>
           <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
-          <Button variant="primary" size="sm" leadingIcon={<PlayIcon size={14} />} disabled={starting} onClick={submit}>
+          <Button
+            variant="primary"
+            size="sm"
+            leadingIcon={<PlayIcon size={14} />}
+            disabled={starting || (isCustomRankProfile && customRankProfile.trim() === "")}
+            onClick={submit}
+          >
             {starting ? "Starting…" : "Run"}
           </Button>
         </>
@@ -616,8 +626,23 @@ function RunConfigDialog({
       )}
       <SelectField label="Entity type" options={TYPE_OPTIONS} value={queryType} onValueChange={(v) => handleQueryTypeChange(v ?? "")} />
       <SelectField label="Rank profile" options={rankProfileOptions} value={rankProfile} onValueChange={(v) => handleRankProfileChange(v ?? "")} />
-      {queryType === "" && (
-        <p className="text-[11px] text-xyne-fg-tertiary">Pick a single entity type to unlock its full rank-profile list (incl. tunable).</p>
+      {isCustomRankProfile && (
+        <TextField
+          label="Custom rank profile name"
+          placeholder="e.g. a profile just added to the .sd schema"
+          hint="Sent to Vespa as-is — not validated against a known list. A typo or a profile missing from the queried schema fails that run with Vespa's error."
+          value={customRankProfile}
+          onChange={(e) => setCustomRankProfile(e.target.value)}
+        />
+      )}
+      {rankProfilesLoading && (
+        <p className="text-[11px] text-xyne-fg-tertiary">Reading rank profiles from Vespa…</p>
+      )}
+      {rankProfilesErr && (
+        <p className="text-[11px] text-xyne-error-fg">Couldn't fetch rank profiles from Vespa ({rankProfilesErr}) — only the default is available.</p>
+      )}
+      {!rankProfilesLoading && !rankProfilesErr && queryType === "" && (
+        <p className="text-[11px] text-xyne-fg-tertiary">"All types" only offers profiles common to every schema. Pick a single entity type to unlock its full list (incl. tunable).</p>
       )}
       {isTunable && (
         <TunableRankInputsEditor fields={tunableFields} value={tunableInputs} onChange={setTunableInputs} />

--- a/apps/xyne-claw-auth/frontend/src/v3/components/ui/Dialog.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/ui/Dialog.tsx
@@ -62,7 +62,9 @@ export function Dialog({
             maxWidth,
             maxHeight: maxHeight !== undefined ? (typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight) : "70vh",
             ...(height !== undefined ? { height: typeof height === "number" ? `${height}px` : height } : {}),
-            width: "calc(100vw - 32px)",
+            width: leftOffset
+              ? `calc(100vw - 32px - ${Math.abs(leftOffset) * 2}px)`
+              : "calc(100vw - 32px)",
             position: "fixed",
             top: "50%",
             left: leftOffset ? `calc(50% + ${leftOffset}px)` : "50%",


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [x] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
