### PR TITLE
fix: XYNE-55135 HMAC-bind user-answer flow-action card + ownership/idempotency guards

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/app-callback.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/app-callback.ts
@@ -370,11 +370,27 @@ router.post("/callback", async (req: Request, res: Response) => {
       return;
     }
 
-    const { getQuestion, deleteQuestion } = await import("./pending-questions.js");
+    const { consumeQuestion } = await import("./pending-questions.js");
     const { setSession } = await import("./webhook.js");
-    const question = await getQuestion(questionId);
-    const questionText = question?.question ?? "a question";
-    const optionsList = question?.options?.join(", ") ?? "";
+    // XYNE-55135: atomically consume — idempotency (double click), existence
+    // (never dispatch a bogus/expired question), ownership + option validation.
+    // This is the requireAuth (cookie-trusted callerUserId) path, so the
+    // per-action HMAC is not required here; the guards below still apply.
+    const question = await consumeQuestion(questionId);
+    if (!question) {
+      log.info(`[app-callback] user-answer: question ${questionId} already answered or expired — dropping`);
+      return;
+    }
+    if (question.userId !== answerUserId) {
+      log.error(`[app-callback] user-answer ownership mismatch: stored ${question.userId} != answerer ${answerUserId}`);
+      return;
+    }
+    if (!question.options.includes(answer)) {
+      log.error(`[app-callback] user-answer invalid option for question ${questionId}`);
+      return;
+    }
+    const questionText = question.question;
+    const optionsList = question.options.join(", ");
 
     try {
       const agent = await findAgent(answerAgentSlug, answerSpacesAppId);
@@ -432,7 +448,6 @@ router.post("/callback", async (req: Request, res: Response) => {
       log.error("[app-callback] Failed to start new run with answer:", err);
     }
 
-    await deleteQuestion(questionId).catch(() => {});
     return;
   }
 

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -972,8 +972,9 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       const answerConversationId = data["conversationId"] as string;
       const answerUserId = data["userId"] as string;
       const answer = values["answer"] as string | undefined;
+      const signature = data["signature"] as string | undefined;
 
-      if (!questionId || !answer || !answerUserId) {
+      if (!questionId || !answer || !answerUserId || !signature) {
         res.status(400).json({ type: "error", message: "Missing user-answer fields" } satisfies AppActionResponse);
         return;
       }
@@ -985,19 +986,57 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         return;
       }
 
-      // Acknowledge immediately so the widget closes
+      // XYNE-55135: the card's identity + routing fields are HMAC-bound at
+      // creation (buildUserQuestionFlow sign site in webhook.ts). Verify here so
+      // a tampered flowJSON.data (agent/app/org, channel, conversation, or
+      // answerer swap) cannot dispatch a run.
+      const { verifyActionSignature } = await import("./mcp.js");
+      const answerActionPayload = {
+        actionType: "user-answer",
+        questionId,
+        userId: answerUserId,
+        agentSlug: answerAgentSlug,
+        spacesAppId: answerSpacesAppId ?? "",
+        channelId: answerChannelId,
+        conversationId: answerConversationId,
+      };
+      if (!verifyActionSignature(answerActionPayload, signature)) {
+        log.error("[flow-action] user-answer HMAC verification failed");
+        res.status(422).json({ type: "error", message: "Answer card verification failed" } satisfies AppActionResponse);
+        return;
+      }
+
+      // Atomically consume the stored question BEFORE acknowledging: idempotency
+      // (a second click gets null), existence (an unknown/expired id never
+      // dispatches a run), and the trusted source for ownership + option checks.
+      const { consumeQuestion } = await import("./pending-questions.js");
+      const question = await consumeQuestion(questionId);
+      if (!question) {
+        res.json({ type: "close_screen", finalMessage: "This question was already answered or has expired." } satisfies AppActionResponse);
+        return;
+      }
+      if (question.userId !== answerUserId) {
+        log.error(`[flow-action] user-answer ownership mismatch: stored ${question.userId} != answerer ${answerUserId}`);
+        res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
+        return;
+      }
+      if (!question.options.includes(answer)) {
+        log.error(`[flow-action] user-answer invalid option for question ${questionId}`);
+        res.status(400).json({ type: "error", message: "Invalid answer option" } satisfies AppActionResponse);
+        return;
+      }
+
+      // Acknowledge now that the answer is validated so the widget closes.
       resp = { type: "close_screen", finalMessage: `✅ You answered: "${answer}"` };
       res.json(resp);
       void replaceFlowCardWithText(messageId, answerAgentSlug, `✅ You answered: **"${answer}"**`, answerConversationId);
 
       // Fire-and-forget: start new /run with the answer as context
       try {
-        const { getQuestion, deleteQuestion } = await import("./pending-questions.js");
         const { setSession } = await import("./webhook.js");
 
-        const question = await getQuestion(questionId);
-        const questionText = question?.question ?? "a question";
-        const optionsList = question?.options?.join(", ") ?? "";
+        const questionText = question.question;
+        const optionsList = question.options.join(", ");
 
         const agent = await findAgentForFlow(answerAgentSlug, answerSpacesAppId);
         const appToken = agent?.spacesAppToken
@@ -1049,7 +1088,6 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         }
 
         log.info(`[flow-action] User answered "${answer}" → new /run (session=${runBody.sessionId})`);
-        await deleteQuestion(questionId).catch(() => {});
       } catch (err) {
         log.error("[flow-action] Failed to start new run with answer:", err);
       }

--- a/apps/xyne-claw-auth/backend/src/routes/pending-questions.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/pending-questions.ts
@@ -43,6 +43,21 @@ export async function deleteQuestion(questionId: string): Promise<void> {
   await redis.del(`${PREFIX}${questionId}`);
 }
 
+/**
+ * Atomically fetch-and-delete a pending question (GETDEL). Serves three roles
+ * for the user-answer flow-action (XYNE-55135): idempotency guard (a second
+ * click on the same card gets null and is dropped), existence/ownership source
+ * (compare question.userId to the answerer), and option source (validate the
+ * chosen answer). Because fetch and delete are one atomic op, a double click
+ * cannot dispatch two runs.
+ */
+export async function consumeQuestion(questionId: string): Promise<StoredQuestion | null> {
+  const redis = redisService.getConnection();
+  const raw = await redis.getdel(`${PREFIX}${questionId}`);
+  if (!raw) return null;
+  return JSON.parse(raw) as StoredQuestion;
+}
+
 // POST / — store a pending question
 router.post("/", requireStrictS2S, async (req: Request, res: Response) => {
   try {

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -5566,6 +5566,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // ── Post question buttons in thread ──
     const pendingQuestions = (payload as { pendingQuestions?: Array<{ questionId: string; question: string; options: string[] }> }).pendingQuestions;
     if (pendingQuestions?.length) {
+      const { signAction: signUserAnswer } = await import("./mcp.js");
       for (const q of pendingQuestions) {
         const questionFlow = withSpacesAppId(buildUserQuestionFlow(q.question, q.options, {
           questionId: q.questionId,
@@ -5574,6 +5575,23 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
           conversationId: ctx.conversationId,
           userId: ctx.senderId,
         }), ctx.spacesAppId);
+        // XYNE-55135: bind the card's identity + routing fields with an HMAC at
+        // creation time. The transport signature only proves Spaces forwarded
+        // the body unmodified; it cannot prove these fields equal what the agent
+        // posted, because Spaces forwards client-controlled flowJSON.data.
+        // flow-action re-derives and verifies this exact payload on click.
+        questionFlow.data = {
+          ...(questionFlow.data ?? {}),
+          signature: signUserAnswer({
+            actionType: "user-answer",
+            questionId: q.questionId,
+            userId: ctx.senderId,
+            agentSlug: ctx.agentSlug ?? "",
+            spacesAppId: ctx.spacesAppId ?? "",
+            channelId: ctx.channelId,
+            conversationId: ctx.conversationId,
+          }),
+        };
         await spacesAppFetch("/chat/postMessage", {
           channelId: ctx.channelId,
           conversationId: ctx.conversationId,


### PR DESCRIPTION
## Ticket
XYNE-55135 (HIGH) — [claw-auth] user-answer flow-action handler has no HMAC — run as victim with injected answer text.

## Problem
The `user-answer` branch of `POST /flow/action` (`apps/xyne-claw-auth/backend/src/routes/flow-action.ts`) dispatched a new `/internal/run` using values read straight from client-controlled `flowJSON.data`, with **no per-action HMAC** — unlike its `write` and `agent-call` siblings which already `verifyActionSignature`. Consequences:
- A crafted/tampered card could dispatch a run attributed to the named `answerUserId` with **injected answer text** and swapped `agentSlug`/`spacesAppId`/`channelId`/`conversationId` routing.
- The stored question was fetched with `getQuestion` and **never checked for ownership** (`question.userId`), so a known `questionId` was readable/consumable cross-user.
- A **null** (expired/unknown) question still dispatched a run (`question?.question ?? "a question"`).
- No idempotency: a **double click** dispatched two runs.

## Fix
Mirror the existing `agent-call`/`write` signing pattern — sign at card creation, verify + guard at handling.

- **`webhook.ts`** — sign the user-answer card at its creation site (`buildUserQuestionFlow`) via `signAction` over `{actionType, questionId, userId, agentSlug, spacesAppId, channelId, conversationId}`, injected into `flow.data.signature`.
- **`flow-action.ts`** — require + `verifyActionSignature` the same payload before dispatch (**422** on mismatch); then atomically `consumeQuestion` **before** acknowledging → existence + idempotency; enforce `question.userId === answerUserId` (**403**) and `answer ∈ question.options` (**400**). Validation now runs *before* the ack, so a failing card never closes with a false success and never fires a victim-attributed run.
- **`pending-questions.ts`** — add `consumeQuestion` (atomic Redis `GETDEL`): one op that is the fetch, the ownership/options source, and the double-click guard.
- **`app-callback.ts`** — apply the same ownership/options/existence/idempotency guards on the legacy cookie-trusted (`requireAuth`) path. The per-action HMAC is **not** required there because `callerUserId` is server-derived from the session cookie; signature enforcement is omitted to avoid breaking any legacy unsigned cards.

## Payload binding note
The signed payload includes `spacesAppId`, so a tampered `spacesAppId` fails the HMAC — this also closes the cross-org agent-swap vector in `findAgentForFlow` for this branch.

## Validation
- claw-auth `typecheck` baseline **unchanged: 545 errors before = 545 after** (all pre-existing environmental: Prisma client not generated in sandbox, missing optional modules, baseline implicit-any). Zero new type errors in the four touched files' edited regions.
- Suggested tests (follow-up): forged `answerUserId` → 403; tampered `data` field → 422; `question.userId` mismatch → 403; `answer ∉ options` → 400; null/expired question → no run; double click → single dispatch; legit browser click still succeeds.

## Scope / follow-ups
- Focused on the ticket's `user-answer` branch (+ its `app-callback` twin). The sibling read-from-`data` branches (`start-goal`, `plan-approval`) should adopt the same sign-at-creation/verify-at-handling pattern in a follow-up for uniformity; `clone-approval`/`skill-update` already re-resolve server-side by requestId + callerUserId so HMAC there is defense-in-depth.
- The separate `SPACES_WEBHOOK_VERIFY_MODE` transport-signature default (`verify-spaces-signature.ts` fails open as `warn`) is being handled separately by the branch owner. It is complementary, not a replacement: the transport signature only proves Spaces forwarded the body unmodified, while this per-action HMAC binds the routing/identity fields Spaces itself forwards verbatim from client-controlled `flowJSON.data`.