### PR TITLE
feat: update ticket merging logic to exclude archived tickets

### DIFF
--- a/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -4283,11 +4283,10 @@ const ChannelCommandMenu = ({
             ? new Date(result.metadata.timestamp).getTime()
             : null,
         }))}
-        onMerge={async parentTicketId => {
+        onMerge={async (parentTicketId, ticketIds) => {
           try {
-            const ticketsToMerge = Array.from(selectedMergeTickets.keys()).filter(
-              id => id !== parentTicketId,
-            );
+            // ticketIds comes pre-filtered from the dialog (archived tickets excluded).
+            const ticketsToMerge = ticketIds.filter(id => id !== parentTicketId);
             await Promise.all(
               ticketsToMerge.map(ticketId =>
                 apiInstance.post(`/tickets/${ticketId}/merge`, { targetTicketId: parentTicketId }),

--- a/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import { X } from 'lucide-react';
 import { Dialog } from '../../ui/Dialog';
 import Button from '../../ui/Button';
 import { RadioGroup, Radio } from '../../ui/RadioGroup';
+import { useQuery } from '../../../hooks/useQuery';
+import { queries } from '../../../zero/queries';
+import { htmlToPlainText } from '../../../utils/sanitizer';
 interface MergeTicket {
   id: string;
   createdAt?: number | null;
@@ -13,7 +17,7 @@ interface MergeTicketsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tickets: MergeTicket[];
-  onMerge: (parentTicketId: string) => void | Promise<void>;
+  onMerge: (parentTicketId: string, ticketIds: string[]) => void | Promise<void>;
 }
 
 export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
@@ -24,36 +28,74 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 }) => {
   const [isMerging, setIsMerging] = useState(false);
   const [selectedParentTicketId, setSelectedParentTicketId] = useState<string | null>(null);
+  const [removedIds, setRemovedIds] = useState<Set<string>>(() => new Set());
 
   const sortedTickets = useMemo(
     () => [...tickets].sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0)),
     [tickets],
   );
 
+  const ticketIds = useMemo(() => tickets.map(t => t.id), [tickets]);
+  // useQuery, not useCachedQuery — the latter can replay a stale "complete" snapshot from its cross-mount cache.
+  const [liveTickets, liveTicketsDetails] = useQuery(queries.ticketsByIds({ ticketIds }), {
+    enabled: open && ticketIds.length > 0,
+  });
+  // Fail closed until the live archived check has actually resolved, not just "no data yet".
+  const archivedStateLoaded = ticketIds.length === 0 || liveTicketsDetails.type === 'complete';
+  const archivedIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (!archivedStateLoaded) return ids;
+    for (const t of liveTickets ?? []) {
+      if (t.isArchived) ids.add(t.id);
+    }
+    return ids;
+  }, [liveTickets, archivedStateLoaded]);
+
+  const excludedTickets = sortedTickets.filter(t => archivedIds.has(t.id));
+  const visibleTickets = useMemo(
+    () =>
+      archivedStateLoaded
+        ? sortedTickets.filter(t => !archivedIds.has(t.id) && !removedIds.has(t.id))
+        : [],
+    [sortedTickets, archivedIds, removedIds, archivedStateLoaded],
+  );
+
   useEffect(() => {
     if (!open) {
       setSelectedParentTicketId(null);
+      setRemovedIds(new Set());
     }
   }, [open]);
 
   useEffect(() => {
-    if (open && selectedParentTicketId === null && sortedTickets.length > 0) {
-      setSelectedParentTicketId(sortedTickets[0]?.id ?? null);
-    }
-  }, [open, sortedTickets, selectedParentTicketId]);
+    if (!open || !archivedStateLoaded) return;
+    if (selectedParentTicketId && visibleTickets.some(t => t.id === selectedParentTicketId)) return;
+    setSelectedParentTicketId(visibleTickets[0]?.id ?? null);
+  }, [open, archivedStateLoaded, visibleTickets, selectedParentTicketId]);
+
+  const handleRemoveTicket = (ticketId: string): void => {
+    setRemovedIds(prev => new Set(prev).add(ticketId));
+  };
 
   const handleMerge = async (): Promise<void> => {
-    if (!selectedParentTicketId) return;
+    if (!selectedParentTicketId || !archivedStateLoaded) return;
     setIsMerging(true);
     try {
-      await onMerge(selectedParentTicketId);
+      await onMerge(
+        selectedParentTicketId,
+        visibleTickets.map(t => t.id),
+      );
     } finally {
       setIsMerging(false);
     }
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange} title={`Merge ${sortedTickets.length} Tickets`}>
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Merge ${visibleTickets.length} Tickets`}
+    >
       <div className='p-6 space-y-4'>
         <p className='text-sm text-muted-foreground'>
           Select the ticket that will be the parent. All other selected tickets will be archived and
@@ -62,6 +104,16 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
 
         {sortedTickets.length === 0 ? (
           <p className='text-sm text-destructive'>Could not load ticket details.</p>
+        ) : !archivedStateLoaded ? (
+          <p className='text-sm text-muted-foreground'>Checking ticket status…</p>
+        ) : visibleTickets.length === 0 ? (
+          <p className='text-sm text-muted-foreground'>
+            All selected tickets are already archived. Cancel and reselect to start over.
+          </p>
+        ) : visibleTickets.length < 2 ? (
+          <p className='text-sm text-muted-foreground'>
+            Only one ticket left to merge. Cancel and reselect at least two.
+          </p>
         ) : (
           <div className='space-y-2'>
             <div className='text-sm font-medium'>Parent ticket</div>
@@ -70,22 +122,48 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
               onChange={value => setSelectedParentTicketId(value)}
               aria-label='Parent ticket'
             >
-              {sortedTickets.map(ticket => (
-                <Radio key={ticket.id} value={ticket.id} subtext={ticket.title || 'No subject'}>
-                  <span className='font-mono text-xs text-muted-foreground'>
-                    {ticket.xyneId || ticket.id.slice(0, 8)}
-                  </span>
-                  <span className='text-muted-foreground ml-2'>
-                    {new Date(ticket.createdAt ?? 0).toLocaleDateString(undefined, {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
-                  </span>
-                </Radio>
-              ))}
+              {visibleTickets.map(ticket => {
+                const plainTitle = ticket.title ? htmlToPlainText(ticket.title) : '';
+                return (
+                  <div key={ticket.id} className='flex items-center gap-2'>
+                    <Radio
+                      value={ticket.id}
+                      subtext={plainTitle || 'No subject'}
+                      className='flex-1'
+                    >
+                      <span className='font-mono text-xs text-muted-foreground'>
+                        {ticket.xyneId || ticket.id.slice(0, 8)}
+                      </span>
+                      <span className='text-muted-foreground ml-2'>
+                        {new Date(ticket.createdAt ?? 0).toLocaleDateString(undefined, {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })}
+                      </span>
+                    </Radio>
+                    <button
+                      type='button'
+                      onClick={() => handleRemoveTicket(ticket.id)}
+                      className='flex size-5 shrink-0 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-xs hover:text-foreground hover:border-input'
+                      aria-label={`Remove ${plainTitle || 'ticket'} from merge`}
+                      data-track-category='Support'
+                      data-track-name='RemoveTicketFromMerge'
+                    >
+                      <X className='size-3' strokeWidth={2.5} />
+                    </button>
+                  </div>
+                );
+              })}
             </RadioGroup>
           </div>
+        )}
+
+        {excludedTickets.length > 0 && (
+          <p className='text-xs text-muted-foreground'>
+            Already archived, excluded from this merge:{' '}
+            {excludedTickets.map(t => t.xyneId || t.id.slice(0, 8)).join(', ')}
+          </p>
         )}
 
         <div className='flex justify-end gap-3 pt-2'>
@@ -99,7 +177,12 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
           </Button>
           <Button
             onClick={() => void handleMerge()}
-            disabled={isMerging || !selectedParentTicketId || sortedTickets.length === 0}
+            disabled={
+              isMerging ||
+              !archivedStateLoaded ||
+              !selectedParentTicketId ||
+              visibleTickets.length < 2
+            }
             data-track-category='Support'
             data-track-name='ConfirmMergeTickets'
           >

--- a/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1477,10 +1477,9 @@ const SupportScreen = (): ReactElement => {
   );
 
   const handleMergeSelectedTickets = useCallback(
-    async (parentTicketId: string): Promise<void> => {
-      if (selectedTickets.size < 2) return;
+    async (parentTicketId: string, ticketIds: string[]): Promise<void> => {
+      if (ticketIds.length < 2) return;
       try {
-        const ticketIds = Array.from(selectedTickets.keys());
         await Promise.all(
           ticketIds
             .filter(id => id !== parentTicketId)


### PR DESCRIPTION
POT:- 

https://github.com/user-attachments/assets/1ac99d21-48f8-4781-a8ef-920b8b2b707c



## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
