### PR TITLE
feat: seed gmail sync cursors

### DIFF
--- a/apps/backend/src/integrations/routes/google-auth.ts
+++ b/apps/backend/src/integrations/routes/google-auth.ts
@@ -1199,19 +1199,13 @@ router.get('/auth/callback', async (req: Request, res: Response): Promise<void> 
 
 /**
  * POST /api/integrations/google/admin/seed-sync-cursors
- * One-shot: give every active Gmail source a starting `lastSyncCursor`, read from
- * `users.getProfile`. Run this before the cursor-resuming ingestion path ships —
- * without a cursor, a source's first push resolves to nothing and skips the mail
- * that triggered it.
+ * Give every active Gmail source a starting `lastSyncCursor` from `users.getProfile`.
+ * Run before the cursor-resuming ingestion path ships.
  *
- * `?dryRun=true` previews. `?overwrite=true` replaces existing cursors, which is
- * only safe while nothing reads the column; once ingestion resumes from it,
- * overwriting moves a desk past mail that was never ingested.
- *
- * Auth: requires a logged-in user. Wrap with an admin role check if the platform
- * has one.
+ * `?dryRun=true` previews. `?overwrite=true` replaces existing cursors — safe only
+ * while nothing reads the column.
  */
-router.post('/admin/seed-sync-cursors', authMiddleware.authenticate, async (req: Request, res: Response): Promise<void> => {
+router.post('/admin/seed-sync-cursors', authMiddleware.authenticate, authMiddleware.requireAdmin, async (req: Request, res: Response): Promise<void> => {
   try {
     const dryRun = req.query.dryRun === 'true' || req.body?.dryRun === true;
     const overwrite = req.query.overwrite === 'true' || req.body?.overwrite === true;

--- a/apps/backend/src/integrations/routes/google-auth.ts
+++ b/apps/backend/src/integrations/routes/google-auth.ts
@@ -1198,6 +1198,41 @@ router.get('/auth/callback', async (req: Request, res: Response): Promise<void> 
 });
 
 /**
+ * POST /api/integrations/google/admin/seed-sync-cursors
+ * One-shot: give every active Gmail source a starting `lastSyncCursor`, read from
+ * `users.getProfile`. Run this before the cursor-resuming ingestion path ships —
+ * without a cursor, a source's first push resolves to nothing and skips the mail
+ * that triggered it.
+ *
+ * `?dryRun=true` previews. `?overwrite=true` replaces existing cursors, which is
+ * only safe while nothing reads the column; once ingestion resumes from it,
+ * overwriting moves a desk past mail that was never ingested.
+ *
+ * Auth: requires a logged-in user. Wrap with an admin role check if the platform
+ * has one.
+ */
+router.post('/admin/seed-sync-cursors', authMiddleware.authenticate, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const dryRun = req.query.dryRun === 'true' || req.body?.dryRun === true;
+    const overwrite = req.query.overwrite === 'true' || req.body?.overwrite === true;
+
+    const report = await GoogleService.seedSyncCursors({ dryRun, overwrite });
+
+    logger.info(`${TAG} seed-sync-cursors finished`, {
+      dryRun: report.dryRun,
+      overwrite: report.overwrite,
+      seededCount: report.seeded.length,
+      skippedCount: report.skipped.length,
+      requestedBy: req.user?.id,
+    });
+    res.json({ success: true, ...report });
+  } catch (error: any) {
+    logger.error(`${TAG} seed-sync-cursors failed`, error);
+    res.status(500).json({ success: false, error: error?.message ?? 'Unknown error' });
+  }
+});
+
+/**
  * POST /api/integrations/google/admin/migrate-to-shared-sub
  * One-shot migration: create shared subscription if missing, then delete every
  * legacy per-source `gmail-google-<src>-push`. Idempotent. Use `?dryRun=true`

--- a/apps/backend/src/integrations/routes/google-auth.ts
+++ b/apps/backend/src/integrations/routes/google-auth.ts
@@ -1205,7 +1205,9 @@ router.get('/auth/callback', async (req: Request, res: Response): Promise<void> 
  * `?dryRun=true` previews. `?overwrite=true` replaces existing cursors — safe only
  * while nothing reads the column.
  */
-router.post('/admin/seed-sync-cursors', authMiddleware.authenticate, authMiddleware.requireAdmin, async (req: Request, res: Response): Promise<void> => {
+// requireAdminOrOwner, not requireAdmin: the latter compares users.role against
+// lowercase 'admin' while the column stores 'ADMIN'/'MEMBER', so it never matches.
+router.post('/admin/seed-sync-cursors', authMiddleware.authenticate, authMiddleware.requireAdminOrOwner, async (req: Request, res: Response): Promise<void> => {
   try {
     const dryRun = req.query.dryRun === 'true' || req.body?.dryRun === true;
     const overwrite = req.query.overwrite === 'true' || req.body?.overwrite === true;

--- a/apps/backend/src/integrations/routes/google-auth.ts
+++ b/apps/backend/src/integrations/routes/google-auth.ts
@@ -3,7 +3,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { EmailMergeMode, WorkspaceRole, DeskType } from '@xyne/shared';
+import { EmailMergeMode, WorkspaceRole, DeskType, AccessType } from '@xyne/shared';
 import express, { Request, Response } from 'express';
 import { WORKSPACE_LEVEL } from '@/integrations/core/sourceScope';
 import { google } from 'googleapis';
@@ -13,6 +13,8 @@ import { ExternalSourceRepository } from '@/database/repositories/externalSource
 import { ExternalSourcePlatform } from '../core/types';
 import { authV2Middleware } from '@/middleware/authV2Middleware';
 import { authMiddleware } from '@/middleware/auth';
+import { authorize } from '@/middleware/authorize';
+import { BACKFILL_ADMIN_RESOURCE } from '@/middleware/backfillAdminAuth';
 import { db } from '@/database/client';
 import { redisService } from '@/services/redisService';
 import { config as appConfig } from '@/config/env';
@@ -28,6 +30,10 @@ import { getFrontendUrl, getBackendUrl } from '@/utils/publicUrls';
 import { pubSubWatchService } from '@/pubsub';
 
 const TAG = '[GoogleAuth]';
+
+// Same ACL the migration/backfill endpoints use — a grantable resource permission
+// rather than a users.role string check.
+const seedCursorsAdminAuth = authorize(BACKFILL_ADMIN_RESOURCE, AccessType.ADMIN);
 const router = express.Router();
 router.use(express.json());
 
@@ -1205,9 +1211,7 @@ router.get('/auth/callback', async (req: Request, res: Response): Promise<void> 
  * `?dryRun=true` previews. `?overwrite=true` replaces existing cursors — safe only
  * while nothing reads the column.
  */
-// requireAdminOrOwner, not requireAdmin: the latter compares users.role against
-// lowercase 'admin' while the column stores 'ADMIN'/'MEMBER', so it never matches.
-router.post('/admin/seed-sync-cursors', authMiddleware.authenticate, authMiddleware.requireAdminOrOwner, async (req: Request, res: Response): Promise<void> => {
+router.post('/admin/seed-sync-cursors', authMiddleware.authenticate, seedCursorsAdminAuth, async (req: Request, res: Response): Promise<void> => {
   try {
     const dryRun = req.query.dryRun === 'true' || req.body?.dryRun === true;
     const overwrite = req.query.overwrite === 'true' || req.body?.overwrite === true;

--- a/apps/backend/src/services/googleService.ts
+++ b/apps/backend/src/services/googleService.ts
@@ -675,6 +675,80 @@ export class GoogleService {
   }
 
   /**
+   * One-shot: plant a starting `lastSyncCursor` on every active Gmail source.
+   *
+   * Run this BEFORE the cursor-resuming ingestion path goes live. A source with no
+   * cursor falls back to the push's own historyId, and `history.list` returns records
+   * *after* that point — so the notification that triggered the first push resolves to
+   * nothing and its messages are skipped. Seeding ahead of time gives every source a
+   * real starting point, and mail arriving between the seed and the deploy is still
+   * picked up, because the cursor sits at the start of that window.
+   *
+   * `overwrite` is for the pre-deploy run only, while nothing reads the column and any
+   * existing value is a stale artifact. Once ingestion resumes from the cursor,
+   * overwriting would move a desk past mail that was never ingested — so it defaults
+   * to false and should stay false from then on.
+   *
+   * `dryRun=true` reports what would change without writing.
+   */
+  static async seedSyncCursors(opts: { dryRun?: boolean; overwrite?: boolean } = {}): Promise<{
+    dryRun: boolean;
+    overwrite: boolean;
+    seeded: Array<{ name: string; from: string | null; to: string }>;
+    skipped: Array<{ name: string; reason: string }>;
+  }> {
+    const dryRun = !!opts.dryRun;
+    const overwrite = !!opts.overwrite;
+    const repo = new ExternalSourceRepository();
+
+    const sources = await repo.findAll({
+      sourceType: ExternalSourcePlatform.GOOGLE,
+      isActive: true,
+    });
+
+    const seeded: Array<{ name: string; from: string | null; to: string }> = [];
+    const skipped: Array<{ name: string; reason: string }> = [];
+
+    for (const source of sources) {
+      if (source.lastSyncCursor && !overwrite) {
+        skipped.push({ name: source.name, reason: 'already has a cursor' });
+        continue;
+      }
+      if (!source.credentials) {
+        skipped.push({ name: source.name, reason: 'no credentials' });
+        continue;
+      }
+
+      try {
+        const historyId = await GoogleService.fromEncryptedCredentials(
+          source.credentials,
+          source.id,
+        ).getCurrentHistoryId();
+
+        if (!historyId) {
+          skipped.push({ name: source.name, reason: 'Gmail returned no historyId' });
+          continue;
+        }
+
+        if (!dryRun) await repo.update(source.id, { lastSyncCursor: historyId });
+        seeded.push({ name: source.name, from: source.lastSyncCursor, to: historyId });
+      } catch (error) {
+        // One unreachable mailbox must not stop the rest of the fleet from being seeded.
+        skipped.push({ name: source.name, reason: getErrorMessage(error) });
+      }
+    }
+
+    logger.info(`${TAG} seedSyncCursors finished`, {
+      dryRun,
+      overwrite,
+      seededCount: seeded.length,
+      skippedCount: skipped.length,
+    });
+
+    return { dryRun, overwrite, seeded, skipped };
+  }
+
+  /**
    * One-shot migration: ensure the env's shared subscription exists, then
    * delete every legacy per-source `gmail-google-<src>-push` subscription on
    * the Gmail topic. Safe to run repeatedly — idempotent on both halves.

--- a/apps/backend/src/services/googleService.ts
+++ b/apps/backend/src/services/googleService.ts
@@ -677,19 +677,12 @@ export class GoogleService {
   /**
    * One-shot: plant a starting `lastSyncCursor` on every active Gmail source.
    *
-   * Run this BEFORE the cursor-resuming ingestion path goes live. A source with no
-   * cursor falls back to the push's own historyId, and `history.list` returns records
-   * *after* that point — so the notification that triggered the first push resolves to
-   * nothing and its messages are skipped. Seeding ahead of time gives every source a
-   * real starting point, and mail arriving between the seed and the deploy is still
-   * picked up, because the cursor sits at the start of that window.
+   * Run before the cursor-resuming ingestion path ships. Without a cursor a source
+   * falls back to the push's own historyId, and `history.list` returns records *after*
+   * that — so the first push resolves to nothing and skips the mail that triggered it.
    *
-   * `overwrite` is for the pre-deploy run only, while nothing reads the column and any
-   * existing value is a stale artifact. Once ingestion resumes from the cursor,
-   * overwriting would move a desk past mail that was never ingested — so it defaults
-   * to false and should stay false from then on.
-   *
-   * `dryRun=true` reports what would change without writing.
+   * `overwrite` is safe only while nothing reads the column; afterwards it would move a
+   * desk past un-ingested mail. Hence false by default.
    */
   static async seedSyncCursors(opts: { dryRun?: boolean; overwrite?: boolean } = {}): Promise<{
     dryRun: boolean;
@@ -733,7 +726,7 @@ export class GoogleService {
         if (!dryRun) await repo.update(source.id, { lastSyncCursor: historyId });
         seeded.push({ name: source.name, from: source.lastSyncCursor, to: historyId });
       } catch (error) {
-        // One unreachable mailbox must not stop the rest of the fleet from being seeded.
+        // Collected, not thrown — one dead mailbox shouldn't stop the rest.
         skipped.push({ name: source.name, reason: getErrorMessage(error) });
       }
     }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
