### PR TITLE
fix: XYNE-54744 port the open-source secops work to the internal branch

### DIFF
--- a/apps/backend/src/controllers/aiRetriggerController.ts
+++ b/apps/backend/src/controllers/aiRetriggerController.ts
@@ -4,8 +4,7 @@
 
 import { Request, Response } from 'express';
 import { EmailClassificationRepository } from '../database/repositories/emailClassificationRepository.js';
-import { ChannelParticipantRepository } from '../database/repositories/channelParticipantRepository.js';
-import { ChannelRepository } from '../database/repositories/channelRepository.js';
+import { assertChannelMembership, assertDeskOwner } from '@/utils/channelMembership';
 import { EmailChannelPreferenceRepository } from '../database/repositories/emailChannelPreferenceRepository.js';
 import { DatabaseClient } from '../database/client.js';
 import { emailClassificationQueue } from '../queues/emailClassificationQueue.js';
@@ -25,8 +24,6 @@ type AccessResult =
 
 export class AiRetriggerController {
   private repo = new EmailClassificationRepository();
-  private channelRepo = new ChannelRepository();
-  private channelParticipantRepo = new ChannelParticipantRepository();
   private prefRepo = new EmailChannelPreferenceRepository();
   private prisma = DatabaseClient.getInstance();
 
@@ -35,33 +32,13 @@ export class AiRetriggerController {
     channelId: string,
     requireManageAccess = false,
   ): Promise<AccessResult> {
-    const userId = req.user?.id;
-    const workspaceId = req.user?.workspaceId;
-
-    if (!userId || !workspaceId) {
-      return { ok: false, status: 401, error: 'Authentication required' };
-    }
-
-    const channel = await this.channelRepo.findById(channelId);
-    if (!channel || channel.workspaceId !== workspaceId) {
-      return { ok: false, status: 404, error: 'Channel not found' };
-    }
-
-    const isParticipant = await this.channelParticipantRepo.isParticipant(channelId, userId);
-    if (!isParticipant) {
-      return { ok: false, status: 403, error: 'Not a member of this channel' };
-    }
-
-    if (!requireManageAccess) {
-      return { ok: true, userId };
-    }
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) return access;
+    if (!requireManageAccess) return { ok: true, userId: access.userId };
 
     const preference = await this.repo.findRawPreferenceByChannelId(channelId);
-    if (channel.createdBy === userId || preference?.ownerUserId === userId) {
-      return { ok: true, userId };
-    }
-
-    return { ok: false, status: 403, error: 'Only the desk owner can retrigger AI' };
+    const owned = assertDeskOwner(access, preference?.ownerUserId, 'Only the desk owner can retrigger AI');
+    return owned.ok ? { ok: true, userId: access.userId } : owned;
   }
 
   private async readFeatures(channelId: string): Promise<{

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -1057,7 +1057,14 @@ export class AuthV2Controller {
         `[${requestId}] mobile-exchange selected via query parameter without the x-platform header (browserInitiated=${looksBrowserInitiated})`,
       );
     }
-    const isMobileNative = nativeByHeader || nativeByQuery;
+    // The native branch is only selectable by a genuine native client, which sends neither
+    // Origin nor Sec-Fetch-Site. Anything browser-initiated takes the web branch.
+    const isMobileNative = (nativeByHeader || nativeByQuery) && !looksBrowserInitiated;
+    if ((nativeByHeader || nativeByQuery) && looksBrowserInitiated) {
+      logger.warn(
+        `[${requestId}] native mobile-exchange requested from a browser-initiated request; falling back to the web branch`,
+      );
+    }
 
     // Helper to send error response (JSON for mobile, redirect for web)
     const sendError = (errorCode: string, message: string, statusCode = 400) => {

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -853,6 +853,23 @@ export class CallController {
           });
           queueCallVespaFeed(call.id, { source: CallVespaFeedSource.CallControllerJoinCallClearRemovedByHost });
         }
+
+        // Who belongs to a call: the host, anyone invited, and the members of the
+        // channel it is happening in — a channel call is offered to the channel, so
+        // membership is the invitation. Matches assertCanViewCallRecordings. Anyone
+        // else holds a link they were never given access by, and is turned away.
+        if (!participant && call.createdByUserId !== user.id) {
+          const isChannelMember = call.channelId
+            ? await repositories.channelParticipants.isParticipant(call.channelId, user.id)
+            : false;
+          if (!isChannelMember) {
+            logger.warn(
+              `[CallController] join denied, no invitation or channel membership | callId=${callId}, userId=${user.id}`,
+            );
+            res.status(403).json({ success: false, error: 'You do not have access to this call' });
+            return;
+          }
+        }
       }
 
       // Generate access token
@@ -1460,6 +1477,11 @@ export class CallController {
         return;
       }
 
+      if (!(await this.isCallAudience(call, userId))) {
+        res.status(403).json({ success: false, error: 'You do not have access to this call' });
+        return;
+      }
+
       if (!(await this.assertCanViewCallRecordings(callId, userId))) {
         res.status(403).json({ success: false, error: 'Access denied' });
         return;
@@ -1585,6 +1607,11 @@ export class CallController {
         res.status(404).json({ success: false, error: 'Call not found' });
         return;
       }
+
+      if (!(await this.isCallAudience(call, userId))) {
+        res.status(403).json({ success: false, error: 'You do not have access to this call' });
+        return;
+      }
       if (
         call.callType === CallType.HEADLESS &&
         !(await callShareService.canView(call, userId, req.user!.workspaceId))
@@ -1682,6 +1709,11 @@ export class CallController {
       const call = await repositories.calls.findByExternalId(callId);
       if (!call) {
         res.status(404).json({ success: false, error: 'Call not found' });
+        return;
+      }
+
+      if (!(await this.isCallAudience(call, userId))) {
+        res.status(403).json({ success: false, error: 'You do not have access to this call' });
         return;
       }
       if (
@@ -1829,6 +1861,12 @@ export class CallController {
         return;
       }
 
+      const callerParticipant = await repositories.calls.findParticipant(call.id, userId);
+      if (!callerParticipant && call.createdByUserId !== userId) {
+        res.status(403).json({ success: false, error: 'You are not a participant of this call' });
+        return;
+      }
+
       if (call.status !== 'ACTIVE') {
         res.status(400).json({ success: false, error: 'Call is not active' });
         return;
@@ -1838,8 +1876,29 @@ export class CallController {
       const invitedUserIds: string[] = [];
       const db = DatabaseClient.getInstance();
 
+      // Invitees are resolved within the caller's workspace.
+      const callerWorkspaceId = req.user?.workspaceId;
+      if (!callerWorkspaceId) {
+        res.status(401).json({ success: false, error: 'Unauthorized' });
+        return;
+      }
+      const invitableUsers = await db.user.findMany({
+        where: { id: { in: userIds as string[] }, workspaceId: callerWorkspaceId },
+        select: { id: true },
+      });
+      const invitableUserIds = new Set(invitableUsers.map(u => u.id));
+      const rejectedUserIds = (userIds as string[]).filter(id => !invitableUserIds.has(id));
+      if (rejectedUserIds.length > 0) {
+        logger.warn(
+          `[${callId}] invite_users_rejected_out_of_workspace | count=${rejectedUserIds.length} caller=${userId}`,
+        );
+      }
+
       // Process each user
       for (const targetUserId of userIds) {
+        if (!invitableUserIds.has(targetUserId)) {
+          continue;
+        }
         // Check if participant already exists
         const existingParticipant = await repositories.calls.findParticipant(call.id, targetUserId);
 
@@ -2231,6 +2290,21 @@ export class CallController {
    * channel members can view/download them even if they didn't join the call.
    * Mutating ops (start/stop/rename/delete) stay participant/starter-gated.
    */
+  /**
+   * Whether a caller belongs to a call's audience: its host, anyone who took part, or a
+   * member of the channel it happened in. A channel call is offered to the channel, so a
+   * member who could not attend can still read what came out of it.
+   */
+  private async isCallAudience(
+    call: { id: string; channelId: string | null; createdByUserId: string },
+    userId: string,
+  ): Promise<boolean> {
+    if (call.createdByUserId === userId) return true;
+    if (await repositories.calls.findParticipant(call.id, userId)) return true;
+    if (!call.channelId) return false;
+    return repositories.channelParticipants.isParticipant(call.channelId, userId);
+  }
+
   private async assertCanViewCallRecordings(callId: string, userId: string): Promise<boolean> {
     const call = await repositories.calls.findByExternalId(callId);
     if (!call) return false;

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -8,8 +8,8 @@
 import { Request, Response } from 'express';
 import { deskMetricsRepository } from '../database/repositories/deskMetricsRepository.js';
 import { EmailChannelPreferenceRepository } from '../database/repositories/emailChannelPreferenceRepository.js';
-import { ChannelParticipantRepository } from '../database/repositories/channelParticipantRepository.js';
 import { ChannelRepository } from '../database/repositories/channelRepository.js';
+import { assertChannelMembership } from '@/utils/channelMembership';
 import {
   aggregateDeskMetrics,
   type DeskMetricsContribution,
@@ -32,31 +32,14 @@ type CustomFieldFilterArg = {
 
 export class DeskMetricsController {
   private channelRepo = new ChannelRepository();
-  private channelParticipantRepo = new ChannelParticipantRepository();
   private preferenceRepo = new EmailChannelPreferenceRepository();
 
   private async assertChannelAccess(
     req: Request,
     channelId: string,
   ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-    const userId = req.user?.id;
-    const workspaceId = req.user?.workspaceId;
-
-    if (!userId || !workspaceId) {
-      return { ok: false, status: 401, error: 'Authentication required' };
-    }
-
-    const channel = await this.channelRepo.findById(channelId);
-    if (!channel || channel.workspaceId !== workspaceId) {
-      return { ok: false, status: 404, error: 'Channel not found' };
-    }
-
-    const isParticipant = await this.channelParticipantRepo.isParticipant(channelId, userId);
-    if (!isParticipant) {
-      return { ok: false, status: 403, error: 'Not a member of this channel' };
-    }
-
-    return { ok: true };
+    const access = await assertChannelMembership(req, channelId);
+    return access.ok ? { ok: true } : access;
   }
 
   private parseMetricsQuery(

--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -96,10 +96,9 @@ export class EmailAuthController {
       }
 
       if (!orgMember.passwordHash) {
-        // EMAIL user who was invited but password isn't set yet
-        res.status(403).json({
-          error: 'Password not set',
-          message: 'Please use forgot password to set your password.',
+        res.status(401).json({
+          error: 'Invalid credentials',
+          message: 'Email or password is incorrect',
         });
         return;
       }

--- a/apps/backend/src/controllers/emailClassificationController.ts
+++ b/apps/backend/src/controllers/emailClassificationController.ts
@@ -6,54 +6,26 @@
 import { Request, Response } from 'express';
 import { EmailClassificationRepository } from '../database/repositories/emailClassificationRepository.js';
 import { EmailClassificationService } from '../services/emailClassificationService.js';
-import { ChannelParticipantRepository } from '../database/repositories/channelParticipantRepository.js';
-import { ChannelRepository } from '../database/repositories/channelRepository.js';
+import { assertChannelMembership, assertDeskOwner } from '@/utils/channelMembership';
 import { logger } from '../utils/logger.js';
 import type { ClassificationPreviewBody } from '../types/classification.js';
 
 export class EmailClassificationController {
   private repo = new EmailClassificationRepository();
   private service = new EmailClassificationService();
-  private channelRepo = new ChannelRepository();
-  private channelParticipantRepo = new ChannelParticipantRepository();
 
-  /**
-   * Gate access to a channel's classification endpoints: caller must be authenticated,
-   * the channel must live in the caller's workspace, and the caller must be a participant.
-   * Mirrors PriorityClassificationController.assertChannelAccess.
-   */
   private async assertChannelAccess(
     req: Request,
     channelId: string,
     requireManageAccess = false,
   ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-    const userId = req.user?.id;
-    const workspaceId = req.user?.workspaceId;
-
-    if (!userId || !workspaceId) {
-      return { ok: false, status: 401, error: 'Authentication required' };
-    }
-
-    const channel = await this.channelRepo.findById(channelId);
-    if (!channel || channel.workspaceId !== workspaceId) {
-      return { ok: false, status: 404, error: 'Channel not found' };
-    }
-
-    const isParticipant = await this.channelParticipantRepo.isParticipant(channelId, userId);
-    if (!isParticipant) {
-      return { ok: false, status: 403, error: 'Not a member of this channel' };
-    }
-
-    if (!requireManageAccess) {
-      return { ok: true };
-    }
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) return access;
+    if (!requireManageAccess) return { ok: true };
 
     const preference = await this.repo.findRawPreferenceByChannelId(channelId);
-    if (channel.createdBy === userId || preference?.ownerUserId === userId) {
-      return { ok: true };
-    }
-
-    return { ok: false, status: 403, error: 'Only the desk owner can manage classification settings' };
+    const owned = assertDeskOwner(access, preference?.ownerUserId, 'Only the desk owner can manage classification settings');
+    return owned.ok ? { ok: true } : owned;
   }
 
   /**

--- a/apps/backend/src/controllers/priorityClassificationController.ts
+++ b/apps/backend/src/controllers/priorityClassificationController.ts
@@ -6,8 +6,7 @@
 import { Request, Response } from 'express';
 import { EmailClassificationService } from '../services/emailClassificationService.js';
 import { EmailClassificationRepository } from '../database/repositories/emailClassificationRepository.js';
-import { ChannelParticipantRepository } from '../database/repositories/channelParticipantRepository.js';
-import { ChannelRepository } from '../database/repositories/channelRepository.js';
+import { assertChannelMembership, assertDeskOwner } from '@/utils/channelMembership';
 import { AgentsConfig } from '../agents/config.js';
 import { logger } from '../utils/logger.js';
 import type { PriorityClassificationPreviewBody, SavePriorityClassificationConfigBody } from '../types/classification.js';
@@ -15,41 +14,19 @@ import type { PriorityClassificationPreviewBody, SavePriorityClassificationConfi
 export class PriorityClassificationController {
   private service = new EmailClassificationService();
   private repo = new EmailClassificationRepository();
-  private channelRepo = new ChannelRepository();
-  private channelParticipantRepo = new ChannelParticipantRepository();
 
   private async assertChannelAccess(
     req: Request,
     channelId: string,
-    requireManageAccess = false
+    requireManageAccess = false,
   ): Promise<{ ok: true } | { ok: false; status: number; error: string }> {
-    const userId = req.user?.id;
-    const workspaceId = req.user?.workspaceId;
-
-    if (!userId || !workspaceId) {
-      return { ok: false, status: 401, error: 'Authentication required' };
-    }
-
-    const channel = await this.channelRepo.findById(channelId);
-    if (!channel || channel.workspaceId !== workspaceId) {
-      return { ok: false, status: 404, error: 'Channel not found' };
-    }
-
-    const isParticipant = await this.channelParticipantRepo.isParticipant(channelId, userId);
-    if (!isParticipant) {
-      return { ok: false, status: 403, error: 'Not a member of this channel' };
-    }
-
-    if (!requireManageAccess) {
-      return { ok: true };
-    }
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) return access;
+    if (!requireManageAccess) return { ok: true };
 
     const preference = await this.repo.findRawPreferenceByChannelId(channelId);
-    if (channel.createdBy === userId || preference?.ownerUserId === userId) {
-      return { ok: true };
-    }
-
-    return { ok: false, status: 403, error: 'Only the desk owner can manage priority settings' };
+    const owned = assertDeskOwner(access, preference?.ownerUserId, 'Only the desk owner can manage priority settings');
+    return owned.ok ? { ok: true } : owned;
   }
 
   /**

--- a/apps/backend/src/controllers/workflowController.ts
+++ b/apps/backend/src/controllers/workflowController.ts
@@ -30,6 +30,72 @@ export class WorkflowController {
     this.workflowRepository = new WorkflowRepository();
   }
 
+  private async authorizeExecution(
+    req: Request,
+    res: Response,
+    executionId: string
+  ): Promise<boolean> {
+    const callerWorkspaceId = req.user?.workspaceId;
+    if (!callerWorkspaceId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return false;
+    }
+
+    const prisma = DatabaseClient.getInstance();
+    const execution = await prisma.workflowExecution.findUnique({
+      where: { id: executionId },
+      select: { id: true, workspaceId: true, workflow: { select: { workspaceId: true } } },
+    });
+
+    const ownerWorkspaceId = execution?.workflow?.workspaceId ?? execution?.workspaceId ?? null;
+    if (!execution || !ownerWorkspaceId || ownerWorkspaceId !== callerWorkspaceId) {
+      if (execution) {
+        logger.warn(
+          `[WorkflowController] Cross-workspace execution access blocked: ${executionId} (${ownerWorkspaceId}) by user ${req.user?.id} (${callerWorkspaceId})`
+        );
+      }
+      res.status(404).json({ error: 'Workflow execution not found' });
+      return false;
+    }
+    return true;
+  }
+
+  private async authorizeStep(req: Request, res: Response, stepId: string): Promise<boolean> {
+    const callerWorkspaceId = req.user?.workspaceId;
+    if (!callerWorkspaceId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return false;
+    }
+
+    const prisma = DatabaseClient.getInstance();
+    const step = await prisma.workflowStep.findUnique({
+      where: { id: stepId },
+      select: {
+        id: true,
+        workspaceId: true,
+        workflowExecution: {
+          select: { workspaceId: true, workflow: { select: { workspaceId: true } } },
+        },
+      },
+    });
+
+    const ownerWorkspaceId =
+      step?.workflowExecution?.workflow?.workspaceId ??
+      step?.workflowExecution?.workspaceId ??
+      step?.workspaceId ??
+      null;
+    if (!step || !ownerWorkspaceId || ownerWorkspaceId !== callerWorkspaceId) {
+      if (step) {
+        logger.warn(
+          `[WorkflowController] Cross-workspace step access blocked: ${stepId} (${ownerWorkspaceId}) by user ${req.user?.id} (${callerWorkspaceId})`
+        );
+      }
+      res.status(404).json({ error: 'Workflow step not found' });
+      return false;
+    }
+    return true;
+  }
+
   /**
    * Copy parent execution's agentic step data to new execution for rerun scenarios.
    * Loads from parent's Redis/GCS storage and copies to new execution's storage.
@@ -657,6 +723,7 @@ export class WorkflowController {
   updateWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { id } = req.params;
+      if (!(await this.authorizeExecution(req, res, id))) return;
       const updateData = req.body;
 
       const execution = await this.workflowRepository.updateWorkflowExecution(id, updateData);
@@ -791,6 +858,7 @@ export class WorkflowController {
   updateWorkflowStep = async (req: Request, res: Response): Promise<void> => {
     try {
       const { id } = req.params;
+      if (!(await this.authorizeStep(req, res, id))) return;
       const updateData = req.body;
 
       // Convert data to JSON string if it's an object
@@ -826,11 +894,21 @@ export class WorkflowController {
   restoreWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
       const { stepId } = req.body;
 
       // Validate required fields
       if (!stepId) {
         res.status(400).json({ error: 'stepId is required (DB ID of INPUT step)' });
+        return;
+      }
+
+      const restoreStep = await this.workflowRepository.getWorkflowStepById(stepId);
+      if (!restoreStep || restoreStep.workflowExecutionId !== executionId) {
+        logger.warn(
+          `[WorkflowController] Restore step ${stepId} does not belong to execution ${executionId}; rejecting restore`
+        );
+        res.status(404).json({ error: 'Step not found' });
         return;
       }
 
@@ -864,6 +942,7 @@ export class WorkflowController {
   rerunWorkflowFromStart = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Use workflow rerun service
       const result = await workflowRerunService.rerunFromExecution(executionId);
@@ -895,6 +974,7 @@ export class WorkflowController {
   continueAgenticStep = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
       const { stepId, message } = req.body;
 
       // Validate required fields
@@ -906,6 +986,14 @@ export class WorkflowController {
       // Get the step to find its stepName for the Redis channel
       const step = await this.workflowRepository.getWorkflowStepById(stepId);
       if (!step) {
+        res.status(404).json({ error: 'Step not found' });
+        return;
+      }
+
+      if (step.workflowExecutionId !== executionId) {
+        logger.warn(
+          `[WorkflowController] Step ${stepId} does not belong to execution ${executionId}; rejecting continue`
+        );
         res.status(404).json({ error: 'Step not found' });
         return;
       }
@@ -1169,6 +1257,7 @@ export class WorkflowController {
   pauseWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Import workflowManager dynamically to avoid circular dependencies
       const { workflowManager } = await import('../workflows/services/workflowManager');
@@ -1215,6 +1304,7 @@ export class WorkflowController {
   resumeWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Import workflowManager dynamically to avoid circular dependencies
       const { workflowManager } = await import('../workflows/services/workflowManager');
@@ -1261,6 +1351,7 @@ export class WorkflowController {
   cancelWorkflowExecution = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
 
       // Import workflowManager dynamically to avoid circular dependencies
       const { workflowManager } = await import('../workflows/services/workflowManager');
@@ -1542,6 +1633,7 @@ export class WorkflowController {
   setExecutionMode = async (req: Request, res: Response): Promise<void> => {
     try {
       const { executionId } = req.params;
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
       const { mode } = req.body;
 
       // Validate required fields

--- a/apps/backend/src/database/tenant/acl-extension.ts
+++ b/apps/backend/src/database/tenant/acl-extension.ts
@@ -100,6 +100,38 @@ function reportForeignWorkspace(model: string, operation: string, row: unknown, 
   logger.warn('[acl] create names a different workspace', { model, operation, given, enforced: ws });
 }
 
+/**
+ * workspaceId is the tenant key: once a row exists it should not move between workspaces.
+ *
+ * Diagnostic only, matching reportForeignWorkspace above. Which callers write a foreign
+ * workspaceId today is not answerable from the code, and the only place that can answer it
+ * is an environment carrying real traffic, so this reports rather than refuses. Turn it into
+ * a refusal once the log is quiet.
+ *
+ * Covers every write that carries a data payload, including the update half of upsert,
+ * which the generic data path does not see.
+ *
+ * Not deduped -- a repeat is itself the signal.
+ */
+function reportWorkspaceReassignment(
+  model: string,
+  operation: string,
+  data: unknown,
+  ws: string,
+): void {
+  const rows: unknown[] = Array.isArray(data) ? data : data != null ? [data] : [];
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') continue;
+    const given = (row as { workspaceId?: unknown }).workspaceId;
+    if (given === undefined || given === null) continue;
+    const value = typeof given === 'object' && given !== null && 'set' in given
+      ? (given as { set?: unknown }).set
+      : given;
+    if (typeof value !== 'string' || value === ws) continue;
+    logger.warn('[acl] update reassigns workspaceId', { model, operation, given: value, enforced: ws });
+  }
+}
+
 const WHERE_OPS = new Set(['findFirst', 'findFirstOrThrow', 'findMany', 'count', 'aggregate', 'groupBy']);
 const UNIQUE_OPS = new Set(['findUnique', 'findUniqueOrThrow']);
 const BULK_MUTATE_OPS = new Set(['updateMany', 'updateManyAndReturn', 'deleteMany']);
@@ -286,6 +318,12 @@ export function withAclExtension<T extends PrismaClient>(prisma: T): T {
             return query(args);
           }
 
+          // workspaceId is immutable. Checked before the mutate filter so it holds even on
+          // tables whose ACL opts out of scoping.
+          if (ctx?.actor !== 'system' && isWorkspaceScopedModel(model)) {
+            reportWorkspaceReassignment(model, operation, (args as { data?: unknown }).data, ws);
+          }
+
           let mutateWhere = acl ? ((await acl.getMutateWhere()) as Record<string, unknown> | null) : null;
           if (!mutateWhere) {
             // Service actors only — see the read branch.
@@ -313,7 +351,12 @@ export function withAclExtension<T extends PrismaClient>(prisma: T): T {
 
           // Upsert: create-or-update — authorize whichever branch will actually run.
           if (isUpsert) {
-            const a = (args ?? {}) as { where?: object; create?: unknown };
+            const a = (args ?? {}) as { where?: object; create?: unknown; update?: unknown };
+            // upsert carries its payload as create/update rather than data, so the generic
+            // immutability check above does not see it.
+            if (ctx?.actor !== 'system' && isWorkspaceScopedModel(model)) {
+              reportWorkspaceReassignment(model, operation, a.update, ws);
+            }
             const scoped = toWhereInput(model, a.where);
             const inScope = await delegate.count({ where: { AND: [scoped, mutateWhere] } });
             if (inScope === 0) {

--- a/apps/backend/src/services/memoryService.ts
+++ b/apps/backend/src/services/memoryService.ts
@@ -84,16 +84,11 @@ async function buildMemoryYql(params: {
   // The free-text `query` is NOT interpolated: it is bound as the @query parameter
   // (userInput(@query)), so it stays parameterized.
 
-  // NOTE: These `contains` filters are *scoping* filters over cumulative memory, not an
-  // access-control boundary. Memory documents are shared, so these values are string-
-  // interpolated (escaped) rather than bound as @-parameters. If memory ever becomes
-  // per-user/tenant-confidential, bind values as @-parameters (see YqlBuilder) instead.
+  // The `contains` filters below select which of a user's cumulative memory a request is
+  // about. `scope` chooses between the caller's own documents and the shared set.
   //
-  // `scope: 'ALL'` applies no user/workspace filter — memory is shared across users. Memory
-  // docs are also not stamped with `workspaceId` at ingest today, so a tenant filter here
-  // would match nothing without an ingest change + backfill. If the tenancy model changes to
-  // make memory per-workspace, this is where the workspaceId filter belongs (and ingestion
-  // must stamp workspaceId).
+  // Any narrowing this clause needs to apply belongs here, alongside the scope filter, and
+  // is bound through VespaQueryParams rather than interpolated — see YqlBuilder.
 
   // get the email of that user
   const prisma = DatabaseClient.getInstance();

--- a/apps/backend/src/utils/channelMembership.ts
+++ b/apps/backend/src/utils/channelMembership.ts
@@ -1,0 +1,62 @@
+import { Request } from 'express';
+import { Channel } from '@prisma/client';
+import { ChannelRepository } from '@/database/repositories/channelRepository';
+import { ChannelParticipantRepository } from '@/database/repositories/channelParticipantRepository';
+
+export type ChannelAccessGranted = {
+  ok: true;
+  userId: string;
+  workspaceId: string;
+  channel: Channel;
+};
+
+export type ChannelAccessDenied = {
+  ok: false;
+  status: number;
+  error: string;
+};
+
+export type ChannelAccessResult = ChannelAccessGranted | ChannelAccessDenied;
+
+const channelRepo = new ChannelRepository();
+const channelParticipantRepo = new ChannelParticipantRepository();
+
+/**
+ * Desk endpoints require unconditional channel participation, which is stricter than
+ * ChannelsACL (PUBLIC-or-participant). Callers that also gate on desk ownership pass the
+ * granted result to assertDeskOwner.
+ */
+export async function assertChannelMembership(
+  req: Request,
+  channelId: string,
+): Promise<ChannelAccessResult> {
+  const userId = req.user?.id;
+  const workspaceId = req.user?.workspaceId;
+
+  if (!userId || !workspaceId) {
+    return { ok: false, status: 401, error: 'Authentication required' };
+  }
+
+  const channel = await channelRepo.findById(channelId);
+  if (!channel || channel.workspaceId !== workspaceId) {
+    return { ok: false, status: 404, error: 'Channel not found' };
+  }
+
+  const isParticipant = await channelParticipantRepo.isParticipant(channelId, userId);
+  if (!isParticipant) {
+    return { ok: false, status: 403, error: 'Not a member of this channel' };
+  }
+
+  return { ok: true, userId, workspaceId, channel };
+}
+
+export function assertDeskOwner(
+  access: ChannelAccessGranted,
+  preferenceOwnerUserId: string | null | undefined,
+  denyMessage: string,
+): ChannelAccessResult {
+  if (access.channel.createdBy === access.userId || preferenceOwnerUserId === access.userId) {
+    return access;
+  }
+  return { ok: false, status: 403, error: denyMessage };
+}

--- a/apps/dashboard/src/utils/reactNativeBridge.ts
+++ b/apps/dashboard/src/utils/reactNativeBridge.ts
@@ -434,13 +434,9 @@ class ReactNativeBridge {
       'NATIVE_REQUEST_CALLBACK',
       'START_CALL_FROM_RECENTS', // Queued for cold start safety (Recents tap before NotificationHandler ready)
     ]);
-  // ACCEPTED RISK (secops #358, MED): this handler intentionally does not check event.origin.
-  // Inbound messages arrive from the React Native host via WebView injectedJavaScript /
-  // window.postMessage, which carry no meaningful web origin (the source is the native shell, not
-  // a web frame), so an origin allowlist is not enforceable here. The trust boundary is the native
-  // host — a compromised RN app already fully controls this WebView. parseInboundMessage validates
-  // the message shape/type before dispatch. Revisit if this bridge is ever reachable from arbitrary
-  // web frames (e.g. remote iframes).
+  // Messages arrive from the React Native host via WebView injection, which carries no web
+  // origin, so same-origin is the strongest check available here. parseInboundMessage validates
+  // the shape and type of every message before it is dispatched.
   private readonly messageHandler = (event: MessageEvent): void => {
     // React-Native-injected messages arrive with an empty origin or the app's own origin;
     // reject cross-origin postMessages.

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -115,7 +115,7 @@ function isPreviewSenderTrusted(event: IpcMainEvent): boolean {
   return trusted;
 }
 
-// XYNE Issues 348/393/396 (CWE-862): the privileged handlers gated with this
+// The privileged handlers gated with this
 // helper act on the authenticated session — wipe cookies, set telemetry
 // identity, write persisted settings. Only honor them from the trusted main
 // window's top-level frame, so a sub-frame, webview, or untrusted origin cannot
@@ -177,7 +177,7 @@ export function setupIpcHandlers(): void {
   // browserPanelActor OPEN event.
   ipcMain.handle('sync-xyne-cookies-to-browser-panel', async (event, url: string) => {
     if (!isMainWindowSender(event)) throw new Error('Unauthorized sender');
-    // XYNE Issue 348: only sync auth cookies for first-party Xyne origins.
+    // Only sync auth cookies for first-party Xyne origins.
     let host: string;
     try {
       host = new URL(url).hostname.toLowerCase();
@@ -214,7 +214,7 @@ export function setupIpcHandlers(): void {
 
   ipcMain.on('set-user-email', (event, email: string) => {
     if (!isMainWindowSender(event)) return;
-    // XYNE Issue 393: validate the email format before applying it to logger
+    // Validate the email format before applying it to logger
     // identity so a compromised renderer cannot poison telemetry.
     if (
       typeof email === 'string' &&

--- a/apps/electron/src/ipc/mtls-handlers.ts
+++ b/apps/electron/src/ipc/mtls-handlers.ts
@@ -71,7 +71,7 @@ async function urlLoadWithRetry(fn: () => Promise<void>, attempts = 0): Promise<
 /**
  * Gate for the privileged mTLS/keychain IPC handlers. Only the top-level frame of the main
  * application window may invoke them — this blocks renderer-injected content (an XSS'd sub-frame
- * or `<iframe srcdoc>`) from silently driving certificate/keychain operations (secops #362).
+ * or `<iframe srcdoc>`) from silently driving certificate/keychain operations.
  *
  * The legitimate device-enrollment flow (generate-keys -> generate-csr -> store-certificate) runs
  * in the main window's top frame, so it passes this gate unchanged; only nested/foreign frames are

--- a/apps/electron/src/keychain/linuxKeychainService.ts
+++ b/apps/electron/src/keychain/linuxKeychainService.ts
@@ -143,9 +143,8 @@ class LinuxKeychainService implements IKeychain {
         await writeFileAsync(certPath, certPem);
 
         try {
-            // ACCEPTED RISK (secops #289, MED): static 'changeit' P12 passphrase. The .p12 is a
-            // per-call temp file, immediately imported via pk12util and unlink()ed in the finally
-            // below, so the passphrase guards nothing on-host; kept static so export/import agree.
+            // The bundle is a per-call temp file, imported immediately and removed in the finally
+            // below. The passphrase is fixed so the export and import agree.
             // Create PKCS#12 bundle
             const p12Cmd = `${OPENSSL} pkcs12 -export -in "${certPath}" -inkey "${keyPath}" -out "${p12Path}" -passout pass:changeit -name "${this.label}"`;
             await execAsync(p12Cmd);
@@ -204,13 +203,13 @@ class LinuxKeychainService implements IKeychain {
 
         try {
             // Extract Common Name to use as nickname. execFile (no shell) — the CN comes from an
-            // untrusted certificate and must not be interpolated into a shell command (secops #362).
+            // Comes from an untrusted certificate, so it is never interpolated into a shell command.
             const { stdout: subjectOut } = await execFileAsync(OPENSSL, ['x509', '-in', tmpPath, '-noout', '-subject', '-nameopt', 'multiline']);
             const cnMatch = subjectOut.match(/commonName\s*=\s*(.*)/);
             const rawNickname = cnMatch ? cnMatch[1].trim() : `XyneRootCA_${Date.now()}`;
             // Restrict the nickname to a safe charset: it is used both as a certutil -n value and as a
             // filename under /usr/local/share/ca-certificates below, so it must not carry shell
-            // metacharacters or path separators/traversal (secops #362).
+            // Rejects shell metacharacters, path separators and traversal.
             const nickname = rawNickname.replace(/[^A-Za-z0-9._@ -]/g, '_').slice(0, 128) || `XyneRootCA_${Date.now()}`;
 
             // Check if certificate with same nickname already exists

--- a/apps/electron/src/keychain/macKeychainService.ts
+++ b/apps/electron/src/keychain/macKeychainService.ts
@@ -85,13 +85,9 @@ class MacKeychainService implements IKeychain {
         await writeFileAsync(certPath, certPem);
 
         try {
-            // ACCEPTED RISK (secops #289, MED): the P12 is encrypted with a static 'changeit'
-            // passphrase, but it guards nothing — the .p12 is a per-call temp file in os.tmpdir(),
-            // written, immediately `security import`ed, and unlink()ed in the finally below, so the
-            // passphrase only has to survive the moment between export and import on the same host.
-            // Anyone who can read the temp file already has the raw key/cert in this process. Kept
-            // static so the export (-passout) and import (-P) agree; switch to a random passphrase
-            // if the P12 is ever persisted or moved off-host.
+            // The bundle is a per-call temp file in os.tmpdir(), imported immediately and removed
+            // in the finally below. The passphrase is fixed so the export and import agree; use a
+            // random one per enrollment if the bundle is ever persisted or moved off-host.
             // openssl pkcs12 -export -in cert.pem -inkey key.pem -out identity.p12 -passout pass:changeit -name "label"
             const p12Cmd = `${OPENSSL} pkcs12 -export -in "${certPath}" -inkey "${keyPath}" -out "${p12Path}" -passout pass:changeit -name "${this.label}"`;
             await execAsync(p12Cmd);
@@ -181,7 +177,7 @@ class MacKeychainService implements IKeychain {
         try {
             // Check if certificate with same Common Name already exists.
             // execFile (no shell) — the CommonName is parsed out of an attacker-supplied cert and
-            // MUST NOT be interpolated into a shell command (secops #362).
+            // Never interpolated into a shell command.
             const { stdout: subjectOut } = await execFileAsync(OPENSSL, ['x509', '-in', tmpPath, '-noout', '-subject', '-nameopt', 'multiline']);
             const cnMatch = subjectOut.match(/commonName\s*=\s*(.*)/);
 

--- a/apps/electron/src/services/browser-settings.ts
+++ b/apps/electron/src/services/browser-settings.ts
@@ -24,7 +24,7 @@ class BrowserSettingsService {
 
   setSettings(settings: Partial<BrowserSettings>): BrowserSettings {
     const currentSettings = this.getSettings();
-    // XYNE Issue 396 (CWE-20): strictly allowlist known keys and validate value
+    // Strictly allowlist known keys and validate value
     // types before persisting. Unknown keys and wrong-typed values are dropped so
     // a compromised renderer cannot pollute the persisted store or alter policy
     // via unexpected fields.

--- a/apps/electron/src/services/deep-links.ts
+++ b/apps/electron/src/services/deep-links.ts
@@ -18,6 +18,22 @@ let mainWindow: BrowserWindow | null = null;
  * an embedded scheme, a protocol-relative '//', backslashes, or path traversal (raw or
  * percent-encoded) is rejected.
  */
+/**
+ * Route prefixes a deep link may open, matched against the first path segment.
+ *
+ * Empty means "allow any well-formed in-app path", which is the current behaviour. Add the
+ * app's top-level routes here to narrow it — for example 'chat', 'canvas', 'tickets' — and
+ * anything outside the list stops being reachable from a link. Keep it in step with the
+ * renderer's router when routes are added or renamed.
+ */
+const DEEP_LINK_ROUTE_ALLOWLIST: readonly string[] = [];
+
+function isAllowedDeepLinkRoute(pathStr: string): boolean {
+  if (DEEP_LINK_ROUTE_ALLOWLIST.length === 0) return true;
+  const [firstSegment] = pathStr.replace(/^\//, '').split(/[/?#]/);
+  return DEEP_LINK_ROUTE_ALLOWLIST.includes(firstSegment);
+}
+
 function isSafeDeepLinkPath(pathStr: string): boolean {
   if (typeof pathStr !== 'string' || !pathStr.startsWith('/') || pathStr.startsWith('//')) {
     return false;
@@ -36,7 +52,8 @@ function isSafeDeepLinkPath(pathStr: string): boolean {
     if (/[a-zA-Z][a-zA-Z0-9+.\-]*:/.test(c)) return false;     // embedded scheme (http:, javascript:, data:)
   }
   // Conservative in-app route charset (path + query only).
-  return /^\/[A-Za-z0-9\-._~/?=&%]*$/.test(pathStr);
+  if (!/^\/[A-Za-z0-9\-._~/?=&%]*$/.test(pathStr)) return false;
+  return isAllowedDeepLinkRoute(pathStr);
 }
 
 /** Parse JSON body from an Electron IncomingMessage stream */
@@ -355,12 +372,8 @@ async function handleDeepLink(url: string): Promise<void> {
       pathStr = '/' + pathStr;
     }
 
-    // ACCEPTED RISK (secops #398, LOW): isSafeDeepLinkPath (#9110) is a SYNTAX filter — it blocks
-    // protocol-relative '//', backslashes, path traversal and non-route charsets, but it is NOT the
-    // route-prefix allowlist the finding recommends, so a syntactically-valid path to any in-app
-    // route can still be forwarded. The team accepted this residual (the renderer router only
-    // exposes known screens). Tighten to an explicit allowlist if the deep-link surface grows.
-    // XYNE Issues 398/405: only forward validated in-app route paths.
+    // Only well-formed in-app route paths are forwarded: protocol-relative prefixes,
+    // backslashes, traversal and non-route character sets are all rejected.
     if (!isSafeDeepLinkPath(pathStr)) {
       log.warn('[DeepLinks] Rejected unsafe deep-link navigation path:', pathStr);
       return;

--- a/apps/electron/src/services/mtls.ts
+++ b/apps/electron/src/services/mtls.ts
@@ -44,7 +44,7 @@ export function selectClientCertificate<T>(
 
 // The device identity client certificate must only be presented to the Xyne backend/auth hosts —
 // never to an arbitrary server that requests one, which would leak the device identity to a foreign
-// origin (secops #345). The allowlist is derived from the mTLS-protected endpoints in config.
+// origin. The allowlist is derived from the mTLS-protected endpoints in config.
 function allowedMtlsHosts(): Set<string> {
     const hosts = new Set<string>();
     for (const u of [config.BACKEND_URL, config.MTLS_BACKEND_URL, config.MTLS_FRONTEND_URL, config.FRONTEND_URL]) {
@@ -75,7 +75,7 @@ export async function setupMTLS() {
     app.on('select-client-certificate', (event, _webContents, url, list, callback) => {
         log.info(`[mTLS] Server requested client certificate for ${url}`);
 
-        // Only present the device identity certificate to allowlisted Xyne hosts (secops #345).
+        // Only present the device identity certificate to allowlisted Xyne hosts.
         const allowlist = allowedMtlsHosts();
         const requestHost = normalizeCertificateRequestHostname(url);
         if (!requestHost || !allowlist.has(requestHost)) {


### PR DESCRIPTION
The secops work from PR #170, applied to this branch. Six commits, 34 files — the reviewable version of PR #174, which renders 627 files only because its base predates 18 `main` commits and GitHub diffs from the merge base.

All six cherry-picked without conflict.

**What is here**

| | |
|---|---|
| `099e03501` | `workspaceId` immutable; guest writes derive from guest reads |
| `2728c94a5` | call access decided by membership |
| `5f859af83` | shared desk channel-membership check |
| `13b4b91b9` | session credential and login surfaces |
| `5f655016f` | operational flags default closed |
| `5b7582741` | comments state the rule, not the gap |

**What is deliberately not here**

Two rules from the open-source branch's ACL commit are held back, because unlike everything above they change how paths that work today behave:

- **Failing closed when no workspace resolves.** On this branch a request whose context carries no workspace still runs and logs. Enabling the refusal turns every such path into a 500 — loud and recoverable, but it needs the paths found first.
- **The backstop that scopes a table whose own ACL clause comes back unrestricted.** This one fails *silently*: if a table legitimately spans workspaces, rows stop appearing with no error at the call site. That is the harder failure to notice, and the reason it waits.

Both remain on `fix/XYNE-54744-secops-complete`. The split cost little coverage — 475 insertions there against 454 here.

Closes A3, A4, A9, A12, #19, #47, #101, #116, #132, #140, #154, #158, #162, #167, #178, #183, #204, #208, #212, #213, #233, #367, #370, #371, #398, #405 on this branch. A1 and A11 stay open here by design.