### PR TITLE
fix: update context pill row muted styling

### DIFF
--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
@@ -842,7 +842,7 @@ export const ContextPillRow = ({
           getBoundingClientRect reports. */}
       <motion.div
         className={`absolute -bottom-[12px] left-0 right-0 overflow-hidden border border-chat-composer-border ${
-          showContextPicker ? 'bg-background' : 'bg-muted/[2%]'
+          showContextPicker ? 'bg-background' : 'bg-muted/10 backdrop-blur-md'
         } ${isMobile ? 'rounded-t-[26px]' : 'rounded-t-2xl'}`}
         animate={{ height: contentHeight + 14 }}
         initial={false}


### PR DESCRIPTION
1. Problem Description:
Context pill row muted background was too transparent and did not apply the requested medium backdrop blur.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Xyne Spaces thread by Milind Pithadia.

3. Explain the solution implemented in the PR:
Updated ContextPillRow muted state from bg-muted/[2%] to bg-muted/10 and added backdrop-blur-md.

4. Documentation (link to confluence docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
Ran git diff --check and pnpm --dir apps/dashboard exec eslint src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx. Captured light and dark mode screenshots in the Spaces thread.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A