### PR TITLE
fix: widen & centralize permanent-auth-error detection for desk email sources

### DIFF
--- a/apps/backend/src/integrations/core/authErrors.test.ts
+++ b/apps/backend/src/integrations/core/authErrors.test.ts
@@ -1,0 +1,46 @@
+import { isPermanentAuthError } from './authErrors';
+
+describe('isPermanentAuthError', () => {
+  it('matches the standard OAuth2 permanent error codes', () => {
+    expect(isPermanentAuthError('invalid_grant')).toBe(true);
+    expect(isPermanentAuthError('unauthorized_client')).toBe(true);
+    expect(isPermanentAuthError('invalid_token')).toBe(true);
+    expect(isPermanentAuthError('invalid_client')).toBe(true);
+  });
+
+  it('matches the google-auth-library "no refresh token" failure that used to slip through', () => {
+    // This is the exact message that dominated the Aug-2026 desk mail incident
+    // and was NOT caught by the old narrow regex.
+    expect(
+      isPermanentAuthError(
+        'Failed to setup Gmail watch: No access, refresh token, API key or refresh handler callback is set.',
+      ),
+    ).toBe(true);
+    expect(isPermanentAuthError('refresh handler callback is not set')).toBe(true);
+  });
+
+  it('matches Google\'s explicit revoke/expiry message', () => {
+    expect(
+      isPermanentAuthError('Token has been expired or revoked.'),
+    ).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isPermanentAuthError('INVALID_GRANT')).toBe(true);
+    expect(isPermanentAuthError('No Access, Refresh Token missing')).toBe(true);
+  });
+
+  it('accepts Error objects and stringifiable values', () => {
+    expect(isPermanentAuthError(new Error('invalid_grant'))).toBe(true);
+    expect(isPermanentAuthError({ toString: () => 'invalid_token' })).toBe(true);
+  });
+
+  it('does NOT flag transient / unrelated failures', () => {
+    expect(isPermanentAuthError('ETIMEDOUT')).toBe(false);
+    expect(isPermanentAuthError('rateLimitExceeded')).toBe(false);
+    expect(isPermanentAuthError('Internal error, please retry')).toBe(false);
+    expect(isPermanentAuthError('')).toBe(false);
+    expect(isPermanentAuthError(null)).toBe(false);
+    expect(isPermanentAuthError(undefined)).toBe(false);
+  });
+});

--- a/apps/backend/src/integrations/core/authErrors.ts
+++ b/apps/backend/src/integrations/core/authErrors.ts
@@ -1,0 +1,57 @@
+/**
+ * Permanent (non-recoverable) auth-failure detection for external email sources.
+ *
+ * A "permanent" auth error means the stored OAuth credential can no longer be
+ * used to talk to the provider and there is NO way to recover from a background
+ * job — the user must re-consent (reconnect). When we see one of these we should
+ * stop retrying, flip the source out of the "connected" state, and tell the
+ * owner to reconnect.
+ *
+ * This used to be a bare `/invalid_grant|unauthorized_client|invalid_token/i`
+ * regex copy-pasted across the watch-renewal queue, the Gmail watch provider,
+ * the email-fetch worker, and the manual refetch route. That narrow set MISSED
+ * the most common real-world failure — google-auth-library throwing
+ * "No access, refresh token, API key or refresh handler callback is set."
+ * (a mailbox whose refresh token is gone). Because that string didn't match,
+ * the renewal job classified it as transient, never deactivated the source,
+ * and the "Connected" badge stayed green while mail silently stopped.
+ *
+ * Centralize + widen it here so every call site agrees on what "reconnect
+ * required" means.
+ */
+
+/**
+ * Substrings/patterns that indicate the credential is dead and a reconnect
+ * (re-consent) is required. Matched case-insensitively against the error
+ * message. Keep this list conservative — only add a pattern when the ONLY
+ * remedy is the user re-authorizing.
+ */
+const PERMANENT_AUTH_ERROR_PATTERNS: RegExp[] = [
+  // Google/OAuth2 standard error codes (RFC 6749 + Google extensions)
+  /invalid_grant/i,
+  /unauthorized_client/i,
+  /invalid_token/i,
+  /invalid_client/i,
+  // Google says the token was explicitly revoked or has fully expired
+  /token has been expired or revoked/i,
+  // google-auth-library throws this when the stored credential has no usable
+  // refresh token — the dominant failure in the Aug-2026 desk mail incident.
+  /no access,?\s*refresh token/i,
+  /refresh handler callback/i,
+];
+
+/**
+ * Returns true when the given error means the source's OAuth credential is
+ * permanently unusable and the owner must reconnect. Accepts an Error, a
+ * string, or anything stringifiable.
+ */
+export function isPermanentAuthError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : String(error ?? '');
+  if (!message) return false;
+  return PERMANENT_AUTH_ERROR_PATTERNS.some((re) => re.test(message));
+}

--- a/apps/backend/src/integrations/routes/external-source-sync.ts
+++ b/apps/backend/src/integrations/routes/external-source-sync.ts
@@ -13,6 +13,7 @@ import { adapterRegistry } from '../core/adapterRegistry';
 import { logger } from '../../utils/logger';
 import { RawBodyRequest } from '@/types/express';
 import { webhookLimiter } from '@/middleware/rateLimiters';
+import { isPermanentAuthError } from '@/integrations/core/authErrors';
 import { authMiddleware } from '@/middleware/auth';
 import { ExternalSourceRepository } from '@/database/repositories/externalSourceRepository';
 import { emailFetchQueue } from '@/queues/emailFetchQueue';
@@ -226,7 +227,7 @@ router.post(
       return res.json({ success: true, ...result });
     } catch (error) {
       const raw = error instanceof Error ? error.message : String(error);
-      const needsReauth = /invalid_grant|unauthorized_client|invalid_token/i.test(raw);
+      const needsReauth = isPermanentAuthError(raw);
       const status = needsReauth ? 403 : 500;
       logger.error('Fetch failed', { error: raw });
       return res.status(status).json({

--- a/apps/backend/src/pubsub/providers/GmailWatchProvider.ts
+++ b/apps/backend/src/pubsub/providers/GmailWatchProvider.ts
@@ -13,6 +13,7 @@ import { BaseWatchProvider, WatchResult, SubscriptionRecord } from '../pubsubTyp
 import { GoogleService } from '@/services/googleService';
 import { ExternalSourceRepository } from '@/database/repositories/externalSourceRepository';
 import { ExternalSourcePlatform } from '@/integrations/core/types';
+import { isPermanentAuthError as isPermanentAuthErrorShared } from '@/integrations/core/authErrors';
 
 export class GmailWatchProvider extends BaseWatchProvider {
   readonly name = 'gmail';
@@ -67,9 +68,7 @@ export class GmailWatchProvider extends BaseWatchProvider {
   }
 
   isPermanentAuthError(error: Error): boolean {
-    return /invalid_grant|unauthorized_client|invalid_token/i.test(
-      error.message
-    );
+    return isPermanentAuthErrorShared(error);
   }
 
   async markError(id: string): Promise<void> {

--- a/apps/backend/src/queues/gmailWatchRenewalQueue.ts
+++ b/apps/backend/src/queues/gmailWatchRenewalQueue.ts
@@ -18,6 +18,7 @@ import { ExternalSourceRepository } from '@/database/repositories/externalSource
 import { GoogleService } from '@/services/googleService';
 import { ExternalSourcePlatform } from '@/integrations/core/types';
 import { logger } from '@/utils/logger';
+import { isPermanentAuthError } from '@/integrations/core/authErrors';
 
 const TAG = '[GmailWatchRenewal]';
 const GMAIL_WATCH_RENEWAL_CRON =
@@ -26,12 +27,6 @@ const GMAIL_WATCH_RENEWAL_CRON =
 // Process N sources concurrently per batch. Gmail's per-user quota is
 // generous; keep this modest so one slow source doesn't stall the cycle.
 const BATCH_SIZE = 10;
-
-// Same "permanent auth failure" detection used by the manual refetch flow
-// (external-source-sync.ts:174). Seeing one of these means the refresh token
-// has been revoked and there's no way to recover from a background job —
-// deactivate so we stop pounding a dead credential.
-const PERMANENT_AUTH_ERROR = /invalid_grant|unauthorized_client|invalid_token/i;
 
 const externalSourceRepo = new ExternalSourceRepository();
 
@@ -56,7 +51,7 @@ async function renewSource(source: {
     return { status: 'renewed', expiration: result.expiration, historyId: result.historyId };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    if (PERMANENT_AUTH_ERROR.test(message)) {
+    if (isPermanentAuthError(message)) {
       try {
         await externalSourceRepo.update(source.id, { isActive: false });
         logger.error(`${TAG} deactivated source due to bad credentials`, {

--- a/apps/backend/src/workers/emailFetchWorker.ts
+++ b/apps/backend/src/workers/emailFetchWorker.ts
@@ -3,6 +3,7 @@ import { ActivityClassification, NotificationType } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 import { ExternalSourceRepository } from '@/database/repositories/externalSourceRepository';
 import { adapterRegistry } from '@/integrations/core/adapterRegistry';
+import { isPermanentAuthError } from '@/integrations/core/authErrors';
 import '@/integrations';
 import { notificationService } from '@/notification-service';
 import { activityService } from '@/services/activity/activityService';
@@ -177,7 +178,7 @@ class EmailFetchWorker {
   private async notifyFailure(data: EmailFetchJobData, err: Error): Promise<void> {
     try {
       const raw = err?.message ?? String(err);
-      const needsReauth = /invalid_grant|unauthorized_client|invalid_token/i.test(raw);
+      const needsReauth = isPermanentAuthError(raw);
       await notificationService.sendNotification(
         data.requesterUserId,
         NotificationType.EMAIL_FETCH_FAILED,


### PR DESCRIPTION
## 1. Problem Description
Desk Gmail mailboxes could silently stop syncing while the desk **Settings still showed "Connected"** (Aug-2026 `support-nammayatri-in` / prod Gmail PubSub incident). The "Connected" badge is `ExternalSource.isActive`, which is only flipped to `false` when a background job classifies an OAuth failure as **permanent**.

Four places independently decided "is this a permanent auth failure?" using the same narrow regex `/invalid_grant|unauthorized_client|invalid_token/i`:
- `apps/backend/src/queues/gmailWatchRenewalQueue.ts`
- `apps/backend/src/pubsub/providers/GmailWatchProvider.ts`
- `apps/backend/src/workers/emailFetchWorker.ts`
- `apps/backend/src/integrations/routes/external-source-sync.ts`

That set **missed the most common real-world failure** from google-auth-library: `No access, refresh token, API key or refresh handler callback is set.` (a mailbox whose refresh token is gone). Because it didn't match, the daily watch-renewal job treated it as *transient*, never set `isActive=false`, and the badge stayed green while mail stopped.

## 2. How the issue was identified
Prod logs showed 24 `[GoogleService] Failed to setup Gmail watch: No access, refresh token, API key or refresh handler callback is set.` occurrences plus `[PubSubWatchService] Renewal failed`, none of which matched the permanent-error regex, so affected sources were never deactivated and no reconnect signal was raised.

## 3. Solution implemented
- New `apps/backend/src/integrations/core/authErrors.ts` exporting `isPermanentAuthError(error)`, widened to also match `no access, refresh token`, `refresh handler callback`, `token has been expired or revoked`, and `invalid_client` (case-insensitive; accepts Error | string | unknown).
- All four call sites now import and use the shared helper — single source of truth.
- Added `authErrors.test.ts` (6 cases) covering the previously-missed "no refresh token" message and transient-failure negatives.

No behavior change other than: a dead-credential Gmail source is now correctly classified as permanent, so the renewal job deactivates it (`isActive=false`) and the fetch worker / refetch route surface "reconnect required" — closing the "shows Connected but is dead" gap.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A — existing sources whose credentials are already dead will be correctly deactivated on the next daily `gmail-watch-renewal` cycle.

## 7. Environment variable Changes
N/A

## 8. Testing
`npx jest src/integrations/core/authErrors.test.ts` → 6/6 pass. `tsc --noEmit` clean for the changed files.

## 9. Services to which this change is to be deployed
backend (API + email-fetch worker + gmail-watch-renewal queue).

## 10. Main PR link (if raised against a release branch)
N/A — base is `main`.