### PR TITLE
Feature/link and cc in automations r04

### DIFF
--- a/backend/src/automations/engine/config-validator.ts
+++ b/backend/src/automations/engine/config-validator.ts
@@ -154,6 +154,24 @@ function isZodCompatible(upstream: z.ZodTypeAny, consumer: z.ZodTypeAny): boolea
   if (consumer instanceof z.ZodUnknown || consumer instanceof z.ZodAny) return true;
   if (upstream instanceof z.ZodUnknown || upstream instanceof z.ZodAny) return true;
 
+  // Output fields may be nullable/optional even when they are consumed as a
+  // string variable. The runtime resolver safely stringifies nullish values,
+  // so compare the underlying value types for reference validation.
+  while (
+    upstream instanceof z.ZodOptional ||
+    upstream instanceof z.ZodNullable ||
+    upstream instanceof z.ZodDefault
+  ) {
+    upstream = upstream._def.innerType;
+  }
+  while (
+    consumer instanceof z.ZodOptional ||
+    consumer instanceof z.ZodNullable ||
+    consumer instanceof z.ZodDefault
+  ) {
+    consumer = consumer._def.innerType;
+  }
+
   const upType = upstream._def.typeName as string;
   const conType = consumer._def.typeName as string;
 

--- a/backend/src/automations/steps/send-email-reply.step.ts
+++ b/backend/src/automations/steps/send-email-reply.step.ts
@@ -12,6 +12,14 @@ import { logger } from '@/utils/logger';
 const SendEmailReplyConfigSchema = z.object({
   conversationId: variableRef(z.string().min(1)),
   body: variableRef(z.string().min(1)),
+  cc: z
+    .array(variableRef(z.string().email()))
+    .optional()
+    .describe('Optional email addresses to copy on the reply.'),
+  bcc: z
+    .array(variableRef(z.string().email()))
+    .optional()
+    .describe('Optional email addresses to blind-copy on the reply.'),
   replyAll: z.boolean().optional(),
 });
 
@@ -36,7 +44,7 @@ export class SendEmailReplyStep extends BaseActionStep<
   readonly outputSchema = SendEmailReplyOutputSchema;
   readonly name = 'Send an email reply';
   readonly description =
-    'Replies to the latest email on the conversation. Body supports {{...}} placeholders. Recipients are derived from the original message.';
+    'Replies to the latest email on the conversation. Body supports {{...}} placeholders. Recipients are derived from the original message, with optional CC and BCC recipients.';
   readonly category = StepCategory.MESSAGING;
   readonly icon = 'Mail';
 
@@ -53,6 +61,8 @@ export class SendEmailReplyStep extends BaseActionStep<
       conversationId,
       body,
       type,
+      cc: config.cc as string[] | undefined,
+      bcc: config.bcc as string[] | undefined,
     });
 
     logger.info(

--- a/backend/src/automations/triggers/email-context.ts
+++ b/backend/src/automations/triggers/email-context.ts
@@ -24,6 +24,22 @@ export function extractDomain(addr: string): string {
   return email.split('@')[1] ?? '';
 }
 
+/** Build a link to a specific email in a desk ticket. */
+function buildEmailUrl(params: {
+  ticketUrl: string | null | undefined;
+  conversationId: string | null | undefined;
+  ticketId: string | null | undefined;
+  emailId: string;
+}): string | null {
+  const { ticketUrl, conversationId, ticketId, emailId } = params;
+  if (!ticketUrl || !conversationId || !emailId) return null;
+
+  const query = new URLSearchParams({ conversationId });
+  if (ticketId) query.set('ticketId', ticketId);
+  query.set('mail', emailId);
+  return `${ticketUrl}?${query.toString()}`;
+}
+
 function uniqueAddresses(addrs: readonly string[]): string[] {
   const out = new Set<string>();
   for (const addr of addrs) {
@@ -130,10 +146,16 @@ export async function hydrateEmailReceivedPayload(
   }
 
   const ticketContext = await loadTicketContextForEmail(email.conversationId);
+  const emailUrl = buildEmailUrl({
+    ticketUrl: ticketContext?.ticket.url,
+    conversationId: ticketContext?.ticket.conversationId ?? email.conversationId,
+    ticketId: ticketContext?.ticket.id,
+    emailId: email.id,
+  });
 
   return {
     ...payload,
-    email: emailRowToOutput(email),
+    email: { ...emailRowToOutput(email), url: emailUrl },
     ...(ticketContext ?? {}),
     requester: {
       email: extractEmailAddress(email.from),
@@ -152,6 +174,12 @@ export async function hydrateEmailSentPayload(
   if (!email) return { ...payload };
 
   const ticketContext = await loadTicketContextForEmail(email.conversationId);
+  const emailUrl = buildEmailUrl({
+    ticketUrl: ticketContext?.ticket.url,
+    conversationId: ticketContext?.ticket.conversationId ?? email.conversationId,
+    ticketId: ticketContext?.ticket.id,
+    emailId: email.id,
+  });
 
   const priorReply = await db.email
     .findFirst({
@@ -168,7 +196,7 @@ export async function hydrateEmailSentPayload(
 
   return {
     ...payload,
-    email: emailRowToOutput(email),
+    email: { ...emailRowToOutput(email), url: emailUrl },
     ...(ticketContext ?? {}),
     sender: {
       email: extractEmailAddress(email.from),

--- a/backend/src/automations/triggers/email-received.trigger.ts
+++ b/backend/src/automations/triggers/email-received.trigger.ts
@@ -92,6 +92,7 @@ const EmailReceivedConfigSchema = z.object({
 export const EmailReceivedOutputSchema = TicketContextSchema.partial().extend({
   email: z.object({
     id: z.string(),
+    url: z.string().url().nullable(),
     subject: z.string(),
     body: z.string(),
     from: z.string(),

--- a/backend/src/automations/triggers/email-sent.trigger.ts
+++ b/backend/src/automations/triggers/email-sent.trigger.ts
@@ -59,6 +59,7 @@ const EmailSentConfigSchema = z.object({
 export const EmailSentOutputSchema = TicketContextSchema.partial().extend({
   email: z.object({
     id: z.string(),
+    url: z.string().url().nullable(),
     subject: z.string(),
     body: z.string(),
     from: z.string(),

--- a/backend/src/automations/triggers/ticket-context.ts
+++ b/backend/src/automations/triggers/ticket-context.ts
@@ -1,10 +1,19 @@
 import { z } from 'zod';
 import { ChannelType, EmailType, TicketPriority, TicketStatusV2 } from '@prisma/client';
 import { db } from '@/database/client';
+import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
+
+const DESK_CHANNEL_TYPES: ReadonlySet<ChannelType> = new Set([
+  ChannelType.EMAIL,
+  ChannelType.SLACK,
+  ChannelType.APP,
+  ChannelType.CALL,
+]);
 
 const TicketSchema = z.object({
   id: z.string(),
+  url: z.string().url().nullable(),
   xyneId: z.string().nullable(),
   title: z.string().nullable(),
   description: z.string().nullable(),
@@ -138,6 +147,31 @@ export interface TicketLike {
   updatedAt?: Date | null;
 }
 
+/** Build an absolute support URL for a desk ticket using trusted configuration. */
+function buildTicketUrl(params: {
+  frontendUrl: string;
+  workspaceId: string;
+  channelType: string | null | undefined;
+  channelId: string;
+  xyneId: string | null | undefined;
+}): string | null {
+  const { frontendUrl, workspaceId, channelType, channelId, xyneId } = params;
+  const base = frontendUrl.trim().replace(/\/+$/, '');
+  if (
+    !base ||
+    !workspaceId ||
+    !DESK_CHANNEL_TYPES.has(channelType as ChannelType) ||
+    !channelId ||
+    !xyneId
+  ) {
+    return null;
+  }
+
+  return [base, workspaceId, 'support', channelId, xyneId]
+    .map((segment, index) => (index === 0 ? segment : encodeURIComponent(segment)))
+    .join('/');
+}
+
 export async function buildTicketContext(ticket: TicketLike): Promise<TicketContext> {
   const lastEmails = await loadLastEmails(ticket);
   const [board, project, channel, assignee, creator, group] = await Promise.all([
@@ -180,8 +214,17 @@ export async function buildTicketContext(ticket: TicketLike): Promise<TicketCont
       : Promise.resolve(null),
   ]);
 
+  const ticketUrl = buildTicketUrl({
+    frontendUrl: config.frontendUrl,
+    workspaceId: ticket.workspaceId,
+    channelType: channel?.type,
+    channelId: ticket.channelId,
+    xyneId: ticket.xyneId,
+  });
+
   const ticketRow: TicketRow = {
     id: ticket.id,
+    url: ticketUrl,
     xyneId: ticket.xyneId ?? null,
     title: ticket.title ?? null,
     description: ticket.description ?? null,

--- a/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -45,6 +45,7 @@ import { API_BASE_URL } from '../../../config';
 import { FlowScreenManager } from '../../flowUI/FlowScreenManager';
 import { ChannelScopeType, type FlowDefinition } from '@xyne/shared';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
+import { withWorkspacePrefix } from '../../../hooks/useShareableOrigin';
 import { formatChannelLabel } from '../ChatDirectory/ChatDirectory.utils';
 
 interface RenderMessageWithHTMLProps {
@@ -103,6 +104,8 @@ const InternalXyneLink = ({
 }: React.AnchorHTMLAttributes<HTMLAnchorElement>): JSX.Element => {
   const resolvedHref = href ?? '';
   const parsedLink = parseInternalXyneLink(resolvedHref);
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
+  const copyHref = withWorkspacePrefix(resolvedHref, workspaceId);
   const channel = useChannel(parsedLink?.channelId ?? '');
   const { userID } = useAuthContextValues();
   const { displayName: channelDisplayName } = useChannelDisplayName(channel, userID);
@@ -133,7 +136,7 @@ const InternalXyneLink = ({
   const handleCopy = (event: React.MouseEvent<HTMLButtonElement>): void => {
     event.preventDefault();
     event.stopPropagation();
-    void navigator.clipboard.writeText(resolvedHref).then(() => {
+    void navigator.clipboard.writeText(copyHref).then(() => {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1200);
     });
@@ -164,7 +167,7 @@ const InternalXyneLink = ({
         onClick={onClick}
         data-track-category='MESSAGE'
         data-track-name='OPEN_INTERNAL_LINK'
-        data-track-metadata={JSON.stringify({ href: resolvedHref, kind: parsedLink.kind })}
+        data-track-metadata={JSON.stringify({ href: copyHref, kind: parsedLink.kind })}
         {...props}
       >
         {children}

--- a/dashboard/src/components/Tickets/TicketActivity/TicketActivity.tsx
+++ b/dashboard/src/components/Tickets/TicketActivity/TicketActivity.tsx
@@ -24,6 +24,7 @@ import {
 import { formatReferenceLabel } from '../../../hooks/useTicketReferences';
 import { formatDistanceToNow, format } from 'date-fns';
 import { Tooltip } from '../../ui/Tooltip/Tooltip';
+import { Switch } from '../../ui/Switch';
 import { TicketPriorityIcon } from '../../../assets/icons';
 import { TicketStatusIcon } from '../../../assets/icons';
 import SmallUserAvatar from '../../UserAvatar/SmallUserAvatar';
@@ -78,7 +79,7 @@ const formatTimestamp = (timestamp: number | Date): string => {
   }
 };
 
-// Full, exact timestamp shown in the hover tooltip (the row itself shows the relative time).
+// Full, exact timestamp shown in the hover tooltip or when exact time is enabled.
 const formatExactTimestamp = (timestamp: number | Date): string => {
   try {
     const date = typeof timestamp === 'number' ? new Date(timestamp) : timestamp;
@@ -633,6 +634,7 @@ export const TicketActivity = ({
   stageVisitFormValues = [],
 }: TicketActivityProps): ReactElement => {
   const [sortOrder, setSortOrder] = useState<SortOrder>('newest');
+  const [showExactTime, setShowExactTime] = useState(false);
 
   const sortedActivities = useMemo(() => {
     if (!activities) return [];
@@ -681,17 +683,28 @@ export const TicketActivity = ({
           Activity
         </h3>
 
-        <button
-          onClick={toggleSort}
-          className='flex items-center text-[13px] text-muted-foreground gap-2'
-          title={sortOrder === 'newest' ? 'Newest to oldest' : 'Oldest to newest'}
-          data-track-category='Tickets'
-          data-track-name='ToggleActivitySort'
-          data-track-metadata={JSON.stringify({ sortOrder })}
-        >
-          <ArrowUpDown size={13} />
-          {sortOrder === 'newest' ? <p>Oldest</p> : <p>Newest</p>}
-        </button>
+        <div className='flex items-center gap-3'>
+          <div className='flex items-center gap-2'>
+            <span className='text-[13px] text-muted-foreground'>Exact time</span>
+            <Switch
+              checked={showExactTime}
+              onCheckedChange={setShowExactTime}
+              aria-label='Show exact activity time'
+            />
+          </div>
+
+          <button
+            onClick={toggleSort}
+            className='flex items-center text-[13px] text-muted-foreground gap-2'
+            title={sortOrder === 'newest' ? 'Newest to oldest' : 'Oldest to newest'}
+            data-track-category='Tickets'
+            data-track-name='ToggleActivitySort'
+            data-track-metadata={JSON.stringify({ sortOrder })}
+          >
+            <ArrowUpDown size={13} />
+            {sortOrder === 'newest' ? <p>Oldest</p> : <p>Newest</p>}
+          </button>
+        </div>
       </div>
 
       {sortedActivities.length > 0 ? (
@@ -705,6 +718,7 @@ export const TicketActivity = ({
               userGroups={userGroups}
               {...(boards !== undefined ? { boards } : {})}
               activities={sortedActivities}
+              showExactTime={showExactTime}
               stageVisitFormValues={stageVisitFormValues}
               customFieldAttachmentFilenameById={customFieldAttachmentFilenameById}
             />
@@ -727,6 +741,7 @@ export const ActivityComponent = ({
   boards,
   userGroups,
   activities,
+  showExactTime,
   stageVisitFormValues = [],
   customFieldAttachmentFilenameById,
 }: {
@@ -736,6 +751,7 @@ export const ActivityComponent = ({
   boards?: { id: string; name: string }[];
   userGroups: UserGroup[] | undefined;
   activities: TicketActivityType[];
+  showExactTime: boolean;
   stageVisitFormValues?: StageVisitFormValues[];
   customFieldAttachmentFilenameById?: ReadonlyMap<string, string>;
 }) => {
@@ -787,7 +803,9 @@ export const ActivityComponent = ({
           </p>
           <Tooltip content={formatExactTimestamp(activity.timestamp)}>
             <span className='text-xs text-muted-foreground whitespace-nowrap flex-shrink-0 cursor-default'>
-              {formatTimestamp(activity.timestamp)}
+              {showExactTime
+                ? formatExactTimestamp(activity.timestamp)
+                : formatTimestamp(activity.timestamp)}
             </span>
           </Tooltip>
         </div>

--- a/dashboard/src/components/Tickets/TicketDetails/EditableFormField.tsx
+++ b/dashboard/src/components/Tickets/TicketDetails/EditableFormField.tsx
@@ -204,7 +204,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
       return (
         <div className='flex items-center gap-2 w-full'>
           <span
-            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 truncate overflow-hidden'
+            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
             title={fieldName}
           >
             {fieldName}
@@ -232,7 +232,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
       return (
         <div className='flex items-center gap-2 w-full'>
           <span
-            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 truncate overflow-hidden'
+            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
             title={fieldName}
           >
             {fieldName}
@@ -261,7 +261,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
       return (
         <div className='flex items-center gap-2 w-full'>
           <span
-            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 truncate overflow-hidden'
+            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
             title={fieldName}
           >
             {fieldName}
@@ -294,7 +294,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
       return (
         <div className='flex items-center gap-2 w-full'>
           <span
-            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 truncate overflow-hidden'
+            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
             title={fieldName}
           >
             {fieldName}
@@ -321,7 +321,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
       return (
         <div className='flex items-start gap-2 w-full'>
           <span
-            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 truncate overflow-hidden'
+            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
             title={fieldName}
           >
             {fieldName}
@@ -347,7 +347,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
     return (
       <div className='flex items-center gap-2 w-full'>
         <span
-          className='text-sm text-muted-foreground w-[120px] flex-shrink-0 truncate overflow-hidden'
+          className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
           title={fieldName}
         >
           {fieldName}
@@ -376,7 +376,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
     return (
       <div className='flex items-start gap-2 w-full'>
         <span
-          className='text-sm text-muted-foreground w-[120px] flex-shrink-0 pt-0.5 truncate overflow-hidden'
+          className='text-sm text-muted-foreground w-[120px] flex-shrink-0 pt-0.5 overflow-x-auto whitespace-nowrap'
           title={fieldName}
         >
           {fieldName}
@@ -423,7 +423,7 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
   return (
     <div className='flex items-center gap-2 w-full'>
       <span
-        className='text-sm text-muted-foreground w-[120px] flex-shrink-0 truncate overflow-hidden'
+        className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
         title={fieldName}
       >
         {fieldName}

--- a/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
+++ b/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
@@ -98,7 +98,10 @@ const IFRAME_STYLES = `
     overflow-wrap: anywhere;
     overflow-y: hidden;
   }
-  html { overflow-x: auto; }
+  html {
+    overflow-x: auto;
+    overscroll-behavior: contain;
+  }
   body { padding: 4px 2px; }
   img { max-width: 100%; height: auto; }
   table { max-width: 100%; }
@@ -514,34 +517,30 @@ export const EmailBodyRenderer = ({
         });
       }
 
+      const hasNestedScrollable = (el: HTMLElement, deltaY: number): boolean => {
+        for (let cur: HTMLElement | null = el; cur; cur = cur.parentElement) {
+          const overflowY = contentDoc.defaultView?.getComputedStyle(cur).overflowY;
+          if (
+            (overflowY !== 'auto' && overflowY !== 'scroll') ||
+            cur.scrollHeight <= cur.clientHeight
+          )
+            continue;
+          const atTop = cur.scrollTop <= 0;
+          const atBottom = cur.scrollTop + cur.clientHeight >= cur.scrollHeight - 1;
+          if ((deltaY < 0 && !atTop) || (deltaY > 0 && !atBottom)) return true;
+        }
+        return false;
+      };
+
       contentDoc.addEventListener(
         'wheel',
         e => {
-          let target = e.target as HTMLElement | null;
-          while (target && target !== contentDoc.body && target !== contentDoc.documentElement) {
-            const style = target.ownerDocument.defaultView?.getComputedStyle(target);
-            const overflowY = style?.overflowY;
-            if (
-              (overflowY === 'auto' || overflowY === 'scroll') &&
-              target.scrollHeight > target.clientHeight
-            ) {
-              return;
-            }
-            target = target.parentElement;
-          }
-
-          const docEl = contentDoc.documentElement;
-          const hasHScroll = !!docEl && docEl.scrollWidth > docEl.clientWidth;
-          if (hasHScroll && Math.abs(e.deltaX) > 0) {
-            if (e.deltaY !== 0) {
-              const container = findScrollContainer(iframe);
-              container.scrollBy({ top: e.deltaY, left: 0 });
-            }
-            return;
-          }
+          if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+          const target = e.target as HTMLElement | null;
+          if (target && hasNestedScrollable(target, e.deltaY)) return;
 
           const container = findScrollContainer(iframe);
-          container.scrollBy({ top: e.deltaY, left: e.deltaX });
+          container.scrollBy({ top: e.deltaY, left: 0 });
           e.preventDefault();
         },
         { passive: false },

--- a/dashboard/src/config.ts
+++ b/dashboard/src/config.ts
@@ -85,8 +85,6 @@ export const LOGGER_BASE_URL = isElectronBundled
 
 export const MAX_RETRIES = 3;
 
-export const SHAREABLE_ORIGIN = window.location.origin;
-
 // Feature flag: show manual GENERATE SUMMARY action button (Generate PRD, Generate Summary, Chat with Transcript)
 // Auto-generation still runs regardless of this flag
 export const ENABLE_SUMMARY_ACTION_BUTTON: boolean =

--- a/dashboard/src/hooks/useShareableOrigin.ts
+++ b/dashboard/src/hooks/useShareableOrigin.ts
@@ -1,5 +1,23 @@
 import { useParams } from 'react-router-dom';
 
+/** Add the active workspace segment to a same-origin app URL when missing. */
+export function withWorkspacePrefix(url: string, workspaceId?: string): string {
+  if (!url || !workspaceId || typeof window === 'undefined') return url;
+
+  try {
+    const parsed = new URL(url, window.location.origin);
+    if (parsed.origin !== window.location.origin) return url;
+
+    const prefix = `/${workspaceId}`;
+    if (parsed.pathname === prefix || parsed.pathname.startsWith(`${prefix}/`)) return url;
+
+    parsed.pathname = `${prefix}${parsed.pathname}`;
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 /**
  * Returns the base URL to use when constructing shareable/copyable links.
  * Automatically includes the current workspace segment when inside `/:workspaceId` context.

--- a/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -214,7 +214,8 @@ import {
 import AddChannelForm from '../../components/Chat/AddChannelForm/AddChannelForm';
 import Info, { ChannelTab } from '../../components/Chat/Info/Info';
 import { useVisibleChannel } from '../../hooks/useChannels';
-import { API_BASE_URL, SHAREABLE_ORIGIN } from '../../config';
+import { API_BASE_URL } from '../../config';
+import { useShareableOrigin } from '../../hooks/useShareableOrigin';
 import { initDeskChannelOAuth } from '../../services/clients/integrationOAuthApi';
 import Dialog from '../../components/ui/Dialog';
 import { MergeTicketsDialog } from '../../components/Tickets/MergeTicketsDialog/MergeTicketsDialog';
@@ -3317,6 +3318,7 @@ export const SupportTicketDetail = ({
     ticketId?: string;
   }>();
   const supportBase = routeWorkspaceId ? `/${routeWorkspaceId}/support` : '/support';
+  const shareableOrigin = useShareableOrigin();
   const { workspaceId, userID } = useAuthContextValues();
   const [isRightPanelOpen, setIsRightPanelOpen] = useState<boolean>(true);
   const isAIPanelOpen = useSelector(
@@ -4137,7 +4139,7 @@ export const SupportTicketDetail = ({
                           toast.error('Cannot copy link');
                           return;
                         }
-                        const url = `${SHAREABLE_ORIGIN}/support/${channelId}/${ticketIdParam}`;
+                        const url = `${shareableOrigin}/support/${channelId}/${ticketIdParam}`;
                         void navigator.clipboard
                           .writeText(url)
                           .then(() => toast.success('Link copied'))

--- a/dashboard/src/utils/board/formFieldOptionsUtils.ts
+++ b/dashboard/src/utils/board/formFieldOptionsUtils.ts
@@ -1,7 +1,7 @@
 import type { ClipboardEvent, KeyboardEvent } from 'react';
 import type { FieldEnumOption } from '@xyne/shared';
 
-export const MAX_FIELD_OPTIONS = 500;
+export const MAX_FIELD_OPTIONS = 2000;
 
 export const parseBulkOptions = (raw: string): string[] =>
   raw


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
