### PR TITLE
refactor: XYNE-54744 share the desk channel-membership check across controllers

### DIFF
--- a/apps/backend/src/controllers/aiRetriggerController.ts
+++ b/apps/backend/src/controllers/aiRetriggerController.ts
@@ -4,8 +4,7 @@
 
 import { Request, Response } from 'express';
 import { EmailClassificationRepository } from '../database/repositories/emailClassificationRepository.js';
-import { ChannelParticipantRepository } from '../database/repositories/channelParticipantRepository.js';
-import { ChannelRepository } from '../database/repositories/channelRepository.js';
+import { assertChannelMembership, assertDeskOwner } from '@/utils/channelMembership';
 import { EmailChannelPreferenceRepository } from '../database/repositories/emailChannelPreferenceRepository.js';
 import { DatabaseClient } from '../database/client.js';
 import { emailClassificationQueue } from '../queues/emailClassificationQueue.js';
@@ -24,8 +23,6 @@ type AccessResult =
 
 export class AiRetriggerController {
   private repo = new EmailClassificationRepository();
-  private channelRepo = new ChannelRepository();
-  private channelParticipantRepo = new ChannelParticipantRepository();
   private prefRepo = new EmailChannelPreferenceRepository();
   private prisma = DatabaseClient.getInstance();
 
@@ -34,33 +31,13 @@ export class AiRetriggerController {
     channelId: string,
     requireManageAccess = false,
   ): Promise<AccessResult> {
-    const userId = req.user?.id;
-    const workspaceId = req.user?.workspaceId;
-
-    if (!userId || !workspaceId) {
-      return { ok: false, status: 401, error: 'Authentication required' };
-    }
-
-    const channel = await this.channelRepo.findById(channelId);
-    if (!channel || channel.workspaceId !== workspaceId) {
-      return { ok: false, status: 404, error: 'Channel not found' };
-    }
-
-    const isParticipant = await this.channelParticipantRepo.isParticipant(channelId, userId);
-    if (!isParticipant) {
-      return { ok: false, status: 403, error: 'Not a member of this channel' };
-    }
-
-    if (!requireManageAccess) {
-      return { ok: true, userId };
-    }
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) return access;
+    if (!requireManageAccess) return { ok: true, userId: access.userId };
 
     const preference = await this.repo.findRawPreferenceByChannelId(channelId);
-    if (channel.createdBy === userId || preference?.ownerUserId === userId) {
-      return { ok: true, userId };
-    }
-
-    return { ok: false, status: 403, error: 'Only the desk owner can retrigger AI' };
+    const owned = assertDeskOwner(access, preference?.ownerUserId, 'Only the desk owner can retrigger AI');
+    return owned.ok ? { ok: true, userId: access.userId } : owned;
   }
 
   private async readFeatures(channelId: string): Promise<{

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -8,8 +8,8 @@
 import { Request, Response } from 'express';
 import { deskMetricsRepository } from '../database/repositories/deskMetricsRepository.js';
 import { EmailChannelPreferenceRepository } from '../database/repositories/emailChannelPreferenceRepository.js';
-import { ChannelParticipantRepository } from '../database/repositories/channelParticipantRepository.js';
 import { ChannelRepository } from '../database/repositories/channelRepository.js';
+import { assertChannelMembership } from '@/utils/channelMembership';
 import {
   aggregateDeskMetrics,
   type DeskMetricsContribution,
@@ -32,31 +32,14 @@ type CustomFieldFilterArg = {
 
 export class DeskMetricsController {
   private channelRepo = new ChannelRepository();
-  private channelParticipantRepo = new ChannelParticipantRepository();
   private preferenceRepo = new EmailChannelPreferenceRepository();
 
   private async assertChannelAccess(
     req: Request,
     channelId: string,
   ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-    const userId = req.user?.id;
-    const workspaceId = req.user?.workspaceId;
-
-    if (!userId || !workspaceId) {
-      return { ok: false, status: 401, error: 'Authentication required' };
-    }
-
-    const channel = await this.channelRepo.findById(channelId);
-    if (!channel || channel.workspaceId !== workspaceId) {
-      return { ok: false, status: 404, error: 'Channel not found' };
-    }
-
-    const isParticipant = await this.channelParticipantRepo.isParticipant(channelId, userId);
-    if (!isParticipant) {
-      return { ok: false, status: 403, error: 'Not a member of this channel' };
-    }
-
-    return { ok: true };
+    const access = await assertChannelMembership(req, channelId);
+    return access.ok ? { ok: true } : access;
   }
 
   private parseMetricsQuery(

--- a/apps/backend/src/controllers/priorityClassificationController.ts
+++ b/apps/backend/src/controllers/priorityClassificationController.ts
@@ -6,8 +6,7 @@
 import { Request, Response } from 'express';
 import { EmailClassificationService } from '../services/emailClassificationService.js';
 import { EmailClassificationRepository } from '../database/repositories/emailClassificationRepository.js';
-import { ChannelParticipantRepository } from '../database/repositories/channelParticipantRepository.js';
-import { ChannelRepository } from '../database/repositories/channelRepository.js';
+import { assertChannelMembership, assertDeskOwner } from '@/utils/channelMembership';
 import { AgentsConfig } from '../agents/config.js';
 import { logger } from '../utils/logger.js';
 import type { PriorityClassificationPreviewBody, SavePriorityClassificationConfigBody } from '../types/classification.js';
@@ -15,41 +14,19 @@ import type { PriorityClassificationPreviewBody, SavePriorityClassificationConfi
 export class PriorityClassificationController {
   private service = new EmailClassificationService();
   private repo = new EmailClassificationRepository();
-  private channelRepo = new ChannelRepository();
-  private channelParticipantRepo = new ChannelParticipantRepository();
 
   private async assertChannelAccess(
     req: Request,
     channelId: string,
-    requireManageAccess = false
+    requireManageAccess = false,
   ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-    const userId = req.user?.id;
-    const workspaceId = req.user?.workspaceId;
-
-    if (!userId || !workspaceId) {
-      return { ok: false, status: 401, error: 'Authentication required' };
-    }
-
-    const channel = await this.channelRepo.findById(channelId);
-    if (!channel || channel.workspaceId !== workspaceId) {
-      return { ok: false, status: 404, error: 'Channel not found' };
-    }
-
-    const isParticipant = await this.channelParticipantRepo.isParticipant(channelId, userId);
-    if (!isParticipant) {
-      return { ok: false, status: 403, error: 'Not a member of this channel' };
-    }
-
-    if (!requireManageAccess) {
-      return { ok: true };
-    }
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) return access;
+    if (!requireManageAccess) return { ok: true };
 
     const preference = await this.repo.findRawPreferenceByChannelId(channelId);
-    if (channel.createdBy === userId || preference?.ownerUserId === userId) {
-      return { ok: true };
-    }
-
-    return { ok: false, status: 403, error: 'Only the desk owner can manage priority settings' };
+    const owned = assertDeskOwner(access, preference?.ownerUserId, 'Only the desk owner can manage priority settings');
+    return owned.ok ? { ok: true } : owned;
   }
 
   /**

--- a/apps/backend/src/utils/channelMembership.ts
+++ b/apps/backend/src/utils/channelMembership.ts
@@ -1,0 +1,62 @@
+import { Request } from 'express';
+import { Channel } from '@prisma/client';
+import { ChannelRepository } from '@/database/repositories/channelRepository';
+import { ChannelParticipantRepository } from '@/database/repositories/channelParticipantRepository';
+
+export type ChannelAccessGranted = {
+  ok: true;
+  userId: string;
+  workspaceId: string;
+  channel: Channel;
+};
+
+export type ChannelAccessDenied = {
+  ok: false;
+  status: number;
+  error: string;
+};
+
+export type ChannelAccessResult = ChannelAccessGranted | ChannelAccessDenied;
+
+const channelRepo = new ChannelRepository();
+const channelParticipantRepo = new ChannelParticipantRepository();
+
+/**
+ * Desk endpoints require unconditional channel participation, which is stricter than
+ * ChannelsACL (PUBLIC-or-participant). Callers that also gate on desk ownership pass the
+ * granted result to assertDeskOwner.
+ */
+export async function assertChannelMembership(
+  req: Request,
+  channelId: string,
+): Promise<ChannelAccessResult> {
+  const userId = req.user?.id;
+  const workspaceId = req.user?.workspaceId;
+
+  if (!userId || !workspaceId) {
+    return { ok: false, status: 401, error: 'Authentication required' };
+  }
+
+  const channel = await channelRepo.findById(channelId);
+  if (!channel || channel.workspaceId !== workspaceId) {
+    return { ok: false, status: 404, error: 'Channel not found' };
+  }
+
+  const isParticipant = await channelParticipantRepo.isParticipant(channelId, userId);
+  if (!isParticipant) {
+    return { ok: false, status: 403, error: 'Not a member of this channel' };
+  }
+
+  return { ok: true, userId, workspaceId, channel };
+}
+
+export function assertDeskOwner(
+  access: ChannelAccessGranted,
+  preferenceOwnerUserId: string | null | undefined,
+  denyMessage: string,
+): ChannelAccessResult {
+  if (access.channel.createdBy === access.userId || preferenceOwnerUserId === access.userId) {
+    return access;
+  }
+  return { ok: false, status: 403, error: denyMessage };
+}


### PR DESCRIPTION
Closes architectural finding **A9**.

## What

Three desk controllers — `deskMetrics`, `priorityClassification`, `aiRetrigger` — each carried a private copy of the same helper: look the channel up, confirm it belongs to the caller's workspace, then require channel participation.

That check is **not** redundant with `ChannelsACL`. The ACL grants PUBLIC-or-participant; these endpoints require participation unconditionally. Replacing it with a plain channel query would let any workspace member read desk metrics or change priority settings on any public desk channel. So the duplication is load-bearing, and a fourth copy drifting out of step is a realistic failure.

Extracted `assertChannelMembership()` and `assertDeskOwner()` into `utils/channelMembership.ts`. Net: 79 lines removed, 78 added, three copies down to one.

## Behaviour is identical — deliberately

Same `401 Authentication required`, `404 Channel not found`, `403 Not a member of this channel`, in the same order. Each controller keeps its own desk-owner message.

The recommendation's optimisation — collapse the two lookups into one participant-filtered `findFirst` — was **not** taken. It converts a non-member's 403 into a 404, and with no test suite there's nothing to catch a client that branches on that distinction. The saved query isn't worth it.

## Scope note

`emailClassificationController` is untouched. It has no channel gate on `main` at all; the gate it needs is added by the tenant-isolation PR (#19). Adding a second version here would conflict on merge.

A fifth variant in `deskMetricsController` was also left alone — it gates tag-generation config on "desk owner **or** channel admin", which is a genuinely different rule rather than a copy.

## Testing

Backend typecheck, backend build, gitleaks on staged changes, and schema-migration validation all pass. No schema changes, no behaviour change, no new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)