### PR TITLE
Feature/disable archived tickets before merging r04

### DIFF
--- a/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -4283,11 +4283,10 @@ const ChannelCommandMenu = ({
             ? new Date(result.metadata.timestamp).getTime()
             : null,
         }))}
-        onMerge={async parentTicketId => {
+        onMerge={async (parentTicketId, ticketIds) => {
           try {
-            const ticketsToMerge = Array.from(selectedMergeTickets.keys()).filter(
-              id => id !== parentTicketId,
-            );
+            // ticketIds comes pre-filtered from the dialog (archived tickets excluded).
+            const ticketsToMerge = ticketIds.filter(id => id !== parentTicketId);
             await Promise.all(
               ticketsToMerge.map(ticketId =>
                 apiInstance.post(`/tickets/${ticketId}/merge`, { targetTicketId: parentTicketId }),

--- a/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -7,6 +7,8 @@ import Avatar from '../../ui/Avatar/Avatar';
 import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
 import { useUser } from '../../../hooks/useUsers';
 import { useUserGroupById } from '../../../hooks/useUserGroup';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { queries } from '../../../zero/queries';
 import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
 import { cn } from '../../../utils/classNames';
@@ -27,7 +29,8 @@ interface MergeTicketsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tickets: MergeTicket[];
-  onMerge: (parentTicketId: string) => void | Promise<void>;
+  /** ticketIds is the eligible (non-archived) subset of `tickets` that should actually be merged. */
+  onMerge: (parentTicketId: string, ticketIds: string[]) => void | Promise<void>;
 }
 
 const formatTicketDate = (timestamp?: number | null): string =>
@@ -98,6 +101,27 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
     [tickets],
   );
 
+  // Selection can go stale: a ticket picked before opening this dialog may have been
+  // archived in the meantime (merged elsewhere, archived by another agent, etc). Re-check
+  // live status for every candidate so an already-archived ticket can't be picked again —
+  // showing it disabled here is clearer than silently dropping it from the list.
+  const ticketIds = useMemo(() => tickets.map(t => t.id), [tickets]);
+  const [liveTickets] = useCachedQuery(queries.ticketsByIds({ ticketIds }), {
+    enabled: open && ticketIds.length > 0,
+  });
+  const archivedIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const t of liveTickets ?? []) {
+      if (t.isArchived) ids.add(t.id);
+    }
+    return ids;
+  }, [liveTickets]);
+
+  const eligibleTickets = useMemo(
+    () => sortedTickets.filter(t => !archivedIds.has(t.id)),
+    [sortedTickets, archivedIds],
+  );
+
   useEffect(() => {
     if (!open) {
       setSelectedParentTicketId(null);
@@ -105,16 +129,21 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   }, [open]);
 
   useEffect(() => {
-    if (open && selectedParentTicketId === null && sortedTickets.length > 0) {
-      setSelectedParentTicketId(sortedTickets[0]?.id ?? null);
+    if (!open) return;
+    // Pick (or fix up) a default parent among tickets that aren't archived.
+    if (selectedParentTicketId === null || archivedIds.has(selectedParentTicketId)) {
+      setSelectedParentTicketId(eligibleTickets[0]?.id ?? null);
     }
-  }, [open, sortedTickets, selectedParentTicketId]);
+  }, [open, eligibleTickets, archivedIds, selectedParentTicketId]);
 
   const handleMerge = async (): Promise<void> => {
-    if (!selectedParentTicketId) return;
+    if (!selectedParentTicketId || archivedIds.has(selectedParentTicketId)) return;
     setIsMerging(true);
     try {
-      await onMerge(selectedParentTicketId);
+      await onMerge(
+        selectedParentTicketId,
+        eligibleTickets.map(t => t.id),
+      );
     } finally {
       setIsMerging(false);
     }
@@ -143,7 +172,8 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
               className='space-y-1.5 max-h-[360px] overflow-y-auto -mx-1 px-1 py-0.5'
             >
               {sortedTickets.map(ticket => {
-                const isParent = ticket.id === selectedParentTicketId;
+                const isArchived = archivedIds.has(ticket.id);
+                const isParent = !isArchived && ticket.id === selectedParentTicketId;
                 const priority = ticket.priority as TicketPriority | undefined;
                 const priorityIcon = priority ? getPriorityIcon(priority) : null;
 
@@ -151,13 +181,16 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
                   <RadioGroupPrimitive.Item
                     key={ticket.id}
                     value={ticket.id}
+                    disabled={isArchived}
                     className={cn(
                       'relative flex w-full flex-col gap-1.5 rounded-md border py-2.5 pl-4 pr-3 text-left',
                       'shadow-sm transition-all outline-none',
                       'focus-visible:ring-2 focus-visible:ring-ring/50',
-                      isParent
-                        ? 'border-primary/40 bg-primary/[0.04]'
-                        : 'border-border bg-card hover:border-input hover:shadow',
+                      isArchived
+                        ? 'border-border bg-muted/40 opacity-60 cursor-not-allowed'
+                        : isParent
+                          ? 'border-primary/40 bg-primary/[0.04]'
+                          : 'border-border bg-card hover:border-input hover:shadow',
                     )}
                     data-track-category='Support'
                     data-track-name='SelectMergeParent'
@@ -171,19 +204,26 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
                         {ticket.xyneId || ticket.id.slice(0, 8)}
                       </span>
                       <TruncatedTooltip content={ticket.title || 'No subject'}>
-                        <h3 className='flex-1 min-w-0 truncate text-[15px] font-semibold text-foreground'>
+                        <h3
+                          className={cn(
+                            'flex-1 min-w-0 truncate text-[15px] font-semibold',
+                            isArchived ? 'text-muted-foreground' : 'text-foreground',
+                          )}
+                        >
                           {ticket.title || 'No subject'}
                         </h3>
                       </TruncatedTooltip>
                       <span
                         className={cn(
                           'shrink-0 inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium whitespace-nowrap',
-                          isParent
-                            ? 'border-primary/30 bg-primary/10 text-primary'
-                            : 'border-border text-muted-foreground',
+                          isArchived
+                            ? 'border-border text-muted-foreground'
+                            : isParent
+                              ? 'border-primary/30 bg-primary/10 text-primary'
+                              : 'border-border text-muted-foreground',
                         )}
                       >
-                        {isParent ? 'Parent' : 'Merges in'}
+                        {isArchived ? 'Already archived' : isParent ? 'Parent' : 'Merges in'}
                       </span>
                     </div>
 
@@ -230,7 +270,12 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </Button>
           <Button
             onClick={() => void handleMerge()}
-            disabled={isMerging || !selectedParentTicketId || sortedTickets.length === 0}
+            disabled={
+              isMerging ||
+              !selectedParentTicketId ||
+              archivedIds.has(selectedParentTicketId) ||
+              eligibleTickets.length < 2
+            }
             data-track-category='Support'
             data-track-name='ConfirmMergeTickets'
           >

--- a/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
-import { User } from 'lucide-react';
+import { User, X } from 'lucide-react';
 import { Dialog } from '../../ui/Dialog';
 import Button from '../../ui/Button';
 import Avatar from '../../ui/Avatar/Avatar';
@@ -12,6 +12,7 @@ import { queries } from '../../../zero/queries';
 import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
 import { cn } from '../../../utils/classNames';
+import { htmlToPlainText } from '../../../utils/sanitizer';
 import type { TicketPriority } from '@xyne/shared';
 
 interface MergeTicket {
@@ -29,7 +30,6 @@ interface MergeTicketsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tickets: MergeTicket[];
-  /** ticketIds is the eligible (non-archived) subset of `tickets` that should actually be merged. */
   onMerge: (parentTicketId: string, ticketIds: string[]) => void | Promise<void>;
 }
 
@@ -95,16 +95,13 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 }) => {
   const [isMerging, setIsMerging] = useState(false);
   const [selectedParentTicketId, setSelectedParentTicketId] = useState<string | null>(null);
+  const [removedIds, setRemovedIds] = useState<Set<string>>(() => new Set());
 
   const sortedTickets = useMemo(
     () => [...tickets].sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0)),
     [tickets],
   );
 
-  // Selection can go stale: a ticket picked before opening this dialog may have been
-  // archived in the meantime (merged elsewhere, archived by another agent, etc). Re-check
-  // live status for every candidate so an already-archived ticket can't be picked again —
-  // showing it disabled here is clearer than silently dropping it from the list.
   const ticketIds = useMemo(() => tickets.map(t => t.id), [tickets]);
   const [liveTickets] = useCachedQuery(queries.ticketsByIds({ ticketIds }), {
     enabled: open && ticketIds.length > 0,
@@ -117,32 +114,36 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
     return ids;
   }, [liveTickets]);
 
-  const eligibleTickets = useMemo(
-    () => sortedTickets.filter(t => !archivedIds.has(t.id)),
-    [sortedTickets, archivedIds],
+  const excludedTickets = sortedTickets.filter(t => archivedIds.has(t.id));
+  const visibleTickets = useMemo(
+    () => sortedTickets.filter(t => !archivedIds.has(t.id) && !removedIds.has(t.id)),
+    [sortedTickets, archivedIds, removedIds],
   );
 
   useEffect(() => {
     if (!open) {
       setSelectedParentTicketId(null);
+      setRemovedIds(new Set());
     }
   }, [open]);
 
   useEffect(() => {
     if (!open) return;
-    // Pick (or fix up) a default parent among tickets that aren't archived.
-    if (selectedParentTicketId === null || archivedIds.has(selectedParentTicketId)) {
-      setSelectedParentTicketId(eligibleTickets[0]?.id ?? null);
-    }
-  }, [open, eligibleTickets, archivedIds, selectedParentTicketId]);
+    if (selectedParentTicketId && visibleTickets.some(t => t.id === selectedParentTicketId)) return;
+    setSelectedParentTicketId(visibleTickets[0]?.id ?? null);
+  }, [open, visibleTickets, selectedParentTicketId]);
+
+  const handleRemoveTicket = (ticketId: string): void => {
+    setRemovedIds(prev => new Set(prev).add(ticketId));
+  };
 
   const handleMerge = async (): Promise<void> => {
-    if (!selectedParentTicketId || archivedIds.has(selectedParentTicketId)) return;
+    if (!selectedParentTicketId) return;
     setIsMerging(true);
     try {
       await onMerge(
         selectedParentTicketId,
-        eligibleTickets.map(t => t.id),
+        visibleTickets.map(t => t.id),
       );
     } finally {
       setIsMerging(false);
@@ -150,7 +151,11 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange} title={`Merge ${sortedTickets.length} Tickets`}>
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Merge ${visibleTickets.length} Tickets`}
+    >
       <div className='p-6 space-y-4'>
         <p className='text-sm text-muted-foreground'>
           Pick the ticket that stays open. The rest will be archived and linked as merged into it —
@@ -160,6 +165,14 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 
         {sortedTickets.length === 0 ? (
           <p className='text-sm text-destructive'>Could not load ticket details.</p>
+        ) : visibleTickets.length === 0 ? (
+          <p className='text-sm text-muted-foreground'>
+            All selected tickets are already archived. Cancel and reselect to start over.
+          </p>
+        ) : visibleTickets.length < 2 ? (
+          <p className='text-sm text-muted-foreground'>
+            Only one ticket left to merge. Cancel and reselect at least two.
+          </p>
         ) : (
           <>
             <div className='text-xs font-medium text-muted-foreground uppercase tracking-wide'>
@@ -171,26 +184,24 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
               aria-label='Parent ticket'
               className='space-y-1.5 max-h-[360px] overflow-y-auto -mx-1 px-1 py-0.5'
             >
-              {sortedTickets.map(ticket => {
-                const isArchived = archivedIds.has(ticket.id);
-                const isParent = !isArchived && ticket.id === selectedParentTicketId;
+              {visibleTickets.map(ticket => {
+                const isParent = ticket.id === selectedParentTicketId;
                 const priority = ticket.priority as TicketPriority | undefined;
                 const priorityIcon = priority ? getPriorityIcon(priority) : null;
+
+                const plainTitle = ticket.title ? htmlToPlainText(ticket.title) : '';
 
                 return (
                   <RadioGroupPrimitive.Item
                     key={ticket.id}
                     value={ticket.id}
-                    disabled={isArchived}
                     className={cn(
                       'relative flex w-full flex-col gap-1.5 rounded-md border py-2.5 pl-4 pr-3 text-left',
                       'shadow-sm transition-all outline-none',
                       'focus-visible:ring-2 focus-visible:ring-ring/50',
-                      isArchived
-                        ? 'border-border bg-muted/40 opacity-60 cursor-not-allowed'
-                        : isParent
-                          ? 'border-primary/40 bg-primary/[0.04]'
-                          : 'border-border bg-card hover:border-input hover:shadow',
+                      isParent
+                        ? 'border-primary/40 bg-primary/[0.04]'
+                        : 'border-border bg-card hover:border-input hover:shadow',
                     )}
                     data-track-category='Support'
                     data-track-name='SelectMergeParent'
@@ -199,31 +210,38 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
                       <span className='absolute inset-y-1.5 left-1 w-[3px] rounded-full bg-primary' />
                     )}
 
+                    <button
+                      type='button'
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleRemoveTicket(ticket.id);
+                      }}
+                      className='absolute -left-1.5 -top-1.5 flex size-4 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-sm hover:text-foreground hover:border-input'
+                      aria-label={`Remove ${plainTitle || 'ticket'} from merge`}
+                      data-track-category='Support'
+                      data-track-name='RemoveTicketFromMerge'
+                    >
+                      <X className='size-2.5' strokeWidth={2.5} />
+                    </button>
+
                     <div className='flex items-center gap-2 min-w-0'>
                       <span className='font-mono text-xs text-muted-foreground shrink-0'>
                         {ticket.xyneId || ticket.id.slice(0, 8)}
                       </span>
-                      <TruncatedTooltip content={ticket.title || 'No subject'}>
-                        <h3
-                          className={cn(
-                            'flex-1 min-w-0 truncate text-[15px] font-semibold',
-                            isArchived ? 'text-muted-foreground' : 'text-foreground',
-                          )}
-                        >
-                          {ticket.title || 'No subject'}
+                      <TruncatedTooltip content={plainTitle || 'No subject'}>
+                        <h3 className='flex-1 min-w-0 truncate text-[15px] font-semibold text-foreground'>
+                          {plainTitle || 'No subject'}
                         </h3>
                       </TruncatedTooltip>
                       <span
                         className={cn(
                           'shrink-0 inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium whitespace-nowrap',
-                          isArchived
-                            ? 'border-border text-muted-foreground'
-                            : isParent
-                              ? 'border-primary/30 bg-primary/10 text-primary'
-                              : 'border-border text-muted-foreground',
+                          isParent
+                            ? 'border-primary/30 bg-primary/10 text-primary'
+                            : 'border-border text-muted-foreground',
                         )}
                       >
-                        {isArchived ? 'Already archived' : isParent ? 'Parent' : 'Merges in'}
+                        {isParent ? 'Parent' : 'Merges in'}
                       </span>
                     </div>
 
@@ -259,6 +277,13 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </>
         )}
 
+        {excludedTickets.length > 0 && (
+          <p className='text-xs text-muted-foreground'>
+            Already archived, excluded from this merge:{' '}
+            {excludedTickets.map(t => t.xyneId || t.id.slice(0, 8)).join(', ')}
+          </p>
+        )}
+
         <div className='flex justify-end gap-3 pt-2'>
           <Button
             variant='secondary'
@@ -270,12 +295,7 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </Button>
           <Button
             onClick={() => void handleMerge()}
-            disabled={
-              isMerging ||
-              !selectedParentTicketId ||
-              archivedIds.has(selectedParentTicketId) ||
-              eligibleTickets.length < 2
-            }
+            disabled={isMerging || !selectedParentTicketId || visibleTickets.length < 2}
             data-track-category='Support'
             data-track-name='ConfirmMergeTickets'
           >

--- a/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -7,7 +7,7 @@ import Avatar from '../../ui/Avatar/Avatar';
 import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
 import { useUser } from '../../../hooks/useUsers';
 import { useUserGroupById } from '../../../hooks/useUserGroup';
-import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useQuery } from '../../../hooks/useQuery';
 import { queries } from '../../../zero/queries';
 import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
@@ -103,21 +103,28 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   );
 
   const ticketIds = useMemo(() => tickets.map(t => t.id), [tickets]);
-  const [liveTickets] = useCachedQuery(queries.ticketsByIds({ ticketIds }), {
+  // useQuery, not useCachedQuery — the latter can replay a stale "complete" snapshot from its cross-mount cache.
+  const [liveTickets, liveTicketsDetails] = useQuery(queries.ticketsByIds({ ticketIds }), {
     enabled: open && ticketIds.length > 0,
   });
+  // Fail closed until the live archived check has actually resolved, not just "no data yet".
+  const archivedStateLoaded = ticketIds.length === 0 || liveTicketsDetails.type === 'complete';
   const archivedIds = useMemo(() => {
     const ids = new Set<string>();
+    if (!archivedStateLoaded) return ids;
     for (const t of liveTickets ?? []) {
       if (t.isArchived) ids.add(t.id);
     }
     return ids;
-  }, [liveTickets]);
+  }, [liveTickets, archivedStateLoaded]);
 
   const excludedTickets = sortedTickets.filter(t => archivedIds.has(t.id));
   const visibleTickets = useMemo(
-    () => sortedTickets.filter(t => !archivedIds.has(t.id) && !removedIds.has(t.id)),
-    [sortedTickets, archivedIds, removedIds],
+    () =>
+      archivedStateLoaded
+        ? sortedTickets.filter(t => !archivedIds.has(t.id) && !removedIds.has(t.id))
+        : [],
+    [sortedTickets, archivedIds, removedIds, archivedStateLoaded],
   );
 
   useEffect(() => {
@@ -128,17 +135,17 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   }, [open]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !archivedStateLoaded) return;
     if (selectedParentTicketId && visibleTickets.some(t => t.id === selectedParentTicketId)) return;
     setSelectedParentTicketId(visibleTickets[0]?.id ?? null);
-  }, [open, visibleTickets, selectedParentTicketId]);
+  }, [open, archivedStateLoaded, visibleTickets, selectedParentTicketId]);
 
   const handleRemoveTicket = (ticketId: string): void => {
     setRemovedIds(prev => new Set(prev).add(ticketId));
   };
 
   const handleMerge = async (): Promise<void> => {
-    if (!selectedParentTicketId) return;
+    if (!selectedParentTicketId || !archivedStateLoaded) return;
     setIsMerging(true);
     try {
       await onMerge(
@@ -165,6 +172,8 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 
         {sortedTickets.length === 0 ? (
           <p className='text-sm text-destructive'>Could not load ticket details.</p>
+        ) : !archivedStateLoaded ? (
+          <p className='text-sm text-muted-foreground'>Checking ticket status…</p>
         ) : visibleTickets.length === 0 ? (
           <p className='text-sm text-muted-foreground'>
             All selected tickets are already archived. Cancel and reselect to start over.
@@ -295,7 +304,12 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </Button>
           <Button
             onClick={() => void handleMerge()}
-            disabled={isMerging || !selectedParentTicketId || visibleTickets.length < 2}
+            disabled={
+              isMerging ||
+              !archivedStateLoaded ||
+              !selectedParentTicketId ||
+              visibleTickets.length < 2
+            }
             data-track-category='Support'
             data-track-name='ConfirmMergeTickets'
           >

--- a/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -1,12 +1,26 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { User } from 'lucide-react';
 import { Dialog } from '../../ui/Dialog';
 import Button from '../../ui/Button';
-import { RadioGroup, Radio } from '../../ui/RadioGroup';
+import Avatar from '../../ui/Avatar/Avatar';
+import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
+import { useUser } from '../../../hooks/useUsers';
+import { useUserGroupById } from '../../../hooks/useUserGroup';
+import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
+import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
+import { cn } from '../../../utils/classNames';
+import type { TicketPriority } from '@xyne/shared';
+
 interface MergeTicket {
   id: string;
-  createdAt?: number | null;
-  title?: string | null;
-  xyneId?: string | null;
+  createdAt?: number | null | undefined;
+  title?: string | null | undefined;
+  xyneId?: string | null | undefined;
+  stageName?: string | null | undefined;
+  priority?: TicketPriority | string | null | undefined;
+  assignedTo?: string | null | undefined;
+  userGroupId?: string | null | undefined;
 }
 
 interface MergeTicketsDialogProps {
@@ -15,6 +29,60 @@ interface MergeTicketsDialogProps {
   tickets: MergeTicket[];
   onMerge: (parentTicketId: string) => void | Promise<void>;
 }
+
+const formatTicketDate = (timestamp?: number | null): string =>
+  new Date(timestamp ?? 0).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+/** Mirrors TicketCard's renderAssignee() — same markup/classes, display-only. */
+const MergeTicketAssignee: React.FC<{
+  assignedTo?: string | null | undefined;
+  userGroupId?: string | null | undefined;
+}> = ({ assignedTo, userGroupId }) => {
+  // Same precedence as TicketCard: a user assignee wins; otherwise fall back to
+  // a legacy `group:<id>` in assignedTo, then the dedicated userGroupId column.
+  const assigneeUserId =
+    assignedTo && !assignedTo.startsWith('group:') ? assignedTo.replace(/^user:/, '') : '';
+  const assigneeGroupId = assigneeUserId
+    ? ''
+    : assignedTo?.startsWith('group:')
+      ? assignedTo.slice('group:'.length)
+      : userGroupId || '';
+  const isGroup = !assigneeUserId && !!assigneeGroupId;
+  const user = useUser(assigneeUserId);
+  const group = useUserGroupById(assigneeGroupId);
+
+  if (!isGroup && user) {
+    return (
+      <Tooltip content={user.name || user.email || 'Unknown user'}>
+        <div className='relative'>
+          <Avatar userId={user.id} showActiveStatus={false} className='size-6' />
+        </div>
+      </Tooltip>
+    );
+  }
+  if (isGroup && group) {
+    return (
+      <Tooltip content={group.name}>
+        <div className='w-6 h-6 rounded-lg bg-border flex items-center justify-center'>
+          <span className='text-xs font-medium text-muted-foreground'>
+            {group.name.charAt(0).toUpperCase()}
+          </span>
+        </div>
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip content='Unassigned'>
+      <div className='w-6 h-6 rounded-lg border border-dashed border-muted-foreground bg-background flex items-center justify-center'>
+        <User className='w-3 h-3 text-muted-foreground' strokeWidth={1.5} />
+      </div>
+    </Tooltip>
+  );
+};
 
 export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
   open,
@@ -56,36 +124,99 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
     <Dialog open={open} onOpenChange={onOpenChange} title={`Merge ${sortedTickets.length} Tickets`}>
       <div className='p-6 space-y-4'>
         <p className='text-sm text-muted-foreground'>
-          Select the ticket that will be the parent. All other selected tickets will be archived and
-          linked as merged into it.
+          Pick the ticket that stays open. The rest will be archived and linked as merged into it —
+          you can split them back out later with{' '}
+          <span className='font-medium text-foreground'>Unmerge</span>.
         </p>
 
         {sortedTickets.length === 0 ? (
           <p className='text-sm text-destructive'>Could not load ticket details.</p>
         ) : (
-          <div className='space-y-2'>
-            <div className='text-sm font-medium'>Parent ticket</div>
-            <RadioGroup
-              value={selectedParentTicketId ?? ''}
-              onChange={value => setSelectedParentTicketId(value)}
+          <>
+            <div className='text-xs font-medium text-muted-foreground uppercase tracking-wide'>
+              Parent ticket
+            </div>
+            <RadioGroupPrimitive.Root
+              value={selectedParentTicketId}
+              onValueChange={setSelectedParentTicketId}
               aria-label='Parent ticket'
+              className='space-y-1.5 max-h-[360px] overflow-y-auto -mx-1 px-1 py-0.5'
             >
-              {sortedTickets.map(ticket => (
-                <Radio key={ticket.id} value={ticket.id} subtext={ticket.title || 'No subject'}>
-                  <span className='font-mono text-xs text-muted-foreground'>
-                    {ticket.xyneId || ticket.id.slice(0, 8)}
-                  </span>
-                  <span className='text-muted-foreground ml-2'>
-                    {new Date(ticket.createdAt ?? 0).toLocaleDateString(undefined, {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
-                  </span>
-                </Radio>
-              ))}
-            </RadioGroup>
-          </div>
+              {sortedTickets.map(ticket => {
+                const isParent = ticket.id === selectedParentTicketId;
+                const priority = ticket.priority as TicketPriority | undefined;
+                const priorityIcon = priority ? getPriorityIcon(priority) : null;
+
+                return (
+                  <RadioGroupPrimitive.Item
+                    key={ticket.id}
+                    value={ticket.id}
+                    className={cn(
+                      'relative flex w-full flex-col gap-1.5 rounded-md border py-2.5 pl-4 pr-3 text-left',
+                      'shadow-sm transition-all outline-none',
+                      'focus-visible:ring-2 focus-visible:ring-ring/50',
+                      isParent
+                        ? 'border-primary/40 bg-primary/[0.04]'
+                        : 'border-border bg-card hover:border-input hover:shadow',
+                    )}
+                    data-track-category='Support'
+                    data-track-name='SelectMergeParent'
+                  >
+                    {isParent && (
+                      <span className='absolute inset-y-1.5 left-1 w-[3px] rounded-full bg-primary' />
+                    )}
+
+                    <div className='flex items-center gap-2 min-w-0'>
+                      <span className='font-mono text-xs text-muted-foreground shrink-0'>
+                        {ticket.xyneId || ticket.id.slice(0, 8)}
+                      </span>
+                      <TruncatedTooltip content={ticket.title || 'No subject'}>
+                        <h3 className='flex-1 min-w-0 truncate text-[15px] font-semibold text-foreground'>
+                          {ticket.title || 'No subject'}
+                        </h3>
+                      </TruncatedTooltip>
+                      <span
+                        className={cn(
+                          'shrink-0 inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium whitespace-nowrap',
+                          isParent
+                            ? 'border-primary/30 bg-primary/10 text-primary'
+                            : 'border-border text-muted-foreground',
+                        )}
+                      >
+                        {isParent ? 'Parent' : 'Merges in'}
+                      </span>
+                    </div>
+
+                    <div className='flex items-center gap-3 pl-0'>
+                      {ticket.stageName !== undefined && (
+                        <TicketStatusWithStages
+                          currentStageName={ticket.stageName}
+                          showLeadingDot={false}
+                          labelClassName='max-w-[120px] truncate'
+                        />
+                      )}
+                      {priorityIcon && (
+                        <Tooltip content={`Priority: ${priority}`}>
+                          <span className='flex items-center'>{priorityIcon}</span>
+                        </Tooltip>
+                      )}
+                      <span className='text-xs text-muted-foreground tabular-nums'>
+                        {formatTicketDate(ticket.createdAt)}
+                      </span>
+                      {(ticket.assignedTo !== undefined || ticket.userGroupId !== undefined) && (
+                        <span className='ml-auto flex items-center'>
+                          <MergeTicketAssignee
+                            assignedTo={ticket.assignedTo}
+                            userGroupId={ticket.userGroupId}
+                          />
+                        </span>
+                      )}
+                    </div>
+                  </RadioGroupPrimitive.Item>
+                );
+              })}
+            </RadioGroupPrimitive.Root>
+          </>
         )}
 
         <div className='flex justify-end gap-3 pt-2'>

--- a/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
+++ b/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
@@ -76,6 +76,10 @@ export interface SelectableRow {
   createdAt: number;
   channelId: string;
   conversationId: string;
+  stageName?: string | null;
+  priority?: TicketListItem['priority'];
+  assignedTo?: string | null;
+  userGroupId?: string | null;
 }
 
 export const TicketListView = function TicketListView({
@@ -477,6 +481,10 @@ export const TicketListView = function TicketListView({
                       createdAt: row.createdAt ?? 0,
                       channelId: row.channelId ?? '',
                       conversationId: row.conversationId ?? '',
+                      stageName: row.stageName,
+                      priority: row.priority,
+                      assignedTo: row.assignedTo,
+                      userGroupId: row.userGroupId,
                       ...(emailReads ? { emailReads } : {}),
                     });
                   },
@@ -503,6 +511,10 @@ export const TicketListView = function TicketListView({
       createdAt: t.createdAt ?? 0,
       channelId: t.channelId ?? '',
       conversationId: t.conversationId ?? '',
+      stageName: t.stageName,
+      priority: t.priority,
+      assignedTo: t.assignedTo,
+      userGroupId: t.userGroupId,
     };
     const emailReads = t.emailReads as
       | ReadonlyArray<{ userId: string; lastReadEmailAt: number }>

--- a/dashboard/src/components/Tickets/TicketListView/TicketListView.types.ts
+++ b/dashboard/src/components/Tickets/TicketListView/TicketListView.types.ts
@@ -10,6 +10,7 @@ export interface TicketListItem {
   lastEmailAt?: number | null;
   priority?: TicketPriority | string | null;
   assignedTo?: string | null;
+  userGroupId?: string | null;
   isArchived?: boolean | null;
   channelId?: string | null;
   boardId?: string | null;

--- a/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
+++ b/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
@@ -50,6 +50,8 @@ interface TicketTableProps {
   visibleColumns?: Set<string>;
   isComfortView?: boolean;
   extraColumns?: ColDef<Ticket>[];
+  selectedIds?: ReadonlySet<string>;
+  onSelectionChange?: (tickets: Ticket[]) => void;
 }
 
 // Index header renderer component
@@ -156,6 +158,8 @@ export const TicketTable: React.FC<TicketTableProps> = ({
   isComfortView = false,
   visibleColumns = new Set(['assignee', 'dueDate', 'status', 'priority', 'stage', 'tags']),
   extraColumns,
+  selectedIds,
+  onSelectionChange,
 }) => {
   const zero = useZero();
   const users = useUsers();
@@ -209,6 +213,15 @@ export const TicketTable: React.FC<TicketTableProps> = ({
 
   const [gridApi, setGridApi] = useState<GridApi | null>(null);
   const [selectedCount, setSelectedCount] = useState(0);
+
+  useEffect(() => {
+    if (!gridApi || selectedIds === undefined) return;
+    gridApi.forEachNode(node => {
+      if (!node.data) return;
+      const shouldBeSelected = selectedIds.has((node.data as Ticket).id);
+      if (node.isSelected() !== shouldBeSelected) node.setSelected(shouldBeSelected);
+    });
+  }, [gridApi, selectedIds, tickets]);
 
   const userGroups = useUserGroups();
 
@@ -712,8 +725,9 @@ export const TicketTable: React.FC<TicketTableProps> = ({
               }
             }}
             onSelectionChanged={params => {
-              const count = params.api.getSelectedRows().length;
-              setSelectedCount(count);
+              const selectedRows = params.api.getSelectedRows() as Ticket[];
+              setSelectedCount(selectedRows.length);
+              onSelectionChange?.(selectedRows);
             }}
             rowData={tickets}
             columnDefs={columnDefs}

--- a/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1378,6 +1378,10 @@ const SupportScreen = (): ReactElement => {
     createdAt: number;
     channelId: string;
     conversationId: string;
+    stageName?: string | null | undefined;
+    priority?: string | null | undefined;
+    assignedTo?: string | null | undefined;
+    userGroupId?: string | null | undefined;
   };
   const [selectedTickets, setSelectedTickets] = useState<Map<string, SelectedTicket>>(
     () => new Map(),
@@ -1399,6 +1403,10 @@ const SupportScreen = (): ReactElement => {
       createdAt: number;
       channelId: string;
       conversationId: string;
+      stageName?: string | null | undefined;
+      priority?: string | null | undefined;
+      assignedTo?: string | null | undefined;
+      userGroupId?: string | null | undefined;
     }): void => {
       setSelectedTickets(prev => {
         const next = new Map(prev);
@@ -1414,6 +1422,10 @@ const SupportScreen = (): ReactElement => {
             createdAt: row.createdAt,
             channelId: row.channelId,
             conversationId: row.conversationId,
+            stageName: row.stageName,
+            priority: row.priority,
+            assignedTo: row.assignedTo,
+            userGroupId: row.userGroupId,
           });
         }
         return next;
@@ -1449,6 +1461,10 @@ const SupportScreen = (): ReactElement => {
         createdAt: number;
         channelId: string;
         conversationId: string;
+        stageName?: string | null | undefined;
+        priority?: string | null | undefined;
+        assignedTo?: string | null | undefined;
+        userGroupId?: string | null | undefined;
       }>,
       select: boolean,
     ): void => {
@@ -1465,6 +1481,10 @@ const SupportScreen = (): ReactElement => {
               createdAt: row.createdAt,
               channelId: row.channelId,
               conversationId: row.conversationId,
+              stageName: row.stageName,
+              priority: row.priority,
+              assignedTo: row.assignedTo,
+              userGroupId: row.userGroupId,
             });
           } else {
             next.delete(row.id);
@@ -1475,6 +1495,35 @@ const SupportScreen = (): ReactElement => {
     },
     [],
   );
+
+  const handleTableSelectionChange = useCallback((tickets: Ticket[]): void => {
+    setSelectedTickets(
+      new Map(
+        tickets.map(ticket => [
+          ticket.id,
+          {
+            id: ticket.id,
+            lastEmailAt: ticket.lastEmailAt ?? 0,
+            emailReads:
+              (
+                ticket as Ticket & {
+                  emailReads?: ReadonlyArray<{ userId: string; lastReadEmailAt: number }>;
+                }
+              ).emailReads ?? [],
+            title: ticket.title ?? '',
+            xyneId: ticket.xyneId ?? '',
+            createdAt: ticket.createdAt ?? 0,
+            channelId: ticket.channelId ?? '',
+            conversationId: ticket.conversationId ?? '',
+            stageName: ticket.stageName,
+            priority: ticket.priority,
+            assignedTo: ticket.assignedTo,
+            userGroupId: ticket.userGroupId,
+          },
+        ]),
+      ),
+    );
+  }, []);
 
   const handleMergeSelectedTickets = useCallback(
     async (parentTicketId: string): Promise<void> => {
@@ -3026,6 +3075,8 @@ const SupportScreen = (): ReactElement => {
                         dynamicFieldColumns={tableDynamicFieldColumns}
                         onBoardIdResolved={setChannelBoardId}
                         onTicketsLoaded={setKanbanTickets}
+                        selectedIds={selectedTicketIds}
+                        onSelectionChange={handleTableSelectionChange}
                         onTicketClick={ticket => {
                           void navigate(`${supportBase}/${ticket.channelId}/${ticket.xyneId}`, {
                             state: {
@@ -3463,6 +3514,47 @@ export const SupportTicketDetail = ({
       });
     return Array.from(ids);
   }, [ticket?.conversationId, ticket?.referencesIn]);
+
+  // conversationId -> the manually-merged-in ticket that owns it (needed so its
+  // thread-root email uses the ticket-level unmerge action; see mergedRootEmailSource).
+  const mergedSourceByConversationId = useMemo(() => {
+    const map = new Map<string, { id: string; xyneId?: string | null | undefined }>();
+    (ticket?.referencesIn ?? [])
+      .filter(ref => ref.relationType === TicketReferenceRelation.MERGED_INTO)
+      .forEach(ref => {
+        if (ref.sourceTicket?.id && ref.sourceTicket?.conversationId) {
+          map.set(ref.sourceTicket.conversationId, {
+            id: ref.sourceTicket.id,
+            xyneId: ref.sourceTicket.xyneId,
+          });
+        }
+      });
+    return map;
+  }, [ticket?.referencesIn]);
+
+  const handleUnmergeMergedSource = useCallback(
+    async (sourceTicketId: string, sourceTicketXyneId?: string | null): Promise<void> => {
+      const toastId = toast.loading('Unmerging ticket...');
+      try {
+        await apiInstance.post(`/tickets/${sourceTicketId}/unmerge`);
+        toast.success('Ticket unmerged successfully', {
+          id: toastId,
+          description: sourceTicketXyneId
+            ? `${sourceTicketXyneId} is now a separate ticket`
+            : undefined,
+        });
+        if (sourceTicketXyneId && channelIdParam) {
+          void navigate(`${navBasePath ?? supportBase}/${channelIdParam}/${sourceTicketXyneId}`);
+        }
+      } catch {
+        toast.error('Unmerge Failed', {
+          id: toastId,
+          description: 'Operation failed. Please try again.',
+        });
+      }
+    },
+    [channelIdParam, navigate, navBasePath, supportBase],
+  );
 
   const [allEmails] = useCachedQuery(
     queries.getEmailsForConversations({ conversationIds: allConversationIds }),
@@ -4558,6 +4650,8 @@ export const SupportTicketDetail = ({
                       }}
                       deskEmail={deskEmail}
                       onMailtoClick={onMailtoClick}
+                      mergedSourceByConversationId={mergedSourceByConversationId}
+                      onUnmergeSource={handleUnmergeMergedSource}
                     />
                   )}
                 </div>
@@ -5076,6 +5170,8 @@ const EmailThread = ({
   onReplyToEmail,
   deskEmail,
   onMailtoClick,
+  mergedSourceByConversationId,
+  onUnmergeSource,
 }: {
   collapseState: EmailCollapseState;
   ticketId?: string | null | undefined;
@@ -5084,9 +5180,16 @@ const EmailThread = ({
   onReplyToEmail?: (emailId: string, mode: 'reply' | 'replyAll') => void;
   deskEmail?: string | null | undefined;
   onMailtoClick: (email: string) => void;
+  mergedSourceByConversationId?: ReadonlyMap<
+    string,
+    { id: string; xyneId?: string | null | undefined }
+  >;
+  onUnmergeSource?: (
+    sourceTicketId: string,
+    sourceTicketXyneId?: string | null,
+  ) => void | Promise<void>;
 }): ReactElement => {
   const { sortedEmails, collapsedIds, toggleOne, lastEmailId } = collapseState;
-  const rootEmail = sortedEmails[0];
   // Thread-level: upsert the current user's email_reads row. `isRead` compares
   // the stored lastReadEmailAt snapshot against the ticket's lastEmailAt, so
   // every email header in the thread flips read/unread together.
@@ -5101,29 +5204,56 @@ const EmailThread = ({
     () => sortedEmails.flatMap(e => e.attachments ?? []),
     [sortedEmails],
   );
+  // The first email (by position in this already-createdAt-sorted list) seen for
+  // each conversationId is that conversation's own root. For a foreign
+  // conversationId this is a manually-merged-in ticket's thread root, which must
+  // use the ticket-level unmerge action — see mergedSourceByConversationId. Root status is
+  // tracked per-conversationId (not against the combined thread's overall first
+  // email) because auto-merge demerge eligibility is validated per-conversation
+  // server-side (EmailDemergeController resolves "root" via
+  // findByConversationIdOrdered on that email's own conversationId).
+  const { mergedRootEmailSource, conversationRootEmailIds } = useMemo(() => {
+    const mergedMap = new Map<string, { id: string; xyneId?: string | null | undefined }>();
+    const rootIds = new Set<string>();
+    const seenConversationIds = new Set<string>();
+    for (const e of sortedEmails) {
+      if (!seenConversationIds.has(e.conversationId)) {
+        seenConversationIds.add(e.conversationId);
+        rootIds.add(e.id);
+        const source = mergedSourceByConversationId?.get(e.conversationId);
+        if (source) mergedMap.set(e.id, source);
+      }
+    }
+    return { mergedRootEmailSource: mergedMap, conversationRootEmailIds: rootIds };
+  }, [sortedEmails, mergedSourceByConversationId]);
   return (
     <div className='divide-y divide-gray-200 relative'>
-      {sortedEmails.map(email => (
-        <EmailThreadItem
-          key={email.id}
-          email={email}
-          isCollapsed={collapsedIds.has(email.id)}
-          canCollapse={email.id !== lastEmailId}
-          onToggleCollapse={() => toggleOne(email.id)}
-          isRead={isRead}
-          threadAttachments={threadAttachments}
-          {...(onReplyToEmail &&
-            email.id !== lastEmailId && {
-              // Per-email Reply / Reply all only on older messages — the
-              // latest already has the dedicated bar at the thread footer,
-              // so showing one here would be a duplicate.
-              onReply: (mode: 'reply' | 'replyAll') => onReplyToEmail(email.id, mode),
-            })}
-          deskEmail={deskEmail}
-          rootEmail={rootEmail}
-          onMailtoClick={onMailtoClick}
-        />
-      ))}
+      {sortedEmails.map(email => {
+        const mergedSource = mergedRootEmailSource.get(email.id);
+        return (
+          <EmailThreadItem
+            key={email.id}
+            email={email}
+            isCollapsed={collapsedIds.has(email.id)}
+            canCollapse={email.id !== lastEmailId}
+            onToggleCollapse={() => toggleOne(email.id)}
+            isRead={isRead}
+            threadAttachments={threadAttachments}
+            {...(onReplyToEmail &&
+              email.id !== lastEmailId && {
+                // Per-email Reply / Reply all only on older messages — the
+                // latest already has the dedicated bar at the thread footer,
+                // so showing one here would be a duplicate.
+                onReply: (mode: 'reply' | 'replyAll') => onReplyToEmail(email.id, mode),
+              })}
+            deskEmail={deskEmail}
+            isConversationRoot={conversationRootEmailIds.has(email.id)}
+            onMailtoClick={onMailtoClick}
+            {...(mergedSource && { mergedSource })}
+            {...(onUnmergeSource && { onUnmergeSource })}
+          />
+        );
+      })}
     </div>
   );
 };
@@ -5136,9 +5266,11 @@ const EmailThreadItem = ({
   isRead = true,
   onReply,
   deskEmail,
-  rootEmail,
+  isConversationRoot,
   threadAttachments,
   onMailtoClick,
+  mergedSource,
+  onUnmergeSource,
 }: {
   email: Email;
   isCollapsed?: boolean;
@@ -5147,9 +5279,19 @@ const EmailThreadItem = ({
   isRead?: boolean;
   onReply?: (mode: 'reply' | 'replyAll') => void;
   deskEmail?: string | null | undefined;
-  rootEmail: Email | undefined;
+  /** True when this email is the earliest email in its own conversationId —
+   * scoped per-conversation (not the combined thread's overall first email) to
+   * match the backend's per-conversation root check. See canDemerge below. */
+  isConversationRoot: boolean;
   threadAttachments?: NonNullable<Email['attachments']>;
   onMailtoClick: (email: string) => void;
+  /** Set when this email is the thread-root of a manually-merged-in ticket and
+   * must use the ticket-level unmerge action. */
+  mergedSource?: { id: string; xyneId?: string | null | undefined };
+  onUnmergeSource?: (
+    sourceTicketId: string,
+    sourceTicketXyneId?: string | null,
+  ) => void | Promise<void>;
 }): ReactElement => {
   const { channelId: channelIdParam } = useParams<{ channelId?: string }>();
   const navigate = useNavigate();
@@ -5161,11 +5303,21 @@ const EmailThreadItem = ({
 
   const [isDemerging, setIsDemerging] = useState(false);
 
+  // mergedSource routes to the ticket-level unmerge API; otherwise email-level demerge.
   const handleDemerge = async (): Promise<void> => {
     if (isDemerging) return;
     setIsDemerging(true);
 
-    const toastId = toast.loading('Demerging email...', {
+    if (mergedSource) {
+      try {
+        await onUnmergeSource?.(mergedSource.id, mergedSource.xyneId);
+      } finally {
+        setIsDemerging(false);
+      }
+      return;
+    }
+
+    const toastId = toast.loading('Unmerging email...', {
       description: 'Creating new ticket from this email',
     });
 
@@ -5175,7 +5327,7 @@ const EmailThreadItem = ({
       });
 
       if (response.data?.success && response.data.newTicket) {
-        toast.success('Demerge Successful', {
+        toast.success('Unmerge Successful', {
           id: toastId,
           description: `Created new ticket ${response.data.newTicket.xyneId}`,
         });
@@ -5191,7 +5343,7 @@ const EmailThreadItem = ({
         }
       }
     } catch {
-      toast.error('Demerge Failed', {
+      toast.error('Unmerge Failed', {
         id: toastId,
         description: 'Operation failed. Please try again.',
       });
@@ -5201,10 +5353,10 @@ const EmailThreadItem = ({
   };
 
   const canDemerge =
-    email.type === EmailType.DEFAULT &&
-    !!rootEmail &&
-    email.id !== rootEmail.id &&
-    email.externalThreadId === email.externalMessageId;
+    !!mergedSource ||
+    (email.type === EmailType.DEFAULT &&
+      !isConversationRoot &&
+      email.externalThreadId === email.externalMessageId);
 
   const demergeButton = canDemerge ? (
     <button
@@ -5214,16 +5366,17 @@ const EmailThreadItem = ({
       }}
       disabled={isDemerging}
       className='flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-orange-600 bg-orange-50 hover:bg-orange-100 rounded-full transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed'
-      title='Demerge this email to a new ticket'
+      title={mergedSource ? 'Unmerge this ticket' : 'Unmerge this email to a new ticket'}
       data-track-category='SUPPORT'
-      data-track-name='DemergeEmail'
+      data-track-name={mergedSource ? 'UnmergeTicket' : 'DemergeEmail'}
       data-track-metadata={JSON.stringify({
         emailId: email.id,
         conversationId: email.conversationId,
+        ...(mergedSource && { sourceTicketId: mergedSource.id }),
       })}
     >
       <Split size={12} />
-      {isDemerging ? 'Demerging...' : 'Demerge'}
+      {isDemerging ? 'Unmerging...' : 'Unmerge'}
     </button>
   ) : null;
 

--- a/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1526,10 +1526,9 @@ const SupportScreen = (): ReactElement => {
   }, []);
 
   const handleMergeSelectedTickets = useCallback(
-    async (parentTicketId: string): Promise<void> => {
-      if (selectedTickets.size < 2) return;
+    async (parentTicketId: string, ticketIds: string[]): Promise<void> => {
+      if (ticketIds.length < 2) return;
       try {
-        const ticketIds = Array.from(selectedTickets.keys());
         await Promise.all(
           ticketIds
             .filter(id => id !== parentTicketId)

--- a/dashboard/src/routes/SupportScreen/SupportTicketTable.tsx
+++ b/dashboard/src/routes/SupportScreen/SupportTicketTable.tsx
@@ -34,6 +34,8 @@ export interface SupportTicketTableProps {
   onBoardIdResolved: (boardId: string) => void;
   onTicketClick: (ticket: Ticket) => void;
   onTicketsLoaded?: (tickets: Ticket[]) => void;
+  selectedIds?: ReadonlySet<string>;
+  onSelectionChange?: (tickets: Ticket[]) => void;
 }
 
 /**
@@ -50,6 +52,8 @@ export const SupportTicketTable = ({
   onBoardIdResolved,
   onTicketClick,
   onTicketsLoaded,
+  selectedIds,
+  onSelectionChange,
 }: SupportTicketTableProps): ReactElement => {
   const channelUserStatus = useGetChannelUserStatus(channelId);
   const isMember = !!channelUserStatus;
@@ -188,6 +192,8 @@ export const SupportTicketTable = ({
       ticketTags={tagsByTicketId}
       availableTags={availableTags}
       onTitleClick={onTicketClick}
+      {...(selectedIds !== undefined ? { selectedIds } : {})}
+      {...(onSelectionChange !== undefined ? { onSelectionChange } : {})}
       {...(visibleColumns ? { visibleColumns } : {})}
       extraColumns={extraColumns}
     />


### PR DESCRIPTION
POT:- 

https://github.com/user-attachments/assets/767ca8f8-dc1b-48b3-b3ee-230b9dc49319



## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
