### PR TITLE
fix: improve ticket description preview and group removal

### DIFF
--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/UserGroupSelector.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/UserGroupSelector.tsx
@@ -13,6 +13,18 @@ interface UserGroupSelectorProps {
 
   /** Callback when group selection changes */
   onGroupSelect: (groupId: string | null) => void;
+
+  /** Show an inline clear button when a group is selected */
+  showClearButton?: boolean;
+
+  /** Show a remove option at the top of the dropdown when a group is selected */
+  showUnassignOption?: boolean;
+
+  /** Label for the remove option */
+  unassignLabel?: string;
+
+  /** Description for the remove option */
+  unassignDescription?: string;
 }
 
 /**
@@ -32,6 +44,10 @@ interface UserGroupSelectorProps {
 export const UserGroupSelector: React.FC<UserGroupSelectorProps> = ({
   selectedGroupId,
   onGroupSelect,
+  showClearButton = false,
+  showUnassignOption = false,
+  unassignLabel = 'Remove user group',
+  unassignDescription = 'Clear the selected user group',
 }) => {
   const [searchValue, setSearchValue] = useState('');
 
@@ -83,6 +99,10 @@ export const UserGroupSelector: React.FC<UserGroupSelectorProps> = ({
       width='auto'
       onSearchChange={setSearchValue}
       disableClientFiltering={true}
+      showClearButton={showClearButton}
+      showUnassignOption={showUnassignOption}
+      unassignLabel={unassignLabel}
+      unassignDescription={unassignDescription}
     />
   );
 };

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -1830,7 +1830,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     void applyTicketUpdate(
       {
         id: ticket.id,
-        userGroupId: groupId ?? undefined,
+        userGroupId: groupId,
         updatedAt: Date.now(),
       },
       'Failed to update team',
@@ -2827,15 +2827,15 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                 <p className='text-sm text-muted-foreground italic'>Add description</p>
               ) : (
                 <>
-                  <p
+                  <div
                     ref={descriptionRef}
                     className={cn(
                       'whitespace-pre-wrap text-foreground break-all text-sm',
-                      !showFullDescription && 'overflow-hidden line-clamp-3 sm:line-clamp-3',
+                      !showFullDescription && 'overflow-hidden line-clamp-6 sm:line-clamp-8',
                     )}
                   >
                     <RenderMessageWithHTML message={ticket.description} />
-                  </p>
+                  </div>
                   {!showFullDescription && needsReadMore && (
                     <button
                       className='text-xs font-semibold cursor-pointer self-start underline py-1'
@@ -3480,6 +3480,9 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                 <UserGroupSelector
                   selectedGroupId={ticket.userGroupId ?? null}
                   onGroupSelect={handleUserGroupChange}
+                  showUnassignOption
+                  unassignLabel='Remove user group'
+                  unassignDescription='Clear the user group from this ticket'
                 />
               }
             />

--- a/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
@@ -42,6 +42,7 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
   testId,
   showUnassignOption = false,
   unassignLabel = 'Unassign',
+  unassignDescription = 'Remove assignee',
   headerAction,
   virtualize = false,
   // Only virtualize (opt-in) once the list is large enough to matter.
@@ -188,7 +189,7 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
       </span>
       <div className='flex-1 min-w-0'>
         <div className='truncate font-medium text-foreground'>{unassignLabel}</div>
-        <div className='truncate text-xs text-muted-foreground'>Remove assignee</div>
+        <div className='truncate text-xs text-muted-foreground'>{unassignDescription}</div>
       </div>
     </button>
   );

--- a/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.types.ts
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.types.ts
@@ -111,6 +111,9 @@ export interface EntitySelectorProps {
   /** Label for the unassign option. Default: 'Unassign' */
   unassignLabel?: string;
 
+  /** Description for the unassign option. Default: 'Remove assignee' */
+  unassignDescription?: string;
+
   /** Optional action rendered at the top of the dropdown (e.g. "Create form") */
   headerAction?: {
     label: string;


### PR DESCRIPTION
## Summary
- Increased collapsed ticket description preview from the tiny 3-line clamp to a larger responsive preview (`line-clamp-6 sm:line-clamp-8`) before the Read More CTA.
- Added a ticket-detail dropdown option to remove the selected user group.
- Preserved explicit `null` in ticket update payloads so the backend clears `userGroupId` instead of ignoring the update.

## Testing
- `cd apps/dashboard && pnpm exec tsc --noEmit --project tsconfig.app.json --pretty`
- `cd apps/backend && NODE_OPTIONS='--max-old-space-size=8192' pnpm exec tsc --noEmit`
- Browser POT at ticket detail route:
  - TC1 PASS: larger description preview still shows Read More
  - TC2 PASS: description expands and collapses
  - TC3 PASS: Remove user group option appears in selector dropdown
  - TC4 PASS: selecting Remove user group changes UI to Assign Group and DB value to NULL
- POT verifier: RESULT PASSED, video `page@faad20780048e48f2c3d28bae0815444.webm` size 1,723,512 bytes