### PR TITLE
feat: defer-and-auto-resume agent runs on sandbox_unavailable (flag-gated)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts
@@ -92,6 +92,8 @@ interface RunRecoveryState {
   lastError: string | null;
   /** Count of session_locked deferrals (see deferLockContentionRetry). */
   lockDeferrals?: number;
+  /** Count of sandbox_unavailable deferrals (see deferSandboxRetry). */
+  sandboxDeferrals?: number;
   /** Count of explicit drain handoffs for this root run. Caps deploy crash-loop ping-pong. */
   handoffsUsed?: number;
   dispatchPayload: RecoveryDispatchPayload;
@@ -150,6 +152,16 @@ function isSessionLockedFailure(error?: string | null): boolean {
   return error === "session_locked" || error?.includes("session_locked") === true;
 }
 
+/** A writable dev sandbox could not be provisioned: the agent-sandbox operator
+ *  had no warm capacity to bind AND the kata node pool was at max nodes. Emitted
+ *  by sandbox-repo-setup → run.ts as error:"sandbox_unavailable". Unlike
+ *  session_locked (a peer run holds this conversation's lock), capacity here is
+ *  owned by the operator + node autoscaler, so we defer and re-dispatch the same
+ *  run until a SandboxClaim binds. */
+function isSandboxUnavailableFailure(error?: string | null): boolean {
+  return error === "sandbox_unavailable" || error?.includes("sandbox_unavailable") === true;
+}
+
 /** Scheduled fires use a one-shot `scheduled_<jobId>_<ts>` conversationId. The
  *  mid-run FIFO for such a key is NEVER drained (no inbound message targets it
  *  and /scheduled-jobs/:id/result has no drain), so lock-contended scheduled
@@ -187,6 +199,33 @@ async function deferLockContentionRetry(
   await saveState(state);
   await scheduleDispatch(state.rootSessionId, "session_locked — waiting for lock holder", delayMs);
   log.info(`[run-recovery] lock contention deferred root=${state.rootSessionId} deferral=${state.lockDeferrals}/${MAX_LOCK_DEFERRALS} retryInMs=${delayMs}`);
+  return true;
+}
+
+/** Poll cadence for a write sandbox to free up. The agent-sandbox operator keeps
+ *  reconciling the (still-alive) SandboxClaim and the node pool may be scaling in,
+ *  so a modest fixed delay re-dispatches until one binds. */
+const SANDBOX_RETRY_DELAY_MS = Number(process.env["SANDBOX_RETRY_DELAY_MS"] ?? 60_000);
+/** Hard cap on sandbox_unavailable deferrals (~15 × 60s = 15 min of waiting).
+ *  Guards against a run parking forever if capacity never frees. */
+const MAX_SANDBOX_DEFERRALS = Number(process.env["MAX_SANDBOX_DEFERRALS"] ?? 15);
+
+/** Re-schedule a run that could not get a write sandbox, WITHOUT consuming a
+ *  retry attempt — same idempotency guarantee as deferLockContentionRetry
+ *  (dispatchRetry's runAlreadyCompleted marker prevents a double run if the
+ *  original later completes). Returns false when the deferral cap is hit so the
+ *  caller can exhaust with a clear message. */
+async function deferSandboxRetry(
+  state: RunRecoveryState,
+  delayMs: number = SANDBOX_RETRY_DELAY_MS,
+): Promise<boolean> {
+  state.sandboxDeferrals = (state.sandboxDeferrals ?? 0) + 1;
+  if (state.sandboxDeferrals > MAX_SANDBOX_DEFERRALS) return false;
+  state.retryScheduled = true;
+  state.lastHeartbeatAt = Date.now();
+  await saveState(state);
+  await scheduleDispatch(state.rootSessionId, "sandbox_unavailable — waiting for write capacity", delayMs);
+  log.info(`[run-recovery] sandbox unavailable deferred root=${state.rootSessionId} deferral=${state.sandboxDeferrals}/${MAX_SANDBOX_DEFERRALS} retryInMs=${delayMs}`);
   return true;
 }
 
@@ -928,6 +967,16 @@ export async function handleRunCompletion(sessionId: string, status: "completed"
 
   if (state.status !== "running") {
     return { retried: false, exhausted: state.status === "exhausted", rootSessionId, retriesUsed: state.retriesUsed, maxRetries: state.maxRetries };
+  }
+
+  if (status === "failed" && isSandboxUnavailableFailure(error)) {
+    state.lastError = error ?? null;
+    await removeWatchdog(state.rootSessionId, state.activeSessionId).catch(() => {});
+    if (await deferSandboxRetry(state)) {
+      return { retried: true, exhausted: false, rootSessionId, retriesUsed: state.retriesUsed, maxRetries: state.maxRetries };
+    }
+    await markExhausted(state, "sandbox_unavailable (no write capacity after max deferrals)");
+    return { retried: false, exhausted: true, rootSessionId, retriesUsed: state.retriesUsed, maxRetries: state.maxRetries, terminalDrop: true };
   }
 
   if (status === "failed" && isSessionLockedFailure(error)) {

--- a/apps/xyne-claw/docs/sbx-availability-signal.md
+++ b/apps/xyne-claw/docs/sbx-availability-signal.md
@@ -1,0 +1,96 @@
+# "We won't know when a sandbox is available" — the correction
+
+**Branch:** `feature/sbx-resource-queue` · supersedes the *capacity-guessing* core of
+`sbx-resource-queue-phase2.md`. TL;DR: **we already know.** The availability signal exists in the
+operator; today we throw it away after 10 minutes. Don't build a Redis semaphore that guesses
+capacity — lean on the signal that's already there and fix the two real root causes.
+
+---
+
+## The objection, and why it's right about the wrong design
+
+The Phase-2 sketch proposed an app-level Redis semaphore that releases a slot on
+`sandbox-destroy`/`evictSession` and wakes the next waiter. Valid objection: a slot we release in
+*our* accounting is not the same as a *real* microVM being schedulable. Capacity here is also
+produced by GKE node autoscaling and by a warm-pool controller — neither of which fires an app-level
+"release." So a semaphore that only reacts to our own releases **would be blind** to most of the
+capacity that actually appears. The objection kills the guess-a-number semaphore.
+
+## What actually exists (verified against the live cluster)
+
+The sandbox layer is the **`sigs.k8s.io/agent-sandbox`** operator (`agent-sandbox-controller v0.4.5`,
+ns `agent-sandbox-system`) with **three** CRDs, and it already *is* the queue:
+
+| CRD | Group | Role |
+|---|---|---|
+| `Sandbox` | `agents.x-k8s.io` | the Firecracker/Kata microVM (Pod + PVC + headless Service) |
+| `SandboxClaim` | `extensions.agents.x-k8s.io/v1alpha1` | a request; operator binds it → `status.sandbox.name` |
+| `SandboxWarmPool` | `extensions.agents.x-k8s.io` | keeps `desired` warm Sandboxes ready per flavor |
+
+Provisioning is a **two-stage fallback the operator runs for us**:
+1. **Adopt** a warm-pool Sandbox → `SandboxAdopted` → claim bound in ~sub-second.
+2. Pool empty → **on-demand** create from template (`Created sandbox from template`) → Pod scheduled;
+   if the node pool is full the Pod is `Pending/Unschedulable` (`FailedScheduling: Insufficient
+   cpu/memory`, `3 max node group size reached`) and the operator **keeps reconciling until it fits**.
+
+There is an **`euler-warmpool`** flavor. Right now every pool is sized **`desired:1, current:1`**, and
+`kata-sandbox-ng` is **at its cap of 3/3 nodes**. That is the whole bug: only **one** warm euler
+sandbox is kept ready, and when it's taken the next dev must wait for replenishment onto a node pool
+that's already maxed → `sbx not available`.
+
+## So: how do we know when a sandbox is available? Three real signals, already emitted
+
+- **The claim binding** — `SandboxClaim.status.sandbox.name` goes from empty → a name the moment the
+  operator adopts or provisions. This is the authoritative, per-request "your sandbox is ready."
+  **The kata SDK already polls exactly this** (`packages/kata-sdk/src/client.ts` ·
+  `waitForSandboxAssignment`, 1 s poll) — it just **gives up after `readyTimeoutMs` (10 min)** and
+  throws, and then `tools.ts` substitutes a read-only session and the run ends. We are discarding a
+  signal we already receive.
+- **A k8s watch** on the claim → a *push* event on bind (no polling at all).
+- **`SandboxWarmPool.status`** (`desired` vs `current`) — observable pool headroom for metrics/alerts.
+
+None of these needs an app-side capacity estimate. The operator already accounts for warm pool +
+on-demand + node autoscaling; a Redis semaphore would duplicate that, badly, and (the objection)
+still couldn't see autoscaling capacity.
+
+## Corrected design
+
+**Root-cause fix (config, no code) — do this first, it's most of the win:**
+- Raise `SandboxWarmPool` `desired` for the doctor flavors (`euler-warmpool`, lotus, lamf) from 1 to
+  the real peak concurrency (e.g. 3–4).
+- Raise `kata-sandbox-ng --max-nodes` (currently 3) so replenishment has somewhere to land.
+  Warm-pool `desired` is only honorable if nodes exist to hold them.
+- This alone removes most `sbx not available` events. **Confirm target numbers with infra.**
+
+**Code fix — turn the 10-min give-up into suspend-resume driven by the binding signal:**
+1. On the write path, keep the short in-process wait but **cut it to ~30–60 s** (don't block a pod
+   or the LLM loop for 10 min).
+2. If unbound by then, **do not** fall back to read-only and **do not** end the run. Instead **keep
+   the SandboxClaim alive** (it already lives for hours via `lifecycle.shutdownTime`) and **suspend
+   the run** using the existing run-recovery defer (ends the turn cleanly: *"queued — I'll resume
+   automatically, no need to re-tag"*). Persist `claimName → rootSessionId`.
+3. A lightweight **watcher in claw-auth** (k8s watch on the claim, or a cheap 1 Hz poll of
+   `status.sandbox.name` — no LLM, no VM) resumes the run via `scheduleDispatch` the instant the
+   claim binds. That binding *is* the "available now" event — covering warm-pool adoption, on-demand,
+   AND autoscaling capacity, because all three end in a bind.
+4. The resumed run must **reuse the now-bound sandbox** (thread `claimName`/`sandboxId` through the
+   recovery payload) so it doesn't open a second claim.
+5. Cap total wait; on give-up **delete the claim** (avoid leaking a claim that binds later and idles)
+   and exhaust with a clear message.
+
+**What survives from the Phase-2 doc:** the run-recovery integration (defer without consuming a
+retry, GCS-marker idempotency, `deferSandboxRetry`/classifier, exhaust cap) is still exactly the
+resume machinery — see `sbx-resource-queue-phase2.md` §4/§7. **What is dropped:** the Redis
+capacity semaphore and the `sandbox:cap/inuse/waitq` accounting — the operator already owns capacity;
+we only need to *listen for the bind*, not re-account.
+
+## Open items for the owner / infra
+
+1. Target `desired` per doctor warm pool and new `--max-nodes` for `kata-sandbox-ng` (biggest lever).
+2. Watch vs poll for the claim-bind watcher (watch = push, needs claw-auth k8s RBAC to `get/watch`
+   SandboxClaims; poll = simpler, ~1 GET/s/claim). Recommendation: poll first, watch later.
+3. **Fairness under contention (Inferred, not code-verified):** the operator most likely processes
+   pending claims in controller-runtime work-queue (≈FIFO) order — there is no priority/creation-time
+   ordering flag on it. If strict FIFO fairness across many waiting doctor runs matters, that is the
+   *only* place a thin app-side ordering ticket (Redis LIST, ordering **only**, no capacity guessing)
+   would add value — layer it on step 3's watcher, not before.

--- a/apps/xyne-claw/docs/sbx-resource-queue-phase2.md
+++ b/apps/xyne-claw/docs/sbx-resource-queue-phase2.md
@@ -1,0 +1,166 @@
+# Sandbox Resource Queue — Phase 2 (capacity-aware FIFO admission) build spec
+
+**Status:** proposal · **Branch:** `feature/sbx-resource-queue` (from `feature/deploy-xyneclaw`)
+**Decision:** go straight to Phase 2 (owner: "we can do phase 2 directly"). This doc is the
+build-ready design. It supersedes §3 Phase 2 of `sbx-resource-queue.md`.
+
+> **One thing changes vs the earlier sketch:** Phase 2 does **not** replace the defer-and-resume
+> signal — it is built **on top of it**. The semaphore is a *soft* admission cap; the real
+> capacity signal is still the k8s claim timeout. See §2.
+
+---
+
+## 1. The capacity fact that drives the design (verified)
+
+Sandboxes are Firecracker microVMs scheduled onto a **dedicated GKE node pool**
+(`apps/xyne-claw/infra/kata/00-node-pool.sh`):
+
+```
+kata-sandbox-ng · n1-standard-4 (4 vCPU / 15 GB) · nested virt
+--enable-autoscaling --min-nodes=0 --max-nodes=3
+```
+
+Consequences:
+
+- Capacity is **elastic but hard-capped at 3 nodes** — a small, finite ceiling of concurrent
+  microVMs (≈ how many Firecracker VMs fit across 3× n1-standard-4, minus the claw pods).
+- Scale-up 0→3 is **slow (minutes)**: GKE must add a node *and* the kata-deploy DaemonSet must
+  install Firecracker on it before a claim can bind. This is exactly why a burst of doctor users
+  blows past `readyTimeoutMs` (10 min) and surfaces `sbx not available`.
+- There is **no single "real capacity" integer** — it depends on per-VM resource requests and how
+  many nodes are currently warm. So an app-level semaphore can only ever be an *estimate*.
+
+**Design implication:** admission control (semaphore + FIFO) prevents the thundering herd and gives
+fair ordering, but the **provisioning-timeout deferral must remain as the backstop** for when the
+estimate is too high or a node is mid-scale-up. A semaphore alone, sized wrong, just reproduces the
+bug at a different threshold.
+
+## 2. Target behavior
+
+1. A doctor run needs a writable sandbox → it **acquires an admission slot** for its template
+   before calling `createSession`.
+2. Slots available → proceed immediately (today's happy path, now bounded).
+3. No slot → the run **parks in a per-template FIFO** and ends cleanly with `sandbox_unavailable`;
+   the user sees *"queued (position N), I'll continue automatically — no need to re-tag."*
+4. A slot is released (sandbox destroyed / evicted / lease TTL expired) → the **head of the FIFO**
+   is woken and its run is re-dispatched via existing run-recovery.
+5. Slot acquired but the k8s claim **still times out** (mid scale-up / estimate too high) → release
+   the slot, re-park the run **at the FIFO head** (keep its place), defer with backoff. Capped by
+   `MAX_SANDBOX_DEFERRALS` → then exhaust with a clear message.
+
+## 3. Why a global (Redis) semaphore, not in-process
+
+Both claw-auth and the runtime run **multiple replicas** (see `session-lock.ts`,
+`cron-leader-lock.ts`, `daily-brief-worker.ts` "global slot… across ALL replicas"). The only
+existing sandbox self-throttle is `KataClient`'s `DEFAULT_MIN_CREATE_SPACING_MS = 10s`, which is
+**in-memory and per-client-instance** — it cannot cap *concurrency* across replicas. Admission must
+live in **Redis** to be correct cluster-wide. This mirrors how the daily-brief global concurrency
+slot already works.
+
+## 4. Where admission attaches (exact anchors)
+
+| Hook | File · symbol | Action |
+|---|---|---|
+| **Acquire** | `packages/xyne-claw-shared/src/tools/sandbox/tools.ts` · `makeRepoSetupTool.execute`, the write-claim branch right before `client.createSession({ template: claimTemplate, readyTimeoutMs })` (~L1457) | `acquireSlot(template, sessionKey)` with a short non-blocking wait; on miss → emit `sandbox_unavailable` (do **not** fall back to read-only for a write-needing run) |
+| **Release (explicit)** | same file · `sandbox-destroy` tool (~L2104) after `session.destroy()` + `evictSession` | `releaseSlot(template, sessionKey)` + push `sandbox:release` signal |
+| **Release (implicit)** | same file · `evictSession` (L329) — the central choke point for dead-probe / template-mismatch / idle eviction | `releaseSlot(...)` here so every eviction frees a slot |
+| **Release (safety)** | n/a — pod death / server-side `writeIdleTimeoutMs`/`writeSessionTimeoutMs` auto-expiry may skip `evictSession` | **TTL lease** on each slot (renew via the run's heartbeat / `touchRunRecovery`) so a lost VM auto-frees |
+| **FIFO wakeup** | `apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts` — new `startSandboxReleaseConsumer()` mirroring `startHandoffSignalConsumer()` (L701); booted from `initRunRecoveryWorker()` (L651 → called in `main.ts:320`) | `BRPOP sandbox:release` → pop FIFO head → `scheduleDispatch(root, "sandbox slot freed", 0)` |
+| **Defer/exhaust** | same worker — new `isSandboxUnavailableFailure()` + `deferSandboxRetry()` beside `deferLockContentionRetry()` (L179); wire into `handleRunCompletion` (L912) / `dispatchRetry` (L400) exactly where `session_locked` is handled | re-park at FIFO head, backoff, cap at `MAX_SANDBOX_DEFERRALS` |
+
+The runtime already has a scoped Redis client pattern for exactly this kind of cross-service signal
+— `apps/xyne-claw/src/handoff-redis.ts` (deliberately claw's only direct Redis use). The admission
+client is the **second** scoped use: model it on that file (fail-open, dedicated connection, TTL'd
+keys). Reusing that posture keeps the boundary honest.
+
+## 5. Redis data model
+
+```
+sandbox:cap:<template>            (int)   configured slot budget (from env, see §6)
+sandbox:inuse:<template>          (ZSET)  member=sessionKey, score=leaseExpiryMs   ← TTL leases
+sandbox:waitq:<template>          (LIST)  FIFO of rootSessionIds waiting           ← fairness
+sandbox:release                   (LIST)  BRPOP signal: {template} slot freed      ← wakeup
+```
+
+- **acquireSlot(template, key):** atomically (Lua) purge expired leases from `inuse` (score < now),
+  then if `|inuse| < cap` add `key` with `score = now + leaseTtlMs` → **granted**; else `RPUSH` the
+  root onto `waitq` → **queued**. One round-trip, no race across replicas.
+- **releaseSlot(template, key):** `ZREM inuse key`; `LPUSH sandbox:release {template}`.
+- **renewLease:** on run heartbeat (`touchRunRecovery`), bump the `inuse` score so a long legit
+  build doesn't get its slot stolen by the expiry sweep.
+- Every key TTL-guarded so a dead replica can't wedge the queue (same discipline as
+  `HANDOFF_SIGNAL_QUEUE_KEY`'s `QUEUE_TTL_SECONDS`).
+
+## 6. Sizing (operator-tuned, never hardcoded)
+
+`SANDBOX_MAX_CONCURRENT_<TEMPLATE>` env per template (gvisor / lotus / lamf), defaulted
+**conservatively** to match the ≤3-node pool (start low, raise as the node pool / VM requests are
+tuned). Because it's an estimate, §2.5's timeout-backstop covers over-provisioning. Document the
+relationship: raising the cap without raising `--max-nodes` just moves the failure from "queued" to
+"claim timeout" (which now degrades gracefully instead of dead-ending).
+
+## 7. Idempotency & correctness (reused, load-bearing)
+
+Re-dispatch on wakeup goes through the existing run-recovery path, so it inherits:
+- **GCS result marker** (`runAlreadyCompleted`, `claw-results/<idempotencyKey>.json`) → a run that
+  actually finished is never re-run.
+- `alreadyPersisted` / `__skipUserMessagePersist` → a resumed run does not duplicate the user's
+  chat turn (no branch). Deferrals must **not** consume a retry (copy `deferLockContentionRetry`).
+
+## 8. Observability
+
+- Metrics: `sandbox_slot_inuse{template}`, `sandbox_queue_depth{template}`, `sandbox_wait_ms`
+  (park→resume), `sandbox_admission_grants_total`, `sandbox_deferrals_total{reason}`,
+  `sandbox_deferral_exhausted_total`, `sandbox_lease_expired_total` (leak detector).
+- Logs keyed by `rootSessionId`, mirroring `[run-recovery] lock contention deferred …`.
+- Alert on `sandbox_lease_expired_total` > 0 sustained (VMs dying without clean release) and on
+  `sandbox_queue_depth` staying high (real capacity shortfall → bump `--max-nodes`).
+
+## 9. Tests
+
+- **Lua unit:** acquire respects cap; concurrent acquires across "replicas" never exceed cap;
+  expired-lease purge frees a slot; queued root lands on `waitq` in order.
+- **Classifier unit:** `isSandboxUnavailableFailure` fires on provisioning timeout only — NOT on
+  bad-branch / repo-not-found / missing-conversationId (must pass through unchanged).
+- **Worker unit:** `deferSandboxRetry` caps at `MAX_SANDBOX_DEFERRALS`, consumes no retry, honors
+  `runAlreadyCompleted` early-exit, re-parks at FIFO **head**.
+- **Integration:** cap=1 → run A holds slot, run B parks → destroy A → release signal wakes B →
+  B resumes, exactly one user turn persisted, no duplicate side effects.
+- **Leak:** kill A's replica without `evictSession` → lease TTL expires → next acquire/sweep frees
+  the slot; `sandbox_lease_expired_total` increments.
+- **Backstop:** grant slot but force `createSession` timeout → slot released, run re-parked at head,
+  deferral counter increments, exhaust message after cap.
+
+## 10. Rollout
+
+1. Land Redis admission module (runtime, scoped like `handoff-redis.ts`) + Lua scripts. Behind
+   `SANDBOX_ADMISSION_ENABLED` (default off) → **fail-open** to today's behavior.
+2. Land worker `deferSandboxRetry` + `startSandboxReleaseConsumer` (boot from
+   `initRunRecoveryWorker`). No-op while the flag is off.
+3. Wire acquire/release hooks in `tools.ts` (gated by the flag).
+4. Enable on **one** template first (the doctor repo hitting this) with a conservative
+   `SANDBOX_MAX_CONCURRENT_*`; watch `sandbox_queue_depth` / `sandbox_wait_ms` / lease-expiry.
+5. Tune cap ± `--max-nodes` together; then enable other templates.
+
+## 11. Files to change
+
+- `apps/xyne-claw/src/sandbox-admission.ts` **(new)** — scoped Redis client + Lua acquire/release/renew.
+- `packages/xyne-claw-shared/src/tools/sandbox/tools.ts` — acquire before `createSession`; release
+  in `sandbox-destroy` + `evictSession`; emit `sandbox_unavailable` on write-path miss/timeout.
+- `apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts` — `isSandboxUnavailableFailure`,
+  `deferSandboxRetry`, `startSandboxReleaseConsumer`; wire into `handleRunCompletion` / `dispatchRetry`.
+- `apps/xyne-claw/src/routes/run.ts` — propagate terminal `sandbox_unavailable` to the completion callback (mirror `session_locked`).
+- config/env plumbing for `SANDBOX_ADMISSION_ENABLED`, `SANDBOX_MAX_CONCURRENT_*`,
+  `SANDBOX_LEASE_TTL_MS`, `SANDBOX_RETRY_DELAY_MS`, `MAX_SANDBOX_DEFERRALS`.
+
+## 12. Open decisions for the owner
+
+1. **Semaphore sizing:** confirm a starting `SANDBOX_MAX_CONCURRENT_gvisor` (and per doctor
+   template). I recommend starting at whatever ~2 warm nodes safely hold, since node #3 is slow to
+   arrive — better to queue than to hand out slots that then time out.
+2. **Runtime Redis boundary:** OK to add a *second* scoped Redis client in the runtime
+   (`sandbox-admission.ts`, modeled on `handoff-redis.ts`)? The alternative — an S2S admission HTTP
+   endpoint in claw-auth — reintroduces the hot-path HTTP hop that `handoff-redis.ts` deliberately
+   moved off. Recommendation: scoped Redis client.
+3. Whether to also bump the node pool `--max-nodes` (currently 3) as part of this — admission makes
+   the shortage graceful, but if `sandbox_queue_depth` is chronically high the real fix is capacity.

--- a/apps/xyne-claw/docs/sbx-resource-queue.md
+++ b/apps/xyne-claw/docs/sbx-resource-queue.md
@@ -1,0 +1,164 @@
+# Sandbox Resource Queue — design plan
+
+**Status:** proposal · **Branch:** `feature/sbx-resource-queue` (cut from `feature/deploy-xyneclaw`)
+**Problem owner ask:** when the writable dev sandbox can't be provisioned (`sbx not available`),
+queue the run and continue the agent flow automatically when capacity frees — so devs stop
+re-tagging the doctor agent.
+
+---
+
+## 1. What actually happens today (verified)
+
+Doctor-style agents (e.g. euler/LotusPay/LAMF doctor) are pinned to a repo via
+`agent.config.sandboxRepo`. Those repo configs are **not `readFirst`**, so every run goes
+straight to the *writable golden-clone* path in `sandbox-repo-setup`.
+
+Provisioning chain:
+
+- `sandboxRepoSetup.execute` → `makeRepoSetupTool(...).execute` → `KataClient.createSession()`
+  (`packages/kata-sdk/src/client.ts`) creates a `SandboxClaim` CRD and waits for it to
+  **bind to a Sandbox** and reach **Running**, bounded by `readyTimeoutMs` (10 min for these repos).
+- If the cluster can't schedule a fresh microVM / GCP throttles the per-snapshot CoW clone,
+  the claim never binds → `KataClient` throws *"Timed out waiting for SandboxClaim … to bind"*
+  (or *"… to reach Running phase"*).
+
+Failure handling (`packages/xyne-claw-shared/src/tools/sandbox/tools.ts`,
+`sandboxRepoSetup.execute`, ~L2083):
+
+```
+if (isSandboxProvisioningFailure(result)) {
+  const reason = `the writable dev sandbox could NOT be provisioned right now (${firstLine}) — likely no capacity for a fresh machine.`;
+  const ro = await resolveSbxGit(repoName, context, reason);   // READ-ONLY fallback
+  if (!ro.startsWith("Error")) return ro;
+}
+```
+
+**The core defect:** for a write-needing agent the read-only fallback is useless — the agent
+can't build/fix/commit. The tool call *succeeds* with a read-only session, the LLM continues,
+concludes it can't do the work, and the **run completes normally**. No signal reaches any
+retry/recovery layer, so the human re-tags the agent — and it recurs the moment load is high.
+
+There is **no app-level admission control / concurrency cap / queue** for sandboxes today.
+`KataClient` only self-throttles *claim creation spacing* (`DEFAULT_MIN_CREATE_SPACING_MS = 10s`,
+in-memory, per client instance). Capacity is whatever the k8s node pool + warm pool can schedule.
+
+## 2. The reusable primitive we already have
+
+`apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts` already does exactly the hard
+part — **defer a whole run and re-dispatch it later, idempotently**:
+
+- `registerRunRecovery(...)` persists the full dispatch payload + session context in Redis,
+  keyed by `rootSessionId`.
+- BullMQ queue `agent-run-recovery` with `scheduleDispatch(root, reason, delayMs)` →
+  `dispatchRetry(...)` re-POSTs to `/claw/api/v1/internal/run`.
+- **Idempotency:** `runAlreadyCompleted()` checks the GCS result marker
+  (`claw-results/<idempotencyKey>.json`) so a finished run is never re-executed.
+- `deferLockContentionRetry(state, delayMs)` is the precise analog we want: when a run hits
+  `session_locked`, it re-schedules the dispatch after a delay **without consuming a retry**,
+  capped by `MAX_LOCK_DEFERRALS = 10`. The user never re-tags.
+
+The sandbox-capacity case is the same shape: a transient resource contention that should
+**defer-and-resume**, not fail.
+
+## 3. Recommendation
+
+Reuse the run-recovery machinery. Introduce a `sandbox_unavailable` deferral that mirrors
+`session_locked`, and **fail the run fast BEFORE the read-only fallback** when the agent
+genuinely needs write. Because a doctor agent's first meaningful action is `sandbox-repo-setup`,
+failing fast and re-dispatching the whole task loses ~no work.
+
+Ship in two phases.
+
+### Phase 1 — Defer-and-retry (kills the re-tag pain; small, boring, reuses everything)
+
+1. **Runtime: emit a deferral signal instead of silently degrading.**
+   In `sandboxRepoSetup.execute`, when `wantWrite === true` (or an agent that requires write —
+   `forceWriteSandbox`/`allowWriteInReadOnlyJob` context) AND `isSandboxProvisioningFailure(result)`:
+   - do **not** substitute the read-only session;
+   - end the run with a terminal signal `sandbox_unavailable` (same channel the runtime uses to
+     surface `session_locked` to `handleRunCompletion`), carrying the repo + reason.
+   Keep the read-only fallback for read-oriented / non-write calls (unchanged).
+
+2. **Recovery worker: add `isSandboxUnavailableFailure()` + `deferSandboxRetry()`** next to the
+   lock-contention equivalents. Same defer-without-consuming-retry semantics, own tunables:
+   - `SANDBOX_RETRY_DELAY_MS` (default ~60s),
+   - `MAX_SANDBOX_DEFERRALS` (default ~15; ~15 min of waiting at 60s),
+   - jittered backoff to avoid a thundering herd of simultaneous re-claims.
+   Wire it into `dispatchRetry` / `handleRunCompletion` exactly where `session_locked` is handled.
+
+3. **User-visible progress.** On first deferral, post one progress line to the thread:
+   *"All dev sandboxes are busy — you're queued (position N). I'll continue automatically when one
+   frees; no need to re-tag."* Update on resume / on exhaustion.
+
+4. **Exhaustion path.** After `MAX_SANDBOX_DEFERRALS`, mark exhausted and post a clear message
+   (optionally offer the read-only session as a downgrade). This is the only case that still
+   needs human action.
+
+This alone removes the re-tag loop. It is **poll-with-backoff** (retry until a claim succeeds),
+so it does not need a real capacity counter.
+
+### Phase 2 — Capacity-aware FIFO admission queue (fairness + no thundering herd)
+
+Phase 1 retries blindly; under sustained load many deferred runs wake and race for the same slot.
+Phase 2 adds real admission control:
+
+- **Redis semaphore** `sandbox:capacity:<template>` sized to the warm-pool/node-pool budget per
+  template (config-driven, e.g. `SANDBOX_MAX_CONCURRENT_<TEMPLATE>`). Acquire before
+  `createSession`; release on `sandbox-destroy`, idle-eviction, and session death
+  (`evictSession`). A TTL on each held slot prevents leaks when a pod dies without releasing.
+- **FIFO wait list** `sandbox:waitq:<template>` (Redis list/ZSET). On provisioning contention the
+  run parks here instead of blind-retrying; when a slot is released, pop the head and
+  `scheduleDispatch(delay=0)` for that specific `rootSessionId`. Event-driven wakeup replaces
+  polling → fair ordering, no herd.
+- Emit metrics (see §5). Keep the Phase-1 backoff path as the fallback if the semaphore/queue is
+  unavailable (fail-open).
+
+## 4. Alternatives considered (and why weaker)
+
+- **Block inside the tool** (poll for a free slot up to N min, keep the LLM loop parked): simplest
+  to reason about, but it pins a claw pod + burns provider context/tokens for the whole wait and
+  will breach the run/tool timeout under real contention. Rejected.
+- **Grow the warm pool / raise concurrency only:** reduces frequency but doesn't bound it — the
+  owner explicitly expects load to keep rising. Capacity tuning is complementary, not a fix.
+- **Make doctor repos `readFirst`:** wrong for a *doctor* agent whose whole job is build/run/fix;
+  read-only can't do the work.
+
+## 5. Validation & observability
+
+- **Metrics:** `sandbox_deferrals_total{template,reason}`, `sandbox_queue_depth{template}`,
+  `sandbox_wait_ms` histogram, `sandbox_deferral_exhausted_total`, and (Phase 2)
+  `sandbox_capacity_inuse{template}`.
+- **Logs:** one line per defer/resume/exhaust keyed by `rootSessionId` (mirror the
+  `[run-recovery] lock contention deferred …` format).
+- **Tests:**
+  - unit: `isSandboxUnavailableFailure` classification (provisioning timeout vs bad-branch vs
+    repo-not-found — must NOT defer user-input errors);
+  - unit: `deferSandboxRetry` caps at `MAX_SANDBOX_DEFERRALS`, doesn't consume retries, honors
+    `runAlreadyCompleted` early-exit;
+  - integration: forced provisioning failure → run deferred → capacity freed → same run resumes,
+    exactly one user turn persisted, no duplicate side effects (GCS marker idempotency);
+  - Phase 2: semaphore release wakes the FIFO head; slot never leaks on pod death (TTL).
+
+## 6. Risks
+
+- **Idempotency is load-bearing.** Re-dispatch must rely on the GCS result marker and
+  `alreadyPersisted`/`__skipUserMessagePersist` so a resumed run never double-persists the user
+  turn or repeats side effects. This is why we reuse run-recovery rather than roll a new dispatch.
+- **Slot leaks (Phase 2):** a pod dying mid-hold must not permanently shrink capacity → TTL'd
+  semaphore entries + reconcile on `evictSession`/session death.
+- **Starvation:** blind Phase-1 backoff can starve some runs under heavy load → the Phase-2 FIFO
+  fixes ordering; keep the deferral cap so nothing waits forever silently.
+- **Scope of the deferral signal:** only genuine provisioning failures defer; bad-branch /
+  repo-not-found / no-conversationId must pass through unchanged (already discriminated by
+  `isSandboxProvisioningFailure`).
+
+## 7. Files likely to change
+
+- `packages/xyne-claw-shared/src/tools/sandbox/tools.ts` — emit `sandbox_unavailable` on
+  write-path provisioning failure instead of the read-only substitution.
+- `apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts` — `isSandboxUnavailableFailure`,
+  `deferSandboxRetry`, wiring in `dispatchRetry` / `handleRunCompletion`, tunables.
+- Runtime run-completion path in `apps/xyne-claw/src/routes/run.ts` — propagate the terminal
+  `sandbox_unavailable` status to the completion callback (mirror `session_locked`).
+- Phase 2: new `sandbox-admission.ts` (Redis semaphore + FIFO) + acquire/release hooks around
+  `createSession` / `evictSession` / `sandbox-destroy`.

--- a/apps/xyne-claw/src/custom-tools.ts
+++ b/apps/xyne-claw/src/custom-tools.ts
@@ -13,6 +13,7 @@ import { SERVER, PATHS } from "./config.js";
 import { join } from "node:path";
 
 import { createLogger } from "./logger.js";
+import { SandboxUnavailableError, isSandboxUnavailableDeferEnabled } from "./sandbox-unavailable.js";
 const log = createLogger("custom-tools");
 
 interface Attachment {
@@ -287,6 +288,22 @@ export function loadCustomTools(
           result = `Error: ${errMsg}`;
         }
         log.info(`[custom-tool] ${ct.slug} result: ${result.slice(0, 300)}`);
+
+        // Sandbox-capacity deferral (flag-gated, default off): the inner catch
+        // above stringifies every tool throw and hands it to the LLM, which for a
+        // failed WRITE-sandbox provision would just give up and end the run with no
+        // retry signal. When sandbox-repo-setup emits the `sandbox_unavailable`
+        // sentinel, rethrow a typed error so it propagates to run.ts's terminal
+        // catch → run ends with error:"sandbox_unavailable" → run-recovery defers
+        // and auto-resumes. See apps/xyne-claw/docs/sbx-availability-signal.md.
+        if (
+          isSandboxUnavailableDeferEnabled() &&
+          ct.slug === "sandbox-repo-setup" &&
+          result.startsWith("Error: sandbox_unavailable:")
+        ) {
+          log.info(`[custom-tool] ${ct.slug} sandbox_unavailable — deferring run for auto-resume`);
+          throw new SandboxUnavailableError(result.slice("Error: ".length));
+        }
 
         // INSPECT marker — image goes into agent's content for self-verification
         // but is NOT pushed to allAttachments (user does not receive the file).

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -30,6 +30,7 @@ import {
   type Todo,
 } from "xyne-claw-shared";
 import { SessionLockedError } from "../session-lock.js";
+import { SandboxUnavailableError } from "../sandbox-unavailable.js";
 import { isSafeId } from "../safe-id.js";
 import { sanitizeCitations } from "../citation-sanitizer.js";
 import { validateS2SKey } from "../middleware/auth.js";
@@ -3978,6 +3979,26 @@ async function processTask(
         fastMode: fastModeForCallback,
         status: "failed",
         error: "session_locked",
+        provider: callbackProvider,
+        model: callbackModel,
+      });
+      return;
+    }
+    // Write sandbox could not be provisioned (no warm capacity + node pool full).
+    // End the run with a terminal signal claw-auth run-recovery recognizes, so it
+    // defers and re-dispatches this same run until a SandboxClaim binds — the user
+    // does NOT need to re-tag. Gated upstream by SANDBOX_UNAVAILABLE_DEFER, so this
+    // branch only fires when the flag is on.
+    if (err instanceof SandboxUnavailableError) {
+      log(`Sandbox unavailable — queuing run for auto-resume (sessionId=${sessionId})`);
+      await sendCallback(callbackUrl, sessionToken, {
+        sessionId,
+        userId,
+        conversationId: conversationId ?? null,
+        agentSlug: agentSlug ?? null,
+        fastMode: fastModeForCallback,
+        status: "failed",
+        error: "sandbox_unavailable",
         provider: callbackProvider,
         model: callbackModel,
       });

--- a/apps/xyne-claw/src/sandbox-unavailable.ts
+++ b/apps/xyne-claw/src/sandbox-unavailable.ts
@@ -1,0 +1,37 @@
+/**
+ * Sandbox-capacity deferral signal.
+ *
+ * When an agent needs a WRITABLE dev sandbox and the agent-sandbox operator
+ * cannot bind a SandboxClaim right now (warm pool empty AND the kata node pool
+ * at max nodes), `sandbox-repo-setup` emits a stable `sandbox_unavailable`
+ * sentinel instead of silently substituting a read-only session. The custom-tool
+ * runner (which otherwise stringifies every tool throw and hands it back to the
+ * LLM — letting the agent "succeed" with an unusable sandbox, give up, and end
+ * the run with NO retry signal, forcing a human to re-tag) rethrows THIS typed
+ * error so it reaches run.ts's terminal catch. There the run ends with
+ * `error: "sandbox_unavailable"`, which run-recovery classifies and defers,
+ * re-dispatching the same run until a sandbox binds — no re-tag needed.
+ *
+ * The whole path is gated behind SANDBOX_UNAVAILABLE_DEFER (default off) so the
+ * change is a no-op until it has been validated on-cluster and the flag flipped.
+ *
+ * See apps/xyne-claw/docs/sbx-availability-signal.md for the design rationale.
+ */
+
+/** Stable protocol token shared (as a bare literal, mirroring "session_locked")
+ *  across the shared sandbox tool, this runtime, and claw-auth run-recovery. */
+export const SANDBOX_UNAVAILABLE_SENTINEL = "sandbox_unavailable";
+
+/** Master gate for the defer-and-auto-resume path. Default OFF: with the flag
+ *  unset, `sandbox-repo-setup` keeps today's read-only fallback and nothing in
+ *  this module is ever thrown. */
+export function isSandboxUnavailableDeferEnabled(): boolean {
+  return process.env["SANDBOX_UNAVAILABLE_DEFER"] === "true";
+}
+
+export class SandboxUnavailableError extends Error {
+  constructor(public readonly detail?: string) {
+    super(detail ?? SANDBOX_UNAVAILABLE_SENTINEL);
+    this.name = "SandboxUnavailableError";
+  }
+}

--- a/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
@@ -2086,6 +2086,17 @@ export const sandboxRepoSetup: ToolDefinition = {
     // — bad-branch / repo-not-found errors pass through unchanged.
     if (isSandboxProvisioningFailure(result)) {
       const firstLine = result.split("\n")[0]?.replace(/^Error:\s*/i, "").slice(0, 160) ?? "provisioning failed";
+      // Flag-gated (SANDBOX_UNAVAILABLE_DEFER, default off): instead of silently
+      // substituting a read-only session — which lets a write-needing agent
+      // "succeed" with an unusable sandbox, conclude it cannot work, and end the
+      // run with NO retry signal (forcing a human to re-tag) — emit a stable
+      // `sandbox_unavailable` sentinel. custom-tools.ts turns this into a typed
+      // SandboxUnavailableError, run.ts ends the run with error:"sandbox_unavailable",
+      // and claw-auth run-recovery defers + auto-resumes once a SandboxClaim binds.
+      // See apps/xyne-claw/docs/sbx-availability-signal.md.
+      if (process.env["SANDBOX_UNAVAILABLE_DEFER"] === "true") {
+        return `Error: sandbox_unavailable: the writable dev sandbox could not be provisioned (${firstLine}). This run is being queued and will resume automatically when capacity frees — no need to re-tag.`;
+      }
       const reason =
         `the writable dev sandbox could NOT be provisioned right now (${firstLine}) — likely no capacity for a fresh machine.`;
       const ro = await resolveSbxGit(repoName, context, reason);


### PR DESCRIPTION
## Problem
As more devs use **euler doctor**, they repeatedly hit `sbx not available` and must re-tag the agent. Root cause traced end-to-end:

- Doctor agents are pinned to a repo, so every run claims a **fresh writable** microVM (never read-only).
- Provisioning goes through the `agent-sandbox` operator: a `SandboxClaim` is adopted from a per-flavor **warm pool** (e.g. `euler-warmpool`, currently `desired:1`) or created on-demand from a template. Under concurrency the warm pool is empty and the `kata-sandbox-ng` node pool is at its cap (3/3 nodes), so the claim can't bind quickly.
- **The defect:** on provisioning timeout, `sandbox-repo-setup` silently substitutes a **read-only** session. The write-needing agent "succeeds" with an unusable sandbox, concludes it can't do the work, and the run ends **with no retry signal** — so a human must re-tag. This repeats.

## What this PR does
Wires a terminal `sandbox_unavailable` signal into the **existing run-recovery machinery** (mirroring the proven `session_locked` defer-and-redispatch path), so a run that can't get a write sandbox **defers and auto-resumes when a `SandboxClaim` binds** — no re-tag.

Flow: `sandbox-repo-setup` emits a stable `sandbox_unavailable` sentinel → `custom-tools.ts` rethrows a typed `SandboxUnavailableError` → `run.ts` terminal catch ends the run with `error: "sandbox_unavailable"` → claw-auth `run-recovery-worker` classifies it and `deferSandboxRetry` re-dispatches the same run (without consuming a retry; GCS result-marker idempotency prevents a double run) until it binds, capped at `MAX_SANDBOX_DEFERRALS`.

## Safety / rollout
**Everything is gated behind `SANDBOX_UNAVAILABLE_DEFER` (default OFF).** With the flag unset, behaviour is unchanged — the read-only fallback is preserved and nothing new is ever thrown. This makes the merge a no-op until validated on-cluster.

The custom-tool runner catches and stringifies every tool throw, so the tool→run-termination propagation is the one piece that **must be validated on a cluster before flipping the flag on**. Enable via env, watch `[run-recovery] sandbox unavailable deferred` logs, then confirm runs resume.

## Files changed
- `packages/xyne-claw-shared/src/tools/sandbox/tools.ts` — flag-gated `sandbox_unavailable` sentinel instead of silent read-only fallback
- `apps/xyne-claw/src/sandbox-unavailable.ts` (new) — typed `SandboxUnavailableError` + flag helper + sentinel constant
- `apps/xyne-claw/src/custom-tools.ts` — detect sentinel, rethrow typed error (flag-gated)
- `apps/xyne-claw/src/routes/run.ts` — terminal catch → failure callback `error: "sandbox_unavailable"`
- `apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts` — `isSandboxUnavailableFailure` + `deferSandboxRetry` + wiring in `handleRunCompletion`; tunables `SANDBOX_RETRY_DELAY_MS` (60s), `MAX_SANDBOX_DEFERRALS` (15)

## Complementary infra action (not in this PR)
The cheapest win is capacity: raise `euler-warmpool` (and other doctor pools) `desired` from 1 to real peak concurrency, and raise `kata-sandbox-ng --max-nodes`. Warm-pool manifests are applied directly to the cluster, not versioned in-repo, so that's an infra change to pair with this.

## Design docs (on branch)
- `apps/xyne-claw/docs/sbx-availability-signal.md` (the corrected design — lean on the SandboxClaim bind signal)
- `apps/xyne-claw/docs/sbx-resource-queue.md`, `apps/xyne-claw/docs/sbx-resource-queue-phase2.md`