### PR TITLE
Feature/dim changes+evaluate vespa 1

### DIFF
--- a/apps/backend/src/controllers/vespaBackfillController.ts
+++ b/apps/backend/src/controllers/vespaBackfillController.ts
@@ -19,7 +19,7 @@ import {
 import { AttachmentEntityType, ChannelType, Prisma } from '@prisma/client';
 import { isSupportedMimeType } from '@/services/fileProcessor';
 
-type BackfillFilters = {
+export type BackfillFilters = {
   channelType?: ChannelType;
 };
 
@@ -48,6 +48,37 @@ function parseBackfillFilters(raw: unknown): BackfillFilters | null {
 }
 
 /**
+ * Parses the `fields` query param: a JSON string mapping schema name -> field names,
+ * e.g. {"tickets":["title","priority"],"messages":["threadMentions"]}
+ * Requesting fields for a schema switches its backfill from a full 'feed' to a
+ * partial 'update' restricted to those fields (see AdminBackfillController.backfillX methods).
+ */
+function parseBackfillFields(raw: unknown): Record<string, string[]> | null {
+  if (!raw) return null;
+  if (typeof raw !== 'string') {
+    throw new Error('fields must be a JSON string');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('fields must be valid JSON');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('fields must be a JSON object mapping schema name to an array of field names');
+  }
+
+  const result: Record<string, string[]> = {};
+  for (const [schemaName, fieldNames] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!Array.isArray(fieldNames) || fieldNames.some((f) => typeof f !== 'string') || fieldNames.length === 0) {
+      throw new Error(`fields.${schemaName} must be a non-empty array of field name strings`);
+    }
+    result[schemaName] = fieldNames;
+  }
+  return result;
+}
+
+/**
  * Admin controller for Vespa backfill operations
  * Provides endpoints to trigger data ingestion into Vespa
  */
@@ -59,7 +90,7 @@ export class AdminBackfillController {
    * Only backfills messages updated within the specified time range
    * If no timeframe is provided, backfills all messages
    */
-  private static async backfillMessages(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillMessages(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {};
 
@@ -116,9 +147,10 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
       await vespaBackfillQueue.addJob({
         schema: messageSchema,
-        jobType: 'feed',
+        jobType: fields?.length ? 'update' : 'feed',
         docId: messageRef.messageId,
-        userId: undefined // backfill jobs don't have a specific user
+        userId: undefined, // backfill jobs don't have a specific user
+        fields,
       });
       totalQueued++;
         } catch (error) {
@@ -140,7 +172,7 @@ export class AdminBackfillController {
    * Only backfills channels updated within the specified time range
    * If no timeframe is provided, backfills all channels
    */
-  private static async backfillChannels(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillChannels(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {};
 
@@ -197,10 +229,11 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
         await vespaBackfillQueue.addJob({
           schema: channelSchema,
-          jobType: 'feed',
+          jobType: fields?.length ? 'update' : 'feed',
           docId: channelRef.id,
           userId: undefined, // backfill jobs don't have a specific user
           workspaceId: channelRef.workspaceId,
+          fields,
         });
         totalQueued++;
         } catch (error) {
@@ -222,7 +255,7 @@ export class AdminBackfillController {
    * Only backfills calls updated within the specified time range.
    * If no timeframe is provided, backfills all calls.
    */
-  private static async backfillCalls(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillCalls(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: Prisma.CallWhereInput = {};
 
@@ -274,9 +307,10 @@ export class AdminBackfillController {
         try {
           await vespaBackfillQueue.addJob({
             schema: callSchema,
-            jobType: 'feed',
+            jobType: fields?.length ? 'update' : 'feed',
             docId: callRef.id,
             userId: undefined,
+            fields,
           });
           totalQueued++;
         } catch (error) {
@@ -297,7 +331,7 @@ export class AdminBackfillController {
    * Only backfills projects updated within the specified time range
    * If no timeframe is provided, backfills all projects
    */
-  private static async backfillProjects(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillProjects(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {};
 
@@ -354,10 +388,11 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
         await vespaBackfillQueue.addJob({
           schema: projectSchema,
-          jobType: 'feed',
+          jobType: fields?.length ? 'update' : 'feed',
           docId: projectRef.id,
           userId: undefined, // backfill jobs don't have a specific user
           workspaceId: projectRef.workspaceId,
+          fields,
         });
         totalQueued++;
         } catch (error) {
@@ -379,7 +414,7 @@ export class AdminBackfillController {
    * Queues a feed job per app; the worker re-fetches the row and derives
    * workspaceId + creator identity from the creator's user record (mapApp).
    */
-  private static async backfillApps(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillApps(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let whereClause: Prisma.AppsWhereInput = {};
     if (cutoffTime) {
       whereClause = fromTime
@@ -410,7 +445,7 @@ export class AdminBackfillController {
 
       for (const app of apps) {
         try {
-          await vespaBackfillQueue.addJob({ schema: appSchema, jobType: 'feed', docId: app.id });
+          await vespaBackfillQueue.addJob({ schema: appSchema, jobType: fields?.length ? 'update' : 'feed', docId: app.id, fields });
           totalQueued++;
         } catch (error) {
           logger.error(`[Backfill] Failed to queue app ${app.id}:`, error);
@@ -434,6 +469,7 @@ export class AdminBackfillController {
     cutoffTime?: Date,
     fromTime?: Date | null,
     filters?: BackfillFilters | null,
+    fields?: string[],
   ): Promise<number> {
     let timeRange: string;
     let whereClause: any = {};
@@ -509,10 +545,11 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
         await vespaBackfillQueue.addJob({
           schema: ticketSchema,
-          jobType: 'feed',
+          jobType: fields?.length ? 'update' : 'feed',
           docId: ticketRef.id,
           userId: undefined, // backfill jobs don't have a specific user
           workspaceId: ticketRef.workspaceId,
+          fields,
         });
         totalQueued++;
         } catch (error) {
@@ -535,7 +572,7 @@ export class AdminBackfillController {
    * Vespa Redis queue; the worker fetches + maps via mapEmail() and feeds Vespa.
    * If no timeframe is provided, backfills all emails.
    */
-  private static async backfillMail(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillMail(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {};
 
@@ -588,9 +625,10 @@ export class AdminBackfillController {
         try {
           await vespaBackfillQueue.addJob({
             schema: mailSchema,
-            jobType: 'feed',
+            jobType: fields?.length ? 'update' : 'feed',
             docId: emailRef.id,
             userId: undefined,
+            fields,
           });
           totalQueued++;
         } catch (error) {
@@ -611,7 +649,7 @@ export class AdminBackfillController {
    * Only backfills canvases updated within the specified time range
    * If no timeframe is provided, backfills all canvases
    */
-  private static async backfillCanvases(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillCanvases(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {};
 
@@ -668,10 +706,11 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
           await vespaBackfillQueue.addJob({
             schema: fileSchema,
-            jobType: 'feed',
+            jobType: fields?.length ? 'update' : 'feed',
             docId: canvasRef.id,
             userId: undefined, // backfill jobs don't have a specific user
             app: SubApp.CANVAS,
+            fields,
           });
           totalQueued++;
         } catch (error) {
@@ -693,28 +732,29 @@ export class AdminBackfillController {
    * Only backfills message attachments with entityType=CHAT updated within the specified time range
    * If no timeframe is provided, backfills all chat attachments
    */
-  private static async backfillChatAttachments(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillChatAttachments(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {
       entityType: AttachmentEntityType.CHAT || AttachmentEntityType.IMPACT, // Backfill both chat attachments
     };
 
     // Build where clause based on provided timeframe
+    // Note: MessageAttachment has no updatedAt field, only createdAt.
     if (cutoffTime) {
       if (fromTime) {
-        timeRange = `(updated between ${fromTime.toISOString()} and ${cutoffTime.toISOString()})`;
+        timeRange = `(created between ${fromTime.toISOString()} and ${cutoffTime.toISOString()})`;
         whereClause = {
           ...whereClause,
-          updatedAt: {
+          createdAt: {
             gte: fromTime,
             lte: cutoffTime,
           },
         };
       } else {
-        timeRange = `(updated before ${cutoffTime.toISOString()})`;
+        timeRange = `(created before ${cutoffTime.toISOString()})`;
         whereClause = {
           ...whereClause,
-          updatedAt: {
+          createdAt: {
             lte: cutoffTime,
           },
         };
@@ -759,11 +799,12 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
           await vespaBackfillQueue.addJob({
             schema: fileSchema,
-            jobType: 'feed',
+            jobType: fields?.length ? 'update' : 'feed',
             docId: attachmentRef.id,
             userId: attachmentRef.createdBy,
             app: SubApp.CHAT_ATTACHMENT,
             workspaceId: attachmentRef.workspaceId,
+            fields,
           });
           totalQueued++;
         } catch (error) {
@@ -785,28 +826,29 @@ export class AdminBackfillController {
    * Only backfills message attachments with entityType=TICKET updated within the specified time range
    * If no timeframe is provided, backfills all ticket attachments
    */
-  private static async backfillTicketAttachments(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillTicketAttachments(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {
       entityType: AttachmentEntityType.TICKET,
     };
 
     // Build where clause based on provided timeframe
+    // Note: MessageAttachment has no updatedAt field, only createdAt.
     if (cutoffTime) {
       if (fromTime) {
-        timeRange = `(updated between ${fromTime.toISOString()} and ${cutoffTime.toISOString()})`;
+        timeRange = `(created between ${fromTime.toISOString()} and ${cutoffTime.toISOString()})`;
         whereClause = {
           ...whereClause,
-          updatedAt: {
+          createdAt: {
             gte: fromTime,
             lte: cutoffTime,
           },
         };
       } else {
-        timeRange = `(updated before ${cutoffTime.toISOString()})`;
+        timeRange = `(created before ${cutoffTime.toISOString()})`;
         whereClause = {
           ...whereClause,
-          updatedAt: {
+          createdAt: {
             lte: cutoffTime,
           },
         };
@@ -851,11 +893,12 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
           await vespaBackfillQueue.addJob({
             schema: fileSchema,
-            jobType: 'feed',
+            jobType: fields?.length ? 'update' : 'feed',
             docId: attachmentRef.id,
             userId: attachmentRef.createdBy,
             app: SubApp.TICKET_ATTACHMENT,
             workspaceId: attachmentRef.workspaceId,
+            fields,
           });
           totalQueued++;
         } catch (error) {
@@ -877,7 +920,7 @@ export class AdminBackfillController {
    * Only backfills calls with transcripts updated within the specified time range
    * If no timeframe is provided, backfills all calls with transcripts
    */
-  private static async backfillTranscripts(cutoffTime?: Date, fromTime?: Date | null): Promise<number> {
+  private static async backfillTranscripts(cutoffTime?: Date, fromTime?: Date | null, fields?: string[]): Promise<number> {
     let timeRange: string;
     let whereClause: any = {
       transcript: {
@@ -939,10 +982,11 @@ export class AdminBackfillController {
           // Queue only the ID - worker will handle the processing
           await vespaBackfillQueue.addJob({
             schema: fileSchema,
-            jobType: 'feed',
+            jobType: fields?.length ? 'update' : 'feed',
             docId: callRef.id,
             userId: undefined, // backfill jobs don't have a specific user
             app: SubApp.TRANSCRIPT,
+            fields,
           });
           totalQueued++;
         } catch (error) {
@@ -1130,6 +1174,7 @@ export class AdminBackfillController {
       const fromTimestampParam = req.query.fromTimestamp as string | undefined;
       const toTimestampParam = req.query.toTimestamp as string | undefined;
       const filtersParam = req.query.filters as string | undefined;
+      const fieldsParam = req.query.fields as string | undefined;
       const queueName = req.query.queueName as string;
 
       // Determine which schemas to backfill
@@ -1228,6 +1273,32 @@ export class AdminBackfillController {
         return;
       }
 
+      let fieldsBySchema: Record<string, string[]> | null = null;
+      if (fieldsParam) {
+        try {
+          fieldsBySchema = parseBackfillFields(fieldsParam);
+        } catch (error) {
+          res.status(400).json({
+            success: false,
+            error: 'Invalid fields parameter',
+            message: error instanceof Error ? error.message : 'Invalid fields parameter',
+            timestamp: new Date().toISOString(),
+          } as ApiResponse);
+          return;
+        }
+
+        const unknownSchemas = Object.keys(fieldsBySchema ?? {}).filter(s => !schemasToBackfill.includes(s));
+        if (unknownSchemas.length > 0) {
+          res.status(400).json({
+            success: false,
+            error: 'fields references schemas not included in this backfill',
+            message: `Add these to schemas or remove them from fields: ${unknownSchemas.join(', ')}`,
+            timestamp: new Date().toISOString(),
+          } as ApiResponse);
+          return;
+        }
+      }
+
       logger.info(`📊 Backfilling schemas: ${schemasToBackfill.join(', ')}`);
 
       // Get initial queue stats
@@ -1250,6 +1321,7 @@ export class AdminBackfillController {
         initialQueueStats: initialStats,
         statusEndpoint: '/api/admin/vespa-backfill/stats',
         filters: filters ?? null,
+        fields: fieldsBySchema ?? null,
       };
 
       // Add time info based on whether we have a timeframe
@@ -1279,6 +1351,7 @@ export class AdminBackfillController {
         cutoffTime,
         fromTime,
         filters,
+        fieldsBySchema,
       )
         .catch((error) => {
           logger.error(`❌ Background backfill failed for job ${backfillJobId}:`, error);
@@ -1298,7 +1371,9 @@ export class AdminBackfillController {
 
   /**
    * Execute backfill in the background without blocking the API response
-   * This method is called asynchronously and runs independently
+   * This method is called asynchronously and runs independently.
+   * When `fieldsBySchema` has an entry for a schema, that schema's jobs are field-scoped
+   * partial updates (only those document fields) instead of full feeds.
    */
   private static async executeBackfillInBackground(
     schemasToBackfill: string[],
@@ -1307,6 +1382,7 @@ export class AdminBackfillController {
     cutoffTime?: Date,
     fromTime?: Date | null,
     filters?: BackfillFilters | null,
+    fieldsBySchema?: Record<string, string[]> | null,
   ): Promise<void> {
     try {
       const timeRangeStr = cutoffTime
@@ -1319,47 +1395,47 @@ export class AdminBackfillController {
       const stats: Record<string, number> = {};
 
       if (schemasToBackfill.includes('projects')) {
-        stats.projects = await AdminBackfillController.backfillProjects(cutoffTime, fromTime);
+        stats.projects = await AdminBackfillController.backfillProjects(cutoffTime, fromTime, fieldsBySchema?.['projects']);
       }
 
       if (schemasToBackfill.includes('channels')) {
-        stats.channels = await AdminBackfillController.backfillChannels(cutoffTime, fromTime);
+        stats.channels = await AdminBackfillController.backfillChannels(cutoffTime, fromTime, fieldsBySchema?.['channels']);
       }
 
       if (schemasToBackfill.includes('messages')) {
-        stats.messages = await AdminBackfillController.backfillMessages(cutoffTime, fromTime);
+        stats.messages = await AdminBackfillController.backfillMessages(cutoffTime, fromTime, fieldsBySchema?.['messages']);
       }
 
       if (schemasToBackfill.includes('tickets')) {
-        stats.tickets = await AdminBackfillController.backfillTickets(cutoffTime, fromTime, filters);
+        stats.tickets = await AdminBackfillController.backfillTickets(cutoffTime, fromTime, filters, fieldsBySchema?.['tickets']);
       }
 
       if (schemasToBackfill.includes('canvases')) {
-        stats.canvases = await AdminBackfillController.backfillCanvases(cutoffTime, fromTime);
+        stats.canvases = await AdminBackfillController.backfillCanvases(cutoffTime, fromTime, fieldsBySchema?.['canvases']);
       }
 
       if (schemasToBackfill.includes('transcripts')) {
-        stats.transcripts = await AdminBackfillController.backfillTranscripts(cutoffTime, fromTime);
+        stats.transcripts = await AdminBackfillController.backfillTranscripts(cutoffTime, fromTime, fieldsBySchema?.['transcripts']);
       }
 
       if (schemasToBackfill.includes('chat_attachments')) {
-        stats.chat_attachments = await AdminBackfillController.backfillChatAttachments(cutoffTime, fromTime);
+        stats.chat_attachments = await AdminBackfillController.backfillChatAttachments(cutoffTime, fromTime, fieldsBySchema?.['chat_attachments']);
       }
 
       if (schemasToBackfill.includes('ticket_attachments')) {
-        stats.ticket_attachments = await AdminBackfillController.backfillTicketAttachments(cutoffTime, fromTime);
+        stats.ticket_attachments = await AdminBackfillController.backfillTicketAttachments(cutoffTime, fromTime, fieldsBySchema?.['ticket_attachments']);
       }
 
       if (schemasToBackfill.includes('mail')) {
-        stats.mail = await AdminBackfillController.backfillMail(cutoffTime, fromTime);
+        stats.mail = await AdminBackfillController.backfillMail(cutoffTime, fromTime, fieldsBySchema?.['mail']);
       }
 
       if (schemasToBackfill.includes('app')) {
-        stats.app = await AdminBackfillController.backfillApps(cutoffTime, fromTime);
+        stats.app = await AdminBackfillController.backfillApps(cutoffTime, fromTime, fieldsBySchema?.['app']);
       }
 
       if (schemasToBackfill.includes('calls')) {
-        stats.calls = await AdminBackfillController.backfillCalls(cutoffTime, fromTime);
+        stats.calls = await AdminBackfillController.backfillCalls(cutoffTime, fromTime, fieldsBySchema?.['calls']);
       }
 
       const totalQueued = Object.values(stats).reduce((sum, count) => sum + count, 0);

--- a/apps/backend/src/services/memoryService.ts
+++ b/apps/backend/src/services/memoryService.ts
@@ -17,6 +17,8 @@ import {
 import { User } from '@prisma/client';
 import { DatabaseClient } from '@/database/client';
 import removeMarkdown from 'remove-markdown';
+import { superpositionClient } from '@/services/superpositionClient';
+import { resolveEmbeddingVariant } from '@/vespa/src/utils/YqlBuilder';
 
 const MEMORY_SCHEMA = memorySchema;
 
@@ -73,8 +75,10 @@ async function buildMemoryYql(params: {
   parentRef?: string;
   reviewStatus?: string;
   docId?: string;
+  useV2Embeddings?: boolean;
 }): Promise<string> {
-  const { query, scope, userId, limit, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus, docId } = params;
+  const { query, scope, userId, limit, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus, docId, useV2Embeddings = false } = params;
+  const { tensor, fieldSuffix } = resolveEmbeddingVariant(useV2Embeddings);
 
   const conditions: string[] = [];
 
@@ -160,7 +164,7 @@ async function buildMemoryYql(params: {
   // Search condition (text + vector)
   if (query && query.trim()) {
     conditions.push(
-      `(userInput(@query) or ({targetHits:${limit}} nearestNeighbor(summary_embeddings, e)))`,
+      `(userInput(@query) or ({targetHits:${limit}} nearestNeighbor(summary_embeddings${fieldSuffix}, ${tensor})))`,
     );
   }
 
@@ -249,6 +253,20 @@ export async function searchMemory(
 ): Promise<MemorySearchResult> {
   const { query, scope, limit = 20, offset = 0, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus , includeQuery = true, includeSummary = true, docId} = request;
 
+  // hf1 dual-embedding migration: switch memory vector retrieval + query embedding
+  // to the bge-large (1024) fields / `e_v2` tensor / `hf1` embedder when enabled.
+  const useV2Embeddings = await superpositionClient.getBooleanValue(
+    'vespa_search_use_v2_embeddings',
+    false,
+    {},
+  );
+  {
+    const v = resolveEmbeddingVariant(useV2Embeddings);
+    logger.info(
+      `[embeddings] memory-search using ${useV2Embeddings ? 'V2 (bge-large 1024)' : 'V1 (bge-base 768)'} — embedder=${v.embedder}, tensor=${v.tensor}, fieldSuffix='${v.fieldSuffix}'`,
+    );
+  }
+
   const yql = await buildMemoryYql({
     query,
     scope,
@@ -265,6 +283,7 @@ export async function searchMemory(
     parentRef,
     reviewStatus,
     docId,
+    useV2Embeddings,
   });
 
 
@@ -279,7 +298,10 @@ export async function searchMemory(
   // Add query and embedding input only when query is present
   if (query && query.trim()) {
     payload.query = query;
-    payload['input.query(e)'] = 'embed(hf-embedder, @query)';
+    // Embedder must be named once hf1 exists (two embedders => ambiguous shorthand).
+    // Tensor + embedder follow the v2 flag (e/hf-embedder vs e_v2/hf1).
+    const { tensor: queryTensor, embedder } = resolveEmbeddingVariant(useV2Embeddings);
+    payload[`input.query(${queryTensor})`] = `embed(${embedder}, @query)`;
     payload['input.query(alpha)'] = 0.5;
     payload['input.query(includeSummary)'] = Number(includeSummary);
     payload['input.query(includeQuery)'] = Number(includeQuery);

--- a/apps/backend/src/services/vespaSamTranscriptTransformer.ts
+++ b/apps/backend/src/services/vespaSamTranscriptTransformer.ts
@@ -5,6 +5,7 @@ import {
   AIAnalysis,
   VespaDocType,
 } from '@/vespa/src/types';
+import { chunkPlainText } from '@/utils/vespaChunking';
 
 export type { SamTranscriptInput, AIAnalysis };
 
@@ -24,6 +25,10 @@ export function transformSamTranscriptToVespa(
   logger.info(`[VESPA_TRANSFORMER] Transforming SAM transcript: docId=${docId}, meetCode=${data.meetCode}`);
 
   const dateTimeTime = toTimestamp(data.dateTime);
+  const chapters = data.aiAnalysedData.chapters?.length ? JSON.stringify(data.aiAnalysedData.chapters) : undefined;
+  const actionItems = data.aiAnalysedData.action_items?.length ? JSON.stringify(data.aiAnalysedData.action_items) : undefined;
+  const others = data.aiAnalysedData.others?.length ? JSON.stringify(data.aiAnalysedData.others) : undefined;
+  const qna = data.aiAnalysedData.q_n_a?.length ? JSON.stringify(data.aiAnalysedData.q_n_a) : undefined;
 
   const vespaDoc: VespaSamTranscriptDocument = {
     docId: docId,
@@ -34,10 +39,11 @@ export function transformSamTranscriptToVespa(
     type: data.type,
     duration: data.duration,
     meetingSummary: data.aiAnalysedData.summary, // SAM sends 'summary', Vespa expects 'meetingSummary' (reserved word workaround)
-    chapters: data.aiAnalysedData.chapters?.length ? JSON.stringify(data.aiAnalysedData.chapters) : undefined,
-    actionItems: data.aiAnalysedData.action_items?.length ? JSON.stringify(data.aiAnalysedData.action_items) : undefined,
-    others: data.aiAnalysedData.others ? JSON.stringify(data.aiAnalysedData.others) : undefined,
-    qna: data.aiAnalysedData.q_n_a?.length ? JSON.stringify(data.aiAnalysedData.q_n_a) : undefined,
+    chapters,
+    actionItems,
+    others,
+    qna,
+    chunks: chunkPlainText(data.aiAnalysedData.summary),
     dateTime: dateTimeTime,
     merchants: data.merchants || [],
   };

--- a/apps/backend/src/utils/vespaChunking.ts
+++ b/apps/backend/src/utils/vespaChunking.ts
@@ -1,0 +1,36 @@
+export const VESPA_EMBEDDING_CHUNK_SIZE = 5;
+
+/**
+ * Split searchable text into non-empty, whitespace-normalized chunks that fit
+ * below the embedding model's input limit. Prefer word boundaries, but hard
+ * split an individual oversized token so the maximum is always respected.
+ *
+ * Vespa's array embedder creates one mapped tensor cell per returned chunk.
+ * An empty input is represented by a single empty chunk to preserve the
+ * existing feed behaviour for optional text fields.
+ */
+export const chunkPlainText = (
+  text: string,
+  maxLen = VESPA_EMBEDDING_CHUNK_SIZE,
+): string[] => {
+  if (!Number.isInteger(maxLen) || maxLen <= 0) {
+    throw new Error('maxLen must be a positive integer');
+  }
+
+  let remaining = text.trim().replace(/\s+/g, ' ');
+  if (!remaining) return [''];
+
+  const chunks: string[] = [];
+  while (remaining.length > maxLen) {
+    let splitAt = remaining.lastIndexOf(' ', maxLen + 1);
+    if (splitAt <= 0) splitAt = maxLen;
+
+    const chunk = remaining.slice(0, splitAt).trim();
+    if (chunk) chunks.push(chunk);
+    remaining = remaining.slice(splitAt).trimStart();
+  }
+
+  if (remaining) chunks.push(remaining);
+  return chunks.length > 0 ? chunks : [''];
+};
+

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -20,7 +20,7 @@ import {
 import VespaClient from '../client/vespaClient';
 import { getErrorMessage } from '../utils';
 import config from '../config';
-import { YqlBuilder, type SlackFilters, type TicketFilters, type FileFilters, type MeetingFilters, type MailFilters, type CallFilters } from '../utils/YqlBuilder';
+import { YqlBuilder, resolveEmbeddingVariant, type SlackFilters, type TicketFilters, type FileFilters, type MeetingFilters, type MailFilters, type CallFilters } from '../utils/YqlBuilder';
 import {
   filterByNativeRank,
 } from '../utils/responseProcessor';
@@ -201,6 +201,16 @@ export class SearchService {
     }
 
     const useSemantic = query.trim().length > 3;
+    // hf1 dual-embedding migration flag (app catalog re-ranks via closeness, no NN clause).
+    const useV2Embeddings = await superpositionClient.getBooleanValue(
+      'vespa_search_use_v2_embeddings',
+      false,
+      {}
+    );
+    const { tensor: queryTensor, embedder } = resolveEmbeddingVariant(useV2Embeddings);
+    this.logger.info(
+      `[embeddings] app-search using ${useV2Embeddings ? 'V2 (bge-large 1024)' : 'V1 (bge-base 768)'} — embedder=${embedder}, tensor=${queryTensor}`,
+    );
 
     const { yql, params } = this.yqlBuilder.buildAppYql({
       view,
@@ -220,7 +230,9 @@ export class SearchService {
       'input.query(alpha)': 0.35,
       timeout: '15s',
       'presentation.summary': 'lean',
-      ...(useSemantic ? { 'input.query(e)': 'embed(hf-embedder, @query)' } : {}),
+      // Embedder must be named: with the hf1 migration two embedders exist, so the
+      // unqualified embed shorthand is ambiguous. Tensor + embedder follow the v2 flag.
+      ...(useSemantic ? { [`input.query(${queryTensor})`]: `embed(${embedder}, @query)` } : {}),
     };
 
     try {
@@ -414,11 +426,13 @@ export class SearchService {
           wsId,
           sort,
           isExactMatch,
+          useV2Embeddings,
         );
 
         const hasQuery = !!(searchQuery && searchQuery.trim());
         const queryLength = searchQuery?.trim().length || 0;
         const shouldEmbed = hasQuery && queryLength > 3 && (useSemanticAnyway || useFuzzy);
+        const { tensor: queryTensor, embedder } = resolveEmbeddingVariant(useV2Embeddings);
 
         return {
           yql,
@@ -433,7 +447,9 @@ export class SearchService {
           "input.query(chunk_limit)": chunkLimit,
           "input.query(query_length)": queryWordCount,
           timeout: '30s',
-          ...(shouldEmbed ? { 'input.query(e)': 'embed(hf-embedder, @query)' } : {}),
+          // Embedder must be named once hf1 exists (two embedders => ambiguous shorthand).
+          // Tensor + embedder follow the v2 flag (e/hf-embedder vs e_v2/hf1).
+          ...(shouldEmbed ? { [`input.query(${queryTensor})`]: `embed(${embedder}, @query)` } : {}),
           ...(useFuzzy ? { "gram.match": "weakAnd" } : {}),
           "input.query(freshness_weight)": freshnessWeight,
           "input.query(filtering_weight)": filteringWeight,
@@ -470,6 +486,19 @@ export class SearchService {
         false,
         {}
       );
+      // hf1 dual-embedding migration: when on, semantic retrieval + query embedding
+      // switch to the bge-large (1024) fields / `e_v2` tensor / `hf1` embedder.
+      const useV2Embeddings = await superpositionClient.getBooleanValue(
+        'vespa_search_use_v2_embeddings',
+        false,
+        {}
+      );
+      {
+        const v = resolveEmbeddingVariant(useV2Embeddings);
+        this.logger.info(
+          `[embeddings] search using ${useV2Embeddings ? 'V2 (bge-large 1024)' : 'V1 (bge-base 768)'} — embedder=${v.embedder}, tensor=${v.tensor}, fieldSuffix='${v.fieldSuffix}'`,
+        );
+      }
       const payload = buildPayload(false, useSemanticAnyway, enableWorkspaceFiltering ? effectiveWorkspaceId : undefined);
       this.logger.info(`Payload: ${JSON.stringify(payload)}`);
       if (captureDebug) {

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -192,6 +192,7 @@ export interface VespaChatAttachmentDocument extends VespaDocument {
 
 export interface VespaChatContainerDocument extends VespaDocument {
   channelName: string;
+  chunks: string[];
   scopeType: string;
   visibility: string;
   isIm: boolean;
@@ -264,6 +265,7 @@ export interface VespaTicketDocument extends Omit<VespaDocument, 'orgId' | 'work
   title: string;
   workflowType: string;
   description: string;
+  chunks: string[];
   description_clean?: string;
   ticketType: string;
   priority: TicketPriority;
@@ -446,6 +448,7 @@ export interface VespaSamTranscriptDocument extends VespaDocument {
   actionItems?: string;   // JSON.stringify'd ActionItem[]
   others?: string;        // JSON.stringify'd OtherItem[] — free-form insights (speaker, content, tags)
   qna?: string;           // JSON.stringify'd QnA[] — questions and answers from the meeting
+  chunks: string[];
   dateTime: number;
   merchants: string[];
 }
@@ -525,6 +528,7 @@ export interface VespaAppDocument {
   version: number;
   name: string;
   description: string;
+  chunks: string[];
   createdBy: string;
   creatorName: string;
   creatorEmail: string;

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -214,6 +214,7 @@ export interface VespaChatContainerDocument extends VespaDocument {
 
 export interface VespaChatMessageDocument extends Omit<VespaDocument, 'orgId' | 'workspaceId'> {
   text: string;
+  chunks: string[];
   userId: string;
   username: string;
   userEmail: string;

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -40,6 +40,77 @@ const userInputClause = (defaultIndex?: string, grammar = 'grammar:"tokenize"'):
   return `({${annotations}} userInput(@query))`;
 };
 
+type SemanticField = { field: string; approximate?: boolean };
+
+// Single source of truth for the dual-embedding (hf1) migration switch. When the
+// `vespa_search_use_v2_embeddings` Superposition flag is on, every semantic path
+// swaps to the bge-large (1024) fields + `hf1` embedder + `e_v2` query tensor;
+// otherwise it stays on the bge-base (768) fields + `hf-embedder` + `e` tensor.
+// The v2 fields are the base field name with a `_v2` suffix (see vespa-core schemas).
+export type EmbeddingVariant = { tensor: string; embedder: string; fieldSuffix: string };
+export const resolveEmbeddingVariant = (useV2: boolean): EmbeddingVariant =>
+  useV2
+    ? { tensor: 'e_v2', embedder: 'hf1', fieldSuffix: '_v2' }
+    : { tensor: 'e', embedder: 'hf-embedder', fieldSuffix: '' };
+
+// Only emit nearest-neighbour clauses for fields declared by at least one of
+// the selected schemas. Vespa rejects a YQL field reference when none of the
+// sources in the query declares that field.
+const SEMANTIC_FIELDS_BY_SCHEMA: Partial<Record<VespaSchema, SemanticField[]>> = {
+  [messageSchema]: [
+    { field: 'text_embeddings' },
+    { field: 'chunk_embeddings' },
+  ],
+  [attachmentSchema]: [{ field: 'chunk_embeddings' }],
+  [channelSchema]: [
+    { field: 'chunk_embeddings' },
+    { field: 'content_chunk_embeddings' },
+  ],
+  [ticketSchema]: [
+    { field: 'combined_embeddings', approximate: false },
+    { field: 'chunk_embeddings' },
+  ],
+  [fileSchema]: [
+    { field: 'chunk_embeddings' },
+    { field: 'image_chunk_embeddings' },
+  ],
+  [mailSchema]: [
+    { field: 'subject_embeddings' },
+    { field: 'chunk_embeddings' },
+  ],
+  [samTranscriptSchema]: [
+    { field: 'meetingSummary_embeddings' },
+    { field: 'chapters_embeddings' },
+    { field: 'actionItems_embeddings' },
+    { field: 'others_embeddings' },
+    { field: 'qna_embeddings' },
+    { field: 'chunk_embeddings' },
+  ],
+  [appSchema]: [
+    { field: 'text_embeddings' },
+    { field: 'chunk_embeddings' },
+  ],
+  [callSchema]: [{ field: 'title_embeddings' }],
+};
+
+const semanticClausesForSchemas = (schemas: VespaSchema[], targetHits: number, useV2: boolean): string[] => {
+  const { tensor, fieldSuffix } = resolveEmbeddingVariant(useV2);
+  const fields = new Map<string, SemanticField>();
+  for (const schema of schemas) {
+    for (const semanticField of SEMANTIC_FIELDS_BY_SCHEMA[schema] ?? []) {
+      fields.set(semanticField.field, semanticField);
+    }
+  }
+
+  return [...fields.values()].map(({ field, approximate }) => {
+    const annotations = [
+      `targetHits:${targetHits}`,
+      approximate === false ? 'approximate:false' : undefined,
+    ].filter(Boolean).join(', ');
+    return `({${annotations}} nearestNeighbor(${field}${fieldSuffix}, ${tensor}))`;
+  });
+};
+
 export interface SlackFilters {
   channelId?: string[];
   projectId?: string[];
@@ -200,6 +271,7 @@ export class YqlBuilder {
     workspaceId?: string,
     sort?: string,
     useExactMatch: boolean = false,
+    useV2Embeddings: boolean = false,
   ): { yql: string; params: Record<string, string> } {
     const schemaNames = schemas.join(', ');
     // `limit` is interpolated raw into non-bindable YQL grammar ({targetHits:N}, max(N)); coerce to
@@ -215,6 +287,8 @@ export class YqlBuilder {
 
     // Optimization: Skip semantic search for short queries (< 3 chars) - lexical only
     const useSemantic = useSemanticAnyway && queryLength > 3;
+    const semanticClauses = semanticClausesForSchemas(schemas, safeLimit, useV2Embeddings);
+    const semanticDisjunction = semanticClauses.join('\n      or ');
 
     if (query && query !== '*') {
       if (useExactMatch) {
@@ -226,13 +300,11 @@ export class YqlBuilder {
       } else if (useFuzzy) {
         // Same user-query fields for both fuzzy branches; grammar:"tokenize" applied per clause.
         const lexicalFieldClauses = LEXICAL_FUZZY_FIELDS.map((field) => userInputClause(field)).join('\n      or ');
-        if (useSemantic) {
+        if (useSemantic && semanticClauses.length > 0) {
           // Hybrid: fuzzy lexical + semantic
           whereConditions.push(`(
       ${lexicalFieldClauses}
-      or ({targetHits:${safeLimit}} nearestNeighbor(text_embeddings, e))
-      or ({targetHits:${safeLimit}} nearestNeighbor(chunk_embeddings, e))
-      or ({targetHits:${safeLimit}, approximate:false} nearestNeighbor(combined_embeddings, e))
+      or ${semanticDisjunction}
     )`);
         } else {
           // Lexical only: short query, skip semantic
@@ -241,24 +313,17 @@ export class YqlBuilder {
     )`);
         }
       } else if (isTranscriptOnly) {
-        // sam_transcript schema uses its own embedding fields; text_embeddings/chunk_embeddings don't exist on it
+        // Transcript search uses the section vectors plus the combined chunk vectors.
         whereConditions.push(`(
         ${userInputClause()}
-      or ({targetHits:${safeLimit}} nearestNeighbor(meetingSummary_embeddings, e))
-      or ({targetHits:${safeLimit}} nearestNeighbor(chapters_embeddings, e))
-      or ({targetHits:${safeLimit}} nearestNeighbor(actionItems_embeddings, e))
-      or ({targetHits:${safeLimit}} nearestNeighbor(others_embeddings, e))
-      or ({targetHits:${safeLimit}} nearestNeighbor(qna_embeddings, e))
+      or ${semanticDisjunction}
     )`);
       } else {
         // Lexical only: short query
-        if (useSemantic) {
-          // approximate:false — combined_embeddings' HNSW returns 0 hits under any filter; drop after index rebuild.
+        if (useSemantic && semanticClauses.length > 0) {
           whereConditions.push(`(
           ${userInputClause()}
-        or ({targetHits:${safeLimit}} nearestNeighbor(text_embeddings, e))
-        or ({targetHits:${safeLimit}} nearestNeighbor(chunk_embeddings, e))
-        or ({targetHits:${safeLimit}, approximate:false} nearestNeighbor(combined_embeddings, e))
+        or ${semanticDisjunction}
         )`);
         } else {
           whereConditions.push(userInputClause());

--- a/apps/backend/src/workers/vespaWorker.ts
+++ b/apps/backend/src/workers/vespaWorker.ts
@@ -5,7 +5,7 @@ import { InsertDocument, samTranscriptSchema, VespaSchema } from '@/vespa/src/ty
 import { VespaJob, VespaJobType } from '@/zero/vespa-injection/core/types';
 import { db } from '@/database/client';
 import { NAMESPACE } from '@/vespa/vespaConfig';
-import { fetchAndMapBySchema, VespaOperationType } from '@/zero/vespa-injection/core/mapper';
+import { fetchAndMapBySchema, fetchDataBySchema, mapBySchema, VespaOperationType } from '@/zero/vespa-injection/core/mapper';
 import { vespaPostIngestHooks } from './vespaPostIngestHooks';
 
 export class VespaWorker {
@@ -189,6 +189,20 @@ export class VespaWorker {
 				}
 				logger.info(`[VESPA_WORKER] Using pre-transformed data for SAM transcript ${docId}`);
 				mappedData = preTransformedData as InsertDocument;
+			} else if (jobType === 'update' && job.data.fields?.length) {
+				// Field-scoped update: build the full document the same way a 'feed' would,
+				// then only keep the requested fields for the partial Vespa update.
+				logger.info(`[VESPA_WORKER] Fetching data from database for field-scoped update ${schema}/${docId}: [${job.data.fields.join(', ')}]`);
+				const rawData = await fetchDataBySchema(schema, docId, app);
+				if (!rawData) {
+					throw new Error(`Data not found for ${schema}/${docId}`);
+				}
+				const fullDoc = await mapBySchema(schema, rawData, 'feed', app, job.data.workspaceId, job.data.orgId);
+				mappedData = Object.fromEntries(
+					job.data.fields
+						.filter((field) => field in fullDoc)
+						.map((field) => [field, (fullDoc as Record<string, unknown>)[field]])
+				) as Partial<InsertDocument>;
 			} else {
 				logger.info(`[VESPA_WORKER] Fetching data from database for ${schema}/${docId}`);
 				mappedData = await fetchAndMapBySchema(schema, docId, jobType, app, job.data.workspaceId, job.data.orgId);

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -22,6 +22,7 @@ import { getStorageService } from '@/services/storage';
 import { convertBlockNoteToMarkdown } from '@/services/canvasService';
 import { buildFormFields, type TicketDynamicFieldValue } from './form-fields';
 import { DESK_EMAIL_SOURCE_TYPE } from '@/tags';
+import { chunkPlainText } from '@/utils/vespaChunking';
 
 type ChannelsSchema = Schema['tables']['channels'];
 type MessagesSchema = Schema['tables']['messages'];
@@ -328,6 +329,7 @@ export const mapChannel = async (
     docId: args.id,
     channelName: channelName,
     description: args.description || '',
+    chunks: chunkPlainText(args.description || ''),
     createdAt: toTimestamp(args.createdAt),
     updatedAt: toTimestamp(args.updatedAt),
     permissions: channelParticipants,
@@ -529,6 +531,7 @@ export const mapApp = async (args: Apps): Promise<VespaAppDocument> => {
     version: args.version,
     name: args.name,
     description: args.description ?? '',
+    chunks: chunkPlainText(args.description ?? ''),
     createdBy: args.createdBy,
     creatorName: creator?.name ?? '',
     creatorEmail: creator?.email ?? '',
@@ -650,6 +653,7 @@ export const mapTicket = async (args: InsertValue<TicketsSchema>): Promise<Vespa
     title: args.title,
     workflowType: "",// later we should populate workflow type
     description: args.description,
+    chunks: chunkPlainText(args.description),
     ticketType: "", // later we should populate ticket type
     priority: args.priority,
     stage: args.stageName,
@@ -1344,26 +1348,6 @@ export const mapFile = async (
     workspaceId: effectiveWorkspaceId,
     orgId: effectiveOrgId,
   };
-};
-
-/**
- * Chunk a plain-text string into segments of at most `maxLen` characters,
- * splitting on word boundaries so search snippets are coherent.
- */
-const chunkPlainText = (text: string, maxLen = 1500): string[] => {
-  const words = text.split(/\s+/).filter(Boolean);
-  const chunks: string[] = [];
-  let current = '';
-  for (const word of words) {
-    if (current.length + word.length + 1 > maxLen && current.length > 0) {
-      chunks.push(current);
-      current = word;
-    } else {
-      current = current ? `${current} ${word}` : word;
-    }
-  }
-  if (current) chunks.push(current);
-  return chunks.length > 0 ? chunks : [''];
 };
 
 /**

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -447,6 +447,7 @@ export const mapMessage = async (
     docId: args.messageId,
     docType: VespaDocType.MESSAGE,
     text: messageContent,
+    chunks: chunkPlainText(messageContent),
     username: sender?.name || '',
     userEmail: sender?.email || '',
     image: "",
@@ -1349,7 +1350,7 @@ export const mapFile = async (
  * Chunk a plain-text string into segments of at most `maxLen` characters,
  * splitting on word boundaries so search snippets are coherent.
  */
-const chunkPlainText = (text: string, maxLen = 2000): string[] => {
+const chunkPlainText = (text: string, maxLen = 1500): string[] => {
   const words = text.split(/\s+/).filter(Boolean);
   const chunks: string[] = [];
   let current = '';

--- a/vespa-core/vespa/common/schemas/chat_message.sd
+++ b/vespa-core/vespa/common/schemas/chat_message.sd
@@ -15,6 +15,17 @@ schema chat_message {
       index: enable-bm25
     }
 
+    # Per-chunk body used for chunk-level embeddings, mirroring mail.sd.
+    # `text` (above) is retained as the single display/summary/lexical field;
+    # `chunks` holds the same body split into <=2000-char segments so long
+    # messages are not truncated at embed time (bge-small-en-v1.5 512-token limit).
+    field chunks type array<string> {
+      indexing: index | summary
+      index {
+        enable-bm25
+      }
+    }
+
     field userId type string {
       indexing: attribute | summary
       attribute: fast-search
@@ -156,7 +167,15 @@ schema chat_message {
       distance-metric: angular
     }
   }
-  
+
+  # Per-chunk embeddings (one vector per `chunks` element).
+  field chunk_embeddings type tensor<bfloat16>(p{}, v[DIMS]) {
+    indexing: input chunks | embed hf-embedder | attribute | index
+    attribute {
+      distance-metric: angular
+    }
+  }
+
 field text_fuzzy type string {
     indexing: input text |tokenize | lowercase | index | summary
     index: enable-bm25
@@ -166,7 +185,7 @@ field text_fuzzy type string {
     }
 }
   fieldset default {
-    fields: text, text_fuzzy, channelId, userId, threadId, attachmentIds, channelName, isPrivate, username, messageChannelName, entityNames
+    fields: text, chunks, text_fuzzy, channelId, userId, threadId, attachmentIds, channelName, isPrivate, username, messageChannelName, entityNames
   }
 
   rank-profile initial {
@@ -232,6 +251,7 @@ field text_fuzzy type string {
     summary text {
       bolding: on
     }
+    summary chunks {}
     summary mentions {}
     summary channelMentions {}
     summary attachmentIds {}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
