### PR TITLE
fix: disable Electron auto-update nudge via kill switch

### DIFF
--- a/dashboard/src/components/ElectronUpdateNudge/ElectronUpdateNudge.tsx
+++ b/dashboard/src/components/ElectronUpdateNudge/ElectronUpdateNudge.tsx
@@ -6,6 +6,11 @@ import { callActor } from '../../machines/callMachine';
 import { roomActor } from '../../machines/roomMachine';
 import { mixpanelService } from '../../services/Analytics/mixpanelService';
 
+// Kill switch for the Electron auto-update nudge. While false the component is
+// fully inert: no event listener is registered and nothing is rendered.
+// Flip to true to re-enable the feature (dashboard-only change, no Electron release needed).
+const ELECTRON_UPDATE_NUDGE_ENABLED = false;
+
 const NUDGE_STORAGE_KEY = 'xyne:electron-update-nudge';
 const UPDATE_ATTEMPT_STORAGE_KEY = 'xyne:electron-update-attempt';
 const UPDATE_RESULT_STORAGE_KEY = 'xyne:electron-update-result';
@@ -234,6 +239,7 @@ export const ElectronUpdateNudge = (): ReactElement | null => {
   }, []);
 
   useEffect(() => {
+    if (!ELECTRON_UPDATE_NUDGE_ENABLED) return undefined;
     const electronAPI = window.electronAPI;
     if (!electronAPI?.onAppUpdateAvailable) return undefined;
 
@@ -393,6 +399,7 @@ export const ElectronUpdateNudge = (): ReactElement | null => {
     setVisible(false);
   };
 
+  if (!ELECTRON_UPDATE_NUDGE_ENABLED) return null;
   if (!window.electronAPI || !nudge || !visible || !updateNudgeSlot) return null;
 
   const title =


### PR DESCRIPTION
## What
Ports the `ELECTRON_UPDATE_NUDGE_ENABLED = false` kill switch into `dashboard/src/components/ElectronUpdateNudge/ElectronUpdateNudge.tsx`. This constant already exists on `main` and `release-20260805`, but was missing on `feature/community_flow_release` — so the community/OSS build still shows the auto-update nudge.

## Why
The "Update now" banner reappears indefinitely (cycling back to "Reminder 1 of 5") because the hard reload behind the button (`clearCache` + `reloadIgnoringCache`) never changes the loaded bundle's `__APP_VERSION__`, so the nudge's success check always fails and re-arms the banner. Disabling the nudge stops this loop for community-flow users. (The underlying reload-convergence fix is separate and tracked independently.)

## Change
Three-line port, identical to the merged change on `main`:
1. Declare `const ELECTRON_UPDATE_NUDGE_ENABLED = false;` after the imports.
2. `if (!ELECTRON_UPDATE_NUDGE_ENABLED) return undefined;` at the top of the effect that registers the `onAppUpdateAvailable` listener (listener no longer registered).
3. `if (!ELECTRON_UPDATE_NUDGE_ENABLED) return null;` at the top of the render (banner never rendered).

While false the component is fully inert.

## Note on target branch
Raised against `feature/community_flow_release` per request, since that is the only branch still missing this change (`release-20260805` already has flag=false). Please confirm the merge is OK given the branch-freeze discussion in the thread.