### PR TITLE
fix: XYNE-55091 Make invitation acceptance an atomic check-and-set

### DIFF
--- a/apps/backend/jest.contract.cjs
+++ b/apps/backend/jest.contract.cjs
@@ -1,0 +1,30 @@
+// Dedicated runner for DB-backed *.contract.ts tests.
+//
+// Why a separate config instead of the default `npm test` (jest.config.cjs)?
+//   1. These tests import real services (e.g. invitationService), whose module graph
+//      pulls @xyne/shared, which ships ESM in `dist`. The CJS jest runtime cannot
+//      evaluate that graph, so @xyne/shared is stubbed here (the accept path only uses
+//      TYPES from it, which are erased at runtime).
+//   2. Full-program ts-jest type-checking of the whole backend OOMs the worker; these
+//      tests only need transpilation, so `isolatedModules` is enabled.
+//   3. They need real DB env loaded before config/env.ts validates it.
+//
+// The default `npm test` glob (*.test.ts / *.spec.ts) intentionally does NOT match
+// *.contract.ts, so this file leaves the default suite's behavior unchanged.
+//
+// Run:  npx jest --config jest.contract.cjs
+const base = require('./jest.config.cjs');
+
+module.exports = {
+  ...base,
+  testMatch: ['**/?(*.)+(contract).ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { isolatedModules: true }],
+  },
+  setupFiles: ['<rootDir>/src/test/loadTestEnv.cjs'],
+  moduleNameMapper: {
+    ...(base.moduleNameMapper || {}),
+    '^@xyne/shared$': '<rootDir>/src/test/__mocks__/xyneSharedStub.cjs',
+    '^@xyne/shared/.*$': '<rootDir>/src/test/__mocks__/xyneSharedStub.cjs',
+  },
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "ysweet": "podman-compose -f ../../docker-compose.dev.yml up -d ysweet",
     "ysweet:down": "podman-compose -f ../../docker-compose.dev.yml stop ysweet",
     "test": "jest",
+    "test:contract": "jest --config jest.contract.cjs",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:zero-fallback": "pnpm exec tsx tests/verify-zero-fallback.ts 2>&1 | sed -n '/Summary/,/procedure/p'",

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -686,178 +686,204 @@ export class InvitationService {
 
     logger.info(`[DEBUG] [acceptInvitation] Invitation valid. workspaceId=${invitation.workspaceId} orgId=${invitation.orgId ?? 'null'} role=${invitation.role}`);
 
-    // Resolve orgId before user creation so a COMMUNITY_MEMBER org row can be
-    // moved/upgraded into the enterprise org when the invite is accepted.
-    const resolvedOrgId = invitation.orgId ?? (
-      await this.prisma.workspace.findUnique({
-        where: { id: invitation.workspaceId! },
-        select: { orgId: true },
-      })
-    )?.orgId ?? null;
-
-    logger.info(`[DEBUG] [acceptInvitation] resolvedOrgId=${resolvedOrgId ?? 'null'} (from invitation.orgId=${invitation.orgId ?? 'null'})`);
-
-    // Check if user already exists in this workspace (duplicate accept guard)
-    const existingWorkspaceUser = await this.prisma.user.findFirst({
-      where: {
-        workspaceId: invitation.workspaceId!,
-        OR: [
-          { providerUserId: userData.providerUserId },
-          { email: userData.email },
-          { email: userData.email.toLowerCase() },
-        ],
-      },
+    // Atomically claim the invitation: flip acceptedAt from NULL -> now in a single
+    // conditional UPDATE (check-and-set). Only one concurrent request can match the
+    // `acceptedAt: null` predicate, so exactly one caller wins; a second concurrent
+    // request (or a replay) updates zero rows and is treated as already-accepted.
+    // This serialises acceptance at the database and prevents double membership.
+    const claim = await this.prisma.invitation.updateMany({
+      where: { invitationId: invitationId, acceptedAt: null },
+      data: { acceptedAt: new Date() },
     });
-    logger.info(`[DEBUG] [acceptInvitation] User providerUserId=${userData.providerUserId} already in workspace ${invitation.workspaceId}: ${!!existingWorkspaceUser}`);
+    if (claim.count === 0) {
+      logger.warn(`[DEBUG] [acceptInvitation] Invitation ${invitationId} already accepted (atomic claim matched 0 rows)`);
+      throw new Error('Invitation has already been accepted');
+    }
+    logger.info(`[DEBUG] [acceptInvitation] Atomically claimed invitation ${invitationId} (acceptedAt set)`);
 
-    let newWorkspaceUser;
-    let redirectPath: string | null = null;
+    try {
+      // Resolve orgId before user creation so a COMMUNITY_MEMBER org row can be
+      // moved/upgraded into the enterprise org when the invite is accepted.
+      const resolvedOrgId = invitation.orgId ?? (
+        await this.prisma.workspace.findUnique({
+          where: { id: invitation.workspaceId! },
+          select: { orgId: true },
+        })
+      )?.orgId ?? null;
 
-    if (!existingWorkspaceUser && invitation.role === 'GUEST') {
-      const guestResult = await this.handleGuestAcceptance(invitation, userData);
-      newWorkspaceUser = guestResult.user;
-      redirectPath = guestResult.redirectPath;
-    } else if (existingWorkspaceUser) {
-      if (invitation.role === 'GUEST') {
-        if (existingWorkspaceUser.role !== 'GUEST') {
-          throw new Error('Existing workspace members cannot accept guest invitations');
-        }
+      logger.info(`[DEBUG] [acceptInvitation] resolvedOrgId=${resolvedOrgId ?? 'null'} (from invitation.orgId=${invitation.orgId ?? 'null'})`);
 
-        const orgMember = await this.prisma.orgMember.findUnique({
-          where: { email: userData.email.toLowerCase() },
-          select: { leftAt: true },
-        });
-        if (orgMember?.leftAt) {
-          throw new Error(`Cannot accept invitation — ${userData.email} is no longer part of the organization`);
-        }
+      // Check if user already exists in this workspace (duplicate accept guard)
+      const existingWorkspaceUser = await this.prisma.user.findFirst({
+        where: {
+          workspaceId: invitation.workspaceId!,
+          OR: [
+            { providerUserId: userData.providerUserId },
+            { email: userData.email },
+            { email: userData.email.toLowerCase() },
+          ],
+        },
+      });
+      logger.info(`[DEBUG] [acceptInvitation] User providerUserId=${userData.providerUserId} already in workspace ${invitation.workspaceId}: ${!!existingWorkspaceUser}`);
 
-        const guestResult = await this.prisma.$transaction(async (tx) => {
-          const reactivatedUser = await tx.user.update({
+      let newWorkspaceUser;
+      let redirectPath: string | null = null;
+
+      if (!existingWorkspaceUser && invitation.role === 'GUEST') {
+        const guestResult = await this.handleGuestAcceptance(invitation, userData);
+        newWorkspaceUser = guestResult.user;
+        redirectPath = guestResult.redirectPath;
+      } else if (existingWorkspaceUser) {
+        if (invitation.role === 'GUEST') {
+          if (existingWorkspaceUser.role !== 'GUEST') {
+            throw new Error('Existing workspace members cannot accept guest invitations');
+          }
+
+          const orgMember = await this.prisma.orgMember.findUnique({
+            where: { email: userData.email.toLowerCase() },
+            select: { leftAt: true },
+          });
+          if (orgMember?.leftAt) {
+            throw new Error(`Cannot accept invitation — ${userData.email} is no longer part of the organization`);
+          }
+
+          const guestResult = await this.prisma.$transaction(async (tx) => {
+            const reactivatedUser = await tx.user.update({
+              where: { id: existingWorkspaceUser.id },
+              data: {
+                leftAt: null,
+                status: 'ACTIVE',
+              },
+            });
+            const path = await this.grantGuestEntityAccess(reactivatedUser.id, invitation, tx);
+            return { user: reactivatedUser, redirectPath: path };
+          });
+          newWorkspaceUser = guestResult.user;
+          redirectPath = guestResult.redirectPath;
+          logger.info(`[DEBUG] [acceptInvitation] Granted existing guest user id=${newWorkspaceUser.id} access to invitation entity`);
+        } else {
+          // User exists - reactivate them if they were removed (leftAt is set)
+          newWorkspaceUser = await this.prisma.user.update({
             where: { id: existingWorkspaceUser.id },
             data: {
               leftAt: null,
+              role: invitation.role,
               status: 'ACTIVE',
             },
           });
-          const path = await this.grantGuestEntityAccess(reactivatedUser.id, invitation, tx);
-          return { user: reactivatedUser, redirectPath: path };
-        });
-        newWorkspaceUser = guestResult.user;
-        redirectPath = guestResult.redirectPath;
-        logger.info(`[DEBUG] [acceptInvitation] Granted existing guest user id=${newWorkspaceUser.id} access to invitation entity`);
+          logger.info(`[DEBUG] [acceptInvitation] Reactivated existing user id=${newWorkspaceUser.id}`);
+        }
       } else {
-        // User exists - reactivate them if they were removed (leftAt is set)
-        newWorkspaceUser = await this.prisma.user.update({
-          where: { id: existingWorkspaceUser.id },
-          data: {
-            leftAt: null,
-            role: invitation.role,
-            status: 'ACTIVE',
-          },
-        });
-        logger.info(`[DEBUG] [acceptInvitation] Reactivated existing user id=${newWorkspaceUser.id}`);
-      }
-    } else {
-      if (resolvedOrgId) {
-        await organizationDomainService.assertOrgMemberLimit(resolvedOrgId, userData.email);
-      }
-
-      // Fetch existing orgMember by email
-      const existingOrgMember = await this.prisma.orgMember.findUnique({
-        where: { email: userData.email.toLowerCase() },
-        select: { memberId: true, role: true }
-      });
-
-      let orgMember: { memberId: string };
-
-      if (!existingOrgMember) {
-        if (!resolvedOrgId) {
-          throw new Error(`orgMember not found for email ${userData.email}. User must be invited to the organization first.`);
+        if (resolvedOrgId) {
+          await organizationDomainService.assertOrgMemberLimit(resolvedOrgId, userData.email);
         }
 
-        orgMember = await this.prisma.orgMember.create({
+        // Fetch existing orgMember by email
+        const existingOrgMember = await this.prisma.orgMember.findUnique({
+          where: { email: userData.email.toLowerCase() },
+          select: { memberId: true, role: true }
+        });
+
+        let orgMember: { memberId: string };
+
+        if (!existingOrgMember) {
+          if (!resolvedOrgId) {
+            throw new Error(`orgMember not found for email ${userData.email}. User must be invited to the organization first.`);
+          }
+
+          orgMember = await this.prisma.orgMember.create({
+            data: {
+              orgId: resolvedOrgId,
+              email: userData.email.toLowerCase(),
+              role: this.toEnterpriseOrgRole(invitation.role),
+            },
+            select: { memberId: true },
+          });
+        } else if (resolvedOrgId) {
+          const wasCommunityMember = existingOrgMember.role === 'COMMUNITY_MEMBER';
+          orgMember = await this.prisma.orgMember.update({
+            where: { memberId: existingOrgMember.memberId },
+            data: {
+              leftAt: null,
+              orgId: resolvedOrgId,
+              role: this.toEnterpriseOrgRole(invitation.role),
+            },
+            select: { memberId: true },
+          });
+
+          if (wasCommunityMember) {
+            await aiProvisioningService.upgradeCommunityToEnterpriseBudget(orgMember.memberId);
+          }
+        } else {
+          orgMember = { memberId: existingOrgMember.memberId };
+        }
+
+        // Create new user in the workspace
+        newWorkspaceUser = await this.prisma.user.create({
           data: {
+            email: userData.email,
+            name: userData.name,
+            providerUserId: userData.providerUserId,
+            authProvider: userData.authProvider as AuthProvider,
+            workspaceId: invitation.workspaceId!,
+            role: invitation.role,
+            status: 'ACTIVE',
+            orgMemberId: orgMember.memberId,
+          },
+        });
+        logger.info(`[DEBUG] [acceptInvitation] Created new workspace user id=${newWorkspaceUser.id}`);
+      }
+
+      // Ensure an OrgMember entry exists for this email (upsert by email - now globally unique)
+      if (resolvedOrgId && invitation.role !== 'GUEST') {
+        await this.prisma.orgMember.upsert({
+          where: { email: userData.email.toLowerCase() },
+          create: {
             orgId: resolvedOrgId,
             email: userData.email.toLowerCase(),
             role: this.toEnterpriseOrgRole(invitation.role),
           },
-          select: { memberId: true },
-        });
-      } else if (resolvedOrgId) {
-        const wasCommunityMember = existingOrgMember.role === 'COMMUNITY_MEMBER';
-        orgMember = await this.prisma.orgMember.update({
-          where: { memberId: existingOrgMember.memberId },
-          data: {
+          update: {
             leftAt: null,
             orgId: resolvedOrgId,
             role: this.toEnterpriseOrgRole(invitation.role),
-          },
-          select: { memberId: true },
+          }, // reactivate and update orgId/role if needed
         });
-
-        if (wasCommunityMember) {
-          await aiProvisioningService.upgradeCommunityToEnterpriseBudget(orgMember.memberId);
-        }
-      } else {
-        orgMember = { memberId: existingOrgMember.memberId };
+        logger.info(`[DEBUG] [acceptInvitation] OrgMember upserted for email=${userData.email} orgId=${resolvedOrgId}`);
+      } else if (invitation.role !== 'GUEST') {
+        logger.warn(`[DEBUG] [acceptInvitation] ⚠️ Could not resolve orgId — OrgMember NOT created for email=${userData.email}`);
       }
 
-      // Create new user in the workspace
-      newWorkspaceUser = await this.prisma.user.create({
-        data: {
-          email: userData.email,
-          name: userData.name,
-          providerUserId: userData.providerUserId,
-          authProvider: userData.authProvider as AuthProvider,
-          workspaceId: invitation.workspaceId!,
-          role: invitation.role,
-          status: 'ACTIVE',
-          orgMemberId: orgMember.memberId,
-        },
-      });
-      logger.info(`[DEBUG] [acceptInvitation] Created new workspace user id=${newWorkspaceUser.id}`);
+      // acceptedAt was already set atomically by the claim above.
+
+      // Grant role-based resource permissions via the centralized permission matrix
+      await grantPermissionsForRole(
+        newWorkspaceUser.id,
+        newWorkspaceUser.email,
+        invitation.role,
+        invitation.workspaceId ?? undefined,
+      );
+      logger.info(`[InvitationService] Permission grants completed for ${invitation.role} user ${userData.email}`);
+
+      logger.info(`[InvitationService] User ${userData.email} accepted invitation to workspace ${invitation.workspaceId}`);
+
+      return { user: newWorkspaceUser, redirectPath };
+    } catch (err) {
+      // The claim already flipped acceptedAt -> now. If the acceptance work above
+      // failed (validation reject, transient DB/service error), release the claim
+      // so the invitation stays usable and the user can retry. The reset is itself
+      // conditional to avoid clobbering a different, successful acceptance.
+      try {
+        await this.prisma.invitation.updateMany({
+          where: { invitationId: invitationId, acceptedAt: { not: null } },
+          data: { acceptedAt: null },
+        });
+        logger.warn(`[DEBUG] [acceptInvitation] Released claim on invitation ${invitationId} after failure`);
+      } catch (resetErr) {
+        logger.error(`[DEBUG] [acceptInvitation] Failed to release claim on invitation ${invitationId}`, resetErr);
+      }
+      throw err;
     }
-
-    // Ensure an OrgMember entry exists for this email (upsert by email - now globally unique)
-    if (resolvedOrgId && invitation.role !== 'GUEST') {
-      await this.prisma.orgMember.upsert({
-        where: { email: userData.email.toLowerCase() },
-        create: {
-          orgId: resolvedOrgId,
-          email: userData.email.toLowerCase(),
-          role: this.toEnterpriseOrgRole(invitation.role),
-        },
-        update: {
-          leftAt: null,
-          orgId: resolvedOrgId,
-          role: this.toEnterpriseOrgRole(invitation.role),
-        }, // reactivate and update orgId/role if needed
-      });
-      logger.info(`[DEBUG] [acceptInvitation] OrgMember upserted for email=${userData.email} orgId=${resolvedOrgId}`);
-    } else if (invitation.role !== 'GUEST') {
-      logger.warn(`[DEBUG] [acceptInvitation] ⚠️ Could not resolve orgId — OrgMember NOT created for email=${userData.email}`);
-    }
-
-    // Update invitation with acceptedAt timestamp instead of deleting
-    await this.prisma.invitation.update({
-      where: { invitationId: invitationId },
-      data: {
-        acceptedAt: new Date(),
-      },
-    });
-
-    // Grant role-based resource permissions via the centralized permission matrix
-    await grantPermissionsForRole(
-      newWorkspaceUser.id,
-      newWorkspaceUser.email,
-      invitation.role,
-      invitation.workspaceId ?? undefined,
-    );
-    logger.info(`[InvitationService] Permission grants completed for ${invitation.role} user ${userData.email}`);
-
-    logger.info(`[InvitationService] User ${userData.email} accepted invitation to workspace ${invitation.workspaceId}`);
-
-    return { user: newWorkspaceUser, redirectPath };
   }
 }
 

--- a/apps/backend/src/test/__mocks__/xyneSharedStub.cjs
+++ b/apps/backend/src/test/__mocks__/xyneSharedStub.cjs
@@ -1,0 +1,19 @@
+// Test-only stub for @xyne/shared.
+// The real package ships ESM (dist) and pulls the @rocicorp/zero ESM graph, which
+// the CJS jest runtime cannot evaluate. The invitation-accept code path only uses
+// TYPES from @xyne/shared (erased at runtime), so a recursive Proxy that answers any
+// property access with a callable proxy is a safe stand-in for module evaluation.
+const handler = {
+  get(_target, prop) {
+    if (prop === '__esModule') return true;
+    if (prop === 'default') return proxy;
+    // eslint-disable-next-line no-use-before-define
+    return proxy;
+  },
+  apply() {
+    // eslint-disable-next-line no-use-before-define
+    return proxy;
+  },
+};
+const proxy = new Proxy(function stub() {}, handler);
+module.exports = proxy;

--- a/apps/backend/src/test/invitationAcceptConcurrency.contract.ts
+++ b/apps/backend/src/test/invitationAcceptConcurrency.contract.ts
@@ -1,0 +1,138 @@
+/**
+ * XYNE-55091 — Invitation acceptance must be an atomic check-and-set.
+ *
+ * Regression guard for the double-membership race: previously acceptInvitation
+ * did a check-then-update, so two concurrent accepts of the same token both
+ * passed validation and both created workspace membership. The fix claims the
+ * invitation with a single conditional UPDATE (`WHERE acceptedAt IS NULL`), so
+ * exactly one concurrent caller wins and the rest are treated as already-accepted.
+ *
+ * This test fires N concurrent accepts of the same PENDING invitation and asserts
+ * that exactly one succeeds, the rest reject as already-accepted, and exactly one
+ * user row is created.
+ */
+import { PrismaClient, WorkspaceRole } from '@prisma/client';
+
+// Isolate the concurrency guard: stub the heavy, non-relevant collaborators so the
+// only real DB effects under test are the invitation claim + user creation.
+jest.mock('../services/permissionMatrix', () => ({
+  grantPermissionsForRole: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../services/organizationDomainService', () => ({
+  organizationDomainService: {
+    assertOrgMemberLimit: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { invitationService } from '../services/invitationService';
+
+const prisma = new PrismaClient();
+
+describe('InvitationService.acceptInvitation — atomic check-and-set (XYNE-55091)', () => {
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const email = `invitee-${suffix}@example.com`;
+  const providerUserId = `provider-${suffix}`;
+  const invitationId = `inv-token-${suffix}`;
+
+  let orgId: string;
+  let workspaceId: string;
+
+  beforeAll(async () => {
+    const org = await prisma.organization.create({
+      data: { name: `Org ${suffix}`, createdBy: 'seed-test' },
+      select: { orgId: true },
+    });
+    orgId = org.orgId;
+
+    const workspace = await prisma.workspace.create({
+      data: { orgId, name: `WS ${suffix}`, createdBy: 'seed-test' },
+      select: { id: true },
+    });
+    workspaceId = workspace.id;
+
+    // Pre-existing org membership so the accept path resolves an orgMember and
+    // creates the workspace user (the branch a double-accept would duplicate).
+    await prisma.orgMember.create({
+      data: { orgId, email: email.toLowerCase(), role: 'MEMBER' },
+    });
+
+    await prisma.invitation.create({
+      data: {
+        orgId,
+        workspaceId,
+        email,
+        role: WorkspaceRole.MEMBER,
+        invitedBy: 'seed-test',
+        invitationId,
+        acceptedAt: null,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({ where: { workspaceId } });
+    await prisma.invitation.deleteMany({ where: { invitationId } });
+    await prisma.orgMember.deleteMany({ where: { email: email.toLowerCase() } });
+    await prisma.workspace.deleteMany({ where: { id: workspaceId } });
+    await prisma.organization.deleteMany({ where: { orgId } });
+    await prisma.$disconnect();
+  });
+
+  it('lets exactly one of N concurrent accepts win; the rest are already-accepted', async () => {
+    const CONCURRENCY = 5;
+    const userData = {
+      id: providerUserId,
+      email,
+      name: 'Concurrent Invitee',
+      providerUserId,
+      authProvider: 'GOOGLE',
+    };
+
+    const results = await Promise.allSettled(
+      Array.from({ length: CONCURRENCY }, () =>
+        invitationService.acceptInvitation({ invitationId, userData }),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter(
+      (r): r is PromiseRejectedResult => r.status === 'rejected',
+    );
+
+    // Exactly one caller wins the atomic claim.
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(CONCURRENCY - 1);
+
+    // Losers fail as already-accepted (zero-rows-updated), not with some other error.
+    for (const r of rejected) {
+      expect((r.reason as Error).message).toMatch(/already been accepted/i);
+    }
+
+    // The invariant that matters: no double membership.
+    const users = await prisma.user.findMany({
+      where: { workspaceId, email },
+    });
+    expect(users).toHaveLength(1);
+
+    // The token is durably marked accepted.
+    const invitation = await prisma.invitation.findUnique({
+      where: { invitationId },
+      select: { acceptedAt: true },
+    });
+    expect(invitation?.acceptedAt).not.toBeNull();
+  });
+
+  it('rejects a subsequent (replayed) accept of an already-accepted token', async () => {
+    const userData = {
+      id: providerUserId,
+      email,
+      name: 'Concurrent Invitee',
+      providerUserId,
+      authProvider: 'GOOGLE',
+    };
+
+    await expect(
+      invitationService.acceptInvitation({ invitationId, userData }),
+    ).rejects.toThrow(/already been accepted/i);
+  });
+});

--- a/apps/backend/src/test/loadTestEnv.cjs
+++ b/apps/backend/src/test/loadTestEnv.cjs
@@ -1,0 +1,20 @@
+// Load environment for the DB-backed contract tests before the app's config/env.ts
+// validates process.env. env.ts calls dotenv.config() (targets .env, absent here), so
+// these tests need the vars loaded first.
+//
+//  - .env.test  (committed) holds CI/docker-compose values (service hostnames postgres/redis).
+//  - .env.local (gitignored) holds a developer/sandbox host's values (localhost + published
+//    ports) and, when present, OVERRIDES .env.test so the same runner works on a dev box.
+const path = require('path');
+const dotenv = require('dotenv');
+const fs = require('fs');
+
+const backendRoot = path.resolve(__dirname, '../..');
+dotenv.config({ path: path.join(backendRoot, '.env.test') });
+
+const localEnv = path.join(backendRoot, '.env.local');
+if (fs.existsSync(localEnv)) {
+  dotenv.config({ path: localEnv, override: true });
+}
+
+process.env.NODE_ENV = 'test';


### PR DESCRIPTION
## What & Why
Invitation acceptance (`InvitationService.acceptInvitation`) was a **check-then-update**: it validated the token, created the workspace user + org membership, and only stamped `acceptedAt` at the very end via an unconditional `update`. Under concurrency, two simultaneous accepts of the same token both passed the "still pending" check and both created membership — producing **duplicate members from a single invite** (double-membership race). Ticket: XYNE-55091 (P1).

## Root Cause
`acceptedAt` (the only "already accepted" signal — the model has no status column; pending = `acceptedAt IS NULL`) was written last, after all side effects, and unconditionally. There was no atomic guard between the pending check and the write, so the check-then-act window allowed concurrent double-accept.

## Fix
Claim the invitation up front with a single **conditional** update:

```ts
const claim = await this.prisma.invitation.updateMany({
  where: { invitationId, acceptedAt: null },   // check-and-set predicate
  data:  { acceptedAt: new Date() },
});
if (claim.count === 0) throw new Error('Invitation has already been accepted');
```

Only one concurrent caller can match `acceptedAt: null`, so exactly one wins; any other concurrent request (or a replay) updates zero rows and is treated as already-accepted. The redundant trailing `acceptedAt` update was removed. The post-claim acceptance work is wrapped in try/catch; on failure the claim is released with a conditional reset (`acceptedAt -> null`, guarded by `acceptedAt: { not: null }`) so a failed accept stays **retryable** without clobbering a genuinely successful one.

## Testing / Proof of Testing
Added `apps/backend/src/test/invitationAcceptConcurrency.contract.ts` (runs against a real Postgres test DB):
- Fires **5 concurrent** `acceptInvitation()` calls → asserts exactly **1 succeeds**, **4 reject** with `already been accepted`, and exactly **1 user row** is created.
- Replays an already-accepted token → asserts rejection.

Run result (green):
```
PASS src/test/invitationAcceptConcurrency.contract.ts
  ✓ lets exactly one of N concurrent accepts win; the rest are already-accepted
  ✓ rejects a subsequent (replayed) accept of an already-accepted token
Tests: 2 passed, 2 tests total
```
Runtime log confirms the invariant: one caller "Atomically claimed invitation …", the other four "already accepted (atomic claim matched 0 rows)", and only one "Created new workspace user".

## Test harness note
The DB-backed test runs under a dedicated runner (`jest.contract.cjs`, `npm run test:contract`) that matches `*.contract.ts`. This is because the default jest harness cannot evaluate `@xyne/shared`'s ESM `dist` at runtime and OOMs on full-program type-checking. The runner stubs `@xyne/shared` (the accept path only uses erased types from it) and enables `isolatedModules`. The default `npm test` glob and behavior are left unchanged.

## Risk & Rollout
- No schema/migration change (uses existing `acceptedAt`).
- Backward compatible; no rollout ordering needed. Safe to deploy on its own.
- Residual: if the winning caller creates the user row and then fails a later step, the claim is released for retry but the created user row is not deleted; a retry is idempotent via the existing `existingWorkspaceUser` reactivation branch. Wrapping user creation + permission grant in a single DB transaction is a reasonable follow-up but is out of scope for this fix.