### PR TITLE
feature: support DELAY and RUN_AGENT inside control-flow branches

### DIFF
--- a/apps/backend/src/automations/engine/automation-context-storage.ts
+++ b/apps/backend/src/automations/engine/automation-context-storage.ts
@@ -4,6 +4,7 @@ export interface AutomationContextStore {
   runId: string;
   automationId: string;
   chain: readonly string[];
+  currentStepName?: string;
 }
 
 export const automationContextStorage = new AsyncLocalStorage<AutomationContextStore>();

--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -11,7 +11,7 @@ import type { AutomationStepConfig } from '../types/automation-config';
 import type { AutomationContext } from '../types/context';
 import type { TriggerType } from '../types/trigger-types';
 import type { StepType } from '../types/step-types';
-import { CONTROL_FLOW_STEP_TYPES } from '../types/known-types';
+import { CONTROL_FLOW_STEP_TYPES, ControlFlowStepType } from '../types/known-types';
 import type { StepRegistry } from '../steps/step-registry';
 import { BaseActionStep, BaseControlFlowStep, StepKind } from '../steps/base-step';
 import { VariableResolver, stripNullForOptionalKeys } from './variable-resolver';
@@ -36,6 +36,7 @@ interface PreparedRun {
   startIndex: number;
   label: 'STARTED' | 'RESUMED';
   resumeAtIndex?: number;
+  resumePath?: string | null;
 }
 
 const EXTERNAL_WAIT_STATUS = 'EXTERNAL_WAIT';
@@ -48,11 +49,68 @@ function safeParseJson(raw: string): unknown {
   }
 }
 
-function parseStepIndexFromName(name: string): number | null {
-  const m = /^step_(\d+)$/.exec(name);
-  if (!m) return null;
-  const n = Number.parseInt(m[1] as string, 10);
-  return Number.isInteger(n) ? n : null;
+type StepPathSegment = number | string;
+
+function parseStepPath(stepName: string): StepPathSegment[] {
+  return stepName.split('.').map((seg, idx) => {
+    if (idx === 0) {
+      const m = /^step_(\d+)$/.exec(seg);
+      return m ? Number.parseInt(m[1] as string, 10) : seg;
+    }
+    const n = Number.parseInt(seg, 10);
+    return Number.isInteger(n) ? n : seg;
+  });
+}
+
+function getBranchSteps(
+  step: AutomationStepConfig,
+  branchKey: string,
+): AutomationStepConfig[] | null {
+  if (step.type === ControlFlowStepType.CONDITIONAL) {
+    const cfg = step.config as {
+      if_true: AutomationStepConfig[];
+      if_false?: AutomationStepConfig[];
+    };
+    if (branchKey === 'if_true') return cfg.if_true;
+    if (branchKey === 'if_false') return cfg.if_false ?? [];
+  }
+  if (step.type === ControlFlowStepType.SWITCH) {
+    const cfg = step.config as {
+      cases: { steps: AutomationStepConfig[] }[];
+      default: AutomationStepConfig[];
+    };
+    if (branchKey === 'default') return cfg.default;
+    const caseMatch = /^case_(\d+)$/.exec(branchKey);
+    if (caseMatch) {
+      const caseIdx = Number.parseInt(caseMatch[1] as string, 10);
+      return cfg.cases[caseIdx]?.steps ?? null;
+    }
+  }
+  return null;
+}
+
+function resolveStepConfigByName(
+  steps: AutomationStepConfig[],
+  stepName: string,
+): AutomationStepConfig | null {
+  const parts = stepName.split('.');
+  const firstMatch = /^step_(\d+)$/.exec(parts[0]!);
+  if (!firstMatch) return null;
+  const firstIdx = Number.parseInt(firstMatch[1] as string, 10);
+  if (firstIdx < 0 || firstIdx >= steps.length) return null;
+  let step: AutomationStepConfig = steps[firstIdx]!;
+
+  for (let idx = 1; idx < parts.length; idx += 2) {
+    const branchKey = parts[idx]!;
+    const indexStr = parts[idx + 1];
+    if (indexStr === undefined) return null;
+    const nestedIdx = Number.parseInt(indexStr, 10);
+    if (!Number.isInteger(nestedIdx)) return null;
+    const branchSteps = getBranchSteps(step, branchKey);
+    if (!branchSteps || nestedIdx < 0 || nestedIdx >= branchSteps.length) return null;
+    step = branchSteps[nestedIdx]!;
+  }
+  return step;
 }
 
 export class AutomationExecutor {
@@ -125,7 +183,11 @@ export class AutomationExecutor {
     config: ReturnType<typeof parseAutomationConfig>,
     prep: PreparedRun,
   ): Promise<unknown> {
-    prep.ctx.__meta = { error: null, chain: prep.chain };
+    prep.ctx.__meta = {
+      error: null,
+      chain: prep.chain,
+      ...(prep.resumePath ? { resumePath: prep.resumePath } : {}),
+    };
     await this.prisma.workflowExecution.update({
       where: { id: executionId },
       data: { status: AutomationRunStatus.RUNNING },
@@ -139,8 +201,8 @@ export class AutomationExecutor {
       prep.ctx,
       prep.chain,
       config.steps,
-      prep.startIndex,
       prep.resumeAtIndex,
+      prep.resumePath,
     );
   }
 
@@ -193,9 +255,7 @@ export class AutomationExecutor {
       });
       for (const row of stepRows) {
         if (!row.stepName || !row.data) continue;
-        const idx = parseStepIndexFromName(row.stepName);
-        if (idx === null) continue;
-        const stepConfig = config.steps[idx];
+        const stepConfig = resolveStepConfigByName(config.steps, row.stepName);
         if (!stepConfig) continue;
         const parsedRow = safeParseJson(row.data);
         if (parsedRow !== undefined && parsedRow !== null && typeof parsedRow === 'object') {
@@ -212,12 +272,14 @@ export class AutomationExecutor {
         }
       }
       const pausedIndex = pauseState.currentStepIndex;
+      const resumePath = initialCtx.__meta?.resumePath ?? null;
       return {
         ctx: initialCtx,
         chain,
         startIndex: pausedIndex,
         label: 'RESUMED',
         resumeAtIndex: pausedIndex,
+        resumePath,
       };
     }
 
@@ -330,14 +392,19 @@ export class AutomationExecutor {
     context: AutomationContext,
     chain: readonly string[],
     steps: AutomationStepConfig[],
-    startIndex: number,
     resumeAtIndex?: number,
+    resumePath?: string | null,
   ): Promise<unknown> {
     const automationId = context.automation.id;
+    const resumeCursor = resumePath
+      ? parseStepPath(resumePath)
+      : resumeAtIndex !== undefined
+        ? [resumeAtIndex]
+        : null;
     try {
       const walkResult = await automationContextStorage.run<Promise<WalkResult>>(
         { runId, automationId, chain },
-        () => this.walkSteps(steps, context, runId, startIndex, resumeAtIndex),
+        () => this.walkStepsRecursive(steps, context, runId, '', resumeCursor),
       );
 
       if (walkResult.kind === 'paused') {
@@ -375,30 +442,50 @@ export class AutomationExecutor {
     }
   }
 
-  private async walkSteps(
+  private async walkStepsRecursive(
     steps: AutomationStepConfig[],
     context: AutomationContext,
     runId: string,
-    startIndex: number = 0,
-    resumeAtIndex?: number,
+    pathPrefix: string,
+    resumeCursor: StepPathSegment[] | null,
   ): Promise<WalkResult> {
+    const store = automationContextStorage.getStore();
+    const startIndex = resumeCursor ? (resumeCursor[0] as number) : 0;
     for (let i = startIndex; i < steps.length; i++) {
       const step = steps[i] as AutomationStepConfig;
-      const stepName = `step_${i}`;
-      const isResuming = resumeAtIndex === i;
+      const stepName = pathPrefix ? `${pathPrefix}.${i}` : `step_${i}`;
+      if (store) store.currentStepName = stepName;
+      const isResuming =
+        resumeCursor !== null && resumeCursor[0] === i && resumeCursor.length === 1;
+      const stepCursor =
+        resumeCursor !== null && resumeCursor[0] === i && resumeCursor.length > 1
+          ? resumeCursor
+          : null;
 
       if (!isResuming) {
         await this.upsertStepRow(runId, stepName, step, 'RUNNING', null);
       }
 
       try {
-        await this.executeStep(step, context, { runId, stepName, isResuming });
+        await this.executeStep(step, context, {
+          runId,
+          stepName,
+          isResuming,
+          resumeCursor: stepCursor,
+        });
 
         const stepCtxEntry = context.steps[step.id];
         await this.markStepCompleted(runId, stepName, stepCtxEntry);
       } catch (err) {
         if (PauseStep.is(err)) {
-          await this.markStepWaiting(runId, stepName, context.steps[step.id], err.statePatch);
+          if (!err.pausePath) {
+            await this.markStepWaiting(runId, stepName, context.steps[step.id], err.statePatch);
+            err.pausePath = stepName;
+          }
+          if (pathPrefix) {
+            throw err;
+          }
+          context.__meta = { ...context.__meta, resumePath: err.pausePath };
           await persistAutomationPauseState(runId, {
             context: JSON.stringify(context),
             currentStepIndex: i,
@@ -415,28 +502,6 @@ export class AutomationExecutor {
       }
     }
     return { kind: 'completed' };
-  }
-
-  private async walkNestedBranch(
-    steps: AutomationStepConfig[],
-    context: AutomationContext,
-  ): Promise<void> {
-    for (const step of steps) {
-      try {
-        await this.executeStep(step, context, {
-          runId: '',
-          stepName: '',
-          isResuming: false,
-        });
-      } catch (err) {
-        if (PauseStep.is(err)) {
-          throw new Error(
-            `Step "${step.id}" (${step.type}) tried to pause inside a control-flow branch. Pausing is only supported at the top level — restructure the automation so the waiting step is not nested.`,
-          );
-        }
-        throw err;
-      }
-    }
   }
 
   private async upsertStepRow(
@@ -530,7 +595,12 @@ export class AutomationExecutor {
   private async executeStep(
     step: AutomationStepConfig,
     context: AutomationContext,
-    callCtx: { runId: string; stepName: string; isResuming: boolean },
+    callCtx: {
+      runId: string;
+      stepName: string;
+      isResuming: boolean;
+      resumeCursor?: StepPathSegment[] | null;
+    },
   ): Promise<void> {
     const stepImpl = this.stepRegistry.get(step.type);
 
@@ -548,7 +618,18 @@ export class AutomationExecutor {
       const t0 = Date.now();
       logger.info(`[automations] step START id=${step.id} type=${step.type}`);
       const output = await controlImpl.execute(safeResult.data, context, {
-        walkBranch: (steps, ctx) => this.walkNestedBranch(steps, ctx),
+        walkBranch: (steps, ctx, branchKey) => {
+          const childPath = `${callCtx.stepName}.${branchKey}`;
+          const subCursor =
+            callCtx.resumeCursor &&
+            callCtx.resumeCursor.length > 1 &&
+            callCtx.resumeCursor[1] === branchKey
+              ? callCtx.resumeCursor.slice(2)
+              : null;
+          return this.walkStepsRecursive(steps, ctx, callCtx.runId, childPath, subCursor).then(
+            () => {},
+          );
+        },
       });
       context.steps[step.id] = { type: step.type, output };
       logger.info(

--- a/apps/backend/src/automations/engine/pause-step.ts
+++ b/apps/backend/src/automations/engine/pause-step.ts
@@ -1,6 +1,7 @@
 export class PauseStep extends Error {
   readonly externalRef: string | undefined;
   readonly statePatch: Record<string, unknown> | undefined;
+  pausePath: string | undefined;
 
   constructor(
     reason: string,

--- a/apps/backend/src/automations/steps/base-step.ts
+++ b/apps/backend/src/automations/steps/base-step.ts
@@ -5,7 +5,11 @@ import type { AutomationStepConfig } from '../types/automation-config';
 import { StepCategory } from '../types/categories';
 
 export interface ControlFlowExecutionContext {
-  walkBranch(steps: AutomationStepConfig[], context: AutomationContext): Promise<void>;
+  walkBranch(
+    steps: AutomationStepConfig[],
+    context: AutomationContext,
+    branchKey: string,
+  ): Promise<void>;
 }
 
 export enum StepKind {

--- a/apps/backend/src/automations/steps/conditional.step.ts
+++ b/apps/backend/src/automations/steps/conditional.step.ts
@@ -38,7 +38,7 @@ export class ConditionalStep extends BaseControlFlowStep<typeof ConditionalConfi
   ): Promise<ConditionalOutput> {
     const result = this.evaluator.evaluate(config.condition, context);
     const branch = (result ? config.if_true : (config.if_false ?? [])) as AutomationStepConfig[];
-    await ctx.walkBranch(branch, context);
+    await ctx.walkBranch(branch, context, result ? 'if_true' : 'if_false');
     return { result };
   }
 }

--- a/apps/backend/src/automations/steps/delay.step.ts
+++ b/apps/backend/src/automations/steps/delay.step.ts
@@ -96,7 +96,8 @@ export class DelayStep extends BaseActionStep<typeof DelayConfigSchema, DelayOut
 
     const stepCount = Object.keys(context.steps).length;
     const currentIndex = Math.max(0, stepCount - 1);
-    const jobId = `${store.runId}:delay:step_${currentIndex}`;
+    const stepName = store.currentStepName ?? `step_${currentIndex}`;
+    const jobId = `${store.runId}:delay:${stepName}`;
 
     logger.info(
       `[DELAY] scheduling wake-up — executionId=${store.runId} jobId=${jobId} amount=${amount} unit=${unit} delayedUntil=${delayedUntil}`,

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -65,9 +65,10 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
 
     const stepCount = Object.keys(context.steps).length;
     const currentIndex = Math.max(0, stepCount - 1);
+    const stepName = store.currentStepName ?? `step_${currentIndex}`;
 
-    const sessionId = `${store.runId}:step_${currentIndex}`;
-    const callbackUrl = buildCallbackUrl(store.runId, `step_${currentIndex}`);
+    const sessionId = `${store.runId}:${stepName}`;
+    const callbackUrl = buildCallbackUrl(store.runId, stepName);
 
     const agentSlug = cfg.agentSlug as string;
     const prompt = cfg.prompt as string;
@@ -161,10 +162,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     if (!store) {
       throw new Error('[RUN_AGENT] retry attempted outside an automation context');
     }
-    const stepName =
-      typeof rowData['stepName'] === 'string'
-        ? (rowData['stepName'] as string)
-        : deriveStepNameFromCtx(context);
+    const stepName = store.currentStepName ?? deriveStepNameFromCtx(context);
     if (!stepName) {
       throw new Error('[RUN_AGENT] cannot derive stepName for retry');
     }

--- a/apps/backend/src/automations/steps/switch.step.ts
+++ b/apps/backend/src/automations/steps/switch.step.ts
@@ -45,12 +45,12 @@ export class SwitchStep extends BaseControlFlowStep<typeof SwitchConfigSchema, S
       const caseEntry = config.cases[i]!;
       const matched = this.evaluator.evaluate(caseEntry.condition, context);
       if (matched) {
-        await ctx.walkBranch(caseEntry.steps as AutomationStepConfig[], context);
+        await ctx.walkBranch(caseEntry.steps as AutomationStepConfig[], context, `case_${i}`);
         return { matchedIndex: i };
       }
     }
     // No case matched — run default branch
-    await ctx.walkBranch(config.default as AutomationStepConfig[], context);
+    await ctx.walkBranch(config.default as AutomationStepConfig[], context, 'default');
     return { matchedIndex: -1 };
   }
 }

--- a/apps/backend/src/automations/types/context.ts
+++ b/apps/backend/src/automations/types/context.ts
@@ -74,5 +74,6 @@ export interface AutomationContext {
   __meta?: {
     error?: string | null;
     chain?: readonly string[];
+    resumePath?: string;
   };
 }


### PR DESCRIPTION
## Problem

DELAY and RUN_AGENT steps inside CONDITIONAL/SWITCH branches fail with:
> Step "stp_..." (DELAY) tried to pause inside a control-flow branch. Pausing is only supported at the top level — restructure the automation so the waiting step is not nested.

This is a deliberate guard in `walkNestedBranch()` (automation-executor.ts:434) that catches `PauseStep` from nested steps and rethrows as a top-level-only error. The guard exists because the resume mechanism could not navigate back into a branch — `currentStepIndex` is a single integer, and `walkNestedBranch` runs with empty `runId`/`stepName`.

## Solution

Replace the split walker (`walkSteps` + `walkNestedBranch`) with a unified recursive walker (`walkStepsRecursive`) that carries a **hierarchical step path** (e.g. `step_2.if_true.1`) and a **resume cursor** for navigation.

### Changes (9 files, +153/-60)

| File | Change |
|---|---|
| `automation-executor.ts` | Replace `walkSteps` + `walkNestedBranch` with `walkStepsRecursive`; add `parseStepPath`, `resolveStepConfigByName`, `getBranchSteps` helpers; thread `resumeCursor` through `executeStep` and `walkBranch` callback; store `resumePath` in `context.__meta` |
| `pause-step.ts` | Add mutable `pausePath` property — set by the walker when catching a nested pause |
| `automation-context-storage.ts` | Add `currentStepName?` to `AutomationContextStore` |
| `context.ts` | Add `resumePath?` to `__meta` |
| `base-step.ts` | Add `branchKey: string` param to `walkBranch` in `ControlFlowExecutionContext` |
| `conditional.step.ts` | Pass `'if_true'` / `'if_false'` as `branchKey` |
| `switch.step.ts` | Pass `` `case_${i}` `` / `'default'` as `branchKey` |
| `delay.step.ts` | Use `store.currentStepName` for `jobId` instead of `Object.keys(context.steps).length - 1` heuristic |
| `run-agent.step.ts` | Use `store.currentStepName` for `sessionId` / `callbackUrl` in both `execute` and `handleValidationFailure` |

### How it works

1. **Walk**: `walkStepsRecursive` walks steps top-level OR nested via `walkBranch`. Each step gets a hierarchical name: `step_0`, `step_1.if_true.0`, `step_2.case_1.3`, etc.
2. **Pause**: When a nested step throws `PauseStep`, the recursive walker catches it, marks the step row as `EXTERNAL_WAIT`, sets `err.pausePath = stepName`, and re-throws. The top-level handler reads `pausePath`, stores it in `context.__meta.resumePath`, persists pause state, and sets the execution to `EXTERNAL_WAIT`.
3. **Resume**: `prepareRun` reads `resumePath` from `context.__meta`. `runSteps` builds a `resumeCursor` (array of path segments) from it. The walker uses the cursor to skip completed steps and navigate into the correct branch, calling `onResume` instead of `execute` for the paused step.

### Backward compatibility

- Old paused runs without `resumePath` in `__meta` fall back to `currentStepIndex` as a top-level cursor
- Top-level step names (`step_0`, `step_1`, ...) are unchanged
- No Prisma migration needed — `resumePath` stored in existing `context` JSON blob

### Testing

- `tsc --noEmit` passes with zero errors
- No existing tests in `automations/` directory to update

## Checklist

- [x] Code changes are minimal and clinical
- [x] TypeScript typecheck passes
- [x] No Prisma migration required
- [x] Backward compatible with in-flight paused runs
- [x] Branch naming follows convention (`feature/` prefix)