### PR TITLE
fix: XYNE-54658 add agent details

### DIFF
--- a/apps/dashboard/src/routes/AIScreen/AIAgentDetailScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/AIAgentDetailScreen.tsx
@@ -1,0 +1,25 @@
+import { type ReactElement } from 'react';
+import { AIShell } from '../../components/AIScreen/AIShell';
+import ClawAgentDetailV2 from '../ClawAgentsScreen/detail-v2/ClawAgentDetailV2';
+import { useAIChatHandoff } from './useAIChatHandoff';
+
+const AIAgentDetailScreen = (): ReactElement => {
+  const { onCreateChat, onSelectSession } = useAIChatHandoff();
+
+  return (
+    <AIShell
+      onCreateChat={onCreateChat}
+      onSelectSession={onSelectSession}
+      mainClassName='ai-page-bg'
+    >
+      <main
+        data-id='ai-agent-detail-view'
+        className='relative flex h-full flex-1 flex-col overflow-hidden border border-border bg-background'
+      >
+        <ClawAgentDetailV2 />
+      </main>
+    </AIShell>
+  );
+};
+
+export default AIAgentDetailScreen;

--- a/apps/dashboard/src/routes/AIScreen/AIAgentEditScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/AIAgentEditScreen.tsx
@@ -1,0 +1,43 @@
+import { type ReactElement } from 'react';
+import { useParams } from 'react-router-dom';
+import { AIShell } from '../../components/AIScreen/AIShell';
+import { Skeleton } from '../../components/ui/Skeleton';
+import { useClawAgentDetail } from '../../hooks/useClawAgentDetail';
+import ClawAgentCreateV2 from '../ClawAgentsScreen/create-v2/ClawAgentCreateV2';
+import { useAIChatHandoff } from './useAIChatHandoff';
+
+const AIAgentEditScreen = (): ReactElement => {
+  const { onCreateChat, onSelectSession } = useAIChatHandoff();
+  const { slug } = useParams<{ slug?: string }>();
+  const { data: agent, isLoading, isError } = useClawAgentDetail(slug);
+
+  return (
+    <AIShell
+      onCreateChat={onCreateChat}
+      onSelectSession={onSelectSession}
+      mainClassName='ai-page-bg'
+    >
+      <main
+        data-id='ai-agent-edit-view'
+        className='relative flex h-full flex-1 flex-col overflow-hidden border border-border bg-background'
+      >
+        {isLoading ? (
+          <div className='mx-auto flex w-full max-w-[800px] flex-col gap-6 px-6 py-6'>
+            <Skeleton className='h-8 w-40' />
+            <Skeleton className='h-6 w-64' />
+            <Skeleton className='h-[86px] w-full rounded-2xl' />
+            <Skeleton className='h-[250px] w-full rounded-2xl' />
+          </div>
+        ) : isError || !agent ? (
+          <p className='py-16 text-center text-sm text-muted-foreground'>
+            Couldn&apos;t load this agent.
+          </p>
+        ) : (
+          <ClawAgentCreateV2 agent={agent} />
+        )}
+      </main>
+    </AIShell>
+  );
+};
+
+export default AIAgentEditScreen;

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -210,6 +210,8 @@ import AILibraryScreen from './AIScreen/AILibraryScreen';
 import AIAgentCreateScreen from './AIScreen/AIAgentCreateScreen';
 import AISubagentCreateScreen from './AIScreen/AISubagentCreateScreen';
 import AISkillCreateScreen from './AIScreen/AISkillCreateScreen';
+import AIAgentDetailScreen from './AIScreen/AIAgentDetailScreen';
+import AIAgentEditScreen from './AIScreen/AIAgentEditScreen';
 import AIKnowledgeScreen from './AIScreen/AIKnowledgeScreen';
 import AISectionLayout from './AIScreen/AISectionLayout';
 import UserGuideScreen from './UserGuideScreen';
@@ -841,6 +843,8 @@ export const router = createBrowserRouter([
                   { path: 'library/agent/create', element: <AIAgentCreateScreen /> },
                   { path: 'library/subagent/create', element: <AISubagentCreateScreen /> },
                   { path: 'library/skill/create', element: <AISkillCreateScreen /> },
+                  { path: 'library/agent/:slug/edit', element: <AIAgentEditScreen /> },
+                  { path: 'library/agent/:slug', element: <AIAgentDetailScreen /> },
                   { path: 'knowledge', element: <AIKnowledgeScreen /> },
                   {
                     element: <AISectionLayout />,

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/ClawAgentCreateV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/ClawAgentCreateV2.tsx
@@ -24,6 +24,9 @@ import {
   slugify,
   type WizardState,
 } from '../create/wizardState';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { wizardStateFromAgent } from './agentDraft';
+import { useSaveClawAgent } from './useSaveClawAgent';
 import { AgentColorRow } from './AgentColorRow';
 import { AutoWidthInput } from './shared/AutoWidthInput';
 import { BuiltinCapabilityRow } from './builtin/BuiltinCapabilityRow';
@@ -36,7 +39,12 @@ function inlineWidth(value: string, placeholder: string): string {
   return `${Math.max(value.length, placeholder.length) - 2}ch`;
 }
 
-const ClawAgentCreateV2 = (): ReactElement => {
+interface ClawAgentCreateV2Props {
+  agent?: Agent;
+}
+
+const ClawAgentCreateV2 = ({ agent }: ClawAgentCreateV2Props = {}): ReactElement => {
+  const isEdit = agent !== undefined;
   const navigate = useNavigate();
   const { workspaceId } = useParams<{ workspaceId?: string }>();
   const libraryPath = workspaceId ? `/${workspaceId}/ai/library` : '/ai/library';
@@ -51,15 +59,18 @@ const ClawAgentCreateV2 = (): ReactElement => {
     if (aiOpen) aiIntentRef.current?.focus();
   }, [aiOpen]);
 
-  const [state, setState] = useState<WizardState>(INITIAL_WIZARD_STATE);
+  const [state, setState] = useState<WizardState>(() =>
+    agent ? wizardStateFromAgent(agent) : INITIAL_WIZARD_STATE,
+  );
   const update = useCallback(
     (patch: Partial<WizardState>) => setState(prev => ({ ...prev, ...patch })),
     [],
   );
 
   const slug = effectiveSlug(state);
-  const nameCheck = useAgentNameCheck(state.name.trim(), slug);
+  const nameCheck = useAgentNameCheck(isEdit ? '' : state.name.trim(), slug);
   const createMutation = useCreateClawAgent();
+  const saveMutation = useSaveClawAgent(agent);
 
   const generate = useMutation({
     mutationFn: generateAgentPrompt,
@@ -80,14 +91,17 @@ const ClawAgentCreateV2 = (): ReactElement => {
     generate.mutate({ intent, agentName: state.name });
   };
 
-  const canCreate =
+  const canSubmit =
     state.name.trim().length > 0 &&
     slug.length > 0 &&
-    nameCheck.nameValid &&
-    !nameCheck.checking &&
+    (isEdit || (nameCheck.nameValid && !nameCheck.checking)) &&
     state.systemPrompt.trim().length > 0;
 
-  const handleCreate = (): void => {
+  const handleSubmit = (): void => {
+    if (isEdit) {
+      void saveMutation.save(state);
+      return;
+    }
     createMutation.mutate({
       slug,
       name: state.name.trim(),
@@ -111,7 +125,7 @@ const ClawAgentCreateV2 = (): ReactElement => {
     <div className='h-full overflow-y-auto no-scrollbar' data-component='ClawAgentCreateV2'>
       <div className='mx-auto flex w-full max-w-[800px] flex-col gap-6 px-6 py-6'>
         <h1 className='text-2xl font-semibold leading-[1.2] tracking-[-0.24px] text-foreground'>
-          Create agent
+          {isEdit ? 'Edit agent' : 'Create agent'}
         </h1>
 
         <div className='flex w-full flex-col gap-4'>
@@ -331,7 +345,9 @@ const ClawAgentCreateV2 = (): ReactElement => {
         <div className='flex w-full items-center justify-end gap-3'>
           <Button
             variant='ghost'
-            onClick={() => void navigate(libraryPath)}
+            onClick={() =>
+              void navigate(isEdit ? `${libraryPath}/agent/${agent.slug}?tab=persona` : libraryPath)
+            }
             className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
             data-track-category='Claw Agents'
             data-track-name='Create agent v2: cancel'
@@ -339,14 +355,14 @@ const ClawAgentCreateV2 = (): ReactElement => {
             Cancel
           </Button>
           <Button
-            onClick={handleCreate}
-            loading={createMutation.isPending}
-            disabled={!canCreate}
+            onClick={handleSubmit}
+            loading={isEdit ? saveMutation.saving : createMutation.isPending}
+            disabled={!canSubmit}
             className='h-auto rounded-xl bg-foreground px-3 py-2.5 text-[15px] text-background hover:bg-foreground/90'
             data-track-category='Claw Agents'
-            data-track-name='Create agent v2: create'
+            data-track-name={`Create agent v2: ${isEdit ? 'save' : 'create'}`}
           >
-            Create
+            {isEdit ? 'Save' : 'Create'}
           </Button>
         </div>
       </div>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/agentDraft.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/agentDraft.ts
@@ -1,0 +1,54 @@
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import type { KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
+import type { ToolboxSelection } from '@/services/claw/clawToolsTypes';
+import { INITIAL_WIZARD_STATE, type WizardState } from '../create/wizardState';
+
+interface ConfigShape {
+  tools?: {
+    subagents?: unknown;
+    direct?: unknown;
+    custom?: unknown;
+    gateway?: unknown;
+  };
+  product_id?: unknown;
+  repository_id?: unknown;
+}
+
+const strings = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+
+export function readToolSelection(config: Record<string, unknown>): Required<ToolboxSelection> {
+  const tools = (config as ConfigShape).tools ?? {};
+  return {
+    subagents: strings(tools.subagents),
+    direct: strings(tools.direct),
+    custom: strings(tools.custom),
+    gateway: strings(tools.gateway),
+  };
+}
+
+export function wizardStateFromAgent(agent: Agent): WizardState {
+  const config = agent.config ?? {};
+  const shape = config as ConfigShape;
+
+  const knowledge: KbSelection[] = (agent.collections ?? []).map(entry => ({
+    collectionId: entry.collectionId,
+    ...(entry.fileId ? { fileId: entry.fileId } : {}),
+  })) as KbSelection[];
+
+  return {
+    ...INITIAL_WIZARD_STATE,
+    name: agent.name,
+    description: agent.description,
+    color: agent.color || INITIAL_WIZARD_STATE.color,
+    slug: agent.slug,
+    slugManual: true,
+    systemPrompt: agent.systemPrompt ?? '',
+    tools: readToolSelection(config),
+    researchAgentProductId: typeof shape.product_id === 'string' ? shape.product_id : '',
+    researchAgentRepositoryId: typeof shape.repository_id === 'string' ? shape.repository_id : '',
+    selectedSkillIds: (agent.skills ?? []).map(entry => entry.skillId),
+    selectedKbScope: agent.kbScope === 'USER' ? 'USER' : 'COLLECTIONS',
+    selectedKbResources: knowledge,
+  };
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/builtin/BuiltinChip.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/builtin/BuiltinChip.tsx
@@ -27,7 +27,7 @@ export function BuiltinChip({ label, selected, onToggle }: BuiltinChipProps): Re
     >
       <span
         className={cn(
-          'max-w-[200px] truncate text-sm font-semibold leading-5',
+          'max-w-[200px] truncate text-sm font-medium leading-5',
           selected ? 'text-foreground' : 'text-foreground/80',
         )}
       >

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/mcp/BrowseMcpsDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/mcp/BrowseMcpsDialog.tsx
@@ -61,7 +61,6 @@ const McpCard = ({
           label={entry.label}
           iconType={entry.iconType}
           verified={entry.verified}
-          weight='medium'
           {...(state.enabled ? { trailing: <EnabledBadge /> } : {})}
         />
         <span className='flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground'>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/mcp/McpIdentity.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/mcp/McpIdentity.tsx
@@ -47,7 +47,7 @@ export function McpIdentity({
   verified,
   gap = 'default',
   muted = false,
-  weight = 'semibold',
+  weight = 'medium',
   trailing,
 }: McpIdentityProps): ReactElement {
   return (

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/mcp/McpLogo.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/mcp/McpLogo.tsx
@@ -1,12 +1,13 @@
-import { useState, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import { cn } from '@/utils/classNames';
 
 const MCP_ICON_BASE = '/assets/mcp';
-const MCP_SVG_ONLY = new Set(['gmail', 'google-drive', 'sequentialthinking', 'xyne-spaces']);
+const EXTENSIONS = ['png', 'svg'] as const;
 const MCP_TRANSPARENT = new Set(['xyne-spaces']);
 
-const SIZE: Record<'sm' | 'lg', string> = {
+const SIZE: Record<'sm' | 'md' | 'lg', string> = {
   sm: 'size-7 rounded-lg p-1 text-[10px]',
+  md: 'size-10 rounded-lg p-1.5 text-xs',
   lg: 'size-11 rounded-xl p-2 text-xs',
 };
 
@@ -23,12 +24,16 @@ export function McpLogo({
 }: {
   type: string;
   name: string;
-  size?: 'sm' | 'lg';
+  size?: keyof typeof SIZE;
 }): ReactElement {
-  const [errored, setErrored] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => setAttempt(0), [type]);
+
+  const extension = EXTENSIONS[attempt];
   const background = MCP_TRANSPARENT.has(type) ? 'bg-transparent' : 'bg-card';
 
-  if (errored || !type) {
+  if (!type || !extension) {
     return (
       <div
         className={cn(
@@ -45,10 +50,11 @@ export function McpLogo({
 
   return (
     <img
-      src={`${MCP_ICON_BASE}/${type}.${MCP_SVG_ONLY.has(type) ? 'svg' : 'png'}`}
+      key={extension}
+      src={`${MCP_ICON_BASE}/${type}.${extension}`}
       alt=''
       aria-hidden='true'
-      onError={() => setErrored(true)}
+      onError={() => setAttempt(next => next + 1)}
       className={cn(
         'shrink-0 border border-border object-contain shadow-sm',
         SIZE[size],

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/shared/ProseBox.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/shared/ProseBox.tsx
@@ -1,0 +1,51 @@
+import { useLayoutEffect, useRef, useState, type ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+
+export const PROSE_BOX_HEIGHT = 298;
+
+interface ProseBoxProps {
+  children: string;
+  height?: number;
+  className?: string;
+}
+
+export function ProseBox({
+  children,
+  height = PROSE_BOX_HEIGHT,
+  className,
+}: ProseBoxProps): ReactElement {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showFade, setShowFade] = useState(false);
+
+  const sync = (): void => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const remaining = el.scrollHeight - el.scrollTop - el.clientHeight;
+    setShowFade(remaining > 1);
+  };
+
+  useLayoutEffect(sync, [children, height]);
+
+  return (
+    <div className='relative w-full' style={{ height }}>
+      <div
+        ref={scrollRef}
+        onScroll={sync}
+        className={cn(
+          'h-full w-full overflow-y-auto rounded-2xl border border-border bg-card p-4',
+          className,
+        )}
+      >
+        <p className='whitespace-pre-wrap break-words text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
+          {children}
+        </p>
+      </div>
+      {showFade && (
+        <span
+          className='pointer-events-none absolute inset-x-px bottom-px h-16 rounded-b-2xl bg-gradient-to-t from-card to-transparent'
+          aria-hidden
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/shared/V2Dialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/shared/V2Dialog.tsx
@@ -1,0 +1,66 @@
+import { type ReactElement, type ReactNode } from 'react';
+import { MultipleCrossCancelDefault } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import { Dialog } from '@/components/ui/Dialog';
+
+const WIDTH = { form: 'max-w-[560px]', wide: 'max-w-[800px]' } as const;
+
+interface V2DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  testId: string;
+  width?: keyof typeof WIDTH;
+  footer?: ReactNode;
+  children: ReactNode;
+}
+
+export function V2Dialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  testId,
+  width = 'form',
+  footer,
+  children,
+}: V2DialogProps): ReactElement {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      description={description}
+      testId={testId}
+      className={cn(
+        'flex max-h-[min(85vh,720px)] w-full flex-col gap-4 overflow-hidden rounded-2xl border-[0.8px] border-border bg-card p-1',
+        WIDTH[width],
+      )}
+    >
+      <div className='flex h-9 shrink-0 items-center justify-between gap-2 pl-[18px] pr-2'>
+        <span className='text-base font-semibold leading-6 tracking-[-0.16px] text-foreground'>
+          {title}
+        </span>
+        <button
+          type='button'
+          onClick={() => onOpenChange(false)}
+          aria-label='Close'
+          data-track-category='Claw Agents'
+          data-track-name={`Close dialog: ${title}`}
+          className='flex size-7 shrink-0 items-center justify-center rounded-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+        >
+          <MultipleCrossCancelDefault className='size-4' aria-hidden />
+        </button>
+      </div>
+
+      <div className='flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-[22px] pb-2'>
+        {children}
+      </div>
+
+      {footer && (
+        <div className='flex shrink-0 items-center justify-end gap-3 px-[22px] pb-3'>{footer}</div>
+      )}
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/skill/SkillChip.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/skill/SkillChip.tsx
@@ -27,7 +27,7 @@ export function SkillChip({ label, selected, onToggle }: SkillChipProps): ReactE
     >
       <span
         className={cn(
-          'max-w-[200px] truncate text-sm font-semibold leading-5',
+          'max-w-[200px] truncate text-sm font-medium leading-5',
           selected ? 'text-foreground' : 'text-foreground/80',
         )}
       >

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/skill/SkillDetailPanel.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/skill/SkillDetailPanel.tsx
@@ -3,7 +3,7 @@ import { Staroflife } from '@xyne/icons';
 import { cn } from '@/utils/classNames';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useClawSkillFiles } from '@/hooks/useClawSkills';
-import { Clamped } from '../shared/Clamped';
+import { ProseBox } from '../shared/ProseBox';
 import { SectionHeading, Separator } from '../shared/Section';
 import { SkillFileTree } from './SkillFileTree';
 import {
@@ -166,13 +166,7 @@ export function SkillDetailPanel({
         <section className='flex w-full flex-col gap-4'>
           <SectionHeading label='Instructions' />
           {entry.skill.content ? (
-            <Clamped
-              maxHeight={PANE_HEIGHT}
-              resetKey={entry.id}
-              className='rounded-2xl border border-border bg-card p-4'
-            >
-              <Body>{entry.skill.content}</Body>
-            </Clamped>
+            <ProseBox height={PANE_HEIGHT}>{entry.skill.content}</ProseBox>
           ) : (
             <Muted>This skill has no instructions yet.</Muted>
           )}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/useSaveClawAgent.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create-v2/useSaveClawAgent.ts
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { clawAgentDetailKey } from '@/hooks/useClawAgentDetail';
+import { updateClawAgent } from '@/services/claw/clawAuthAgentsService';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import type { WizardState } from '../create/wizardState';
+
+export interface SaveClawAgent {
+  save: (state: WizardState) => Promise<void>;
+  saving: boolean;
+}
+
+export function useSaveClawAgent(agent: Agent | undefined): SaveClawAgent {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
+  const [saving, setSaving] = useState(false);
+
+  const save = async (state: WizardState): Promise<void> => {
+    if (!agent || saving) return;
+    setSaving(true);
+    try {
+      const config: Record<string, unknown> = {
+        ...(agent.config ?? {}),
+        tools: {
+          subagents: state.tools.subagents,
+          direct: state.tools.direct,
+          custom: state.tools.custom,
+          gateway: state.tools.gateway,
+        },
+      };
+      if (state.researchAgentProductId) config['product_id'] = state.researchAgentProductId;
+      if (state.researchAgentRepositoryId)
+        config['repository_id'] = state.researchAgentRepositoryId;
+
+      const updated = await updateClawAgent(agent.slug, {
+        name: state.name.trim(),
+        description: state.description.trim(),
+        systemPrompt: state.systemPrompt.trim(),
+        color: state.color,
+        kbScope: state.selectedKbScope,
+        ...(state.selectedKbScope === 'USER' ? {} : { knowledgeBase: state.selectedKbResources }),
+        config,
+        skills: state.selectedSkillIds,
+      });
+
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), updated);
+      void queryClient.invalidateQueries({ queryKey: ['claw-auth-agents'] });
+      toast.success('Changes saved');
+
+      const base = workspaceId ? `/${workspaceId}/ai/library` : '/ai/library';
+      void navigate(`${base}/agent/${agent.slug}?tab=persona`);
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not save this agent'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return { save, saving };
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/AgentDetailHeaderV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/AgentDetailHeaderV2.tsx
@@ -1,0 +1,250 @@
+import { useState, type ReactElement, type ReactNode } from 'react';
+import {
+  ChevronBigLeft,
+  CopyDefault,
+  DeleteDustbin01,
+  PencilEditLine,
+  ThreeDotsMenuHorizontal,
+} from '@xyne/icons';
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/utils/classNames';
+import { Popover } from '@/components/ui/Popover';
+import { CloneAgentDialog } from '@/components/ClawAgents/CloneAgentDialog';
+import { ConfirmDialog } from '@/components/ClawAgents/ConfirmDialog';
+import { RenameHandleDialog } from '@/components/ClawAgents/RenameHandleDialog';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import type { AgentDetailActions } from './useAgentDetailActions';
+
+const Action = ({
+  label,
+  icon,
+  primary = false,
+  busy = false,
+  disabled = false,
+  onClick,
+}: {
+  label: string;
+  icon?: ReactNode;
+  primary?: boolean;
+  busy?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}): ReactElement => (
+  <button
+    type='button'
+    onClick={onClick}
+    disabled={disabled || busy}
+    data-track-category='Claw Agents'
+    data-track-name={`Agent detail v2: ${label}`}
+    className={cn(
+      'flex h-7 shrink-0 items-center gap-1.5 rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors disabled:pointer-events-none disabled:opacity-50',
+      primary
+        ? 'border-border bg-primary text-primary-foreground hover:bg-primary/90'
+        : 'border-transparent text-foreground hover:bg-muted',
+    )}
+  >
+    {busy ? <Loader2 className='size-3.5 animate-spin' aria-hidden /> : icon}
+    {label}
+  </button>
+);
+
+const MenuItem = ({
+  label,
+  danger = false,
+  icon,
+  onClick,
+}: {
+  label: string;
+  danger?: boolean;
+  icon?: ReactNode;
+  onClick: () => void;
+}): ReactElement => (
+  <button
+    type='button'
+    onClick={onClick}
+    data-track-category='Claw Agents'
+    data-track-name={`Agent detail v2: ${label}`}
+    className={cn(
+      'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted',
+      danger ? 'text-destructive' : 'text-foreground',
+    )}
+  >
+    {icon}
+    {label}
+  </button>
+);
+
+interface AgentDetailHeaderV2Props {
+  agent: Agent;
+  actions: AgentDetailActions;
+  onBack: () => void;
+  onEdit: () => void;
+}
+
+export function AgentDetailHeaderV2({
+  agent,
+  actions,
+  onBack,
+  onEdit,
+}: AgentDetailHeaderV2Props): ReactElement {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [cloneOpen, setCloneOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [moderateOpen, setModerateOpen] = useState<'promote' | 'demote' | null>(null);
+
+  const { permissions, isAdmin, isOwner, busy } = actions;
+  const canEdit = permissions?.canEdit ?? false;
+  const isGlobal = agent.scope === 'global';
+
+  const showModerate = isAdmin;
+  const showPublish = !isAdmin && isOwner && !isGlobal;
+
+  const hasMenu = canEdit || isOwner;
+
+  return (
+    <div className='flex w-full items-center justify-between gap-4'>
+      <button
+        type='button'
+        onClick={onBack}
+        data-track-category='Claw Agents'
+        data-track-name='Agent detail v2: back'
+        className='flex h-7 shrink-0 items-center rounded-[10px] pr-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+      >
+        <span className='flex h-7 w-[22px] shrink-0 items-center justify-center'>
+          <ChevronBigLeft className='size-4' aria-hidden />
+        </span>
+        <span className='text-base font-semibold leading-6 tracking-[-0.32px] text-foreground'>
+          Agents
+        </span>
+      </button>
+
+      <div className='flex shrink-0 items-center gap-1.5'>
+        {showModerate && (
+          <Action
+            label={isGlobal ? 'Unpublish' : 'Publish'}
+            busy={busy.moderating !== null}
+            onClick={() => setModerateOpen(isGlobal ? 'demote' : 'promote')}
+          />
+        )}
+        {showPublish && (
+          <Action label='Publish' busy={busy.publishing} onClick={() => void actions.publish()} />
+        )}
+
+        <Action
+          label='Clone'
+          icon={<CopyDefault className='size-4' aria-hidden />}
+          busy={busy.cloning}
+          onClick={() => setCloneOpen(true)}
+        />
+
+        {canEdit && (
+          <Action
+            label='Edit'
+            primary
+            icon={<PencilEditLine className='size-4' aria-hidden />}
+            onClick={onEdit}
+          />
+        )}
+
+        {hasMenu && (
+          <Popover
+            open={menuOpen}
+            onOpenChange={setMenuOpen}
+            align='end'
+            sideOffset={4}
+            trigger={
+              <button
+                type='button'
+                aria-label='More actions'
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: more actions'
+                className='flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+              >
+                <ThreeDotsMenuHorizontal className='size-4' aria-hidden />
+              </button>
+            }
+            className='w-52 rounded-xl border border-border bg-popover p-1 shadow-md'
+          >
+            {canEdit && (
+              <MenuItem
+                label={agent.enabled ? 'Pause agent' : 'Enable agent'}
+                onClick={() => {
+                  setMenuOpen(false);
+                  void actions.toggleEnabled(!agent.enabled);
+                }}
+              />
+            )}
+            {isOwner && (
+              <MenuItem
+                label='Rename handle'
+                onClick={() => {
+                  setMenuOpen(false);
+                  setRenameOpen(true);
+                }}
+              />
+            )}
+            {isOwner && (
+              <MenuItem
+                label='Delete agent'
+                danger
+                icon={<DeleteDustbin01 className='size-4 shrink-0' aria-hidden />}
+                onClick={() => {
+                  setMenuOpen(false);
+                  setDeleteOpen(true);
+                }}
+              />
+            )}
+          </Popover>
+        )}
+      </div>
+
+      <CloneAgentDialog
+        open={cloneOpen}
+        onOpenChange={setCloneOpen}
+        sourceName={agent.name}
+        needsApproval={!canEdit}
+        submitting={busy.cloning}
+        onConfirm={name => {
+          void actions.clone(name).then(() => setCloneOpen(false));
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title={`Delete ${agent.name}?`}
+        description='This removes the agent and its configuration. It cannot be undone.'
+        confirmLabel='Delete'
+        danger
+        loading={busy.deleting}
+        onConfirm={() => void actions.remove()}
+      />
+
+      <ConfirmDialog
+        open={moderateOpen !== null}
+        onOpenChange={open => setModerateOpen(open ? moderateOpen : null)}
+        title={moderateOpen === 'demote' ? `Unpublish ${agent.name}?` : `Publish ${agent.name}?`}
+        description={
+          moderateOpen === 'demote'
+            ? 'It becomes personal again and leaves the shared library.'
+            : 'It becomes global and everyone in the workspace can use it.'
+        }
+        confirmLabel={moderateOpen === 'demote' ? 'Unpublish' : 'Publish'}
+        loading={busy.moderating !== null}
+        onConfirm={() => {
+          const action = moderateOpen;
+          if (!action) return;
+          void actions.moderate(action).then(() => setModerateOpen(null));
+        }}
+      />
+
+      <RenameHandleDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        currentHandle={agent.slug}
+        onRename={actions.rename}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/AgentPersonaTabV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/AgentPersonaTabV2.tsx
@@ -1,0 +1,44 @@
+import { type ReactElement } from 'react';
+import { ProseBox } from '../create-v2/shared/ProseBox';
+import { CredentialsCard } from './credentials/CredentialsCard';
+import { ModelCard } from './model/ModelCard';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { DetailCard, DetailEmpty, DetailProse, DetailSection } from './DetailPrimitives';
+
+export function AgentPersonaTabV2({
+  agent,
+  canEdit,
+  canManageCredentials,
+}: {
+  agent: Agent;
+  canEdit: boolean;
+  canManageCredentials: boolean;
+}): ReactElement {
+  return (
+    <div className='flex w-full flex-col gap-8'>
+      <DetailSection label='Description' info='What this agent is for'>
+        <DetailCard>
+          {agent.description ? (
+            <DetailProse>{agent.description}</DetailProse>
+          ) : (
+            <DetailEmpty>No description added</DetailEmpty>
+          )}
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection label='System Prompt' info='The instructions this agent runs with'>
+        {agent.systemPrompt ? (
+          <ProseBox>{agent.systemPrompt}</ProseBox>
+        ) : (
+          <DetailCard>
+            <DetailEmpty>No system prompt set</DetailEmpty>
+          </DetailCard>
+        )}
+      </DetailSection>
+
+      <ModelCard agent={agent} canEdit={canEdit} />
+
+      <CredentialsCard slug={agent.slug} canRead={canEdit} canManage={canManageCredentials} />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/ClawAgentDetailV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/ClawAgentDetailV2.tsx
@@ -1,0 +1,164 @@
+import { type ReactElement } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { cn } from '@/utils/classNames';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useClawAgentDetail } from '@/hooks/useClawAgentDetail';
+import { Pill } from '../create-v2/shared/Pill';
+import { LibraryIconTile } from '../library/components/LibraryCard';
+import { AgentDetailHeaderV2 } from './AgentDetailHeaderV2';
+import { AgentPersonaTabV2 } from './AgentPersonaTabV2';
+import { AgentActivityTabV2 } from './activity/AgentActivityTabV2';
+import { AgentBehaviourTabV2 } from './behaviour/AgentBehaviourTabV2';
+import { AgentKnowledgeTabV2 } from './knowledge/AgentKnowledgeTabV2';
+import { AgentPeopleTabV2 } from './people/AgentPeopleTabV2';
+import { AgentToolsTabV2 } from './tools/AgentToolsTabV2';
+import { AGENT_DETAIL_TABS, resolveTab, type AgentDetailTabId } from './detailTabs';
+import { useAgentDetailActions } from './useAgentDetailActions';
+
+const DATE = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+function formatUpdated(value: string | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : DATE.format(parsed).replace(',', ',');
+}
+
+const ClawAgentDetailV2 = (): ReactElement => {
+  const navigate = useNavigate();
+  const { workspaceId, slug } = useParams<{ workspaceId?: string; slug?: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const libraryPath = workspaceId ? `/${workspaceId}/ai/library` : '/ai/library';
+  const tab = resolveTab(searchParams.get('tab'));
+
+  const { data: agent, isLoading, isError } = useClawAgentDetail(slug);
+  const actions = useAgentDetailActions(agent);
+
+  const setTab = (next: AgentDetailTabId): void => {
+    const params = new URLSearchParams(searchParams);
+    params.set('tab', next);
+    setSearchParams(params, { replace: true });
+  };
+
+  const updated = formatUpdated(agent?.updatedAt);
+  const version = agent?.activePromptVersion;
+
+  return (
+    <div className='h-full overflow-y-auto no-scrollbar' data-component='ClawAgentDetailV2'>
+      <div className='mx-auto flex w-full max-w-[800px] flex-col gap-6 px-6 pb-6'>
+        <div className='sticky top-0 z-10 flex flex-col gap-6 bg-background pb-3 pt-6'>
+          {agent && (
+            <AgentDetailHeaderV2
+              agent={agent}
+              actions={actions}
+              onBack={() => void navigate(`${libraryPath}?tab=agents`)}
+              onEdit={() => void navigate(`${libraryPath}/agent/${agent.slug}/edit`)}
+            />
+          )}
+
+          <div className='flex w-full items-center gap-1'>
+            {AGENT_DETAIL_TABS.map(entry => (
+              <button
+                key={entry.id}
+                type='button'
+                onClick={() => setTab(entry.id)}
+                aria-current={entry.id === tab ? 'page' : undefined}
+                data-track-category='Claw Agents'
+                data-track-name={`Agent detail v2 tab: ${entry.label}`}
+                className={cn(
+                  'flex h-8 items-center justify-center rounded-[10px] px-3 py-1 text-sm transition-colors',
+                  entry.id === tab
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                )}
+              >
+                {entry.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className='flex w-full flex-col gap-4'>
+            <Skeleton className='size-10 rounded-xl' />
+            <Skeleton className='h-6 w-52' />
+            <Skeleton className='h-4 w-80' />
+            <Skeleton className='h-32 w-full rounded-2xl' />
+          </div>
+        ) : isError || !agent ? (
+          <p className='py-16 text-center text-sm text-muted-foreground'>
+            Couldn&apos;t load this agent.
+          </p>
+        ) : (
+          <>
+            <div className='flex w-full items-start gap-3'>
+              <LibraryIconTile name={agent.name} color={agent.color || '#6366f1'} size='md' />
+
+              <div className='flex min-w-0 flex-1 flex-col gap-0.5 overflow-hidden'>
+                <div className='flex min-w-0 items-center gap-2'>
+                  <span className='truncate text-sm font-semibold leading-[22px] text-foreground'>
+                    {agent.name}
+                  </span>
+                  <Pill tone={agent.enabled ? 'success' : 'neutral'}>
+                    {agent.enabled ? 'Enabled' : 'Disabled'}
+                  </Pill>
+                </div>
+
+                <div className='flex flex-wrap items-center gap-1.5 text-xs leading-[22px] text-foreground/80 opacity-70'>
+                  <span>@{agent.slug}</span>
+                  {version !== null && version !== undefined && (
+                    <>
+                      <span aria-hidden>·</span>
+                      <span>v{version}</span>
+                    </>
+                  )}
+                  {updated && (
+                    <>
+                      <span aria-hidden>·</span>
+                      <span>Last updated on: {updated}</span>
+                    </>
+                  )}
+                  <button
+                    type='button'
+                    data-track-category='Claw Agents'
+                    data-track-name='Agent detail v2: version history'
+                    className='underline underline-offset-2'
+                  >
+                    Version history
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {tab === 'persona' ? (
+              <AgentPersonaTabV2
+                agent={agent}
+                canEdit={actions.permissions?.canEdit ?? false}
+                canManageCredentials={actions.isOwner || actions.isAdmin}
+              />
+            ) : tab === 'behaviour' ? (
+              <AgentBehaviourTabV2 agent={agent} canEdit={actions.permissions?.canEdit ?? false} />
+            ) : tab === 'tools' ? (
+              <AgentToolsTabV2 agent={agent} canEdit={actions.permissions?.canEdit ?? false} />
+            ) : tab === 'knowledge' ? (
+              <AgentKnowledgeTabV2 agent={agent} canEdit={actions.permissions?.canEdit ?? false} />
+            ) : tab === 'people' ? (
+              <AgentPeopleTabV2 agent={agent} actions={actions} />
+            ) : (
+              <AgentActivityTabV2 agent={agent} canEdit={actions.permissions?.canEdit ?? false} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ClawAgentDetailV2;

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/DetailListCard.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/DetailListCard.tsx
@@ -1,0 +1,146 @@
+import { useState, type ReactElement, type ReactNode } from 'react';
+import { MultipleCrossCancelDefault } from '@xyne/icons';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { McpLogo } from '../create-v2/mcp/McpLogo';
+import { DetailCard, DetailEmpty } from './DetailPrimitives';
+
+const VISIBLE = 5;
+
+export interface DetailListItem {
+  key: string;
+  name: string;
+  description: string;
+  iconType?: string;
+  badge?: ReactNode;
+  meta?: string;
+}
+
+export function DetailListRow({
+  item,
+  canEdit,
+  removeLabel,
+  onRemove,
+}: {
+  item: DetailListItem;
+  canEdit: boolean;
+  removeLabel: string;
+  onRemove: () => void;
+}): ReactElement {
+  return (
+    <div className='flex w-full items-center gap-3 border-b border-border p-4 last:border-b-0'>
+      {item.iconType !== undefined && <McpLogo type={item.iconType} name={item.name} size='md' />}
+
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5 overflow-hidden'>
+        <span className='flex min-w-0 items-center gap-1.5'>
+          <span className='truncate text-sm font-medium leading-[22px] text-foreground'>
+            {item.name}
+          </span>
+          {item.badge}
+        </span>
+        <span className='truncate text-sm leading-5 text-foreground/60'>
+          {item.description || 'No description added'}
+        </span>
+      </div>
+
+      {item.meta && (
+        <span className='shrink-0 whitespace-nowrap text-xs leading-4 text-muted-foreground'>
+          {item.meta}
+        </span>
+      )}
+
+      {canEdit && (
+        <button
+          type='button'
+          onClick={onRemove}
+          aria-label={removeLabel}
+          title={removeLabel}
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: remove list item'
+          className='flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+        >
+          <MultipleCrossCancelDefault className='size-4' aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface DetailListCardProps {
+  items: readonly DetailListItem[];
+  loading: boolean;
+  emptyLabel: string;
+  canEdit: boolean;
+  removeLabel: (item: DetailListItem) => string;
+  onRemove: (item: DetailListItem) => void;
+  /** Rendered above the rows — the read-only note when the user can't edit. */
+  note?: ReactElement | null;
+  /** Extra rows rendered above the list, e.g. a section's settings. */
+  children?: ReactNode;
+}
+
+export function DetailListCard({
+  items,
+  loading,
+  emptyLabel,
+  canEdit,
+  removeLabel,
+  onRemove,
+  note = null,
+  children,
+}: DetailListCardProps): ReactElement {
+  const [expanded, setExpanded] = useState(false);
+
+  const hidden = Math.max(0, items.length - VISIBLE);
+  const shown = expanded ? items : items.slice(0, VISIBLE);
+
+  return (
+    <DetailCard>
+      {note}
+      {children}
+
+      {loading ? (
+        <div className='flex w-full flex-col'>
+          {[0, 1, 2].map(row => (
+            <div
+              key={row}
+              className='flex items-center gap-3 border-b border-border p-4 last:border-b-0'
+            >
+              <Skeleton className='size-10 shrink-0 rounded-lg' />
+              <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
+                <Skeleton className='h-3.5 w-32' />
+                <Skeleton className='h-3 w-full max-w-72' />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <DetailEmpty>{emptyLabel}</DetailEmpty>
+      ) : (
+        <div className='flex w-full flex-col'>
+          {shown.map(item => (
+            <DetailListRow
+              key={item.key}
+              item={item}
+              canEdit={canEdit}
+              removeLabel={removeLabel(item)}
+              onRemove={() => onRemove(item)}
+            />
+          ))}
+        </div>
+      )}
+
+      {hidden > 0 && (
+        <button
+          type='button'
+          onClick={() => setExpanded(open => !open)}
+          aria-expanded={expanded}
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: expand list'
+          className='flex w-full items-center border-t border-border bg-muted/40 px-4 py-3 text-sm leading-5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground'
+        >
+          {expanded ? 'Show less' : `View ${hidden} other${hidden === 1 ? '' : 's'}`}
+        </button>
+      )}
+    </DetailCard>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/DetailPrimitives.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/DetailPrimitives.tsx
@@ -1,0 +1,190 @@
+import { type ReactElement, type ReactNode } from 'react';
+import { InformationCircle, LockClose } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
+
+export function DetailSectionHeading({
+  label,
+  info,
+  trailing,
+  trailingAlign = 'inline',
+}: {
+  label: string;
+  info?: string;
+  trailing?: ReactNode;
+  trailingAlign?: 'inline' | 'end';
+}): ReactElement {
+  return (
+    <div className='flex w-full items-center gap-2'>
+      <span className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+        {label}
+      </span>
+      {info && (
+        <Tooltip side='top' content={info}>
+          <span className='inline-flex'>
+            <InformationCircle className='size-4 shrink-0 text-muted-foreground' aria-hidden />
+          </span>
+        </Tooltip>
+      )}
+      {trailing && (
+        <span className={cn('flex shrink-0 items-center', trailingAlign === 'end' && 'ml-auto')}>
+          {trailing}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function DetailCard({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <div className={cn('w-full rounded-2xl border border-border bg-card', className)}>
+      {children}
+    </div>
+  );
+}
+
+export function DetailSection({
+  label,
+  info,
+  trailing,
+  trailingAlign,
+  children,
+}: {
+  label: string;
+  info?: string;
+  trailing?: ReactNode;
+  trailingAlign?: 'inline' | 'end';
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <section className='flex w-full flex-col gap-3'>
+      <DetailSectionHeading
+        label={label}
+        {...(info === undefined ? {} : { info })}
+        {...(trailing === undefined ? {} : { trailing })}
+        {...(trailingAlign === undefined ? {} : { trailingAlign })}
+      />
+      {children}
+    </section>
+  );
+}
+
+export function DetailRow({
+  title,
+  hint,
+  children,
+  last = false,
+}: {
+  title: string;
+  hint?: string;
+  children?: ReactNode;
+  last?: boolean;
+}): ReactElement {
+  return (
+    <div
+      className={cn(
+        'flex w-full items-center justify-between gap-4 px-4 py-3',
+        !last && 'border-b border-border',
+      )}
+    >
+      <div className='flex min-w-0 flex-col gap-0.5'>
+        <span className='truncate text-sm font-medium leading-5 text-foreground'>{title}</span>
+        {hint && (
+          <span className='truncate text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+            {hint}
+          </span>
+        )}
+      </div>
+      {children && <div className='flex shrink-0 items-center gap-2'>{children}</div>}
+    </div>
+  );
+}
+
+export function DetailProse({ children }: { children: string }): ReactElement {
+  return (
+    <p className='whitespace-pre-wrap break-words p-4 text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
+      {children}
+    </p>
+  );
+}
+
+export function DetailEmpty({ children }: { children: ReactNode }): ReactElement {
+  return <p className='p-4 text-sm font-normal leading-5 text-muted-foreground'>{children}</p>;
+}
+
+/**
+ * Centred empty state for a whole card — an icon, a headline, a line of
+ * explanation, and an optional call to action.
+ */
+export function DetailEmptyState({
+  icon,
+  title,
+  description,
+  action,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  action?: ReactNode;
+}): ReactElement {
+  return (
+    <div className='flex w-full flex-col items-center justify-center gap-4 p-8 text-center'>
+      <span
+        className='flex size-14 items-center justify-center rounded-2xl bg-muted text-muted-foreground'
+        aria-hidden
+      >
+        {icon}
+      </span>
+      <span className='flex flex-col gap-1'>
+        <span className='text-base font-semibold leading-5 text-foreground/80'>{title}</span>
+        <span className='text-sm font-normal leading-5 text-muted-foreground'>{description}</span>
+      </span>
+      {action}
+    </div>
+  );
+}
+
+export function DetailTabPlaceholder({ label }: { label: string }): ReactElement {
+  return (
+    <div className='flex w-full flex-col gap-3'>
+      <DetailSectionHeading label={label} />
+      <DetailCard>
+        <DetailEmpty>Coming next.</DetailEmpty>
+      </DetailCard>
+    </div>
+  );
+}
+
+export function ReadOnlyBadge(): ReactElement {
+  return (
+    <span className='flex h-4 shrink-0 items-center gap-1 rounded-md bg-muted px-1.5 text-[10px] font-medium leading-4 tracking-[0.02em] text-muted-foreground'>
+      <LockClose className='size-2.5 shrink-0' aria-hidden />
+      Read only
+    </span>
+  );
+}
+
+export function DetailLockedNote({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <div className='flex w-full items-center gap-2 border-b border-border bg-muted/40 px-4 py-2.5'>
+      <LockClose className='size-3.5 shrink-0 text-muted-foreground' aria-hidden />
+      <span className='text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+export function DetailValue({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <span className='max-w-[280px] truncate text-sm font-normal leading-5 text-foreground'>
+      {children}
+    </span>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/AgentActivityTabV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/AgentActivityTabV2.tsx
@@ -1,0 +1,355 @@
+import { useMemo, useRef, useState, type ReactElement } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { CalendarClock, Loader2, Workflow } from 'lucide-react';
+import { PlusDefault, SearchDefault } from '@xyne/icons';
+import { useAuth } from '@/hooks/useAuth';
+import { useClawAgentRuns, type AgentRunStatusFilter } from '@/hooks/useClawAgentRuns';
+import { useClawScheduledJobMutations, useClawScheduledJobs } from '@/hooks/useClawScheduledJobs';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { Pill } from '../../create-v2/shared/Pill';
+import { BehaviourSelect } from '../behaviour/BehaviourRows';
+import { DetailListCard, type DetailListItem } from '../DetailListCard';
+import { DetailCard, DetailEmpty, DetailEmptyState, DetailSection } from '../DetailPrimitives';
+import { useAgentChainWorkflows } from './chainWorkflowsService';
+import { createScheduledJob, type NewScheduledJob } from './createScheduledJob';
+import { CreateScheduleDialog } from './CreateScheduleDialog';
+
+const ICON_BUTTON =
+  'flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40';
+
+const STATUS_OPTIONS: ReadonlyArray<{ value: AgentRunStatusFilter; label: string }> = [
+  { value: 'all', label: 'All runs' },
+  { value: 'running', label: 'Running' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
+
+const RUN_TONE: Record<string, 'success' | 'neutral' | 'danger'> = {
+  completed: 'success',
+  running: 'neutral',
+  failed: 'danger',
+  cancelled: 'neutral',
+};
+
+function relativeTime(value: string | null): string {
+  if (!value) return '';
+  const parsed = new Date(value).getTime();
+  if (Number.isNaN(parsed)) return '';
+  const minutes = Math.floor((Date.now() - parsed) / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return days < 14 ? `${days}d ago` : new Date(parsed).toLocaleDateString();
+}
+
+function scheduleCadence(cron: string | null, nextRunAt: string | null): string {
+  if (cron) return `Repeats · ${cron}`;
+  if (!nextRunAt) return 'One-off';
+  const parsed = new Date(nextRunAt);
+  return Number.isNaN(parsed.getTime()) ? 'One-off' : `Runs once · ${parsed.toLocaleString()}`;
+}
+
+export function AgentActivityTabV2({
+  agent,
+  canEdit,
+}: {
+  agent: Agent;
+  canEdit: boolean;
+}): ReactElement {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [scheduleQuery, setScheduleQuery] = useState('');
+  const [scheduleSearchOpen, setScheduleSearchOpen] = useState(false);
+  const [runQuery, setRunQuery] = useState('');
+  const [runSearchOpen, setRunSearchOpen] = useState(false);
+  const [runStatus, setRunStatus] = useState<AgentRunStatusFilter>('all');
+  const scheduleSearchRef = useRef<HTMLInputElement>(null);
+  const runSearchRef = useRef<HTMLInputElement>(null);
+
+  const jobs = useClawScheduledJobs(agent.slug);
+  const jobMutations = useClawScheduledJobMutations(agent.slug);
+  const workflows = useAgentChainWorkflows(agent.slug);
+  const runs = useClawAgentRuns(agent.slug, { status: runStatus, allUsers: true });
+
+  const scheduleItems = useMemo<DetailListItem[]>(() => {
+    const q = scheduleQuery.trim().toLowerCase();
+    return (jobs.data ?? [])
+      .map(job => ({
+        key: job.id,
+        name: job.label || job.task,
+        description: scheduleCadence(job.cronExpression, job.nextRunAt),
+        badge: <Pill tone={job.status === 'active' ? 'success' : 'neutral'}>{job.status}</Pill>,
+        ...(job.runsCount || job.runCount ? { meta: `${job.runsCount ?? job.runCount} runs` } : {}),
+      }))
+      .filter(item => !q || item.name.toLowerCase().includes(q));
+  }, [jobs.data, scheduleQuery]);
+
+  const workflowItems = useMemo<DetailListItem[]>(
+    () =>
+      (workflows.data ?? []).map(workflow => ({
+        key: workflow.id,
+        name: workflow.name,
+        description: `${(workflow.definition?.nodes ?? []).length} step${
+          (workflow.definition?.nodes ?? []).length === 1 ? '' : 's'
+        }`,
+        badge: (
+          <Pill tone={workflow.isPublished ? 'success' : 'neutral'}>
+            {workflow.isPublished ? 'Published' : 'Draft'}
+          </Pill>
+        ),
+      })),
+    [workflows.data],
+  );
+
+  const runItems = useMemo(() => {
+    const q = runQuery.trim().toLowerCase();
+    return (runs.data ?? []).filter(
+      run =>
+        !q || run.task.toLowerCase().includes(q) || (run.userName ?? '').toLowerCase().includes(q),
+    );
+  }, [runs.data, runQuery]);
+
+  const createSchedule = async (job: NewScheduledJob): Promise<void> => {
+    if (!user?.id || creating) return;
+    setCreating(true);
+    try {
+      await createScheduledJob(user.id, job);
+      void queryClient.invalidateQueries({
+        queryKey: ['claw-scheduled-jobs', agent.slug, user.id],
+      });
+      toast.success('Schedule created');
+      setScheduleOpen(false);
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not create that schedule'));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const removeSchedule = (id: string, name: string): void => {
+    jobMutations.remove.mutate(id, {
+      onSuccess: () => toast.success(`${name} removed`),
+      onError: err => toast.error(clawErrorText(err, 'Could not remove that schedule')),
+    });
+  };
+
+  const toggle = (
+    open: boolean,
+    setOpen: (next: boolean) => void,
+    setQuery: (next: string) => void,
+    ref: React.RefObject<HTMLInputElement | null>,
+  ): void => {
+    if (open) {
+      setQuery('');
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    setTimeout(() => ref.current?.focus(), 0);
+  };
+
+  const searchButton = (
+    open: boolean,
+    onClick: () => void,
+    label: string,
+    trackName: string,
+  ): ReactElement => (
+    <button
+      type='button'
+      onClick={onClick}
+      aria-label={label}
+      aria-expanded={open}
+      data-track-category='Claw Agents'
+      data-track-name={trackName}
+      className={ICON_BUTTON}
+    >
+      <SearchDefault className='size-4' aria-hidden />
+    </button>
+  );
+
+  return (
+    <div className='flex w-full flex-col gap-8'>
+      <DetailSection
+        label='Schedules'
+        info='Runs this agent starts on its own'
+        trailing={searchButton(
+          scheduleSearchOpen,
+          () =>
+            toggle(scheduleSearchOpen, setScheduleSearchOpen, setScheduleQuery, scheduleSearchRef),
+          'Search schedules',
+          'Agent detail v2: toggle schedule search',
+        )}
+        trailingAlign='end'
+      >
+        {jobs.isLoading || scheduleItems.length > 0 || scheduleQuery.trim() ? (
+          <DetailListCard
+            items={scheduleItems}
+            loading={jobs.isLoading}
+            emptyLabel='No schedules matched that search.'
+            canEdit={canEdit && !jobMutations.remove.isPending}
+            removeLabel={item => `Remove ${item.name}`}
+            onRemove={item => removeSchedule(item.key, item.name)}
+          >
+            {scheduleSearchOpen && (
+              <div className='border-b border-border p-3'>
+                <input
+                  ref={scheduleSearchRef}
+                  value={scheduleQuery}
+                  onChange={e => setScheduleQuery(e.target.value)}
+                  placeholder='Filter schedules'
+                  aria-label='Filter schedules'
+                  data-track-category='Claw Agents'
+                  data-track-name='Agent detail v2: filter schedules'
+                  className='h-9 w-full rounded-[10px] border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+                />
+              </div>
+            )}
+          </DetailListCard>
+        ) : (
+          <DetailCard>
+            <DetailEmptyState
+              icon={<CalendarClock className='size-6' aria-hidden />}
+              title='No Schedules'
+              description='This agent only runs when someone asks it to'
+              action={
+                canEdit ? (
+                  <button
+                    type='button'
+                    onClick={() => setScheduleOpen(true)}
+                    data-track-category='Claw Agents'
+                    data-track-name='Agent detail v2: open create schedule'
+                    className='flex items-center gap-1.5 rounded-md bg-muted px-2 py-1.5 text-sm leading-5 text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground'
+                  >
+                    <PlusDefault className='size-4' aria-hidden />
+                    Create Schedule
+                  </button>
+                ) : undefined
+              }
+            />
+          </DetailCard>
+        )}
+      </DetailSection>
+
+      <DetailSection label='Workflows' info='Multi-agent chains that include this agent'>
+        {workflows.isLoading || workflowItems.length > 0 ? (
+          <DetailListCard
+            items={workflowItems}
+            loading={workflows.isLoading}
+            emptyLabel='No workflows use this agent.'
+            canEdit={false}
+            removeLabel={item => `Remove ${item.name}`}
+            onRemove={() => undefined}
+          />
+        ) : (
+          <DetailCard>
+            <DetailEmptyState
+              icon={<Workflow className='size-6' aria-hidden />}
+              title='No workflow yet'
+              description='Start by creating workflow to show them here'
+            />
+          </DetailCard>
+        )}
+      </DetailSection>
+
+      <DetailSection
+        label='Recent runs'
+        info='Every time this agent has been asked to do something'
+        trailing={
+          <span className='flex items-center gap-1'>
+            {searchButton(
+              runSearchOpen,
+              () => toggle(runSearchOpen, setRunSearchOpen, setRunQuery, runSearchRef),
+              'Search runs',
+              'Agent detail v2: toggle run search',
+            )}
+            <BehaviourSelect
+              value={runStatus}
+              options={STATUS_OPTIONS}
+              editable
+              label='Filter runs by status'
+              trackName='Agent detail v2: filter runs'
+              onChange={next => setRunStatus(next as AgentRunStatusFilter)}
+            />
+          </span>
+        }
+        trailingAlign='end'
+      >
+        <DetailCard>
+          {runSearchOpen && (
+            <div className='border-b border-border p-3'>
+              <input
+                ref={runSearchRef}
+                value={runQuery}
+                onChange={e => setRunQuery(e.target.value)}
+                placeholder='Filter runs'
+                aria-label='Filter runs'
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: filter runs input'
+                className='h-9 w-full rounded-[10px] border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+              />
+            </div>
+          )}
+
+          {runs.isLoading ? (
+            <DetailEmpty>Loading runs…</DetailEmpty>
+          ) : runItems.length === 0 ? (
+            <DetailEmpty>
+              {runQuery.trim() || runStatus !== 'all'
+                ? 'No runs matched those filters.'
+                : 'This agent hasn’t run yet.'}
+            </DetailEmpty>
+          ) : (
+            runItems.slice(0, 20).map(run => (
+              <div
+                key={run.id}
+                className='flex w-full items-center gap-3 border-b border-border p-4 last:border-b-0'
+              >
+                <div className='flex min-w-0 flex-1 flex-col gap-0.5 overflow-hidden'>
+                  <span className='flex min-w-0 items-center gap-1.5'>
+                    <span className='truncate text-sm font-medium leading-[22px] text-foreground'>
+                      {run.task || 'Untitled run'}
+                    </span>
+                    <Pill tone={RUN_TONE[run.status] ?? 'neutral'}>{run.status}</Pill>
+                  </span>
+                  <span className='truncate text-sm leading-5 text-foreground/60'>
+                    {[run.userName || run.userEmail, run.triggerSource, relativeTime(run.startedAt)]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </span>
+                </div>
+                {run.status === 'running' && (
+                  <Loader2
+                    className='size-3.5 shrink-0 animate-spin text-muted-foreground'
+                    aria-hidden
+                  />
+                )}
+              </div>
+            ))
+          )}
+
+          {runItems.length > 20 && (
+            <p className='flex w-full items-center border-t border-border bg-muted/40 px-4 py-3 text-sm leading-5 text-muted-foreground'>
+              Showing the 20 most recent of {runItems.length}.
+            </p>
+          )}
+        </DetailCard>
+      </DetailSection>
+
+      <CreateScheduleDialog
+        open={scheduleOpen}
+        onOpenChange={setScheduleOpen}
+        agentSlug={agent.slug}
+        saving={creating}
+        onCreate={job => void createSchedule(job)}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/CreateScheduleDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/CreateScheduleDialog.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { Button } from '@/components/ui/Button';
+import { V2Dialog } from '../../create-v2/shared/V2Dialog';
+import { BehaviourSelect } from '../behaviour/BehaviourRows';
+import { MINUTE_MS, type NewScheduledJob } from './createScheduledJob';
+
+const LABEL = 'text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground';
+const FIELD =
+  'w-full rounded-2xl border border-border bg-card p-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+
+const TYPE_OPTIONS = [
+  { value: 'cron', label: 'Repeating' },
+  { value: 'once', label: 'Once' },
+];
+
+interface CreateScheduleDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agentSlug: string;
+  saving: boolean;
+  onCreate: (job: NewScheduledJob) => void;
+}
+
+export function CreateScheduleDialog({
+  open,
+  onOpenChange,
+  agentSlug,
+  saving,
+  onCreate,
+}: CreateScheduleDialogProps): ReactElement {
+  const [task, setTask] = useState('');
+  const [label, setLabel] = useState('');
+  const [type, setType] = useState<'once' | 'cron'>('cron');
+  const [cron, setCron] = useState('0 9 * * *');
+  const [minutes, setMinutes] = useState('60');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setTask('');
+    setLabel('');
+    setType('cron');
+    setCron('0 9 * * *');
+    setMinutes('60');
+    setError(null);
+  }, [open]);
+
+  const submit = (): void => {
+    if (!task.trim()) {
+      setError('Describe what the agent should do.');
+      return;
+    }
+    if (type === 'cron' && cron.trim().split(/\s+/).length !== 5) {
+      setError('A cron expression needs five fields, e.g. 0 9 * * 1-5');
+      return;
+    }
+    const delay = Number(minutes);
+    if (type === 'once' && (!Number.isFinite(delay) || delay <= 0)) {
+      setError('Enter how many minutes from now it should run.');
+      return;
+    }
+
+    onCreate({
+      agentSlug,
+      task: task.trim(),
+      type,
+      ...(label.trim() ? { label: label.trim() } : {}),
+      ...(type === 'cron' ? { cronExpression: cron.trim() } : { delayMs: delay * MINUTE_MS }),
+    });
+  };
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Create schedule'
+      description='Run this agent automatically, without anyone asking.'
+      testId='create-schedule-dialog'
+      footer={
+        <>
+          <Button
+            variant='ghost'
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+            className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: cancel create schedule'
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            loading={saving}
+            className='h-auto rounded-xl bg-foreground px-3 py-2.5 text-[15px] text-background hover:bg-foreground/90'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: confirm create schedule'
+          >
+            Create
+          </Button>
+        </>
+      }
+    >
+      <section className='flex w-full flex-col gap-3'>
+        <label htmlFor='schedule-task' className={LABEL}>
+          Task
+        </label>
+        <textarea
+          id='schedule-task'
+          value={task}
+          onChange={e => {
+            setTask(e.target.value);
+            setError(null);
+          }}
+          placeholder='eg. Summarise yesterday’s error buckets and post the top three'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: schedule task'
+          className={`${FIELD} h-[86px] resize-y`}
+        />
+      </section>
+
+      <section className='flex w-full flex-col gap-3'>
+        <label htmlFor='schedule-label' className={LABEL}>
+          Name
+        </label>
+        <input
+          id='schedule-label'
+          value={label}
+          onChange={e => setLabel(e.target.value)}
+          placeholder='Optional — shown in the schedules list'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: schedule label'
+          className={`${FIELD} h-11 py-0`}
+        />
+      </section>
+
+      <section className='flex w-full flex-col gap-3'>
+        <span className={LABEL}>When</span>
+        <BehaviourSelect
+          value={type}
+          options={TYPE_OPTIONS}
+          editable
+          disabled={saving}
+          label='How often it runs'
+          trackName='Agent detail v2: schedule type'
+          onChange={next => {
+            setType(next === 'once' ? 'once' : 'cron');
+            setError(null);
+          }}
+        />
+
+        {type === 'cron' ? (
+          <>
+            <input
+              value={cron}
+              onChange={e => {
+                setCron(e.target.value);
+                setError(null);
+              }}
+              spellCheck={false}
+              aria-label='Cron expression'
+              placeholder='0 9 * * 1-5'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: schedule cron'
+              className={`${FIELD} h-11 py-0 font-mono text-xs`}
+            />
+            <span className='text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+              Five fields: minute, hour, day of month, month, day of week. `0 9 * * 1-5` is 9am on
+              weekdays.
+            </span>
+          </>
+        ) : (
+          <>
+            <input
+              value={minutes}
+              onChange={e => {
+                setMinutes(e.target.value);
+                setError(null);
+              }}
+              inputMode='numeric'
+              aria-label='Minutes from now'
+              placeholder='60'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: schedule delay'
+              className={`${FIELD} h-11 py-0`}
+            />
+            <span className='text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+              Minutes from now.
+            </span>
+          </>
+        )}
+      </section>
+
+      {error && (
+        <p className='text-xs font-normal leading-4 tracking-[-0.24px] text-destructive'>{error}</p>
+      )}
+    </V2Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/chainWorkflowsService.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/chainWorkflowsService.ts
@@ -1,0 +1,56 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/useAuth';
+import { clawApiRequest } from '@/services/claw/clawRequest';
+
+export interface ChainWorkflowNode {
+  readonly id?: string;
+  readonly agentSlug?: string;
+}
+
+export interface ChainWorkflowTrigger {
+  readonly id: string;
+  readonly type?: string;
+}
+
+export interface ChainWorkflow {
+  readonly id: string;
+  readonly name: string;
+  readonly definition: { readonly nodes?: ChainWorkflowNode[] };
+  readonly isPublished: boolean;
+  readonly global?: boolean;
+  readonly createdByUserId: string;
+  readonly triggers?: ChainWorkflowTrigger[];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+type ChainWorkflowRow = ChainWorkflow | { readonly workflow: ChainWorkflow };
+
+function unwrap(row: ChainWorkflowRow): ChainWorkflow {
+  return 'workflow' in row ? row.workflow : row;
+}
+
+export function listChainWorkflows(userId: string): Promise<ChainWorkflowRow[]> {
+  return clawApiRequest<ChainWorkflowRow[]>('/chain-workflows', { userId });
+}
+
+export function useAgentChainWorkflows(
+  agentSlug: string | undefined,
+): UseQueryResult<ChainWorkflow[], Error> {
+  const { user } = useAuth();
+  const userId = user?.id;
+
+  return useQuery({
+    queryKey: ['claw-chain-workflows', userId, agentSlug],
+    queryFn: () => listChainWorkflows(userId!),
+    enabled: !!userId && !!agentSlug,
+    retry: false,
+    staleTime: 60 * 1000,
+    select: rows =>
+      rows
+        .map(unwrap)
+        .filter(workflow =>
+          (workflow.definition?.nodes ?? []).some(node => node.agentSlug === agentSlug),
+        ),
+  });
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/createScheduledJob.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/activity/createScheduledJob.ts
@@ -1,0 +1,21 @@
+import { clawApiRequest } from '@/services/claw/clawRequest';
+import type { ScheduledJob } from '@/services/claw/clawScheduledJobsService';
+
+export interface NewScheduledJob {
+  agentSlug: string;
+  task: string;
+  type: 'once' | 'cron';
+  delayMs?: number;
+  cronExpression?: string;
+  label?: string;
+}
+
+export function createScheduledJob(userId: string, job: NewScheduledJob): Promise<ScheduledJob> {
+  return clawApiRequest<ScheduledJob>('/scheduled-jobs', {
+    method: 'POST',
+    userId,
+    body: JSON.stringify({ userId, ...job }),
+  });
+}
+
+export const MINUTE_MS = 60 * 1000;

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/AgentBehaviourTabV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/AgentBehaviourTabV2.tsx
@@ -1,0 +1,404 @@
+import { useState, type ReactElement } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { clawAgentDetailKey } from '@/hooks/useClawAgentDetail';
+import { useClawResearchAgentOptions } from '@/hooks/useClawResearchAgentOptions';
+import { updateClawAgent } from '@/services/claw/clawAuthAgentsService';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import {
+  applyBehaviour,
+  readBehaviourDraft,
+  type BehaviourDraft,
+} from '@/services/claw/behaviourConfig';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { DetailCard, DetailLockedNote, DetailSection, ReadOnlyBadge } from '../DetailPrimitives';
+import {
+  BehaviourEditButton,
+  BehaviourRow,
+  BehaviourSelect,
+  BehaviourToggle,
+} from './BehaviourRows';
+import { BehaviourTextDialog } from './BehaviourTextDialog';
+import { StructuredOutputDialog } from './StructuredOutputDialog';
+import {
+  applySandbox,
+  readSandboxDraft,
+  useSandboxRepos,
+  type SandboxDraft,
+} from './sandboxConfig';
+
+const NONE = '__none__';
+
+const LOCK_NOTE = 'Only the owner, a contributor, or an admin can change how this agent behaves.';
+
+export function AgentBehaviourTabV2({
+  agent,
+  canEdit,
+}: {
+  agent: Agent;
+  canEdit: boolean;
+}): ReactElement {
+  const queryClient = useQueryClient();
+  const [saving, setSaving] = useState(false);
+  const [outputOpen, setOutputOpen] = useState(false);
+  const [criteriaOpen, setCriteriaOpen] = useState(false);
+
+  const { data: repos } = useSandboxRepos();
+  const research = useClawResearchAgentOptions();
+
+  const behaviour = readBehaviourDraft(agent.config);
+  const sandbox = readSandboxDraft(agent.config);
+
+  const [reminders, setReminders] = useState(behaviour.promptInjection);
+  const remindersDirty = reminders.trim() !== behaviour.promptInjection.trim();
+
+  const persist = async (config: Record<string, unknown>, message: string): Promise<boolean> => {
+    if (saving) return false;
+    setSaving(true);
+    const previous = agent;
+    queryClient.setQueryData(clawAgentDetailKey(agent.slug), { ...agent, config });
+    try {
+      const updated = await updateClawAgent(agent.slug, { config });
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), updated);
+      void queryClient.invalidateQueries({ queryKey: ['claw-auth-agents'] });
+      toast.success(message);
+      return true;
+    } catch (err) {
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), previous);
+      toast.error(clawErrorText(err, 'Could not update this agent'));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveBehaviour = async (patch: Partial<BehaviourDraft>, message: string): Promise<boolean> =>
+    persist(applyBehaviour(agent.config, { ...behaviour, ...patch }), message);
+
+  const setBehaviour = (patch: Partial<BehaviourDraft>, message: string): void => {
+    void saveBehaviour(patch, message);
+  };
+
+  const setSandbox = (patch: Partial<SandboxDraft>, message: string): void => {
+    void persist(applySandbox(agent.config, { ...sandbox, ...patch }), message);
+  };
+
+  const lockNote = canEdit ? null : <DetailLockedNote>{LOCK_NOTE}</DetailLockedNote>;
+  const badge = canEdit ? {} : { trailing: <ReadOnlyBadge /> };
+  const editable = canEdit;
+  const busy = saving;
+
+  const repoOptions = [
+    { value: NONE, label: 'None (agent chooses)' },
+    ...(repos ?? []).map(repo => ({ value: repo.key, label: repo.name })),
+  ];
+  const productOptions = [
+    { value: NONE, label: 'None' },
+    ...research.products.map(option => ({ value: option.id, label: option.name })),
+  ];
+  const repositoryOptions = [
+    { value: NONE, label: 'None' },
+    ...research.repositories.map(option => ({ value: option.id, label: option.name })),
+  ];
+
+  return (
+    <div className='flex w-full flex-col gap-8'>
+      <DetailSection
+        label='Constant reminders'
+        info='Extra instructions injected on every single turn'
+        {...badge}
+      >
+        <DetailCard>
+          {lockNote}
+          <div className='flex w-full flex-col gap-3 p-4'>
+            <label
+              htmlFor='behaviour-reminders'
+              className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'
+            >
+              Description
+            </label>
+            <textarea
+              id='behaviour-reminders'
+              value={reminders}
+              readOnly={!editable}
+              onChange={e => setReminders(e.target.value)}
+              placeholder="eg. Always respond in the user's language"
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: reminders'
+              className='h-[86px] w-full resize-y rounded-2xl border border-border bg-card p-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground read-only:opacity-70 focus:outline-none focus:ring-1 focus:ring-ring'
+            />
+            {editable && remindersDirty && (
+              <div className='flex items-center justify-end gap-3'>
+                <Button
+                  variant='ghost'
+                  onClick={() => setReminders(behaviour.promptInjection)}
+                  disabled={busy}
+                  className='h-auto rounded-xl px-3 py-2 text-sm'
+                  data-track-category='Claw Agents'
+                  data-track-name='Agent detail v2: discard reminders'
+                >
+                  Discard
+                </Button>
+                <Button
+                  onClick={() => {
+                    void saveBehaviour({ promptInjection: reminders }, 'Reminders updated').then(
+                      ok => {
+                        if (!ok) return;
+                        setReminders(reminders.trim());
+                      },
+                    );
+                  }}
+                  loading={busy}
+                  className='h-auto rounded-xl bg-foreground px-3 py-2 text-sm text-background hover:bg-foreground/90'
+                  data-track-category='Claw Agents'
+                  data-track-name='Agent detail v2: save reminders'
+                >
+                  Save
+                </Button>
+              </div>
+            )}
+          </div>
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection label='Sandbox' info='Which code this agent can reach' {...badge}>
+        <DetailCard>
+          {lockNote}
+          <BehaviourRow
+            title='Sandbox repository'
+            hint="Pin this agent to one repo setup so a run can't pick the wrong one."
+          >
+            <BehaviourSelect
+              value={sandbox.sandboxRepo || NONE}
+              options={repoOptions}
+              editable={editable}
+              disabled={busy}
+              label='Sandbox repository'
+              trackName='Agent detail v2: set sandbox repo'
+              onChange={next =>
+                setSandbox({ sandboxRepo: next === NONE ? '' : next }, 'Sandbox repository updated')
+              }
+            />
+          </BehaviourRow>
+
+          <BehaviourRow
+            title='Read-only multi-repo sandbox'
+            hint='Grep across every cloned repo with no per-project clone. Mutating tools are stripped, so this suits agents that only read code.'
+          >
+            <BehaviourToggle
+              checked={sandbox.forceReadOnlySandbox}
+              editable={editable}
+              disabled={busy}
+              label='Read-only multi-repo sandbox'
+              trackName='Agent detail v2: toggle read-only sandbox'
+              onChange={next => setSandbox({ forceReadOnlySandbox: next }, 'Sandbox mode updated')}
+            />
+          </BehaviourRow>
+
+          <BehaviourRow
+            title='Research product'
+            hint='Used by query-codebase and review-pull-request. Takes priority over the repository below.'
+          >
+            <BehaviourSelect
+              value={sandbox.researchProductId || NONE}
+              options={productOptions}
+              editable={editable}
+              disabled={busy}
+              label='Research product'
+              trackName='Agent detail v2: set research product'
+              onChange={next =>
+                setSandbox(
+                  { researchProductId: next === NONE ? '' : next },
+                  'Research product updated',
+                )
+              }
+            />
+          </BehaviourRow>
+
+          <BehaviourRow
+            title='Research repository'
+            hint='Used for code research when no product is pinned.'
+            last
+          >
+            <BehaviourSelect
+              value={sandbox.researchRepositoryId || NONE}
+              options={repositoryOptions}
+              editable={editable}
+              disabled={busy}
+              label='Research repository'
+              trackName='Agent detail v2: set research repository'
+              onChange={next =>
+                setSandbox(
+                  { researchRepositoryId: next === NONE ? '' : next },
+                  'Research repository updated',
+                )
+              }
+            />
+          </BehaviourRow>
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection label='Autonomy' info='How far the agent runs on its own' {...badge}>
+        <DetailCard>
+          {lockNote}
+          <BehaviourRow
+            title='Suggest goals'
+            hint='Let this agent propose an autonomous run. At the end of a multi-step plan the user gets a one-click button to take the work to completion.'
+          >
+            <BehaviourToggle
+              checked={behaviour.suggestGoal}
+              editable={editable}
+              disabled={busy}
+              label='Suggest goals'
+              trackName='Agent detail v2: toggle suggest goals'
+              onChange={next => setBehaviour({ suggestGoal: next }, 'Autonomy updated')}
+            />
+          </BehaviourRow>
+
+          <BehaviourRow
+            title='Always goal'
+            hint='Run every message as an autonomous loop. Only for agents purpose-built for it — users can type /stop to cancel mid-run.'
+            last
+          >
+            <BehaviourToggle
+              checked={behaviour.autoGoal}
+              editable={editable}
+              disabled={busy}
+              label='Always goal'
+              trackName='Agent detail v2: toggle always goal'
+              onChange={next => setBehaviour({ autoGoal: next }, 'Autonomy updated')}
+            />
+          </BehaviourRow>
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection label='Verification' info='Checks run before the agent replies' {...badge}>
+        <DetailCard>
+          {lockNote}
+          <BehaviourRow
+            title='Verify responses'
+            hint='Check factual claims against the gathered tool results before replying. Adds one model call per response.'
+          >
+            {editable && behaviour.verifyResponses && (
+              <BehaviourEditButton
+                label='Edit delivery criteria'
+                trackName='Agent detail v2: edit verify criteria'
+                disabled={busy}
+                onClick={() => setCriteriaOpen(true)}
+              />
+            )}
+            <BehaviourToggle
+              checked={behaviour.verifyResponses}
+              editable={editable}
+              disabled={busy}
+              label='Verify responses'
+              trackName='Agent detail v2: toggle verify responses'
+              onChange={next => setBehaviour({ verifyResponses: next }, 'Verification updated')}
+            />
+          </BehaviourRow>
+
+          <BehaviourRow
+            title='Enforce citations'
+            hint='Nudge the agent to rewrite with inline citations when it used citeable sources but cited none. No extra model call.'
+          >
+            <BehaviourToggle
+              checked={behaviour.citationReflection}
+              editable={editable}
+              disabled={busy}
+              label='Enforce citations'
+              trackName='Agent detail v2: toggle enforce citations'
+              onChange={next => setBehaviour({ citationReflection: next }, 'Verification updated')}
+            />
+          </BehaviourRow>
+
+          <BehaviourRow
+            title='Auto-cite all tools'
+            hint='Inject citation tokens into every tool result so any output can be cited back to its source.'
+            last
+          >
+            <BehaviourToggle
+              checked={behaviour.autoToolCitations}
+              editable={editable}
+              disabled={busy}
+              label='Auto-cite all tools'
+              trackName='Agent detail v2: toggle auto-cite tools'
+              onChange={next => setBehaviour({ autoToolCitations: next }, 'Verification updated')}
+            />
+          </BehaviourRow>
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection label='Output' info='Shape of the final answer' {...badge}>
+        <DetailCard>
+          {lockNote}
+          <BehaviourRow
+            title='Structured output'
+            hint='Force the final answer into a fixed format. The agent still works normally — only the answer is constrained.'
+            last
+          >
+            {editable && behaviour.outputFormatEnabled && (
+              <BehaviourEditButton
+                label='Edit output format'
+                trackName='Agent detail v2: edit structured output'
+                disabled={busy}
+                onClick={() => setOutputOpen(true)}
+              />
+            )}
+            <BehaviourToggle
+              checked={behaviour.outputFormatEnabled}
+              editable={editable}
+              disabled={busy}
+              label='Structured output'
+              trackName='Agent detail v2: toggle structured output'
+              onChange={next => {
+                // Turning it on needs a schema, so the dialog collects one first.
+                if (next) setOutputOpen(true);
+                else setBehaviour({ outputFormatEnabled: false }, 'Structured output turned off');
+              }}
+            />
+          </BehaviourRow>
+        </DetailCard>
+      </DetailSection>
+
+      {busy && (
+        <span className='flex items-center gap-2 text-xs font-normal leading-4 text-muted-foreground'>
+          <Loader2 className='size-3.5 animate-spin' aria-hidden />
+          Saving…
+        </span>
+      )}
+
+      <BehaviourTextDialog
+        open={criteriaOpen}
+        onOpenChange={setCriteriaOpen}
+        title='Delivery criteria'
+        description='Extra conditions the verifier checks before an answer is delivered.'
+        label='Criteria'
+        placeholder='eg. Every number must come from a tool result, never from memory.'
+        testId='verify-criteria-dialog'
+        value={behaviour.verifyResponseCriteria}
+        saving={busy}
+        onSave={next => {
+          void saveBehaviour({ verifyResponseCriteria: next }, 'Delivery criteria updated').then(
+            ok => {
+              if (ok) setCriteriaOpen(false);
+            },
+          );
+        }}
+      />
+
+      <StructuredOutputDialog
+        open={outputOpen}
+        onOpenChange={setOutputOpen}
+        behaviour={behaviour}
+        saving={busy}
+        onSave={next => {
+          void saveBehaviour(next, 'Structured output updated').then(ok => {
+            if (ok) setOutputOpen(false);
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/BehaviourRows.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/BehaviourRows.tsx
@@ -1,0 +1,152 @@
+import { type ReactElement, type ReactNode } from 'react';
+import { PencilEditLine } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { DetailValue } from '../DetailPrimitives';
+
+export function BehaviourRow({
+  title,
+  hint,
+  children,
+  last = false,
+}: {
+  title: string;
+  hint: string;
+  children: ReactNode;
+  last?: boolean;
+}): ReactElement {
+  return (
+    <div
+      className={cn(
+        'flex w-full items-start justify-between gap-6 px-4 py-3',
+        !last && 'border-b border-border',
+      )}
+    >
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+        <span className='text-sm font-medium leading-5 text-foreground'>{title}</span>
+        <span className='text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+          {hint}
+        </span>
+      </div>
+      <div className='flex shrink-0 items-center gap-2 pt-0.5'>{children}</div>
+    </div>
+  );
+}
+
+/** Switch styled to the v2 language. Falls back to text when not editable. */
+export function BehaviourToggle({
+  checked,
+  editable,
+  disabled = false,
+  label,
+  trackName,
+  onChange,
+}: {
+  checked: boolean;
+  editable: boolean;
+  disabled?: boolean;
+  label: string;
+  trackName: string;
+  onChange: (next: boolean) => void;
+}): ReactElement {
+  if (!editable) return <DetailValue>{checked ? 'On' : 'Off'}</DetailValue>;
+
+  return (
+    <button
+      type='button'
+      role='switch'
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      data-track-category='Claw Agents'
+      data-track-name={trackName}
+      className={cn(
+        'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        checked ? 'bg-foreground' : 'bg-border',
+      )}
+    >
+      <span
+        className={cn(
+          'inline-block size-4 rounded-full bg-background shadow-sm transition-transform',
+          checked ? 'translate-x-[18px]' : 'translate-x-0.5',
+        )}
+      />
+    </button>
+  );
+}
+
+export function BehaviourSelect({
+  value,
+  options,
+  editable,
+  disabled = false,
+  label,
+  trackName,
+  onChange,
+}: {
+  value: string;
+  options: ReadonlyArray<{ value: string; label: string }>;
+  editable: boolean;
+  disabled?: boolean;
+  label: string;
+  trackName: string;
+  onChange: (next: string) => void;
+}): ReactElement {
+  const current = options.find(option => option.value === value);
+  if (!editable) return <DetailValue>{current?.label ?? '—'}</DetailValue>;
+
+  return (
+    <Select value={value} onValueChange={onChange} disabled={disabled}>
+      <SelectTrigger
+        size='sm'
+        aria-label={label}
+        data-track-category='Claw Agents'
+        data-track-name={trackName}
+        className='h-9 w-auto min-w-0 max-w-[240px] gap-2 rounded-[10px]'
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align='end'>
+        {options.map(option => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+/** Opens the dialog that carries a setting's detail fields. */
+export function BehaviourEditButton({
+  label,
+  trackName,
+  disabled = false,
+  onClick,
+}: {
+  label: string;
+  trackName: string;
+  disabled?: boolean;
+  onClick: () => void;
+}): ReactElement {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      data-track-category='Claw Agents'
+      data-track-name={trackName}
+      className='flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40'
+    >
+      <PencilEditLine className='size-4' aria-hidden />
+    </button>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/BehaviourTextDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/BehaviourTextDialog.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { Button } from '@/components/ui/Button';
+import { V2Dialog } from '../../create-v2/shared/V2Dialog';
+
+interface BehaviourTextDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  label: string;
+  placeholder: string;
+  hint?: string;
+  testId: string;
+  value: string;
+  saving: boolean;
+  onSave: (next: string) => void;
+}
+
+export function BehaviourTextDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  label,
+  placeholder,
+  hint,
+  testId,
+  value,
+  saving,
+  onSave,
+}: BehaviourTextDialogProps): ReactElement {
+  const [draft, setDraft] = useState(value);
+
+  useEffect(() => {
+    if (open) setDraft(value);
+  }, [open, value]);
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      description={description}
+      testId={testId}
+      footer={
+        <>
+          <Button
+            variant='ghost'
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+            className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+            data-track-category='Claw Agents'
+            data-track-name={`Agent detail v2: cancel ${testId}`}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onSave(draft)}
+            loading={saving}
+            className='h-auto rounded-xl bg-foreground px-3 py-2.5 text-[15px] text-background hover:bg-foreground/90'
+            data-track-category='Claw Agents'
+            data-track-name={`Agent detail v2: save ${testId}`}
+          >
+            Save
+          </Button>
+        </>
+      }
+    >
+      <p className='text-sm font-normal leading-5 text-muted-foreground'>{description}</p>
+
+      <section className='flex w-full flex-col gap-3'>
+        <label
+          htmlFor={`${testId}-field`}
+          className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'
+        >
+          {label}
+        </label>
+        <textarea
+          id={`${testId}-field`}
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          placeholder={placeholder}
+          data-track-category='Claw Agents'
+          data-track-name={`Agent detail v2: ${testId} field`}
+          className='h-[140px] w-full resize-y rounded-2xl border border-border bg-card p-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+        />
+        {hint && (
+          <span className='text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+            {hint}
+          </span>
+        )}
+      </section>
+    </V2Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/StructuredOutputDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/StructuredOutputDialog.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { Button } from '@/components/ui/Button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { validateBehaviour, type BehaviourDraft } from '@/services/claw/behaviourConfig';
+import { V2Dialog } from '../../create-v2/shared/V2Dialog';
+
+const LABEL = 'text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground';
+const FIELD =
+  'w-full rounded-2xl border border-border bg-card p-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+
+const TYPE_OPTIONS = [
+  { value: 'json', label: 'JSON' },
+  { value: 'markdown', label: 'Markdown' },
+] as const;
+
+interface StructuredOutputDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  behaviour: BehaviourDraft;
+  saving: boolean;
+  onSave: (next: BehaviourDraft) => void;
+}
+
+export function StructuredOutputDialog({
+  open,
+  onOpenChange,
+  behaviour,
+  saving,
+  onSave,
+}: StructuredOutputDialogProps): ReactElement {
+  const [draft, setDraft] = useState<BehaviourDraft>(behaviour);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setDraft({ ...behaviour, outputFormatEnabled: true });
+      setError(null);
+    }
+  }, [open, behaviour]);
+
+  const patch = (next: Partial<BehaviourDraft>): void => {
+    setDraft(current => ({ ...current, ...next }));
+    setError(null);
+  };
+
+  const submit = (): void => {
+    const message = validateBehaviour(draft);
+    if (message) {
+      setError(message);
+      return;
+    }
+    onSave(draft);
+  };
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Structured output'
+      description='Constrain the final answer to a fixed shape.'
+      testId='structured-output-dialog'
+      footer={
+        <>
+          <Button
+            variant='ghost'
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+            className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: cancel structured output'
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            loading={saving}
+            className='h-auto rounded-xl bg-foreground px-3 py-2.5 text-[15px] text-background hover:bg-foreground/90'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: save structured output'
+          >
+            Save
+          </Button>
+        </>
+      }
+    >
+      <p className='text-sm font-normal leading-5 text-muted-foreground'>
+        The agent still works normally — only its final answer is constrained.
+      </p>
+
+      <section className='flex w-full flex-col gap-3'>
+        <span className={LABEL}>Format</span>
+        <Select
+          value={draft.outputType}
+          onValueChange={next => patch({ outputType: next === 'markdown' ? 'markdown' : 'json' })}
+        >
+          <SelectTrigger
+            size='sm'
+            aria-label='Output format'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: set output format'
+            className='h-9 w-full gap-2 rounded-[10px]'
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TYPE_OPTIONS.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </section>
+
+      {draft.outputType === 'json' && (
+        <section className='flex w-full flex-col gap-3'>
+          <label htmlFor='behaviour-output-schema' className={LABEL}>
+            JSON Schema
+          </label>
+          <textarea
+            id='behaviour-output-schema'
+            value={draft.outputSchema}
+            onChange={e => patch({ outputSchema: e.target.value })}
+            spellCheck={false}
+            placeholder={'{\n  "type": "object",\n  "properties": {}\n}'}
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: output schema'
+            className={`${FIELD} h-[180px] resize-y font-mono text-xs leading-5`}
+          />
+        </section>
+      )}
+
+      <section className='flex w-full flex-col gap-3'>
+        <label htmlFor='behaviour-output-template' className={LABEL}>
+          Template
+        </label>
+        <textarea
+          id='behaviour-output-template'
+          value={draft.outputTemplate}
+          onChange={e => patch({ outputTemplate: e.target.value })}
+          placeholder='Optional outline the answer should follow'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: output template'
+          className={`${FIELD} h-[86px] resize-y`}
+        />
+      </section>
+
+      <section className='flex w-full flex-col gap-3'>
+        <label htmlFor='behaviour-output-require-tools' className={LABEL}>
+          Required tools
+        </label>
+        <input
+          id='behaviour-output-require-tools'
+          value={draft.outputRequireTools}
+          onChange={e => patch({ outputRequireTools: e.target.value })}
+          placeholder='search, read-file'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: output required tools'
+          className={`${FIELD} h-11 py-0`}
+        />
+        <span className='text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+          Comma separated. The agent can&apos;t submit an answer until it has called a tool whose
+          name contains each of these.
+        </span>
+      </section>
+
+      {error && (
+        <p className='text-xs font-normal leading-4 tracking-[-0.24px] text-destructive'>{error}</p>
+      )}
+    </V2Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/sandboxConfig.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/behaviour/sandboxConfig.ts
@@ -1,0 +1,68 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { clawApiRequest } from '@/services/claw/clawRequest';
+
+/** A selectable sandbox repo setup for the "Sandbox repository" picker. */
+export interface SandboxRepoOption {
+  readonly key: string;
+  readonly name: string;
+  readonly description?: string;
+}
+
+export function listSandboxRepos(): Promise<SandboxRepoOption[]> {
+  return clawApiRequest<SandboxRepoOption[]>('/sandbox/repos');
+}
+
+export function useSandboxRepos(): UseQueryResult<SandboxRepoOption[], Error> {
+  return useQuery({
+    queryKey: ['claw-sandbox-repos'],
+    queryFn: listSandboxRepos,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export interface SandboxDraft {
+  sandboxRepo: string;
+  forceReadOnlySandbox: boolean;
+  researchProductId: string;
+  researchRepositoryId: string;
+}
+
+interface SandboxShape {
+  sandboxRepo?: unknown;
+  forceReadOnlySandbox?: unknown;
+  product_id?: unknown;
+  repository_id?: unknown;
+}
+
+const str = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+export function readSandboxDraft(config: Record<string, unknown> | undefined): SandboxDraft {
+  const c = (config ?? {}) as SandboxShape;
+  return {
+    sandboxRepo: str(c.sandboxRepo),
+    forceReadOnlySandbox: c.forceReadOnlySandbox === true,
+    researchProductId: str(c.product_id),
+    researchRepositoryId: str(c.repository_id),
+  };
+}
+
+export function applySandbox(
+  config: Record<string, unknown> | undefined,
+  draft: SandboxDraft,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...(config ?? {}) };
+
+  if (draft.sandboxRepo) next['sandboxRepo'] = draft.sandboxRepo;
+  else delete next['sandboxRepo'];
+
+  if (draft.forceReadOnlySandbox) next['forceReadOnlySandbox'] = true;
+  else delete next['forceReadOnlySandbox'];
+
+  if (draft.researchProductId) next['product_id'] = draft.researchProductId;
+  else delete next['product_id'];
+
+  if (draft.researchRepositoryId) next['repository_id'] = draft.researchRepositoryId;
+  else delete next['repository_id'];
+
+  return next;
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/AgentKeysDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/AgentKeysDialog.tsx
@@ -1,0 +1,231 @@
+import { useState, type ReactElement } from 'react';
+import { MultipleCrossCancelDefault, PencilEditLine, PlusDefault } from '@xyne/icons';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { Pill } from '../../create-v2/shared/Pill';
+import { V2Dialog } from '../../create-v2/shared/V2Dialog';
+import type { AgentProviderCredentialStatus } from './agentCredentialsService';
+import { CredentialFormFields } from './CredentialFormFields';
+import {
+  CREDENTIAL_PROVIDERS,
+  CREDENTIAL_PROVIDER_LABELS,
+  EMPTY_CREDENTIAL_FORM,
+  formFromCredential,
+  supportsReasoning,
+  type CredentialForm,
+  type CredentialProvider,
+} from './credentialForm';
+import { useAgentCredentialMutations, useAgentCredentials } from './useAgentCredentials';
+
+const ICON_BUTTON =
+  'flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40';
+
+const SECTION_LABEL = 'text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground';
+
+interface AgentKeysDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  slug: string;
+  canManage: boolean;
+}
+
+const label = (provider: string): string => CREDENTIAL_PROVIDER_LABELS[provider] ?? provider;
+
+function summarise(entry: AgentProviderCredentialStatus): string {
+  if (entry.sharedCredentialName) return `Shared — ${entry.sharedCredentialName}`;
+  const parts = [entry.model, entry.baseUrl, entry.reasoningEffort].filter(Boolean);
+  return parts.length > 0 ? parts.join(' · ') : (entry.authType ?? 'Configured');
+}
+
+export function AgentKeysDialog({
+  open,
+  onOpenChange,
+  slug,
+  canManage,
+}: AgentKeysDialogProps): ReactElement {
+  const { data: credentials, isLoading } = useAgentCredentials(slug, open);
+  const { save, remove, saving, removing } = useAgentCredentialMutations(slug);
+
+  const [form, setForm] = useState<CredentialForm | null>(null);
+  const [editingProvider, setEditingProvider] = useState<string | null>(null);
+
+  const configured = (credentials ?? []).filter(entry => entry.configured);
+  const configuredKeys = new Set(configured.map(entry => entry.provider));
+  const available = CREDENTIAL_PROVIDERS.filter(provider => !configuredKeys.has(provider));
+
+  const reset = (): void => {
+    setForm(null);
+    setEditingProvider(null);
+  };
+
+  const editing = editingProvider !== null;
+  const canSubmit = form !== null && (editing || form.apiKey.trim().length > 0);
+
+  const submit = async (): Promise<void> => {
+    if (!form || !canSubmit) return;
+    await save({
+      provider: form.provider,
+      ...(form.apiKey.trim() ? { apiKey: form.apiKey.trim() } : {}),
+      ...(form.model.trim() ? { model: form.model.trim() } : {}),
+      ...(form.baseUrl.trim() ? { baseUrl: form.baseUrl.trim() } : {}),
+      authType: form.authType,
+      ...(supportsReasoning(form.provider)
+        ? { reasoningEffort: form.reasoningEffort === '' ? null : form.reasoningEffort }
+        : {}),
+    });
+    reset();
+  };
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={next => {
+        onOpenChange(next);
+        if (!next) reset();
+      }}
+      title='Agent keys'
+      description='Provider keys this agent runs with.'
+      testId='agent-keys-dialog'
+      footer={
+        form === null ? (
+          <Button
+            variant='ghost'
+            onClick={() => onOpenChange(false)}
+            className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: done agent keys'
+          >
+            Done
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant='ghost'
+              onClick={reset}
+              disabled={saving}
+              className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: cancel agent key'
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void submit()}
+              loading={saving}
+              disabled={!canSubmit}
+              className='h-auto rounded-xl bg-foreground px-3 py-2.5 text-[15px] text-background hover:bg-foreground/90'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: save agent key'
+            >
+              Save
+            </Button>
+          </>
+        )
+      }
+    >
+      <p className='text-sm font-normal leading-5 text-muted-foreground'>
+        Without a key here, everyone falls through to their own provider, or to Spaces.
+      </p>
+
+      <section className='flex w-full flex-col gap-3'>
+        <span className={SECTION_LABEL}>Configured</span>
+
+        {isLoading ? (
+          <div className='flex flex-col gap-2'>
+            <Skeleton className='h-11 w-full rounded-[10px]' />
+            <Skeleton className='h-11 w-full rounded-[10px]' />
+          </div>
+        ) : configured.length === 0 ? (
+          <p className='text-sm font-normal leading-5 text-muted-foreground'>No agent keys yet.</p>
+        ) : (
+          <div className='flex w-full flex-col gap-2'>
+            {configured.map(entry => (
+              <div
+                key={entry.provider}
+                className='flex min-h-11 w-full items-center gap-2 rounded-[10px] border-[0.8px] border-border bg-muted px-3 py-2'
+              >
+                <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+                  <span className='truncate text-sm font-medium leading-5 text-foreground'>
+                    {label(entry.provider)}
+                  </span>
+                  <span className='truncate text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+                    {summarise(entry)}
+                  </span>
+                </div>
+                <Pill tone='success'>Configured</Pill>
+                {canManage && (
+                  <>
+                    <button
+                      type='button'
+                      onClick={() => {
+                        setEditingProvider(entry.provider);
+                        setForm(formFromCredential(entry));
+                      }}
+                      aria-label={`Edit ${label(entry.provider)} credential`}
+                      data-track-category='Claw Agents'
+                      data-track-name='Agent detail v2: edit agent key'
+                      className={ICON_BUTTON}
+                    >
+                      <PencilEditLine className='size-4' aria-hidden />
+                    </button>
+                    <button
+                      type='button'
+                      onClick={() => void remove(entry.provider)}
+                      disabled={removing}
+                      aria-label={`Remove ${label(entry.provider)} credential`}
+                      data-track-category='Claw Agents'
+                      data-track-name='Agent detail v2: remove agent key'
+                      className={ICON_BUTTON}
+                    >
+                      {removing ? (
+                        <Loader2 className='size-4 animate-spin' aria-hidden />
+                      ) : (
+                        <MultipleCrossCancelDefault className='size-4' aria-hidden />
+                      )}
+                    </button>
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {canManage && form === null && available.length > 0 && (
+        <section className='flex w-full flex-col gap-3'>
+          <span className={SECTION_LABEL}>Add a key</span>
+          <div className='flex flex-wrap items-start gap-2'>
+            {available.map((provider: CredentialProvider) => (
+              <button
+                key={provider}
+                type='button'
+                onClick={() => {
+                  setEditingProvider(null);
+                  setForm({ ...EMPTY_CREDENTIAL_FORM, provider });
+                }}
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: add agent key'
+                className='flex h-7 shrink-0 items-center gap-1.5 overflow-hidden rounded-[10px] border-[0.8px] border-dashed border-border bg-card px-2 transition-colors hover:bg-muted/50'
+              >
+                <span className='max-w-[200px] truncate text-sm font-medium leading-5 text-foreground/80'>
+                  {label(provider)}
+                </span>
+                <PlusDefault className='size-3 shrink-0 text-muted-foreground' aria-hidden />
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {form !== null && (
+        <section className='flex w-full flex-col gap-3'>
+          <span className={SECTION_LABEL}>
+            {editing ? `Edit ${label(form.provider)}` : `New ${label(form.provider)} key`}
+          </span>
+          <CredentialFormFields form={form} onChange={setForm} editing={editing} />
+        </section>
+      )}
+    </V2Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/CredentialFormFields.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/CredentialFormFields.tsx
@@ -1,0 +1,152 @@
+import { type ReactElement } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import {
+  AUTH_TYPE_OPTIONS,
+  baseUrlPlaceholder,
+  REASONING_OPTIONS,
+  supportsAuthType,
+  supportsReasoning,
+  type CredentialForm,
+} from './credentialForm';
+
+const FIELD =
+  'h-11 w-full rounded-2xl border border-border bg-card px-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+
+const Field = ({
+  label,
+  optional = false,
+  children,
+}: {
+  label: string;
+  optional?: boolean;
+  children: ReactElement;
+}): ReactElement => (
+  <div className='flex w-full flex-col gap-1.5'>
+    <span className='flex items-center gap-1 text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+      {label}
+      {optional && <span className='text-xs font-normal text-muted-foreground'>(optional)</span>}
+    </span>
+    {children}
+  </div>
+);
+
+interface CredentialFormFieldsProps {
+  form: CredentialForm;
+  onChange: (next: CredentialForm) => void;
+  editing: boolean;
+}
+
+export function CredentialFormFields({
+  form,
+  onChange,
+  editing,
+}: CredentialFormFieldsProps): ReactElement {
+  const set = <K extends keyof CredentialForm>(key: K, value: CredentialForm[K]): void =>
+    onChange({ ...form, [key]: value });
+
+  return (
+    <div className='flex w-full flex-col gap-3'>
+      <Field label='API key' optional={editing}>
+        <input
+          value={form.apiKey}
+          onChange={e => set('apiKey', e.target.value)}
+          type='password'
+          placeholder={editing ? 'Leave blank to keep the stored key' : 'sk-…'}
+          aria-label='API key'
+          autoComplete='off'
+          autoFocus
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: credential api key'
+          className={FIELD}
+        />
+      </Field>
+
+      <Field label='Model' optional>
+        <input
+          value={form.model}
+          onChange={e => set('model', e.target.value)}
+          placeholder='Provider default'
+          aria-label='Model'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: credential model'
+          className={FIELD}
+        />
+      </Field>
+
+      <Field label='Base URL' optional>
+        <input
+          value={form.baseUrl}
+          onChange={e => set('baseUrl', e.target.value)}
+          placeholder={baseUrlPlaceholder(form.provider)}
+          aria-label='Base URL'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: credential base url'
+          className={FIELD}
+        />
+      </Field>
+
+      {supportsAuthType(form.provider) && (
+        <Field label='Auth type'>
+          <Select
+            value={form.authType}
+            onValueChange={next => set('authType', next as CredentialForm['authType'])}
+          >
+            <SelectTrigger
+              size='sm'
+              aria-label='Auth type'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: credential auth type'
+              className='h-11 w-full rounded-2xl'
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AUTH_TYPE_OPTIONS.map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      )}
+
+      {supportsReasoning(form.provider) && (
+        <Field label='Reasoning effort' optional>
+          <Select
+            value={form.reasoningEffort === '' ? 'default' : form.reasoningEffort}
+            onValueChange={next =>
+              set('reasoningEffort', next === 'default' ? '' : (next as 'low' | 'medium' | 'high'))
+            }
+          >
+            <SelectTrigger
+              size='sm'
+              aria-label='Reasoning effort'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: credential reasoning effort'
+              className='h-11 w-full rounded-2xl'
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {REASONING_OPTIONS.map(option => (
+                <SelectItem
+                  key={option.value || 'default'}
+                  value={option.value === '' ? 'default' : option.value}
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/CredentialsCard.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/CredentialsCard.tsx
@@ -1,0 +1,74 @@
+import { useState, type ReactElement } from 'react';
+import { ChevronBigDown } from '@xyne/icons';
+import { Pill } from '../../create-v2/shared/Pill';
+import {
+  DetailCard,
+  DetailRow,
+  DetailSection,
+  DetailLockedNote,
+  DetailValue,
+  ReadOnlyBadge,
+} from '../DetailPrimitives';
+import { AgentKeysDialog } from './AgentKeysDialog';
+import { useAgentCredentials } from './useAgentCredentials';
+
+interface CredentialsCardProps {
+  slug: string;
+  canRead: boolean;
+  canManage: boolean;
+}
+
+export function CredentialsCard({ slug, canRead, canManage }: CredentialsCardProps): ReactElement {
+  const [keysOpen, setKeysOpen] = useState(false);
+  const { data: credentials } = useAgentCredentials(slug, canRead);
+
+  const configured = (credentials ?? []).filter(entry => entry.configured).length;
+
+  return (
+    <DetailSection
+      label='Credentials'
+      info='Which keys this agent calls providers with'
+      {...(canManage ? {} : { trailing: <ReadOnlyBadge /> })}
+    >
+      <DetailCard>
+        {!canManage && (
+          <DetailLockedNote>
+            {canRead
+              ? 'Only the owner or an admin can add or remove agent keys.'
+              : 'Only the owner or an admin can view and change agent keys.'}
+          </DetailLockedNote>
+        )}
+        <DetailRow title='Spaces' hint='Platform default no key required'>
+          <Pill tone='success'>Always Available</Pill>
+        </DetailRow>
+        <DetailRow
+          title='Agent keys'
+          hint='Everyone falls through to their own provider, or to Spaces'
+          last
+        >
+          {canRead ? (
+            <button
+              type='button'
+              onClick={() => setKeysOpen(true)}
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: open agent keys'
+              className='flex h-9 shrink-0 items-center gap-2 rounded-[10px] border border-border bg-card px-3 text-sm font-normal leading-5 text-foreground transition-colors hover:bg-muted'
+            >
+              {configured > 0 ? `${configured} configured` : 'Configure'}
+              <ChevronBigDown className='size-4 shrink-0 text-muted-foreground' aria-hidden />
+            </button>
+          ) : (
+            <DetailValue>—</DetailValue>
+          )}
+        </DetailRow>
+      </DetailCard>
+
+      <AgentKeysDialog
+        open={keysOpen}
+        onOpenChange={setKeysOpen}
+        slug={slug}
+        canManage={canManage}
+      />
+    </DetailSection>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/agentCredentialsService.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/agentCredentialsService.ts
@@ -1,0 +1,64 @@
+import { clawApiRequest } from '@/services/claw/clawRequest';
+
+export interface AgentProviderCredentialStatus {
+  readonly provider: string;
+  readonly model: string | null;
+  readonly baseUrl: string | null;
+  readonly authType: string | null;
+  readonly reasoningEffort: 'low' | 'medium' | 'high' | null;
+  readonly configured: boolean;
+  readonly createdByUserId: string | null;
+  readonly sharedCredentialId: string | null;
+  readonly sharedCredentialName: string | null;
+  readonly createdAt: string;
+}
+
+export interface SetAgentCredentialPayload {
+  provider: string;
+  apiKey?: string;
+  model?: string;
+  baseUrl?: string;
+  authType?: 'api_key' | 'oauth_token';
+  reasoningEffort?: 'low' | 'medium' | 'high' | null;
+}
+
+const base = (slug: string): string => `/agents/${encodeURIComponent(slug)}/provider-credentials`;
+
+export async function listAgentProviderCredentials(
+  slug: string,
+): Promise<AgentProviderCredentialStatus[]> {
+  const data = await clawApiRequest<{ providers: AgentProviderCredentialStatus[] }>(base(slug));
+  return data.providers;
+}
+
+export function setAgentProviderCredential(
+  slug: string,
+  payload: SetAgentCredentialPayload,
+): Promise<unknown> {
+  return clawApiRequest<unknown>(base(slug), {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function deleteAgentProviderCredential(slug: string, provider: string): Promise<unknown> {
+  return clawApiRequest<unknown>(`${base(slug)}/${encodeURIComponent(provider)}`, {
+    method: 'DELETE',
+  });
+}
+
+export interface ShareCredentialResult {
+  sharedCredentialId: string;
+  results: Array<{ agentId: string; slug?: string; ok: boolean; error?: string }>;
+}
+
+export function shareAgentProviderCredential(
+  slug: string,
+  provider: string,
+  payload: { name?: string; agentIds: string[] },
+): Promise<ShareCredentialResult> {
+  return clawApiRequest<ShareCredentialResult>(
+    `${base(slug)}/${encodeURIComponent(provider)}/share`,
+    { method: 'POST', body: JSON.stringify(payload) },
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/credentialForm.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/credentialForm.ts
@@ -1,0 +1,69 @@
+import type { AgentProviderCredentialStatus } from './agentCredentialsService';
+
+export const CREDENTIAL_PROVIDERS = [
+  'codex',
+  'claude',
+  'copilot',
+  'openrouter',
+  'litellm',
+] as const;
+
+export type CredentialProvider = (typeof CREDENTIAL_PROVIDERS)[number];
+
+export const CREDENTIAL_PROVIDER_LABELS: Record<string, string> = {
+  codex: 'OpenAI Codex',
+  claude: 'Anthropic Claude',
+  copilot: 'GitHub Copilot',
+  openrouter: 'OpenRouter',
+  litellm: 'LiteLLM (own key)',
+  spaces: 'Spaces',
+};
+
+export const AUTH_TYPE_OPTIONS = [
+  { value: 'api_key', label: 'API key' },
+  { value: 'oauth_token', label: 'OAuth token' },
+] as const;
+
+export const REASONING_OPTIONS = [
+  { value: '', label: 'Default' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+] as const;
+
+export interface CredentialForm {
+  provider: CredentialProvider;
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+  authType: 'api_key' | 'oauth_token';
+  reasoningEffort: '' | 'low' | 'medium' | 'high';
+}
+
+export const EMPTY_CREDENTIAL_FORM: CredentialForm = {
+  provider: 'codex',
+  apiKey: '',
+  model: '',
+  baseUrl: '',
+  authType: 'api_key',
+  reasoningEffort: '',
+};
+
+export function formFromCredential(entry: AgentProviderCredentialStatus): CredentialForm {
+  return {
+    provider: (CREDENTIAL_PROVIDERS as readonly string[]).includes(entry.provider)
+      ? (entry.provider as CredentialProvider)
+      : 'codex',
+    apiKey: '',
+    model: entry.model ?? '',
+    baseUrl: entry.baseUrl ?? '',
+    authType: entry.authType === 'oauth_token' ? 'oauth_token' : 'api_key',
+    reasoningEffort: entry.reasoningEffort ?? '',
+  };
+}
+
+export const supportsAuthType = (provider: string): boolean => provider !== 'litellm';
+export const supportsReasoning = (provider: string): boolean => provider !== 'litellm';
+
+export const baseUrlPlaceholder = (provider: string): string =>
+  provider === 'litellm' ? 'blank = platform LiteLLM proxy' : 'https://openrouter.ai/api/v1';

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/useAgentCredentials.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/credentials/useAgentCredentials.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import {
+  deleteAgentProviderCredential,
+  listAgentProviderCredentials,
+  setAgentProviderCredential,
+  type AgentProviderCredentialStatus,
+  type SetAgentCredentialPayload,
+} from './agentCredentialsService';
+
+export const agentCredentialsKey = (slug: string | undefined): [string, string | undefined] => [
+  'claw-agent-provider-credentials',
+  slug,
+];
+
+export function useAgentCredentials(
+  slug: string | undefined,
+  enabled = true,
+): UseQueryResult<AgentProviderCredentialStatus[], Error> {
+  return useQuery({
+    queryKey: agentCredentialsKey(slug),
+    queryFn: () => listAgentProviderCredentials(slug as string),
+    enabled: Boolean(slug) && enabled,
+    staleTime: 60 * 1000,
+  });
+}
+
+export interface AgentCredentialMutations {
+  save: (payload: SetAgentCredentialPayload) => Promise<void>;
+  remove: (provider: string) => Promise<void>;
+  saving: boolean;
+  removing: boolean;
+}
+
+export function useAgentCredentialMutations(slug: string | undefined): AgentCredentialMutations {
+  const queryClient = useQueryClient();
+  const invalidate = (): void => {
+    void queryClient.invalidateQueries({ queryKey: agentCredentialsKey(slug) });
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: SetAgentCredentialPayload) =>
+      setAgentProviderCredential(slug as string, payload),
+    onSuccess: () => {
+      invalidate();
+      toast.success('Credential saved');
+    },
+    onError: (err: Error) => toast.error(clawErrorText(err, 'Could not save this credential')),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (provider: string) => deleteAgentProviderCredential(slug as string, provider),
+    onSuccess: () => {
+      invalidate();
+      toast.success('Credential removed');
+    },
+    onError: (err: Error) => toast.error(clawErrorText(err, 'Could not remove this credential')),
+  });
+
+  return {
+    save: async payload => {
+      await saveMutation.mutateAsync(payload).catch(() => undefined);
+    },
+    remove: async provider => {
+      await removeMutation.mutateAsync(provider).catch(() => undefined);
+    },
+    saving: saveMutation.isPending,
+    removing: removeMutation.isPending,
+  };
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/detailTabs.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/detailTabs.ts
@@ -1,0 +1,28 @@
+export type AgentDetailTabId =
+  | 'persona'
+  | 'behaviour'
+  | 'tools'
+  | 'knowledge'
+  | 'people'
+  | 'activity';
+
+export interface AgentDetailTab {
+  id: AgentDetailTabId;
+  label: string;
+}
+
+export const AGENT_DETAIL_TABS: readonly AgentDetailTab[] = [
+  { id: 'persona', label: 'Persona' },
+  { id: 'behaviour', label: 'Behaviour' },
+  { id: 'tools', label: 'Tools' },
+  { id: 'knowledge', label: 'Knowledge' },
+  { id: 'people', label: 'People' },
+  { id: 'activity', label: 'Activity' },
+];
+
+export const DEFAULT_AGENT_DETAIL_TAB: AgentDetailTabId = 'persona';
+
+export function resolveTab(raw: string | null): AgentDetailTabId {
+  const match = AGENT_DETAIL_TABS.find(tab => tab.id === raw);
+  return match ? match.id : DEFAULT_AGENT_DETAIL_TAB;
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/AgentKnowledgeTabV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/AgentKnowledgeTabV2.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import { PlusDefault } from '@xyne/icons';
+import { useClawKnowledgeBaseTree } from '@/hooks/useClawKnowledgeBaseTree';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { Pill } from '../../create-v2/shared/Pill';
+import { BrowseKnowledgeDialog } from '../../create-v2/knowledge/BrowseKnowledgeDialog';
+import {
+  buildKbIndex,
+  describeGrants,
+  removeGrant,
+} from '../../create-v2/knowledge/knowledgeCatalog';
+import { BrowseSkillsDialog } from '../../create-v2/skill/BrowseSkillsDialog';
+import { disableSkill, isSkillSelected } from '../../create-v2/skill/skillCatalog';
+import { useSkillCatalog } from '../../create-v2/skill/useSkillCatalog';
+import { DetailListCard, type DetailListItem } from '../DetailListCard';
+import {
+  DetailLockedNote,
+  DetailRow,
+  DetailSection,
+  DetailValue,
+  ReadOnlyBadge,
+} from '../DetailPrimitives';
+import { BehaviourSelect } from '../behaviour/BehaviourRows';
+import {
+  agentMemoryKey,
+  deleteAgentMemory,
+  isDigitalTwin,
+  useAgentMemories,
+  useAgentMemoryStatus,
+} from './agentMemoryService';
+import { MemoryManageDialog } from './MemoryManageDialog';
+import { useAgentKnowledge } from './useAgentKnowledge';
+
+const LOCK_NOTE = 'Only the owner, a contributor, or an admin can change what this agent knows.';
+
+const SOURCE_LABELS: Record<string, string> = {
+  seeded: 'Built-in',
+  'user-created': 'Custom',
+  uploaded: 'Uploaded',
+};
+
+const SCOPE_OPTIONS = [
+  { value: 'COLLECTIONS', label: 'Same set for everyone' },
+  { value: 'USER', label: "Each person's own access" },
+];
+
+const DATE = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+
+function formatAdded(value: string | null): string {
+  if (!value) return 'Added recently';
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? 'Added recently' : `Added ${DATE.format(parsed)}`;
+}
+
+function ManageButton({ label, onClick }: { label: string; onClick: () => void }): ReactElement {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      aria-label={label}
+      data-track-category='Claw Agents'
+      data-track-name='Agent detail v2: manage knowledge'
+      className='flex h-6 shrink-0 items-center rounded-md bg-muted px-1.5 text-sm leading-5 text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground'
+    >
+      Manage
+    </button>
+  );
+}
+
+export function AgentKnowledgeTabV2({
+  agent,
+  canEdit,
+}: {
+  agent: Agent;
+  canEdit: boolean;
+}): ReactElement {
+  const queryClient = useQueryClient();
+  const knowledge = useAgentKnowledge(agent);
+  const skills = useSkillCatalog();
+  const tree = useClawKnowledgeBaseTree();
+
+  const [memoryOpen, setMemoryOpen] = useState(false);
+  const [removingMemory, setRemovingMemory] = useState(false);
+
+  const memories = useAgentMemories(agent.slug);
+  const memoryStatus = useAgentMemoryStatus(agent.slug);
+
+  const skillItems = useMemo<DetailListItem[]>(
+    () =>
+      skills.entries
+        .filter(entry => isSkillSelected(knowledge.skillIds, entry))
+        .map(entry => ({
+          key: entry.id,
+          name: `/${entry.slug}`,
+          description: entry.description,
+          badge: <Pill tone='neutral'>{SOURCE_LABELS[entry.source] ?? entry.scope}</Pill>,
+        })),
+    [skills.entries, knowledge.skillIds],
+  );
+
+  const grantItems = useMemo<DetailListItem[]>(() => {
+    if (knowledge.scope === 'USER') return [];
+    const index = buildKbIndex(tree.data?.collections ?? []);
+    return describeGrants(knowledge.grants, index).map(grant => ({
+      key: grant.key,
+      name: grant.label,
+      description: grant.detail ?? '',
+    }));
+  }, [tree.data?.collections, knowledge.grants, knowledge.scope]);
+
+  const memoryItems = useMemo<DetailListItem[]>(
+    () =>
+      (memories.data ?? []).map(memory => ({
+        key: memory.id,
+        name: memory.content,
+        description: formatAdded(memory.createdAt),
+        ...(memory.category ? { badge: <Pill tone='neutral'>{memory.category}</Pill> } : {}),
+        ...(memory.recallHits7d > 0
+          ? { meta: `${memory.recallHits7d} recall${memory.recallHits7d === 1 ? '' : 's'}` }
+          : {}),
+      })),
+    [memories.data],
+  );
+
+  const note = canEdit ? null : <DetailLockedNote>{LOCK_NOTE}</DetailLockedNote>;
+
+  const trailingFor = (label: string, onClick: () => void): ReactElement =>
+    canEdit ? <ManageButton label={label} onClick={onClick} /> : <ReadOnlyBadge />;
+
+  const removeMemory = async (id: string): Promise<void> => {
+    if (removingMemory) return;
+    setRemovingMemory(true);
+    try {
+      await deleteAgentMemory(agent.slug, id);
+      void queryClient.invalidateQueries({ queryKey: agentMemoryKey(agent.slug) });
+      toast.success('Memory removed');
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not remove that memory'));
+    } finally {
+      setRemovingMemory(false);
+    }
+  };
+
+  return (
+    <div className='flex w-full flex-col gap-8'>
+      <DetailSection
+        label='Skills'
+        info='Reusable instruction packs this agent can run as a slash command'
+        trailing={trailingFor('Manage skills', () => knowledge.openBrowse('skills'))}
+        trailingAlign='end'
+      >
+        <DetailListCard
+          items={skillItems}
+          loading={skills.loading}
+          emptyLabel='No skills attached yet.'
+          canEdit={canEdit}
+          note={note}
+          removeLabel={item => `Remove ${item.name}`}
+          onRemove={item => {
+            const entry = skills.entries.find(candidate => candidate.id === item.key);
+            if (!entry) return;
+            knowledge.saveSkills(disableSkill(knowledge.skillIds, entry), `${item.name} removed`);
+          }}
+        />
+      </DetailSection>
+
+      <DetailSection
+        label='Documents'
+        info='Collections and files this agent can look things up in'
+        {...(canEdit ? {} : { trailing: <ReadOnlyBadge />, trailingAlign: 'end' as const })}
+      >
+        <DetailListCard
+          items={grantItems}
+          loading={tree.isLoading && knowledge.scope === 'COLLECTIONS'}
+          emptyLabel={
+            knowledge.scope === 'USER'
+              ? 'This agent reads whatever the person running it can already see.'
+              : 'No collections attached yet.'
+          }
+          canEdit={canEdit}
+          note={note}
+          removeLabel={item => `Remove ${item.name}`}
+          onRemove={item => {
+            const index = buildKbIndex(tree.data?.collections ?? []);
+            const target = describeGrants(knowledge.grants, index).find(
+              grant => grant.key === item.key,
+            );
+            if (!target) return;
+            knowledge.saveKb(
+              knowledge.scope,
+              removeGrant(knowledge.grants, target.selection),
+              `${item.name} removed`,
+            );
+          }}
+        >
+          <DetailRow title='Applies To' hint='Whose access decides what this agent can read'>
+            <BehaviourSelect
+              value={knowledge.scope}
+              options={SCOPE_OPTIONS}
+              editable={canEdit}
+              disabled={knowledge.saving}
+              label='Who this applies to'
+              trackName='Agent detail v2: set kb scope'
+              onChange={next =>
+                knowledge.saveKb(
+                  next === 'USER' ? 'USER' : 'COLLECTIONS',
+                  knowledge.grants,
+                  'Document access updated',
+                )
+              }
+            />
+          </DetailRow>
+
+          <DetailRow title='Collections' hint='What it can look things up in'>
+            {knowledge.scope === 'USER' ? (
+              <DetailValue>Not used</DetailValue>
+            ) : canEdit ? (
+              <button
+                type='button'
+                onClick={() => knowledge.openBrowse('documents')}
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: add collections'
+                className='flex h-9 shrink-0 items-center gap-2 rounded-[10px] border border-border bg-card px-3 text-sm leading-5 text-foreground transition-colors hover:bg-muted/50'
+              >
+                <PlusDefault className='size-4 shrink-0 text-muted-foreground' aria-hidden />
+                Add
+              </button>
+            ) : (
+              <DetailValue>{knowledge.grants.length} attached</DetailValue>
+            )}
+          </DetailRow>
+        </DetailListCard>
+      </DetailSection>
+
+      {!isDigitalTwin(agent.slug) && (
+        <DetailSection
+          label='Memory'
+          info='Facts this agent carries between sessions'
+          trailing={trailingFor('Manage memory', () => setMemoryOpen(true))}
+          trailingAlign='end'
+        >
+          <DetailListCard
+            items={memoryItems}
+            loading={memories.isLoading}
+            emptyLabel={
+              memoryStatus.data?.memoryEnabled === false
+                ? 'Memory is off for this agent.'
+                : 'Nothing remembered yet.'
+            }
+            canEdit={canEdit && !removingMemory}
+            note={note}
+            removeLabel={() => 'Forget this memory'}
+            onRemove={item => void removeMemory(item.key)}
+          />
+        </DetailSection>
+      )}
+
+      {knowledge.saving && (
+        <span className='flex items-center gap-2 text-xs font-normal leading-4 text-muted-foreground'>
+          <Loader2 className='size-3.5 animate-spin' aria-hidden />
+          Saving…
+        </span>
+      )}
+
+      <BrowseSkillsDialog
+        open={knowledge.browse === 'skills'}
+        onOpenChange={open => {
+          if (!open) knowledge.closeBrowse();
+        }}
+        catalog={skills.entries}
+        loading={skills.loading}
+        isError={skills.isError}
+        onRetry={skills.refetch}
+        selectedIds={knowledge.draftSkillIds}
+        onChange={knowledge.setDraftSkillIds}
+      />
+
+      <BrowseKnowledgeDialog
+        open={knowledge.browse === 'documents'}
+        onOpenChange={open => {
+          if (!open) knowledge.closeBrowse();
+        }}
+        scope={knowledge.draftScope}
+        onScopeChange={knowledge.setDraftScope}
+        grants={knowledge.draftGrants}
+        onGrantsChange={knowledge.setDraftGrants}
+      />
+
+      <MemoryManageDialog
+        open={memoryOpen}
+        onOpenChange={setMemoryOpen}
+        slug={agent.slug}
+        status={memoryStatus.data}
+        memoryCount={memoryItems.length}
+        canEdit={canEdit}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/MemoryManageDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/MemoryManageDialog.tsx
@@ -1,0 +1,175 @@
+import { useState, type ReactElement } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/Button';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import { V2Dialog } from '../../create-v2/shared/V2Dialog';
+import { BehaviourRow, BehaviourToggle } from '../behaviour/BehaviourRows';
+import { DetailCard } from '../DetailPrimitives';
+import {
+  agentMemoryKey,
+  agentMemoryStatusKey,
+  clearAgentMemories,
+  setAgentMemoryEnabled,
+  type AgentMemoryStatus,
+} from './agentMemoryService';
+
+const APPROVAL_LABELS: Record<AgentMemoryStatus['memoryApprovalStrategy'], string> = {
+  HUMAN_ONLY: 'Human review',
+  EVALS_ONLY: 'Auto via evals',
+  EVALS_THEN_HUMAN: 'Evals, then human',
+};
+
+interface MemoryManageDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  slug: string;
+  status: AgentMemoryStatus | undefined;
+  memoryCount: number;
+  canEdit: boolean;
+}
+
+export function MemoryManageDialog({
+  open,
+  onOpenChange,
+  slug,
+  status,
+  memoryCount,
+  canEdit,
+}: MemoryManageDialogProps): ReactElement {
+  const queryClient = useQueryClient();
+  const [busy, setBusy] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  const enabled = status?.memoryEnabled ?? false;
+
+  const toggleEnabled = async (next: boolean): Promise<void> => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const updated = await setAgentMemoryEnabled(slug, next);
+      queryClient.setQueryData(agentMemoryStatusKey(slug), updated);
+      toast.success(next ? 'Memory enabled' : 'Memory disabled');
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not change the memory setting'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clearAll = async (): Promise<void> => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await clearAgentMemories(slug);
+      void queryClient.invalidateQueries({ queryKey: agentMemoryKey(slug) });
+      toast.success('All memories cleared');
+      setConfirmClear(false);
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not clear the memories'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={next => {
+        setConfirmClear(false);
+        onOpenChange(next);
+      }}
+      title='Memory'
+      description='What this agent remembers between sessions.'
+      testId='memory-manage-dialog'
+      footer={
+        <Button
+          variant='ghost'
+          onClick={() => onOpenChange(false)}
+          className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: close memory dialog'
+        >
+          Done
+        </Button>
+      }
+    >
+      <p className='text-sm font-normal leading-5 text-muted-foreground'>
+        When memory is on, each session is summarised by the nightly curator and the useful facts
+        are recalled at the start of later sessions.
+      </p>
+
+      <DetailCard>
+        <BehaviourRow
+          title='Memory enabled'
+          hint='Enrols this agent in the memory pipeline from its next session onwards.'
+        >
+          <BehaviourToggle
+            checked={enabled}
+            editable={canEdit}
+            disabled={busy}
+            label='Memory enabled'
+            trackName='Agent detail v2: toggle memory'
+            onChange={next => void toggleEnabled(next)}
+          />
+        </BehaviourRow>
+
+        <BehaviourRow
+          title='Approval'
+          hint='How a curated memory gets accepted into the bank.'
+          last
+        >
+          <span className='text-sm font-normal leading-5 text-foreground'>
+            {APPROVAL_LABELS[status?.memoryApprovalStrategy ?? 'HUMAN_ONLY']}
+          </span>
+        </BehaviourRow>
+      </DetailCard>
+
+      {canEdit && (
+        <section className='flex w-full flex-col gap-3'>
+          <span className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+            Clear memories
+          </span>
+          <p className='text-sm font-normal leading-5 text-muted-foreground'>
+            Deletes all {memoryCount} stored {memoryCount === 1 ? 'memory' : 'memories'} for this
+            agent. This can&apos;t be undone.
+          </p>
+          {confirmClear ? (
+            <div className='flex items-center gap-3'>
+              <Button
+                variant='ghost'
+                onClick={() => setConfirmClear(false)}
+                disabled={busy}
+                className='h-auto rounded-xl px-3 py-2 text-sm'
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: cancel clear memories'
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={() => void clearAll()}
+                loading={busy}
+                className='h-auto rounded-xl bg-destructive px-3 py-2 text-sm text-destructive-foreground hover:bg-destructive/90'
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: confirm clear memories'
+              >
+                Yes, clear everything
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant='ghost'
+              onClick={() => setConfirmClear(true)}
+              disabled={busy || memoryCount === 0}
+              className='h-auto w-fit rounded-xl px-3 py-2 text-sm text-destructive hover:bg-destructive/10'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: clear memories'
+            >
+              Clear all memories
+            </Button>
+          )}
+        </section>
+      )}
+    </V2Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/agentMemoryService.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/agentMemoryService.ts
@@ -1,0 +1,79 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { clawApiRequest } from '@/services/claw/clawRequest';
+
+export interface AgentMemory {
+  readonly id: string;
+  readonly hindsightMemoryId: string;
+  readonly content: string;
+  readonly category: string | null;
+  readonly scope: 'user' | 'shared' | null;
+  readonly createdAt: string | null;
+  readonly recallHits7d: number;
+  readonly lastRecalledAt: string | null;
+}
+
+export interface AgentMemoryStatus {
+  readonly memoryEnabled: boolean;
+  readonly memorySharedAllowed: boolean;
+  readonly memoryApprovalStrategy: 'HUMAN_ONLY' | 'EVALS_ONLY' | 'EVALS_THEN_HUMAN';
+}
+
+const bank = (slug: string): string => `/memory/banks/${encodeURIComponent(slug)}`;
+
+export const agentMemoryKey = (slug: string): readonly unknown[] => ['claw-agent-memories', slug];
+export const agentMemoryStatusKey = (slug: string): readonly unknown[] => [
+  'claw-agent-memory-status',
+  slug,
+];
+
+export function listAgentMemories(slug: string, limit = 50): Promise<AgentMemory[]> {
+  return clawApiRequest<AgentMemory[]>(`${bank(slug)}/memories?limit=${limit}`);
+}
+
+export function getAgentMemoryStatus(slug: string): Promise<AgentMemoryStatus> {
+  return clawApiRequest<AgentMemoryStatus>(`${bank(slug)}/status`);
+}
+
+export function deleteAgentMemory(slug: string, memoryId: string): Promise<unknown> {
+  return clawApiRequest<unknown>(`${bank(slug)}/memories/${encodeURIComponent(memoryId)}`, {
+    method: 'DELETE',
+  });
+}
+
+export function setAgentMemoryEnabled(slug: string, enabled: boolean): Promise<AgentMemoryStatus> {
+  return clawApiRequest<AgentMemoryStatus>(`${bank(slug)}/${enabled ? 'enable' : 'disable'}`, {
+    method: 'POST',
+  });
+}
+
+export function clearAgentMemories(slug: string): Promise<unknown> {
+  return clawApiRequest<unknown>(`${bank(slug)}/clear-all`, { method: 'POST' });
+}
+
+/**
+ * The digital-twin bank is per-user and gated behind its own endpoints, so the
+ * agent-detail screen never lists it. Everything else is agent-scoped.
+ */
+export function isDigitalTwin(slug: string): boolean {
+  return slug === 'digital-twin';
+}
+
+export function useAgentMemories(slug: string): UseQueryResult<AgentMemory[], Error> {
+  return useQuery({
+    queryKey: agentMemoryKey(slug),
+    queryFn: () => listAgentMemories(slug),
+    enabled: !isDigitalTwin(slug),
+    retry: false,
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useAgentMemoryStatus(slug: string): UseQueryResult<AgentMemoryStatus, Error> {
+  return useQuery({
+    queryKey: agentMemoryStatusKey(slug),
+    queryFn: () => getAgentMemoryStatus(slug),
+    enabled: !isDigitalTwin(slug),
+    retry: false,
+    staleTime: 60 * 1000,
+  });
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/useAgentKnowledge.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/knowledge/useAgentKnowledge.ts
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { clawAgentDetailKey } from '@/hooks/useClawAgentDetail';
+import { updateClawAgent } from '@/services/claw/clawAuthAgentsService';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import type { Agent, UpdateAgentPayload } from '@/services/claw/clawAuthAgentTypes';
+import type { KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
+import type { KbScope } from '../../create-v2/knowledge/knowledgeCatalog';
+
+export type KnowledgeSection = 'skills' | 'documents' | null;
+
+export interface AgentKnowledge {
+  skillIds: string[];
+  scope: KbScope;
+  grants: KbSelection[];
+  draftSkillIds: string[];
+  draftScope: KbScope;
+  draftGrants: KbSelection[];
+  browse: KnowledgeSection;
+  saving: boolean;
+  openBrowse: (section: Exclude<KnowledgeSection, null>) => void;
+  closeBrowse: () => void;
+  setDraftSkillIds: (next: string[]) => void;
+  setDraftScope: (next: KbScope) => void;
+  setDraftGrants: (next: KbSelection[]) => void;
+  saveSkills: (next: string[], message: string) => void;
+  saveKb: (scope: KbScope, grants: KbSelection[], message: string) => void;
+}
+
+function sameIds(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every(id => b.includes(id));
+}
+
+function grantKey(grant: KbSelection): string {
+  return `${grant.collectionId}:${grant.fileId ?? '*'}`;
+}
+
+function sameGrants(a: readonly KbSelection[], b: readonly KbSelection[]): boolean {
+  const keys = new Set(b.map(grantKey));
+  return a.length === b.length && a.every(grant => keys.has(grantKey(grant)));
+}
+
+export function useAgentKnowledge(agent: Agent): AgentKnowledge {
+  const queryClient = useQueryClient();
+  const [saving, setSaving] = useState(false);
+  const [browse, setBrowse] = useState<KnowledgeSection>(null);
+  const [draft, setDraft] = useState<{
+    skillIds: string[];
+    scope: KbScope;
+    grants: KbSelection[];
+  } | null>(null);
+
+  const skillIds = (agent.skills ?? []).map(entry => entry.skillId);
+  const scope: KbScope = agent.kbScope === 'USER' ? 'USER' : 'COLLECTIONS';
+  const grants: KbSelection[] = (agent.collections ?? []).map(entry => ({
+    collectionId: entry.collectionId,
+    ...(entry.fileId ? { fileId: entry.fileId } : {}),
+  })) as KbSelection[];
+
+  const persist = async (payload: UpdateAgentPayload, message: string): Promise<void> => {
+    if (saving) return;
+    setSaving(true);
+    const previous = agent;
+    try {
+      const updated = await updateClawAgent(agent.slug, payload);
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), updated);
+      void queryClient.invalidateQueries({ queryKey: ['claw-auth-agents'] });
+      toast.success(message);
+    } catch (err) {
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), previous);
+      toast.error(clawErrorText(err, 'Could not update this agent'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // A USER-scoped agent follows the running user's own access, so no grants are
+  // sent — matching what the create flow writes.
+  const kbPayload = (nextScope: KbScope, nextGrants: KbSelection[]): UpdateAgentPayload => ({
+    kbScope: nextScope,
+    ...(nextScope === 'USER' ? {} : { knowledgeBase: nextGrants }),
+  });
+
+  return {
+    skillIds,
+    scope,
+    grants,
+    draftSkillIds: draft?.skillIds ?? skillIds,
+    draftScope: draft?.scope ?? scope,
+    draftGrants: draft?.grants ?? grants,
+    browse,
+    saving,
+    openBrowse: section => {
+      setDraft({ skillIds, scope, grants });
+      setBrowse(section);
+    },
+    closeBrowse: () => {
+      const next = draft;
+      const section = browse;
+      setBrowse(null);
+      setDraft(null);
+      if (!next) return;
+      if (section === 'skills' && !sameIds(next.skillIds, skillIds)) {
+        void persist({ skills: next.skillIds }, 'Skills updated');
+      }
+      if (section === 'documents' && (next.scope !== scope || !sameGrants(next.grants, grants))) {
+        void persist(kbPayload(next.scope, next.grants), 'Documents updated');
+      }
+    },
+    setDraftSkillIds: next =>
+      setDraft(current => ({ ...(current ?? { scope, grants }), skillIds: next })),
+    setDraftScope: next =>
+      setDraft(current => ({ ...(current ?? { skillIds, grants }), scope: next })),
+    setDraftGrants: next =>
+      setDraft(current => ({ ...(current ?? { skillIds, scope }), grants: next })),
+    saveSkills: (next, message) => void persist({ skills: next }, message),
+    saveKb: (nextScope, nextGrants, message) =>
+      void persist(kbPayload(nextScope, nextGrants), message),
+  };
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/model/ModelCard.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/model/ModelCard.tsx
@@ -1,0 +1,198 @@
+import { useState, type ReactElement } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { PencilEditLine } from '@xyne/icons';
+import { Loader2 } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { clawAgentDetailKey } from '@/hooks/useClawAgentDetail';
+import { updateClawAgent } from '@/services/claw/clawAuthAgentsService';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import { PROVIDER_DISPLAY } from '@/services/claw/modelProviderConfig';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import {
+  DetailCard,
+  DetailRow,
+  DetailSection,
+  DetailLockedNote,
+  DetailValue,
+  ReadOnlyBadge,
+} from '../DetailPrimitives';
+import { ProviderOrderDialog } from './ProviderOrderDialog';
+import {
+  applyModelCard,
+  AUTOMATION_OPTIONS,
+  ALWAYS_ON_OPTIONS,
+  readModelCardDraft,
+  SUBAGENT_OPTIONS,
+  type ModelCardDraft,
+} from './modelConfig';
+
+const RowSelect = <T extends string>({
+  value,
+  options,
+  editable,
+  onChange,
+  label,
+  trackName,
+}: {
+  value: T;
+  options: ReadonlyArray<{ value: string; label: string }>;
+  editable: boolean;
+  onChange: (next: T) => void;
+  label: string;
+  trackName: string;
+}): ReactElement =>
+  !editable ? (
+    <DetailValue>{options.find(o => o.value === value)?.label ?? value}</DetailValue>
+  ) : (
+    <Select value={value} onValueChange={next => onChange(next as T)}>
+      <SelectTrigger
+        size='sm'
+        aria-label={label}
+        data-track-category='Claw Agents'
+        data-track-name={trackName}
+        className='h-9 w-auto min-w-0 gap-2 rounded-[10px]'
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align='end'>
+        {options.map(option => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+export function ModelCard({ agent, canEdit }: { agent: Agent; canEdit: boolean }): ReactElement {
+  const queryClient = useQueryClient();
+  const [saving, setSaving] = useState(false);
+  const [orderOpen, setOrderOpen] = useState(false);
+
+  const draft = readModelCardDraft(agent.config);
+
+  const persist = async (next: ModelCardDraft, successMessage: string): Promise<void> => {
+    if (saving) return;
+    setSaving(true);
+    const previous = agent;
+    const config = applyModelCard(agent.config, next);
+    queryClient.setQueryData(clawAgentDetailKey(agent.slug), { ...agent, config });
+    try {
+      const updated = await updateClawAgent(agent.slug, { config });
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), updated);
+      toast.success(successMessage);
+    } catch (err) {
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), previous);
+      toast.error(clawErrorText(err, 'Could not update the model settings'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const providerLabel =
+    draft.providerOrder.length > 0
+      ? draft.providerOrder.map(key => PROVIDER_DISPLAY[key] ?? key).join(', ')
+      : 'Spaces platform model';
+
+  return (
+    <DetailSection
+      label='Model'
+      info='Which provider answers, and when'
+      {...(canEdit ? {} : { trailing: <ReadOnlyBadge /> })}
+    >
+      <DetailCard>
+        {!canEdit && (
+          <DetailLockedNote>
+            Only the owner, a contributor, or an admin can change the model settings.
+          </DetailLockedNote>
+        )}
+        <DetailRow title='Providers' hint='Top to bottom order'>
+          {saving && (
+            <Loader2 className='size-3.5 animate-spin text-muted-foreground' aria-hidden />
+          )}
+          <DetailValue>{providerLabel}</DetailValue>
+          {canEdit && (
+            <button
+              type='button'
+              onClick={() => setOrderOpen(true)}
+              aria-label='Edit provider order'
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: edit provider order'
+              className='flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+            >
+              <PencilEditLine className='size-4' aria-hidden />
+            </button>
+          )}
+        </DetailRow>
+
+        <DetailRow title='Applies To' hint='When the provider order takes effect'>
+          <RowSelect
+            value={draft.alwaysOn ? 'always' : 'upgrade'}
+            options={ALWAYS_ON_OPTIONS}
+            editable={canEdit && !saving}
+            label="When to use the agent's premium provider"
+            trackName='Agent detail v2: set provider applies-to'
+            onChange={next =>
+              void persist({ ...draft, alwaysOn: next === 'always' }, 'Provider policy updated')
+            }
+          />
+        </DetailRow>
+
+        <DetailRow title='Subagents' hint='A per-subagent override always wins over this'>
+          <RowSelect
+            value={draft.subagentMode}
+            options={SUBAGENT_OPTIONS}
+            editable={canEdit && !saving}
+            label='Which provider subagents run on'
+            trackName='Agent detail v2: set subagent provider'
+            onChange={next =>
+              void persist(
+                { ...draft, subagentMode: next === 'parent' ? 'parent' : 'spaces' },
+                'Subagent routing updated',
+              )
+            }
+          />
+        </DetailRow>
+
+        <DetailRow
+          title='Automated runs'
+          hint='Scheduled jobs, automations and error-pipeline runs'
+          last
+        >
+          <RowSelect
+            value={draft.automationMode}
+            options={AUTOMATION_OPTIONS}
+            editable={canEdit && !saving}
+            label='Which provider automation and scheduled runs use'
+            trackName='Agent detail v2: set automation provider'
+            onChange={next =>
+              void persist(
+                { ...draft, automationMode: next === 'platform' ? 'platform' : 'chat' },
+                'Automated runs updated',
+              )
+            }
+          />
+        </DetailRow>
+      </DetailCard>
+
+      <ProviderOrderDialog
+        open={orderOpen}
+        onOpenChange={setOrderOpen}
+        order={draft.providerOrder}
+        saving={saving}
+        onSave={next => {
+          void persist({ ...draft, providerOrder: next }, 'Provider order updated').then(() =>
+            setOrderOpen(false),
+          );
+        }}
+      />
+    </DetailSection>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/model/ProviderOrderDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/model/ProviderOrderDialog.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { ChevronBigDown, ChevronBigUp, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
+import { Button } from '@/components/ui/Button';
+import { ALL_PROVIDERS, PROVIDER_DISPLAY } from '@/services/claw/modelProviderConfig';
+import { V2Dialog } from '../../create-v2/shared/V2Dialog';
+
+const ICON_BUTTON =
+  'flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40';
+
+interface ProviderOrderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  order: readonly string[];
+  saving: boolean;
+  onSave: (next: string[]) => void;
+}
+
+export function ProviderOrderDialog({
+  open,
+  onOpenChange,
+  order,
+  saving,
+  onSave,
+}: ProviderOrderDialogProps): ReactElement {
+  const [draft, setDraft] = useState<string[]>([...order]);
+
+  useEffect(() => {
+    if (open) setDraft([...order]);
+  }, [open, order]);
+
+  const available = ALL_PROVIDERS.filter(provider => !draft.includes(provider));
+
+  const move = (index: number, delta: number): void => {
+    const target = index + delta;
+    if (target < 0 || target >= draft.length) return;
+    const next = [...draft];
+    const [moved] = next.splice(index, 1);
+    if (moved) next.splice(target, 0, moved);
+    setDraft(next);
+  };
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Providers'
+      description='Top to bottom order. The first provider is used, the rest are fallbacks.'
+      testId='provider-order-dialog'
+      footer={
+        <>
+          <Button
+            variant='ghost'
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+            className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: cancel provider order'
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onSave(draft)}
+            loading={saving}
+            className='h-auto rounded-xl bg-foreground px-3 py-2.5 text-[15px] text-background hover:bg-foreground/90'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: save provider order'
+          >
+            Save
+          </Button>
+        </>
+      }
+    >
+      <p className='text-sm font-normal leading-5 text-muted-foreground'>
+        Runs use the first provider and fall through the rest on quota limits.
+      </p>
+
+      <section className='flex w-full flex-col gap-3'>
+        <span className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+          Order
+        </span>
+
+        {draft.length === 0 ? (
+          <p className='text-sm font-normal leading-5 text-muted-foreground'>
+            No providers chosen — runs use the Spaces platform model.
+          </p>
+        ) : (
+          <div className='flex w-full flex-col gap-2'>
+            {draft.map((provider, index) => (
+              <div
+                key={provider}
+                className='flex h-11 w-full items-center gap-2 rounded-[10px] border-[0.8px] border-border bg-muted px-3'
+              >
+                <span className='w-4 shrink-0 text-xs font-normal leading-4 tabular-nums text-muted-foreground'>
+                  {index + 1}
+                </span>
+                <span className='min-w-0 flex-1 truncate text-sm font-medium leading-5 text-foreground'>
+                  {PROVIDER_DISPLAY[provider] ?? provider}
+                </span>
+                <button
+                  type='button'
+                  onClick={() => move(index, -1)}
+                  disabled={index === 0}
+                  aria-label={`Move ${provider} up`}
+                  data-track-category='Claw Agents'
+                  data-track-name='Agent detail v2: move provider up'
+                  className={ICON_BUTTON}
+                >
+                  <ChevronBigUp className='size-4' aria-hidden />
+                </button>
+                <button
+                  type='button'
+                  onClick={() => move(index, 1)}
+                  disabled={index === draft.length - 1}
+                  aria-label={`Move ${provider} down`}
+                  data-track-category='Claw Agents'
+                  data-track-name='Agent detail v2: move provider down'
+                  className={ICON_BUTTON}
+                >
+                  <ChevronBigDown className='size-4' aria-hidden />
+                </button>
+                <button
+                  type='button'
+                  onClick={() => setDraft(draft.filter(entry => entry !== provider))}
+                  aria-label={`Remove ${provider}`}
+                  data-track-category='Claw Agents'
+                  data-track-name='Agent detail v2: remove provider'
+                  className={ICON_BUTTON}
+                >
+                  <MultipleCrossCancelDefault className='size-4' aria-hidden />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {available.length > 0 && (
+        <section className='flex w-full flex-col gap-3'>
+          <span className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+            Add a provider
+          </span>
+          <div className='flex flex-wrap items-start gap-2'>
+            {available.map(provider => (
+              <button
+                key={provider}
+                type='button'
+                onClick={() => setDraft([...draft, provider])}
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: add provider'
+                className='flex h-7 shrink-0 items-center gap-1.5 overflow-hidden rounded-[10px] border-[0.8px] border-dashed border-border bg-card px-2 transition-colors hover:bg-muted/50'
+              >
+                <span className='max-w-[200px] truncate text-sm font-medium leading-5 text-foreground/80'>
+                  {PROVIDER_DISPLAY[provider] ?? provider}
+                </span>
+                <PlusDefault className='size-3 shrink-0 text-muted-foreground' aria-hidden />
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+    </V2Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/model/modelConfig.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/model/modelConfig.ts
@@ -1,0 +1,49 @@
+import {
+  applyModelProvider,
+  readModelProviderDraft,
+  type ModelProviderDraft,
+} from '@/services/claw/modelProviderConfig';
+
+export type AutomationMode = 'chat' | 'platform';
+
+export interface ModelCardDraft extends ModelProviderDraft {
+  automationMode: AutomationMode;
+}
+
+export function readModelCardDraft(config: Record<string, unknown> | undefined): ModelCardDraft {
+  const base = readModelProviderDraft(config);
+  const raw = (config ?? {})['automationProvider'];
+  return { ...base, automationMode: raw === 'platform' ? 'platform' : 'chat' };
+}
+
+export function applyModelCard(
+  config: Record<string, unknown> | undefined,
+  draft: ModelCardDraft,
+): Record<string, unknown> {
+  const next = applyModelProvider(config, draft);
+  if (draft.automationMode === 'platform') next['automationProvider'] = 'platform';
+  else delete next['automationProvider'];
+  return next;
+}
+
+export function modelCardDirty(
+  config: Record<string, unknown> | undefined,
+  draft: ModelCardDraft,
+): boolean {
+  return JSON.stringify(readModelCardDraft(config)) !== JSON.stringify(draft);
+}
+
+export const ALWAYS_ON_OPTIONS = [
+  { value: 'always', label: 'Always on' },
+  { value: 'upgrade', label: 'On /upgrade' },
+] as const;
+
+export const SUBAGENT_OPTIONS = [
+  { value: 'spaces', label: 'Spaces default' },
+  { value: 'parent', label: 'Follow parent' },
+] as const;
+
+export const AUTOMATION_OPTIONS = [
+  { value: 'chat', label: 'Same as chat' },
+  { value: 'platform', label: 'Platform default' },
+] as const;

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/AddMemberDialog.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/AddMemberDialog.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Search } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { useAuth } from '@/hooks/useAuth';
+import { searchClawUsers } from '@/services/claw/clawAuthAgentsService';
+import type { AgentShareRole, ClawUser } from '@/services/claw/clawAuthAgentTypes';
+import { cn } from '@/utils/classNames';
+import { V2Dialog } from '../../create-v2/shared/V2Dialog';
+import { BehaviourSelect } from '../behaviour/BehaviourRows';
+import { ROLE_OPTIONS } from './roles';
+import { PersonRow } from './PersonRow';
+
+interface AddMemberDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingUserIds: ReadonlySet<string>;
+  defaultRole: AgentShareRole;
+  saving: boolean;
+  onAdd: (user: ClawUser, role: AgentShareRole) => void;
+}
+
+export function AddMemberDialog({
+  open,
+  onOpenChange,
+  existingUserIds,
+  defaultRole,
+  saving,
+  onAdd,
+}: AddMemberDialogProps): ReactElement {
+  const { user } = useAuth();
+  const [query, setQuery] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [role, setRole] = useState<AgentShareRole>(defaultRole);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setDebounced('');
+    setRole(defaultRole);
+  }, [open, defaultRole]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(query.trim()), 250);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const results = useQuery({
+    queryKey: ['claw-user-search', debounced, user?.id],
+    queryFn: () => searchClawUsers(debounced, user!.id),
+    enabled: open && debounced.length >= 2 && !!user?.id,
+    staleTime: 30 * 1000,
+  });
+
+  const candidates = (results.data ?? []).filter(entry => !existingUserIds.has(entry.id));
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Add people'
+      description='Give someone access to this agent.'
+      testId='add-member-dialog'
+      footer={
+        <Button
+          variant='ghost'
+          onClick={() => onOpenChange(false)}
+          className='h-auto rounded-xl px-3 py-2.5 text-[15px]'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: close add member'
+        >
+          Done
+        </Button>
+      }
+    >
+      <div className='flex w-full items-center gap-3'>
+        <div className='relative min-w-0 flex-1'>
+          <Search
+            className='pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground'
+            aria-hidden
+          />
+          <input
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder='Search by name or email'
+            aria-label='Search people'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: search people'
+            className='h-9 w-full rounded-[10px] border border-border bg-background pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+          />
+        </div>
+        <BehaviourSelect
+          value={role}
+          options={ROLE_OPTIONS}
+          editable
+          disabled={saving}
+          label='Role for the person being added'
+          trackName='Agent detail v2: set new member role'
+          onChange={next => setRole(next as AgentShareRole)}
+        />
+      </div>
+
+      <div className={cn('w-full overflow-hidden rounded-2xl border border-border bg-card')}>
+        {debounced.length < 2 ? (
+          <p className='p-4 text-sm leading-5 text-muted-foreground'>
+            Type at least two characters to search your workspace.
+          </p>
+        ) : results.isLoading ? (
+          <p className='p-4 text-sm leading-5 text-muted-foreground'>Searching…</p>
+        ) : candidates.length === 0 ? (
+          <p className='p-4 text-sm leading-5 text-muted-foreground'>
+            No one new matched “{debounced}”.
+          </p>
+        ) : (
+          candidates.map(candidate => (
+            <PersonRow
+              key={candidate.id}
+              userId={candidate.id}
+              name={candidate.name || candidate.email}
+              detail={candidate.email}
+              trailing={
+                <Button
+                  onClick={() => onAdd(candidate, role)}
+                  disabled={saving}
+                  className='h-auto rounded-xl bg-foreground px-3 py-1.5 text-sm text-background hover:bg-foreground/90'
+                  data-track-category='Claw Agents'
+                  data-track-name='Agent detail v2: add member'
+                >
+                  Add
+                </Button>
+              }
+            />
+          ))
+        )}
+      </div>
+    </V2Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/AgentPeopleTabV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/AgentPeopleTabV2.tsx
@@ -1,0 +1,392 @@
+import { useMemo, useRef, useState, type ReactElement } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import {
+  CheckTickSingle,
+  MultipleCrossCancelDefault,
+  PlusDefault,
+  SearchDefault,
+} from '@xyne/icons';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useAuth } from '@/hooks/useAuth';
+import { useClawAgentShares } from '@/hooks/useClawAgentDetail';
+import { useClawCloneRequests } from '@/hooks/useClawCloneRequests';
+import { addClawAgentShare, removeClawAgentShare } from '@/services/claw/clawAuthAgentsService';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import type { Agent, AgentShareRole, ClawUser } from '@/services/claw/clawAuthAgentTypes';
+import { Pill } from '../../create-v2/shared/Pill';
+import { BehaviourSelect } from '../behaviour/BehaviourRows';
+import {
+  DetailCard,
+  DetailEmpty,
+  DetailLockedNote,
+  DetailRow,
+  DetailSection,
+  DetailValue,
+  ReadOnlyBadge,
+} from '../DetailPrimitives';
+import type { AgentDetailActions } from '../useAgentDetailActions';
+import { AddMemberDialog } from './AddMemberDialog';
+import { PersonRow } from './PersonRow';
+import { isShareRole, ROLE_OPTIONS, roleLabel } from './roles';
+
+const VISIBILITY_OPTIONS = [
+  { value: 'global', label: 'Global (Anyone in the workspace)' },
+  { value: 'personal', label: 'Personal (Only people you add)' },
+];
+
+const ICON_BUTTON =
+  'flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40';
+
+export function AgentPeopleTabV2({
+  agent,
+  actions,
+}: {
+  agent: Agent;
+  actions: AgentDetailActions;
+}): ReactElement {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const shares = useClawAgentShares(agent.slug);
+  const cloneRequests = useClawCloneRequests(agent.id, agent.slug);
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const [defaultRole, setDefaultRole] = useState<AgentShareRole>('VIEWER');
+
+  const { isAdmin, isOwner } = actions;
+  const canShare = isOwner || isAdmin;
+
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const entries = (shares.data ?? []).map(share => ({
+      key: share.id,
+      userId: share.userId,
+      name: share.user.name || share.user.email,
+      detail: share.user.email,
+      role: share.role,
+      owner: false,
+    }));
+
+    if (agent.ownerUserId) {
+      entries.unshift({
+        key: `owner-${agent.ownerUserId}`,
+        userId: agent.ownerUserId,
+        name: agent.owner?.name || agent.owner?.email || 'Owner',
+        detail: agent.owner?.email ?? 'Agent creator',
+        role: 'OWNER',
+        owner: true,
+      });
+    }
+
+    return q
+      ? entries.filter(
+          entry => entry.name.toLowerCase().includes(q) || entry.detail.toLowerCase().includes(q),
+        )
+      : entries;
+  }, [shares.data, agent.ownerUserId, agent.owner, query]);
+
+  const existingUserIds = useMemo(
+    () =>
+      new Set([
+        ...(agent.ownerUserId ? [agent.ownerUserId] : []),
+        ...(shares.data ?? []).map(share => share.userId),
+      ]),
+    [agent.ownerUserId, shares.data],
+  );
+
+  const refreshShares = (): void => {
+    void queryClient.invalidateQueries({ queryKey: ['claw-agent-shares', agent.slug, user?.id] });
+  };
+
+  const setRole = async (targetUserId: string, role: AgentShareRole): Promise<void> => {
+    if (!user?.id || busyUserId) return;
+    setBusyUserId(targetUserId);
+    try {
+      // The shares endpoint upserts, so a role change is the same call as an add.
+      await addClawAgentShare(agent.slug, user.id, targetUserId, role);
+      refreshShares();
+      toast.success('Role updated');
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not change that role'));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const addMember = async (target: ClawUser, role: AgentShareRole): Promise<void> => {
+    if (!user?.id || busyUserId) return;
+    setBusyUserId(target.id);
+    try {
+      await addClawAgentShare(agent.slug, user.id, target.id, role);
+      refreshShares();
+      toast.success(`${target.name || target.email} added`);
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not add that person'));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const removeMember = async (targetUserId: string, name: string): Promise<void> => {
+    if (!user?.id || busyUserId) return;
+    setBusyUserId(targetUserId);
+    try {
+      await removeClawAgentShare(agent.slug, user.id, targetUserId);
+      refreshShares();
+      toast.success(`${name} removed`);
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not remove that person'));
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const toggleSearch = (): void => {
+    setSearchOpen(open => {
+      if (open) {
+        setQuery('');
+        return false;
+      }
+      setTimeout(() => searchRef.current?.focus(), 0);
+      return true;
+    });
+  };
+
+  const pending = cloneRequests.data ?? [];
+  const resolving = cloneRequests.approve.isPending || cloneRequests.reject.isPending;
+
+  return (
+    <div className='flex w-full flex-col gap-8'>
+      <DetailSection
+        label='Access'
+        info='Who can find and run this agent'
+        {...(isAdmin ? {} : { trailing: <ReadOnlyBadge />, trailingAlign: 'end' as const })}
+      >
+        <DetailCard>
+          {!isAdmin && (
+            <DetailLockedNote>
+              Only an admin can change who this agent is visible to.
+            </DetailLockedNote>
+          )}
+
+          <DetailRow title='Visibility' hint='Who can find and run this agent'>
+            <BehaviourSelect
+              value={agent.scope === 'global' ? 'global' : 'personal'}
+              options={VISIBILITY_OPTIONS}
+              editable={isAdmin}
+              disabled={actions.busy.moderating !== null}
+              label='Agent visibility'
+              trackName='Agent detail v2: set visibility'
+              onChange={next => {
+                const wantsGlobal = next === 'global';
+                if (wantsGlobal === (agent.scope === 'global')) return;
+                void actions.moderate(wantsGlobal ? 'promote' : 'demote');
+              }}
+            />
+          </DetailRow>
+
+          <DetailRow title='Default role' hint='What new people get when added' last>
+            <BehaviourSelect
+              value={defaultRole}
+              options={ROLE_OPTIONS}
+              editable={canShare}
+              disabled={busyUserId !== null}
+              label='Default role for new people'
+              trackName='Agent detail v2: set default role'
+              onChange={next => {
+                if (isShareRole(next)) setDefaultRole(next);
+              }}
+            />
+          </DetailRow>
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection
+        label='Members'
+        trailing={
+          <span className='flex items-center gap-1'>
+            <button
+              type='button'
+              onClick={toggleSearch}
+              aria-label={searchOpen ? 'Hide search' : 'Search members'}
+              aria-expanded={searchOpen}
+              data-track-category='Claw Agents'
+              data-track-name='Agent detail v2: toggle member search'
+              className={ICON_BUTTON}
+            >
+              <SearchDefault className='size-4' aria-hidden />
+            </button>
+            {canShare && (
+              <button
+                type='button'
+                onClick={() => setAddOpen(true)}
+                aria-label='Add people'
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: open add member'
+                className={ICON_BUTTON}
+              >
+                <PlusDefault className='size-4' aria-hidden />
+              </button>
+            )}
+          </span>
+        }
+        trailingAlign='end'
+      >
+        <DetailCard>
+          {searchOpen && (
+            <div className='border-b border-border p-3'>
+              <input
+                ref={searchRef}
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder='Filter members'
+                aria-label='Filter members'
+                data-track-category='Claw Agents'
+                data-track-name='Agent detail v2: filter members'
+                className='h-9 w-full rounded-[10px] border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring'
+              />
+            </div>
+          )}
+
+          {shares.isLoading ? (
+            <div className='flex w-full flex-col'>
+              {[0, 1, 2].map(row => (
+                <div
+                  key={row}
+                  className='flex items-center gap-3 border-b border-border p-4 last:border-b-0'
+                >
+                  <Skeleton className='size-10 shrink-0 rounded-full' />
+                  <div className='flex min-w-0 flex-1 flex-col gap-1.5'>
+                    <Skeleton className='h-3.5 w-32' />
+                    <Skeleton className='h-3 w-48' />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : rows.length === 0 ? (
+            <DetailEmpty>
+              {query.trim() ? 'No members matched that search.' : 'No one has access yet.'}
+            </DetailEmpty>
+          ) : (
+            rows.map(row => (
+              <PersonRow
+                key={row.key}
+                userId={row.userId}
+                name={row.name}
+                detail={row.detail}
+                trailing={
+                  row.owner ? (
+                    <Pill tone='neutral'>Agent Creator</Pill>
+                  ) : (
+                    <>
+                      {busyUserId === row.userId && (
+                        <Loader2
+                          className='size-3.5 animate-spin text-muted-foreground'
+                          aria-hidden
+                        />
+                      )}
+                      {canShare ? (
+                        <BehaviourSelect
+                          value={row.role}
+                          options={ROLE_OPTIONS}
+                          editable
+                          disabled={busyUserId !== null}
+                          label={`Role for ${row.name}`}
+                          trackName='Agent detail v2: set member role'
+                          onChange={next => {
+                            if (isShareRole(next)) void setRole(row.userId, next);
+                          }}
+                        />
+                      ) : (
+                        <DetailValue>{roleLabel(row.role)}</DetailValue>
+                      )}
+                      {canShare && (
+                        <button
+                          type='button'
+                          onClick={() => void removeMember(row.userId, row.name)}
+                          disabled={busyUserId !== null}
+                          aria-label={`Remove ${row.name}`}
+                          title={`Remove ${row.name}`}
+                          data-track-category='Claw Agents'
+                          data-track-name='Agent detail v2: remove member'
+                          className={ICON_BUTTON}
+                        >
+                          <MultipleCrossCancelDefault className='size-4' aria-hidden />
+                        </button>
+                      )}
+                    </>
+                  )
+                }
+              />
+            ))
+          )}
+        </DetailCard>
+      </DetailSection>
+
+      {canShare && (
+        <DetailSection label='Pending Requests' info='People asking for a copy of this agent'>
+          <DetailCard>
+            {cloneRequests.isLoading ? (
+              <DetailEmpty>Loading requests…</DetailEmpty>
+            ) : pending.length === 0 ? (
+              <DetailEmpty>No pending requests.</DetailEmpty>
+            ) : (
+              pending.map(request => (
+                <PersonRow
+                  key={request.id}
+                  userId={request.requesterId}
+                  name={request.requesterName || request.requesterEmail || request.requesterId}
+                  detail={request.requesterEmail ?? 'Requested a copy of this agent'}
+                  trailing={
+                    <>
+                      <button
+                        type='button'
+                        onClick={() => cloneRequests.approve.mutate(request)}
+                        disabled={resolving}
+                        aria-label='Approve request'
+                        title='Approve request'
+                        data-track-category='Claw Agents'
+                        data-track-name='Agent detail v2: approve clone request'
+                        className={ICON_BUTTON}
+                      >
+                        <CheckTickSingle className='size-4' aria-hidden />
+                      </button>
+                      <button
+                        type='button'
+                        onClick={() => cloneRequests.reject.mutate(request)}
+                        disabled={resolving}
+                        aria-label='Reject request'
+                        title='Reject request'
+                        data-track-category='Claw Agents'
+                        data-track-name='Agent detail v2: reject clone request'
+                        className={ICON_BUTTON}
+                      >
+                        <MultipleCrossCancelDefault className='size-4' aria-hidden />
+                      </button>
+                    </>
+                  }
+                />
+              ))
+            )}
+          </DetailCard>
+        </DetailSection>
+      )}
+
+      <AddMemberDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        existingUserIds={existingUserIds}
+        defaultRole={defaultRole}
+        saving={busyUserId !== null}
+        onAdd={(target, role) => void addMember(target, role)}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/PersonRow.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/PersonRow.tsx
@@ -1,0 +1,27 @@
+import { type ReactElement, type ReactNode } from 'react';
+import Avatar from '@/components/ui/Avatar/Avatar';
+
+export function PersonRow({
+  userId,
+  name,
+  detail,
+  trailing,
+}: {
+  userId: string;
+  name: string;
+  detail: string;
+  trailing?: ReactNode;
+}): ReactElement {
+  return (
+    <div className='flex w-full items-center gap-3 border-b border-border p-4 last:border-b-0'>
+      <Avatar userId={userId} size='md' showActiveStatus className='size-10 shrink-0' />
+
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5 overflow-hidden'>
+        <span className='truncate text-sm leading-5 text-foreground'>{name}</span>
+        <span className='truncate text-sm leading-5 text-foreground/60'>{detail}</span>
+      </div>
+
+      {trailing && <div className='flex shrink-0 items-center gap-1.5'>{trailing}</div>}
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/roles.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/people/roles.ts
@@ -1,0 +1,15 @@
+import type { AgentShareRole } from '@/services/claw/clawAuthAgentTypes';
+
+export const ROLE_OPTIONS: ReadonlyArray<{ value: AgentShareRole; label: string }> = [
+  { value: 'VIEWER', label: 'Viewer (Can view & run)' },
+  { value: 'CONTRIBUTOR', label: 'Contributor (Can edit)' },
+  { value: 'EDITOR', label: 'Editor (Can edit & share)' },
+];
+
+export function roleLabel(role: string): string {
+  return role.charAt(0) + role.slice(1).toLowerCase();
+}
+
+export function isShareRole(value: string): value is AgentShareRole {
+  return value === 'VIEWER' || value === 'CONTRIBUTOR' || value === 'EDITOR';
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/tools/AgentToolsTabV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/tools/AgentToolsTabV2.tsx
@@ -1,0 +1,235 @@
+import { useMemo, type ReactElement } from 'react';
+import { Loader2 } from 'lucide-react';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { BrowseBuiltinToolsDialog } from '../../create-v2/builtin/BrowseBuiltinToolsDialog';
+import {
+  disableEntry as disableBuiltinEntry,
+  isEntryEnabled as isBuiltinEnabled,
+  selectedTools as selectedBuiltinTools,
+} from '../../create-v2/builtin/builtinCatalog';
+import { useBuiltinCatalog } from '../../create-v2/builtin/useBuiltinCatalog';
+import { BrowseMcpsDialog } from '../../create-v2/mcp/BrowseMcpsDialog';
+import {
+  disableEntry as disableMcpEntry,
+  humanizeToolName,
+  isEntryEnabled as isMcpEnabled,
+  selectedTools as selectedMcpTools,
+} from '../../create-v2/mcp/mcpCatalog';
+import { useMcpCatalog } from '../../create-v2/mcp/useMcpCatalog';
+import { BrowseSubagentsDialog } from '../../create-v2/subagent/BrowseSubagentsDialog';
+import { disableSubagent, isSubagentSelected } from '../../create-v2/subagent/subagentCatalog';
+import { useSubagentCatalog } from '../../create-v2/subagent/useSubagentCatalog';
+import { DetailLockedNote, DetailSection, ReadOnlyBadge } from '../DetailPrimitives';
+import { DetailListCard, type DetailListItem } from '../DetailListCard';
+import { useAgentToolSelection, type ManageSectionId } from './useAgentToolSelection';
+
+const LOCK_NOTE = 'Only the owner, a contributor, or an admin can change this agent’s tools.';
+
+function toolCountLabel(count: number): string {
+  return `${count} ${count === 1 ? 'tool' : 'tools'}`;
+}
+
+function ManageButton({ label, onClick }: { label: string; onClick: () => void }): ReactElement {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      aria-label={label}
+      data-track-category='Claw Agents'
+      data-track-name='Agent detail v2: manage tools'
+      className='flex h-6 shrink-0 items-center rounded-md bg-muted px-1.5 text-sm leading-5 text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground'
+    >
+      Manage
+    </button>
+  );
+}
+
+export function AgentToolsTabV2({
+  agent,
+  canEdit,
+}: {
+  agent: Agent;
+  canEdit: boolean;
+}): ReactElement {
+  const tools = useAgentToolSelection(agent);
+  const subagents = useSubagentCatalog();
+  const mcp = useMcpCatalog();
+  const builtin = useBuiltinCatalog();
+
+  const { saved } = tools;
+
+  const subagentItems = useMemo<DetailListItem[]>(
+    () =>
+      subagents.entries
+        .filter(entry => isSubagentSelected(saved, entry))
+        .map(entry => ({
+          key: entry.name,
+          iconType: entry.serverType,
+          name: entry.name,
+          description: entry.description,
+        })),
+    [subagents.entries, saved],
+  );
+
+  const mcpItems = useMemo<DetailListItem[]>(
+    () =>
+      mcp.entries
+        .filter(entry => isMcpEnabled(saved, entry))
+        .map(entry => {
+          const picked = selectedMcpTools(saved, entry);
+          return {
+            key: entry.slug,
+            iconType: entry.iconType,
+            name: entry.label,
+            description:
+              entry.description || picked.map(tool => humanizeToolName(tool.name)).join(', '),
+            meta: toolCountLabel(picked.length),
+          };
+        }),
+    [mcp.entries, saved],
+  );
+
+  const builtinItems = useMemo<DetailListItem[]>(
+    () =>
+      builtin.entries
+        .filter(entry => isBuiltinEnabled(saved, entry))
+        .map(entry => {
+          const picked = selectedBuiltinTools(saved, entry);
+          return {
+            key: entry.source,
+            iconType: '',
+            name: entry.label,
+            description: picked.map(tool => humanizeToolName(tool.name)).join(', '),
+            meta: toolCountLabel(picked.length),
+          };
+        }),
+    [builtin.entries, saved],
+  );
+
+  const note = canEdit ? null : <DetailLockedNote>{LOCK_NOTE}</DetailLockedNote>;
+
+  /** Manage opens the same browse dialog the create flow uses; read-only says why. */
+  const trailingFor = (label: string, section: ManageSectionId): ReactElement =>
+    canEdit ? (
+      <ManageButton label={`Manage ${label}`} onClick={() => tools.openManage(section)} />
+    ) : (
+      <ReadOnlyBadge />
+    );
+
+  return (
+    <div className='flex w-full flex-col gap-8'>
+      <DetailSection
+        label='Subagents'
+        info='Specialists this agent can delegate a whole task to'
+        trailing={trailingFor('subagents', 'subagents')}
+        trailingAlign='end'
+      >
+        <DetailListCard
+          items={subagentItems}
+          loading={subagents.loading}
+          emptyLabel='No subagents added yet.'
+          canEdit={canEdit}
+          note={note}
+          removeLabel={item => `Remove ${item.name}`}
+          onRemove={item => {
+            const entry = subagents.entries.find(candidate => candidate.name === item.key);
+            if (!entry) return;
+            tools.commit(disableSubagent(saved, entry), `${item.name} removed`);
+          }}
+        />
+      </DetailSection>
+
+      <DetailSection
+        label='MCP Tools'
+        info='Tools this agent calls directly on connected integrations'
+        trailing={trailingFor('MCP tools', 'mcp')}
+        trailingAlign='end'
+      >
+        <DetailListCard
+          items={mcpItems}
+          loading={mcp.loading}
+          emptyLabel='No MCP tools added yet.'
+          canEdit={canEdit}
+          note={note}
+          removeLabel={item => `Remove ${item.name}`}
+          onRemove={item => {
+            const entry = mcp.entries.find(candidate => candidate.slug === item.key);
+            if (!entry) return;
+            tools.commit(disableMcpEntry(mcp.entries, saved, entry), `${item.name} removed`);
+          }}
+        />
+      </DetailSection>
+
+      <DetailSection
+        label='Built-In tools'
+        info='Tools that ship with the platform, no connection needed'
+        trailing={trailingFor('built-in tools', 'builtin')}
+        trailingAlign='end'
+      >
+        <DetailListCard
+          items={builtinItems}
+          loading={builtin.loading}
+          emptyLabel='No built-in tools added yet.'
+          canEdit={canEdit}
+          note={note}
+          removeLabel={item => `Remove ${item.name}`}
+          onRemove={item => {
+            const entry = builtin.entries.find(candidate => candidate.source === item.key);
+            if (!entry) return;
+            tools.commit(disableBuiltinEntry(saved, entry), `${item.name} removed`);
+          }}
+        />
+      </DetailSection>
+
+      {tools.saving && (
+        <span className='flex items-center gap-2 text-xs font-normal leading-4 text-muted-foreground'>
+          <Loader2 className='size-3.5 animate-spin' aria-hidden />
+          Saving…
+        </span>
+      )}
+
+      <BrowseSubagentsDialog
+        open={tools.manage === 'subagents'}
+        onOpenChange={open => {
+          if (!open) tools.closeManage();
+        }}
+        catalog={subagents.entries}
+        loading={subagents.loading}
+        isError={subagents.isError}
+        onRetry={subagents.refetch}
+        selection={tools.draft}
+        onSelectionChange={tools.setDraft}
+        suggested={[]}
+      />
+
+      <BrowseMcpsDialog
+        open={tools.manage === 'mcp'}
+        onOpenChange={open => {
+          if (!open) tools.closeManage();
+        }}
+        catalog={mcp.entries}
+        connectedServerIds={mcp.connectedServerIds}
+        loading={mcp.loading}
+        isError={mcp.isError}
+        onRetry={mcp.refetch}
+        selection={tools.draft}
+        onSelectionChange={tools.setDraft}
+        suggested={[]}
+      />
+
+      <BrowseBuiltinToolsDialog
+        open={tools.manage === 'builtin'}
+        onOpenChange={open => {
+          if (!open) tools.closeManage();
+        }}
+        catalog={builtin.entries}
+        loading={builtin.loading}
+        isError={builtin.isError}
+        onRetry={builtin.refetch}
+        selection={tools.draft}
+        onSelectionChange={tools.setDraft}
+        suggested={[]}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/tools/useAgentToolSelection.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/tools/useAgentToolSelection.ts
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { clawAgentDetailKey } from '@/hooks/useClawAgentDetail';
+import { updateClawAgent } from '@/services/claw/clawAuthAgentsService';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import type { ToolboxSelection } from '@/services/claw/clawToolsTypes';
+import { readToolSelection } from '../../create-v2/agentDraft';
+
+export type ToolSelection = Required<ToolboxSelection>;
+
+export type ManageSectionId = 'subagents' | 'mcp' | 'builtin';
+
+export type ManageSection = ManageSectionId | null;
+
+export interface AgentToolSelection {
+  saved: ToolSelection;
+  draft: ToolSelection;
+  manage: ManageSection;
+  saving: boolean;
+  openManage: (section: ManageSectionId) => void;
+  closeManage: () => void;
+  setDraft: (next: ToolSelection) => void;
+  commit: (next: ToolSelection, message: string) => void;
+}
+
+function sameList(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every(entry => b.includes(entry));
+}
+
+export function selectionEqual(a: ToolSelection, b: ToolSelection): boolean {
+  return (
+    sameList(a.subagents, b.subagents) &&
+    sameList(a.direct, b.direct) &&
+    sameList(a.custom, b.custom) &&
+    sameList(a.gateway, b.gateway)
+  );
+}
+
+export function useAgentToolSelection(agent: Agent): AgentToolSelection {
+  const queryClient = useQueryClient();
+  const [saving, setSaving] = useState(false);
+  const [manage, setManage] = useState<ManageSection>(null);
+  const [draft, setDraft] = useState<ToolSelection | null>(null);
+
+  const saved = readToolSelection(agent.config ?? {});
+
+  const persist = async (next: ToolSelection, message: string): Promise<void> => {
+    if (saving) return;
+    setSaving(true);
+    const previous = agent;
+    const config = { ...(agent.config ?? {}), tools: next };
+    queryClient.setQueryData(clawAgentDetailKey(agent.slug), { ...agent, config });
+    try {
+      const updated = await updateClawAgent(agent.slug, { config });
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), updated);
+      void queryClient.invalidateQueries({ queryKey: ['claw-auth-agents'] });
+      toast.success(message);
+    } catch (err) {
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), previous);
+      toast.error(clawErrorText(err, 'Could not update this agent'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return {
+    saved,
+    draft: draft ?? saved,
+    manage,
+    saving,
+    openManage: section => {
+      setDraft(saved);
+      setManage(section);
+    },
+    closeManage: () => {
+      const next = draft;
+      setManage(null);
+      setDraft(null);
+      if (next && !selectionEqual(next, saved)) void persist(next, 'Tools updated');
+    },
+    setDraft,
+    commit: (next, message) => void persist(next, message),
+  };
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/useAgentDetailActions.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/detail-v2/useAgentDetailActions.ts
@@ -1,0 +1,200 @@
+import { useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useAuth } from '@/hooks/useAuth';
+import { useIsClawAdmin } from '@/hooks/useIsClawAdmin';
+import { clawAgentDetailKey, useClawAgentShares } from '@/hooks/useClawAgentDetail';
+import { getAgentPermissions, type AgentPermissions } from '@/services/claw/agentPermissions';
+import {
+  ClawApiError,
+  cloneClawAgent,
+  demoteClawAgent,
+  deleteClawAgent,
+  promoteClawAgent,
+  submitClawAgentRequest,
+  updateClawAgent,
+} from '@/services/claw/clawAuthAgentsService';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+
+export type ModerationAction = 'promote' | 'demote';
+
+export interface AgentDetailActions {
+  permissions: AgentPermissions | null;
+  isAdmin: boolean;
+  /** True ownership — an admin is NOT an owner for Publish-vs-Promote gating. */
+  isOwner: boolean;
+  busy: {
+    toggling: boolean;
+    deleting: boolean;
+    cloning: boolean;
+    publishing: boolean;
+    moderating: ModerationAction | null;
+    renaming: boolean;
+  };
+  toggleEnabled: (next: boolean) => Promise<void>;
+  remove: () => Promise<void>;
+  clone: (name: string) => Promise<void>;
+  publish: () => Promise<void>;
+  moderate: (action: ModerationAction) => Promise<void>;
+  rename: (nextSlug: string) => Promise<void>;
+}
+export function useAgentDetailActions(agent: Agent | undefined): AgentDetailActions {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const userId = user?.id;
+
+  const { data: isAdmin = false } = useIsClawAdmin();
+  const { data: shares } = useClawAgentShares(agent?.slug);
+
+  const [toggling, setToggling] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [cloning, setCloning] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [moderating, setModerating] = useState<ModerationAction | null>(null);
+
+  const permissions = useMemo(
+    () => (agent ? getAgentPermissions(agent, userId ?? '', shares ?? [], isAdmin) : null),
+    [agent, userId, shares, isAdmin],
+  );
+
+  const isOwner = Boolean(agent && userId && agent.ownerUserId === userId);
+
+  // Absolute, not relative: `..` resolves against the matched route
+  // (`library/agent/:slug`), which lands on `/library/agent` — not a real route.
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
+  const libraryPath = workspaceId ? `/${workspaceId}/ai/library` : '/ai/library';
+  const detailPath = (slug: string): string => `${libraryPath}/agent/${slug}?tab=persona`;
+
+  const refreshLists = (): void => {
+    void queryClient.invalidateQueries({ queryKey: ['claw-auth-agents'] });
+  };
+
+  const toggleEnabled = async (next: boolean): Promise<void> => {
+    if (!agent || toggling) return;
+    setToggling(true);
+    const previous = agent;
+    queryClient.setQueryData(clawAgentDetailKey(agent.slug), { ...agent, enabled: next });
+    try {
+      const updated = await updateClawAgent(agent.slug, { enabled: next });
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), updated);
+      refreshLists();
+      toast.success(next ? `${agent.name} enabled` : `${agent.name} paused`);
+    } catch (err) {
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), previous);
+      toast.error(clawErrorText(err, 'Could not update this agent'));
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const remove = async (): Promise<void> => {
+    if (!agent || !userId || deleting) return;
+    setDeleting(true);
+    try {
+      await deleteClawAgent(agent.slug, userId);
+      refreshLists();
+      toast.success(`${agent.name} deleted`);
+      void navigate(`${libraryPath}?tab=agents`);
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Failed to delete agent'));
+      setDeleting(false);
+    }
+  };
+
+  const clone = async (name: string): Promise<void> => {
+    if (!agent || !userId || cloning) return;
+    setCloning(true);
+    try {
+      const result = await cloneClawAgent(agent.slug, userId, name);
+      refreshLists();
+      if (result.cloned && result.agent) {
+        toast.success(`Cloned “${agent.name}”`, { description: `Saved as ${result.agent.name}.` });
+        void navigate(`${libraryPath}?tab=agents`);
+      } else {
+        toast.success('Clone request sent', {
+          description: `${agent.name}’s owner will review it.`,
+        });
+      }
+    } catch (err) {
+      if (err instanceof ClawApiError && err.status === 409) {
+        toast.info('Request already pending');
+      } else {
+        toast.error(clawErrorText(err, 'Clone failed'));
+      }
+    } finally {
+      setCloning(false);
+    }
+  };
+
+  const publish = async (): Promise<void> => {
+    if (!agent || !userId || publishing) return;
+    setPublishing(true);
+    try {
+      await submitClawAgentRequest(agent.slug, userId, 'push_to_global');
+      toast.success('Publish request sent', { description: 'An admin will review it.' });
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Publish failed'));
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  const moderate = async (action: ModerationAction): Promise<void> => {
+    if (!agent || !userId || moderating) return;
+    setModerating(action);
+    const previous = agent;
+    const scope = action === 'promote' ? 'global' : 'personal';
+    queryClient.setQueryData(clawAgentDetailKey(agent.slug), { ...agent, scope });
+    try {
+      if (action === 'promote') await promoteClawAgent(agent.slug, userId);
+      else await demoteClawAgent(agent.slug, userId);
+      refreshLists();
+      void queryClient.invalidateQueries({ queryKey: clawAgentDetailKey(agent.slug) });
+      toast.success(
+        `${agent.name} ${action === 'promote' ? 'promoted to global' : 'demoted to personal'}`,
+      );
+    } catch (err) {
+      queryClient.setQueryData(clawAgentDetailKey(agent.slug), previous);
+      toast.error(clawErrorText(err, action === 'promote' ? 'Promote failed' : 'Demote failed'));
+    } finally {
+      setModerating(null);
+    }
+  };
+
+  const rename = async (nextSlug: string): Promise<void> => {
+    if (!agent || !isOwner || renaming) return;
+    setRenaming(true);
+    try {
+      const updated = await updateClawAgent(agent.slug, { slug: nextSlug });
+      queryClient.removeQueries({ queryKey: clawAgentDetailKey(agent.slug), exact: true });
+      queryClient.setQueryData(clawAgentDetailKey(nextSlug), updated);
+      refreshLists();
+      toast.success(`Handle renamed to @${nextSlug}`);
+      void navigate(detailPath(nextSlug), { replace: true });
+    } catch (err) {
+      if (err instanceof ClawApiError && err.status === 409) {
+        throw new Error(`The handle “${nextSlug}” is already in use.`);
+      }
+      throw new Error(clawErrorText(err, 'Could not rename this handle'));
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  return {
+    permissions,
+    isAdmin,
+    isOwner,
+    busy: { toggling, deleting, cloning, publishing, moderating, renaming },
+    toggleEnabled,
+    remove,
+    clone,
+    publish,
+    moderate,
+    rename,
+  };
+}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/library/AgentsV2.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/library/AgentsV2.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { useClawAuthAgents } from '@/hooks/useClawAuthAgents';
 import type { Agent } from '@/services/claw/clawAuthAgentTypes';
@@ -14,6 +15,8 @@ import { LibraryToolbarPortal } from './components/LibraryToolbarSlot';
 import { useCategoryFilter } from './hooks/useCategoryFilter';
 
 const AgentsV2 = ({ query }: { query: string }): ReactElement => {
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
+  const prefixWs = (path: string): string => (workspaceId ? `/${workspaceId}${path}` : path);
   const { data, isLoading, isError, refetch } = useClawAuthAgents();
   const agents = useMemo(() => data ?? [], [data]);
 
@@ -85,7 +88,7 @@ const AgentsV2 = ({ query }: { query: string }): ReactElement => {
           items: section.agents.map(agent => (
             <LibraryCard
               key={agent.id}
-              to={`/claw-agents/agents/${agent.slug}?tab=persona`}
+              to={prefixWs(`/ai/library/agent/${agent.slug}?tab=persona`)}
               testId='claw-agent-card'
               icon={<LibraryIconTile name={agent.name} color={agent.color || '#6366f1'} />}
               name={agent.name}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/library/components/LibraryCard.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/library/components/LibraryCard.tsx
@@ -11,20 +11,24 @@ const getInitials = (name: string): string => {
   }
   return name.slice(0, 2).toUpperCase();
 };
+const TILE_SIZE = { sm: 'size-8', md: 'size-10' } as const;
 
 export function LibraryIconTile({
   name,
   color,
+  size = 'sm',
   children,
 }: {
   name?: string;
   color?: string;
+  size?: keyof typeof TILE_SIZE;
   children?: ReactNode;
 }): ReactElement {
   return (
     <span
       className={cn(
-        'flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg text-sm font-normal shadow-sm',
+        'flex shrink-0 items-center justify-center overflow-hidden rounded-lg text-sm font-normal shadow-sm',
+        TILE_SIZE[size],
 
         color ? 'text-white' : 'border border-border bg-card text-muted-foreground',
       )}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
