### PR TITLE
fix: XYNE-17198  stop one slow LiteLLM call from stalling all

### DIFF
--- a/apps/xyne-claw/src/entity-llm.ts
+++ b/apps/xyne-claw/src/entity-llm.ts
@@ -22,8 +22,42 @@ const log = createLogger("entity-llm");
 // Own model knob: entity extraction deliberately runs a different (cheaper,
 // non-reasoning) model than the agent loop, so this is not LITELLM.model.
 const ENTITY_MODEL = process.env["ENTITY_EXTRACTION_MODEL"] ?? "glm-latest";
+/**
+ * Per-attempt budget for one LiteLLM call.
+ *
+ * Deliberately well under claw-auth's transport timeout. A real 60k-char batch
+ * completes in ~15s; 120s is generous headroom, and anything beyond it is a
+ * stuck request, not a slow one — waiting the old 300s bought nothing and cost
+ * the caller its entire budget.
+ */
 const ENTITY_TIMEOUT_MS = Number(
-  process.env["ENTITY_EXTRACTION_TIMEOUT_MS"] ?? 300_000,
+  process.env["ENTITY_EXTRACTION_TIMEOUT_MS"] ?? 120_000,
+);
+
+/**
+ * Retries AFTER the first attempt. One, not the client default of three.
+ *
+ * Retrying past the point the caller gave up is not resilience, it is damage:
+ * the reply goes nowhere, and at ENTITY_LLM_MAX_CONCURRENT=1 the dead request
+ * holds the only slot while every live one queues behind it. Three retries at
+ * the old 300s timeout meant a single stuck call blocked entity extraction for
+ * ~21 minutes.
+ *
+ * The whole budget — attempts plus backoff — must stay under the caller's
+ * timeout, which ENTITY_TOTAL_BUDGET_MS asserts below.
+ */
+const ENTITY_MAX_RETRIES = Number(process.env["ENTITY_LLM_MAX_RETRIES"] ?? 1);
+
+/** Worst case: every attempt burns its full timeout, plus the 5s first backoff. */
+const ENTITY_TOTAL_BUDGET_MS =
+  ENTITY_TIMEOUT_MS * (ENTITY_MAX_RETRIES + 1) + 5_000 * ENTITY_MAX_RETRIES;
+
+// Surfaced at boot so a bad override is caught by reading one log line, rather
+// than by watching a run die 300s at a time.
+log.info(
+  `[entity-llm] model=${ENTITY_MODEL} attemptTimeout=${ENTITY_TIMEOUT_MS}ms ` +
+    `retries=${ENTITY_MAX_RETRIES} worstCase=${Math.round(ENTITY_TOTAL_BUDGET_MS / 1000)}s ` +
+    `slotWait=${Math.round(ENTITY_SLOT_WAIT_MS / 1000)}s concurrency=${ENTITY_MAX_CONCURRENT}`,
 );
 
 /**
@@ -43,13 +77,46 @@ const ENTITY_MAX_CONCURRENT = Math.max(
   Number(process.env["ENTITY_LLM_MAX_CONCURRENT"] ?? 1),
 );
 
+/**
+ * How long a request may wait for the single entity slot before giving up.
+ *
+ * This bound is the difference between a slow run and a dead one. The wait
+ * happens BEFORE the LiteLLM call, so an unbounded queue means the caller's
+ * socket times out while its request has not even started — claw-auth sees
+ * `TypeError: fetch failed` with no status and no upstream error to report.
+ *
+ * Worse, it is self-sustaining at concurrency 1: one slow call parks the slot,
+ * every queued request ages past the caller's timeout, and the backlog outlives
+ * the congestion that caused it. Refusing fast turns that into a 503 the caller
+ * can log, count and retry sanely.
+ */
+const ENTITY_SLOT_WAIT_MS = Number(process.env["ENTITY_LLM_SLOT_WAIT_MS"] ?? 45_000);
+
 let entityActive = 0;
 const entityWaiters: Array<() => void> = [];
 
 async function withEntitySlot<T>(fn: () => Promise<T>): Promise<T> {
   if (entityActive >= ENTITY_MAX_CONCURRENT) {
-    await new Promise<void>((resolve) => entityWaiters.push(resolve));
+    let waiter!: () => void;
+    const admitted = await new Promise<boolean>((resolve) => {
+      waiter = () => resolve(true);
+      entityWaiters.push(waiter);
+      setTimeout(() => resolve(false), ENTITY_SLOT_WAIT_MS);
+    });
+
+    if (!admitted) {
+      // Drop our own waiter so a later release does not hand the slot to a
+      // request that has already been refused.
+      const index = entityWaiters.indexOf(waiter);
+      if (index !== -1) entityWaiters.splice(index, 1);
+      throw new EntityLlmError(
+        `Entity LLM slot busy for ${Math.round(ENTITY_SLOT_WAIT_MS / 1000)}s ` +
+          `(${entityActive}/${ENTITY_MAX_CONCURRENT} in use, ${entityWaiters.length} queued)`,
+        503,
+      );
+    }
   }
+
   entityActive += 1;
   try {
     return await fn();
@@ -119,6 +186,7 @@ export async function completeEntityPrompt(
         },
         {
           timeoutMs: ENTITY_TIMEOUT_MS,
+          maxRetries: ENTITY_MAX_RETRIES,
           label: `entity-llm${purpose ? `:${purpose}` : ""}`,
         },
       ),

--- a/apps/xyne-claw/src/entity-llm.ts
+++ b/apps/xyne-claw/src/entity-llm.ts
@@ -52,13 +52,6 @@ const ENTITY_MAX_RETRIES = Number(process.env["ENTITY_LLM_MAX_RETRIES"] ?? 1);
 const ENTITY_TOTAL_BUDGET_MS =
   ENTITY_TIMEOUT_MS * (ENTITY_MAX_RETRIES + 1) + 5_000 * ENTITY_MAX_RETRIES;
 
-// Surfaced at boot so a bad override is caught by reading one log line, rather
-// than by watching a run die 300s at a time.
-log.info(
-  `[entity-llm] model=${ENTITY_MODEL} attemptTimeout=${ENTITY_TIMEOUT_MS}ms ` +
-    `retries=${ENTITY_MAX_RETRIES} worstCase=${Math.round(ENTITY_TOTAL_BUDGET_MS / 1000)}s ` +
-    `slotWait=${Math.round(ENTITY_SLOT_WAIT_MS / 1000)}s concurrency=${ENTITY_MAX_CONCURRENT}`,
-);
 
 /**
  * Entity extraction is background work; a live agent turn is not. Even inside
@@ -91,6 +84,15 @@ const ENTITY_MAX_CONCURRENT = Math.max(
  * can log, count and retry sanely.
  */
 const ENTITY_SLOT_WAIT_MS = Number(process.env["ENTITY_LLM_SLOT_WAIT_MS"] ?? 45_000);
+
+// Surfaced at boot so a bad override is caught by reading one log line, rather
+// than by watching a run die 300s at a time. Declared here, below every value
+// it reads, since these are const bindings and not hoisted.
+log.info(
+  `[entity-llm] model=${ENTITY_MODEL} attemptTimeout=${ENTITY_TIMEOUT_MS}ms ` +
+    `retries=${ENTITY_MAX_RETRIES} worstCase=${Math.round(ENTITY_TOTAL_BUDGET_MS / 1000)}s ` +
+    `slotWait=${Math.round(ENTITY_SLOT_WAIT_MS / 1000)}s concurrency=${ENTITY_MAX_CONCURRENT}`,
+);
 
 let entityActive = 0;
 const entityWaiters: Array<() => void> = [];


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/xyne-claw` 

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
