### PR TITLE
fix: fixed md internal link rendering for automation links

### DIFF
--- a/apps/backend/src/automations/triggers/ticket-context.ts
+++ b/apps/backend/src/automations/triggers/ticket-context.ts
@@ -11,6 +11,49 @@ const DESK_CHANNEL_TYPES: ReadonlySet<ChannelType> = new Set([
   ChannelType.CALL,
 ]);
 
+export interface TicketUrlParams {
+  frontendUrl: string;
+  ticketId: string;
+  workspaceId: string;
+  channelType: string | null | undefined;
+  channelId: string;
+  conversationId: string | null | undefined;
+  xyneId: string | null | undefined;
+}
+
+/** Build the same deep-link a dashboard ticket navigation uses. */
+export function buildTicketUrl(params: TicketUrlParams): string | null {
+  const {
+    frontendUrl,
+    ticketId,
+    workspaceId,
+    channelType,
+    channelId,
+    conversationId,
+    xyneId,
+  } = params;
+  const base = frontendUrl.trim().replace(/\/+$/, '');
+  if (!base || !ticketId || !workspaceId || !channelId) return null;
+
+  const workspacePath = encodeURIComponent(workspaceId);
+  const channelPath = encodeURIComponent(channelId);
+
+  // Desk tickets have a dedicated support route keyed by their human-readable
+  // id. This mirrors the navigation used by the dashboard and notifications.
+  if (channelType && DESK_CHANNEL_TYPES.has(channelType as ChannelType) || !conversationId) {
+    return xyneId
+      ? `${base}/${workspacePath}/support/${channelPath}/${encodeURIComponent(xyneId)}`
+      : `${base}/${workspacePath}/support/${channelPath}`;
+  }
+
+  const query = new URLSearchParams({
+    tab: 'tickets',
+    ticketId,
+    conversationId,
+  });
+  return `${base}/${workspacePath}/chat/dir/${channelPath}?${query.toString()}`;
+}
+
 const TicketSchema = z.object({
   id: z.string(),
   url: z.string().url().nullable(),
@@ -147,31 +190,6 @@ export interface TicketLike {
   updatedAt?: Date | null;
 }
 
-/** Build an absolute support URL for a desk ticket using trusted configuration. */
-function buildTicketUrl(params: {
-  frontendUrl: string;
-  workspaceId: string;
-  channelType: string | null | undefined;
-  channelId: string;
-  xyneId: string | null | undefined;
-}): string | null {
-  const { frontendUrl, workspaceId, channelType, channelId, xyneId } = params;
-  const base = frontendUrl.trim().replace(/\/+$/, '');
-  if (
-    !base ||
-    !workspaceId ||
-    !DESK_CHANNEL_TYPES.has(channelType as ChannelType) ||
-    !channelId ||
-    !xyneId
-  ) {
-    return null;
-  }
-
-  return [base, workspaceId, 'support', channelId, xyneId]
-    .map((segment, index) => (index === 0 ? segment : encodeURIComponent(segment)))
-    .join('/');
-}
-
 export async function buildTicketContext(ticket: TicketLike): Promise<TicketContext> {
   const lastEmails = await loadLastEmails(ticket);
   const [board, project, channel, assignee, creator, group] = await Promise.all([
@@ -216,9 +234,11 @@ export async function buildTicketContext(ticket: TicketLike): Promise<TicketCont
 
   const ticketUrl = buildTicketUrl({
     frontendUrl: config.frontendUrl,
+    ticketId: ticket.id,
     workspaceId: ticket.workspaceId,
     channelType: channel?.type,
     channelId: ticket.channelId,
+    conversationId: ticket.conversationId,
     xyneId: ticket.xyneId,
   });
 

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -95,7 +95,7 @@ const getOptionalChannelScopeType = (value: unknown): ChannelScopeType | undefin
   return isChannelScopeType(scopeType) ? scopeType : undefined;
 };
 
-const InternalXyneLink = ({
+export const InternalXyneLink = ({
   href,
   children,
   className,

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -10,6 +10,11 @@ import { D2Block } from '../components/Markdown/D2Block';
 import { ClawCitationGroup } from '../components/Chat/XyneAISidebar/components/ClawCitationGroup';
 import { ThreadCitationChip } from '../components/ui/MessageBubble/ThreadCitationChip';
 import { parseCiteGroupHref } from '../components/ui/TipTapExtensions/CitationMark';
+import { InternalXyneLink } from '../components/Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import {
+  getAnchorTargetProps,
+  parseInternalXyneLink,
+} from '../components/Chat/RenderMessageWithHTML/internalLinkUtils';
 import type { ToolInvocation } from '../components/Chat/XyneAISidebar/utils/XyneAITypes';
 
 /**
@@ -215,6 +220,23 @@ export const createMarkdownComponents = (
       }
     }
 
+    // Keep Markdown messages consistent with the regular HTML message path.
+    // Automation SEND_MESSAGE stores content as Markdown, so without this
+    // branch internal Xyne links render as unstyled browser anchors even
+    // though they are valid clickable links.
+    if (href && parseInternalXyneLink(href)) {
+      return (
+        <InternalXyneLink
+          href={href}
+          {...props}
+          {...getAnchorTargetProps(href)}
+          className={props.className ?? 'text-primary'}
+        >
+          {children}
+        </InternalXyneLink>
+      );
+    }
+
     const isExternal = ((): boolean => {
       if (!href) return false;
       try {
@@ -243,6 +265,7 @@ export const createMarkdownComponents = (
           data-track-category='MESSAGE'
           data-track-name='OPEN_EXTERNAL_LINK'
           {...props}
+          className={props.className ?? 'text-primary hover:underline'}
         >
           {children}
         </a>


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
fixed md internal link rendering for automation links


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
