### PR TITLE
fix: XYNE-55240 passing workspaceId in remaining places

### DIFF
--- a/backend/src/controllers/emailController.ts
+++ b/backend/src/controllers/emailController.ts
@@ -394,7 +394,7 @@ export class EmailController {
 
         const ticketForActivity = await db.ticket.findFirst({
           where: { conversationId },
-          select: { id: true },
+          select: { id: true, workspaceId: true },
         });
 
         await recordTicketTimelineEvent({
@@ -408,6 +408,7 @@ export class EmailController {
                   type: emailType,
                   to: toRecipients,
                 } as Prisma.InputJsonValue,
+                workspaceId: ticketForActivity.workspaceId,
               }
             : undefined,
           message: {

--- a/backend/src/services/invitationService.ts
+++ b/backend/src/services/invitationService.ts
@@ -332,7 +332,7 @@ export class InvitationService {
     return result;
   }
 
-  private async ensureChannelGuestState(channelId: string, userId: string, tx: TxClient): Promise<void> {
+  private async ensureChannelGuestState(channelId: string, userId: string, workspaceId: string, tx: TxClient): Promise<void> {
     await tx.channelParticipant.upsert({
       where: {
         channelId_userId: {
@@ -345,6 +345,7 @@ export class InvitationService {
         channelId,
         userId,
         role: ChannelRole.MEMBER,
+        workspaceId,
       },
     });
 
@@ -533,7 +534,7 @@ export class InvitationService {
         throw new Error('Guest invitation target channel is archived');
       }
 
-      await this.ensureChannelGuestState(entityId, userId, tx);
+      await this.ensureChannelGuestState(entityId, userId, workspaceId, tx);
       return `/${workspaceId}/chat/dir/${entityId}`;
     }
 
@@ -551,6 +552,7 @@ export class InvitationService {
           canvasId: entityId,
           userId,
           role: CanvasRole.VIEWER,
+          workspaceId,
         },
       });
       return `/${workspaceId}/chat/canvas/${entityId}`;
@@ -584,7 +586,7 @@ export class InvitationService {
         throw new Error('Guest invitation target channel does not exist in this project');
       }
 
-      await this.ensureChannelGuestState(targetChannelId, userId, tx);
+      await this.ensureChannelGuestState(targetChannelId, userId, workspaceId, tx);
       return `/${workspaceId}/chat/dir/${targetChannelId}`;
     }
 

--- a/backend/src/services/permissionMatrix.ts
+++ b/backend/src/services/permissionMatrix.ts
@@ -251,8 +251,9 @@ export async function syncResourceAdminAccess(
     );
 
     if (shouldHaveAccess && !hasAdminAccess) {
+      const user = await db.user.findUnique({ where: { id: userId }, select: { workspaceId: true } });
       await repositories.resourceAccess.grantAccess(
-        { userId, resourceId: resource.id, accessType: AccessType.ADMIN },
+        { userId, resourceId: resource.id, accessType: AccessType.ADMIN, workspaceId: user?.workspaceId },
         actorUserId,
       );
       logger.debug(`${logPrefix} Granted ADMIN access to ${resourceName} for user ${userId}.`);


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
