### PR TITLE
fix: XYNE-54744 scope memory documents and bind Vespa query values

### DIFF
--- a/apps/backend/src/controllers/documentController.ts
+++ b/apps/backend/src/controllers/documentController.ts
@@ -6,7 +6,7 @@ import { config } from '@/config/env';
 import { DatabaseClient } from '@/database/client';
 import { documentIngestQueue } from '@/queues/documentIngestQueue';
 import { vespaKnowledgeIngestionService } from '@/services/vespaKnowledgeIngestionService';
-import { searchMemory, deleteMemory } from '@/services/memoryService';
+import { searchMemory, deleteMemory , ALL_WORKSPACES } from '@/services/memoryService';
 import { MemoryScope } from '@/vespa/src/types';
 import { getStorageService } from '@/services/storage';
 
@@ -180,6 +180,7 @@ export class DocumentController {
             offset: 0,
           },
           '',
+          ALL_WORKSPACES,
         );
 
         const docs = result.documents;
@@ -188,7 +189,7 @@ export class DocumentController {
           break;
         }
 
-        await Promise.all(docs.map((doc) => deleteMemory(doc.docId)));
+        await Promise.all(docs.map((doc) => deleteMemory(doc.docId, ALL_WORKSPACES)));
         totalDeleted += docs.length;
         logger.info(`[DocumentController] cleanupAllVespaMemory deleted batch=${docs.length} total=${totalDeleted}`);
 

--- a/apps/backend/src/controllers/memoryController.ts
+++ b/apps/backend/src/controllers/memoryController.ts
@@ -32,8 +32,13 @@ export class MemoryController {
     try {
       const document: VespaMemoryDocument = req.body;
       const userId = req.user?.id;
+      const workspaceId = req.user?.workspaceId;
 
-      if (!userId) {
+      // The stored document always carries the caller's workspace, never one supplied
+      // in the request body.
+      document.workspaceId = workspaceId;
+
+      if (!userId || !workspaceId) {
         res.status(401).json({ success: false, error: 'Unauthorized' });
         return;
       }
@@ -66,7 +71,7 @@ export class MemoryController {
 
       // The underlying insert is an upsert keyed on the caller-supplied docId, so reject when
       // the docId already belongs to another user. The owner is stored as either email or id.
-      const existingDoc = await getMemoryById(document.docId);
+      const existingDoc = await getMemoryById(document.docId, workspaceId);
       if (
         existingDoc &&
         existingDoc.userId !== user.email &&
@@ -121,8 +126,9 @@ export class MemoryController {
       const { query, scope, limit, offset, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus, includeQuery, includeSummary, docId } = req.body;
 
       const userId = req.user?.id;
+      const workspaceId = req.user?.workspaceId;
 
-      if (!userId) {
+      if (!userId || !workspaceId) {
         res.status(401).json({ success: false, error: 'Unauthorized' });
         return;
       }
@@ -137,6 +143,7 @@ export class MemoryController {
       const result = await searchMemory(
         { query, scope, limit, offset, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus, includeQuery, includeSummary , docId },
         userId,
+        workspaceId,
       );
 
       res.status(200).json({
@@ -165,6 +172,12 @@ export class MemoryController {
     try {
       const { docId } = req.params;
 
+      const workspaceId = req.user?.workspaceId;
+      if (!workspaceId) {
+        res.status(401).json({ success: false, error: 'Unauthorized' });
+        return;
+      }
+
       if (!docId) {
         res.status(400).json({
           success: false,
@@ -175,7 +188,7 @@ export class MemoryController {
 
       logger.info('Getting memory document', { docId });
 
-      const document = await getMemoryById(docId);
+      const document = await getMemoryById(docId, workspaceId);
 
       if (!document) {
         res.status(404).json({
@@ -215,6 +228,13 @@ export class MemoryController {
     try {
       const { docId } = req.params;
 
+      const workspaceId = req.user?.workspaceId;
+      if (!workspaceId) {
+        res.status(401).json({ success: false, error: 'Unauthorized' });
+        return;
+      }
+
+
       if (!docId) {
         res.status(400).json({
           success: false,
@@ -228,7 +248,7 @@ export class MemoryController {
       // Only the owner may modify a memory document. The doc's `userId` field stores the
       // owner's email (buildMemoryYql scope 'my'); accept the caller's email OR id to match
       // the stored convention.
-      const existingDoc = await getMemoryById(docId);
+      const existingDoc = await getMemoryById(docId, workspaceId);
       if (!existingDoc) {
         res.status(404).json({ success: false, error: 'Memory document not found' });
         return;
@@ -239,7 +259,7 @@ export class MemoryController {
         return;
       }
 
-      const updated = await updateMemory(docId, req.body);
+      const updated = await updateMemory(docId, req.body, workspaceId);
 
       if (!updated) {
         res.status(404).json({
@@ -275,6 +295,13 @@ export class MemoryController {
     try {
       const { docId } = req.params;
 
+      const workspaceId = req.user?.workspaceId;
+      if (!workspaceId) {
+        res.status(401).json({ success: false, error: 'Unauthorized' });
+        return;
+      }
+
+
       if (!docId) {
         res.status(400).json({
           success: false,
@@ -287,7 +314,7 @@ export class MemoryController {
 
       // Only the owner may delete a memory document (see updateMemoryDocument). The doc's
       // `userId` holds the owner's email.
-      const docToDelete = await getMemoryById(docId);
+      const docToDelete = await getMemoryById(docId, workspaceId);
       if (!docToDelete) {
         res.status(404).json({ success: false, error: 'Memory document not found' });
         return;
@@ -298,7 +325,7 @@ export class MemoryController {
         return;
       }
 
-      await deleteMemory(docId);
+      await deleteMemory(docId, workspaceId);
 
       res.status(204).send();
     } catch (error) {
@@ -324,8 +351,9 @@ export class MemoryController {
       const { sessionId } = req.params;
       const { docType } = req.query;
       const userId = req.user?.id;
+      const workspaceId = req.user?.workspaceId;
 
-      if (!userId) {
+      if (!userId || !workspaceId) {
         res.status(401).json({ success: false, error: 'Unauthorized' });
         return;
       }
@@ -350,6 +378,7 @@ export class MemoryController {
           docType: docType as VespaDocType,
         },
         userId,
+        workspaceId,
       );
 
       res.status(200).json({
@@ -469,7 +498,8 @@ export class MemoryController {
   replaceSessionMemory = async (req: Request, res: Response): Promise<void> => {
     try {
       const userId = req.user?.id;
-      if (!userId) {
+      const workspaceId = req.user?.workspaceId;
+      if (!userId || !workspaceId) {
         res.status(401).json({ success: false, error: 'Unauthorized' });
         return;
       }
@@ -497,6 +527,7 @@ export class MemoryController {
       const existing = await searchMemory(
         { query: '', scope: 'all', limit: 1, offset: 0, sessionId },
         userId,
+        workspaceId,
       );
       const contextDoc = existing.documents[0];
 

--- a/apps/backend/src/services/conversationAnalysisService.ts
+++ b/apps/backend/src/services/conversationAnalysisService.ts
@@ -2,7 +2,7 @@ import { Agent } from 'agentic-framework';
 import { createUserMessage } from '@framework';
 import { agentService } from './agentService';
 import { logger } from '@/utils/logger';
-import { searchMemory } from './memoryService';
+import { searchMemory, ALL_WORKSPACES } from './memoryService';
 import { MemoryScope, VespaDocType, type VespaMemoryDocument } from '@/vespa/src/types';
 import type { ConversationSourceAdapter, MemoryIngestionContext } from './conversationIngestion/types';
 
@@ -94,8 +94,8 @@ async function fetchExistingKnowledge(
   };
 
   const [sopsResult, factsResult] = await Promise.all([
-    searchMemory({ ...searchParams, docType: VespaDocType.SOP }, ''),
-    searchMemory({ ...searchParams, docType: VespaDocType.FACT }, ''),
+    searchMemory({ ...searchParams, docType: VespaDocType.SOP }, '', ALL_WORKSPACES),
+    searchMemory({ ...searchParams, docType: VespaDocType.FACT }, '', ALL_WORKSPACES),
   ]);
 
   return {

--- a/apps/backend/src/services/conversationIngestion/tools/searchMemoryTool.ts
+++ b/apps/backend/src/services/conversationIngestion/tools/searchMemoryTool.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { BaseTool, Tool } from '@framework';
 import type { ToolExecutionContext, ToolExecutionResult } from '@framework';
-import { searchMemory } from '@/services/memoryService';
+import { searchMemory, ALL_WORKSPACES } from '@/services/memoryService';
 import { MemoryScope, VespaDocType } from '@/vespa/src/types';
 import { logger } from '@/utils/logger';
 
@@ -82,6 +82,7 @@ export class SearchMemoryTool extends BaseTool<Input, Output, Output> {
         ...(input.repoUrl && { repoUrl: input.repoUrl }),
       },
       userId,
+      ALL_WORKSPACES,
     );
 
     const filteredDocs = input.excludeSessionId

--- a/apps/backend/src/services/memoryService.ts
+++ b/apps/backend/src/services/memoryService.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/utils/logger';
-import { escapeYqlString } from '@/utils/yqlEscape';
+import { VespaQueryParams } from '@/vespa/src/utils/YqlBuilder';
 import { vespaClient } from '@/services/vespaSearch';
 import { NAMESPACE, CLUSTER } from '@/vespa/vespaConfig';
 import {
@@ -19,6 +19,13 @@ import { DatabaseClient } from '@/database/client';
 import removeMarkdown from 'remove-markdown';
 
 const MEMORY_SCHEMA = memorySchema;
+
+/**
+ * Passed as workspaceId by background ingestion paths whose job payload carries no workspace.
+ * Every request-serving caller passes a real workspace id; this constant exists so the small
+ * number of unscoped callers are greppable rather than implicit.
+ */
+export const ALL_WORKSPACES = '__all_workspaces__';
 
 /**
  * Strip markdown syntax to produce clean plain text
@@ -61,6 +68,7 @@ async function buildMemoryYql(params: {
   query?: string;
   scope: MemoryScope;
   userId: string;
+  workspaceId: string;
   limit: number;
   offset: number;
   docType?: VespaDocType;
@@ -73,10 +81,11 @@ async function buildMemoryYql(params: {
   parentRef?: string;
   reviewStatus?: string;
   docId?: string;
-}): Promise<string> {
-  const { query, scope, userId, limit, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus, docId } = params;
+}): Promise<{ yql: string; params: VespaQueryParams }> {
+  const { query, scope, userId, workspaceId, limit, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus, docId } = params;
 
   const conditions: string[] = [];
+  const queryParams = new VespaQueryParams();
 
   // Escape any value interpolated into a YQL string literal: a raw `"` or `\` in a filter
   // value (a docId/tag/repoUrl, or an ingested value such as an email subject that lands in
@@ -84,11 +93,11 @@ async function buildMemoryYql(params: {
   // The free-text `query` is NOT interpolated: it is bound as the @query parameter
   // (userInput(@query)), so it stays parameterized.
 
-  // The `contains` filters below select which of a user's cumulative memory a request is
-  // about. `scope` chooses between the caller's own documents and the shared set.
-  //
-  // Any narrowing this clause needs to apply belongs here, alongside the scope filter, and
-  // is bound through VespaQueryParams rather than interpolated — see YqlBuilder.
+
+  // Every memory query is scoped to the caller's workspace.
+  if (workspaceId !== ALL_WORKSPACES) {
+    conditions.push(`workspaceId contains ${queryParams.bind('workspaceId', workspaceId)}`);
+  }
 
   // get the email of that user
   const prisma = DatabaseClient.getInstance();
@@ -98,58 +107,58 @@ async function buildMemoryYql(params: {
 
   // Scope filter: 'my' restricts to user's own documents
   if (scope === 'my') {
-    conditions.push(`userId contains "${escapeYqlString(user?.email)}"`);
+    conditions.push(`userId contains ${queryParams.bind('userId', user?.email ?? '')}`);
   }
 
   // DocType filter
   if (docType) {
-    conditions.push(`docType contains "${escapeYqlString(docType)}"`);
+    conditions.push(`docType contains ${queryParams.bind('docType', docType)}`);
   }
 
   // DocId filter
   if (docId) {
-    conditions.push(`docId contains "${escapeYqlString(docId)}"`);
+    conditions.push(`docId contains ${queryParams.bind('docId', docId)}`);
   }
 
   // Tags filter
   if (tags && tags.length > 0) {
-    const tagConditions = tags.map((tag) => `tags contains "${escapeYqlString(tag)}"`);
+    const tagConditions = tags.map((tag) => `tags contains ${queryParams.bind('tags', tag)}`);
     conditions.push(`(${tagConditions.join(' or ')})`);
   }
 
   // RepoUrl filter
   if (repoUrl) {
-    conditions.push(`repoUrl contains "${escapeYqlString(repoUrl)}"`);
+    conditions.push(`repoUrl contains ${queryParams.bind('repoUrl', repoUrl)}`);
   }
 
   // CommitId filter (exact match)
   if (commitId) {
-    conditions.push(`commitId contains "${escapeYqlString(commitId)}"`);
+    conditions.push(`commitId contains ${queryParams.bind('commitId', commitId)}`);
   }
 
   // SessionId filter (exact match)
   if (sessionId) {
-    conditions.push(`sessionId contains "${escapeYqlString(sessionId)}"`);
+    conditions.push(`sessionId contains ${queryParams.bind('sessionId', sessionId)}`);
   }
 
   // FilePointers filter
   if (filePointers) {
-    conditions.push(`filePointers contains "${escapeYqlString(filePointers)}"`);
+    conditions.push(`filePointers contains ${queryParams.bind('filePointers', filePointers)}`);
   }
 
   // TicketId filter
   if (ticketId) {
-    conditions.push(`ticketId contains "${escapeYqlString(ticketId)}"`);
+    conditions.push(`ticketId contains ${queryParams.bind('ticketId', ticketId)}`);
   }
 
   // ParentRef filter (exact match)
   if (parentRef) {
-    conditions.push(`parentRef contains "${escapeYqlString(parentRef)}"`);
+    conditions.push(`parentRef contains ${queryParams.bind('parentRef', parentRef)}`);
   }
 
   // ReviewStatus filter
   if (reviewStatus) {
-    conditions.push(`reviewStatus contains "${escapeYqlString(reviewStatus)}"`);
+    conditions.push(`reviewStatus contains ${queryParams.bind('reviewStatus', reviewStatus)}`);
   }
 
   // Search condition (text + vector)
@@ -161,7 +170,7 @@ async function buildMemoryYql(params: {
 
   const whereClause = conditions.length > 0 ? ` where ${conditions.join(' and ')}` : ` where true`;
 
-  return `select * from sources ${MEMORY_SCHEMA}${whereClause}`;
+  return { yql: `select * from sources ${MEMORY_SCHEMA}${whereClause}`, params: queryParams };
 }
 
 /**
@@ -241,13 +250,15 @@ async function attachPullRequestsToDocuments(
 export async function searchMemory(
   request: MemorySearchRequest,
   userId: string,
+  workspaceId: string,
 ): Promise<MemorySearchResult> {
   const { query, scope, limit = 20, offset = 0, docType, tags, repoUrl, commitId, sessionId, filePointers, ticketId, parentRef, reviewStatus , includeQuery = true, includeSummary = true, docId} = request;
 
-  const yql = await buildMemoryYql({
+  const { yql, params } = await buildMemoryYql({
     query,
     scope,
     userId,
+    workspaceId,
     limit,
     offset,
     docType,
@@ -269,6 +280,7 @@ export async function searchMemory(
     offset,
     'ranking.profile': 'default_native',
     timeout: '10s',
+    ...params.toRequestProperties(),
   };
 
   // Add query and embedding input only when query is present
@@ -313,6 +325,7 @@ export async function searchMemory(
  */
 export async function getMemoryById(
   docId: string,
+  workspaceId: string,
 ): Promise<VespaMemoryDocument | null> {
   try {
     const result = await vespaClient.getDocument({
@@ -323,6 +336,13 @@ export async function getMemoryById(
     });
 
     if (!result || !result.fields) {
+      return null;
+    }
+
+    // A document from another workspace is treated as absent.
+    const docWorkspaceId = (result.fields as { workspaceId?: unknown }).workspaceId;
+    if (workspaceId !== ALL_WORKSPACES && (typeof docWorkspaceId !== 'string' || docWorkspaceId !== workspaceId)) {
+      logger.warn('[Memory] Document requested outside its workspace', { docId });
       return null;
     }
 
@@ -371,9 +391,10 @@ export async function insertMemory(doc: VespaMemoryDocument): Promise<void> {
 export async function updateMemory(
   docId: string,
   fields: MemoryUpdateFields,
+  workspaceId: string,
 ): Promise<VespaMemoryDocument | null> {
   try {
-    const oldDoc = await getMemoryById(docId);
+    const oldDoc = await getMemoryById(docId, workspaceId);
     if (!oldDoc) throw new Error(`Document ${docId} not found`);
 
     // If rawContent is being updated, auto-derive chatSummary from it
@@ -393,7 +414,7 @@ export async function updateMemory(
     );
 
     logger.info(`[Memory] In-place updated document ${docId}`, { fields: Object.keys(fields) });
-    return getMemoryById(docId);
+    return getMemoryById(docId, workspaceId);
   } catch (error) {
     logger.error(`[Memory] Error updating document ${docId}:`, error);
     throw error;
@@ -403,7 +424,12 @@ export async function updateMemory(
 /**
  * Delete a memory document from Vespa
  */
-export async function deleteMemory(docId: string): Promise<void> {
+export async function deleteMemory(docId: string, workspaceId: string): Promise<void> {
+  const existing = await getMemoryById(docId, workspaceId);
+  if (!existing) {
+    logger.warn('[Memory] Refusing delete outside the caller workspace', { docId });
+    return;
+  }
   try {
     await vespaClient.deleteDocument({
       namespace: NAMESPACE,

--- a/apps/backend/src/services/vespaKnowledgeIngestionService.ts
+++ b/apps/backend/src/services/vespaKnowledgeIngestionService.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import removeMarkdown from 'remove-markdown';
 import { logger } from '@/utils/logger';
-import { searchMemory, insertMemory, deleteMemory } from './memoryService';
+import { searchMemory, ALL_WORKSPACES, insertMemory, deleteMemory } from './memoryService';
 import { MemoryScope, VespaDocType, type VespaMemoryDocument } from '@/vespa/src/types';
 import type { ConversationSourceAdapter } from './conversationIngestion/types';
 import type { ExtractedSOP, ExtractedFACT } from './conversationAnalysisService';
@@ -51,6 +51,7 @@ async function getAllDocumentsForSession(sessionId: string): Promise<VespaMemory
       sessionId,
     },
     '',
+    ALL_WORKSPACES,
   );
   return result.documents;
 }
@@ -70,7 +71,7 @@ async function deleteAllForSession(sessionId: string): Promise<void> {
   
   for (const doc of existingDocs) {
     try {
-      await deleteMemory(doc.docId);
+      await deleteMemory(doc.docId, ALL_WORKSPACES);
     } catch (err) {
       logger.error(`[VESPA-KNOWLEDGE] Failed to delete doc ${doc.docId}:`, err);
     }

--- a/apps/backend/src/utils/vespaDuplicateDetector.ts
+++ b/apps/backend/src/utils/vespaDuplicateDetector.ts
@@ -7,7 +7,7 @@ import { vespaClient } from '@/services/vespaSearch';
 import { convert } from 'html-to-text';
 import { type VespaTicketDocument, type VespaSearchResponse } from '@/vespa/src/types';
 import { logger } from '@/utils/logger';
-import { escapeYqlString } from '@/utils/yqlEscape';
+import { VespaQueryParams } from '@/vespa/src/utils/YqlBuilder';
 import { repositories } from '@/database/repositories';
 
 export interface DuplicateMatch {
@@ -149,8 +149,11 @@ export async function findDuplicateEmailConversation(
   const incomingEmailDomain = getEmailDomain(extractedEmailFrom);
 
   // Build and execute Vespa query with channelId filter for better performance.
-  const excludeCondition = excludeTicketId ? ` and docId != "${escapeYqlString(excludeTicketId)}"` : '';
-  const yql = `select * from sources ticket where docType contains "ticket" and title contains "${escapeYqlString(normalizedSubject)}" and channelId contains "${escapeYqlString(channelId)}"${excludeCondition}`;
+  const queryParams = new VespaQueryParams();
+  const excludeCondition = excludeTicketId
+    ? ` and docId != ${queryParams.bind('excludeTicketId', excludeTicketId)}`
+    : '';
+  const yql = `select * from sources ticket where docType contains "ticket" and title contains ${queryParams.bind('title', normalizedSubject)} and channelId contains ${queryParams.bind('channelId', channelId)}${excludeCondition}`;
 
   logger.info('[VESPA_DUPLICATE_SEARCH]', { channelId, emailFrom, normalizedSubject, excludeTicketId });
 
@@ -162,6 +165,7 @@ export async function findDuplicateEmailConversation(
       'ranking.profile': 'default_native',
       'ranking.listFeatures': false,
       timeout: '5s',
+      ...queryParams.toRequestProperties(),
     });
 
     const hits = response.root?.children || [];

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -470,7 +470,7 @@ export class SearchService {
       // caller's workspace. The flag is controlled remotely via Superposition.
       const enableWorkspaceFiltering = await superpositionClient.getBooleanValue(
         'enableWorkSpaceFiltering',
-        false,
+        true,
         {}
       );
       const payload = buildPayload(false, useSemanticAnyway, enableWorkspaceFiltering ? effectiveWorkspaceId : undefined);

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -138,7 +138,7 @@ export interface CallFilters {
  * `bind()` returns an `@placeholder` and the value rides as a separate request property, so it
  * is matched as data, never parsed as YQL. Repeated (field, value) pairs reuse one placeholder.
  */
-class VespaQueryParams {
+export class VespaQueryParams {
   private readonly placeholdersByField = new Map<string, Map<string, string>>();
 
   /**


### PR DESCRIPTION
Lifted out of PR #170 so it can be exercised against a live index before it lands. Everything here depends on the shape of the index, not only on the code, and a green build proves none of it.

**What it does**
- Memory documents are scoped to the caller's workspace across read, update and delete. The four background paths that legitimately span workspaces declare it with an explicit sentinel instead of omitting the argument, so the compiler names any call site nobody considered.
- Vespa query values are bound rather than concatenated — `buildMemoryYql` returns the query with its parameters and every value goes through `bind()`.
- Workspace filtering on search defaults on.

**Before this merges**

1. **Backfill `workspaceId` on existing memory documents.** They predate the field. Scope them without the backfill and they stop matching — the symptom is a user's memory quietly emptying, not an error.
2. **Exercise the bound queries against a real index.** A binding that names a field the schema spells differently returns zero rows and reports success. This cannot be caught by a build or a typecheck.
3. **Confirm the search default.** Turning workspace filtering on is right, but it changes what existing queries return.

Closes #68, #98, #126, #181, #251, A17 once merged.