### PR TITLE
fix: backport non_zero exclusion to schema-migration validator

### DIFF
--- a/scripts/validate-schema-migrations.sh
+++ b/scripts/validate-schema-migrations.sh
@@ -145,6 +145,27 @@ get_migration_content_preview() {
     get_migration_content "$migration_file" | head -20 || echo "(unable to read file)"
 }
 
+# Return definitions (models or enums) in schema.prisma that live in the "non_zero"
+# Postgres schema — these are server-only and are not replicated to Zero.
+get_non_zero_definitions() {
+    local schema_file="$1"
+    local definition_type="$2"
+
+    [ -f "$schema_file" ] || return 0
+
+    awk -v type="$definition_type" '
+        $0 ~ "^"type"[[:space:]]+[A-Za-z0-9_]+" { name=$2; in_block=1 }
+        in_block && /@@schema\("non_zero"\)/ { print name }
+        /^}/ { in_block=0; name="" }
+    ' "$schema_file"
+}
+
+in_list() {
+    local needle="$1"
+    local haystack="$2"
+    [ -n "$needle" ] && grep -qxF "$needle" <<< "$haystack"
+}
+
 # Validate that new models/enums added to schema.prisma are also reflected in shared/src/zero/schema.ts
 # This enforces that any Prisma schema change is manually synced to the Zero TS schema
 validate_prisma_zero_sync() {
@@ -165,6 +186,13 @@ validate_prisma_zero_sync() {
 
     log_info "Checking Prisma<>Zero schema sync (schema.prisma → schema.ts)..."
 
+    # Definitions in the "non_zero" Postgres schema are not replicated to Zero and
+    # must be excluded from the sync requirement.
+    local non_zero_models
+    non_zero_models=$(get_non_zero_definitions "$prisma_schema" "model")
+    local non_zero_enums
+    non_zero_enums=$(get_non_zero_definitions "$prisma_schema" "enum")
+
     # Extract newly added Prisma model names from the staged diff
     local new_prisma_models
     new_prisma_models=$(git diff --cached -- "$prisma_schema" 2>/dev/null | \
@@ -183,6 +211,11 @@ validate_prisma_zero_sync() {
     if [ -n "$new_prisma_models" ]; then
         while IFS= read -r model; do
             [ -z "$model" ] && continue
+            # Skip models that live in the "non_zero" schema — they are not synced to Zero.
+            if in_list "$model" "$non_zero_models"; then
+                log_info "  ⏭ Prisma model '$model' is in the non_zero schema — skipping Zero sync check"
+                continue
+            fi
             # Case-insensitive grep to handle both PascalCase and snake_case table names
             if ! grep -qi "table(.*${model}" "$zero_schema"; then
                 log_error "Prisma model '$model' added to schema.prisma but no matching table() found in $zero_schema"
@@ -198,6 +231,11 @@ validate_prisma_zero_sync() {
     if [ -n "$new_prisma_enums" ]; then
         while IFS= read -r enum_name; do
             [ -z "$enum_name" ] && continue
+            # Skip enums that live in the "non_zero" schema — they are not synced to Zero.
+            if in_list "$enum_name" "$non_zero_enums"; then
+                log_info "  ⏭ Prisma enum '$enum_name' is in the non_zero schema — skipping Zero sync check"
+                continue
+            fi
             if ! grep -qi "export enum ${enum_name}" "$zero_schema"; then
                 log_error "Prisma enum '$enum_name' added to schema.prisma but not found in $zero_schema"
                 log_error "  → Add a corresponding enum definition in $zero_schema"


### PR DESCRIPTION
Backports main's `non_zero` exclusion to `scripts/validate-schema-migrations.sh` on the community branch.

The Prisma<>Zero sync check on this branch predates main's exclusion for models/enums living in the `non_zero` Postgres schema. Those are server-only (outside Zero replication) and must not be required to appear in `shared/src/zero/schema.ts`. Ports main's `get_non_zero_definitions`/`in_list` helpers and skip logic verbatim.

Unblocks #251 (its new `PrThreadLink` model is `non_zero`; without this, the "Validate schema migrations" check fails). Merge this before re-running checks on #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)