### PR TITLE
fix: surface real ticket mutation/API errors in UI toasts

### DIFF
--- a/apps/dashboard/src/components/Release/ReleaseStagePicker.tsx
+++ b/apps/dashboard/src/components/Release/ReleaseStagePicker.tsx
@@ -5,6 +5,7 @@ import { Popover } from '../ui/Popover/Popover';
 import { useZero } from '../../hooks/useZero';
 import { mutators } from '../../zero/mutators';
 import { getStageColor } from '../../routes/KanbanBoardScreen/KanbanBoardScreen.utils';
+import { surfaceMutationError } from '../../utils/zeroMutationToast';
 import { cn } from '../../utils/classNames';
 import { StagePicker } from '../Tickets/TicketListView/StagePicker';
 
@@ -72,13 +73,16 @@ export function ReleaseStagePicker({
         // Caller handles persistence — skip ticket.update entirely.
         onSelect(next);
       } else {
-        void zero.mutate(
-          mutators.ticket.update({
-            id: ticketId,
-            stageName: next.name,
-            ...(next.defaultTicketStatusV2 && { statusV2: next.defaultTicketStatusV2 }),
-            updatedAt: Date.now(),
-          }),
+        void surfaceMutationError(
+          zero.mutate(
+            mutators.ticket.update({
+              id: ticketId,
+              stageName: next.name,
+              ...(next.defaultTicketStatusV2 && { statusV2: next.defaultTicketStatusV2 }),
+              updatedAt: Date.now(),
+            }),
+          ),
+          'Failed to update stage',
         );
       }
       onAfterChange?.(next.name);

--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
@@ -59,6 +59,7 @@ import { useBoardSuggestion } from '../../../hooks/useBoardSuggestion';
 import { apiInstance } from '../../../services/clients/apiClient';
 import { cn } from '../../../utils/classNames';
 import { mutators } from '../../../zero/mutators';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import { queries } from '../../../zero/queries';
 import { SubTicketCountIcon } from '../../../assets/icons';
 import Avatar from '../../ui/Avatar/Avatar';
@@ -1296,16 +1297,19 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         const masterTicketId = createdTicketResponse.id;
         const masterConversationId = createdTicketResponse.conversationId;
         subticketsToCreate.forEach((subTicket, index) => {
-          void zero.mutate(
-            mutators.subTicket.create({
-              subTicketId: uuidv4(),
-              mappingId: uuidv4(),
-              timestamp: baseTimestamp + index,
-              title: subTicket.title,
-              ...(subTicket.description ? { description: subTicket.description } : {}),
-              ticketId: masterTicketId,
-              ...(masterConversationId ? { conversationId: masterConversationId } : {}),
-            }),
+          void surfaceMutationError(
+            zero.mutate(
+              mutators.subTicket.create({
+                subTicketId: uuidv4(),
+                mappingId: uuidv4(),
+                timestamp: baseTimestamp + index,
+                title: subTicket.title,
+                ...(subTicket.description ? { description: subTicket.description } : {}),
+                ticketId: masterTicketId,
+                ...(masterConversationId ? { conversationId: masterConversationId } : {}),
+              }),
+            ),
+            `Failed to create sub-ticket "${subTicket.title}"`,
           );
         });
       }

--- a/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
@@ -16,6 +16,7 @@ import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
 import { RenderMessageWithHTML } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import { TagSelector } from '../TicketTable/TagSelector';
 import Avatar from '../../ui/Avatar/Avatar';
 import { useUserGroupById, useUserGroups } from '../../../hooks/useUserGroup';
@@ -306,22 +307,28 @@ export const TicketCard: React.FC<TicketCardProps> = ({
     const toRemove = oldTagNames.filter(t => !newTags.includes(t));
 
     toAdd.forEach(tagName => {
-      zero.mutate(
-        mutators.ticketTagV2.create({
-          ticketId: ticket.id,
-          tagId: uuidv4(),
-          projectTagId: uuidv4(),
-          mappingId: uuidv4(),
-          projectId: ticket.projectId,
-          tagName,
-        }),
+      void surfaceMutationError(
+        zero.mutate(
+          mutators.ticketTagV2.create({
+            ticketId: ticket.id,
+            tagId: uuidv4(),
+            projectTagId: uuidv4(),
+            mappingId: uuidv4(),
+            projectId: ticket.projectId,
+            tagName,
+          }),
+        ),
+        'Failed to add tag',
       );
     });
 
     toRemove.forEach(tagName => {
       const tag = tags?.find(t => t.name === tagName);
       if (tag?.id) {
-        zero.mutate(mutators.ticketTagV2.delete({ tagId: tag.id, mappingId: tag.id }));
+        void surfaceMutationError(
+          zero.mutate(mutators.ticketTagV2.delete({ tagId: tag.id, mappingId: tag.id })),
+          'Failed to remove tag',
+        );
       }
     });
   };
@@ -340,23 +347,29 @@ export const TicketCard: React.FC<TicketCardProps> = ({
           : assigneeUserId
             ? { assignedTo: null }
             : { assignedTo: null, userGroupId: '' };
-    zero.mutate(
-      mutators.ticket.update({
-        id: ticket.id,
-        ...updates,
-        updatedAt: Date.now(),
-      }),
+    void surfaceMutationError(
+      zero.mutate(
+        mutators.ticket.update({
+          id: ticket.id,
+          ...updates,
+          updatedAt: Date.now(),
+        }),
+      ),
+      'Failed to update assignee',
     );
     setIsEditingAssignee(false);
   };
 
   const handlePriorityChange = (value: string | null) => {
-    zero.mutate(
-      mutators.ticket.update({
-        id: ticket.id,
-        priority: value as typeof ticket.priority,
-        updatedAt: Date.now(),
-      }),
+    void surfaceMutationError(
+      zero.mutate(
+        mutators.ticket.update({
+          id: ticket.id,
+          priority: value as typeof ticket.priority,
+          updatedAt: Date.now(),
+        }),
+      ),
+      'Failed to update priority',
     );
     setIsEditingPriority(false);
   };

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -85,6 +85,7 @@ import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
 import { calculateETADeadline, calculateWorkingDurationMs } from '../../../utils/etaCalculation';
 import { formatETADisplay, getLocalISOString, getStatusBadgeConfig } from '../utils';
 import { cn } from '../../../utils/classNames';
+import { getApiErrorMessage } from '../../../utils/apiError';
 import Button from '../../ui/Button';
 import { Dialog } from '../../ui/Dialog';
 import { FileBubble } from '../../ui/FileBubble/FileBubble';
@@ -1555,15 +1556,18 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     async (
       update: Parameters<typeof mutators.ticket.update>[0],
       errorFallback = 'Failed to update ticket',
-    ): Promise<void> => {
+    ): Promise<boolean> => {
       try {
         const result = await zero.mutate(mutators.ticket.update(update)).server;
         if (result.type === 'error') {
           toast.error(result.error.message || errorFallback);
+          return false;
         }
+        return true;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         toast.error(message || errorFallback);
+        return false;
       }
     },
     [zero],
@@ -1749,8 +1753,8 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
           void navigate(`${basePath}/${channelId}/${sourceTicketXyneId}`);
         }
       }
-    } catch {
-      toast.error('Failed to unmerge ticket');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to unmerge ticket'));
     }
   };
 
@@ -2225,13 +2229,14 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     }
 
     // Default: Direct stage update
-    void zero.mutate(
-      mutators.ticket.update({
+    void applyTicketUpdate(
+      {
         id: ticket.id,
         stageName,
         ...(newStatus && { statusV2: newStatus }),
         updatedAt: Date.now(),
-      }),
+      },
+      'Failed to update stage',
     );
   };
 
@@ -2318,7 +2323,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
       updateData.eta = newETADate.getTime();
     }
 
-    void zero.mutate(mutators.ticket.update(updateData));
+    void applyTicketUpdate(updateData, 'Failed to update due date');
     setEditingETA(false);
   };
 
@@ -2334,12 +2339,13 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
 
     zero.mutate(mutators.ticketStageRequest.deleteByTicketId({ ticketId: ticket.id }));
 
-    void zero.mutate(
-      mutators.ticket.update({
+    void applyTicketUpdate(
+      {
         id: ticket.id,
         boardId: pendingBoardChange,
         updatedAt: Date.now(),
-      }),
+      },
+      'Failed to change board',
     );
 
     setShowBoardChangeConfirmDialog(false);
@@ -2406,14 +2412,12 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     }
     setShowArchiveConfirmDialog(false);
 
-    void zero.mutate(
-      mutators.ticket.update({
-        id: ticket.id,
-        isArchived: true,
-        updatedAt: Date.now(),
-      }),
-    );
-    toast.success('Ticket archived successfully');
+    void applyTicketUpdate(
+      { id: ticket.id, isArchived: true, updatedAt: Date.now() },
+      'Failed to archive ticket',
+    ).then(ok => {
+      if (ok) toast.success('Ticket archived successfully');
+    });
   };
 
   const handleMinimizeExpandedView = (): void => {

--- a/apps/dashboard/src/components/Tickets/TicketListView/AssigneePicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/AssigneePicker.tsx
@@ -10,6 +10,7 @@ import { getUserDisplayName, withYouLabel } from '../../../utils/userDisplayName
 import { cn } from '../../../utils/classNames';
 import { useChannelAssignGate } from '../../../hooks/useChannelAssignGate';
 import { channelMembersFirst, currentUserFirst } from '../../../utils/channelMembersFirst';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 
 interface AssigneePickerProps {
   ticketId: string;
@@ -58,8 +59,11 @@ export function AssigneePicker({
   }, [users, search, gate.memberIds, selfId]);
 
   const assign = (userId: string | null): void => {
-    void zero.mutate(
-      mutators.ticket.update({ id: ticketId, assignedTo: userId, updatedAt: Date.now() }),
+    void surfaceMutationError(
+      zero.mutate(
+        mutators.ticket.update({ id: ticketId, assignedTo: userId, updatedAt: Date.now() }),
+      ),
+      'Failed to update assignee',
     );
     setOpen(false);
     setSearch('');

--- a/apps/dashboard/src/components/Tickets/TicketListView/PriorityPicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/PriorityPicker.tsx
@@ -4,6 +4,7 @@ import { Popover } from '../../ui/Popover/Popover';
 import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import { cn } from '../../../utils/classNames';
 
 interface PriorityPickerProps {
@@ -33,8 +34,11 @@ export function PriorityPicker({
 
   const setPriority = (next: TicketPriority): void => {
     if (next !== current) {
-      void zero.mutate(
-        mutators.ticket.update({ id: ticketId, priority: next, updatedAt: Date.now() }),
+      void surfaceMutationError(
+        zero.mutate(
+          mutators.ticket.update({ id: ticketId, priority: next, updatedAt: Date.now() }),
+        ),
+        'Failed to update priority',
       );
     }
     setOpen(false);

--- a/apps/dashboard/src/components/Tickets/TicketListView/StagePicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/StagePicker.tsx
@@ -9,6 +9,7 @@ import { queries } from '../../../zero/queries';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { getStageColor } from '../../../routes/KanbanBoardScreen/KanbanBoardScreen.utils';
 import { cn } from '../../../utils/classNames';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import { useAuth } from '../../../hooks/useAuth';
 import { useCurrentUserRoleIds } from '../../../hooks/useRoles';
 import { TicketStageRequestStatus, BoardType, ApproverType, FormContextType } from '@xyne/shared';
@@ -606,15 +607,18 @@ export function StagePicker({
         }
       });
     } else {
-      void zero.mutate(
-        mutators.ticket.update({
-          id: ticketId,
-          stageName: next,
-          ...(targetStageObj?.defaultTicketStatusV2 && {
-            statusV2: targetStageObj.defaultTicketStatusV2,
+      void surfaceMutationError(
+        zero.mutate(
+          mutators.ticket.update({
+            id: ticketId,
+            stageName: next,
+            ...(targetStageObj?.defaultTicketStatusV2 && {
+              statusV2: targetStageObj.defaultTicketStatusV2,
+            }),
+            updatedAt: Date.now(),
           }),
-          updatedAt: Date.now(),
-        }),
+        ),
+        'Failed to update stage',
       );
       onAfterStageChange?.(next);
     }

--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
@@ -22,6 +22,7 @@ import { Calendar, Check, User } from 'lucide-react';
 import Tooltip, { TruncatedTooltip } from '../../ui/Tooltip';
 import { formatStatusLabel, getPriorityIcon, isEtaUrgent } from '../TicketCard/TicketCard.utils';
 import { mutators } from '../../../zero/mutators';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import {
   AssigneeCellEditor,
   StatusCellEditor,
@@ -204,8 +205,11 @@ export const TicketTable: React.FC<TicketTableProps> = ({
           return;
         }
       }
-      zero.mutate(
-        mutators.ticket.update({ id: ticketId, stageName: toStageName, updatedAt: Date.now() }),
+      void surfaceMutationError(
+        zero.mutate(
+          mutators.ticket.update({ id: ticketId, stageName: toStageName, updatedAt: Date.now() }),
+        ),
+        'Failed to update stage',
       );
     },
     [zero],
@@ -275,12 +279,15 @@ export const TicketTable: React.FC<TicketTableProps> = ({
           const oldValue = typeof params.oldValue === 'string' ? params.oldValue : '';
 
           if (newTitle && newTitle !== oldValue && params.data) {
-            zero.mutate(
-              mutators.ticket.update({
-                id: params.data.id,
-                title: newTitle,
-                updatedAt: Date.now(),
-              }),
+            void surfaceMutationError(
+              zero.mutate(
+                mutators.ticket.update({
+                  id: params.data.id,
+                  title: newTitle,
+                  updatedAt: Date.now(),
+                }),
+              ),
+              'Failed to update title',
             );
           } else if (!newTitle) {
             params.node?.setDataValue('title', oldValue);
@@ -419,12 +426,15 @@ export const TicketTable: React.FC<TicketTableProps> = ({
         },
         onCellValueChanged: params => {
           if (params.newValue !== params.oldValue && params.data) {
-            zero.mutate(
-              mutators.ticket.update({
-                id: params.data.id,
-                assignedTo: typeof params.newValue === 'string' ? params.newValue : undefined,
-                updatedAt: Date.now(),
-              }),
+            void surfaceMutationError(
+              zero.mutate(
+                mutators.ticket.update({
+                  id: params.data.id,
+                  assignedTo: typeof params.newValue === 'string' ? params.newValue : undefined,
+                  updatedAt: Date.now(),
+                }),
+              ),
+              'Failed to update assignee',
             );
           }
         },
@@ -478,12 +488,15 @@ export const TicketTable: React.FC<TicketTableProps> = ({
         cellEditor: StatusCellEditor,
         onCellValueChanged: params => {
           if (params.newValue !== params.oldValue && params.data) {
-            zero.mutate(
-              mutators.ticket.update({
-                id: params.data.id,
-                statusV2: String(params.newValue),
-                updatedAt: Date.now(),
-              }),
+            void surfaceMutationError(
+              zero.mutate(
+                mutators.ticket.update({
+                  id: params.data.id,
+                  statusV2: String(params.newValue),
+                  updatedAt: Date.now(),
+                }),
+              ),
+              'Failed to update status',
             );
           }
         },
@@ -517,12 +530,15 @@ export const TicketTable: React.FC<TicketTableProps> = ({
         cellEditor: PriorityCellEditor,
         onCellValueChanged: params => {
           if (params.newValue !== params.oldValue && params.data) {
-            zero.mutate(
-              mutators.ticket.update({
-                id: params.data.id,
-                priority: params.newValue as Ticket['priority'],
-                updatedAt: Date.now(),
-              }),
+            void surfaceMutationError(
+              zero.mutate(
+                mutators.ticket.update({
+                  id: params.data.id,
+                  priority: params.newValue as Ticket['priority'],
+                  updatedAt: Date.now(),
+                }),
+              ),
+              'Failed to update priority',
             );
           }
         },
@@ -600,15 +616,18 @@ export const TicketTable: React.FC<TicketTableProps> = ({
           const toRemove = oldTagNames.filter(t => !newTagNames.includes(t));
           toAdd.forEach(tagName => {
             if (params.data) {
-              zero.mutate(
-                mutators.ticketTagV2.create({
-                  ticketId: params.data.id,
-                  tagId: uuidv4(),
-                  projectTagId: uuidv4(),
-                  mappingId: uuidv4(),
-                  projectId: params.data.projectId,
-                  tagName,
-                }),
+              void surfaceMutationError(
+                zero.mutate(
+                  mutators.ticketTagV2.create({
+                    ticketId: params.data.id,
+                    tagId: uuidv4(),
+                    projectTagId: uuidv4(),
+                    mappingId: uuidv4(),
+                    projectId: params.data.projectId,
+                    tagName,
+                  }),
+                ),
+                'Failed to add tag',
               );
             }
           });
@@ -616,7 +635,10 @@ export const TicketTable: React.FC<TicketTableProps> = ({
           toRemove.forEach(tagName => {
             const tag = oldTags.find(t => t.name === tagName);
             if (tag?.id) {
-              zero.mutate(mutators.ticketTagV2.delete({ tagId: tag.id, mappingId: tag.id }));
+              void surfaceMutationError(
+                zero.mutate(mutators.ticketTagV2.delete({ tagId: tag.id, mappingId: tag.id })),
+                'Failed to remove tag',
+              );
             }
           });
           return false;

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -58,6 +58,7 @@ import { useAllChannels, useChannel, useGetChannelUserStatus } from '../../hooks
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { queries } from '../../zero/queries';
 import { mutators } from '../../zero/mutators';
+import { surfaceMutationError } from '../../utils/zeroMutationToast';
 import { apiInstance } from '../../services/clients/apiClient';
 import type {
   Ticket,
@@ -3102,15 +3103,18 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                     );
 
                     // Directly update the stage for backward movement
-                    void zero.mutate(
-                      mutators.ticket.update({
-                        id: backwardStageChange.ticketId,
-                        stageName: backwardStageChange.stageName,
-                        ...(backwardStageChange.newStatus && {
-                          statusV2: backwardStageChange.newStatus,
+                    void surfaceMutationError(
+                      zero.mutate(
+                        mutators.ticket.update({
+                          id: backwardStageChange.ticketId,
+                          stageName: backwardStageChange.stageName,
+                          ...(backwardStageChange.newStatus && {
+                            statusV2: backwardStageChange.newStatus,
+                          }),
+                          updatedAt: Date.now(),
                         }),
-                        updatedAt: Date.now(),
-                      }),
+                      ),
+                      'Failed to move ticket',
                     );
 
                     setShowBackwardConfirmDialog(false);

--- a/apps/dashboard/src/routes/SupportScreen/SupportKanbanBoard.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportKanbanBoard.tsx
@@ -22,6 +22,7 @@ import { TicketPriority, TicketStatusV2, BoardType, TicketStageRequestStatus } f
 import { useZero } from '../../hooks/useZero';
 import { queries } from '../../zero/queries';
 import { mutators } from '../../zero/mutators';
+import { surfaceMutationError } from '../../utils/zeroMutationToast';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { dataLoadDuration, safeRecordMetric } from '../../services/otel';
 import { logger, Event } from '../../utils/logger';
@@ -493,12 +494,15 @@ export const SupportKanbanBoard = ({
                         fromSequenceNumber: backwardStageChange.fromSequenceNumber,
                       }),
                     );
-                    void zero.mutate(
-                      mutators.ticket.update({
-                        id: backwardStageChange.ticketId,
-                        stageName: backwardStageChange.stageName,
-                        updatedAt: Date.now(),
-                      }),
+                    void surfaceMutationError(
+                      zero.mutate(
+                        mutators.ticket.update({
+                          id: backwardStageChange.ticketId,
+                          stageName: backwardStageChange.stageName,
+                          updatedAt: Date.now(),
+                        }),
+                      ),
+                      'Failed to move ticket',
                     );
                   }
                   setShowBackwardConfirmDialog(false);

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -73,6 +73,8 @@ import {
 } from './supportSidebarWidth';
 import { useHasResourceAccess } from '../../hooks/usePermissions';
 import { cn } from '../../utils/classNames';
+import { getApiErrorMessage } from '../../utils/apiError';
+import { surfaceMutationError } from '../../utils/zeroMutationToast';
 import { Hashtag, Star } from '@xyne/icons';
 import ChannelIcon from '../../components/Chat/ChannelIcon/ChannelIcon';
 import { logger, Event } from '../../utils/logger';
@@ -3620,10 +3622,10 @@ export const SupportTicketDetail = ({
         if (sourceTicketXyneId && channelIdParam) {
           void navigate(`${navBasePath ?? supportBase}/${channelIdParam}/${sourceTicketXyneId}`);
         }
-      } catch {
+      } catch (err) {
         toast.error('Unmerge Failed', {
           id: toastId,
-          description: 'Operation failed. Please try again.',
+          description: getApiErrorMessage(err, 'Operation failed. Please try again.'),
         });
       }
     },
@@ -3962,17 +3964,22 @@ export const SupportTicketDetail = ({
       }
 
       setIsArchivingTicket(true);
-      zero.mutate(
-        mutators.ticket.archiveDeskTicket({
-          id: ticket.id,
-          updatedAt: Date.now(),
-        }),
-      );
-
-      setIsArchivingTicket(false);
       setShowArchiveConfirmDialog(false);
-      toast.success('Ticket archived successfully');
-      goBackToTicketList();
+      void surfaceMutationError(
+        zero.mutate(
+          mutators.ticket.archiveDeskTicket({
+            id: ticket.id,
+            updatedAt: Date.now(),
+          }),
+        ),
+        'Failed to archive ticket',
+      ).then(ok => {
+        setIsArchivingTicket(false);
+        if (ok) {
+          toast.success('Ticket archived successfully');
+          goBackToTicketList();
+        }
+      });
     } catch (err) {
       setIsArchivingTicket(false);
       toast.error('Failed to archive ticket', {
@@ -5469,10 +5476,10 @@ const EmailThreadItem = ({
           });
         }
       }
-    } catch {
+    } catch (err) {
       toast.error('Unmerge Failed', {
         id: toastId,
-        description: 'Operation failed. Please try again.',
+        description: getApiErrorMessage(err, 'Operation failed. Please try again.'),
       });
     } finally {
       setIsDemerging(false);

--- a/apps/dashboard/src/utils/apiError.ts
+++ b/apps/dashboard/src/utils/apiError.ts
@@ -1,11 +1,15 @@
 /**
  * Extracts a human-readable message from an error thrown by the REST layer.
- * Prefers the backend's `{ message }` envelope (axios `error.response.data.message`),
- * then a plain `Error.message`, then a raw string, falling back to `fallback`.
+ * Prefers the backend's error envelope — `{ error }` (used by the ticket
+ * controller) or `{ message }` (axios `error.response.data`) — then a plain
+ * `Error.message`, then a raw string, falling back to `fallback`.
  */
 export function getApiErrorMessage(err: unknown, fallback = 'Unknown error'): string {
-  const apiMessage = (err as { response?: { data?: { message?: unknown } } } | null)?.response?.data
-    ?.message;
+  const data = (err as { response?: { data?: { error?: unknown; message?: unknown } } } | null)
+    ?.response?.data;
+  const apiError = data?.error;
+  if (typeof apiError === 'string' && apiError.length > 0) return apiError;
+  const apiMessage = data?.message;
   if (typeof apiMessage === 'string' && apiMessage.length > 0) return apiMessage;
   if (typeof err === 'string' && err.length > 0) return err;
   if (err instanceof Error && err.message.length > 0) return err.message;

--- a/apps/dashboard/src/utils/zeroMutationToast.ts
+++ b/apps/dashboard/src/utils/zeroMutationToast.ts
@@ -1,0 +1,39 @@
+import { toast } from 'sonner';
+
+/**
+ * The shape `zero.mutate(...)` returns. Zero applies the mutation optimistically
+ * and RESOLVES `.server` with the authoritative result — it does NOT reject for
+ * application errors, which arrive as `{ type: 'error', error: { message } }`.
+ */
+type ZeroMutationResult = {
+  server: Promise<{ type?: string; error?: { message?: string } } | undefined>;
+};
+
+/**
+ * Awaits a Zero mutator's server result and surfaces the REAL error as a toast.
+ *
+ * A bare `void zero.mutate(...)` drops the server result, so a server-side
+ * rejection (permission, board constraint, terminal-status guard, "not
+ * found"…) silently rolls back the optimistic write and the user sees nothing.
+ * Routing the mutation through this helper turns that silent rollback into the
+ * actual server message instead of a generic/absent one.
+ *
+ * Returns `true` when the mutation succeeded and `false` otherwise, so callers
+ * that need a success side effect (success toast, navigation) can gate on it.
+ */
+export async function surfaceMutationError(
+  mutation: ZeroMutationResult,
+  fallback = 'Something went wrong. Please try again.',
+): Promise<boolean> {
+  try {
+    const result = await mutation.server;
+    if (result?.type === 'error') {
+      toast.error(result.error?.message || fallback);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    toast.error(err instanceof Error ? err.message : fallback);
+    return false;
+  }
+}


### PR DESCRIPTION
## What & why
Across ticket create/update/upsert/modify flows, the dashboard was hiding the real failure reason from the user. Three classes of bug were fixed so the actual mutator/API error is shown as a toast instead of a generic/absent one.

## Categories fixed
**A — real error caught then replaced with a hardcoded string**
- `TicketDetails.tsx` `handleUnmerge` — empty `catch {}` → `toast.error('Failed to unmerge ticket')`. Now uses `getApiErrorMessage(err, …)`.
- `SupportScreen.tsx` `handleUnmergeMergedSource` and the email demerge handler — both replaced the API error with `'Operation failed. Please try again.'`. Now surface the real message via `getApiErrorMessage`.

**B — fire-and-forget mutator + unconditional success toast (false success)**
- `SupportScreen.tsx` desk `handleArchiveTicket` (`archiveDeskTicket`) and `TicketDetails.tsx` `handleArchiveTicket` — the mutator was not awaited and a success toast + navigation fired regardless. Now the `.server` result is awaited; success toast/navigation only run on success, and mutator errors (`Only Desk tickets can be archived`, `Ticket is already archived`, `Ticket has no associated channel`, `Ticket not found`) surface to the user.

**C — silent `void zero.mutate(...)` with no `.server` (silent rollback, no toast)**
Routed through a new `surfaceMutationError` helper: `PriorityPicker`, `AssigneePicker`, `StagePicker` (linear branch), `ReleaseStagePicker`, `TicketCard` (tag add/remove, assignee, priority), `TicketTable` (stage, title, assignee, status, priority, inline tag add/remove), `KanbanBoardScreen` and `SupportKanbanBoard` backward-move, and `CreateTicketModal` sub-ticket create. In `TicketDetails` the standalone stage/ETA/board/archive writes were routed through the existing `applyTicketUpdate` (now returns a success boolean).

## New/changed utilities
- `utils/zeroMutationToast.ts` (new) — `surfaceMutationError(mutation, fallback)` awaits `.server`, toasts the real error on `{ type: 'error' }`, returns success boolean.
- `utils/apiError.ts` — `getApiErrorMessage` now also reads the backend `{ error }` envelope (the ticket controller returns `{ error }`, not `{ message }`).

## Deliberately out of scope
- Bulk multi-row loops in `TicketTable` (`handleBulkStatusUpdate`, `handleBulkTagUpdate`) were left as-is — surfacing per-row would spam N identical toasts; they need aggregated error handling.
- Secondary post-transition `ticket.update` writes inside `useDragAndDrop.ts` (the transition itself already surfaces `.server` errors).

## Validation
- `npm run typecheck` (dashboard) — passes.
- `eslint --quiet` on all changed files + the new util — clean.