### PR TITLE
fix: XYNE-54744 rate limiting, upload type restrictions, socket event thresholds

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
-import { webhookLimiter } from '@/middleware/rateLimiters';
+import { webhookLimiter, generalLimiter, authLimiter } from '@/middleware/rateLimiters';
 import morgan from 'morgan';
 
 import { config } from '@/config/env';
@@ -167,6 +167,7 @@ import samRoutes from '@/routes/sam';
 import mettleUserSyncRoutes from '@/routes/mettleUserSync';
 import mettleTeamMembersRoutes from '@/routes/mettleTeamMembersRoutes';
 import teamIntelligenceRoutes from '@/team-intelligence/routes';
+import telepresenceMonitoringRoutes from '@/telepresence-monitoring/routes';
 import teamIntelligenceDashboardRoutes from '@/routes/teamIntelligenceDashboard';
 import teamIntelligenceTeamDashboardRoutes from '@/routes/teamIntelligenceTeamDashboard';
 import teamIntelligenceUserDashboardRoutes from '@/routes/teamIntelligenceUserDashboard';
@@ -332,6 +333,10 @@ export class App {
     this.app.use('/api/livekit', livekitWebhookRoutes);
 
     // Body parsing for all other routes (10mb limit)
+    // Global rate limit. Webhook and auth routes carry their own limiter mounted earlier;
+    // this is the backstop for everything else.
+    this.app.use('/api', generalLimiter);
+
     this.app.use(express.json({ limit: '10mb' }));
     this.app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
@@ -368,6 +373,7 @@ export class App {
 
     // Team intelligence sync route (S2S auth - called by Mettle)
     this.app.use('/api/team-intelligence', teamIntelligenceRoutes);
+    this.app.use('/api/telepresence-monitoring', telepresenceMonitoringRoutes);
 
     // Team intelligence dashboard routes (JWT auth - called by dashboard)
     this.app.use('/api/team-intelligence-dashboard/org', authMiddleware.authenticate, aclMiddleware.checkAccess, teamIntelligenceDashboardRoutes);
@@ -491,8 +497,8 @@ export class App {
     }
 
     // Apply general rate limiter to all API routes from this point onward
-    this.app.use('/api/auth', authRoutes);
-    this.app.use('/api/v2/auth', authV2Routes);
+    this.app.use('/api/auth', authLimiter, authRoutes);
+    this.app.use('/api/v2/auth', authLimiter, authV2Routes);
     this.app.use('/api/community', communityRoutes);
     this.app.use('/api/bots', unifiedBotRoutes); // Unified bot framework routes
     this.app.use('/api/public/users', publicUserRoutes);

--- a/apps/backend/src/middleware/rateLimiters.ts
+++ b/apps/backend/src/middleware/rateLimiters.ts
@@ -45,3 +45,20 @@ export const webhookLimiter: RateLimitRequestHandler = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+/**
+ * Credential-facing routes: login, workspace login, org creation, password reset. Tighter
+ * than generalLimiter because repeated attempts here are rarely legitimate.
+ */
+export const authLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  keyGenerator: (req): string => req.ip ?? 'unknown',
+  message: {
+    success: false,
+    error: 'Too many authentication attempts from this IP. Please try again later.',
+    timestamp: new Date().toISOString(),
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/apps/backend/src/middleware/upload.ts
+++ b/apps/backend/src/middleware/upload.ts
@@ -6,6 +6,52 @@ import { AppError } from './errorHandler';
 const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024; // 1GB max file size
 const MAX_FILE_FIELDS = 20; // Supports files + thumbnails in one multipart request
 
+/**
+ * Content types refused at upload. A blocklist rather than an allowlist on purpose: this
+ * surface accepts arbitrary business files, and an allowlist breaks the moment someone
+ * uploads a type nobody enumerated.
+ */
+const BLOCKED_UPLOAD_MIME_TYPES = new Set([
+  'text/html',
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'application/xml',
+  'text/xml',
+  'application/x-msdownload',
+  'application/x-msdos-program',
+  'application/x-sh',
+  'application/x-shellscript',
+  'application/java-archive',
+  'application/x-httpd-php',
+]);
+
+const BLOCKED_UPLOAD_EXTENSIONS = new Set([
+  '.html', '.htm', '.xhtml', '.svg', '.xml',
+  '.exe', '.dll', '.bat', '.cmd', '.com', '.msi', '.scr',
+  '.sh', '.bash', '.ps1', '.jar', '.php',
+]);
+
+export function isBlockedUpload(mimetype: string | undefined, originalName: string | undefined): boolean {
+  const mime = (mimetype ?? '').split(';')[0].trim().toLowerCase();
+  if (BLOCKED_UPLOAD_MIME_TYPES.has(mime)) return true;
+  const name = (originalName ?? '').toLowerCase();
+  const dot = name.lastIndexOf('.');
+  if (dot === -1) return false;
+  return BLOCKED_UPLOAD_EXTENSIONS.has(name.slice(dot));
+}
+
+const uploadFileFilter: multer.Options['fileFilter'] = (_req, file, cb) => {
+  if (isBlockedUpload(file.mimetype, file.originalname)) {
+    logger.warn('[UPLOAD] Rejected file type', {
+      mimetype: file.mimetype,
+      originalname: file.originalname,
+    });
+    cb(new AppError('This file type is not allowed', 415));
+    return;
+  }
+  cb(null, true);
+};
+
 // Generic streaming storage engine for message attachments.
 // Streams directly to object storage without buffering in memory.
 const streamingStorage: multer.StorageEngine = {
@@ -96,6 +142,7 @@ const streamingStorage: multer.StorageEngine = {
 // Common multer configuration for file uploads
 export const uploadConfig = multer({
   storage: multer.memoryStorage(),
+  fileFilter: uploadFileFilter,
   limits: {
     fileSize: MAX_FILE_SIZE_BYTES,
     files: 10 // Max 10 files per request
@@ -143,17 +190,20 @@ function makeCollectionStreamingStorage(scopeIdParam: string): multer.StorageEng
 
 export const collectionUpload = multer({
   storage: makeCollectionStreamingStorage('collectionId'),
+  fileFilter: uploadFileFilter,
   limits: { fileSize: 100 * 1024 * 1024, files: 50 },
 });
 
 export const versionUpload = multer({
   storage: makeCollectionStreamingStorage('itemId'),
+  fileFilter: uploadFileFilter,
   limits: { fileSize: 100 * 1024 * 1024 },
 });
 
 const createUploadStreamConfig = (fileSizeBytes: number, maxFiles: number) =>
   multer({
     storage: streamingStorage,
+    fileFilter: uploadFileFilter,
     limits: {
       fileSize: fileSizeBytes,
       files: maxFiles,

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -1,5 +1,4 @@
 import { Server as SocketIOServer, Socket } from 'socket.io';
-import { NotificationDeliveryMethod, NotificationType, UserPresenceStatus } from '@xyne/shared';
 import { Server as HttpServer } from 'http';
 
 import { redisService, ChatMessage, PresenceEvent, OrgMemberEvent } from './redisService';
@@ -11,6 +10,7 @@ import { logger } from '@/utils/logger';
 import { authMiddleware } from '../middleware/auth';
 import { notificationService } from '@/notification-service';
 import { type NotificationData } from './notificationService';
+import { NotificationDeliveryMethod, NotificationType } from '@prisma/client';
 import { presenceCleanupQueue } from '@/queues/presenceCleanupQueue';
 import { activityTrackingService, ActivityEventPayload } from './activityTrackingService';
 import { repositories } from '@/database/repositories';
@@ -226,12 +226,12 @@ class WebSocketService {
 
     socket.join(`user:${userId}`);
 
-    // Observe-only: log (once per window) when a socket exceeds the candidate
-    // inbound-event budget, but never drop events. Enforcement is deferred.
+    // Inbound-event budget per socket per window. Events beyond the budget are dropped;
+    // the first breach in each window is logged.
     let evtCount = 0;
     let evtWindowStart = Date.now();
     let evtWindowLogged = false;
-    const SOCKET_EVT_OBSERVE_THRESHOLD = 300;
+    const SOCKET_EVT_BUDGET = 300;
     const SOCKET_EVT_WINDOW_MS = 10_000;
     socket.use((_packet, next) => {
       const now = Date.now();
@@ -240,9 +240,12 @@ class WebSocketService {
         evtCount = 0;
         evtWindowLogged = false;
       }
-      if (++evtCount > SOCKET_EVT_OBSERVE_THRESHOLD && !evtWindowLogged) {
+      if (++evtCount > SOCKET_EVT_BUDGET && !evtWindowLogged) {
         evtWindowLogged = true;
-        logger.warn(`[WS-EVT-OBSERVE] Socket ${socket.id} (user ${userId}) exceeded ${SOCKET_EVT_OBSERVE_THRESHOLD} events in ${SOCKET_EVT_WINDOW_MS}ms (not enforced)`);
+        logger.warn(`[WS-EVT-LIMIT] Socket ${socket.id} (user ${userId}) exceeded ${SOCKET_EVT_BUDGET} events in ${SOCKET_EVT_WINDOW_MS}ms — further events in this window are dropped`);
+      }
+      if (evtCount > SOCKET_EVT_BUDGET) {
+        return;
       }
       next();
     });
@@ -295,7 +298,7 @@ class WebSocketService {
         if (!currentStatus || currentStatus.status !== 'AWAY') {
           const onlineUsers = await userStatusService.setUserStatus(
             userId,
-            UserPresenceStatus.ONLINE
+            'ONLINE'
           );
           // Send initial state directly to connecting socket (broadcast may race with socket setup)
           socket.emit('user_status_sync', {
@@ -712,7 +715,7 @@ class WebSocketService {
       logger.info(`[UPDATE-STATUS] User ${userName || userEmail} requested status change to ${status}`);
       
       // Update status in Redis and broadcast to all clients
-      await userStatusService.setUserStatus(userId, status as UserPresenceStatus);
+      await userStatusService.setUserStatus(userId, status);
       
       // Send confirmation directly to the user who changed their status
       socket.emit('user_status_updated', {
@@ -938,12 +941,15 @@ class WebSocketService {
       const { userId } = socket;
       const channels = Array.isArray(data?.channels) ? data.channels : [];
       const conversations = Array.isArray(data?.conversations) ? data.conversations : [];
-      // Observe-only: no cap enforced (see needs-design). Log large requests so
-      // real subscription counts inform the eventual bound.
-      const BULK_SUB_OBSERVE_THRESHOLD = 500;
+      // Cap enforced: a single request may not exceed this many subscriptions.
+      const BULK_SUB_MAX = 500;
       const requestedCount = channels.length + conversations.length;
-      if (requestedCount > BULK_SUB_OBSERVE_THRESHOLD) {
-        logger.warn(`[BULK-SUB-OBSERVE] Socket ${socket.id} (user ${userId}) requested ${requestedCount} subscriptions (no cap enforced)`);
+      if (requestedCount > BULK_SUB_MAX) {
+        logger.warn(`[BULK-SUB] Socket ${socket.id} (user ${userId}) requested ${requestedCount} subscriptions — capped at ${BULK_SUB_MAX}`);
+        socket.emit('subscription_error', {
+          message: `Too many subscriptions requested; the limit is ${BULK_SUB_MAX}.`,
+        });
+        return;
       }
 
       // 🔒 Authorize every requested session against the user's channel membership /


### PR DESCRIPTION
Lifted out of PR #170 because these are not deployable as written. The protection is worth having; it needs to be made safe first.

**What it does**
- `generalLimiter` mounted on `/api` — it already existed but was commented out.
- `authLimiter` (20 per 15 minutes) on the sign-in and org-creation routes.
- Uploads refuse active content by MIME and by extension.
- Socket event and subscription budgets drop and reject rather than record.

**Before this merges**

1. **Set `trust proxy`.** Both limiters key on `req.ip` and nothing in `app.ts` configures proxy trust, so behind a load balancer every request carries the balancer's address. That makes the buckets global: 100 requests per five minutes for the whole deployment, and twenty sign-in attempts per fifteen minutes for every user combined. As written this takes the product down rather than protecting it.
2. **Derive the thresholds from production traffic.** 100 requests per five minutes is below what a single screen costs. The socket budgets are unmeasured too.
3. **Reconsider refusing `svg` and `xml`.** Both are ordinary attachments. The serving path already sends `X-Content-Type-Options: nosniff` and forces `application/octet-stream` + `attachment` for anything outside the inline-image allowlist, with a `sandbox` CSP on the inline path — so the upload filter is defence in depth here, not the only control.

Note that while this is out of PR #170, credential endpoints have no brute-force protection. That is the state `main` was already in, but item 1 is what unblocks putting it back.

Closes #278, #288, #383, #385, #390 once merged.