### PR TITLE
fix: post HITL write-approval cards for external-callback runs

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -4259,6 +4259,34 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     externalResultCallback = metadata?.externalResultCallback;
   }
   if (externalResultCallback) {
+    // HITL for API/service-token runs: the external caller receives its result
+    // via the callback, but a gated write (spaces-create-ticket, user-send-message,
+    // ...) still needs a human to approve/decline. Those approval cards are only
+    // posted on the normal channel path further below - which this branch returns
+    // before reaching. When the run is bound to a Spaces channel (the service
+    // token carried spaces:channels:post, so /run let channelId survive), post the
+    // cards into that channel BEFORE we tear the session down. Implicitly gated by
+    // ctx.channelId: headless runs with no bound channel skip this, exactly as before.
+    const externalPendingActions = (payload as { pendingActions?: Array<Record<string, unknown>> }).pendingActions;
+    const cbCtx = ctx;
+    if (cbCtx?.channelId && cbCtx.appToken && externalPendingActions?.length) {
+      const cbAppToken = cbCtx.appToken;
+      let approvalCardsSent = 0;
+      for (const action of externalPendingActions) {
+        try {
+          const targetValidation = await pendingActionTargetValidation(action, cbCtx, cbAppToken);
+          if (targetValidation.error) {
+            clog.info(`[webhook/result] external-callback skipped write approval card tool=${String(action["tool"] ?? "")}: ${targetValidation.error}`);
+            continue;
+          }
+          await postWriteApprovalAction({ action, ctx: cbCtx, token: cbAppToken, targetValidation });
+          approvalCardsSent += 1;
+        } catch (err) {
+          clog.warn(`[webhook/result] external-callback approval card failed tool=${String(action["tool"] ?? "")} sessionId=${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      clog.info(`[webhook/result] external-callback sent ${approvalCardsSent}/${externalPendingActions.length} write approval card(s) channelId=${cbCtx.channelId} sessionId=${sessionId}`);
+    }
     await deleteSession(sessionId);
     await sendStoredExternalResultCallback(
       externalResultCallback,


### PR DESCRIPTION
## What
Post write-tool approval (HITL) cards into the bound Spaces channel for API / service-token triggered runs that use an external result callback.

## Why
External API callers hit `POST /claw/api/v1/run` with a `callbackUrl`; the run is stored with an `externalResultCallback` and Claw posts its result to the internal `/webhook/result`. In that handler the `if (externalResultCallback)` branch forwards the result to the caller and `return`s **before** the normal channel path that posts pending write-approval cards.

Result: even after `channelId` survives into the run (the merged scope/`channelId` fix), a gated write (`spaces-create-ticket`, `user-send-message`, ...) queues an approvable `pendingAction` that is visible/approvable in the dashboard but **no Approve/Decline card is ever posted to the channel or thread**. HITL for API-triggered runs was effectively broken.

## Fix
In the `externalResultCallback` branch of `/webhook/result`, before `deleteSession` + the callback forward + `return`, post the pending write-approval cards into the bound channel, reusing the existing `pendingActionTargetValidation` + `postWriteApprovalAction` helpers (no new card-rendering logic).

- Implicitly gated by `ctx.channelId` — only populated when the service token carried `spaces:channels:post`. Headless runs with no bound channel skip it, exactly as before.
- Uses `ctx.appToken` (the agent's decrypted Spaces bot token, already set on the API-run session context in `run.ts`).
- Fail-safe per card: a card error is caught, logged, and never blocks the external callback delivery — the external system still gets its result.

## Scope
- `apps/xyne-claw-auth/backend/src/routes/webhook.ts` — +28 lines, one file.

## Testing / typecheck
- `tsc --noEmit`: webhook.ts had 11 pre-existing (Prisma/implicit-any) errors on the base branch; still 11 after this change — zero new type errors introduced.

## Notes / follow-up
- Once a card posts to the channel, any member of that channel can approve the write the external system requested — point these runs at a controlled channel.
