### PR TITLE
fix: XYNE-55323 workspaceId in new table husky check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -35,6 +35,11 @@ else
   echo "   Install it: brew install gitleaks   (https://github.com/gitleaks/gitleaks)"
 fi
 
+# New-table tenant-scoping guard: new Prisma models must have a non-nullable workspaceId/orgId
+# Runs early (before the expensive backend build/typecheck) so it fails fast.
+echo "Running tenant-key (workspaceId/orgId) guard..."
+bash scripts/validate-workspace-id.sh || exit 1
+
 # Get list of changed files
 CHANGED_FILES=$(git diff --cached --name-only)
 

--- a/scripts/validate-workspace-id.sh
+++ b/scripts/validate-workspace-id.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# New-Table Tenant-Scoping Guard
+#
+# When a brand new Prisma model (table) is added to schema.prisma, it must carry
+# a non-nullable `workspaceId` or `orgId` scalar field. Tables without a tenant
+# key are exactly the shape of bug this guard exists to catch: repositories and
+# the ACL extension both key off workspaceId to enforce tenant isolation, so a
+# table that never had the column can never be scoped, no matter how carefully
+# the query code is written later.
+#
+# Only runs against genuinely NEW models (added in this diff) — existing models
+# are untouched, so this never blocks unrelated schema edits.
+#
+# Escape hatch: a model that is intentionally global/cross-tenant (e.g. a shared
+# lookup table) can opt out by placing `// workspace-check:ignore` on the line
+# directly above `model X {`.
+
+set -e
+
+SCHEMA_PATHS=(
+    "apps/backend/prisma/schema.prisma"
+    "apps/xyne-claw-auth/backend/prisma/schema.prisma"
+)
+
+if [ -t 1 ]; then
+    RED='\033[1;31m'
+    GREEN='\033[1;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[1;34m'
+    RESET='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    RESET=''
+fi
+
+log_info() { echo -e "${BLUE}ℹ️  $1${RESET}"; }
+log_success() { echo -e "${GREEN}✅ $1${RESET}"; }
+log_warning() { echo -e "${YELLOW}⚠️  $1${RESET}"; }
+log_error() { echo -e "${RED}❌ $1${RESET}"; }
+
+# Staged content of a schema file, so validation matches what's actually being committed.
+get_schema_content() {
+    local schema_file="$1"
+    git show ":$schema_file" 2>/dev/null || cat "$schema_file" 2>/dev/null || echo ""
+}
+
+# Names of models that are newly added in the staged diff (not touched, not removed — added).
+extract_new_models() {
+    local schema_file="$1"
+    git diff --cached -- "$schema_file" 2>/dev/null | \
+        grep -E '^\+model[[:space:]]+[A-Za-z0-9_]+' | \
+        sed -E 's/^\+model[[:space:]]+([A-Za-z0-9_]+).*/\1/' | \
+        sort -u
+}
+
+# Whether the model is annotated with the opt-out comment on the line before `model X {`.
+model_opts_out() {
+    local schema_file="$1"
+    local model_name="$2"
+
+    get_schema_content "$schema_file" | awk -v model_name="$model_name" '
+        $1 == "model" && $2 == model_name {
+            if (prev ~ /workspace-check:ignore/) { print "yes" }
+            exit
+        }
+        { prev = $0 }
+    '
+}
+
+# Print "present" / "nullable" / "missing" for the model'"'"'s workspaceId/orgId field.
+check_model_tenant_key() {
+    local schema_file="$1"
+    local model_name="$2"
+
+    get_schema_content "$schema_file" | awk -v model_name="$model_name" '
+        $1 == "model" && $2 == model_name { in_model=1; next }
+        in_model && /^[[:space:]]*}/ { exit }
+        in_model && $1 ~ /^(workspaceId|orgId)$/ {
+            if ($2 ~ /\?$/) {
+                print "nullable:" $1
+            } else {
+                print "present:" $1
+            }
+            exit
+        }
+    '
+}
+
+validate_workspace_id() {
+    local has_errors=false
+    local checked_any=false
+
+    for schema_file in "${SCHEMA_PATHS[@]}"; do
+        [ -f "$schema_file" ] || continue
+
+        if ! git diff --cached --name-only | grep -q "^${schema_file}$"; then
+            continue
+        fi
+
+        local new_models
+        new_models=$(extract_new_models "$schema_file")
+        [ -z "$new_models" ] && continue
+
+        checked_any=true
+        log_info "New model(s) detected in $schema_file — checking for workspaceId/orgId..."
+
+        while IFS= read -r model; do
+            [ -z "$model" ] && continue
+
+            if [ "$(model_opts_out "$schema_file" "$model")" = "yes" ]; then
+                log_info "  ⏭ model '$model' has workspace-check:ignore — skipping"
+                continue
+            fi
+
+            local result
+            result=$(check_model_tenant_key "$schema_file" "$model")
+
+            case "$result" in
+                present:*)
+                    log_info "  ✓ model '$model' has non-nullable ${result#present:}"
+                    ;;
+                nullable:*)
+                    has_errors=true
+                    log_error "model '$model' has ${result#nullable:} but it is nullable (has '?') — must be non-nullable"
+                    ;;
+                *)
+                    has_errors=true
+                    log_error "model '$model' has no workspaceId or orgId field"
+                    ;;
+            esac
+        done <<< "$new_models"
+    done
+
+    if [ "$checked_any" = false ]; then
+        log_info "No new Prisma models in this commit. Skipping tenant-key check."
+        return 0
+    fi
+
+    if [ "$has_errors" = true ]; then
+        echo ""
+        echo "New tables must carry a non-nullable tenant key:"
+        echo "  Add a non-nullable 'workspaceId String' (or 'orgId String') field to the model."
+        echo "  If the table is intentionally global/cross-tenant, add"
+        echo "  '// workspace-check:ignore' on the line directly above 'model X {'."
+        echo ""
+        return 1
+    fi
+
+    log_success "Tenant-key validation passed for new models."
+    return 0
+}
+
+# Skip validation if HUSKY=0 (for automated commits)
+if [ "${HUSKY:-}" = "0" ]; then
+    log_info "HUSKY=0 detected, skipping workspaceId validation"
+    exit 0
+fi
+
+if ! validate_workspace_id; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
