### PR TITLE
fix: XYNE MCP file forwarding honors resource uri filename (extForMime misses docx/pptx/mp4)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/attachment-filename.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/attachment-filename.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  extForMime,
+  fileNameFromResource,
+  sanitizeResourceFileName,
+} from "./attachment-filename.js";
+
+const BS = String.fromCharCode(92); // a single backslash
+
+describe("extForMime", () => {
+  it("maps Office + mp4 + common types that previously fell back to bin", () => {
+    expect(extForMime("application/vnd.openxmlformats-officedocument.wordprocessingml.document")).toBe("docx");
+    expect(extForMime("application/vnd.openxmlformats-officedocument.presentationml.presentation")).toBe("pptx");
+    expect(extForMime("application/msword")).toBe("doc");
+    expect(extForMime("application/vnd.ms-powerpoint")).toBe("ppt");
+    expect(extForMime("video/mp4")).toBe("mp4");
+    expect(extForMime("text/plain")).toBe("txt");
+    expect(extForMime("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")).toBe("xlsx");
+  });
+  it("keeps existing mappings and falls back to bin for unknown", () => {
+    expect(extForMime("application/pdf")).toBe("pdf");
+    expect(extForMime("image/png")).toBe("png");
+    expect(extForMime("application/octet-stream")).toBe("bin");
+  });
+});
+
+describe("sanitizeResourceFileName", () => {
+  it("returns the basename of a uri", () => {
+    expect(sanitizeResourceFileName("npci-doc://host/dir/product_note_v1.docx")).toBe("product_note_v1.docx");
+  });
+  it("strips query and fragment", () => {
+    expect(sanitizeResourceFileName("doc://a/file.pdf?token=abc#frag")).toBe("file.pdf");
+  });
+  it("neutralises ../ path traversal (basename only)", () => {
+    expect(sanitizeResourceFileName("npci-doc://x/../../etc/passwd")).toBe("passwd");
+  });
+  it("neutralises backslash traversal", () => {
+    expect(sanitizeResourceFileName("evil" + BS + ".." + BS + "secret.docx")).toBe("secret.docx");
+  });
+  it("re-cuts on percent-encoded separators after decoding", () => {
+    expect(sanitizeResourceFileName("doc://a/%2Fetc%2Fpasswd")).toBe("passwd");
+  });
+  it("strips leading dots", () => {
+    expect(sanitizeResourceFileName("path/....hidden")).toBe("hidden");
+  });
+  it("removes control chars", () => {
+    expect(sanitizeResourceFileName("doc://a/re" + String.fromCharCode(0) + "port.pdf")).toBe("report.pdf");
+  });
+  it("returns empty when nothing usable remains", () => {
+    expect(sanitizeResourceFileName("doc://host/")).toBe("");
+    expect(sanitizeResourceFileName("doc://host/...")).toBe("");
+  });
+});
+
+describe("fileNameFromResource", () => {
+  it("honors the uri filename when it already has an extension", () => {
+    expect(
+      fileNameFromResource("npci-doc://x/product_note_v1.docx", "application/octet-stream", "fetch_document_file", 1),
+    ).toBe("product_note_v1.docx");
+  });
+  it("appends the mime extension when the uri basename has none", () => {
+    expect(
+      fileNameFromResource(
+        "npci-doc://x/product_note",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "fetch_document_file",
+        1,
+      ),
+    ).toBe("product_note.docx");
+  });
+  it("falls back to tool-idx.ext when there is no uri", () => {
+    expect(fileNameFromResource(undefined, "video/mp4", "gen", 2)).toBe("gen-2.mp4");
+    expect(fileNameFromResource(null, "application/octet-stream", "gen", 3)).toBe("gen-3.bin");
+  });
+  it("falls back when the uri has no usable basename", () => {
+    expect(fileNameFromResource("npci-doc://host/", "application/pdf", "tool", 4)).toBe("tool-4.pdf");
+  });
+  it("sanitises a hostile uri instead of trusting it", () => {
+    expect(
+      fileNameFromResource("npci-doc://x/../../etc/passwd", "application/octet-stream", "tool", 5),
+    ).toBe("passwd.bin");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/mcp/attachment-filename.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/attachment-filename.ts
@@ -1,0 +1,107 @@
+/**
+ * Filename derivation for binary files forwarded out of MCP tool results.
+ *
+ * Extracted from mcp/runner.ts so the logic is pure and unit-testable without
+ * pulling in the runner's session/DB/MCP-SDK import graph.
+ */
+
+/**
+ * Map a MIME type to a file extension. Best-effort substring matching over a
+ * curated set; falls back to "bin" for anything unrecognised. Used both for
+ * image/audio content (which carries no uri) and as the extension fallback
+ * when a forwarded resource's uri has no usable name.
+ */
+export function extForMime(mime: string): string {
+  const m = mime.toLowerCase();
+  if (m.includes("pdf")) return "pdf";
+  if (m.includes("png")) return "png";
+  if (m.includes("jpeg") || m.includes("jpg")) return "jpg";
+  if (m.includes("gif")) return "gif";
+  if (m.includes("webp")) return "webp";
+  if (m.includes("svg")) return "svg";
+  if (m.includes("csv")) return "csv";
+  // Office documents (OOXML + legacy). Match the specific OOXML tokens before
+  // the generic spreadsheet/excel fallbacks below so .docx/.pptx win.
+  if (m.includes("wordprocessingml")) return "docx";
+  if (m.includes("presentationml")) return "pptx";
+  if (m.includes("msword")) return "doc";
+  if (m.includes("ms-powerpoint") || m.includes("powerpoint")) return "ppt";
+  if (m.includes("spreadsheet") || m.includes("excel") || m.includes("xlsx")) return "xlsx";
+  if (m.includes("mp4")) return "mp4";
+  if (m.startsWith("audio") && m.includes("mpeg")) return "mp3";
+  if (m.includes("wav")) return "wav";
+  if (m.includes("json")) return "json";
+  if (m.includes("zip")) return "zip";
+  if (m.includes("html")) return "html";
+  if (m.includes("xml")) return "xml";
+  if (m === "text/plain" || m.includes("plain")) return "txt";
+  return "bin";
+}
+
+/**
+ * Reduce a resource `uri` to a safe download basename.
+ *
+ * SECURITY: `uri` is tool-controlled and untrusted. We take the basename only,
+ * strip path separators, control chars and leading dots, and cap length — so a
+ * hostile name can never traverse or overwrite paths if the filename is later
+ * used as a filesystem path. Returns "" when nothing usable remains.
+ */
+export function sanitizeResourceFileName(raw: string): string {
+  const BSLASH = String.fromCharCode(92); // a single backslash
+  // Drop any query/fragment, then take the basename (last path segment,
+  // handling both forward-slash and backslash separators).
+  let name = (raw.split("?")[0] ?? "").split("#")[0] ?? "";
+  const cut = Math.max(name.lastIndexOf("/"), name.lastIndexOf(BSLASH));
+  if (cut >= 0) name = name.slice(cut + 1);
+  try {
+    name = decodeURIComponent(name);
+  } catch {
+    /* keep raw basename on malformed %-encoding */
+  }
+  // Re-take the basename after decoding, in case %2F / %5C decoded to a
+  // separator, then remove control chars (0x00-0x1f, 0x7f) and any residual
+  // separators.
+  const cut2 = Math.max(name.lastIndexOf("/"), name.lastIndexOf(BSLASH));
+  if (cut2 >= 0) name = name.slice(cut2 + 1);
+  name = Array.from(name)
+    .filter((ch) => {
+      const code = ch.charCodeAt(0);
+      if (code < 0x20 || code === 0x7f) return false;
+      return ch !== "/" && ch !== BSLASH;
+    })
+    .join("");
+  // Strip leading dots (".", "..", ".hidden" traversal attempts).
+  let i = 0;
+  while (i < name.length && name.charAt(i) === ".") i++;
+  name = name.slice(i).trim();
+  if (name === "") return "";
+  return name.slice(0, 200);
+}
+
+/**
+ * Choose the download filename for a forwarded EmbeddedResource.
+ *
+ * MCP resource contents always carry a `uri` (e.g.
+ * "npci-doc://.../product_note_v1.docx"); the producing tool has already
+ * encoded the real name there, so we honor it — keeping BOTH the human-
+ * meaningful basename and a correct extension for any type. We fall back to the
+ * type-only "tool-idx.ext" form when the uri has no usable name (or for
+ * image/audio content, which carries no uri at all). The idx disambiguator on
+ * the fallback keeps multiple files from one tool from colliding.
+ */
+export function fileNameFromResource(
+  uri: unknown,
+  mime: string,
+  tool: string,
+  idx: number,
+): string {
+  const base = typeof uri === "string" ? sanitizeResourceFileName(uri) : "";
+  if (base) {
+    // Keep the name's own extension when it already has a short one; otherwise
+    // append the mime-derived extension so the file still opens correctly.
+    const dot = base.lastIndexOf(".");
+    const hasExt = dot > 0 && dot < base.length - 1 && base.length - dot <= 9;
+    return hasExt ? base : `${base}.${extForMime(mime)}`;
+  }
+  return `${tool}-${idx}.${extForMime(mime)}`;
+}

--- a/apps/xyne-claw-auth/backend/src/mcp/runner.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/runner.ts
@@ -4,6 +4,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { McpAdapter, McpCallResult, McpServerTools, McpToolInfo } from "./types.js";
+import { extForMime, fileNameFromResource } from "./attachment-filename.js";
 import { STATIC_ADAPTERS } from "./static-adapters.js";
 import { resolveConnectorDefinition } from "./connector-definitions.js";
 import { getSpacesAuthForUser, getWorkspaceIdForUser } from "../lib/spaces-db.js";
@@ -386,18 +387,6 @@ async function shouldForwardFiles(serverType: string): Promise<boolean> {
   return val;
 }
 
-function extForMime(mime: string): string {
-  const m = mime.toLowerCase();
-  if (m.includes("pdf")) return "pdf";
-  if (m.includes("png")) return "png";
-  if (m.includes("jpeg") || m.includes("jpg")) return "jpg";
-  if (m.includes("csv")) return "csv";
-  if (m.includes("spreadsheet") || m.includes("excel") || m.includes("xlsx")) return "xlsx";
-  if (m.includes("json")) return "json";
-  if (m.includes("zip")) return "zip";
-  return "bin";
-}
-
 /**
  * Many file-fetching MCP tools (e.g. bitbucket-mcp-server's get_file_content)
  * return the fetched file as a STRING field nested inside a JSON envelope —
@@ -436,7 +425,8 @@ function unwrapFileContentEnvelope(text: string): string {
 
 /**
  * Pull binary files out of an MCP result's content array:
- *   • EmbeddedResource ({type:"resource", resource:{blob, mimeType}}) → file
+ *   • EmbeddedResource ({type:"resource", resource:{blob, mimeType, uri}}) → file
+ *     (download name is taken from the resource `uri`; see fileNameFromResource)
  *   • ImageContent / AudioContent ({type:"image"|"audio", data, mimeType}) → file
  * Returns base64 attachments; ignores text items (incl. base64 text fallbacks).
  */
@@ -452,7 +442,7 @@ function extractAttachments(
       const res = c["resource"] as Record<string, unknown>;
       if (typeof res["blob"] === "string") {
         const mime = typeof res["mimeType"] === "string" ? res["mimeType"] : "application/octet-stream";
-        out.push({ fileName: `${tool}-${++idx}.${extForMime(mime)}`, mimeType: mime, data: res["blob"] });
+        out.push({ fileName: fileNameFromResource(res["uri"], mime, tool, ++idx), mimeType: mime, data: res["blob"] });
       }
     } else if ((type === "image" || type === "audio") && typeof c["data"] === "string") {
       const mime = typeof c["mimeType"] === "string"


### PR DESCRIPTION
## Problem
When a Claw MCP tool forwards a binary via an EmbeddedResource, `apps/xyne-claw-auth/backend/src/mcp/runner.ts` named every file `${tool}-${idx}.${extForMime(mime)}`. `extForMime()` only mapped pdf/png/jpg/csv/xlsx/json/zip and returned `bin` for everything else, so docx/pptx/doc/ppt/mp4/txt arrived as e.g. `fetch_document_file-1.bin`. The bytes were correct (rename-on-download worked), but the name/extension were wrong. Root cause: the EmbeddedResource branch read `res.blob` and `res.mimeType` but ignored `res.uri`, which per the MCP spec is always present and already carries the real filename (e.g. `npci-doc://…/product_note_v1.docx`).

## Fix
- Honor the filename in the resource `uri` as the primary source — recovers both the human-meaningful basename AND a correct extension for any type, instead of maintaining an ever-growing mime→ext map.
- Sanitize the uri (basename only; strip path separators, control chars and leading dots; re-cut the basename after percent-decoding so `%2F`/`%5C` can't smuggle a separator; cap length). The uri is tool-controlled/untrusted, so this closes a path-traversal/overwrite vector if the filename is ever used as a filesystem path downstream.
- Extend `extForMime()` with docx/doc/pptx/ppt/mp4/txt/gif/webp/svg/mp3/wav/html/xml as the extension fallback (image/audio content carries no uri, so it still relies on the mime map).
- Extract the pure helpers (`extForMime`, `sanitizeResourceFileName`, `fileNameFromResource`) into `apps/xyne-claw-auth/backend/src/mcp/attachment-filename.ts` so they are unit-testable without the runner's session/DB/MCP-SDK import graph.

## Tests
- New hermetic vitest suite `attachment-filename.test.ts` — 15 cases covering extForMime mappings, uri honoring (with/without extension), tool-idx fallback, and adversarial sanitization (`../`, backslash, `%2F`, leading dots, control chars). All 15 pass.
- `tsc --noEmit` adds zero new type errors over the pre-existing baseline.

## Notes
- Behavior change is limited to the download filename; bytes/mimeType are unchanged.
- Follow-up (out of scope): the image/audio branch still relies solely on the mime map since those content items have no uri.