### PR TITLE
fix: derive invitation email links from FRONTEND_URL

### DIFF
--- a/apps/backend/src/services/email/base-email-service.ts
+++ b/apps/backend/src/services/email/base-email-service.ts
@@ -1,4 +1,5 @@
 import { invitationEmailHtml, invitationEmailText } from './templates/invitation';
+import { config } from '../../config/env';
 
 export interface EmailResult {
   success: boolean;
@@ -28,6 +29,7 @@ export interface SendInvitationEmailParams {
   invitationLink: string;
   invitationId: string;
   tempPassword?: string;
+  frontendUrl?: string;
 }
 
 /**
@@ -61,8 +63,9 @@ export abstract class BaseEmailService {
     const { to, inviterName, workspaceName, invitationLink, tempPassword } = params;
 
     const subject = `You've been invited to join ${workspaceName} on Xyne Spaces`;
-    const html = invitationEmailHtml({ inviterName, workspaceName, invitationLink, tempPassword });
-    const text = invitationEmailText({ inviterName, workspaceName, invitationLink, tempPassword });
+    const frontendUrl = params.frontendUrl ?? config.frontendUrl;
+    const html = invitationEmailHtml({ inviterName, workspaceName, invitationLink, tempPassword, frontendUrl });
+    const text = invitationEmailText({ inviterName, workspaceName, invitationLink, tempPassword, frontendUrl });
 
     return this.sendEmail({ to, subject, html, text });
   }

--- a/apps/backend/src/services/email/templates/invitation.ts
+++ b/apps/backend/src/services/email/templates/invitation.ts
@@ -5,7 +5,11 @@ export function invitationEmailHtml({
   workspaceName,
   invitationLink,
   tempPassword,
-}: Pick<SendInvitationEmailParams, 'inviterName' | 'workspaceName' | 'invitationLink' | 'tempPassword'>): string {
+  frontendUrl,
+}: Pick<
+  SendInvitationEmailParams,
+  'inviterName' | 'workspaceName' | 'invitationLink' | 'tempPassword' | 'frontendUrl'
+>): string {
   return `
 <!DOCTYPE html>
 <html>
@@ -62,9 +66,12 @@ export function invitationEmailHtml({
                   <td valign="top">
                     <strong style="display:block;color:#1f2937;font-size:15px;margin-bottom:6px;">Download &amp; Install the Xyne Spaces Desktop App</strong>
                     <p style="color:#6b7280;font-size:13px;margin:0 0 14px 0;">The desktop app is required to access your workspace. Download it for your platform from the link below and complete the installation before proceeding.</p>
-                    <a href="https://spaces.xyne.juspay.net/invite" style="display:inline-block;background:#6366f1;color:#ffffff;text-decoration:none;padding:11px 24px;border-radius:8px;font-weight:600;font-size:14px;">Download Xyne Spaces App</a>
+                    <a href="${frontendUrl}/apps/downloads" style="display:inline-block;background:#6366f1;color:#ffffff;text-decoration:none;padding:11px 24px;border-radius:8px;font-weight:600;font-size:14px;">Download Xyne Spaces App</a>
                     <p style="color:#6b7280;font-size:12px;margin:10px 0 0 0;">
-                      Or visit: <a href="https://spaces.xyne.juspay.net/invite" style="color:#6366f1;word-break:break-all;">https://spaces.xyne.juspay.net/invite</a>
+                      Or visit: <a href="${frontendUrl}/apps/downloads" style="color:#6366f1;word-break:break-all;">${frontendUrl}/apps/downloads</a>
+                    </p>
+                    <p style="color:#6b7280;font-size:12px;margin:6px 0 0 0;">
+                      Already set up? Open your invite: <a href="${frontendUrl}/invite" style="color:#6366f1;word-break:break-all;">${frontendUrl}/invite</a>
                     </p>
                   </td>
                 </tr>
@@ -139,7 +146,11 @@ export function invitationEmailText({
   workspaceName,
   invitationLink,
   tempPassword,
-}: Pick<SendInvitationEmailParams, 'inviterName' | 'workspaceName' | 'invitationLink' | 'tempPassword'>): string {
+  frontendUrl,
+}: Pick<
+  SendInvitationEmailParams,
+  'inviterName' | 'workspaceName' | 'invitationLink' | 'tempPassword' | 'frontendUrl'
+>): string {
   return `
 You've been invited to join ${workspaceName} on Xyne Spaces!
 
@@ -152,7 +163,9 @@ STEP 1 — Download & Install the Desktop App (REQUIRED)
 ──────────────────────────────────────────
 Before doing anything else, download and install the Xyne Spaces desktop app for your platform:
 
-  https://spaces.xyne.juspay.net/invite
+  ${frontendUrl}/apps/downloads
+
+Already set up? Open your invite: ${frontendUrl}/invite
 
 Complete the installation before moving to Step 2.
 


### PR DESCRIPTION
The 'Download app' link in the invitation email was hardcoded to https://spaces.xyne.juspay.net/invite, forcing a per-deployment fork of the template. Build the in-email links from config.frontendUrl (FRONTEND_URL) instead, and surface both the app-download and invite URLs.

- SendInvitationEmailParams gains an optional frontendUrl; sendInvitationEmail falls back to config.frontendUrl when the caller omits it.
- invitationEmailHtml/Text take frontendUrl and render ${frontendUrl}/apps/downloads for the download button and ${frontendUrl}/invite as an explicit invite line.

Host now follows the environment (dev/test/prod); paths stay hardcoded.

