### PR TITLE
fix:XYNE-55104 slack user resolver perf fix

### DIFF
--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackUserResolver.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackUserResolver.ts
@@ -316,6 +316,35 @@ async function resolveApiUser(
   return { dbUserId: user?.id, displayName };
 }
 
+/**
+ * Runs `fn` over `items` with at most `limit` promises in flight at once.
+ *
+ * Used to import Slack usergroup members concurrently without firing an unbounded
+ * number of `users.info` calls (Slack rate limits) or DB writes (connection pool)
+ * at the same time. Results preserve input order; `fn` errors reject the whole run,
+ * so callers that want per-item resilience must catch inside `fn`.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(limit, 1), items.length) },
+    async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= items.length) break;
+        results[i] = await fn(items[i], i);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 export async function resolveApiGroup(slackGroupId: string, botOauthToken: string, workspaceId?: string): Promise<string | undefined> {
   if (!slackGroupId || !botOauthToken) {
     return undefined;
@@ -341,38 +370,44 @@ export async function resolveApiGroup(slackGroupId: string, botOauthToken: strin
     workspace: { connect: { id: resolvedWorkspaceId } },
   });
 
-  // Resolve each group member — create if not in DB (same pattern as channel resolution)
-  const dbUserIds: string[] = [];
-  for (const slackUserId of slackGroup.users) {
+  // Resolve each group member — create if not in DB. Members are imported with
+  // bounded concurrency (rather than one-by-one) so a large group doesn't serialize
+  // N `users.info` round-trips; the concurrency cap keeps us under Slack rate limits
+  // and the DB connection pool. Each member is fully self-contained and returns its
+  // resolved DB user id (or undefined if it should be skipped).
+  const importMember = async (slackUserId: string): Promise<string | undefined> => {
     // First try: find by slackId metadata in the target workspace
     const existingBySlackId = await userRepo.findByMetadataField('slackId', slackUserId, resolvedWorkspaceId);
     if (existingBySlackId) {
-      dbUserIds.push(existingBySlackId.id);
-      continue;
+      return existingBySlackId.id;
     }
 
     // Second try: find by fetching Slack user info (they may not have slackId metadata yet)
     const slackUserInfo = await fetchSlackUserInfo(slackUserId, botOauthToken);
     if (!slackUserInfo || slackUserInfo.is_bot) {
       logger.debug('[resolveApiGroup] Skipping bot or unfetchable user', { slackUserId });
-      continue;
+      return undefined;
     }
 
-    // Try to find user by email
-    if (slackUserInfo.profile?.email) {
-      const existingByEmail = await userRepo.findByEmailCaseInsensitive(
-        slackUserInfo.profile.email.toLowerCase(),
-        resolvedWorkspaceId,
-      );
+    const userName = slackUserInfo.profile?.real_name || slackUserInfo.profile?.display_name || slackUserId;
+    const hasRealEmail = !!slackUserInfo.profile?.email;
+    const email = hasRealEmail
+      ? slackUserInfo.profile!.email!.toLowerCase()
+      : `${slackUserId}@cross-platform.in`;
+
+    // For a real email, an existing user may already be present — link slackId to it.
+    if (hasRealEmail) {
+      const existingByEmail = await userRepo.findByEmailCaseInsensitive(email, resolvedWorkspaceId);
       if (existingByEmail) {
         await userRepo.upsertMetaDataField(existingByEmail.id, 'slackId', slackUserId);
-        dbUserIds.push(existingByEmail.id);
-        continue;
+        return existingByEmail.id;
       }
+    }
 
-      // User not in this workspace — create them with synthetic or real email
-      const userName = slackUserInfo.profile.real_name || slackUserInfo.profile.display_name || slackUserId;
-      const email = slackUserInfo.profile.email.toLowerCase();
+    // Create OrgMember + User. Guard against a concurrent import (the same member can
+    // appear in two groups resolved in parallel) creating the row first — on a failure
+    // re-fetch by email and link to the now-existing user instead of throwing.
+    try {
       let orgMember = await dbClient.orgMember.findUnique({
         where: { email },
         select: { memberId: true },
@@ -384,7 +419,7 @@ export async function resolveApiGroup(slackGroupId: string, botOauthToken: strin
         });
         if (!workspace) {
           logger.warn('[resolveApiGroup] Workspace not found', { workspaceId: resolvedWorkspaceId });
-          continue;
+          return undefined;
         }
         orgMember = await dbClient.orgMember.create({
           data: {
@@ -405,53 +440,22 @@ export async function resolveApiGroup(slackGroupId: string, botOauthToken: strin
         workspace: { connect: { id: resolvedWorkspaceId } },
         orgMember: { connect: { memberId: orgMember.memberId } },
       });
-      logger.info('[resolveApiGroup] User created for group member', { userId: user.id, email });
+      logger.info('[resolveApiGroup] User created for group member', { userId: user.id, email, hasRealEmail });
       await userRepo.upsertMetaDataField(user.id, 'slackId', slackUserId);
-      dbUserIds.push(user.id);
-    } else {
-      // No email — use synthetic email
-      const syntheticEmail = `${slackUserId}@cross-platform.in`;
-      const userName = slackUserInfo.profile.real_name || slackUserInfo.profile.display_name || slackUserId;
-      let orgMember = await dbClient.orgMember.findUnique({
-        where: { email: syntheticEmail },
-        select: { memberId: true },
-      });
-      if (!orgMember) {
-        const workspace = await dbClient.workspace.findUnique({
-          where: { id: resolvedWorkspaceId },
-          select: { orgId: true },
-        });
-        if (!workspace) {
-          logger.warn('[resolveApiGroup] Workspace not found', { workspaceId: resolvedWorkspaceId });
-          continue;
-        }
-        orgMember = await dbClient.orgMember.create({
-          data: {
-            orgId: workspace.orgId,
-            email: syntheticEmail,
-            role: 'MEMBER',
-          },
-          select: { memberId: true },
-        });
+      return user.id;
+    } catch (error) {
+      const existing = await userRepo.findByEmailCaseInsensitive(email, resolvedWorkspaceId);
+      if (existing) {
+        await userRepo.upsertMetaDataField(existing.id, 'slackId', slackUserId);
+        return existing.id;
       }
-      const user = await userRepo.create({
-        email: syntheticEmail,
-        name: userName,
-        providerUserId: `slack-migrated-${syntheticEmail}`,
-        authProvider: AuthProvider.GOOGLE,
-        status: slackUserInfo.deleted ? 'INACTIVE' : 'ACTIVE',
-        workspace: { connect: { id: resolvedWorkspaceId } },
-        orgMember: { connect: { memberId: orgMember.memberId } },
-      });
-      logger.info('[resolveApiGroup] User created with synthetic email for group member', {
-        userId: user.id,
-        syntheticEmail,
-        userName,
-      });
-      await userRepo.upsertMetaDataField(user.id, 'slackId', slackUserId);
-      dbUserIds.push(user.id);
+      logger.error('[resolveApiGroup] Failed to import group member', { slackUserId, email, error });
+      return undefined;
     }
-  }
+  };
+
+  const memberResults = await mapWithConcurrency(slackGroup.users, 6, importMember);
+  const dbUserIds: string[] = memberResults.filter((id): id is string => !!id);
 
   // Add all resolved users to the group
   if (dbUserIds.length > 0) {
@@ -599,6 +603,37 @@ function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Resolves each `<#C…>` channel mention to its replacement HTML, concurrently.
+ * The DB read (and Slack `conversations.info` fallback) for each channel is
+ * independent, so they run in parallel; the caller applies the replacements after.
+ */
+async function resolveChannelReplacements(
+  channelIds: { id: string; name?: string }[],
+  channelRepo: ChannelRepository,
+  botOauthToken: string,
+  quote: string,
+): Promise<{ channelId: string; html: string }[]> {
+  return Promise.all(
+    channelIds.map(async ({ id: channelId, name: slackChannelName }) => {
+      const channel = await channelRepo.findById(channelId);
+      if (channel) {
+        return { channelId, html: buildChannelMentionSpan(channel, quote) };
+      }
+      if (slackChannelName) {
+        return { channelId, html: `<span>#${escapeHtml(slackChannelName)}</span>` };
+      }
+      if (botOauthToken) {
+        const slackChannel = await fetchSlackChannelInfo(channelId, botOauthToken);
+        if (slackChannel) {
+          return { channelId, html: `<span>#${escapeHtml(slackChannel.name)}</span>` };
+        }
+      }
+      return { channelId, html: `<span>#${escapeHtml(channelId)}</span>` };
+    }),
+  );
+}
+
 export async function resolveSlackMentions(
   text: string,
   botOauthToken: string = '',
@@ -614,24 +649,40 @@ export async function resolveSlackMentions(
 
   // Use provided workspaceId or fall back to default
   const resolvedWorkspaceId = workspaceId ?? config.defaultWorkspaceId;
-
-  const userMapper = await resolveSlackIds(userIds, botOauthToken, 'user', resolvedWorkspaceId);
-  const groupMapper = await resolveSlackIds(groupIds, botOauthToken, 'group', resolvedWorkspaceId);
   const quote = isStringified ? "'" : '"'
   const userRepo = new UserRepository();
   const groupRepo = new UserGroupRepository();
   const channelRepo = new ChannelRepository();
 
+  // Users, groups and channels are independent — resolve them concurrently instead
+  // of one phase after another. (resolveSlackIds only writes for groups; user
+  // resolution is read-only, so there is no cross-write race between these.)
+  const [userMapper, groupMapper, channelReplacements] = await Promise.all([
+    resolveSlackIds(userIds, botOauthToken, 'user', resolvedWorkspaceId),
+    resolveSlackIds(groupIds, botOauthToken, 'group', resolvedWorkspaceId),
+    resolveChannelReplacements(channelIds, channelRepo, botOauthToken, quote),
+  ]);
+
+  // Batch-load every resolved user/group row in a single query each, instead of a
+  // per-entity findById in the render loops below.
+  const userDbIds = userMapper
+    ? [...userMapper.values()].map((v) => v.dbId).filter((id): id is string => !!id)
+    : [];
+  const groupDbIds = groupMapper
+    ? [...groupMapper.values()].map((v) => v.dbId).filter((id): id is string => !!id)
+    : [];
+  const [userRows, groupRows] = await Promise.all([
+    userDbIds.length ? userRepo.findMany({ where: { id: { in: userDbIds } } }) : Promise.resolve([]),
+    groupDbIds.length ? groupRepo.findMany({ where: { id: { in: groupDbIds } } }) : Promise.resolve([]),
+  ]);
+  const userById = new Map(userRows.map((u) => [u.id, u]));
+  const groupById = new Map(groupRows.map((g) => [g.id, g]));
+
   if (userMapper) {
     for (const [slackId, { dbId, displayName }] of userMapper.entries()) {
-      if (dbId) {
-        const user = await userRepo.findById(dbId);
-        if (user) {
-          text = replaceSlackUserMention(text, slackId, `<span ${buildMentionAttrs(user.id, user.name, false, quote, undefined, undefined, user.email, user.picture || undefined).join(' ')}>@${escapeHtml(user.name)}</span>`);
-      } else {
-        const name = displayName ?? 'unknown user';
-        text = replaceSlackUserMention(text, slackId, `<span>@${escapeHtml(name)}</span>`);
-      }
+      const user = dbId ? userById.get(dbId) : undefined;
+      if (user) {
+        text = replaceSlackUserMention(text, slackId, `<span ${buildMentionAttrs(user.id, user.name, false, quote, undefined, undefined, user.email, user.picture || undefined).join(' ')}>@${escapeHtml(user.name)}</span>`);
       } else {
         const name = displayName ?? 'unknown user';
         text = replaceSlackUserMention(text, slackId, `<span>@${escapeHtml(name)}</span>`);
@@ -640,36 +691,17 @@ export async function resolveSlackMentions(
   }
   if (groupMapper) {
     for (const [slackId, { dbId, displayName }] of groupMapper.entries()) {
-      if (dbId) {
-        const group = await groupRepo.findById(dbId);
-        if (group) {
-          text = replaceSlackGroupMention(text, slackId, `<span ${buildMentionAttrs(group.id, group.name, true, quote, group.alias || undefined, group.description || undefined).join(' ')}>@${escapeHtml(group.alias || group.name)}</span>`);
-        } else {
-          const name = displayName ?? 'unknown group';
-          text = replaceSlackGroupMention(text, slackId, `<span>@${escapeHtml(name)}</span>`);
-        }
+      const group = dbId ? groupById.get(dbId) : undefined;
+      if (group) {
+        text = replaceSlackGroupMention(text, slackId, `<span ${buildMentionAttrs(group.id, group.name, true, quote, group.alias || undefined, group.description || undefined).join(' ')}>@${escapeHtml(group.alias || group.name)}</span>`);
       } else {
         const name = displayName ?? 'unknown group';
         text = replaceSlackGroupMention(text, slackId, `<span>@${escapeHtml(name)}</span>`);
       }
     }
   }
-  for (const { id: channelId, name: slackChannelName } of channelIds) {
-    const channel = await channelRepo.findById(channelId);
-    if (channel) {
-      text = replaceSlackChannelMention(text, channelId, buildChannelMentionSpan(channel, quote));
-    } else if (slackChannelName) {
-      text = replaceSlackChannelMention(text, channelId, `<span>#${escapeHtml(slackChannelName)}</span>`);
-    } else if (botOauthToken) {
-      const slackChannel = await fetchSlackChannelInfo(channelId, botOauthToken);
-      if (slackChannel) {
-        text = replaceSlackChannelMention(text, channelId, `<span>#${escapeHtml(slackChannel.name)}</span>`);
-      } else {
-        text = replaceSlackChannelMention(text, channelId, `<span>#${escapeHtml(channelId)}</span>`);
-      }
-    } else {
-      text = replaceSlackChannelMention(text, channelId, `<span>#${escapeHtml(channelId)}</span>`);
-    }
+  for (const { channelId, html } of channelReplacements) {
+    text = replaceSlackChannelMention(text, channelId, html);
   }
   return resolveSpecialMentions(text, isStringified);
 }


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
