### PR TITLE
feat: XYNE-55314 adding the support of dynamic column visiblity in views

### DIFF
--- a/apps/backend/src/zero/acl/tables/saved-user-configuration-values-acl.ts
+++ b/apps/backend/src/zero/acl/tables/saved-user-configuration-values-acl.ts
@@ -49,6 +49,9 @@ function validateTicketValue(fieldName: string, fieldValue: string): void {
   // Virtual UI-state field (the groupBy column name), not a real column.
   if (fieldName === '__groupBy') return;
 
+  // Virtual UI-state field (the comma-separated list of visible table columns), not a real column.
+  if (fieldName === '__columns') return;
+
   if (fieldName === 'roleAssignments') {
     const [roleId, userIdsCsv] = fieldValue.split('|');
     if (!roleId) {

--- a/apps/backend/src/zero/acl/tables/saved-user-configuration-values-acl.ts
+++ b/apps/backend/src/zero/acl/tables/saved-user-configuration-values-acl.ts
@@ -42,15 +42,14 @@ const TICKET_FILTER_SCHEMA: Record<string, TicketFilterFieldDescriptor> = {
 function validateTicketValue(fieldName: string, fieldValue: string): void {
   const table = 'saved_user_configuration_values' as const;
 
+  if (fieldName === '__columns') return;
+
   if (!fieldValue) {
     throw new MutationACLError(`Field value cannot be empty for field: ${fieldName}`, table);
   }
 
   // Virtual UI-state field (the groupBy column name), not a real column.
   if (fieldName === '__groupBy') return;
-
-  // Virtual UI-state field (the comma-separated list of visible table columns), not a real column.
-  if (fieldName === '__columns') return;
 
   if (fieldName === 'roleAssignments') {
     const [roleId, userIdsCsv] = fieldValue.split('|');

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -149,7 +149,21 @@ const WORKSPACE_VIEW_NUMERIC_KEYS = [
   'createdDateEnd',
 ] as const satisfies (keyof TicketFilters)[];
 
-function filtersToValues(filters: TicketFilters, groupBy?: string): SavedConfigValue[] {
+const DERIVED_COLUMNS = ['stage', 'board'];
+
+function mergeSavedColumns(prev: Set<string>, saved: string[]): Set<string> {
+  const next = new Set(saved);
+  for (const key of DERIVED_COLUMNS) {
+    if (prev.has(key)) next.add(key);
+  }
+  return next;
+}
+
+function filtersToValues(
+  filters: TicketFilters,
+  groupBy?: string,
+  columns?: string[],
+): SavedConfigValue[] {
   const values: SavedConfigValue[] = [];
   const addTicket = (fieldName: string, fieldValue: string): void => {
     values.push({ id: uuidv4(), entityName: SavedConfigEntityName.TICKET, fieldName, fieldValue });
@@ -181,6 +195,7 @@ function filtersToValues(filters: TicketFilters, groupBy?: string): SavedConfigV
     });
   }
   if (groupBy && groupBy !== 'none') addTicket('__groupBy', groupBy);
+  if (columns?.length) addTicket('__columns', columns.join(','));
   return values;
 }
 
@@ -201,6 +216,7 @@ interface BoardKanbanScreenProps {
   initialName?: string;
   initialFilters?: TicketFilters;
   initialGroupBy?: string;
+  initialColumns?: string[];
 }
 
 type GroupByType = 'none' | 'assignee' | 'status' | 'priority' | FormFieldGroup;
@@ -247,6 +263,17 @@ function uniqueProjectIds(boards: readonly { projectId?: string | null }[]): str
   return Array.from(ids);
 }
 
+const availableColumns = [
+  { key: 'assignee', label: 'Assignee', icon: <User className='h-4 w-4' /> },
+  { key: 'dueDate', label: 'Due Date', icon: <Calendar className='h-4 w-4' /> },
+  { key: 'status', label: 'Status Category', icon: <CircleCheckBig className='h-4 w-4' /> },
+  { key: 'priority', label: 'Priority', icon: <Vote className='h-4 w-4' /> },
+  { key: 'tags', label: 'Labels', icon: <Tag className='h-4 w-4' /> },
+  { key: 'stage', label: 'Sub-status', icon: <CircleCheckBig className='h-4 w-4' /> },
+  { key: 'createdAt', label: 'Created At', icon: <Clock className='h-4 w-4' /> },
+  { key: 'createdBy', label: 'Created By', icon: <User className='h-4 w-4' /> },
+];
+
 const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   viewMode: viewModeProp,
   channelId,
@@ -257,6 +284,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   initialName,
   initialFilters,
   initialGroupBy,
+  initialColumns,
 }) => {
   const { projectId: projectIdParam, boardId } = useParams<{
     projectId?: string;
@@ -321,8 +349,10 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   // click and route desk/support tickets to the Support desk instead of chat.
   const allChannels = useAllChannels();
   const channelsById = useMemo(() => new Map(allChannels.map(c => [c.id, c])), [allChannels]);
-  const [visibleColumns, setVisibleColumns] = useState<Set<string>>(
-    new Set(['assignee', 'dueDate', 'status', 'priority', 'tags']),
+  const [visibleColumns, setVisibleColumns] = useState<Set<string>>(() =>
+    initialColumns?.length
+      ? new Set(initialColumns)
+      : new Set(['assignee', 'dueDate', 'status', 'priority', 'tags']),
   );
   // The tickets table always surfaces the Stage column (parity with the Support
   // desk table, which renders TicketTable with its stage-inclusive defaults).
@@ -410,18 +440,6 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       {} as Record<string, Ticket[]>,
     );
   };
-
-  // available columns
-  const availableColumns = [
-    { key: 'assignee', label: 'Assignee', icon: <User className='h-4 w-4' /> },
-    { key: 'dueDate', label: 'Due Date', icon: <Calendar className='h-4 w-4' /> },
-    { key: 'status', label: 'Status Category', icon: <CircleCheckBig className='h-4 w-4' /> },
-    { key: 'priority', label: 'Priority', icon: <Vote className='h-4 w-4' /> },
-    { key: 'tags', label: 'Labels', icon: <Tag className='h-4 w-4' /> },
-    { key: 'stage', label: 'Sub-status', icon: <CircleCheckBig className='h-4 w-4' /> },
-    { key: 'createdAt', label: 'Created At', icon: <Clock className='h-4 w-4' /> },
-    { key: 'createdBy', label: 'Created By', icon: <User className='h-4 w-4' /> },
-  ];
 
   const handleColumnVisibilityChange = (columnKey: string, isVisible: boolean) => {
     if (columnKey === 'stage') {
@@ -769,7 +787,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   const persistWorkspaceView = useCallback(
     async (name: string): Promise<void> => {
-      const values = filtersToValues(filters, groupByKey);
+      const values = filtersToValues(
+        filters,
+        groupByKey,
+        Array.from(visibleColumns).filter(key => !DERIVED_COLUMNS.includes(key)),
+      );
       setIsSavingWorkspaceView(true);
       try {
         if (viewId) {
@@ -810,7 +832,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         setIsSavingWorkspaceView(false);
       }
     },
-    [filters, groupByKey, viewId, workspaceId, zero, navigate],
+    [filters, groupByKey, visibleColumns, viewId, workspaceId, zero, navigate],
   );
 
   const handleSavePopoverOpenChange = useCallback(
@@ -2200,7 +2222,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       return availableColumns.filter(col => !['stage', 'board', 'createdBy'].includes(col.key));
     }
     return availableColumns.filter(col => col.key !== 'status');
-  }, [layoutView, availableColumns]);
+  }, [layoutView]);
 
   return (
     <div
@@ -2574,10 +2596,21 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                                 const groupByEntry = allValues.find(
                                   v => v.fieldName === '__groupBy',
                                 );
+                                const columnsEntry = allValues.find(
+                                  v => v.fieldName === '__columns',
+                                );
                                 const filterValues = allValues.filter(
-                                  v => v.fieldName !== '__groupBy',
+                                  v => v.fieldName !== '__groupBy' && v.fieldName !== '__columns',
                                 );
                                 const newFilters = valuesToFilters(filterValues);
+                                if (columnsEntry) {
+                                  const savedColumns = columnsEntry.fieldValue
+                                    .split(',')
+                                    .filter(Boolean);
+                                  setVisibleColumns(prev =>
+                                    mergeSavedColumns(prev, savedColumns),
+                                  );
+                                }
                                 if (filters.boards) newFilters.boards = filters.boards;
                                 setFilters(newFilters);
                                 setSelectedViewId(config.id);
@@ -2639,8 +2672,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                       <div className='flex items-center justify-between gap-2 rounded-lg bg-muted p-1 shadow-inner'>
                         <button
                           onClick={() => setIsComfortView(true)}
-                          className={`flex flex-1 flex-col items-center gap-1 rounded-md px-4 py-2 
-            transition hover:bg-muted focus:outline-none 
+                          className={`flex flex-1 flex-col items-center gap-1 rounded-md px-4 py-2
+            transition hover:bg-muted focus:outline-none
             ${isComfortView ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground'}`}
                           data-track-event='BUTTON_CLICK'
                           data-track-category='TICKETS'
@@ -2655,7 +2688,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
                         <button
                           onClick={() => setIsComfortView(false)}
-                          className={`flex flex-1 flex-col items-center gap-1 rounded-md px-4 py-2 
+                          className={`flex flex-1 flex-col items-center gap-1 rounded-md px-4 py-2
             transition hover:bg-background hover:text-foreground
             ${!isComfortView ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground'}`}
                           data-track-event='BUTTON_CLICK'

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -151,6 +151,8 @@ const WORKSPACE_VIEW_NUMERIC_KEYS = [
 
 const DERIVED_COLUMNS = ['stage', 'board'];
 
+const DEFAULT_VISIBLE_COLUMNS = ['assignee', 'dueDate', 'status', 'priority', 'tags'];
+
 function mergeSavedColumns(prev: Set<string>, saved: string[]): Set<string> {
   const next = new Set(saved);
   for (const key of DERIVED_COLUMNS) {
@@ -195,7 +197,7 @@ function filtersToValues(
     });
   }
   if (groupBy && groupBy !== 'none') addTicket('__groupBy', groupBy);
-  if (columns?.length) addTicket('__columns', columns.join(','));
+  if (columns) addTicket('__columns', columns.join(','));
   return values;
 }
 
@@ -350,9 +352,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const allChannels = useAllChannels();
   const channelsById = useMemo(() => new Map(allChannels.map(c => [c.id, c])), [allChannels]);
   const [visibleColumns, setVisibleColumns] = useState<Set<string>>(() =>
-    initialColumns?.length
-      ? new Set(initialColumns)
-      : new Set(['assignee', 'dueDate', 'status', 'priority', 'tags']),
+    initialColumns ? new Set(initialColumns) : new Set(DEFAULT_VISIBLE_COLUMNS),
   );
   // The tickets table always surfaces the Stage column (parity with the Support
   // desk table, which renders TicketTable with its stage-inclusive defaults).
@@ -2608,6 +2608,10 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                                     .split(',')
                                     .filter(Boolean);
                                   setVisibleColumns(prev => mergeSavedColumns(prev, savedColumns));
+                                } else {
+                                  setVisibleColumns(prev =>
+                                    mergeSavedColumns(prev, DEFAULT_VISIBLE_COLUMNS),
+                                  );
                                 }
                                 if (filters.boards) newFilters.boards = filters.boards;
                                 setFilters(newFilters);

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -2607,9 +2607,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                                   const savedColumns = columnsEntry.fieldValue
                                     .split(',')
                                     .filter(Boolean);
-                                  setVisibleColumns(prev =>
-                                    mergeSavedColumns(prev, savedColumns),
-                                  );
+                                  setVisibleColumns(prev => mergeSavedColumns(prev, savedColumns));
                                 }
                                 if (filters.boards) newFilters.boards = filters.boards;
                                 setFilters(newFilters);

--- a/apps/dashboard/src/routes/ProjectViewsScreen/ProjectViewBuilder.tsx
+++ b/apps/dashboard/src/routes/ProjectViewsScreen/ProjectViewBuilder.tsx
@@ -11,6 +11,7 @@ interface SeedConfig {
   name: string;
   filters: TicketFilters;
   groupBy?: string;
+  columns?: string[];
 }
 
 // Decode the #cfg= share-link payload.
@@ -53,6 +54,10 @@ const ProjectViewBuilder = (): ReactElement => {
       if (!ownView) return null;
       const values = ownView.values ?? [];
       const groupBy = values.find(v => v.fieldName === '__groupBy')?.fieldValue;
+      const columns = values
+        .find(v => v.fieldName === '__columns')
+        ?.fieldValue.split(',')
+        .filter(Boolean);
       const filters = valuesToFilters(values);
       // Legacy per-board saved views store their board in contextId (no 'boards' value rows).
       if (!filters.boards?.length && ownView.contextId) {
@@ -62,6 +67,7 @@ const ProjectViewBuilder = (): ReactElement => {
         name: ownView.name,
         filters,
         ...(groupBy ? { groupBy } : {}),
+        ...(columns?.length ? { columns } : {}),
       };
     }
     return sharedConfig;
@@ -95,6 +101,7 @@ const ProjectViewBuilder = (): ReactElement => {
       {...(seed?.name ? { initialName: seed.name } : {})}
       {...(seed?.filters ? { initialFilters: seed.filters } : {})}
       {...(seed?.groupBy ? { initialGroupBy: seed.groupBy } : {})}
+      {...(seed?.columns?.length ? { initialColumns: seed.columns } : {})}
     />
   );
 };

--- a/apps/dashboard/src/routes/ProjectViewsScreen/ProjectViewBuilder.tsx
+++ b/apps/dashboard/src/routes/ProjectViewsScreen/ProjectViewBuilder.tsx
@@ -67,7 +67,7 @@ const ProjectViewBuilder = (): ReactElement => {
         name: ownView.name,
         filters,
         ...(groupBy ? { groupBy } : {}),
-        ...(columns?.length ? { columns } : {}),
+        ...(columns ? { columns } : {}),
       };
     }
     return sharedConfig;
@@ -101,7 +101,7 @@ const ProjectViewBuilder = (): ReactElement => {
       {...(seed?.name ? { initialName: seed.name } : {})}
       {...(seed?.filters ? { initialFilters: seed.filters } : {})}
       {...(seed?.groupBy ? { initialGroupBy: seed.groupBy } : {})}
-      {...(seed?.columns?.length ? { initialColumns: seed.columns } : {})}
+      {...(seed?.columns ? { initialColumns: seed.columns } : {})}
     />
   );
 };


### PR DESCRIPTION
POT - https://drive.google.com/file/d/18uUQJSG4jNZvjHoXNdTLktg73uK9kbYO/view?usp=sharing
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
