### PR TITLE
fix: preserve markdown formatting in forwarded messages

### DIFF
--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -467,6 +467,7 @@ export class ChannelController {
       let effectiveSenderName = originalSenderInfo.name || 'Unknown User';
 
       const meta = originalMessage.metadata as any;
+      const isOriginalMarkdownContent = !useOptionalText && meta?.contentFormat === 'markdown';
       const contentStr = typeof originalMessage.content === 'string' ? originalMessage.content : '';
       
       const isCall = 
@@ -511,6 +512,9 @@ export class ChannelController {
       });
 
         const forwardedMessageMetadata = {} as Record<string, unknown>;
+        if (isOriginalMarkdownContent) {
+          forwardedMessageMetadata['contentFormat'] = 'markdown';
+        }
         if (isCall) {
           forwardedMessageMetadata['isCallMessage'] = true;
           if (meta?.callId) {

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -2719,6 +2719,20 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           const originalAttachments = useOptionalText
             ? []
             : await tx.run(zql.message_attachments.where('entityId', originalMessageId));
+          const originalMetadata = originalMessage.metadata as Record<string, unknown> | undefined;
+          const isOriginalMarkdownContent =
+          !useOptionalText && originalMetadata?.['contentFormat'] === 'markdown';
+          const isCallMessage = originalMetadata?.['isCallMessage'] === true;
+          const forwardedMessageMetadata = {} as Record<string, unknown>;
+          if (isOriginalMarkdownContent) {
+            forwardedMessageMetadata['contentFormat'] = 'markdown';
+          }
+          if (isCallMessage) {
+            forwardedMessageMetadata['isCallMessage'] = true;
+            if (originalMetadata?.['callId']) {
+              forwardedMessageMetadata['callId'] = originalMetadata['callId'];
+            }
+          }
 
           const now = timestamp;
 
@@ -2765,7 +2779,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
             isSent: true,
             showInChannel: false,
             createdAt: now,
-            metadata: undefined,
+            metadata: Object.keys(forwardedMessageMetadata).length > 0 ? forwardedMessageMetadata as any : undefined,
           });
 
           // Copy attachments from the original message
@@ -2794,23 +2808,6 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           // --- Call Message Forwarding Specifics ---
 
           let replyCount = 0;
-          const originalMetadata = originalMessage.metadata as Record<string, unknown> | undefined;
-          const isCallMessage = originalMetadata?.['isCallMessage'] === true;
-
-          // Define metadata for the new forwarded message
-          if (isCallMessage) {
-            const forwardedMessageMetadata = { ...(originalMessage.metadata as Record<string, unknown> || {}) };
-            forwardedMessageMetadata['isCallMessage'] = true;
-            if (originalMetadata?.['callId']) {
-              forwardedMessageMetadata['callId'] = originalMetadata['callId'];
-            }
-
-            // Re-update the inserted message metadata with call indicators
-            await tx.mutate.messages.update({
-              messageId,
-              metadata: forwardedMessageMetadata as any,
-            });
-          }
 
           // If it is a call message, we want to clone all non-user messages (like transcipts/summaries/system msg)
           if (isCallMessage) {

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../hooks/useChannels';
 import { useMentionSearch } from '../../../hooks/useMentionSearch';
 import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWithHTML';
+import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
 import { MessageAttachment } from '../MessageAttachment/MessageAttachment';
 import { formatRelativeTimestamp } from '../../../utils/dateUtils';
 import HuddleIcon from '../../icons/HuddleIcon';
@@ -46,6 +47,7 @@ import { queries } from '../../../zero/queries';
 import { useQuery } from '../../../hooks/useQuery';
 import { VisibleChannel } from '../../../machines/stateMachine';
 import { logger, Event } from '../../../utils/logger';
+import { createMarkdownComponents } from '../../../utils/markdownComponents';
 
 /**
  * ForwardMessageForm component allows users to forward a message to channels or users.
@@ -265,6 +267,10 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
 
   // Check if we're using optionalText (affects both content and attachments display)
   const useOptionalText = isReForwarding && !!forwardedMessageData?.optionalText;
+  const messageMetadata = message.metadata as Record<string, unknown> | undefined;
+  const shouldRenderPreviewAsMarkdown =
+    !useOptionalText && messageMetadata?.['contentFormat'] === 'markdown';
+  const markdownComponents = useMemo(() => createMarkdownComponents(message.messageId), [message.messageId]);
 
   // Compute the preview content for the modal
   // For forwarded messages: show optionalText as main content (if exists), otherwise show forwarded content
@@ -815,7 +821,14 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
                   <div
                     className={`text-foreground whitespace-pre-wrap break-words ${getEmojiFontSizeClass(previewContent)}`}
                   >
-                    <RenderMessageWithHTML message={previewContent} />
+                    {shouldRenderPreviewAsMarkdown ? (
+                      <MarkdownMessageRenderer
+                        content={previewContent}
+                        markdownComponents={markdownComponents}
+                      />
+                    ) : (
+                      <RenderMessageWithHTML message={previewContent} />
+                    )}
                   </div>
                 )}
                 {/* Attachments - hide when using optionalText (it's either optionalText OR content with attachments) */}

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -601,15 +601,19 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   const isMentionUserAddition = metadata?.messageSubtype === 'user_not_in_channel';
   const isTicketNudge = metadata?.messageSubtype === 'ticket_nudge';
   const isPrivateSystemNotice = isMentionUserAddition || isTicketNudge;
-  // Detect any message with markdown content format (call_summary, call_prd, etc.)
+  // Detect any message with markdown content format (call_summary, call_prd, etc.).
+  // Forwarded messages store the original body inside forwarded XML, so keep the
+  // forwarded branch in charge and render only that nested body as markdown.
   const isMarkdownContent = metadata?.['contentFormat'] === 'markdown';
+  const shouldRenderMessageAsMarkdown = isMarkdownContent && !isForwardedMessage;
+  const shouldRenderForwardedContentAsMarkdown = isMarkdownContent && isForwardedMessage;
   const hasSuggestedTickets = metadata?.['hasSuggestedTickets'] === true;
   const parsedMarkdown = useMemo(() => {
-    if (isMarkdownContent) {
+    if (shouldRenderMessageAsMarkdown) {
       return parseMarkdownWithTicketSuggestions(message.content, hasSuggestedTickets);
     }
     return { ticketSuggestions: [], ticketsCreated: [], content: message.content };
-  }, [isMarkdownContent, hasSuggestedTickets, message.content]);
+  }, [shouldRenderMessageAsMarkdown, hasSuggestedTickets, message.content]);
 
   const ticketSuggestions = parsedMarkdown.ticketSuggestions;
   const ticketsCreated = parsedMarkdown.ticketsCreated;
@@ -711,14 +715,14 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   // Postgres and never hit the /messages sidebar path.
   const clawCitations = metadata?.['clawCitations'] as ToolInvocation[] | undefined;
   const clawCitationCtx = useMemo(() => {
-    if (!isMarkdownContent || !clawCitations?.length) return undefined;
+    if (!shouldRenderMessageAsMarkdown || !clawCitations?.length) return undefined;
     // Register the de-duplicated icon bytes so chip icons resolve at render time
     // (mirrors the sidebar's registerClawIcons on the /messages `icons` map).
     registerClawIcons(metadata?.['clawCitationIcons']);
     const toolNumbers = buildClawCitationToolNumbers(parsedMarkdown.content);
     if (toolNumbers.size === 0) return undefined;
     return { toolInvocations: clawCitations, toolNumbers };
-  }, [isMarkdownContent, clawCitations, metadata, parsedMarkdown.content]);
+  }, [shouldRenderMessageAsMarkdown, clawCitations, metadata, parsedMarkdown.content]);
 
   // Linkify inline [clf-…#n] tokens into the synthetic cite:/cite-group: links
   // the `a` override turns into chips. When no citation metadata is present
@@ -1208,7 +1212,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                   emailId={message.messageId}
                   attachments={attachments}
                 />
-              ) : isMarkdownContent ? (
+              ) : shouldRenderMessageAsMarkdown ? (
                 <>
                   <MarkdownMessageRenderer
                     content={citationContent}
@@ -1348,7 +1352,13 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                         <div
                           className={`jp-message-html whitespace-pre-wrap break-all-words inline-block text-muted-foreground ${getEmojiFontSizeClass(resolvedForwardedContent)}`}
                         >
-                          {isMobile ? (
+                          {shouldRenderForwardedContentAsMarkdown ? (
+                            <MarkdownMessageRenderer
+                              content={resolvedForwardedContent}
+                              markdownComponents={markdownComponents}
+                              messageSubtype={metadata?.messageSubtype}
+                            />
+                          ) : isMobile ? (
                             <ExpandableMessage
                               message={resolvedForwardedContent}
                               showEdited={false}

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -1889,6 +1889,24 @@ export const mutators = defineMutators({
           if (parsed?.title) forwardedContent = parsed.title;
         }
         const forwardedHasAttachment = useOptionalText ? false : originalMessage.hasAttachment;
+        const originalMetadata = originalMessage.metadata as Record<string, unknown> | undefined;
+        const isOriginalMarkdownContent =
+          !useOptionalText && originalMetadata?.['contentFormat'] === 'markdown';
+        const isCallMessage = originalMetadata?.['isCallMessage'] === true;
+
+        // Define metadata for the new forwarded message.
+        // Preserve markdown content format so forwarded previews/bubbles render the
+        // nested forwarded content with the same renderer as the original message.
+        const forwardedMessageMetadata = {} as Record<string, unknown>;
+        if (isOriginalMarkdownContent) {
+          forwardedMessageMetadata['contentFormat'] = 'markdown';
+        }
+        if (isCallMessage) {
+          forwardedMessageMetadata['isCallMessage'] = true;
+          if (originalMetadata?.['callId']) {
+            forwardedMessageMetadata['callId'] = originalMetadata['callId'];
+          }
+        }
 
         const now = timestamp;
 
@@ -1925,6 +1943,7 @@ export const mutators = defineMutators({
             msgType: MessageType.FORWARDED,
             hasAttachment: forwardedHasAttachment,
             createdAt: now,
+            metadata: forwardedMessageMetadata,
           }),
         });
 
@@ -1954,17 +1973,6 @@ export const mutators = defineMutators({
         // --- Call Message Forwarding Specifics ---
 
         let replyCount = 0;
-        const originalMetadata = originalMessage.metadata as Record<string, unknown> | undefined;
-        const isCallMessage = originalMetadata?.['isCallMessage'] === true;
-
-        // Define metadata for the new forwarded message
-        const forwardedMessageMetadata = {} as Record<string, unknown>;
-        if (isCallMessage) {
-          forwardedMessageMetadata['isCallMessage'] = true;
-          if (originalMetadata?.['callId']) {
-            forwardedMessageMetadata['callId'] = originalMetadata['callId'];
-          }
-        }
 
         // If it is a call message, we want to clone all non-user bot messages (like transcipts/summaries)
         if (isCallMessage) {


### PR DESCRIPTION
## Root cause
Forwarding stored the original message body inside forwarded XML but did not preserve the original markdown content-format metadata. The forward preview and forwarded bubble then rendered TraceX/BOT markdown content through the HTML renderer, exposing/collapsing raw markdown.

## Fix
- Preserve `contentFormat: 'markdown'` metadata when forwarding markdown source messages through channel/Zero and backend DM forwarding paths.
- Render forward modal previews with `MarkdownMessageRenderer` when the source content format is markdown.
- Render forwarded XML content with `MarkdownMessageRenderer` when the forwarded message metadata marks it as markdown; non-markdown forwarded messages keep the existing HTML path.
- Avoid marking optional forwarder notes as markdown content.

## Verification
- `cd apps/backend && NODE_OPTIONS='--max-old-space-size=4096' npx tsc --noEmit` ✅
- `cd apps/dashboard && npx tsc --noEmit --project tsconfig.app.json` ✅
- `git diff --check` ✅
- POT TC1: original and forwarded TraceX markdown render as formatted HTML; DOM has markdown elements for both and no visible raw markdown markers.
- POT TC2: forward modal preview code path selects markdown renderer for markdown source messages.

## Evidence
- Forward preview: `apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx:270`, `apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx:824`
- Forwarded bubble render: `apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx:607`, `apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx:1355`
- Metadata preservation: `packages/shared/src/zero/mutators.ts:1893`, `packages/shared/src/zero/mutators.ts:1901`, `apps/backend/src/controllers/channelController.ts:470`, `apps/backend/src/controllers/channelController.ts:515`