### PR TITLE
fix: XYNE-55092 stream attachment/file downloads instead of buffering in heap

### DIFF
--- a/apps/backend/src/apps/controllers/filesController.ts
+++ b/apps/backend/src/apps/controllers/filesController.ts
@@ -96,19 +96,43 @@ export class FilesController {
         ? getStorageService(config.gcs.transcriptionBucketName)
         : storageService;
 
-      const buffer = await service.getFileBuffer(filePath);
+      const fileExists = await service.fileExists(filePath);
+      if (!fileExists) {
+        logger.error(`File not found in storage: ${filePath}`);
+        res.status(404).json({ error: 'File not found in storage', code: 'NOT_FOUND' });
+        return;
+      }
 
-      res.setHeader('Content-Length', buffer.length);
+      const fileMetadata = await service.getFileMetadata(filePath);
+      const fileSize = parseInt(String(fileMetadata.size || '0'), 10);
+
+      if (fileSize > 0) {
+        res.setHeader('Content-Length', fileSize);
+      }
       setSafeDownloadHeaders(res, {
         mimetype: attachment.mimetype,
         filename: attachment.originalFilename,
       });
       res.setHeader('Cache-Control', 'private, max-age=3600');
 
-      res.send(buffer);
+      // Stream directly from object storage to the client instead of buffering
+      // the whole object in heap (previously getFileBuffer + res.send).
+      const stream = await service.createReadStream(filePath);
+      stream.pipe(res);
+
+      stream.on('error', (error) => {
+        logger.error('File download stream error:', error);
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Failed to download file' });
+        } else {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
     } catch (error) {
       logger.error('Error downloading file:', error);
-      res.status(500).json({ error: 'Failed to download file' });
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Failed to download file' });
+      }
     }
   };
 

--- a/apps/backend/src/controllers/attachmentController.ts
+++ b/apps/backend/src/controllers/attachmentController.ts
@@ -226,10 +226,20 @@ export class AttachmentController {
 
       logger.info(`Streaming attachment ${attachmentId} from path: ${filePath}`);
 
-      const buffer = await service.getFileBuffer(filePath);
+      const fileExists = await service.fileExists(filePath);
+      if (!fileExists) {
+        logger.error(`Attachment file not found in storage: ${filePath}`);
+        res.status(404).json({ error: 'File not found in storage' });
+        return;
+      }
+
+      const fileMetadata = await service.getFileMetadata(filePath);
+      const fileSize = parseInt(String(fileMetadata.size || '0'), 10);
 
       // Set response headers (safe disposition/type to prevent stored XSS)
-      res.setHeader('Content-Length', buffer.length);
+      if (fileSize > 0) {
+        res.setHeader('Content-Length', fileSize);
+      }
       setSafeDownloadHeaders(res, {
         mimetype: attachment.mimetype,
         filename: attachment.originalFilename,
@@ -244,12 +254,26 @@ export class AttachmentController {
         res.setHeader('Cache-Control', 'private, max-age=3600');
       }
 
-      // Stream the file
-      res.send(buffer);
+      // Stream directly from object storage to the client. Piping avoids
+      // buffering the whole object in heap (previously getFileBuffer +
+      // res.send), which could OOM the process on large downloads.
+      const stream = await service.createReadStream(filePath);
+      stream.pipe(res);
+
+      stream.on('error', (error) => {
+        logger.error('Attachment download stream error:', error);
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'Failed to download attachment' });
+        } else {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
 
     } catch (error) {
       logger.error('Error downloading attachment:', error);
-      res.status(500).json({ error: 'Failed to download attachment' });
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Failed to download attachment' });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
`downloadAttachment` (attachmentController) and `filesController.downloadFile` loaded the entire object into a `Buffer` via `getFileBuffer()` and then `res.send(buffer)`. That buffered the whole file in heap on every download, so large files / concurrent downloads could OOM the backend — the download-side counterpart of XYNE-55092. Both handlers now pipe `service.createReadStream(filePath)` straight to the response, the same backend-as-proxy streaming pattern already used by `streamAttachment` and `downloadThumbnail`.

Ticket: XYNE-55092 (P1 · Replace 1 GB memory-buffered uploads with streaming and endpoint-specific limits) — this PR is the download half.

---
1. Problem Description: Attachment/file download endpoints buffered the entire object in heap (`getFileBuffer` + `res.send`), risking OOM on large or concurrent downloads.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Code review during XYNE-55092; download paths still used full-buffer reads while upload paths and `streamAttachment` already stream.
3. Explain the solution implemented in the PR: Replaced `getFileBuffer()`/`res.send(buffer)` with `createReadStream(filePath).pipe(res)` in `downloadAttachment` and `downloadFile`. Content-Length now comes from `getFileMetadata`, missing objects return 404, and a `stream.on('error')` handler avoids double-sending headers. No API/response-shape change; transcript-bucket routing and safe-download headers are preserved.
4. Documentation: N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): N/A
7. Environment variable Changes (if any): N/A
8. Testing: Local review + typecheck (the sandbox lacks the built `@xyne/storage` workspace package so tsc cannot resolve storage types there; the two new `stream.on('error', (error) =>` handlers use the identical untyped pattern as the pre-existing `streamAttachment`/`downloadThumbnail` handlers that already ship in production, so they compile in CI). Recommend a manual large-file download check + a heap-flat assertion test as the follow-up (ticket acceptance criterion).
9. Services to which this change is to be deployed: xyne-spaces backend (API).
10. Main PR link (if this PR is raised against a release branch): N/A (targets main).