### PR TITLE
fix: XYNE-55244 query optimization

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -1413,6 +1413,27 @@ export const queries = defineQueries({
         .one();
     }
   ),
+
+  supportTicketDetailV2: defineQuery(
+    z.object({
+      id: z.string().optional(),
+      xyneId: z.string().optional(),
+      workspaceId: z.string(),
+      channelId: z.string(),
+      isMember: z.boolean(),
+    }),
+    ({ args: { id, xyneId, workspaceId } }) => {
+      const base = id
+        ? zql.tickets.where('id', id)
+        : zql.tickets.where('xyneId', xyneId ?? '').where('workspaceId', workspaceId);
+      return base
+        .related('referencesIn', ref =>
+          ref.where('relationType', TicketReferenceRelation.MERGED_INTO)
+            .related('sourceTicket'),
+        )
+        .one();
+    }
+  ),
   // Paginated variant of supportTicketsFiltered for use with @rocicorp/zero-virtual.
   // Cursor = (lastEmailAt, id) matching the orderBy. Active threads bubble up.
   // channelId + isMember are forwarded to TicketsACL for membership gating.

--- a/apps/dashboard/src/components/Activity/ActivitySupportTicket/ActivitySupportTicket.tsx
+++ b/apps/dashboard/src/components/Activity/ActivitySupportTicket/ActivitySupportTicket.tsx
@@ -46,6 +46,10 @@ const ActivitySupportTicket = (): ReactElement => {
     () => !!channelId && userChannelStatuses.some(status => status.channelId === channelId),
     [userChannelStatuses, channelId],
   );
+  const [channelPreferenceRows, channelPreferenceDetails] = useCachedQuery(
+    queries.getEmailChannelPreference({ channelId: channelId || '' }),
+    { enabled: !!channelId },
+  );
 
   // No ticket id in the URL yet — resolve it from the conversation, then redirect.
   if (!ticketId) {
@@ -57,6 +61,8 @@ const ActivitySupportTicket = (): ReactElement => {
       ticketFilter={EMPTY_TICKET_FILTER}
       isMember={isMember}
       onMailtoClick={email => window.open(`mailto:${email}`, '_blank', 'noopener,noreferrer')}
+      channelPreference={channelPreferenceRows?.[0]}
+      channelPreferenceLoaded={channelPreferenceDetails.type === 'complete'}
       navBasePath={ticketBase}
       onBack={() => {
         void navigate(activityBase);

--- a/apps/dashboard/src/components/xyne-desk/CallThread/CallThread.tsx
+++ b/apps/dashboard/src/components/xyne-desk/CallThread/CallThread.tsx
@@ -13,8 +13,6 @@ interface CallThreadEmail {
 interface CallThreadProps {
   emails: CallThreadEmail[];
   ticketId?: string | null | undefined;
-  lastEmailAt?: number | null | undefined;
-  emailReads?: ReadonlyArray<{ userId: string; lastReadEmailAt: number }> | undefined;
 }
 
 interface OzonetelSharedFields {
@@ -237,13 +235,11 @@ const CallThreadItem = ({
   isCollapsed = false,
   canCollapse = true,
   onToggleCollapse,
-  isRead = true,
 }: {
   email: CallThreadEmail;
   isCollapsed?: boolean;
   canCollapse?: boolean;
   onToggleCollapse?: () => void;
-  isRead?: boolean;
 }): ReactElement => {
   const headerClickable = canCollapse && !!onToggleCollapse;
   return (
@@ -257,7 +253,7 @@ const CallThreadItem = ({
       )}
     >
       <div
-        className={cn('px-4 py-3', headerClickable && 'cursor-pointer', !isRead && 'bg-primary/5')}
+        className={cn('px-4 py-3', headerClickable && 'cursor-pointer')}
         data-track-category='Support'
         data-track-name={isCollapsed ? 'ExpandCallEntry' : 'CollapseCallEntry'}
         onClick={headerClickable ? onToggleCollapse : undefined}
@@ -288,12 +284,7 @@ const CallThreadItem = ({
   );
 };
 
-const CallThread = ({
-  emails,
-  ticketId,
-  lastEmailAt,
-  emailReads,
-}: CallThreadProps): ReactElement => {
+const CallThread = ({ emails, ticketId }: CallThreadProps): ReactElement => {
   const sortedEmails = useMemo(() => {
     return [...emails].sort((a, b) => {
       const aTime = a.createdAt || 0;
@@ -328,13 +319,7 @@ const CallThread = ({
     });
   }, [emailIdsKey, lastEmailId, sortedEmails]);
 
-  const { isRead } = useMarkEmailRead(
-    ticketId,
-    lastEmailId ?? null,
-    lastEmailAt ?? null,
-    emailReads,
-    true,
-  );
+  useMarkEmailRead(ticketId, lastEmailId ?? null, true);
 
   const toggleOne = (id: string): void => {
     if (id === lastEmailId) return;
@@ -355,7 +340,6 @@ const CallThread = ({
           isCollapsed={collapsedIds.has(email.id)}
           canCollapse={email.id !== lastEmailId}
           onToggleCollapse={() => toggleOne(email.id)}
-          isRead={isRead}
         />
       ))}
     </div>

--- a/apps/dashboard/src/components/xyne-desk/ConversationLabels/ConversationLabels.tsx
+++ b/apps/dashboard/src/components/xyne-desk/ConversationLabels/ConversationLabels.tsx
@@ -15,6 +15,11 @@ interface ConversationLabelsProps {
   conversationId: string;
   channelId: string;
   slot: ConversationLabelSlot;
+  appliedMappings: ReadonlyArray<{
+    id: string;
+    labelId: string;
+    labelName: string;
+  }>;
 }
 
 // Fallback palette used when a label has no stored color. Deterministic per name
@@ -46,24 +51,20 @@ export const ConversationLabels = ({
   conversationId,
   channelId,
   slot,
+  appliedMappings,
 }: ConversationLabelsProps): JSX.Element | null => {
   const zero = useZero();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [search, setSearch] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [appliedMappings] = useCachedQuery(
-    queries.conversationLabelMappingsByConversationId({ conversationId }),
-    { enabled: !!conversationId },
-  );
   const [catalog] = useCachedQuery(queries.conversationLabelsByChannelId({ channelId }), {
     enabled: !!channelId && pickerOpen,
   });
 
-  const applied = useMemo(() => appliedMappings ?? [], [appliedMappings]);
   const appliedNames = useMemo(
-    () => new Set(applied.map(m => m.labelName.toLowerCase())),
-    [applied],
+    () => new Set(appliedMappings.map(m => m.labelName.toLowerCase())),
+    [appliedMappings],
   );
 
   useEffect(() => {
@@ -118,7 +119,7 @@ export const ConversationLabels = ({
 
   const toggleByName = (labelId: string, name: string, color: string): void => {
     if (appliedNames.has(name.toLowerCase())) {
-      const mapping = applied.find(m => m.labelName.toLowerCase() === name.toLowerCase());
+      const mapping = appliedMappings.find(m => m.labelName.toLowerCase() === name.toLowerCase());
       if (mapping) void removeLabel(mapping.labelId);
     } else {
       void applyLabel(name, color, labelId);
@@ -198,10 +199,10 @@ export const ConversationLabels = ({
   );
 
   if (slot === 'chips') {
-    if (applied.length === 0) return null;
+    if (appliedMappings.length === 0) return null;
     return (
       <div className='flex items-center gap-1.5 flex-wrap min-w-0'>
-        {applied.map(mapping => {
+        {appliedMappings.map(mapping => {
           const color = colorForName(mapping.labelName);
           return (
             <span

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/MetricsTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/MetricsTab.tsx
@@ -22,11 +22,17 @@ export const MetricsTab: React.FC<MetricsTabProps> = ({ form }) => {
     channelId,
   } = form;
 
-  const [channelTickets] = useCachedQuery(
-    queries.supportTicketsFilteredV3({ channelId: channelId ?? '', isMember: true }),
+  const [ticketBoardFallback] = useCachedQuery(
+    queries.supportTicketsPageV3({
+      channelId: channelId ?? '',
+      isMember: true,
+      limit: 1,
+      start: null,
+      dir: 'forward',
+    }),
     { enabled: !!channelId && !boardId },
   );
-  const effectiveBoardId = boardId ?? channelTickets?.[0]?.boardId ?? null;
+  const effectiveBoardId = boardId ?? ticketBoardFallback?.[0]?.boardId ?? null;
 
   const [stages] = useCachedQuery(queries.stagesByBoard({ boardId: effectiveBoardId ?? '' }), {
     enabled: !!effectiveBoardId,

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/MetricsTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/MetricsTab.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Switch } from '../../../ui/Switch';
 import { Checkbox } from '../../../ui/Checkbox/Checkbox';
 import { useCachedQuery } from '../../../../hooks/useCachedQuery';
+import { useZero } from '../../../../hooks/useZero';
 import { queries } from '../../../../zero/queries';
 import type { useDeskSettingsForm } from '../useDeskSettingsForm';
 
@@ -12,6 +13,7 @@ interface MetricsTabProps {
 }
 
 export const MetricsTab: React.FC<MetricsTabProps> = ({ form }) => {
+  const zero = useZero();
   const {
     metricsEnabled,
     setMetricsEnabled,
@@ -22,17 +24,33 @@ export const MetricsTab: React.FC<MetricsTabProps> = ({ form }) => {
     channelId,
   } = form;
 
-  const [ticketBoardFallback] = useCachedQuery(
-    queries.supportTicketsPageV3({
-      channelId: channelId ?? '',
-      isMember: true,
-      limit: 1,
-      start: null,
-      dir: 'forward',
-    }),
-    { enabled: !!channelId && !boardId },
-  );
-  const effectiveBoardId = boardId ?? ticketBoardFallback?.[0]?.boardId ?? null;
+  const [fallbackBoardId, setFallbackBoardId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!channelId || boardId) return;
+
+    let cancelled = false;
+    void zero
+      .run(
+        queries.supportTicketsPageV3({
+          channelId,
+          isMember: true,
+          limit: 1,
+          start: null,
+          dir: 'forward',
+        }),
+        { type: 'complete' },
+      )
+      .then(rows => {
+        if (!cancelled) setFallbackBoardId(rows[0]?.boardId ?? null);
+      });
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, [boardId, channelId, zero]);
+
+  const effectiveBoardId = boardId ?? fallbackBoardId;
 
   const [stages] = useCachedQuery(queries.stagesByBoard({ boardId: effectiveBoardId ?? '' }), {
     enabled: !!effectiveBoardId,

--- a/apps/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
@@ -400,7 +400,7 @@ export const EmailBodyRenderer = ({
     setShowRemoteImages(false);
   }, [emailId]);
 
-  const { rewrite: rewriteCidRefs, blobUrlToAttachmentId } = useCidImageResolver(attachments);
+  const { rewrite: rewriteCidRefs, blobUrlToAttachmentId } = useCidImageResolver(attachments, body);
 
   // Refs so the iframe's event handler always sees the latest values without
   // needing to re-register on every render.

--- a/apps/dashboard/src/components/xyne-desk/EmailBody/EmailThreadHeader.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailBody/EmailThreadHeader.tsx
@@ -22,7 +22,6 @@ interface EmailThreadHeaderProps {
   isCollapsed: boolean;
   previewText?: string;
   extras?: ReactNode;
-  isRead?: boolean;
   deskEmail?: string | null | undefined;
   emailId?: string;
 }
@@ -79,7 +78,6 @@ export const EmailThreadHeader = ({
   isCollapsed,
   previewText,
   extras,
-  isRead = true,
   deskEmail,
   emailId,
 }: EmailThreadHeaderProps): JSX.Element => {
@@ -130,14 +128,7 @@ export const EmailThreadHeader = ({
         <div className='flex items-start justify-between gap-3'>
           <div className='flex-1 min-w-0'>
             <div className='flex items-center gap-1.5 flex-wrap'>
-              {!isRead && (
-                <span className='size-2 rounded-full bg-blue-500 shrink-0' aria-label='Unread' />
-              )}
-              <span
-                className={cn('text-sm text-foreground', isRead ? 'font-semibold' : 'font-bold')}
-              >
-                {fromName}
-              </span>
+              <span className='text-sm text-foreground font-semibold'>{fromName}</span>
               {fromEmail && (
                 <span className='text-xs text-muted-foreground font-normal truncate'>
                   {`<${fromEmail}>`}

--- a/apps/dashboard/src/components/xyne-desk/EmailBody/useCidImageResolver.ts
+++ b/apps/dashboard/src/components/xyne-desk/EmailBody/useCidImageResolver.ts
@@ -5,27 +5,39 @@ import { createPreviewUrl } from '../../../services/clients/fileFetchService';
  * Resolves `cid:<contentId>` references in an email body to authenticated
  * blob object URLs.
  *
- * Caller passes the email's attachment rows (already loaded via the
- * `email.attachments` Zero relation). Each inline image's `metadata.contentId`
- * is mapped to its row id; the bytes are fetched via the auth-aware blob
- * pipeline. Unresolved `cid:` refs render an inline-SVG placeholder so
- * recipients never see the browser's broken-image icon.
+ * Caller may pass attachment rows from the full thread so quoted history can
+ * resolve images owned by an older email. Only content IDs referenced by the
+ * current body are mapped and fetched through the auth-aware blob pipeline.
+ * Unresolved `cid:` refs render an inline-SVG placeholder so recipients never
+ * see the browser's broken-image icon.
  */
 export const useCidImageResolver = (
   attachments?: ReadonlyArray<{ id: string; metadata?: unknown }>,
+  body?: string,
 ): {
   rewrite: (html: string) => string;
   blobUrlToAttachmentId: Map<string, string>;
 } => {
-  // Map contentId → MessageAttachment.id (pure derivation, no effects).
+  const referencedCids = useMemo(() => {
+    const cids = new Set<string>();
+    const cidRe = /cid:([^\s"'>]+)/gi;
+    let match: RegExpExecArray | null;
+    while ((match = cidRe.exec(body ?? '')) !== null) {
+      if (match[1]) cids.add(match[1].trim());
+    }
+    return cids;
+  }, [body]);
+
   const cidToAttachmentId = useMemo(() => {
     const map = new Map<string, string>();
     for (const a of attachments ?? []) {
       const meta = a.metadata as { contentId?: string } | null | undefined;
-      if (meta?.contentId) map.set(meta.contentId, a.id);
+      if (meta?.contentId && referencedCids.has(meta.contentId)) {
+        map.set(meta.contentId, a.id);
+      }
     }
     return map;
-  }, [attachments]);
+  }, [attachments, referencedCids]);
 
   // Fetch each cid's blob once and stash a stable object URL.
   const [cidToBlobUrl, setCidToBlobUrl] = useState<Record<string, string>>({});
@@ -36,22 +48,25 @@ export const useCidImageResolver = (
     }
     let cancelled = false;
     const created: string[] = [];
-    void (async () => {
+    void (async (): Promise<void> => {
+      const results = await Promise.allSettled(
+        [...cidToAttachmentId].map(async ([cid, attId]) => ({
+          cid,
+          blob: await createPreviewUrl(attId),
+        })),
+      );
+      if (cancelled) return;
+
       const next: Record<string, string> = {};
-      for (const [cid, attId] of cidToAttachmentId) {
-        try {
-          const blob = await createPreviewUrl(attId);
-          if (cancelled) return;
-          const url = URL.createObjectURL(blob);
-          created.push(url);
-          next[cid] = url;
-        } catch {
-          /* skip — rewrite will use the placeholder */
-        }
+      for (const result of results) {
+        if (result.status !== 'fulfilled') continue;
+        const url = URL.createObjectURL(result.value.blob);
+        created.push(url);
+        next[result.value.cid] = url;
       }
-      if (!cancelled) setCidToBlobUrl(next);
+      setCidToBlobUrl(next);
     })();
-    return () => {
+    return (): void => {
       cancelled = true;
       for (const u of created) URL.revokeObjectURL(u);
     };

--- a/apps/dashboard/src/components/xyne-desk/EmailComposer/ComposeEmailModal.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailComposer/ComposeEmailModal.tsx
@@ -1,11 +1,18 @@
 import { ReactElement, useCallback, useEffect, useState } from 'react';
 import { ChevronUp, ChevronsDownUp, X } from 'lucide-react';
+import type { EmailChannelPreference } from '@xyne/shared';
 import { EmailComposer } from './EmailComposer';
+import { useChannelIntegrationInfo } from '../../../hooks/useChannelConnectedEmail';
+import type { ComposeDraftRecord } from '../../../hooks/useComposeDraft';
 
 interface ComposeEmailModalProps {
   open: boolean;
   channelId: string;
   channelName: string;
+  channelPreference: EmailChannelPreference | undefined;
+  channelPreferenceLoaded: boolean;
+  composeDrafts: readonly ComposeDraftRecord[];
+  composeDraftsLoaded: boolean;
   resetKey?: number;
   minimized?: boolean;
   onMinimizedChange?: (next: boolean) => void;
@@ -44,6 +51,10 @@ export const ComposeEmailModal = ({
   open,
   channelId,
   channelName,
+  channelPreference,
+  channelPreferenceLoaded,
+  composeDrafts,
+  composeDraftsLoaded,
   resetKey,
   minimized: minimizedProp,
   onMinimizedChange,
@@ -52,6 +63,7 @@ export const ComposeEmailModal = ({
   draftId,
   initialTo,
 }: ComposeEmailModalProps): ReactElement | null => {
+  const channelIntegrationInfo = useChannelIntegrationInfo(channelId);
   const [internalMinimized, setInternalMinimized] = useState(false);
   const isControlled = typeof minimizedProp === 'boolean';
   const minimized = isControlled ? minimizedProp : internalMinimized;
@@ -182,6 +194,11 @@ export const ComposeEmailModal = ({
             key={`${resetKey}-${draftId ?? channelId}`}
             mode='compose'
             channelId={channelId}
+            channelConnectedEmail={channelIntegrationInfo.email ?? ''}
+            channelPreference={channelPreference}
+            channelPreferenceLoaded={channelPreferenceLoaded}
+            composeDrafts={composeDrafts}
+            composeDraftsLoaded={composeDraftsLoaded}
             onClose={onClose}
             {...(initialTo ? { initialTo } : {})}
             {...(onDiscard ? { onDiscard } : {})}

--- a/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
@@ -58,20 +58,11 @@ import { queries } from '../../../zero/queries';
 import { useUsers } from '../../../hooks/useUsers';
 import { useAuthContextValues } from '../../../hooks/useAuth';
 import { useComposeSubjectAI } from '../../../hooks/useComposeSubjectAI';
-import { AutoDraftStatus } from '@xyne/shared';
-import {
-  useEmailDraft,
-  useEmailDraftOperations,
-  type EmailDraftRecord,
-} from '../../../hooks/useEmailDraft';
-import {
-  useComposeDraftOperations,
-  parseComposeDraftRow,
-  type ComposeDraftRecord,
-} from '../../../hooks/useComposeDraft';
+import { AutoDraftStatus, type EmailChannelPreference } from '@xyne/shared';
+import { useEmailDraftOperations, type EmailDraftRecord } from '../../../hooks/useEmailDraft';
+import { useComposeDraftOperations, type ComposeDraftRecord } from '../../../hooks/useComposeDraft';
 import { useDeskAIDraft } from '../../../hooks/useDeskAIDraft';
 import { useDeskContacts } from '../../../hooks/useDeskContacts';
-import { useChannelConnectedEmail } from '../../../hooks/useChannelConnectedEmail';
 import { useChannelClawAgents } from '../../../hooks/useChannelClawAgents';
 
 import { DraftCard } from '../DraftCard/DraftCard';
@@ -183,6 +174,10 @@ const sameEmailList = (a: string[] | null | undefined, b: string[] | null | unde
 
 interface EmailComposerProps {
   conversationId?: string | null | undefined;
+  drafts?: readonly EmailDraftRecord[];
+  composeDrafts?: readonly ComposeDraftRecord[];
+  composeDraftsLoaded?: boolean;
+  channelConnectedEmail: string;
   emails?: ReadonlyArray<ComposerEmail> | undefined;
   onClose?: () => void;
   onDiscard?: () => void;
@@ -217,10 +212,16 @@ interface EmailComposerProps {
   showSeeSources?: boolean;
   /** Pre-fill the To field when the composer mounts (draft restoration takes precedence). */
   initialTo?: string[];
+  channelPreference: EmailChannelPreference | undefined;
+  channelPreferenceLoaded: boolean;
 }
 
 export const EmailComposer = ({
   conversationId,
+  drafts,
+  composeDrafts = [],
+  composeDraftsLoaded = false,
+  channelConnectedEmail,
   emails: propEmails,
   onClose,
   onDiscard,
@@ -243,6 +244,8 @@ export const EmailComposer = ({
   onSeeSources,
   showSeeSources = false,
   initialTo,
+  channelPreference,
+  channelPreferenceLoaded,
 }: EmailComposerProps): ReactElement => {
   const isComposeMode = mode === 'compose';
   const features = resolveFeatures(mode, featureOverrides);
@@ -252,30 +255,19 @@ export const EmailComposer = ({
   // One-shot AI helper for the wand button next to the Subject field.
   const subjectAI = useComposeSubjectAI(channelId ?? null);
   const emails = propEmails;
-  // Use the existing `useChannelConnectedEmail` API for the desk's mailbox
-  // address. Contacts still come from the desk-mailbox address book hook.
-  const channelConnectedEmail = useChannelConnectedEmail(channelId || null);
-  // Use the raw query so we get `details.type` to distinguish "not loaded yet"
-  // from "loaded but no preference row" — both return undefined for
-  // channelPreference otherwise, which would stall the default-CC seeding.
-  const [channelPreferenceList, channelPreferenceDetails] = useCachedQuery(
-    queries.getEmailChannelPreference({ channelId: channelId || '' }),
-    { enabled: !!channelId },
-  );
-  const channelPreference = channelPreferenceList?.[0];
   const channelAliasEmail = channelPreference?.sendAsEmail ?? null;
   const clawAgents = useChannelClawAgents(channelId || null);
   const draftAgentName =
     clawAgents.find(a => a.slug === channelPreference?.autoDraftAgentSlug)?.name ?? 'Xyne AI';
   const deskContacts = useDeskContacts(channelId);
-  const draft: EmailDraftRecord | undefined = useEmailDraft(conversationId);
   const {
     saveDraft,
     saveRecipients,
     deleteDraft,
     draftId,
     draft: ownDraft,
-  } = useEmailDraftOperations(conversationId, channelId);
+    latestDraft: draft,
+  } = useEmailDraftOperations(conversationId, channelId, drafts);
   const isAutoDraftGenerating =
     !isComposeMode && draft?.autoDraftStatus === AutoDraftStatus.GENERATING;
   const [emailContent, setEmailContent] = useState<string>('');
@@ -848,19 +840,10 @@ export const EmailComposer = ({
 
   const { saveComposeDraft, deleteComposeDraft: deleteComposeDraftRow } =
     useComposeDraftOperations(channelId);
-  const [composeRows, composeRowsDetails] = useCachedQuery(
-    queries.composeDraftsByChannel({ channelId: channelId || '' }),
-    { enabled: isComposeMode && !!channelId },
-  );
   const serverComposeDraft = useMemo<ComposeDraftRecord | undefined>(() => {
     if (!composeDraftServerId) return undefined;
-    // Direct query (bypasses useComposeDrafts), so the TEXT recipient columns must be
-    // parsed back to string[] here too before the hydration effect's Array.isArray gates.
-    const row = (composeRows as unknown as ComposeDraftRecord[] | undefined)?.find(
-      d => d.id === composeDraftServerId,
-    );
-    return row ? parseComposeDraftRow(row) : undefined;
-  }, [composeRows, composeDraftServerId]);
+    return composeDrafts.find(d => d.id === composeDraftServerId);
+  }, [composeDrafts, composeDraftServerId]);
 
   // Restore compose draft on mount
   const [composeDraftLoaded, setComposeDraftLoaded] = useState(false);
@@ -881,7 +864,7 @@ export const EmailComposer = ({
     if (!isComposeMode || composeDraftLoaded || !composeDraftServerId) return;
     // Wait until the compose-drafts query has settled, otherwise an as-yet-unloaded
     // row would be mistaken for "no draft" and we'd mark the composer loaded too early.
-    if (composeRowsDetails.type !== 'complete') return;
+    if (!composeDraftsLoaded) return;
     const okEmail = (s: unknown): s is string => typeof s === 'string' && s.includes('@');
     let snapshotTo: string[] = [];
     let snapshotCc: string[] = [];
@@ -965,7 +948,7 @@ export const EmailComposer = ({
     isComposeMode,
     composeDraftLoaded,
     composeDraftServerId,
-    composeRowsDetails.type,
+    composeDraftsLoaded,
     serverComposeDraft,
     composeMetaKey,
   ]);
@@ -982,7 +965,7 @@ export const EmailComposer = ({
     // Already seeded for this compose session.
     if (defaultCcSeededKeyRef.current === composeDraftServerId) return;
     // Preference query hasn't settled yet — wait for next render.
-    if (channelPreferenceDetails?.type !== 'complete') return;
+    if (!channelPreferenceLoaded) return;
     // Only seed when the user hasn't already entered CC (saved draft or manual).
     if (ccEmails.length > 0) {
       defaultCcSeededKeyRef.current = composeDraftServerId;
@@ -1001,7 +984,7 @@ export const EmailComposer = ({
     composeDraftLoaded,
     composeDraftServerId,
     channelPreference?.defaultCc,
-    channelPreferenceDetails?.type,
+    channelPreferenceLoaded,
     ccEmails.length,
   ]);
 
@@ -1112,7 +1095,7 @@ export const EmailComposer = ({
   useEffect(() => {
     // In compose mode there's no thread to derive recipients from — start blank.
     if (isComposeMode) return;
-    if (channelPreferenceDetails?.type !== 'complete') return;
+    if (!channelPreferenceLoaded) return;
     const replyModeChanged =
       lastDerivedReplyModeRef.current !== null && lastDerivedReplyModeRef.current !== replyMode;
     // Prefer recipients persisted on the draft in the DB (synced across devices). Fall
@@ -1299,7 +1282,7 @@ export const EmailComposer = ({
     recipientsStorageKey,
     isComposeMode,
     channelPreference?.defaultCc,
-    channelPreferenceDetails?.type,
+    channelPreferenceLoaded,
     ownDraft,
   ]);
 

--- a/apps/dashboard/src/components/xyne-desk/MailboxActions/MailboxActions.tsx
+++ b/apps/dashboard/src/components/xyne-desk/MailboxActions/MailboxActions.tsx
@@ -3,10 +3,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { Star, Ban, Inbox as InboxIcon, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { MailboxState } from '@xyne/shared';
-import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
 import { useZero } from '../../../hooks/useZero';
-import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import Tooltip from '../../ui/Tooltip';
 import { cn } from '../../../utils/classNames';
 
@@ -16,6 +14,12 @@ interface MailboxActionsProps {
   ticketId: string;
   channelId: string;
   slot: MailboxSlot;
+  mailboxOverlay:
+    | {
+        state?: MailboxState | null;
+        starred?: boolean | null;
+      }
+    | undefined;
 }
 
 // The mailbox location rendered as a removable chip (Gmail-style), like a label.
@@ -36,12 +40,11 @@ export const MailboxActions = ({
   ticketId,
   channelId,
   slot,
+  mailboxOverlay,
 }: MailboxActionsProps): ReactElement | null => {
   const zero = useZero();
-  const [rows] = useCachedQuery(queries.myTicketMailbox({ ticketId }), { enabled: !!ticketId });
-  const overlay = (rows ?? [])[0];
-  const state = overlay?.state ?? MailboxState.INBOX;
-  const starred = overlay?.starred ?? false;
+  const state = mailboxOverlay?.state ?? MailboxState.INBOX;
+  const starred = mailboxOverlay?.starred ?? false;
 
   const setState = async (next: MailboxState): Promise<void> => {
     try {

--- a/apps/dashboard/src/components/xyne-desk/SlackThread/SlackComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/SlackThread/SlackComposer.tsx
@@ -12,7 +12,7 @@ import { AutoDraftStatus } from '@xyne/shared';
 import { apiInstance, BASE_URL } from '../../../services/clients/apiClient';
 import { useSlackUserAuth, useDisconnectSlackUser } from '../../../hooks/useSlackUserAuth';
 import { useSlackUsers } from '../../../hooks/useSlackUsers';
-import { useEmailDraft, useEmailDraftOperations } from '../../../hooks/useEmailDraft';
+import { useEmailDraftOperations, type EmailDraftRecord } from '../../../hooks/useEmailDraft';
 import Tooltip from '../../ui/Tooltip';
 import { EditorToolbar, EmojiPickerButton } from '../../ui/EditorToolbar';
 import { MentionExtension, mentionPluginKey } from '../../ui/TipTapExtensions';
@@ -25,6 +25,7 @@ const lowlight = createLowlight(all);
 interface SlackComposerProps {
   conversationId: string;
   channelId?: string | null;
+  drafts?: readonly EmailDraftRecord[];
   variant?: 'slack' | 'app';
   recordOnly?: boolean;
 }
@@ -32,6 +33,7 @@ interface SlackComposerProps {
 const SlackComposer = ({
   conversationId,
   channelId,
+  drafts,
   variant = 'slack',
   recordOnly = false,
 }: SlackComposerProps): ReactElement => {
@@ -44,8 +46,11 @@ const SlackComposer = ({
   const { data: slackAuth, isLoading: authLoading } = useSlackUserAuth();
   const disconnectMutation = useDisconnectSlackUser();
   const { filteredUsers, searchUsers } = useSlackUsers();
-  const draft = useEmailDraft(conversationId);
-  const { deleteDraft } = useEmailDraftOperations(conversationId, channelId);
+  const { deleteDraft, latestDraft: draft } = useEmailDraftOperations(
+    conversationId,
+    channelId,
+    drafts,
+  );
   const isAutoDraftGenerating = draft?.autoDraftStatus === AutoDraftStatus.GENERATING;
   const lastLoadedDraftRef = useRef<string>('');
 

--- a/apps/dashboard/src/components/xyne-desk/SlackThread/SlackThread.tsx
+++ b/apps/dashboard/src/components/xyne-desk/SlackThread/SlackThread.tsx
@@ -5,16 +5,9 @@ import { useMarkEmailRead } from '../../../hooks/useMarkEmailRead';
 interface SlackThreadProps {
   emails: SlackEmailMessage[];
   ticketId?: string | null | undefined;
-  lastEmailAt?: number | null | undefined;
-  emailReads?: ReadonlyArray<{ userId: string; lastReadEmailAt: number }> | undefined;
 }
 
-const SlackThread = ({
-  emails,
-  ticketId,
-  lastEmailAt,
-  emailReads,
-}: SlackThreadProps): ReactElement => {
+const SlackThread = ({ emails, ticketId }: SlackThreadProps): ReactElement => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Sort oldest-first for chat-style display
@@ -26,7 +19,7 @@ const SlackThread = ({
   // Thread-level: upsert the current user's email_reads row on open, same as
   // EmailThread. Newest message is last in the oldest-first sorted list.
   const latestEmailId = sorted[sorted.length - 1]?.id ?? null;
-  useMarkEmailRead(ticketId, latestEmailId, lastEmailAt ?? null, emailReads, true);
+  useMarkEmailRead(ticketId, latestEmailId, true);
 
   // Auto-scroll to bottom on new messages
   useEffect(() => {

--- a/apps/dashboard/src/hooks/useComposeDraft.ts
+++ b/apps/dashboard/src/hooks/useComposeDraft.ts
@@ -73,13 +73,18 @@ export function parseComposeDraftRow(row: ComposeDraftRecord): ComposeDraftRecor
  * All of the caller's compose drafts for a channel (most-recent first). Reactive —
  * surfaces drafts saved on other devices too.
  */
-export function useComposeDrafts(channelId: string | null | undefined): ComposeDraftRecord[] {
-  const [rows] = useCachedQuery(queries.composeDraftsByChannel({ channelId: channelId || '' }), {
-    enabled: !!channelId,
-  });
+export function useComposeDrafts(channelId: string | null | undefined): {
+  drafts: ComposeDraftRecord[];
+  isLoaded: boolean;
+} {
+  const [rows, details] = useCachedQuery(
+    queries.composeDraftsByChannel({ channelId: channelId || '' }),
+    { enabled: !!channelId },
+  );
   const raw = rows as unknown as ComposeDraftRecord[] | undefined;
   // Memoized on the row snapshot so consumers keep stable references between renders.
-  return useMemo(() => (raw ?? []).map(parseComposeDraftRow), [raw]);
+  const drafts = useMemo(() => (raw ?? []).map(parseComposeDraftRow), [raw]);
+  return { drafts, isLoaded: details.type === 'complete' };
 }
 
 /**

--- a/apps/dashboard/src/hooks/useEmailDraft.ts
+++ b/apps/dashboard/src/hooks/useEmailDraft.ts
@@ -56,19 +56,17 @@ function sameStringList(a: string[] | null | undefined, b: string[] | null | und
 }
 
 /**
- * Returns the current draft for a conversation from Zero cache.
+ * Returns all drafts visible to the current user for a conversation from Zero cache.
  */
-export function useEmailDraft(
-  conversationId: string | null | undefined,
-): EmailDraftRecord | undefined {
+export function useEmailDrafts(conversationId: string | null | undefined): EmailDraftRecord[] {
   const [dbDrafts] = useCachedQuery(
     queries.getDraftForConversation({ conversationId: conversationId || '' }),
     { enabled: !!conversationId },
   );
-  const rows = (dbDrafts as unknown as EmailDraftRecord[] | undefined) ?? [];
-  const row = rows[0];
-  // Memoized on the row snapshot so consumers keep stable references between renders.
-  return useMemo(() => (row ? parseDraftRecipients(row) : undefined), [row]);
+  return useMemo(() => {
+    const rows = (dbDrafts as unknown as EmailDraftRecord[] | undefined) ?? [];
+    return rows.map(parseDraftRecipients);
+  }, [dbDrafts]);
 }
 
 /**
@@ -83,6 +81,7 @@ export function useEmailDraft(
 export function useEmailDraftOperations(
   conversationId: string | null | undefined,
   channelId: string | null | undefined,
+  drafts?: readonly EmailDraftRecord[],
 ): {
   saveDraft: (
     content: string,
@@ -93,21 +92,14 @@ export function useEmailDraftOperations(
   deleteDraft: () => void;
   draftId: string | null;
   draft: EmailDraftRecord | undefined;
+  latestDraft: EmailDraftRecord | undefined;
 } {
   const zero = useZero();
   const { userID } = useAuthContextValues();
-  const [dbDrafts] = useCachedQuery(
-    queries.getDraftForConversation({ conversationId: conversationId || '' }),
-    { enabled: !!conversationId },
+  const ownDraft = useMemo(
+    () => (userID ? drafts?.find(draft => draft.userId === userID) : undefined),
+    [drafts, userID],
   );
-
-  const ownRow =
-    dbDrafts && userID
-      ? (dbDrafts as unknown as EmailDraftRecord[]).find(d => d.userId === userID)
-      : undefined;
-  // Memoized on the row snapshot: the sameStringList guard below and EmailComposer's
-  // hydration effect both depend on this object keeping a stable reference.
-  const ownDraft = useMemo(() => (ownRow ? parseDraftRecipients(ownRow) : undefined), [ownRow]);
   const ownDraftId = ownDraft?.id;
 
   const deleteDraft = useCallback(() => {
@@ -190,5 +182,12 @@ export function useEmailDraftOperations(
     ],
   );
 
-  return { saveDraft, saveRecipients, deleteDraft, draftId: ownDraftId ?? null, draft: ownDraft };
+  return {
+    saveDraft,
+    saveRecipients,
+    deleteDraft,
+    draftId: ownDraftId ?? null,
+    draft: ownDraft,
+    latestDraft: drafts?.[0],
+  };
 }

--- a/apps/dashboard/src/hooks/useMarkEmailRead.ts
+++ b/apps/dashboard/src/hooks/useMarkEmailRead.ts
@@ -1,37 +1,19 @@
 import { useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useZero } from './useZero';
-import { useAuthContextValues } from './useAuth';
 import { mutators } from '../zero/mutators';
 
-type EmailReadRow = { userId: string; lastReadEmailAt: number };
-
 /**
- * Thread-level read state for the xyne desk.
- *
- * Rule: a ticket (= one email thread) is "read" for a user when their
- * `email_reads.lastReadEmailAt` — a snapshot of `ticket.lastEmailAt` taken
- * when they last opened the thread — is at or after the ticket's current
- * `lastEmailAt`. Opening the ticket upserts that row. When a reply arrives,
- * `lastEmailAt` advances past the stored snapshot — unread.
- *
- * Assignment state is intentionally NOT a shortcut — auto-assigned boards
- * would otherwise mark every inbound email read for everyone instantly.
+ * Marks a Desk ticket's latest email as read when its detail thread opens.
+ * The mutator performs the existing-row comparison, so the detail view does
+ * not need to subscribe to email_reads before issuing this idempotent update.
  */
 export function useMarkEmailRead(
   ticketId: string | null | undefined,
   latestEmailId: string | null | undefined,
-  lastEmailAt: number | null | undefined,
-  emailReads: readonly EmailReadRow[] | undefined,
   shouldMark: boolean,
-): { isRead: boolean } {
-  const { userID } = useAuthContextValues();
+): void {
   const zero = useZero();
-
-  const userRow = (emailReads ?? []).find(r => r.userId === userID);
-  const lastReadAt = userRow?.lastReadEmailAt;
-  const isRead =
-    typeof lastEmailAt === 'number' && typeof lastReadAt === 'number' && lastReadAt >= lastEmailAt;
 
   const markedRef = useRef<string | null>(null);
 
@@ -41,7 +23,6 @@ export function useMarkEmailRead(
     if (!latestEmailId) return;
     if (markedRef.current === latestEmailId) return;
     markedRef.current = latestEmailId;
-    if (isRead) return;
     void zero.mutate(
       mutators.emailRead.markAsRead({
         id: uuidv4(),
@@ -50,7 +31,5 @@ export function useMarkEmailRead(
         updatedAt: Date.now(),
       }),
     );
-  }, [shouldMark, ticketId, latestEmailId, isRead, zero]);
-
-  return { isRead };
+  }, [shouldMark, ticketId, latestEmailId, zero]);
 }

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -95,7 +95,6 @@ import { useRefetchExternalSource } from '../../hooks/useRefetchExternalSource';
 import { useDlMemberSyncStatus } from '../../hooks/useDlMemberSyncStatus';
 import { RefetchRangeDialog } from '../../components/Chat/EmailRefetch/RefetchRangeDialog';
 import { DlMemberSyncDialog } from '../../components/Chat/EmailRefetch/DlMemberSyncDialog';
-import { useEmailChannelPreference } from '../../hooks/useEmailChannelPreference';
 import { useMarkTicketsAsRead } from '../../hooks/useMarkTicketsAsRead';
 import * as Popover from '@radix-ui/react-popover';
 import {
@@ -152,7 +151,7 @@ import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { SupportKanbanBoard } from './SupportKanbanBoard';
 import { SupportTicketTable } from './SupportTicketTable';
 import { TicketPriority, parseFieldOptionValues } from '@xyne/shared';
-import type { Ticket, FormFields } from '@xyne/shared';
+import type { Ticket, FormFields, EmailChannelPreference } from '@xyne/shared';
 import { getDraft } from '../../hooks/useDraft';
 import { useShortcut, invokeShortcut } from '../../shortcuts';
 import { v4 as uuidv4 } from 'uuid';
@@ -184,7 +183,7 @@ import { EmailThreadHeader } from '../../components/xyne-desk/EmailBody/EmailThr
 import { CloudAgentDock } from '../../components/xyne-desk/CloudAgentDock/CloudAgentDock';
 import { ConversationLabels } from '../../components/xyne-desk/ConversationLabels/ConversationLabels';
 import { TicketTagsRow } from '../../components/xyne-desk/EmailBody/TagsBadgePopover';
-import { useEmailDraft } from '../../hooks/useEmailDraft';
+import { useEmailDrafts } from '../../hooks/useEmailDraft';
 import {
   useComposeDrafts,
   useComposeDraftOperations,
@@ -211,7 +210,6 @@ import {
 import { DeskSettings } from '../../components/xyne-desk/DeskSettings';
 import { DeskMetricsDashboard } from '../../components/xyne-desk/DeskMetrics';
 import {
-  useChannelConnectedEmail,
   useChannelIntegrationInfo,
   clearChannelConnectedEmailCache,
 } from '../../hooks/useChannelConnectedEmail';
@@ -654,7 +652,13 @@ const SupportScreen = (): ReactElement => {
     label: string;
   }>({ key: 'inbox', label: 'Inbox' });
 
-  const channelPreference = useEmailChannelPreference(selectedChannelId);
+  const preferenceChannelId =
+    selectedChannelId && selectedChannelId !== ALL_CHANNELS_ID ? selectedChannelId : null;
+  const [channelPreferenceList, channelPreferenceDetails] = useCachedQuery(
+    queries.getEmailChannelPreference({ channelId: preferenceChannelId || '' }),
+    { enabled: !!preferenceChannelId },
+  );
+  const channelPreference = channelPreferenceList?.[0];
   const deskBoardId = channelPreference?.boardId || channelBoardId;
   const [channelBoardDetail] = useCachedQuery(
     queries.boardDetailById({ boardId: deskBoardId || '' }),
@@ -1048,7 +1052,8 @@ const SupportScreen = (): ReactElement => {
   // Server-backed compose drafts for the selected channel (synced across devices).
   // The composer itself autosaves each window's content; here we only read the list
   // and delete rows on discard.
-  const composeDraftRows = useComposeDrafts(selectedChannelId);
+  const { drafts: composeDraftRows, isLoaded: composeDraftRowsLoaded } =
+    useComposeDrafts(selectedChannelId);
   const { deleteComposeDraft: deleteComposeDraftRow } =
     useComposeDraftOperations(selectedChannelId);
 
@@ -1397,13 +1402,12 @@ const SupportScreen = (): ReactElement => {
   const { refetch: handleRefetch, isPending: isRefetching } =
     useRefetchExternalSource(refetchChannelId);
   const canRefetch = !!refetchChannelId;
-  const selectedChannelPref = useEmailChannelPreference(refetchChannelId ?? null);
-  const isDlDesk = selectedChannelPref?.deskType === DeskType.DL;
+  const isDlDesk = channelPreference?.deskType === DeskType.DL;
   useEffect(() => {
-    if (selectedChannelPref?.boardId) {
-      setChannelBoardId(selectedChannelPref.boardId);
+    if (channelPreference?.boardId) {
+      setChannelBoardId(channelPreference.boardId);
     }
-  }, [selectedChannelId, selectedChannelPref?.boardId]);
+  }, [selectedChannelId, channelPreference?.boardId]);
   const { data: dlMemberSyncStatus } = useDlMemberSyncStatus(refetchChannelId, isDlDesk);
   const isDlMemberSyncing = dlMemberSyncStatus?.active === true;
   const dlMemberSyncTooltip = isDlMemberSyncing
@@ -2396,7 +2400,7 @@ const SupportScreen = (): ReactElement => {
                         ))}
                       {isSelectedChannelJoined &&
                         selectedChannelId !== ALL_CHANNELS_ID &&
-                        selectedChannelPref?.metricsEnabled && (
+                        channelPreference?.metricsEnabled && (
                           <Tooltip content='Desk metrics' side='bottom'>
                             <button
                               onClick={() => {
@@ -3163,6 +3167,8 @@ const SupportScreen = (): ReactElement => {
                 isMember={isSelectedChannelJoined}
                 onMailtoClick={handleMailtoClick}
                 navTickets={kanbanTickets}
+                channelPreference={channelPreference}
+                channelPreferenceLoaded={channelPreferenceDetails?.type === 'complete'}
               />
             </div>
           </Panel>
@@ -3302,6 +3308,10 @@ const SupportScreen = (): ReactElement => {
                   open
                   channelId={inst.channelId}
                   channelName={selectedChannelName}
+                  channelPreference={channelPreference}
+                  channelPreferenceLoaded={channelPreferenceDetails?.type === 'complete'}
+                  composeDrafts={composeDraftRows}
+                  composeDraftsLoaded={composeDraftRowsLoaded}
                   draftId={inst.id}
                   resetKey={inst.key}
                   minimized={inst.minimized}
@@ -3385,6 +3395,8 @@ type SupportTicketDetailProps = {
   };
   isMember: boolean;
   onMailtoClick: (email: string) => void;
+  channelPreference: EmailChannelPreference | undefined;
+  channelPreferenceLoaded: boolean;
   /**
    * Base path used to build in-detail ticket navigation (e.g. next/prev ticket).
    * Defaults to the Support inbox base (`/{workspaceId}/support`). Embedded
@@ -3411,6 +3423,8 @@ export const SupportTicketDetail = ({
   ticketFilter,
   isMember,
   onMailtoClick,
+  channelPreference,
+  channelPreferenceLoaded,
   navBasePath,
   onBack,
   navTickets,
@@ -3477,10 +3491,8 @@ export const SupportTicketDetail = ({
     ticketId?: string | null;
     returnToUrl?: string | null;
   };
-  // Router state is a perf hint from list navigation (instant paint); direct
-  // URL loads and new-tab openings fall back to the supportTicketByXyneId fetch
-  // below using the :ticketId path param. Title is NOT carried in state so that
-  // it always reflects the current ticket row (and disappears when ACL hides it).
+  // List navigation supplies stable IDs in router state; direct URL loads and
+  // new-tab openings fall back to the :ticketId path parameter below.
   const stateConversationId = routerState?.conversationId ?? null;
   const ticketId = routerState?.ticketId ?? null;
 
@@ -3492,12 +3504,11 @@ export const SupportTicketDetail = ({
   // matching EmailThreadItem after emails load.
   const targetMailId = searchParams.get('mail');
 
-  // Single consolidated fetch: the ticket row with `.related('emails')` gives us emails,
-  // channelId (scalar on ticket), conversationId, and everything else we need — replaces
-  // getEmailsForTicket + getConversationById. supportTicketDetail looks up by `id` when
-  // list navigation supplied it (router state), else by `xyneId` from the URL path param.
+  // Fetch the ticket metadata needed to resolve the detail view. Emails and drafts use
+  // their dedicated conversation-scoped queries below. supportTicketDetailV2 looks up by
+  // `id` when list navigation supplied it, else by `xyneId` from the URL path param.
   const [ticket] = useCachedQuery(
-    queries.supportTicketDetail({
+    queries.supportTicketDetailV2({
       id: ticketId || undefined,
       xyneId: ticketIdParam || undefined,
       workspaceId,
@@ -3506,18 +3517,9 @@ export const SupportTicketDetail = ({
     }),
     { enabled: (!!ticketId || !!ticketIdParam) && !!routeChannelId },
   );
-  const ticketEmailDrafts = (
-    ticket as
-      | {
-          emailDrafts?: ReadonlyArray<{
-            draftContent?: string | null;
-            userId?: string | null;
-          }>;
-        }
-      | null
-      | undefined
-  )?.emailDrafts;
-  const ticketEmailDraftCount = ticketEmailDrafts?.length ?? 0;
+  const detailConversationId = ticket?.conversationId ?? stateConversationId;
+  const ticketEmailDrafts = useEmailDrafts(detailConversationId);
+  const ticketEmailDraftCount = ticketEmailDrafts.length;
   const draftBodyHtml = useMemo<string | null>(() => {
     if (!ticketEmailDrafts || ticketEmailDrafts.length === 0) return null;
 
@@ -3549,18 +3551,18 @@ export const SupportTicketDetail = ({
     (visibleAutoDraftCitations.length > 0 || visibleInlineCitations.length > 0);
   const hasUserDraftAgentSession = !!userDraftSession?.answered;
 
-  // Gather conversation IDs for this ticket AND any tickets merged into it, so
-  // the email thread shows emails from the merged-away tickets too.
+  // Start the primary email query from router state while ticket metadata loads,
+  // then include any merged-ticket conversations once the detail query resolves.
   const allConversationIds = useMemo(() => {
     const ids = new Set<string>();
-    if (ticket?.conversationId) ids.add(ticket.conversationId);
+    if (detailConversationId) ids.add(detailConversationId);
     (ticket?.referencesIn ?? [])
       .filter(ref => ref.relationType === TicketReferenceRelation.MERGED_INTO)
       .forEach(ref => {
         if (ref.sourceTicket?.conversationId) ids.add(ref.sourceTicket.conversationId);
       });
     return Array.from(ids);
-  }, [ticket?.conversationId, ticket?.referencesIn]);
+  }, [detailConversationId, ticket?.referencesIn]);
 
   // conversationId -> the manually-merged-in ticket that owns it (needed so its
   // thread-root email uses the ticket-level unmerge action; see mergedRootEmailSource).
@@ -3650,16 +3652,25 @@ export const SupportTicketDetail = ({
   const channelId = ticket?.channelId || '';
   const conversationId = ticket?.conversationId ?? stateConversationId;
   const title = ticket?.title ?? null;
+  const [threadConversation] = useCachedQuery(
+    queries.threadConversationV2({
+      conversationId: conversationId || '',
+      channelId: channelId || undefined,
+      isMember,
+    }),
+    { enabled: !!conversationId && !!channelId },
+  );
+  const conversation = threadConversation ?? undefined;
+  const messages = useMemo(
+    () => [...(threadConversation?.messages ?? [])],
+    [threadConversation?.messages],
+  );
   // DB ticket id (not the xyneId) for per-user mailbox actions; router state carries it
   // on list navigation, else it comes from the fetched ticket row.
   const mailboxTicketId = ticket?.id ?? ticketId ?? null;
   const boardId = ticket?.boardId ?? null;
 
-  const [channelPreferenceList] = useCachedQuery(
-    queries.getEmailChannelPreference({ channelId: channelId || '' }),
-    { enabled: !!channelId },
-  );
-  const draftAgentSlug = channelPreferenceList?.[0]?.autoDraftAgentSlug || 'draft-agent';
+  const draftAgentSlug = channelPreference?.autoDraftAgentSlug || 'draft-agent';
   const { setSelectedAgentSlug } = useSelectedAgent();
 
   const openDraftAgentSession = useCallback(
@@ -3772,19 +3783,16 @@ export const SupportTicketDetail = ({
     [conversationId],
   );
 
-  // Desk's connected mailbox — used as the "me" reference in thread headers
-  // and recipient summaries. Sourced from the existing `/channels/:id/connected-email`
-  // API via `useChannelConnectedEmail`. Empty string until loaded.
-  const deskEmail = useChannelConnectedEmail(channelId || null);
-  const { outboundConfigured } = useChannelIntegrationInfo(channelId || null);
+  const channelIntegrationInfo = useChannelIntegrationInfo(channelId || null);
+  const deskEmail = channelIntegrationInfo.email ?? '';
+  const { outboundConfigured } = channelIntegrationInfo;
 
   useAskAiTicketContext({
     channelId: channelId || null,
     conversationId: conversationId ?? null,
     previewText: title || 'Ticket conversation',
   });
-  const conversation = ticket?.conversation;
-  const ticketDraft = useEmailDraft(conversationId ?? null);
+  const ticketDraft = ticketEmailDrafts[0];
   const draftAutoOpenedConversationRef = useRef<string | null>(null);
   useEffect(() => {
     if (!conversationId) return;
@@ -4094,16 +4102,6 @@ export const SupportTicketDetail = ({
     [conversationId],
   );
 
-  // Fetch messages for the conversation
-  const [messages] = useCachedQuery(
-    queries.conversationMessagesV2({
-      conversationId: conversationId || '',
-    }),
-    {
-      enabled: !!conversationId && !!channelId,
-    },
-  );
-
   const targetMessageId = searchParams.get('messageId');
   useEffect(() => {
     if (!targetMessageId || !conversationId) return;
@@ -4125,6 +4123,15 @@ export const SupportTicketDetail = ({
 
   // Get channel info and user status
   const channel = useChannel(channelId);
+  const [mailboxRows] = useCachedQuery(
+    queries.myTicketMailbox({ ticketId: mailboxTicketId ?? '' }),
+    { enabled: channel?.type === ChannelType.EMAIL && !!mailboxTicketId },
+  );
+  const mailboxOverlay = mailboxRows?.[0];
+  const [conversationLabelMappings] = useCachedQuery(
+    queries.conversationLabelMappingsByConversationId({ conversationId: conversationId || '' }),
+    { enabled: !!conversationId },
+  );
   const channelParticipation = useGetChannelUserStatus(channelId);
   const isUserMember = !!channelParticipation;
 
@@ -4232,7 +4239,12 @@ export const SupportTicketDetail = ({
                   {ticketIdParam}
                 </span>
                 {channel?.type === ChannelType.EMAIL && mailboxTicketId && channelId && (
-                  <MailboxActions ticketId={mailboxTicketId} channelId={channelId} slot='star' />
+                  <MailboxActions
+                    ticketId={mailboxTicketId}
+                    channelId={channelId}
+                    slot='star'
+                    mailboxOverlay={mailboxOverlay}
+                  />
                 )}
                 {/* `min-w-[8rem]` (rem, so it tracks font scaling) is what makes the
                     row break its flex line instead of crushing the title to nothing. */}
@@ -4257,6 +4269,7 @@ export const SupportTicketDetail = ({
                         conversationId={conversationId}
                         channelId={channelId}
                         slot='picker'
+                        appliedMappings={conversationLabelMappings ?? []}
                       />
                     )}
                     {channel?.type === ChannelType.EMAIL && mailboxTicketId && channelId && (
@@ -4264,6 +4277,7 @@ export const SupportTicketDetail = ({
                         ticketId={mailboxTicketId}
                         channelId={channelId}
                         slot='actions'
+                        mailboxOverlay={mailboxOverlay}
                       />
                     )}
                   </div>
@@ -4501,6 +4515,7 @@ export const SupportTicketDetail = ({
                           ticketId={mailboxTicketId}
                           channelId={channelId}
                           slot='chip'
+                          mailboxOverlay={mailboxOverlay}
                         />
                       )}
                       {conversationId && (
@@ -4508,6 +4523,7 @@ export const SupportTicketDetail = ({
                           conversationId={conversationId}
                           channelId={channelId}
                           slot='chips'
+                          appliedMappings={conversationLabelMappings ?? []}
                         />
                       )}
                     </div>
@@ -4715,37 +4731,13 @@ export const SupportTicketDetail = ({
               {emails && emails.length > 0 && (
                 <div className='mb-6'>
                   {channel?.type === ChannelType.SLACK || channel?.type === ChannelType.APP ? (
-                    <SlackThread
-                      emails={emails}
-                      ticketId={ticket?.id}
-                      lastEmailAt={ticket?.lastEmailAt}
-                      emailReads={
-                        ticket?.emailReads as
-                          | Array<{ userId: string; lastReadEmailAt: number }>
-                          | undefined
-                      }
-                    />
+                    <SlackThread emails={emails} ticketId={ticket?.id} />
                   ) : channel?.type === ChannelType.CALL ? (
-                    <CallThread
-                      emails={emails}
-                      ticketId={ticket?.id}
-                      lastEmailAt={ticket?.lastEmailAt}
-                      emailReads={
-                        ticket?.emailReads as
-                          | Array<{ userId: string; lastReadEmailAt: number }>
-                          | undefined
-                      }
-                    />
+                    <CallThread emails={emails} ticketId={ticket?.id} />
                   ) : (
                     <EmailThread
                       collapseState={emailCollapseState}
                       ticketId={ticket?.id}
-                      lastEmailAt={ticket?.lastEmailAt}
-                      emailReads={
-                        ticket?.emailReads as
-                          | Array<{ userId: string; lastReadEmailAt: number }>
-                          | undefined
-                      }
                       onReplyToEmail={(emailId, mode) => {
                         clearStoredRecipients(conversationId);
                         setReplyToEmailId(emailId);
@@ -4770,6 +4762,7 @@ export const SupportTicketDetail = ({
                   <SlackComposer
                     conversationId={conversationId}
                     channelId={channel?.id ?? null}
+                    drafts={ticketEmailDrafts}
                     variant={channel?.type === ChannelType.APP ? 'app' : 'slack'}
                     recordOnly={channel.type === ChannelType.APP && !outboundConfigured}
                   />
@@ -4786,6 +4779,8 @@ export const SupportTicketDetail = ({
                     >
                       <EmailComposer
                         conversationId={conversationId}
+                        drafts={ticketEmailDrafts}
+                        channelConnectedEmail={deskEmail}
                         emails={emails}
                         onClose={() => {
                           setComposerOpen(false);
@@ -4809,6 +4804,8 @@ export const SupportTicketDetail = ({
                         showSeeSources={hasUserDraftAgentSession}
                         onDraftInlineCitationsChange={setDraftInlineCitations}
                         channelId={channelId}
+                        channelPreference={channelPreference}
+                        channelPreferenceLoaded={channelPreferenceLoaded}
                         ticketId={ticketId}
                         replyToEmailId={replyToEmailId}
                         replyMode={replyMode}
@@ -5270,8 +5267,6 @@ const useEmailCollapseState = (emails: Email[]): EmailCollapseState => {
 const EmailThread = ({
   collapseState,
   ticketId,
-  lastEmailAt,
-  emailReads,
   onReplyToEmail,
   deskEmail,
   onMailtoClick,
@@ -5280,8 +5275,6 @@ const EmailThread = ({
 }: {
   collapseState: EmailCollapseState;
   ticketId?: string | null | undefined;
-  lastEmailAt?: number | null | undefined;
-  emailReads?: ReadonlyArray<{ userId: string; lastReadEmailAt: number }> | undefined;
   onReplyToEmail?: (emailId: string, mode: 'reply' | 'replyAll') => void;
   deskEmail?: string | null | undefined;
   onMailtoClick: (email: string) => void;
@@ -5295,16 +5288,7 @@ const EmailThread = ({
   ) => void | Promise<void>;
 }): ReactElement => {
   const { sortedEmails, collapsedIds, toggleOne, lastEmailId } = collapseState;
-  // Thread-level: upsert the current user's email_reads row. `isRead` compares
-  // the stored lastReadEmailAt snapshot against the ticket's lastEmailAt, so
-  // every email header in the thread flips read/unread together.
-  const { isRead } = useMarkEmailRead(
-    ticketId,
-    lastEmailId ?? null,
-    lastEmailAt ?? null,
-    emailReads,
-    true,
-  );
+  useMarkEmailRead(ticketId, lastEmailId ?? null, true);
   const threadAttachments = useMemo(
     () => sortedEmails.flatMap(e => e.attachments ?? []),
     [sortedEmails],
@@ -5342,7 +5326,6 @@ const EmailThread = ({
             isCollapsed={collapsedIds.has(email.id)}
             canCollapse={email.id !== lastEmailId}
             onToggleCollapse={() => toggleOne(email.id)}
-            isRead={isRead}
             threadAttachments={threadAttachments}
             {...(onReplyToEmail &&
               email.id !== lastEmailId && {
@@ -5368,7 +5351,6 @@ const EmailThreadItem = ({
   isCollapsed = false,
   canCollapse = true,
   onToggleCollapse,
-  isRead = true,
   onReply,
   deskEmail,
   isConversationRoot,
@@ -5381,7 +5363,6 @@ const EmailThreadItem = ({
   isCollapsed?: boolean;
   canCollapse?: boolean;
   onToggleCollapse?: () => void;
-  isRead?: boolean;
   onReply?: (mode: 'reply' | 'replyAll') => void;
   deskEmail?: string | null | undefined;
   /** True when this email is the earliest email in its own conversationId —
@@ -5486,10 +5467,14 @@ const EmailThreadItem = ({
   ) : null;
 
   const headerClickable = canCollapse && !!onToggleCollapse;
-  const preview = stripHtml(email.body || '')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .slice(0, 140);
+  const preview = useMemo(
+    () =>
+      stripHtml(email.body || '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 140),
+    [email.body],
+  );
 
   return (
     <div
@@ -5529,7 +5514,6 @@ const EmailThreadItem = ({
           createdAt={email.createdAt}
           isCollapsed={isCollapsed}
           previewText={preview}
-          isRead={isRead}
           deskEmail={deskEmail}
           extras={demergeButton}
           emailId={email.id}

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -1249,6 +1249,27 @@ export const queries = defineQueries({
         .one();
     },
   ),
+
+  supportTicketDetailV2: defineQuery(
+    z.object({
+      id: z.string().optional(),
+      xyneId: z.string().optional(),
+      workspaceId: z.string(),
+      channelId: z.string(),
+      isMember: z.boolean(),
+    }),
+    ({ args: { id, xyneId, workspaceId } }) => {
+      const base = id
+        ? zql.tickets.where('id', id)
+        : zql.tickets.where('xyneId', xyneId ?? '').where('workspaceId', workspaceId);
+      return base
+        .related('referencesIn', ref =>
+          ref.where('relationType', TicketReferenceRelation.MERGED_INTO)
+            .related('sourceTicket'),
+        )
+        .one();
+    },
+  ),
   // Paginated variant of supportTicketsFiltered for use with @rocicorp/zero-virtual.
   // Cursor = (lastEmailAt, id) matching the orderBy. Active threads bubble up.
   // channelId + isMember are forwarded to TicketsACL for membership gating.


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [*] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
Added a lightweight ticket-detail query and split heavy relations into focused queries.
Consolidated duplicate subscriptions for preferences, drafts, mailbox state, labels, and connected-email data.
Reduced CID attachment downloads by fetching only referenced inline images in parallel.
Removed live read-state subscriptions and retained idempotent mark-as-read behavior.
Reduced unnecessary React renders through memoization and guarded toolbar state updates.
## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
