### PR TITLE
fix: render code blocks inline in condensed Activity previews

### DIFF
--- a/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
+++ b/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
@@ -48,7 +48,11 @@ export const DirectMessageActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          <RenderMessageWithHTML
+            message={message.content}
+            showEdited={message.edited}
+            singleLinePreview
+          />
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
+++ b/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
@@ -51,7 +51,11 @@ export const KeywordMatchActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          <RenderMessageWithHTML
+            message={message.content}
+            showEdited={message.edited}
+            singleLinePreview
+          />
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
@@ -52,7 +52,11 @@ export const MessageMentionActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          <RenderMessageWithHTML
+            message={message.content}
+            showEdited={message.edited}
+            singleLinePreview
+          />
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
@@ -46,7 +46,11 @@ export const MessageRepliedActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          <RenderMessageWithHTML
+            message={message.content}
+            showEdited={message.edited}
+            singleLinePreview
+          />
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
@@ -106,6 +106,7 @@ export const MessageRepliedActivityV2 = ({
           <RenderMessageWithHTML
             message={latestReplyMessage.content}
             showEdited={latestReplyMessage.edited}
+            singleLinePreview
           />
         </div>
       )}

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -59,6 +59,12 @@ interface RenderMessageWithHTMLProps {
   messageId?: string;
   conversationId?: string;
   preserveThreadRoute?: boolean;
+  /**
+   * Render code blocks as inline single-line snippets instead of full <pre>
+   * boxes. Used by condensed/line-clamped previews (e.g. the Activity feed) so
+   * a code-containing message stays on one line.
+   */
+  singleLinePreview?: boolean;
 }
 
 const MAX_HTML_LENGTH = 100000;
@@ -68,6 +74,24 @@ const URL_REGEX = /https?:\/\/[^\s<]+[^<.,:;"')\]\s]/gi;
 const CODE_BLOCK_COLLAPSE_THRESHOLD = 50;
 const CODE_BLOCK_PREVIEW_LINES = 10;
 const CODE_BLOCK_PREVIEW_MAX_HEIGHT = CODE_BLOCK_PREVIEW_LINES * 24 + 32;
+
+/**
+ * When true (provided via SingleLinePreviewContext), a code block is collapsed
+ * to an inline monospace snippet instead of a multi-line <pre> box. A block
+ * level <pre> ignores an ancestor's `line-clamp-1`/`truncate`, so in the
+ * Activity feed's condensed view a code-containing message rendered its full
+ * code box instead of a one-line preview. Consumers opt in via the
+ * `singleLinePreview` prop on RenderMessageWithHTML.
+ */
+const SingleLinePreviewContext = React.createContext(false);
+
+/**
+ * Flatten a code block's raw text into a single-line snippet for previews:
+ * collapse every run of whitespace (including newlines) to a single space and
+ * trim. Exported for unit testing.
+ */
+export const collapseCodeForPreview = (codeText: string): string =>
+  codeText.replace(/\s+/g, ' ').trim();
 
 const getInternalLinkIcon = (kind: InternalXyneLinkKind): JSX.Element => {
   switch (kind) {
@@ -632,6 +656,42 @@ function CollapsibleCodeBlock({
       </div>
     </div>
   );
+}
+
+function PreviewAwareCodeBlock({
+  children,
+  codeText,
+  lineCount,
+  keyPrefix,
+}: {
+  children: React.ReactNode;
+  codeText: string;
+  lineCount: number;
+  keyPrefix: string;
+}): JSX.Element {
+  const isSingleLinePreview = React.useContext(SingleLinePreviewContext);
+
+  // Condensed / single-line preview: render an inline snippet so the message
+  // stays on one clamped line instead of expanding into a full code box.
+  if (isSingleLinePreview) {
+    return (
+      <code className='font-mono text-[0.85em] text-foreground/90'>
+        {collapseCodeForPreview(codeText)}
+      </code>
+    );
+  }
+
+  const copyablePre = <CopyableCodeBlock codeText={codeText}>{children}</CopyableCodeBlock>;
+
+  if (lineCount > CODE_BLOCK_COLLAPSE_THRESHOLD) {
+    return (
+      <CollapsibleCodeBlock keyPrefix={keyPrefix} lineCount={lineCount}>
+        {copyablePre}
+      </CollapsibleCodeBlock>
+    );
+  }
+
+  return copyablePre;
 }
 
 const tokenizeToReactNodes = (
@@ -1337,25 +1397,16 @@ const parseNode = (
     const codeText = el.textContent ?? '';
     const lineCount = codeText.length > 0 ? codeText.replace(/\n$/, '').split('\n').length : 0;
     const preElement = React.createElement(tag, props, ...children);
-    const copyablePre = (
-      <CopyableCodeBlock key={`${keyPrefix}-copyable-pre-${idx}`} codeText={codeText}>
+    return (
+      <PreviewAwareCodeBlock
+        key={`${keyPrefix}-pre-${idx}`}
+        codeText={codeText}
+        lineCount={lineCount}
+        keyPrefix={`${keyPrefix}-${idx}`}
+      >
         {preElement}
-      </CopyableCodeBlock>
+      </PreviewAwareCodeBlock>
     );
-
-    if (lineCount > CODE_BLOCK_COLLAPSE_THRESHOLD) {
-      return (
-        <CollapsibleCodeBlock
-          key={`${keyPrefix}-collapsible-pre-${idx}`}
-          keyPrefix={`${keyPrefix}-${idx}`}
-          lineCount={lineCount}
-        >
-          {copyablePre}
-        </CollapsibleCodeBlock>
-      );
-    }
-
-    return copyablePre;
   }
 
   return React.createElement(tag, props, ...children);
@@ -1369,6 +1420,7 @@ export const RenderMessageWithHTML: React.FC<RenderMessageWithHTMLProps> = ({
   messageId,
   conversationId,
   preserveThreadRoute = false,
+  singleLinePreview = false,
 }): JSX.Element => {
   const navigate = useNavigate();
   const keyPrefix = useMemo<string>(() => Math.random().toString(36).slice(2), []);
@@ -1493,13 +1545,15 @@ export const RenderMessageWithHTML: React.FC<RenderMessageWithHTMLProps> = ({
   }, [parsedContent, showEdited, keyPrefix]);
 
   return (
-    <div
-      className={cn(
-        'message-html-root jp-message-html',
-        isSystemMessage ? 'text-muted-foreground' : '',
-      )}
-    >
-      {contentWithEdited}
-    </div>
+    <SingleLinePreviewContext.Provider value={singleLinePreview}>
+      <div
+        className={cn(
+          'message-html-root jp-message-html',
+          isSystemMessage ? 'text-muted-foreground' : '',
+        )}
+      >
+        {contentWithEdited}
+      </div>
+    </SingleLinePreviewContext.Provider>
   );
 };


### PR DESCRIPTION
## 1. Problem Description
In the Activity feed, each row honors a per-user view setting (Condensed vs Detailed). In Condensed mode every activity should show its message on a single truncated line. When the message contained a code block, the row instead rendered the full multi-line code box, breaking the condensed layout even though the user has Condensed selected. Reported in #xyne-spaces-feedback (screen recording from Ishaan Rawat).

## 2. How the issue was identified
The condensed branch of the message-activity components wraps `RenderMessageWithHTML` in a `line-clamp-1 truncate` container. `RenderMessageWithHTML` renders a code block as a block-level `<pre>` (via `CopyableCodeBlock` / `CollapsibleCodeBlock`). A block-level `<pre>` with its own padding/background ignores the ancestor's `line-clamp-1`/`truncate`, so the code box renders at full height and blows the row open. Affects all five condensed message previews: mention, keyword match, DM, replied, replied v2.

## 3. Solution implemented
- Added an opt-in `singleLinePreview` prop to `RenderMessageWithHTML`.
- Introduced `SingleLinePreviewContext` and a `PreviewAwareCodeBlock` component. When `singleLinePreview` is set, a code block is collapsed to an inline monospace snippet (`<code>`), so it flows within the single clamped line instead of rendering a block `<pre>` box. When not set, behavior is unchanged (Copyable/Collapsible code block).
- Extracted `collapseCodeForPreview(codeText)` — a pure, exported helper that flattens whitespace/newlines to a single line (kept pure for unit testing).
- The five condensed message-activity previews now pass `singleLinePreview`. Expanded/Detailed rendering (which uses `MessageBubble`) is untouched.

Files changed:
- apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
- apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
- apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
- apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
- apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
- apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A

## 8. Testing
- `tsc --noEmit` (tsconfig.app.json): no errors in changed files (pre-existing unrelated errors in other files remain).
- Prettier: all changed files conform.
- ESLint: 0 errors on changed files.
- Note: the dashboard has no committed unit-test runner (no vitest/jest) or Playwright suite, so an in-repo automated test could not be added without standing up test infra. `collapseCodeForPreview` was intentionally exported as a pure function so a unit test can be added once a runner exists. Manual verification steps: with Activity view set to Condensed, an activity whose message contains a fenced code block should render on a single truncated line (inline snippet) rather than a full code box; Detailed view is unchanged.

## 9. Services to which this change is to be deployed
Dashboard (frontend) only.

## 10. Main PR link (if raised against a release branch)
N/A