### PR TITLE
feat: using org member id for provisioning

### DIFF
--- a/apps/backend/src/apps/core/emailUtils.ts
+++ b/apps/backend/src/apps/core/emailUtils.ts
@@ -134,6 +134,7 @@ export async function dispatchEmailEventForEmailId(emailId: string): Promise<voi
       id: email.id,
       ticketId: ticket?.id ?? '',
       channelName: channel?.name ?? '',
+      ...(channel?.workspaceId ? { workspaceId: channel.workspaceId } : {}),
     };
 
     const event: BaseAppEvent = {

--- a/apps/backend/src/apps/types/index.ts
+++ b/apps/backend/src/apps/types/index.ts
@@ -53,6 +53,10 @@ export interface AppEventAttachment {
  * Payload type for APP_MENTION events
  */
 export interface AppMentionEventPayload {
+    /** Additive trusted routing context for headless recipients such as Claw. */
+    workspaceId?: string;
+    orgId?: string;
+    orgMemberId?: string;
     conversationId: string;
     messageId: string;
     content: string;
@@ -70,6 +74,9 @@ export interface AppMentionEventPayload {
  * Payload type for DM events
  */
 export interface DMEventPayload {
+    workspaceId?: string;
+    orgId?: string;
+    orgMemberId?: string;
     conversationId: string;
     messageId: string;
     content: string;
@@ -88,6 +95,9 @@ export interface DMEventPayload {
  * in a channel where an app is a participant.
  */
 export interface UserMentionedEventPayload {
+    workspaceId?: string;
+    orgId?: string;
+    orgMemberId?: string;
     conversationId: string;
     messageId: string;
     content: string;
@@ -105,6 +115,8 @@ export interface UserMentionedEventPayload {
  * Payload type for EMAIL events
  */
 export interface EmailEventPayload {
+    workspaceId?: string;
+    orgId?: string;
     conversationId: string;
     subject: string;
     content: string;
@@ -133,6 +145,7 @@ export interface AdditionalFormFieldUpdatedPayload {
     previousValue?: string;
     updatedBy: string;
     workspaceId: string;
+    orgId?: string;
 }
 
 export interface DeskReplyAttachment {

--- a/apps/backend/src/automations/services/claw-client.ts
+++ b/apps/backend/src/automations/services/claw-client.ts
@@ -26,10 +26,9 @@ export interface RunAgentRequest {
   agentSlug: string;
   task: string;
   userId: string;
-  /** Additive context for headless calls. Existing Claw callbacks ignore it. */
-  spacesWorkspaceId?: string;
-  spacesOrgId?: string;
-  spacesOrgMemberId?: string;
+  spacesWorkspaceId: string;
+  spacesOrgId: string;
+  spacesOrgMemberId: string;
   callbackUrl: string;
   context?: string;
   conversationId?: string;
@@ -90,9 +89,9 @@ class ClawClient {
       sessionId: req.sessionId,
       task: req.task,
       userId: req.userId,
-      ...(req.spacesWorkspaceId ? { spacesWorkspaceId: req.spacesWorkspaceId } : {}),
-      ...(req.spacesOrgId ? { spacesOrgId: req.spacesOrgId } : {}),
-      ...(req.spacesOrgMemberId ? { spacesOrgMemberId: req.spacesOrgMemberId } : {}),
+      spacesWorkspaceId: req.spacesWorkspaceId,
+      spacesOrgId: req.spacesOrgId,
+      spacesOrgMemberId: req.spacesOrgMemberId,
       callbackUrl: req.callbackUrl,
       ...(req.context ? { context: req.context } : {}),
       ...(req.conversationId ? { conversationId: req.conversationId } : {}),

--- a/apps/backend/src/automations/services/claw-client.ts
+++ b/apps/backend/src/automations/services/claw-client.ts
@@ -26,6 +26,10 @@ export interface RunAgentRequest {
   agentSlug: string;
   task: string;
   userId: string;
+  /** Additive context for headless calls. Existing Claw callbacks ignore it. */
+  spacesWorkspaceId?: string;
+  spacesOrgId?: string;
+  spacesOrgMemberId?: string;
   callbackUrl: string;
   context?: string;
   conversationId?: string;
@@ -86,6 +90,9 @@ class ClawClient {
       sessionId: req.sessionId,
       task: req.task,
       userId: req.userId,
+      ...(req.spacesWorkspaceId ? { spacesWorkspaceId: req.spacesWorkspaceId } : {}),
+      ...(req.spacesOrgId ? { spacesOrgId: req.spacesOrgId } : {}),
+      ...(req.spacesOrgMemberId ? { spacesOrgMemberId: req.spacesOrgMemberId } : {}),
       callbackUrl: req.callbackUrl,
       ...(req.context ? { context: req.context } : {}),
       ...(req.conversationId ? { conversationId: req.conversationId } : {}),

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -336,15 +336,21 @@ async function resolveRunUserId(spacesAppId: string, fallbackUserId: string): Pr
 async function resolveHeadlessIdentityContext(
   userId: string,
   workspaceId: string,
-): Promise<{ spacesWorkspaceId: string; spacesOrgId?: string; spacesOrgMemberId?: string }> {
+): Promise<{ spacesWorkspaceId: string; spacesOrgId: string; spacesOrgMemberId: string }> {
   const [workspace, user] = await Promise.all([
     db.workspace.findUnique({ where: { id: workspaceId }, select: { orgId: true } }),
     db.user.findUnique({ where: { id: userId }, select: { orgMemberId: true } }),
   ]);
+  if (!workspace?.orgId) {
+    throw new Error(`[RUN_AGENT] workspace ${workspaceId} has no organization`);
+  }
+  if (!user?.orgMemberId) {
+    throw new Error(`[RUN_AGENT] user ${userId} has no orgMemberId`);
+  }
   return {
     spacesWorkspaceId: workspaceId,
-    ...(workspace?.orgId ? { spacesOrgId: workspace.orgId } : {}),
-    ...(user?.orgMemberId ? { spacesOrgMemberId: user.orgMemberId } : {}),
+    spacesOrgId: workspace.orgId,
+    spacesOrgMemberId: user.orgMemberId,
   };
 }
 

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -73,6 +73,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const prompt = cfg.prompt as string;
     const spacesAppId = await resolveSpacesAppId(cfg, agentSlug, context.automation.workspaceId);
     const runUserId = await resolveRunUserId(spacesAppId, context.automation.createdById);
+    const identityContext = await resolveHeadlessIdentityContext(runUserId, context.automation.workspaceId);
     const visibleContext = resolveVisibleConversationContext(context);
 
     logger.info(
@@ -86,6 +87,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
         agentSlug,
         task: prompt,
         userId: runUserId,
+        ...identityContext,
         callbackUrl,
         ...(visibleContext ? visibleContext : {}),
       });
@@ -180,6 +182,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     );
     const spacesAppId = await resolveSpacesAppId(cfg, agentSlug, context.automation.workspaceId);
     const runUserId = await resolveRunUserId(spacesAppId, context.automation.createdById);
+    const identityContext = await resolveHeadlessIdentityContext(runUserId, context.automation.workspaceId);
     const callbackUrl = buildCallbackUrl(store.runId, stepName);
     const visibleContext = resolveVisibleConversationContext(context);
 
@@ -194,6 +197,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
         agentSlug,
         task: retryPrompt,
         userId: runUserId,
+        ...identityContext,
         callbackUrl,
         ...(visibleContext ? visibleContext : {}),
       });
@@ -322,6 +326,26 @@ async function resolveRunUserId(spacesAppId: string, fallbackUserId: string): Pr
     );
   }
   return fallbackUserId;
+}
+
+/**
+ * Queue workers do not have a browser cookie. Resolve the workspace context
+ * from Spaces itself and send it as optional metadata, preserving the legacy
+ * raw userId field for older Claw deployments.
+ */
+async function resolveHeadlessIdentityContext(
+  userId: string,
+  workspaceId: string,
+): Promise<{ spacesWorkspaceId: string; spacesOrgId?: string; spacesOrgMemberId?: string }> {
+  const [workspace, user] = await Promise.all([
+    db.workspace.findUnique({ where: { id: workspaceId }, select: { orgId: true } }),
+    db.user.findUnique({ where: { id: userId }, select: { orgMemberId: true } }),
+  ]);
+  return {
+    spacesWorkspaceId: workspaceId,
+    ...(workspace?.orgId ? { spacesOrgId: workspace.orgId } : {}),
+    ...(user?.orgMemberId ? { spacesOrgMemberId: user.orgMemberId } : {}),
+  };
 }
 
 function deriveStepNameFromCtx(context: AutomationContext): string | null {

--- a/apps/backend/src/controllers/aiProvisioningBackfillController.ts
+++ b/apps/backend/src/controllers/aiProvisioningBackfillController.ts
@@ -1,0 +1,700 @@
+import { Request, Response } from 'express';
+import {
+  AIProvisioningProvider,
+  AIProvisioningStatus as AIProvisioningStatusValue,
+  AIProvisioningSubjectType,
+  OrgLLMServiceAccountCredentialStatus,
+  OrgLLMServiceAccountProvider,
+  OrgLLMServiceAccountPurpose,
+  WorkspaceType,
+} from '@xyne/shared';
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+import { config } from '@/config/env';
+import { decrypt, encrypt } from '@/services/encryptionService';
+import {
+  clawSpacesSyncClient,
+  ClawSyncOrgPayload,
+  ClawSyncWorkspacePayload,
+  ClawSyncUserPayload,
+} from '@/services/clawSpacesSyncClient';
+import {
+  litellmProvisioningClient,
+  LiteLLMProvisioningError,
+} from '@/services/litellmProvisioningClient';
+import type { ApiResponse } from '@/types/express';
+
+type BackfillMode = 'orgs' | 'workspaces' | 'users';
+
+type BackfillOptions = {
+  mode: BackfillMode;
+  dryRun: boolean;
+  batchSize: number;
+};
+
+type SubjectSummary = {
+  total: number;
+  skipped: number;
+  success: number;
+  errors: number;
+};
+
+type BackfillResult = {
+  mode: BackfillMode;
+  summary: SubjectSummary;
+  errors: Array<{ id: string; error: string }>;
+};
+
+const ORG_SERVICE_ACCOUNT_PURPOSES = [
+  OrgLLMServiceAccountPurpose.DEFAULT,
+  OrgLLMServiceAccountPurpose.ASK_AI,
+  OrgLLMServiceAccountPurpose.CALL_TRANSCRIPT,
+  OrgLLMServiceAccountPurpose.ACTIVITY_CLASSIFICATION,
+] as const;
+
+interface OrgLiteLLMServiceAccountCredentials {
+  source: 'xyne-spaces';
+  litellmTeamId: string;
+  litellmUserId?: string;
+  key?: string;
+  tokenId?: string;
+  keyName?: string;
+  keyAlias?: string;
+  providerUrl: string;
+  defaultModel?: string | null;
+  defaultModels?: string[];
+  serviceAccountName?: string;
+  serviceAccountAlias?: string;
+  expires?: string;
+  teamAlias?: string;
+  purpose?: OrgLLMServiceAccountPurpose;
+  provisionedAt: string;
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'org';
+}
+
+export class AiProvisioningBackfillController {
+  private static prisma = DatabaseClient.getInstance();
+
+  private static buildOptions(body: unknown): BackfillOptions {
+    const payload = body as Partial<{ mode: BackfillMode; dryRun: boolean; batchSize: number }>;
+    return {
+      mode: payload.mode ?? 'orgs',
+      dryRun: payload.dryRun === true,
+      batchSize: payload.batchSize && payload.batchSize > 0 ? payload.batchSize : 5,
+    };
+  }
+
+  private static async isProvisioned(
+    subjectType: AIProvisioningSubjectType,
+    subjectId: string,
+  ): Promise<boolean> {
+    const row = await this.prisma.aiProvisioningStatus.findUnique({
+      where: {
+        subjectType_subjectId_provider: {
+          subjectType,
+          subjectId,
+          provider: AIProvisioningProvider.CLAW_LITELLM,
+        },
+      },
+      select: { status: true },
+    });
+    return row?.status === AIProvisioningStatusValue.SUCCESS;
+  }
+
+  private static async markStatus(
+    subjectType: AIProvisioningSubjectType,
+    subjectId: string,
+    status: AIProvisioningStatusValue,
+    error?: string,
+  ): Promise<void> {
+    const now = new Date();
+    const existing = await this.prisma.aiProvisioningStatus.findUnique({
+      where: {
+        subjectType_subjectId_provider: {
+          subjectType,
+          subjectId,
+          provider: AIProvisioningProvider.CLAW_LITELLM,
+        },
+      },
+    });
+
+    if (existing) {
+      await this.prisma.aiProvisioningStatus.update({
+        where: { id: existing.id },
+        data: {
+          status,
+          lastError: error ?? null,
+          lastAttemptedAt: now,
+          updatedAt: now,
+        },
+      });
+    } else {
+      await this.prisma.aiProvisioningStatus.create({
+        data: {
+          subjectType,
+          subjectId,
+          provider: AIProvisioningProvider.CLAW_LITELLM,
+          status,
+          attempts: 1,
+          lastError: error ?? null,
+          lastAttemptedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+    }
+  }
+
+  // ── ORG PROVISIONING ──────────────────────────────────────────────────
+
+  private static async provisionOrg(orgId: string): Promise<void> {
+    const org = await this.prisma.organization.findUnique({
+      where: { orgId },
+      select: { orgId: true, name: true, description: true, createdBy: true, status: true },
+    });
+    if (!org) {
+      throw new Error(`Organization not found: ${orgId}`);
+    }
+
+    const orgPayload: ClawSyncOrgPayload = {
+      spacesOrgId: org.orgId,
+      name: org.name,
+      description: org.description,
+      createdBySpacesUserId: org.createdBy,
+      status: org.status,
+    };
+
+    await clawSpacesSyncClient.syncOrg(orgPayload);
+
+    const teamId = await this.ensureLiteLLMTeam(orgPayload);
+    await this.ensureOrgCredentials(orgPayload, teamId);
+  }
+
+  private static async ensureLiteLLMTeam(orgPayload: ClawSyncOrgPayload): Promise<string> {
+    const existing = await this.getOrgLiteLLMTeamId(orgPayload.spacesOrgId);
+    if (existing) {
+      await litellmProvisioningClient.storeTeam({
+        orgId: orgPayload.spacesOrgId,
+        teamId: existing,
+        teamAlias: orgPayload.name,
+        status: orgPayload.status,
+      });
+      return existing;
+    }
+
+    const team = await litellmProvisioningClient.createTeam({
+      orgId: orgPayload.spacesOrgId,
+      teamAlias: orgPayload.name,
+    });
+
+    await litellmProvisioningClient.storeTeam({
+      orgId: orgPayload.spacesOrgId,
+      teamId: team.teamId,
+      teamAlias: team.teamAlias ?? orgPayload.name,
+      status: orgPayload.status,
+    });
+    return team.teamId;
+  }
+
+  private static async getOrgLiteLLMTeamId(orgId: string): Promise<string | null> {
+    const credential = await this.prisma.orgLLMServiceAccountCredential.findUnique({
+      where: {
+        orgId_provider_purpose: {
+          orgId,
+          provider: OrgLLMServiceAccountProvider.LITELLM,
+          purpose: OrgLLMServiceAccountPurpose.DEFAULT,
+        },
+      },
+      select: { credentials: true, status: true },
+    });
+
+    if (!credential || credential.status === OrgLLMServiceAccountCredentialStatus.REVOKED) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(decrypt(credential.credentials)) as Partial<OrgLiteLLMServiceAccountCredentials>;
+      return typeof parsed.litellmTeamId === 'string' && parsed.litellmTeamId.trim()
+        ? parsed.litellmTeamId
+        : null;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new LiteLLMProvisioningError(
+        `Failed to read org LiteLLM service account credentials for org ${orgId}: ${message}`,
+        { retryable: false },
+      );
+    }
+  }
+
+  private static async ensureOrgCredentials(
+    orgPayload: ClawSyncOrgPayload,
+    litellmTeamId: string,
+  ): Promise<void> {
+    for (const purpose of ORG_SERVICE_ACCOUNT_PURPOSES) {
+      await this.ensureOrgCredential(orgPayload, litellmTeamId, purpose);
+    }
+  }
+
+  private static async ensureOrgCredential(
+    orgPayload: ClawSyncOrgPayload,
+    litellmTeamId: string,
+    purpose: OrgLLMServiceAccountPurpose,
+  ): Promise<void> {
+    const existing = await this.prisma.orgLLMServiceAccountCredential.findUnique({
+      where: {
+        orgId_provider_purpose: {
+          orgId: orgPayload.spacesOrgId,
+          provider: OrgLLMServiceAccountProvider.LITELLM,
+          purpose,
+        },
+      },
+      select: { status: true },
+    });
+
+    if (existing?.status === OrgLLMServiceAccountCredentialStatus.ACTIVE) {
+      return;
+    }
+
+    const orgName = orgPayload.name || orgPayload.spacesOrgId;
+    const serviceAccountName = `${purpose}-${orgName}-service-account`;
+    const orgSlug = slugify(orgName);
+    const purposeSlug = purpose.toLowerCase().replace(/_/g, '-');
+    const litellmUserId = `claw-service-account-${orgPayload.spacesOrgId}-${purpose}`;
+    const externalUserId = `${orgPayload.spacesOrgId}-${purpose}`;
+
+    await this.storeOrgCredential({
+      orgPayload,
+      litellmTeamId,
+      purpose,
+      status: OrgLLMServiceAccountCredentialStatus.PENDING,
+      litellmUserId,
+      keyAlias: serviceAccountName,
+      serviceAccountName,
+    });
+
+    try {
+      await litellmProvisioningClient.createUser({
+        orgId: orgPayload.spacesOrgId,
+        userId: externalUserId,
+        email: `${purposeSlug}@${orgSlug}-service-account`,
+        name: serviceAccountName,
+        teamId: litellmTeamId,
+        litellmUserId,
+        metadata: { purpose, source: 'xyne-spaces', service_account: true },
+      });
+    } catch (error) {
+      if (error instanceof LiteLLMProvisioningError && error.statusCode === 409) {
+        logger.info(`[AiProvisioningBackfill] Service account user already exists for ${purpose}, continuing`);
+      } else {
+        throw error;
+      }
+    }
+
+    const key = await litellmProvisioningClient.generateKey({
+      orgId: orgPayload.spacesOrgId,
+      userId: externalUserId,
+      email: `${purposeSlug}@${orgSlug}-service-account`,
+      litellmUserId,
+      teamId: litellmTeamId,
+      keyAlias: serviceAccountName,
+      metadata: { purpose, source: 'xyne-spaces', service_account: true },
+    });
+
+    await this.storeOrgCredential({
+      orgPayload,
+      litellmTeamId,
+      purpose,
+      status: OrgLLMServiceAccountCredentialStatus.ACTIVE,
+      litellmUserId,
+      key: key.key,
+      tokenId: key.tokenId,
+      keyName: key.keyName,
+      keyAlias: key.keyAlias,
+      serviceAccountName,
+      expires: key.expires,
+    });
+  }
+
+  private static async storeOrgCredential(params: {
+    orgPayload: ClawSyncOrgPayload;
+    litellmTeamId: string;
+    purpose: OrgLLMServiceAccountPurpose;
+    status: OrgLLMServiceAccountCredentialStatus;
+    litellmUserId?: string;
+    key?: string;
+    tokenId?: string;
+    keyName?: string;
+    keyAlias?: string;
+    serviceAccountName?: string;
+    expires?: string;
+  }): Promise<void> {
+    const { orgPayload, litellmTeamId, purpose, status, ...rest } = params;
+    const now = new Date();
+    const credentials: OrgLiteLLMServiceAccountCredentials = {
+      source: 'xyne-spaces',
+      litellmTeamId,
+      ...rest,
+      providerUrl: config.litellm.baseUrl,
+      defaultModel: config.aiProvisioning.orgDefaultModels[0] ?? null,
+      defaultModels: config.aiProvisioning.orgDefaultModels,
+      teamAlias: orgPayload.name,
+      purpose,
+      provisionedAt: now.toISOString(),
+    };
+
+    const encrypted = encrypt(JSON.stringify(credentials));
+
+    await this.prisma.orgLLMServiceAccountCredential.upsert({
+      where: {
+        orgId_provider_purpose: {
+          orgId: orgPayload.spacesOrgId,
+          provider: OrgLLMServiceAccountProvider.LITELLM,
+          purpose,
+        },
+      },
+      create: {
+        orgId: orgPayload.spacesOrgId,
+        provider: OrgLLMServiceAccountProvider.LITELLM,
+        purpose,
+        credentials: encrypted,
+        status,
+        lastProvisionedAt: status === OrgLLMServiceAccountCredentialStatus.ACTIVE ? now : null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      update: {
+        credentials: encrypted,
+        status,
+        lastProvisionedAt: status === OrgLLMServiceAccountCredentialStatus.ACTIVE ? now : null,
+        updatedAt: now,
+      },
+    });
+  }
+
+  // ── WORKSPACE PROVISIONING ────────────────────────────────────────────
+
+  private static async provisionWorkspace(workspaceId: string): Promise<void> {
+    const workspace = await this.prisma.workspace.findUnique({
+      where: { id: workspaceId },
+      select: {
+        id: true,
+        orgId: true,
+        name: true,
+        description: true,
+        createdBy: true,
+        status: true,
+        organization: { select: { name: true } },
+      },
+    });
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
+    }
+
+    const workspacePayload: ClawSyncWorkspacePayload = {
+      spacesWorkspaceId: workspace.id,
+      spacesOrgId: workspace.orgId,
+      name: workspace.name,
+      orgName: workspace.organization.name,
+      description: workspace.description,
+      createdBySpacesUserId: workspace.createdBy,
+      status: workspace.status,
+    };
+
+    await clawSpacesSyncClient.syncWorkspace(workspacePayload);
+  }
+
+  // ── USER PROVISIONING ────────────────────────────────────────────────
+
+  private static async provisionUser(orgMemberId: string): Promise<void> {
+    const user = await this.prisma.user.findFirst({
+      where: { orgMemberId, leftAt: null },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        orgMemberId: true,
+        status: true,
+        workspace: {
+          select: {
+            id: true,
+            orgId: true,
+            name: true,
+            workspaceType: true,
+            createdBy: true,
+            organization: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    if (!user) {
+      throw new Error(`No active workspace user found for org member: ${orgMemberId}`);
+    }
+
+    const orgId = user.workspace.orgId;
+    const teamId = await this.getOrgLiteLLMTeamId(orgId);
+    if (!teamId) {
+      throw new Error(`Org ${orgId} has no LiteLLM team — provision orgs first`);
+    }
+
+    const workspaceType = user.workspace.workspaceType ?? null;
+    const budget = this.getUserBudget(workspaceType);
+
+    const clawUserPayload: ClawSyncUserPayload = {
+      spacesUserId: user.id,
+      spacesWorkspaceId: user.workspace.id,
+      spacesOrgId: orgId,
+      spacesOrgMemberId: user.orgMemberId,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      workspaceName: user.workspace.name,
+      orgName: user.workspace.organization.name,
+      createdBySpacesUserId: user.workspace.createdBy,
+      status: user.status,
+    };
+
+    await clawSpacesSyncClient.syncUser(clawUserPayload);
+
+    const litellmUserId = `claw-user-${user.orgMemberId}`;
+
+    try {
+      await litellmProvisioningClient.createUser({
+        orgId,
+        userId: user.orgMemberId,
+        email: user.email,
+        name: user.name,
+        teamId,
+        budget,
+        litellmUserId,
+      });
+    } catch (error) {
+      if (error instanceof LiteLLMProvisioningError && error.statusCode === 409) {
+        logger.info(`[AiProvisioningBackfill] LiteLLM user already exists for org member ${user.orgMemberId}, continuing`);
+      } else {
+        throw error;
+      }
+    }
+
+    const key = await litellmProvisioningClient.generateKey({
+      orgId,
+      userId: user.orgMemberId,
+      email: user.email,
+      litellmUserId,
+      teamId,
+      budget,
+    });
+
+    await litellmProvisioningClient.storeUserKey({
+      userId: user.orgMemberId,
+      orgId,
+      spacesOrgId: orgId,
+      spacesWorkspaceId: user.workspace.id,
+      spacesOrgMemberId: user.orgMemberId,
+      litellmUserId,
+      teamId,
+      key: key.key,
+      tokenId: key.tokenId,
+      keyName: key.keyName,
+      keyAlias: key.keyAlias,
+      expires: key.expires,
+    });
+  }
+
+  private static getUserBudget(workspaceType: string | null | undefined): number | undefined {
+    const budget = workspaceType === WorkspaceType.COMMUNITY
+      ? config.aiProvisioning.communityWorkspaceUserBudget
+      : config.aiProvisioning.enterpriseWorkspaceUserBudget;
+    return budget ?? undefined;
+  }
+
+  // ── BATCH RUNNER ─────────────────────────────────────────────────────
+
+  private static async runBatched<T>(
+    items: T[],
+    getId: (item: T) => string,
+    process: (item: T) => Promise<void>,
+    isAlreadyDone: (id: string) => Promise<boolean>,
+    markDone: (id: string) => Promise<void>,
+    markFailed: (id: string, error: string) => Promise<void>,
+    batchSize: number,
+    dryRun: boolean,
+  ): Promise<{ summary: SubjectSummary; errors: Array<{ id: string; error: string }> }> {
+    const summary: SubjectSummary = { total: items.length, skipped: 0, success: 0, errors: 0 };
+    const errors: Array<{ id: string; error: string }> = [];
+
+    for (let i = 0; i < items.length; i += batchSize) {
+      const batch = items.slice(i, i + batchSize);
+      await Promise.all(
+        batch.map(async (item) => {
+          const id = getId(item);
+
+          if (await isAlreadyDone(id)) {
+            summary.skipped++;
+            return;
+          }
+
+          if (dryRun) {
+            summary.success++;
+            return;
+          }
+
+          try {
+            await process(item);
+            await markDone(id);
+            summary.success++;
+          } catch (error) {
+            summary.errors++;
+            const errorMsg = error instanceof Error ? error.message : String(error);
+            logger.error(`[AiProvisioningBackfill] Failed to provision ${id}:`, error);
+            errors.push({ id, error: errorMsg });
+            await markFailed(id, errorMsg);
+          }
+        }),
+      );
+    }
+
+    return { summary, errors };
+  }
+
+  // ── ENTRY POINT ──────────────────────────────────────────────────────
+
+  static async triggerBackfill(req: Request, res: Response<ApiResponse>) {
+    try {
+      const options = this.buildOptions(req.body);
+      logger.info('[AiProvisioningBackfill] Starting', options);
+
+      const result: BackfillResult = {
+        mode: options.mode,
+        summary: { total: 0, skipped: 0, success: 0, errors: 0 },
+        errors: [],
+      };
+
+      if (options.mode === 'orgs') {
+        const orgs = await this.prisma.organization.findMany({
+          select: { orgId: true },
+          orderBy: { orgId: 'asc' },
+        });
+
+        const batchResult = await this.runBatched<{ orgId: string }>(
+          orgs,
+          (o) => o.orgId,
+          (o) => this.provisionOrg(o.orgId),
+          (id) => this.isProvisioned(AIProvisioningSubjectType.ORG, id),
+          (id) => this.markStatus(AIProvisioningSubjectType.ORG, id, AIProvisioningStatusValue.SUCCESS),
+          (id, err) => this.markStatus(AIProvisioningSubjectType.ORG, id, AIProvisioningStatusValue.FAILED, err),
+          1,
+          options.dryRun,
+        );
+        result.summary = batchResult.summary;
+        result.errors = batchResult.errors;
+      } else if (options.mode === 'workspaces') {
+        const workspaces = await this.prisma.workspace.findMany({
+          select: { id: true },
+          orderBy: { id: 'asc' },
+        });
+
+        const batchResult = await this.runBatched<{ id: string }>(
+          workspaces,
+          (w) => w.id,
+          (w) => this.provisionWorkspace(w.id),
+          (id) => this.isProvisioned(AIProvisioningSubjectType.WORKSPACE, id),
+          (id) => this.markStatus(AIProvisioningSubjectType.WORKSPACE, id, AIProvisioningStatusValue.SUCCESS),
+          (id, err) => this.markStatus(AIProvisioningSubjectType.WORKSPACE, id, AIProvisioningStatusValue.FAILED, err),
+          1,
+          options.dryRun,
+        );
+        result.summary = batchResult.summary;
+        result.errors = batchResult.errors;
+      } else if (options.mode === 'users') {
+        const users = await this.prisma.orgMember.findMany({
+          where: {
+            leftAt: null,
+            users: { some: { leftAt: null } },
+          },
+          select: { memberId: true },
+          orderBy: { memberId: 'asc' },
+        });
+
+        const batchResult = await this.runBatched<{ memberId: string }>(
+          users,
+          (u) => u.memberId,
+          (u) => this.provisionUser(u.memberId),
+          (id) => this.isProvisioned(AIProvisioningSubjectType.USER, id),
+          (id) => this.markStatus(AIProvisioningSubjectType.USER, id, AIProvisioningStatusValue.SUCCESS),
+          (id, err) => this.markStatus(AIProvisioningSubjectType.USER, id, AIProvisioningStatusValue.FAILED, err),
+          options.batchSize,
+          options.dryRun,
+        );
+        result.summary = batchResult.summary;
+        result.errors = batchResult.errors;
+      }
+
+      res.status(200).json({
+        success: true,
+        message: `AI provisioning backfill completed for ${options.mode}${options.dryRun ? ' (dry run)' : ''}`,
+        data: result,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error('[AiProvisioningBackfill] Error:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to run backfill',
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  static async getStatus(_req: Request, res: Response<ApiResponse>) {
+    try {
+      const [orgs, workspaces, users] = await Promise.all([
+        this.prisma.organization.count(),
+        this.prisma.workspace.count(),
+        this.prisma.user.count(),
+      ]);
+
+      const [orgsDone, workspacesDone, usersDone] = await Promise.all([
+        this.prisma.aiProvisioningStatus.count({
+          where: { subjectType: AIProvisioningSubjectType.ORG, status: AIProvisioningStatusValue.SUCCESS },
+        }),
+        this.prisma.aiProvisioningStatus.count({
+          where: { subjectType: AIProvisioningSubjectType.WORKSPACE, status: AIProvisioningStatusValue.SUCCESS },
+        }),
+        this.prisma.aiProvisioningStatus.count({
+          where: { subjectType: AIProvisioningSubjectType.USER, status: AIProvisioningStatusValue.SUCCESS },
+        }),
+      ]);
+
+      res.status(200).json({
+        success: true,
+        data: {
+          orgs: { total: orgs, provisioned: orgsDone, unprovisioned: orgs - orgsDone },
+          workspaces: { total: workspaces, provisioned: workspacesDone, unprovisioned: workspaces - workspacesDone },
+          users: { total: users, provisioned: usersDone, unprovisioned: users - usersDone },
+        },
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error('[AiProvisioningBackfill] Error fetching status:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to fetch status',
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+}

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -1494,7 +1494,7 @@ export class AuthV2Controller {
 
       if (isNewUser) {
         try {
-          await aiProvisioningService.enqueueUserSync(workspaceUser.id);
+          await aiProvisioningService.enqueueUserSync(workspaceUser.orgMemberId);
         } catch (error) {
           logger.error('[LOGIN-WORKSPACE] Failed to enqueue AI user provisioning', {
             userId: workspaceUser.id,

--- a/apps/backend/src/controllers/dashboardController.ts
+++ b/apps/backend/src/controllers/dashboardController.ts
@@ -778,6 +778,7 @@ export class DashboardController {
 
     const runReq: ClawRunRequest = {
       userId,
+      spacesWorkspaceId: req.user?.workspaceId,
       userName: user.name ?? user.displayName ?? 'Unknown',
       userEmail: user.email ?? '',
       query: `${errorBlock}${prompt}`,
@@ -837,7 +838,12 @@ export class DashboardController {
       res.status(400).json({ error: 'BadRequest', message: 'runId is required' });
       return;
     }
-    const result = await cancelClawAgentRun(req, ctx.userId, runId);
+    const result = await cancelClawAgentRun(
+      req,
+      ctx.userId,
+      runId,
+      req.user?.workspaceId,
+    );
     if (!result.success) {
       res.status(502).json({ success: false, error: result.error ?? 'Cancel failed' });
       return;

--- a/apps/backend/src/controllers/emailController.ts
+++ b/apps/backend/src/controllers/emailController.ts
@@ -792,6 +792,10 @@ export class EmailController {
         agentSlug,
         conversationId,
         userId: personaUserId,
+        // The insight is scoped to the current channel, so use the
+        // authenticated viewer's verified workspace context to disambiguate
+        // the persona's Spaces surface identity for the S2S Claw request.
+        spacesWorkspaceId: req.user?.workspaceId,
       });
 
       res.setHeader('Cache-Control', 'no-store');

--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -398,6 +398,7 @@ export class XyneAIControllerV2 {
         // Build the ClawRunRequest
         const runReq: ClawRunRequest = {
           userId,
+          spacesWorkspaceId: req.user?.workspaceId,
           userName: user?.name || 'Unknown',
           userEmail: user?.email || '',
           query,
@@ -551,7 +552,12 @@ export class XyneAIControllerV2 {
         res.status(400).json({ error: 'sessionId is required' });
         return;
       }
-      const result = await cancelClawAgentRun(req, userId, sessionId);
+      const result = await cancelClawAgentRun(
+        req,
+        userId,
+        sessionId,
+        req.user?.workspaceId,
+      );
       if (!result.success) {
         res.status(502).json({ success: false, error: result.error ?? 'Cancel failed' });
         return;

--- a/apps/backend/src/services/aiProvisioningService.ts
+++ b/apps/backend/src/services/aiProvisioningService.ts
@@ -22,8 +22,8 @@ class AIProvisioningService {
     );
   }
 
-  async enqueueUserSync(spacesUserId: string) {
-    return this.ensureStatusAndEnqueue(AIProvisioningSubjectType.USER, spacesUserId);
+  async enqueueUserSync(spacesOrgMemberId: string) {
+    return this.ensureStatusAndEnqueue(AIProvisioningSubjectType.USER, spacesOrgMemberId);
   }
 
   async upgradeCommunityToEnterpriseBudget(orgMemberId: string): Promise<void> {

--- a/apps/backend/src/services/aiProvisioningService.ts
+++ b/apps/backend/src/services/aiProvisioningService.ts
@@ -5,8 +5,6 @@ import {
 } from '@xyne/shared';
 import { DatabaseClient } from '@/database/client';
 import { aiProvisioningQueue } from '@/queues/aiProvisioningQueue';
-import { litellmProvisioningClient } from '@/services/litellmProvisioningClient';
-import { logger } from '@/utils/logger';
 
 class AIProvisioningService {
   private prisma = DatabaseClient.getInstance();
@@ -29,52 +27,25 @@ class AIProvisioningService {
   async upgradeCommunityToEnterpriseBudget(orgMemberId: string): Promise<void> {
     const memberRow = await this.prisma.orgMember.findUnique({
       where: { memberId: orgMemberId },
-      select: {
-        memberId: true,
-        users: {
-          select: { id: true, leftAt: true },
-          where: { leftAt: null },
-        },
-      },
+      select: { memberId: true },
     });
 
     if (!memberRow) return;
 
-    const activeUserIds = memberRow.users.map(u => u.id);
+    await this.prisma.aiProvisioningStatus.updateMany({
+      where: {
+        subjectType: AIProvisioningSubjectType.USER,
+        subjectId: memberRow.memberId,
+        provider: AIProvisioningProvider.CLAW_LITELLM,
+      },
+      data: {
+        status: AIProvisioningStatusValue.PENDING,
+        lastError: null,
+        updatedAt: new Date(),
+      },
+    });
 
-    for (const userId of activeUserIds) {
-      const litellmUserId = `claw-user-${userId}`;
-      try {
-        await litellmProvisioningClient.deleteUser(litellmUserId);
-        logger.info('[AI-PROVISIONING-SERVICE] Deleted LiteLLM user for community→enterprise transition', {
-          orgMemberId,
-          userId,
-          litellmUserId,
-        });
-      } catch (error) {
-        logger.error('[AI-PROVISIONING-SERVICE] Failed to delete LiteLLM user for community→enterprise transition', {
-          orgMemberId,
-          userId,
-          litellmUserId,
-          error,
-        });
-      }
-
-      await this.prisma.aiProvisioningStatus.updateMany({
-        where: {
-          subjectType: AIProvisioningSubjectType.USER,
-          subjectId: userId,
-          provider: AIProvisioningProvider.CLAW_LITELLM,
-        },
-        data: {
-          status: AIProvisioningStatusValue.PENDING,
-          lastError: null,
-          updatedAt: new Date(),
-        },
-      });
-
-      await this.enqueueUserSync(userId);
-    }
+    await this.enqueueUserSync(memberRow.memberId);
   }
 
   private async ensureStatusAndEnqueue(

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -229,6 +229,9 @@ export interface S2SRunAgentRequest {
   userId: string;
   userName: string;
   userEmail: string;
+  spacesWorkspaceId?: string;
+  spacesOrgId?: string;
+  spacesOrgMemberId?: string;
   callbackUrl: string;
   conversationId?: string;
   channelId?: string;
@@ -295,7 +298,10 @@ function extractCookieHeader(req: { headers?: { cookie?: string } }): Record<str
 }
 
 function extractUserIdHeader(userId: string): Record<string, string> {
-  return { 'x-user-id': userId };
+  // `userId` is the raw, workspace-scoped Spaces user id. Keep the legacy
+  // x-user-id header for older Claw deployments, and send the explicit source
+  // identity for Claw versions that canonicalize it at the auth boundary.
+  return { 'x-user-id': userId, 'x-spaces-user-id': userId };
 }
 
 // ============================================================================
@@ -1268,6 +1274,9 @@ export async function runS2SClawAgent(req: S2SRunAgentRequest): Promise<S2SRunAg
         agentSlug: req.agentSlug,
         task: req.task,
         userId: req.userId,
+        ...(req.spacesWorkspaceId ? { spacesWorkspaceId: req.spacesWorkspaceId } : {}),
+        ...(req.spacesOrgId ? { spacesOrgId: req.spacesOrgId } : {}),
+        ...(req.spacesOrgMemberId ? { spacesOrgMemberId: req.spacesOrgMemberId } : {}),
         callbackUrl: req.callbackUrl,
         ...(req.conversationId ? { conversationId: req.conversationId } : {}),
         ...(req.channelId ? { channelId: req.channelId } : {}),
@@ -1298,6 +1307,10 @@ export interface AppMentionAgentRequest {
   channelId: string;
   workspaceId: string;
   resultForwardUrl: string;
+  /** Optional when the caller already resolved the Spaces identity. */
+  spacesWorkspaceId?: string;
+  spacesOrgId?: string;
+  spacesOrgMemberId?: string;
 }
 
 export async function runClawAgent(
@@ -1352,6 +1365,8 @@ export async function runClawAgent(
     return { dispatched: false };
   }
 
+  const identityContext = await resolveHeadlessAppEventIdentity(req);
+
   const event: BaseAppEvent = {
     eventType: AppEventType.APP_MENTION,
     payload: {
@@ -1363,12 +1378,37 @@ export async function runClawAgent(
       userId: req.userId,
       senderName: req.userName,
       channelId: req.channelId,
+      ...identityContext,
       metadata: { resultForwardUrl: req.resultForwardUrl },
     },
     timestamp: new Date().toISOString(),
   };
   await sendWebhookNotification(installedApp.webhookUrl, event, decrypt(signingSecretEnc));
   return { dispatched: true };
+}
+
+async function resolveHeadlessAppEventIdentity(req: AppMentionAgentRequest): Promise<{
+  workspaceId?: string;
+  orgId?: string;
+  orgMemberId?: string;
+}> {
+  // A server-initiated event has no browser cookie. Resolve from the channel
+  // and actor records rather than trusting caller-supplied identity fields.
+  const [actor, channel] = await Promise.all([
+    db.user.findUnique({ where: { id: req.userId }, select: { orgMemberId: true } }),
+    db.channel.findUnique({ where: { id: req.channelId }, select: { workspaceId: true } }),
+  ]);
+  const workspaceId = req.spacesWorkspaceId ?? channel?.workspaceId;
+  const workspace = workspaceId
+    ? await db.workspace.findUnique({ where: { id: workspaceId }, select: { orgId: true } })
+    : null;
+  const orgId = req.spacesOrgId ?? workspace?.orgId;
+  const orgMemberId = req.spacesOrgMemberId ?? actor?.orgMemberId;
+  return {
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(orgId ? { orgId } : {}),
+    ...(orgMemberId ? { orgMemberId } : {}),
+  };
 }
 
 /** Fetch the latest assistant reasoning and tool invocations from a claw conversation. Used by email auto-draft. */
@@ -1383,7 +1423,7 @@ export async function getConversationInsight(params: {
   try {
     res = await fetch(url, {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json', 'x-user-id': userId, ...getS2SHeaders() },
+      headers: { 'Content-Type': 'application/json', ...extractUserIdHeader(userId), ...getS2SHeaders() },
       signal: AbortSignal.timeout(15_000),
     });
   } catch (err) {

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -22,6 +22,11 @@ export interface ChannelClawAgent {
 
 export interface ClawRunRequest {
   userId: string;
+  /**
+   * Verified Spaces workspace for this raw, workspace-scoped user id. Claw
+   * uses it with x-spaces-user-id to resolve the exact surface identity.
+   */
+  spacesWorkspaceId?: string;
   userName: string;
   userEmail: string;
   query: string;
@@ -297,11 +302,20 @@ function extractCookieHeader(req: { headers?: { cookie?: string } }): Record<str
   return cookie ? { Cookie: cookie } : {};
 }
 
-function extractUserIdHeader(userId: string): Record<string, string> {
+function extractUserIdHeader(
+  userId: string,
+  workspaceId?: string,
+): Record<string, string> {
   // `userId` is the raw, workspace-scoped Spaces user id. Keep the legacy
   // x-user-id header for older Claw deployments, and send the explicit source
   // identity for Claw versions that canonicalize it at the auth boundary.
-  return { 'x-user-id': userId, 'x-spaces-user-id': userId };
+  // The workspace completes the compound Spaces surface identity and prevents
+  // a canonicalizer from guessing a membership for a multi-workspace person.
+  return {
+    'x-user-id': userId,
+    'x-spaces-user-id': userId,
+    ...(workspaceId ? { 'x-spaces-workspace-id': workspaceId } : {}),
+  };
 }
 
 // ============================================================================
@@ -526,6 +540,7 @@ export async function runClawAgentStream(
 
   const payload: Record<string, unknown> = {
     userId: request.userId,
+    ...(request.spacesWorkspaceId && { spacesWorkspaceId: request.spacesWorkspaceId }),
     userName: request.userName,
     userEmail: request.userEmail,
     task: request.query,
@@ -592,6 +607,7 @@ export async function runClawAgentStream(
       'Content-Type': 'application/json',
       Accept: 'text/event-stream',
       ...cookieHeader,
+      ...extractUserIdHeader(request.userId, request.spacesWorkspaceId),
     },
     body: JSON.stringify(payload),
     ...(opts.signal ? { signal: opts.signal } : {}),
@@ -775,7 +791,8 @@ export async function runClawAgentStream(
 export async function cancelClawAgentRun(
   req: { headers?: { cookie?: string } },
   userId: string,
-  sessionId: string
+  sessionId: string,
+  workspaceId?: string,
 ): Promise<{ success: boolean; status: string; error?: string }> {
   const url = `${getClawBaseUrl()}/claw/api/v1/run/stream/cancel`;
   try {
@@ -783,7 +800,7 @@ export async function cancelClawAgentRun(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...extractUserIdHeader(userId),
+        ...extractUserIdHeader(userId, workspaceId),
         ...extractCookieHeader(req),
       },
       body: JSON.stringify({ sessionId }),
@@ -1421,14 +1438,19 @@ export async function getConversationInsight(params: {
   agentSlug: string;
   conversationId: string;
   userId: string;
+  spacesWorkspaceId?: string;
 }): Promise<ConversationInsight> {
-  const { agentSlug, conversationId, userId } = params;
+  const { agentSlug, conversationId, userId, spacesWorkspaceId } = params;
   const url = `${getClawBaseUrl()}/claw/api/v1/agent-chat/${encodeURIComponent(agentSlug)}/chat/${encodeURIComponent(conversationId)}/messages`;
   let res: globalThis.Response;
   try {
     res = await fetch(url, {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json', ...extractUserIdHeader(userId), ...getS2SHeaders() },
+      headers: {
+        'Content-Type': 'application/json',
+        ...extractUserIdHeader(userId, spacesWorkspaceId),
+        ...getS2SHeaders(),
+      },
       signal: AbortSignal.timeout(15_000),
     });
   } catch (err) {

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -229,9 +229,9 @@ export interface S2SRunAgentRequest {
   userId: string;
   userName: string;
   userEmail: string;
-  spacesWorkspaceId?: string;
-  spacesOrgId?: string;
-  spacesOrgMemberId?: string;
+  spacesWorkspaceId: string;
+  spacesOrgId: string;
+  spacesOrgMemberId: string;
   callbackUrl: string;
   conversationId?: string;
   channelId?: string;
@@ -1274,9 +1274,9 @@ export async function runS2SClawAgent(req: S2SRunAgentRequest): Promise<S2SRunAg
         agentSlug: req.agentSlug,
         task: req.task,
         userId: req.userId,
-        ...(req.spacesWorkspaceId ? { spacesWorkspaceId: req.spacesWorkspaceId } : {}),
-        ...(req.spacesOrgId ? { spacesOrgId: req.spacesOrgId } : {}),
-        ...(req.spacesOrgMemberId ? { spacesOrgMemberId: req.spacesOrgMemberId } : {}),
+        spacesWorkspaceId: req.spacesWorkspaceId,
+        spacesOrgId: req.spacesOrgId,
+        spacesOrgMemberId: req.spacesOrgMemberId,
         callbackUrl: req.callbackUrl,
         ...(req.conversationId ? { conversationId: req.conversationId } : {}),
         ...(req.channelId ? { channelId: req.channelId } : {}),
@@ -1388,9 +1388,9 @@ export async function runClawAgent(
 }
 
 async function resolveHeadlessAppEventIdentity(req: AppMentionAgentRequest): Promise<{
-  workspaceId?: string;
-  orgId?: string;
-  orgMemberId?: string;
+  workspaceId: string;
+  orgId: string;
+  orgMemberId: string;
 }> {
   // A server-initiated event has no browser cookie. Resolve from the channel
   // and actor records rather than trusting caller-supplied identity fields.
@@ -1404,10 +1404,15 @@ async function resolveHeadlessAppEventIdentity(req: AppMentionAgentRequest): Pro
     : null;
   const orgId = req.spacesOrgId ?? workspace?.orgId;
   const orgMemberId = req.spacesOrgMemberId ?? actor?.orgMemberId;
+  if (!workspaceId || !orgId || !orgMemberId) {
+    throw new Error(
+      `[ClawAgentService] Cannot dispatch a headless Claw event without workspace, org, and org-member identity for user ${req.userId}`,
+    );
+  }
   return {
-    ...(workspaceId ? { workspaceId } : {}),
-    ...(orgId ? { orgId } : {}),
-    ...(orgMemberId ? { orgMemberId } : {}),
+    workspaceId,
+    orgId,
+    orgMemberId,
   };
 }
 

--- a/apps/backend/src/services/clawSpacesSyncClient.ts
+++ b/apps/backend/src/services/clawSpacesSyncClient.ts
@@ -24,7 +24,7 @@ export interface ClawSyncUserPayload {
   spacesWorkspaceId: string;
   spacesOrgId: string;
   /** Stable identity for one person within a Spaces organization. */
-  spacesOrgMemberId?: string;
+  spacesOrgMemberId: string;
   email: string;
   name: string;
   role?: string | null;

--- a/apps/backend/src/services/clawSpacesSyncClient.ts
+++ b/apps/backend/src/services/clawSpacesSyncClient.ts
@@ -32,6 +32,7 @@ export interface ClawSyncUserPayload {
   orgName?: string | null;
   createdBySpacesUserId?: string | null;
   status?: string;
+  grantClawAdmin?: boolean;
 }
 
 export class ClawSpacesSyncError extends Error {
@@ -168,6 +169,7 @@ class ClawSpacesSyncClient {
       spacesUserId: value.spacesUserId,
       role: value.role,
       status: value.status,
+      grantClawAdmin: value.grantClawAdmin,
     };
 
     return JSON.stringify(safePayload);

--- a/apps/backend/src/services/clawSpacesSyncClient.ts
+++ b/apps/backend/src/services/clawSpacesSyncClient.ts
@@ -23,6 +23,8 @@ export interface ClawSyncUserPayload {
   spacesUserId: string;
   spacesWorkspaceId: string;
   spacesOrgId: string;
+  /** Stable identity for one person within a Spaces organization. */
+  spacesOrgMemberId?: string;
   email: string;
   name: string;
   role?: string | null;

--- a/apps/backend/src/services/communityWorkspaceService.ts
+++ b/apps/backend/src/services/communityWorkspaceService.ts
@@ -410,7 +410,7 @@ export class CommunityWorkspaceService {
     }
 
     try {
-      await aiProvisioningService.enqueueUserSync(result.workspaceUser.id);
+      await aiProvisioningService.enqueueUserSync(result.workspaceUser.orgMemberId);
     } catch (error) {
       logger.error('[CommunityWorkspaceService] Failed to enqueue AI provisioning job', {
         workspaceId: params.workspace.id,

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -877,7 +877,7 @@ export class InvitationService {
     logger.info(`[InvitationService] User ${userData.email} accepted invitation to workspace ${invitation.workspaceId}`);
 
     try {
-      await aiProvisioningService.enqueueUserSync(newWorkspaceUser.id);
+      await aiProvisioningService.enqueueUserSync(newWorkspaceUser.orgMemberId);
     } catch (error) {
       logger.error('[InvitationService] Failed to enqueue AI user provisioning', {
         userId: newWorkspaceUser.id,

--- a/apps/backend/src/services/litellmProvisioningClient.ts
+++ b/apps/backend/src/services/litellmProvisioningClient.ts
@@ -83,9 +83,22 @@ export interface StoreUserKeyParams {
   userId: string;
   orgId: string;
   spacesOrgId: string;
+  /** Additive fields: older claw-auth versions safely ignore these. */
+  spacesWorkspaceId?: string;
+  spacesOrgMemberId?: string;
   litellmUserId: string;
   teamId: string;
   key: string;
+  tokenId?: string;
+  keyName?: string;
+  keyAlias?: string;
+  expires?: string;
+}
+
+export interface StoreOrgKeyParams {
+  orgId: string;
+  key: string;
+  teamId?: string;
   tokenId?: string;
   keyName?: string;
   keyAlias?: string;
@@ -196,18 +209,6 @@ class LiteLLMProvisioningClient {
     };
   }
 
-  async storeOrgKey(params: {
-    orgId: string;
-    teamId: string;
-    key: string;
-    tokenId?: string;
-    keyName?: string;
-    keyAlias?: string;
-    expires?: string;
-  }): Promise<unknown> {
-    return this.postClawStore('/org-key', params);
-  }
-
   async deleteUser(litellmUserId: string): Promise<void> {
     await this.postLiteLLM('/user/delete', { user_ids: [litellmUserId] });
   }
@@ -226,9 +227,24 @@ class LiteLLMProvisioningClient {
       userId: params.userId,
       orgId: params.orgId,
       spacesOrgId: params.spacesOrgId,
+      ...(params.spacesWorkspaceId ? { spacesWorkspaceId: params.spacesWorkspaceId } : {}),
+      ...(params.spacesOrgMemberId ? { spacesOrgMemberId: params.spacesOrgMemberId } : {}),
       litellmUserId: params.litellmUserId,
       teamId: params.teamId,
       key: params.key,
+      tokenId: params.tokenId,
+      keyName: params.keyName,
+      keyAlias: params.keyAlias,
+      expires: params.expires,
+    });
+  }
+
+  /** Store the org's DEFAULT service-account key for headless Claw work. */
+  async storeOrgKey(params: StoreOrgKeyParams): Promise<void> {
+    await this.postClawStore('/org-key', {
+      orgId: params.orgId,
+      key: params.key,
+      teamId: params.teamId,
       tokenId: params.tokenId,
       keyName: params.keyName,
       keyAlias: params.keyAlias,

--- a/apps/backend/src/services/litellmProvisioningClient.ts
+++ b/apps/backend/src/services/litellmProvisioningClient.ts
@@ -1,6 +1,6 @@
 import { config } from '@/config/env';
 
-const TEAM_MODELS = ['external-kimi', 'external-glm'];
+const TEAM_MODELS = ['kimi-latest', 'private-large'];
 const USER_MODELS = ['no-default-models'];
 const KEY_MODELS = ['all-team-models'];
 const KEY_TYPE = 'llm_api';

--- a/apps/backend/src/services/litellmProvisioningClient.ts
+++ b/apps/backend/src/services/litellmProvisioningClient.ts
@@ -83,9 +83,8 @@ export interface StoreUserKeyParams {
   userId: string;
   orgId: string;
   spacesOrgId: string;
-  /** Additive fields: older claw-auth versions safely ignore these. */
-  spacesWorkspaceId?: string;
-  spacesOrgMemberId?: string;
+  spacesWorkspaceId: string;
+  spacesOrgMemberId: string;
   litellmUserId: string;
   teamId: string;
   key: string;
@@ -227,8 +226,8 @@ class LiteLLMProvisioningClient {
       userId: params.userId,
       orgId: params.orgId,
       spacesOrgId: params.spacesOrgId,
-      ...(params.spacesWorkspaceId ? { spacesWorkspaceId: params.spacesWorkspaceId } : {}),
-      ...(params.spacesOrgMemberId ? { spacesOrgMemberId: params.spacesOrgMemberId } : {}),
+      spacesWorkspaceId: params.spacesWorkspaceId,
+      spacesOrgMemberId: params.spacesOrgMemberId,
       litellmUserId: params.litellmUserId,
       teamId: params.teamId,
       key: params.key,

--- a/apps/backend/src/services/litellmProvisioningClient.ts
+++ b/apps/backend/src/services/litellmProvisioningClient.ts
@@ -1,6 +1,5 @@
 import { config } from '@/config/env';
 
-const TEAM_MODELS = ['kimi-latest', 'private-large'];
 const USER_MODELS = ['no-default-models'];
 const KEY_MODELS = ['all-team-models'];
 const KEY_TYPE = 'llm_api';
@@ -108,7 +107,7 @@ class LiteLLMProvisioningClient {
   async createTeam(params: CreateTeamParams): Promise<CreateTeamResult> {
     const body = {
       team_alias: truncate(params.teamAlias, 180),
-      models: TEAM_MODELS,
+      models: config.aiProvisioning.orgDefaultModels,
       max_budget: TEAM_MAX_BUDGET,
       budget_duration: DURATION,
       rpm_limit: TEAM_RPM_LIMIT,

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -1058,7 +1058,7 @@ export class UserService {
       try {
         await aiProvisioningService.enqueueOrgSync(organization.orgId);
         await aiProvisioningService.enqueueWorkspaceSync(workspace.id);
-        await aiProvisioningService.enqueueUserSync(workspaceUser.id);
+        await aiProvisioningService.enqueueUserSync(workspaceUser.orgMemberId);
       } catch (error) {
         logger.error('[UserService] Failed to enqueue AI provisioning jobs for new organization', {
           orgId: organization.orgId,
@@ -1216,7 +1216,7 @@ export class UserService {
 
       try {
         await aiProvisioningService.enqueueWorkspaceSync(workspace.id);
-        await aiProvisioningService.enqueueUserSync(workspaceUser.id);
+        await aiProvisioningService.enqueueUserSync(workspaceUser.orgMemberId);
       } catch (error) {
         logger.error('[UserService] Failed to enqueue AI provisioning jobs for new workspace', {
           orgId: org.orgId,

--- a/apps/backend/src/workers/aiProvisioningWorker.ts
+++ b/apps/backend/src/workers/aiProvisioningWorker.ts
@@ -236,12 +236,6 @@ class AIProvisioningWorker {
     // belong to the person within the organization, so all key provisioning
     // uses the stable org-member ID.
     const canonicalProvisioningUserId = userPayload.spacesOrgMemberId;
-    if (!canonicalProvisioningUserId) {
-      throw new ClawSpacesSyncError(
-        `Cannot provision AI credentials without an org member id for Spaces user ${userPayload.spacesUserId}`,
-        { retryable: false },
-      );
-    }
     const { litellmUserId } = await litellmProvisioningClient.createUser({
       orgId: userPayload.spacesOrgId,
       userId: canonicalProvisioningUserId,
@@ -674,6 +668,12 @@ class AIProvisioningWorker {
       throw new ClawSpacesSyncError(`User not found for AI provisioning: ${userId}`, {
         retryable: false,
       });
+    }
+    if (!user.orgMemberId.trim()) {
+      throw new ClawSpacesSyncError(
+        `Cannot provision AI credentials without an org member id for Spaces user ${user.id}`,
+        { retryable: false },
+      );
     }
 
     return {

--- a/apps/backend/src/workers/aiProvisioningWorker.ts
+++ b/apps/backend/src/workers/aiProvisioningWorker.ts
@@ -207,8 +207,20 @@ class AIProvisioningWorker {
     await this.ensureOrgLiteLLMServiceAccountCredentials(orgPayload, teamId);
   }
 
-  private async provisionUser(userId: string): Promise<void> {
-    const userPayload = await this.buildUserPayload(userId);
+  private async provisionUser(orgMemberId: string): Promise<void> {
+    const sourceUser = await this.prisma.user.findFirst({
+      where: { orgMemberId, leftAt: null },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true },
+    });
+    if (!sourceUser) {
+      throw new ClawSpacesSyncError(
+        `No active workspace user found for AI provisioning org member: ${orgMemberId}`,
+        { retryable: false },
+      );
+    }
+
+    const userPayload = await this.buildUserPayload(sourceUser.id);
     const { workspaceType, ...clawUserPayload } = userPayload;
     const orgPayload = await this.buildOrgPayload(userPayload.spacesOrgId);
     const workspacePayload = await this.buildWorkspacePayload(userPayload.spacesWorkspaceId);
@@ -220,27 +232,49 @@ class AIProvisioningWorker {
 
     const teamId = await this.ensureLiteLLMTeamForOrg(orgPayload);
     await this.ensureOrgLiteLLMServiceAccountCredentials(orgPayload, teamId);
+    // A Spaces user row is a workspace membership. LiteLLM keys must instead
+    // belong to the person within the organization, so all key provisioning
+    // uses the stable org-member ID.
+    const canonicalProvisioningUserId = userPayload.spacesOrgMemberId;
+    if (!canonicalProvisioningUserId) {
+      throw new ClawSpacesSyncError(
+        `Cannot provision AI credentials without an org member id for Spaces user ${userPayload.spacesUserId}`,
+        { retryable: false },
+      );
+    }
     const { litellmUserId } = await litellmProvisioningClient.createUser({
       orgId: userPayload.spacesOrgId,
-      userId: userPayload.spacesUserId,
+      userId: canonicalProvisioningUserId,
       email: userPayload.email,
       name: userPayload.name,
       teamId,
       budget: userBudget,
+      metadata: {
+        spaces_org_member_id: userPayload.spacesOrgMemberId,
+        spaces_workspace_id: userPayload.spacesWorkspaceId,
+        spaces_user_id: userPayload.spacesUserId,
+      },
     });
     const key = await litellmProvisioningClient.generateKey({
       orgId: userPayload.spacesOrgId,
-      userId: userPayload.spacesUserId,
+      userId: canonicalProvisioningUserId,
       email: userPayload.email,
       litellmUserId,
       teamId,
       budget: userBudget,
+      metadata: {
+        spaces_org_member_id: userPayload.spacesOrgMemberId,
+        spaces_workspace_id: userPayload.spacesWorkspaceId,
+        spaces_user_id: userPayload.spacesUserId,
+      },
     });
 
     await litellmProvisioningClient.storeUserKey({
-      userId: userPayload.spacesUserId,
+      userId: canonicalProvisioningUserId,
       orgId: userPayload.spacesOrgId,
       spacesOrgId: userPayload.spacesOrgId,
+      spacesWorkspaceId: userPayload.spacesWorkspaceId,
+      spacesOrgMemberId: userPayload.spacesOrgMemberId,
       litellmUserId,
       teamId,
       key: key.key,
@@ -617,6 +651,7 @@ class AIProvisioningWorker {
         email: true,
         name: true,
         role: true,
+        orgMemberId: true,
         status: true,
         workspace: {
           select: {
@@ -645,6 +680,7 @@ class AIProvisioningWorker {
       spacesUserId: user.id,
       spacesWorkspaceId: user.workspace.id,
       spacesOrgId: user.workspace.orgId,
+      spacesOrgMemberId: user.orgMemberId,
       email: user.email,
       name: user.name,
       role: user.role,

--- a/apps/backend/src/workers/aiProvisioningWorker.ts
+++ b/apps/backend/src/workers/aiProvisioningWorker.ts
@@ -226,6 +226,14 @@ class AIProvisioningWorker {
     const workspacePayload = await this.buildWorkspacePayload(userPayload.spacesWorkspaceId);
     const userBudget = this.getUserLiteLLMBudget(workspaceType);
 
+    const isFirstOrgMember = await this.isFirstOrgMember(
+      userPayload.spacesOrgId,
+      userPayload.spacesOrgMemberId,
+    );
+    if (isFirstOrgMember) {
+      clawUserPayload.grantClawAdmin = true;
+    }
+
     await clawSpacesSyncClient.syncOrg(orgPayload);
     await clawSpacesSyncClient.syncWorkspace(workspacePayload);
     await clawSpacesSyncClient.syncUser(clawUserPayload);
@@ -690,6 +698,15 @@ class AIProvisioningWorker {
       createdBySpacesUserId: user.workspace.createdBy,
       status: user.status,
     };
+  }
+
+  private async isFirstOrgMember(orgId: string, orgMemberId: string): Promise<boolean> {
+    const firstMember = await this.prisma.orgMember.findFirst({
+      where: { orgId, leftAt: null },
+      orderBy: { joinedAt: 'asc' },
+      select: { memberId: true },
+    });
+    return firstMember?.memberId === orgMemberId;
   }
 
   private isRetryable(error: unknown): boolean {

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -2177,9 +2177,20 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
     payload: AppMentionEventPayload | DMEventPayload | UserMentionedEventPayload,
     userIds: string[],
   ): Promise<void> {
+    // App event delivery happens asynchronously and therefore cannot rely on
+    // the sender's browser cookie. Stamp the trusted workspace from the Zero
+    // context; retain every legacy payload field unchanged.
+    const sender = await db.user.findUnique({
+      where: { id: payload.userId },
+      select: { orgMemberId: true },
+    });
     const event: BaseAppEvent = {
       eventType,
-      payload,
+      payload: {
+        ...payload,
+        workspaceId: payload.workspaceId ?? this.ctx.workspaceId,
+        ...(sender?.orgMemberId ? { orgMemberId: sender.orgMemberId } : {}),
+      },
       timestamp: new Date().toISOString(),
     };
 

--- a/apps/xyne-claw-auth/backend/prisma/seed.ts
+++ b/apps/xyne-claw-auth/backend/prisma/seed.ts
@@ -529,7 +529,7 @@ async function main() {
   // Create "spaces" Surface if it doesn't exist
   const spacesSurface = await prisma.surface.upsert({
     where: { key: "spaces" },
-    create: { key: "spaces", identityMode: "USER_ID", supportsUserResolution: true },
+    create: { id: "spaces", key: "spaces", identityMode: "USER_ID", supportsUserResolution: true },
     update: {},
   });
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
