### PR TITLE
fix: XYNE-17383 backfill legacy threads to be read

### DIFF
--- a/apps/backend/src/controllers/conversationParticipantBackfillController.ts
+++ b/apps/backend/src/controllers/conversationParticipantBackfillController.ts
@@ -3,13 +3,19 @@ import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
 import { ApiResponse } from '@/types/express';
 
-type BackfillType = 'lastReplyAt' | 'channelId' | 'staleLastReplyAt' | 'orphanedParticipants';
+type BackfillType =
+  | 'lastReplyAt'
+  | 'legacyLastReadAt'
+  | 'channelId'
+  | 'staleLastReplyAt'
+  | 'orphanedParticipants';
 
 type BackfillOptions = {
   types: BackfillType[];
   batchSize: number;
   delayMs: number;
   dryRun: boolean;
+  lastReadAtCutoff: Date | null;
 };
 
 type BackfillSummary = {
@@ -19,9 +25,35 @@ type BackfillSummary = {
   errors: number;
 };
 
+type LegacyLastReadAtSummary = BackfillSummary & {
+  cutoff: string;
+};
+
+type LegacyLastReadAtCandidate = {
+  id: string;
+  conversationId: string;
+  userId: string;
+  lastReplyAt: Date | null;
+};
+
+class BackfillValidationError extends Error {}
+
 export class ConversationParticipantBackfillController {
   private static sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private static parseLastReadAtCutoff(value: unknown): Date {
+    if (typeof value !== 'string') {
+      throw new BackfillValidationError('lastReadAtCutoff is required for legacyLastReadAt');
+    }
+
+    const cutoff = new Date(value);
+    if (Number.isNaN(cutoff.getTime())) {
+      throw new BackfillValidationError('lastReadAtCutoff must be a valid timestamp');
+    }
+
+    return cutoff;
   }
 
   private static buildDefaultOptions(body: unknown): BackfillOptions {
@@ -30,11 +62,13 @@ export class ConversationParticipantBackfillController {
       batchSize: number;
       delayMs: number;
       dryRun: boolean;
+      lastReadAtCutoff: unknown;
     }>;
 
     const defaultTypes: BackfillType[] = ['lastReplyAt', 'channelId'];
     const validTypes: BackfillType[] = [
       ...defaultTypes,
+      'legacyLastReadAt',
       'staleLastReplyAt',
       'orphanedParticipants',
     ];
@@ -52,7 +86,115 @@ export class ConversationParticipantBackfillController {
     const delayMs = payload.delayMs && payload.delayMs >= 0 ? payload.delayMs : 50;
     const dryRun = payload.dryRun === true;
 
-    return { types, batchSize, delayMs, dryRun };
+    let lastReadAtCutoff: Date | null = null;
+    if (types.includes('legacyLastReadAt')) {
+      lastReadAtCutoff = ConversationParticipantBackfillController.parseLastReadAtCutoff(
+        payload.lastReadAtCutoff
+      );
+    }
+
+    return { types, batchSize, delayMs, dryRun, lastReadAtCutoff };
+  }
+
+  /**
+   * lastReadAt did not exist for legacy threads, so NULL cannot distinguish an
+   * unread thread from one read before the column was deployed. Treat a legacy
+   * participant as read when its latest reply predates the fixed rollout cutoff.
+   */
+  private static async backfillLegacyLastReadAt(
+    options: BackfillOptions
+  ): Promise<LegacyLastReadAtSummary> {
+    const cutoff = options.lastReadAtCutoff;
+    if (!cutoff) {
+      throw new BackfillValidationError('lastReadAtCutoff is required for legacyLastReadAt');
+    }
+    const summary: LegacyLastReadAtSummary = {
+      processed: 0,
+      updated: 0,
+      skipped: 0,
+      errors: 0,
+      cutoff: cutoff.toISOString(),
+    };
+    let cursor: string | null = null;
+    let batchNumber = 0;
+
+    do {
+      batchNumber += 1;
+      const participants: LegacyLastReadAtCandidate[] = await db.conversationParticipant.findMany({
+        where: {
+          lastReadAt: null,
+          lastReplyAt: { not: null, lt: cutoff },
+          ...(cursor ? { id: { gt: cursor } } : {}),
+        },
+        select: {
+          id: true,
+          conversationId: true,
+          userId: true,
+          lastReplyAt: true,
+        },
+        orderBy: { id: 'asc' },
+        take: options.batchSize,
+      });
+
+      if (participants.length === 0) break;
+
+      cursor = participants[participants.length - 1]?.id ?? null;
+      summary.processed += participants.length;
+
+      for (const participant of participants) {
+        if (!participant.lastReplyAt) {
+          summary.skipped += 1;
+          continue;
+        }
+
+        if (options.dryRun) {
+          summary.updated += 1;
+          continue;
+        }
+
+        try {
+          // Recheck both fields so a read or post-cutoff reply racing this
+          // backfill is never overwritten.
+          const result = await db.conversationParticipant.updateMany({
+            where: {
+              id: participant.id,
+              lastReadAt: null,
+              lastReplyAt: participant.lastReplyAt,
+            },
+            data: { lastReadAt: participant.lastReplyAt },
+          });
+          if (result.count === 1) {
+            summary.updated += 1;
+          } else {
+            summary.skipped += 1;
+          }
+        } catch (error) {
+          summary.errors += 1;
+          logger.warn('[ConvParticipantBackfill] Failed legacy lastReadAt update', {
+            id: participant.id,
+            conversationId: participant.conversationId,
+            userId: participant.userId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      logger.info(`[ConvParticipantBackfill] legacy lastReadAt batch #${batchNumber} completed`, {
+        batchSize: participants.length,
+        dryRun: options.dryRun,
+        cutoff: summary.cutoff,
+        processed: summary.processed,
+        updated: summary.updated,
+        skipped: summary.skipped,
+        errors: summary.errors,
+      });
+
+      if (options.delayMs > 0) {
+        await this.sleep(options.delayMs);
+      }
+    } while (cursor);
+
+    return summary;
   }
 
   private static async findConversationIdsWithLiveReplies(
@@ -151,7 +293,7 @@ export class ConversationParticipantBackfillController {
       skipped: 0,
       errors: 0,
     };
-    const batchSize = Math.min(options.batchSize, 1_000);
+    const batchSize = options.batchSize;
     let cursor: string | null = null;
     let batchNumber = 0;
 
@@ -326,7 +468,7 @@ export class ConversationParticipantBackfillController {
       skipped: 0,
       errors: 0,
     };
-    const batchSize = Math.min(options.batchSize, 1_000);
+    const batchSize = options.batchSize;
     let cursor: string | null = null;
     let batchNumber = 0;
 
@@ -416,6 +558,11 @@ export class ConversationParticipantBackfillController {
           await ConversationParticipantBackfillController.clearStaleLastReplyAt(options);
       }
 
+      if (options.types.includes('legacyLastReadAt')) {
+        results.legacyLastReadAt =
+          await ConversationParticipantBackfillController.backfillLegacyLastReadAt(options);
+      }
+
       if (options.types.includes('channelId')) {
         results.channelId = await ConversationParticipantBackfillController.backfillChannelId(options);
       }
@@ -437,12 +584,13 @@ export class ConversationParticipantBackfillController {
       res.status(200).json(response);
     } catch (error) {
       logger.error('[ConvParticipantBackfill] Error during backfill:', error);
+      const statusCode = error instanceof BackfillValidationError ? 400 : 500;
       const response: ApiResponse = {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to run backfill',
         timestamp: new Date().toISOString(),
       };
-      res.status(500).json(response);
+      res.status(statusCode).json(response);
     }
   }
 }

--- a/apps/backend/src/routes/conversationParticipantBackfill.ts
+++ b/apps/backend/src/routes/conversationParticipantBackfill.ts
@@ -13,7 +13,14 @@ const backfillAdminAuth = authorize('TICKET-MIGRATION', AccessType.ADMIN);
  * @desc Backfill or reconcile denormalized conversation_participant fields
  * @access TICKET-MIGRATION Admin only
  * @body {
- *   types?: ('lastReplyAt' | 'staleLastReplyAt' | 'channelId' | 'orphanedParticipants')[],
+ *   types?: (
+ *     | 'lastReplyAt'
+ *     | 'legacyLastReadAt'
+ *     | 'staleLastReplyAt'
+ *     | 'channelId'
+ *     | 'orphanedParticipants'
+ *   )[],
+ *   lastReadAtCutoff?: string, // Required for legacyLastReadAt; valid timestamp
  *   batchSize?: number,
  *   delayMs?: number,
  *   dryRun?: boolean

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -889,7 +889,7 @@ export const ThreadMessages = ({
             />
 
             {/* ChatInput at the bottom - only show if user is a member */}
-            {previewCardMode ? null : isUserMember || channel?.isArchived ? (
+            {isUserMember || channel?.isArchived ? (
               <div className='pb-3 bg-background px-[var(--composer-px)] [--composer-px:0.75rem]'>
                 <ChatInput
                   ref={inputRef}
@@ -1201,7 +1201,7 @@ export const ThreadMessages = ({
                   />
 
                   {/* ChatInput at the bottom - only show if user is a member */}
-                  {previewCardMode ? null : isUserMember || channel?.isArchived ? (
+                  {isUserMember || channel?.isArchived ? (
                     <div className='pb-3 bg-background px-[var(--composer-px)] [--composer-px:0.75rem]'>
                       <ChatInput
                         ref={inputRef}
@@ -1455,7 +1455,7 @@ export const ThreadMessages = ({
                 />
 
                 {/* ChatInput at the bottom - only show if user is a member */}
-                {previewCardMode ? null : isUserMember || channel?.isArchived ? (
+                {isUserMember || channel?.isArchived ? (
                   <div className='pb-3 bg-background px-[var(--composer-px)] [--composer-px:0.75rem]'>
                     <ChatInput
                       // eslint-disable-next-line jsx-a11y/no-autofocus

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from '../ui/Button';
 import { queries } from '../../zero/queries';
 import { mutators } from '../../zero/mutators';
-import { useChannel, useGetChannelUserStatus } from '../../hooks/useChannels';
+import { useChannel, useChannelParticipation } from '../../hooks/useChannels';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useIsInPanelWebview } from '../../hooks/useIsInPanelWebview';
@@ -176,7 +176,10 @@ export const ThreadMessages = ({
   const isFocusedThread = searchParams.get('focusThread') === '1';
   const skipInputAutoFocus = propSkipInputAutoFocus || searchParams.get('nofocus') === '1';
 
-  const participationStatus = useGetChannelUserStatus(derivedChannelId);
+  // The initial visible-channel cache excludes closed DMs. Query the specific
+  // channel as a fallback so a subscribed thread in a closed DM is not treated
+  // as proof that the user is a non-member.
+  const participationStatus = useChannelParticipation(derivedChannelId);
   const isMember = !!participationStatus;
 
   // Single enriched query: replaces getConversationById + ticketById + conversationMessagesV2
@@ -185,7 +188,15 @@ export const ThreadMessages = ({
     () =>
       queries.threadConversationV2({
         conversationId: derivedConversationId || ' ',
-        ...(derivedChannelId ? { channelId: derivedChannelId, isMember } : {}),
+        // While membership is unresolved, omit isMember instead of passing
+        // false. The general ACL can then check channel_participants directly;
+        // passing false would reject a private DM before status hydration.
+        ...(derivedChannelId
+          ? {
+              channelId: derivedChannelId,
+              ...(isMember ? { isMember: true } : {}),
+            }
+          : {}),
       }),
     [derivedConversationId, derivedChannelId, isMember],
   );
@@ -878,7 +889,7 @@ export const ThreadMessages = ({
             />
 
             {/* ChatInput at the bottom - only show if user is a member */}
-            {isUserMember || channel?.isArchived ? (
+            {previewCardMode ? null : isUserMember || channel?.isArchived ? (
               <div className='pb-3 bg-background px-[var(--composer-px)] [--composer-px:0.75rem]'>
                 <ChatInput
                   ref={inputRef}
@@ -1190,7 +1201,7 @@ export const ThreadMessages = ({
                   />
 
                   {/* ChatInput at the bottom - only show if user is a member */}
-                  {isUserMember || channel?.isArchived ? (
+                  {previewCardMode ? null : isUserMember || channel?.isArchived ? (
                     <div className='pb-3 bg-background px-[var(--composer-px)] [--composer-px:0.75rem]'>
                       <ChatInput
                         ref={inputRef}
@@ -1444,7 +1455,7 @@ export const ThreadMessages = ({
                 />
 
                 {/* ChatInput at the bottom - only show if user is a member */}
-                {isUserMember || channel?.isArchived ? (
+                {previewCardMode ? null : isUserMember || channel?.isArchived ? (
                   <div className='pb-3 bg-background px-[var(--composer-px)] [--composer-px:0.75rem]'>
                     <ChatInput
                       // eslint-disable-next-line jsx-a11y/no-autofocus


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] Enhancement


## Description
- setting lastReadAt from null to read for legacy threads
- closed dms threads made visible now by hook


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`

---



## Schema & Data Changes

- [ ] Backfill / data migration included

If any of the above:

- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->


## API Contract

- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---



