### PR TITLE
fix: XYNE-54744 read the session reference from the cookie only

### DIFF
--- a/apps/backend/src/middleware/authV2Middleware.ts
+++ b/apps/backend/src/middleware/authV2Middleware.ts
@@ -45,13 +45,12 @@ class AuthV2Middleware {
    * Helper to get global session ID (not workspace-scoped)
    */
   private getSessionId(req: Request): string | undefined {
-    // Header-based session ID (API clients / old dashboards that can't set cookies)
-    const headerSessionId = req.headers['x-session-id'] as string | undefined;
-    if (headerSessionId) {
-      return headerSessionId;
+    // The session reference is read from the httpOnly cookie only. A request header is not
+    // accepted here: headers are copied into access logs, proxies and crash reports far more
+    // readily than a cookie the browser will not hand to script.
+    if (req.headers['x-session-id']) {
+      logger.warn('[AuthV2] Ignoring x-session-id header; session is read from the cookie');
     }
-
-    // Backward compat: user_session_id cookie (for old dashboard versions)
     return req.cookies?.user_session_id;
   }
 


### PR DESCRIPTION
Lifted out of PR #170 so it can be observed before it lands.

The session reference was accepted from an `x-session-id` request header as well as from the cookie. A header travels through proxies, logs and referrers in ways a cookie with its flags does not, and any caller able to set one could present a session it had merely observed. The cookie is now the only source.

**Before this merges**

The middleware logs a warning whenever a request still carries the header (`authV2Middleware.ts:51`). Deploy, watch that line, and confirm it is quiet. Which clients still send it is not answerable from the code — a client that does will break on the day this merges, and the log is the only way to find out in advance.

One file, five lines. The risk is entirely in the rollout, not the change.

Closes #116's header half once merged.


---

Replaces #176, which GitHub closed when the branch was renamed to satisfy the repository naming rule. Same commits, same diff.
