### PR TITLE
Fix/desk metrics fix release 05

### DIFF
--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -186,7 +186,7 @@ export class DeskMetricsRepository {
       )`;
 
     const frtStop = frtStopSql();
-    const [aggregates, tickets, emailRepliesInRange, stageCounts, priority, csat, trend, agents] =
+    const [aggregates, tickets, emailRepliesInRange, stageCounts, priority, csat, agents] =
       await Promise.all([
         this.frtRtAggregates(db, cohortCte, frtStop, resolvedAtSql),
         this.ticketRows(db, cohortCte, frtStop, resolvedAtSql),
@@ -194,7 +194,6 @@ export class DeskMetricsRepository {
         this.stageCounts(db, cohortCte),
         this.priorityBreakdown(db, cohortCte),
         this.csatStats(db, channelId, gte, lte, assigneeId, customFieldExists),
-        this.trendByDay(db, channelId, gte, lte, resolvedPredicate, assigneeId, customFieldExists),
         this.agentPerformance(
           db,
           cohortCte,
@@ -220,7 +219,7 @@ export class DeskMetricsRepository {
         stageCounts,
       },
       priority,
-      trend,
+      trend: [],
       tickets,
       agents,
     };
@@ -663,100 +662,6 @@ export class DeskMetricsRepository {
     };
   }
 
-  private async trendByDay(
-    db: ReturnType<DeskMetricsRepository['getDbInstance']>,
-    channelId: string,
-    gte: Date,
-    lte: Date,
-    resolvedPredicate: Prisma.Sql,
-    assigneeId?: string | null,
-    customFieldExists: Prisma.Sql = Prisma.sql``,
-  ): Promise<Array<{ date: string; opened: number; closed: number }>> {
-    const rangeDays = (lte.getTime() - gte.getTime()) / DAY_MS;
-    const hourly = rangeDays <= 1;
-    const bucketFn = hourly
-      ? Prisma.sql`to_char(date_trunc('hour', (ta."timestamp" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD HH24:00')`
-      : Prisma.sql`to_char(date_trunc('day',  (ta."timestamp" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD')`;
-    const bucketFnR = hourly
-      ? Prisma.sql`to_char(date_trunc('hour', (r.first_resolved AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD HH24:00')`
-      : Prisma.sql`to_char(date_trunc('day',  (r.first_resolved AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD')`;
-
-    const ticketFilter = activeTicketFilter(assigneeId);
-
-    const [openedRows, closedRows] = await Promise.all([
-      db.$queryRaw<Array<{ day: string; count: number }>>(
-        Prisma.sql`
-          SELECT ${bucketFn} AS day, COUNT(*)::int AS count
-          FROM "public"."ticket_activities" ta
-          WHERE ta."channelId" = ${channelId}
-            AND ta."activityType" = 'TICKET_CREATED'
-            AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-            ${ticketFilter}
-            ${customFieldExists}
-          GROUP BY 1
-        `,
-      ),
-      db.$queryRaw<Array<{ day: string; count: number }>>(
-        Prisma.sql`
-          SELECT ${bucketFnR} AS day, COUNT(*)::int AS count
-          FROM (
-            SELECT ta."ticketId", MAX(ta."timestamp") AS first_resolved
-            FROM "public"."ticket_activities" ta
-            WHERE ta."channelId" = ${channelId} AND ${resolvedPredicate}
-              ${ticketFilter}
-              ${customFieldExists}
-            GROUP BY ta."ticketId"
-          ) r
-          WHERE r.first_resolved >= ${gte} AND r.first_resolved <= ${lte}
-          GROUP BY 1
-        `,
-      ),
-    ]);
-
-    const opened = new Map(openedRows.map(r => [r.day, r.count]));
-    const closed = new Map(closedRows.map(r => [r.day, r.count]));
-
-    // Fill all buckets so the chart has no gaps
-    const buckets: string[] = [];
-    const HOUR_MS = 60 * 60 * 1000;
-    const IST_TZ = 'Asia/Kolkata';
-    const toISTDateStr = (ms: number): string =>
-      new Date(ms).toLocaleDateString('en-CA', { timeZone: IST_TZ }); // → 'YYYY-MM-DD'
-    const toISTHourStr = (ms: number): string => {
-      const d = new Date(ms);
-      const date = d.toLocaleDateString('en-CA', { timeZone: IST_TZ });
-      const hour = d.toLocaleTimeString('en-GB', { timeZone: IST_TZ, hour: '2-digit', minute: '2-digit' }).slice(0, 2);
-      return `${date} ${hour}:00`;
-    };
-    const floorToISTDay = (ms: number): number =>
-      new Date(`${toISTDateStr(ms)}T00:00:00+05:30`).getTime();
-    const floorToISTHour = (ms: number): number => {
-      const d = new Date(ms);
-      const date = d.toLocaleDateString('en-CA', { timeZone: IST_TZ });
-      const hour = d.toLocaleTimeString('en-GB', { timeZone: IST_TZ, hour: '2-digit', minute: '2-digit' }).slice(0, 2);
-      return new Date(`${date}T${hour}:00:00+05:30`).getTime();
-    };
-
-    if (hourly) {
-      const startHour = floorToISTHour(gte.getTime());
-      const endHour   = floorToISTHour(lte.getTime());
-      for (let t = startHour; t <= endHour; t += HOUR_MS) {
-        buckets.push(toISTHourStr(t));
-      }
-    } else {
-      const startDay = floorToISTDay(gte.getTime());
-      const endDay   = floorToISTDay(lte.getTime());
-      for (let t = startDay; t <= endDay; t += DAY_MS) {
-        buckets.push(toISTDateStr(t));
-      }
-    }
-
-    return buckets.map(date => ({
-      date,
-      opened: opened.get(date) ?? 0,
-      closed: closed.get(date) ?? 0,
-    }));
-  }
 }
 
 export const deskMetricsRepository = new DeskMetricsRepository();

--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -21,6 +21,20 @@ import { logger } from '@/utils/logger';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+const activeTicketFilter = (assigneeId?: string | null): Prisma.Sql => {
+  const assigneeCondition = assigneeId
+    ? Prisma.sql`AND t."assignedTo" = ${assigneeId}`
+    : Prisma.sql``;
+
+  return Prisma.sql`AND EXISTS (
+    SELECT 1
+    FROM "public"."tickets" t
+    WHERE t.id = ta."ticketId"
+      AND t."isArchived" = false
+      ${assigneeCondition}
+  )`;
+};
+
 export class DeskMetricsRepository {
   private getDbInstance() {
     const replica = readReplicaDb;
@@ -121,9 +135,7 @@ export class DeskMetricsRepository {
     )`;
 
     // Cohort: tickets created in range. Optionally filtered by assignee and/or custom field.
-    const assigneeJoin = assigneeId
-      ? Prisma.sql`JOIN "public"."tickets" tf ON tf.id = ta."ticketId" AND tf."assignedTo" = ${assigneeId}`
-      : Prisma.sql``;
+    const ticketFilter = activeTicketFilter(assigneeId);
 
     let customFieldExists: Prisma.Sql = Prisma.sql``;
     if (customFieldFilter && customFieldFilter.keys.length > 0) {
@@ -166,10 +178,10 @@ export class DeskMetricsRepository {
       cohort AS (
         SELECT ta."ticketId", ta."timestamp" AS created_at
         FROM "public"."ticket_activities" ta
-        ${assigneeJoin}
         WHERE ta."channelId" = ${channelId}
           AND ta."activityType" = 'TICKET_CREATED'
           AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
+          ${ticketFilter}
           ${customFieldExists}
       )`;
 
@@ -393,6 +405,7 @@ export class DeskMetricsRepository {
     const replyActorFilter = assigneeId
       ? Prisma.sql`AND ta."updatedBy" = ${assigneeId}`
       : Prisma.sql``;
+    const ticketFilter = activeTicketFilter();
 
     const [ownershipRows, replyRows, stageRows] = await Promise.all([
       db.$queryRaw<
@@ -468,6 +481,7 @@ export class DeskMetricsRepository {
           WHERE ta."channelId" = ${channelId}
             AND ta."activityType" = 'EMAIL_SENT'
             AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
+            ${ticketFilter}
             ${replyActorFilter}
             ${customFieldExists}
           GROUP BY ta."updatedBy", COALESCE(u."displayName", u.name)
@@ -564,9 +578,7 @@ export class DeskMetricsRepository {
     assigneeId?: string | null,
     customFieldExists: Prisma.Sql = Prisma.sql``,
   ): Promise<number> {
-    const assigneeFilter = assigneeId
-      ? Prisma.sql`AND EXISTS (SELECT 1 FROM "public"."tickets" t WHERE t.id = ta."ticketId" AND t."assignedTo" = ${assigneeId})`
-      : Prisma.sql``;
+    const ticketFilter = activeTicketFilter(assigneeId);
     const rows = await db.$queryRaw<Array<{ count: number }>>(
       Prisma.sql`
         SELECT COUNT(*)::int AS count
@@ -574,7 +586,7 @@ export class DeskMetricsRepository {
         WHERE ta."channelId" = ${channelId}
           AND ta."activityType" = 'EMAIL_SENT'
           AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-          ${assigneeFilter}
+          ${ticketFilter}
           ${customFieldExists}
       `,
     );
@@ -625,9 +637,7 @@ export class DeskMetricsRepository {
     assigneeId?: string | null,
     customFieldExists: Prisma.Sql = Prisma.sql``,
   ): Promise<{ avgScore: number | null; scoredResponses: number; good: number; bad: number }> {
-    const assigneeFilter = assigneeId
-      ? Prisma.sql`AND EXISTS (SELECT 1 FROM "public"."tickets" t WHERE t.id = ta."ticketId" AND t."assignedTo" = ${assigneeId})`
-      : Prisma.sql``;
+    const ticketFilter = activeTicketFilter(assigneeId);
     const rows = await db.$queryRaw<
       Array<{ avg_score: number | null; scored_responses: number; good: number; bad: number }>
     >(
@@ -641,7 +651,7 @@ export class DeskMetricsRepository {
         WHERE ta."channelId" = ${channelId}
           AND ta."activityType" = 'CSAT_RECEIVED'
           AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-          ${assigneeFilter}
+          ${ticketFilter}
           ${customFieldExists}
       `,
     );
@@ -671,9 +681,7 @@ export class DeskMetricsRepository {
       ? Prisma.sql`to_char(date_trunc('hour', (r.first_resolved AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD HH24:00')`
       : Prisma.sql`to_char(date_trunc('day',  (r.first_resolved AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD')`;
 
-    const assigneeFilter = assigneeId
-      ? Prisma.sql`AND EXISTS (SELECT 1 FROM "public"."tickets" t WHERE t.id = ta."ticketId" AND t."assignedTo" = ${assigneeId})`
-      : Prisma.sql``;
+    const ticketFilter = activeTicketFilter(assigneeId);
 
     const [openedRows, closedRows] = await Promise.all([
       db.$queryRaw<Array<{ day: string; count: number }>>(
@@ -683,7 +691,7 @@ export class DeskMetricsRepository {
           WHERE ta."channelId" = ${channelId}
             AND ta."activityType" = 'TICKET_CREATED'
             AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-            ${assigneeFilter}
+            ${ticketFilter}
             ${customFieldExists}
           GROUP BY 1
         `,
@@ -695,7 +703,7 @@ export class DeskMetricsRepository {
             SELECT ta."ticketId", MAX(ta."timestamp") AS first_resolved
             FROM "public"."ticket_activities" ta
             WHERE ta."channelId" = ${channelId} AND ${resolvedPredicate}
-              ${assigneeFilter}
+              ${ticketFilter}
               ${customFieldExists}
             GROUP BY ta."ticketId"
           ) r

--- a/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDashboard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDashboard.tsx
@@ -85,8 +85,6 @@ const PRIORITY_BADGE: Record<string, string> = {
 };
 
 const PAGE_SIZE = 15;
-const HOUR_MS = 60 * 60 * 1000;
-const DAY_MS = 24 * HOUR_MS;
 
 const dateTimeMs = (date: Date, time: string, isEnd: boolean): number => {
   const [hour = 0, minute = 0] = time.split(':').map(Number);
@@ -109,32 +107,6 @@ export const formatDuration = (seconds: number | null): string => {
 
 const priorityLabel = (p: string): string =>
   p.charAt(0) + p.slice(1).toLowerCase().replace(/_/g, ' ');
-
-const formatTrendLabel = (dateStr: string, hourly: boolean): string => {
-  if (hourly) {
-    // dateStr = 'YYYY-MM-DD HH:00' in IST
-    const hour = parseInt(dateStr.slice(11, 13), 10);
-    const suffix = hour >= 12 ? 'pm' : 'am';
-    return `${hour % 12 || 12}${suffix}`;
-  }
-  // dateStr = 'YYYY-MM-DD' in IST
-  const [, m, d] = dateStr.split('-').map(Number);
-  const months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
-  return `${months[(m ?? 1) - 1]} ${d}`;
-};
 
 const getCustomFieldKeys = (tickets: DeskMetricsTicketRow[]): string[] =>
   [...new Set(tickets.flatMap(t => Object.keys(t.customFields ?? {})))].sort();
@@ -821,14 +793,11 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     [channelId, comparedChannelIds, selectedDeskIds.length, setComparedChannelIds],
   );
 
-  const [chartView, setChartView] = useState<'priority' | 'trend' | 'assignee'>('priority');
-  const [expandedChart, setExpandedChart] = useState<'priority' | 'trend' | 'assignee' | null>(
-    null,
-  );
+  const [chartView, setChartView] = useState<'priority' | 'assignee'>('priority');
+  const [expandedChart, setExpandedChart] = useState<'priority' | 'assignee' | null>(null);
   const rangeStartMs = dateTimeMs(dateRange.startDate, startTime, false);
   const rangeEndMs = dateTimeMs(dateRange.endDate, endTime, true);
   const timeRangeParam = `${rangeStartMs}_${rangeEndMs}`;
-  const isHourly = rangeEndMs - rangeStartMs <= DAY_MS;
   const [ownerSearch, setOwnerSearch] = useState('');
   const ownerSearchInputRef = useRef<HTMLInputElement>(null);
   const [fieldKeySearch, setFieldKeySearch] = useState('');
@@ -1000,11 +969,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     color: PRIORITY_COLORS[p.priority] ?? '#94a3b8',
   }));
 
-  const trendData = useMemo(
-    () => (data?.trend ?? []).map(d => ({ ...d, label: formatTrendLabel(d.date, isHourly) })),
-    [data?.trend, isHourly],
-  );
-
   const assigneeData = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const t of data?.tickets ?? []) {
@@ -1022,13 +986,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
-
-  const tickInterval = useMemo(() => {
-    const n = trendData.length;
-    if (n <= 8) return 0;
-    if (n <= 31) return 4;
-    return Math.floor(n / 6);
-  }, [trendData.length]);
 
   const csatTotal = (data?.csat.good ?? 0) + (data?.csat.bad ?? 0);
   const isEmpty = !!data && data.tickets.length === 0 && data.counts.stageCounts.length === 0;
@@ -2081,8 +2038,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                       <div className='mb-3 flex items-center justify-between gap-3'>
                         <div className='text-sm font-medium text-foreground'>
                           {chartView === 'priority' && 'Tickets by priority'}
-                          {chartView === 'trend' &&
-                            `Tickets created vs resolved ${isHourly ? '(hourly)' : '(daily)'}`}
                           {chartView === 'assignee' && 'Tickets by assignee'}
                         </div>
                         <div className='flex items-center gap-2'>
@@ -2100,20 +2055,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                               )}
                             >
                               By Priority
-                            </button>
-                            <button
-                              type='button'
-                              onClick={() => setChartView('trend')}
-                              data-track-category='DeskMetrics'
-                              data-track-name='ChartViewTrend'
-                              className={cn(
-                                'rounded-[6px] px-2.5 py-1 text-xs font-medium transition-colors',
-                                chartView === 'trend'
-                                  ? 'bg-background text-foreground shadow-sm'
-                                  : 'text-muted-foreground hover:text-foreground',
-                              )}
-                            >
-                              Created vs Resolved
                             </button>
                             <button
                               type='button'
@@ -2167,41 +2108,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                                 <RechartsTooltip cursor={false} />
                                 <Legend />
                               </PieChart>
-                            </ResponsiveContainer>
-                          </div>
-                        ))}
-
-                      {chartView === 'trend' &&
-                        (trendData.length === 0 ? (
-                          <div className='flex h-[280px] items-center justify-center text-xs text-muted-foreground'>
-                            No data in range
-                          </div>
-                        ) : (
-                          <div className='h-[280px]'>
-                            <ResponsiveContainer width='100%' height='100%'>
-                              <BarChart data={trendData} margin={{ left: -16, right: 4 }}>
-                                <CartesianGrid strokeDasharray='3 3' vertical={false} />
-                                <XAxis
-                                  dataKey='label'
-                                  tick={{ fontSize: 11 }}
-                                  interval={tickInterval}
-                                />
-                                <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
-                                <RechartsTooltip cursor={false} />
-                                <Legend />
-                                <Bar
-                                  dataKey='opened'
-                                  name='Created'
-                                  fill='#6366f1'
-                                  radius={[4, 4, 0, 0]}
-                                />
-                                <Bar
-                                  dataKey='closed'
-                                  name='Resolved'
-                                  fill='#10b981'
-                                  radius={[4, 4, 0, 0]}
-                                />
-                              </BarChart>
                             </ResponsiveContainer>
                           </div>
                         ))}
@@ -2295,8 +2201,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
             <div className='mb-4 flex items-center justify-between'>
               <h2 className='text-base font-semibold text-foreground'>
                 {expandedChart === 'priority' && 'Tickets by priority'}
-                {expandedChart === 'trend' &&
-                  `Tickets created vs resolved ${isHourly ? '(hourly)' : '(daily)'}`}
                 {expandedChart === 'assignee' && 'Tickets by assignee'}
               </h2>
               <button
@@ -2333,24 +2237,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                       <RechartsTooltip cursor={false} />
                       <Legend />
                     </PieChart>
-                  </ResponsiveContainer>
-                ))}
-              {expandedChart === 'trend' &&
-                (trendData.length === 0 ? (
-                  <div className='flex h-full items-center justify-center text-sm text-muted-foreground'>
-                    No data in range
-                  </div>
-                ) : (
-                  <ResponsiveContainer width='100%' height='100%'>
-                    <BarChart data={trendData} margin={{ left: -16, right: 8 }}>
-                      <CartesianGrid strokeDasharray='3 3' vertical={false} />
-                      <XAxis dataKey='label' tick={{ fontSize: 12 }} interval={tickInterval} />
-                      <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
-                      <RechartsTooltip cursor={false} />
-                      <Legend />
-                      <Bar dataKey='opened' name='Created' fill='#6366f1' radius={[4, 4, 0, 0]} />
-                      <Bar dataKey='closed' name='Resolved' fill='#10b981' radius={[4, 4, 0, 0]} />
-                    </BarChart>
                   </ResponsiveContainer>
                 ))}
               {expandedChart === 'assignee' &&


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
