### PR TITLE
fix: XYNE-55085 make DB the single source of truth for delayed-message content

### DIFF
--- a/apps/backend/src/queues/delayedMessageQueue.ts
+++ b/apps/backend/src/queues/delayedMessageQueue.ts
@@ -7,8 +7,6 @@ export interface DelayedMessageJobData {
   channelId: string;
   conversationId?: string | null;
   senderId: string;
-  content: string;
-  hasAttachment: boolean;
   scheduledFor: number;
 }
 

--- a/apps/backend/src/workers/delayedMessageWorker.ts
+++ b/apps/backend/src/workers/delayedMessageWorker.ts
@@ -105,8 +105,6 @@ class DelayedMessageWorker {
             channelId: record.channelId,
             conversationId: record.conversationId,
             senderId: record.senderId,
-            content: record.content,
-            hasAttachment: record.hasAttachment,
             scheduledFor,
           },
           { jobId: record.id, delay: delayMs }
@@ -120,8 +118,6 @@ class DelayedMessageWorker {
             channelId: record.channelId,
             conversationId: record.conversationId,
             senderId: record.senderId,
-            content: record.content,
-            hasAttachment: record.hasAttachment,
             scheduledFor,
           },
           { jobId: record.id, delay: 0 }
@@ -167,7 +163,7 @@ class DelayedMessageWorker {
   }
 
   private async processJob(job: Bull.Job<DelayedMessageJobData>): Promise<void> {
-    const { delayedMessageId, channelId, conversationId, senderId, content } = job.data;
+    const { delayedMessageId, channelId, conversationId, senderId } = job.data;
 
     logger.info(
       `[DelayedMessageWorker] Processing job ${job.id} delayedMessageId=${delayedMessageId}`
@@ -180,7 +176,7 @@ class DelayedMessageWorker {
       | { kind: 'missing' }
       | { kind: 'terminal'; status: string }
       | { kind: 'delivery_blocked'; failureReason: string; log: string }
-      | { kind: 'ready' };
+      | { kind: 'ready'; content: string; hasAttachment: boolean };
 
     const preflight: Preflight = await prisma.$transaction(async (ptx: any) => {
       const msg = await ptx.delayedMessage.findUnique({ where: { id: delayedMessageId } });
@@ -226,7 +222,7 @@ class DelayedMessageWorker {
         };
       }
 
-      return { kind: 'ready' as const };
+      return { kind: 'ready' as const, content: msg.content, hasAttachment: msg.hasAttachment };
     });
 
     if (preflight.kind === 'missing') {
@@ -274,8 +270,8 @@ class DelayedMessageWorker {
         channelId,
         conversationId,
         senderId,
-        content,
-        hasAttachment: job.data.hasAttachment,
+        content: preflight.content,
+        hasAttachment: preflight.hasAttachment,
       });
 
       if (!result.success) {

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -15206,9 +15206,19 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
             );
           }
 
+          // Recompute hasAttachment from the actual attachment rows so the
+          // denormalized column stays truthful for the worker's DB read
+          // (attachments are the source of truth, resolved by entityId at delivery).
+          const scheduledAttachments = await tx.run(
+            zql.message_attachments
+              .where('entityId', id)
+              .where('entityType', AttachmentEntityType.DELAYED_MESSAGE),
+          );
+
           await tx.mutate.delayed_messages.update({
             id,
             content: content.trim(),
+            hasAttachment: scheduledAttachments.length > 0,
             updatedAt,
           });
         }

--- a/apps/backend/src/zero/side-effects/tables/delayed-messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/delayed-messages-handler.ts
@@ -34,8 +34,6 @@ export class DelayedMessagesSideEffectHandler extends BaseSideEffectHandler {
       channelId: record.channelId,
       conversationId: record.conversationId,
       senderId: record.senderId,
-      content: record.content,
-      hasAttachment: record.hasAttachment,
       scheduledFor: record.scheduledFor,
     });
 
@@ -95,8 +93,6 @@ export class DelayedMessagesSideEffectHandler extends BaseSideEffectHandler {
           channelId: record.channelId,
           conversationId: record.conversationId,
           senderId: record.senderId,
-          content: record.content,
-          hasAttachment: record.hasAttachment,
           scheduledFor: record.scheduledFor,
         });
 


### PR DESCRIPTION
## What & why
Delayed ("send later") messages previously embedded the message `content` and `hasAttachment` flag directly in the Bull/Redis job payload. When a user edited the text of a pending scheduled message, the `edit` mutator updated the `delayed_messages` row in Postgres, but the side-effect handler treats a content-only change as a no-op and never updates the queued Bull job. The worker then delivered the **stale, pre-edit** content from the Redis payload — two sources of truth for the same content.

This makes the database the single source of truth. Ref: XYNE-55085.

## Changes
- **`queues/delayedMessageQueue.ts`** — `DelayedMessageJobData` slimmed to identity + immutable routing fields only (`delayedMessageId`, `channelId`, `conversationId`, `senderId`, `scheduledFor`). Dropped `content` and `hasAttachment`.
- **`workers/delayedMessageWorker.ts`** — `processJob` now sources `content`/`hasAttachment` from the `delayed_messages` row it already loads in its preflight transaction (returned on the `ready` branch) instead of `job.data`. Boot-time `reenqueuePendingMessages` no longer copies content/attachment into the payload.
- **`zero/side-effects/tables/delayed-messages-handler.ts`** — `scheduleMessage()` calls (insert + reschedule) no longer pass content/hasAttachment.
- **`zero/mutators.ts`** — `delayedMessages.edit` recomputes `hasAttachment` from the actual `message_attachments` rows (entityType = DELAYED_MESSAGE) so the denormalized column stays truthful for the worker's DB read.

## Why it's safe
- `delayed_messages.content` is `NOT NULL` and always set at create time, so the DB read is always authoritative — including for any in-flight old-shape jobs still sitting in Redis during rollout (their embedded content is simply ignored).
- Attachments were already resolved from the DB by `entityId` at delivery time (`deliverServerMessage` / `fetchSourceAttachmentsAsUploaded`) and never used the payload boolean, so delivery behavior is unchanged.
- The `sendNow` immediate-delivery path already reads from a freshly-loaded DB record and is untouched.

## Validation
- `tsc --noEmit` passes on `apps/backend`.
- No remaining references to `job.data.content` / `job.data.hasAttachment`.

## Rollout
- No DB migration required (uses existing columns).
- Safe to deploy worker + backend together; no payload-shape coordination needed because the worker ignores the old embedded fields.

## Test plan
- Edit a pending scheduled message's text, let it fire → delivered text equals the latest DB value (previously delivered stale text).
- Reschedule / cancel / sendNow still behave correctly (they key off `status`/`scheduledFor`).
- Restart backend with pending messages → re-enqueue delivers current DB content.