### PR TITLE
fix: XYNE-55089 make DM channel creation concurrency-safe

### DIFF
--- a/apps/backend/prisma/migrations/20260805120000_dm_channel_unique_participant_key/migration.sql
+++ b/apps/backend/prisma/migrations/20260805120000_dm_channel_unique_participant_key/migration.sql
@@ -1,0 +1,23 @@
+-- XYNE-55089: Make DM / GROUP_DM channel creation concurrency-safe.
+--
+-- `channels.name` already materializes the normalized participant set:
+--   * self-DM   -> "<userId>"
+--   * 1:1 DM    -> sorted "<userIdA>,<userIdB>"
+--   * group DM  -> sorted "<id1>,<id2>,...,<idN>"
+-- This partial unique index makes (workspaceId, name) the DB-enforced source of
+-- truth for DM/GROUP_DM channels, closing the check-then-create race where two
+-- concurrent "open DM" requests both insert a duplicate channel.
+--
+-- IMPORTANT (rollout): if any workspace already has duplicate DM/GROUP_DM
+-- channels from past races, this CREATE UNIQUE INDEX will FAIL. Run the
+-- de-duplication script FIRST and confirm zero duplicates:
+--   npx tsx scripts/backfill/dedup-dm-channels.ts --dry-run   (audit)
+--   npx tsx scripts/backfill/dedup-dm-channels.ts             (apply)
+-- The query below returns the offending groups (should be empty pre-deploy):
+--   SELECT "workspaceId", "name", COUNT(*) FROM "public"."channels"
+--   WHERE "scopeType" IN ('DM','GROUP_DM')
+--   GROUP BY "workspaceId", "name" HAVING COUNT(*) > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "channels_workspaceId_name_dm_key"
+  ON "public"."channels" ("workspaceId", "name")
+  WHERE "scopeType" IN ('DM', 'GROUP_DM');

--- a/apps/backend/scripts/backfill/dedup-dm-channels.ts
+++ b/apps/backend/scripts/backfill/dedup-dm-channels.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env tsx
+/**
+ * XYNE-55089 — De-duplicate DM / GROUP_DM channels before applying the
+ * `channels_workspaceId_name_dm_key` partial unique index.
+ *
+ * A past check-then-create race could produce two channels that share the same
+ * normalized participant key (`channels.name`) within a workspace. The unique
+ * index migration will FAIL if any such duplicates still exist, so run this
+ * FIRST.
+ *
+ * Behaviour:
+ *   - Groups DM/GROUP_DM channels by (workspaceId, name) with COUNT(*) > 1.
+ *   - Picks a canonical channel per group: the one that actually holds
+ *     conversations; if none (or more than one) do, the OLDEST channel wins.
+ *   - EMPTY losers (zero conversations) are safe race orphans — this script can
+ *     delete them (with --apply). Their participant / status / stats rows are
+ *     removed first so the channel row can be deleted.
+ *   - CONTENT-BEARING losers (have conversations) are NOT auto-merged — merging
+ *     across the many channelId-referencing tables is a manual, reviewed
+ *     operation. They are reported and the script exits non-zero so the operator
+ *     resolves them before the migration runs.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill/dedup-dm-channels.ts --dry-run   # audit only (default)
+ *   npx tsx scripts/backfill/dedup-dm-channels.ts --apply     # delete empty orphans
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const APPLY = process.argv.includes('--apply');
+
+interface DupGroup {
+  workspaceId: string;
+  name: string;
+  count: number;
+}
+
+async function main() {
+  console.log(`🔎 dedup-dm-channels — mode: ${APPLY ? 'APPLY (will delete empty orphans)' : 'DRY-RUN (no writes)'}`);
+
+  // Find (workspaceId, name) groups with more than one DM/GROUP_DM channel.
+  const groups = await prisma.$queryRaw<DupGroup[]>`
+    SELECT "workspaceId", "name", COUNT(*)::int AS count
+    FROM "public"."channels"
+    WHERE "scopeType" IN ('DM', 'GROUP_DM')
+    GROUP BY "workspaceId", "name"
+    HAVING COUNT(*) > 1
+  `;
+
+  if (groups.length === 0) {
+    console.log('✅ No duplicate DM/GROUP_DM channels found — safe to apply the unique index.');
+    return;
+  }
+
+  console.log(`⚠️  Found ${groups.length} duplicate participant-key group(s).`);
+
+  let deletedOrphans = 0;
+  let manualMergeRequired = 0;
+
+  for (const g of groups) {
+    const channels = await prisma.channel.findMany({
+      where: { workspaceId: g.workspaceId, name: g.name, scopeType: { in: ['DM', 'GROUP_DM'] } },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const withCounts = await Promise.all(
+      channels.map(async (c) => ({
+        channel: c,
+        conversationCount: await prisma.conversation.count({ where: { channelId: c.id } }),
+      })),
+    );
+
+    const contentful = withCounts.filter((c) => c.conversationCount > 0);
+    // Canonical: the single content-bearing channel if unambiguous, else oldest.
+    const canonical = contentful.length === 1 ? contentful[0].channel : withCounts[0].channel;
+    const losers = withCounts.filter((c) => c.channel.id !== canonical.id);
+
+    console.log(`\n• ws=${g.workspaceId} name="${g.name}" — ${channels.length} channels; canonical=${canonical.id}`);
+
+    for (const loser of losers) {
+      if (loser.conversationCount === 0) {
+        console.log(`   - orphan (empty) loser ${loser.channel.id} → deletable`);
+        if (APPLY) {
+          await prisma.$transaction([
+            prisma.channelUserStatus.deleteMany({ where: { channelId: loser.channel.id } }),
+            prisma.channelParticipant.deleteMany({ where: { channelId: loser.channel.id } }),
+            prisma.channelStats.deleteMany({ where: { channelId: loser.channel.id } }),
+            prisma.channel.delete({ where: { id: loser.channel.id } }),
+          ]);
+          deletedOrphans++;
+        } else {
+          deletedOrphans++;
+        }
+      } else {
+        manualMergeRequired++;
+        console.log(
+          `   - ⛔ loser ${loser.channel.id} has ${loser.conversationCount} conversation(s) — MANUAL MERGE required into ${canonical.id} before the migration can run`,
+        );
+      }
+    }
+  }
+
+  console.log(
+    `\n📊 Summary: ${deletedOrphans} empty orphan(s) ${APPLY ? 'deleted' : 'would be deleted'}; ${manualMergeRequired} content-bearing loser(s) need manual merge.`,
+  );
+
+  if (manualMergeRequired > 0) {
+    console.error('\n❌ Content-bearing duplicates remain — resolve them manually, then re-run. Migration will fail until clean.');
+    process.exitCode = 1;
+  } else if (!APPLY && deletedOrphans > 0) {
+    console.log('\nℹ️  Re-run with --apply to delete the empty orphans, then apply the migration.');
+  } else if (APPLY && manualMergeRequired === 0) {
+    console.log('\n✅ All duplicates were empty orphans and have been removed — safe to apply the unique index.');
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/backend/src/bots/unified/services/unified-dm-service.ts
+++ b/apps/backend/src/bots/unified/services/unified-dm-service.ts
@@ -56,7 +56,8 @@ class UnifiedDMService {
 
     // Create new DM channel with bot
     const channelName = [userId, botUserId].sort().join(',');
-    const channel = await channelRepository.create({
+    // Concurrency-safe: partial unique index guards against duplicate bot DMs.
+    const { channel } = await channelRepository.getOrCreateDmChannel({
       scopeType: ChannelScopeType.DM,
       name: channelName,
       visibility: ChannelVisibility.PRIVATE,

--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -2107,7 +2107,7 @@ export class ChannelController {
           workspaceId,
         };
 
-        const channel = await this.channelRepository.create(channelData);
+        const { channel, created } = await this.channelRepository.getOrCreateDmChannel(channelData);
 
         // Add current user as the only participant
         await this.channelParticipantRepository.addParticipant(channel.id, currentUserId, ChannelRole.ADMIN);
@@ -2123,7 +2123,7 @@ export class ChannelController {
         const currentUserInfo = await this.getUserInfo(currentUserId);
 
         const response = {
-          message: 'Self-DM channel created successfully',
+          message: created ? 'Self-DM channel created successfully' : 'Self-DM channel already exists',
           id: channel.id,
           name: channel.name,
           scopeType: channel.scopeType,
@@ -2142,11 +2142,11 @@ export class ChannelController {
             email: currentUserInfo.email,
             picture: currentUserInfo.picture
           },
-          isExisting: false,
+          isExisting: !created,
           initialConversation
         };
 
-        res.status(201).json(response);
+        res.status(created ? 201 : 200).json(response);
 
         // Queue Vespa job in background for self-DM
         vespaQueue.addJob({
@@ -2224,7 +2224,7 @@ export class ChannelController {
           workspaceId,
         };
 
-        const channel = await this.channelRepository.create(channelData);
+        const { channel, created } = await this.channelRepository.getOrCreateDmChannel(channelData);
 
         // Add participants - creator sees DM immediately unless this is a silent auto-create
         // without an initial message, in which case the channel is hidden until the first
@@ -2246,7 +2246,7 @@ export class ChannelController {
         }
 
         const response = {
-          message: 'DM channel created successfully',
+          message: created ? 'DM channel created successfully' : 'DM channel already exists',
           id: channel.id,
           name: channel.name,
           scopeType: channel.scopeType,
@@ -2264,11 +2264,11 @@ export class ChannelController {
             email: targetUser.email,
             picture: targetUser.picture
           },
-          isExisting: false,
+          isExisting: !created,
           initialConversation
         };
 
-        res.status(201).json(response);
+        res.status(created ? 201 : 200).json(response);
 
         // Queue Vespa job in background for DM - worker will handle all processing
         vespaQueue.addJob({
@@ -2343,7 +2343,7 @@ export class ChannelController {
           workspaceId,
         };
 
-        const channel = await this.channelRepository.create(channelData);
+        const { channel, created } = await this.channelRepository.getOrCreateDmChannel(channelData);
 
         // Add all participants - creator sees DM immediately unless this is a silent auto-create
         // without an initial message, in which case the channel is hidden until the first
@@ -2384,7 +2384,7 @@ export class ChannelController {
         }
 
         const response = {
-          message: 'Group DM created successfully',
+          message: created ? 'Group DM created successfully' : 'Group DM already exists',
           id: channel.id,
           name: channel.name,
           scopeType: channel.scopeType,
@@ -2397,11 +2397,11 @@ export class ChannelController {
           lastActivityAt: channel.createdAt,
           createdAt: channel.createdAt,
           participants: allParticipantDetails,
-          isExisting: false,
+          isExisting: !created,
           initialConversation
         };
 
-        res.status(201).json(response);
+        res.status(created ? 201 : 200).json(response);
 
         // Queue Vespa job in background for Group DM - worker will handle all processing
         vespaQueue.addJob({

--- a/apps/backend/src/database/repositories/__tests__/channelRepository.dm-concurrency.test.ts
+++ b/apps/backend/src/database/repositories/__tests__/channelRepository.dm-concurrency.test.ts
@@ -1,0 +1,152 @@
+/**
+ * XYNE-55089 — Concurrency safety for DM / GROUP_DM channel creation.
+ *
+ * Verifies that many simultaneous "open DM" requests for the same participant
+ * set converge on a SINGLE channel row (the partial unique index on
+ * (workspaceId, name) WHERE scopeType IN ('DM','GROUP_DM') plus the P2002
+ * get-or-create fallback), rather than inserting duplicates.
+ *
+ * Requires the migration `20260805120000_dm_channel_unique_participant_key`
+ * to be applied to the test database.
+ */
+import { PrismaClient } from '@prisma/client';
+import { ChannelRepository } from '../channelRepository';
+import { ChannelScopeType, ChannelVisibility } from '@xyne/shared';
+
+const prisma = new PrismaClient();
+const repo = new ChannelRepository();
+
+const suffix = `${Date.now()}`;
+let workspaceId: string;
+let projectId: string;
+const userIds: string[] = [];
+const orgMemberIds: string[] = [];
+let orgId: string;
+
+async function makeUser(tag: string): Promise<string> {
+  const member = await prisma.orgMember.create({
+    data: {
+      orgId,
+      email: `dmconc-${tag}-${suffix}@example.test`,
+      role: 'MEMBER',
+    },
+  });
+  orgMemberIds.push(member.memberId);
+  const u = await prisma.user.create({
+    data: {
+      name: `dmconc-${tag}-${suffix}`,
+      email: `dmconc-${tag}-${suffix}@example.test`,
+      providerUserId: `dmconc-${tag}-${suffix}`,
+      workspaceId,
+      orgMemberId: member.memberId,
+    },
+  });
+  return u.id;
+}
+
+beforeAll(async () => {
+  const org = await prisma.organization.create({
+    data: { name: `dmconc-org-${suffix}`, createdBy: 'test' },
+  });
+  orgId = org.orgId;
+  const ws = await prisma.workspace.create({
+    data: { name: `dmconc-ws-${suffix}`, orgId: org.orgId, createdBy: 'test' },
+  });
+  workspaceId = ws.id;
+  const project = await prisma.project.create({
+    data: {
+      name: `dmconc-dm-${suffix}`,
+      code: `DMC${suffix.slice(-5)}`,
+      type: 'DM',
+      workspaceId,
+      createdBy: 'test',
+    },
+  });
+  projectId = project.id;
+  for (const tag of ['a', 'b', 'c']) {
+    userIds.push(await makeUser(tag));
+  }
+});
+
+afterAll(async () => {
+  // Channels created by these tests carry no participants/stats, so a direct
+  // delete by workspace is safe.
+  await prisma.channel.deleteMany({ where: { workspaceId } });
+  await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+  await prisma.orgMember.deleteMany({ where: { memberId: { in: orgMemberIds } } });
+  await prisma.project.deleteMany({ where: { id: projectId } });
+  const ws = await prisma.workspace.findUnique({ where: { id: workspaceId } });
+  await prisma.workspace.deleteMany({ where: { id: workspaceId } });
+  if (ws) await prisma.organization.deleteMany({ where: { orgId: ws.orgId } });
+  await prisma.$disconnect();
+});
+
+const N = 10;
+
+it('collapses concurrent 1:1 DM opens into a single channel', async () => {
+  const [a, b] = userIds;
+  const name = [a, b].sort().join(',');
+
+  const results = await Promise.all(
+    Array.from({ length: N }, () =>
+      repo.getOrCreateDmChannel({
+        scopeType: ChannelScopeType.DM,
+        name,
+        visibility: ChannelVisibility.PRIVATE,
+        createdBy: a,
+        projectId,
+        workspaceId,
+      }),
+    ),
+  );
+
+  // Exactly one row in the DB for this participant key.
+  const rows = await prisma.channel.findMany({ where: { workspaceId, name } });
+  expect(rows).toHaveLength(1);
+
+  // Every caller received the same channel id.
+  const ids = new Set(results.map((r) => r.channel.id));
+  expect(ids.size).toBe(1);
+  expect([...ids][0]).toBe(rows[0].id);
+
+  // Exactly one caller actually inserted; the rest lost the race.
+  expect(results.filter((r) => r.created)).toHaveLength(1);
+});
+
+it('collapses concurrent group DM opens into a single channel', async () => {
+  const name = [...userIds].sort().join(',');
+
+  const results = await Promise.all(
+    Array.from({ length: N }, () =>
+      repo.getOrCreateDmChannel({
+        scopeType: ChannelScopeType.GROUP_DM,
+        name,
+        visibility: ChannelVisibility.PRIVATE,
+        createdBy: userIds[0],
+        projectId,
+        workspaceId,
+      }),
+    ),
+  );
+
+  const rows = await prisma.channel.findMany({
+    where: { workspaceId, name, scopeType: 'GROUP_DM' },
+  });
+  expect(rows).toHaveLength(1);
+
+  const ids = new Set(results.map((r) => r.channel.id));
+  expect(ids.size).toBe(1);
+  expect(results.filter((r) => r.created)).toHaveLength(1);
+});
+
+it('rejects non-DM scope types', async () => {
+  await expect(
+    repo.getOrCreateDmChannel({
+      scopeType: ChannelScopeType.DEFAULT,
+      name: `not-a-dm-${suffix}`,
+      createdBy: userIds[0],
+      projectId,
+      workspaceId,
+    }),
+  ).rejects.toThrow();
+});

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -1,5 +1,5 @@
 import { BaseRepository } from './base';
-import { Channel } from '@prisma/client';
+import { Channel, Prisma } from '@prisma/client';
 import { ChannelScopeType, ChannelVisibility, ChannelType, ProjectType } from '@xyne/shared';
 import { QueryOptions } from '@/types/database';
 import { logger } from '@/utils/logger';
@@ -74,6 +74,66 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
 
 
     return result;
+  }
+
+  /**
+   * Concurrency-safe get-or-create for DM / GROUP_DM / self-DM channels.
+   *
+   * The normalized participant set is materialized in `channel.name` (sorted,
+   * comma-joined user IDs), and a partial unique index on
+   * (workspaceId, name) WHERE scopeType IN ('DM','GROUP_DM') is the real
+   * source of truth. We insert optimistically and, if a concurrent request
+   * won the race (Prisma P2002), we re-fetch and return the existing channel.
+   *
+   * Unlike `create()`, this path deliberately skips the app-level
+   * `checkDuplicateName` SELECT — that check is itself part of the check-then-
+   * create race; the DB constraint is what actually guarantees uniqueness.
+   *
+   * @returns the channel plus `created` = false when an existing channel was
+   *          returned because of a concurrent insert.
+   */
+  async getOrCreateDmChannel(
+    data: CreateChannelInput,
+  ): Promise<{ channel: Channel; created: boolean }> {
+    if (data.scopeType !== ChannelScopeType.DM && data.scopeType !== ChannelScopeType.GROUP_DM) {
+      throw new Error(`getOrCreateDmChannel only supports DM/GROUP_DM, got ${data.scopeType}`);
+    }
+
+    try {
+      const channel = await this.db.channel.create({
+        data: {
+          scopeType: data.scopeType,
+          name: data.name,
+          description: data.description,
+          visibility: data.visibility || 'PRIVATE',
+          createdBy: data.createdBy,
+          projectId: data.projectId,
+          workspaceId: data.workspaceId,
+          ...(data.type && { type: data.type }),
+        },
+      });
+      return { channel, created: true };
+    } catch (error) {
+      // A concurrent "open DM" request inserted the same (workspaceId, name)
+      // between our lookup and this insert — the partial unique index rejects
+      // it (P2002). Return the winner's channel instead of a duplicate.
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        const existing = await this.db.channel.findFirst({
+          where: {
+            workspaceId: data.workspaceId,
+            name: data.name,
+            scopeType: data.scopeType,
+          },
+        });
+        if (existing) {
+          logger.info(
+            `[getOrCreateDmChannel] Lost create race for ${data.scopeType} "${data.name}" in workspace ${data.workspaceId}; returning existing channel ${existing.id}`,
+          );
+          return { channel: existing, created: false };
+        }
+      }
+      throw error;
+    }
   }
 
   /**
@@ -353,14 +413,15 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
       // Create new DM channel
       const dmChannelName = [userId, targetUserId].sort().join(',');
 
-      dmChannel = await this.create({
+      // Concurrency-safe: partial unique index guards against duplicate DMs.
+      dmChannel = (await this.getOrCreateDmChannel({
         scopeType: ChannelScopeType.DM,
         name: dmChannelName,
         visibility: ChannelVisibility.PRIVATE,
         createdBy: userId,
         projectId,
         workspaceId,
-      });
+      })).channel;
 
       // Add both users as participants
       await channelParticipants.addParticipant(dmChannel.id, userId, 'ADMIN', false);
@@ -386,14 +447,15 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
       }
 
       // Create new group DM channel
-      const groupDMChannel = await this.create({
+      // Concurrency-safe: partial unique index guards against duplicate group DMs.
+      const groupDMChannel = (await this.getOrCreateDmChannel({
         scopeType: ChannelScopeType.GROUP_DM,
         name: groupDmName,
         visibility: ChannelVisibility.PRIVATE,
         createdBy: userId,
         projectId,
         workspaceId,
-      });
+      })).channel;
 
       // Add all users as participants
       await channelParticipants.addParticipant(groupDMChannel.id, userId, 'ADMIN', false);


### PR DESCRIPTION
## What & why
DM / self-DM / group-DM channel creation used a check-then-create (TOCTOU) pattern: look up the existing channel, and if none is found, create it. Two concurrent "open DM" requests for the same participant set both pass the existence check and both insert, producing **duplicate DM channels**. This affects 1:1 DMs, self-DMs, group DMs, and bot DMs. (XYNE-55089, P1)

## Fix
`channels.name` already stores the normalized participant key (self-DM = `userId`; 1:1 = sorted `"a,b"`; group = sorted joined ids). We make that the DB-enforced source of truth:

- **Migration** `20260805120000_dm_channel_unique_participant_key`: partial unique index on `(workspaceId, name) WHERE scopeType IN ('DM','GROUP_DM')`.
- **`ChannelRepository.getOrCreateDmChannel()`**: optimistic insert; on unique-violation (Prisma `P2002`) it re-fetches and returns the existing channel as `{ channel, created: false }`. Mirrors the existing `appCommandRepository` P2002 pattern.
- Wired into `findOrCreateDMChannel` (1:1 + group branches), `channelController.createNewDM` (self / 1:1 / group branches), and `unified-dm-service` (bot DM). A request that loses the race now returns **200 + `isExisting: true`** instead of 201 or a raw error.
- **`scripts/backfill/dedup-dm-channels.ts`**: pre-migration audit/cleanup. Empty race-orphan duplicates are deleted; content-bearing duplicates are reported for manual merge and cause a non-zero exit so the operator resolves them before the index is created.

## Rollout order (important)
1. Run `npx tsx scripts/backfill/dedup-dm-channels.ts --dry-run` (audit), then `--apply` if only empty orphans exist. The `CREATE UNIQUE INDEX` will FAIL if duplicates remain.
2. Deploy the migration.
3. Deploy the app changes.

## Validation
- `tsc --noEmit`: passes (0 errors) across the backend including all changed files.
- Migration applied to a live DB; index verified via `pg_indexes` with the exact expected definition.
- Dedup script runs against the DB and reports correctly.
- Added a concurrency test (`channelRepository.dm-concurrency.test.ts`): N parallel opens for the same 1:1 and group set collapse to a single channel with exactly one winner. NOTE: the test type-checks but could not be executed in the dev sandbox because the sandbox's jest harness + DB snapshot are broken by pre-existing golden drift (the untouched `ticket.test.ts` also fails to run there) — it must run in CI.

## Residual / out of scope
- Channel create + participant add are still not wrapped in a single `$transaction` (separate follow-up).
- Large groups whose `name` would exceed the column limit already fall back to a DEFAULT channel and are intentionally excluded from the index.