### PR TITLE
fix: stop "Maximum update depth exceeded" in EmailEditorToolbar

### DIFF
--- a/apps/dashboard/src/components/xyne-desk/EmailEditor/EmailEditorToolbar.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailEditor/EmailEditorToolbar.tsx
@@ -178,7 +178,7 @@ export const EmailEditorToolbar: React.FC<EmailEditorToolbarProps> = ({
     if (!editor) return;
 
     const updateActiveStates = (): void => {
-      setIsActive({
+      const next = {
         bold: editor.isActive('bold'),
         italic: editor.isActive('italic'),
         underline: editor.isActive('underline'),
@@ -187,7 +187,14 @@ export const EmailEditorToolbar: React.FC<EmailEditorToolbarProps> = ({
         orderedList: editor.isActive('orderedList'),
         blockquote: editor.isActive('blockquote'),
         link: editor.isActive('link'),
-      });
+      };
+      // Return the previous object when nothing changed so React can bail out.
+      // A fresh object literal never compares equal, which made every editor
+      // transaction re-render the toolbar — and, once a re-render dispatched
+      // another transaction, looped until "Maximum update depth exceeded".
+      setIsActive(prev =>
+        (Object.keys(next) as (keyof typeof next)[]).every(k => prev[k] === next[k]) ? prev : next,
+      );
     };
 
     updateActiveStates();


### PR DESCRIPTION
## What

`EmailEditorToolbar` subscribed to the editor's `transaction` event and called `setIsActive` with a **fresh object literal** on every transaction. A new object is never `Object.is`-equal to the previous state, so React could never bail out of the re-render.

## Why it started now

`@tiptap/react` resolves to **3.29.2** (up from 3.15.3) — `apps/dashboard/package.json` declares `"@tiptap/react": "^3.8.0"`, but the pinned `@tiptap/core: 3.29.2` / `@tiptap/pm: 3.29.2` drag the resolution up. Verified in `pnpm-lock.yaml` (`'@tiptap/react@3.29.2'`) and in `node_modules/@tiptap/react/package.json`.

In 3.29.2, `useEditor` internally calls `useEditorState` with an `EditorStateManager` that subscribes to **both** `transaction` **and** `update` and bumps a `transactionNumber` through `useSyncExternalStore`, re-rendering the whole editor subtree per transaction. Combined with the unconditional `setState` in the toolbar, the render/transaction feedback loop never reached a fixed point and React aborted with `Maximum update depth exceeded`.

**User impact:** Xyne Desk froze on the currently open ticket — the user could not navigate back to the ticket list or to the Spaces home screen. Hard refresh, restart, and re-login did not help, because the loop re-armed as soon as the composer mounted again.

## The fix

Compare the next active-state map field by field and return the **previous** object when nothing changed, so React bails out and the loop terminates.

```ts
const next = { bold: editor.isActive('bold'), /* … */ };
setIsActive(prev =>
  (Object.keys(next) as (keyof typeof next)[]).every(k => prev[k] === next[k]) ? prev : next,
);
```

Single file, 9 insertions / 2 deletions — `apps/dashboard/src/components/xyne-desk/EmailEditor/EmailEditorToolbar.tsx`.

## Validation

- `pnpm run typecheck` — pass (exit 0)
- `npx eslint <file>` — clean
- `npx prettier --check <file>` — clean
- Manual: navigate across Xyne Desk (ticket list ↔ ticket detail, composer open/close) with DevTools console open — no `Maximum update depth exceeded`.

## Follow-up (not in this PR)

Two things worth a separate ticket:
1. The sibling effect at the same site (`updateAttributes`, `setCurrentFontFamily` / `setCurrentFontSize`) is safe today only because both values are strings — same pattern, latent risk if it ever becomes an object.
2. `@tiptap/react` is declared `^3.8.0` but resolves to `3.29.2`. Consider pinning it explicitly alongside the already-pinned `@tiptap/core` / `@tiptap/pm` so the version is intentional rather than transitively dragged.
