### PR TITLE
fix: canvas read endpoint requires view access not edit

### DIFF
--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -427,9 +427,10 @@ export class CanvasController {
         return;
       }
 
-      // Check read permission
+      // Read endpoint: require VIEW access (creator / OWNER-EDITOR-VIEWER role / PUBLIC-visibility
+      // channel or project access). Do NOT require edit here — a read must not demand editor rights.
       try {
-        await canvasAuthService.requireEditAccess(canvas.id, userId);
+        await canvasAuthService.requireViewAccess(canvas.id, userId);
       } catch (error) {
         logger.warn(`[CANVAS-READ] Permission denied for user ${userId} on canvas ${canvas.id}`);
         res.status(403).json({ error: 'Permission denied' });


### PR DESCRIPTION
## 1. Problem Description
The internal canvas read endpoint `GET /api/internal/canvas/view/:canvasId` (used by the `spaces-read-canvas` MCP tool) gated reads with `requireEditAccess`. As a result, any identity that only has VIEW rights on a canvas — PUBLIC-visibility canvases, or channel/project viewers who are not owners/editors — received `403 {"error":"Permission denied"}` on a purely read-only operation. This blocked reading public canvases in channels the caller is a member of.

## 2. How the issue was identified
Reproduced against public canvases in the `#upi` and `#upi-dashboard` channels: `spaces-read-canvas` returned `403 Permission denied` for a member with view access. Traced to `readCanvas` in `apps/backend/src/controllers/canvasController.ts`, whose comment says "Check read permission" but called `requireEditAccess`. `requireEditAccess` throws unless `canEdit` (creator / OWNER / EDITOR), while PUBLIC visibility + channel membership only grants `canView`.

## 3. Solution implemented
Switch `readCanvas` to `requireViewAccess` (which already exists in `canvasAuthService`). Reads now succeed for creators, OWNER/EDITOR/VIEWER roles, PUBLIC-visibility access, and guest container access — i.e. anyone with `canView`. `updateCanvas` is unchanged and still calls `requireEditAccess`, so write access is unaffected. Added a comment documenting that a read endpoint must not demand edit rights.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A

## 8. Testing
- `tsc --noEmit` on `apps/backend` shows no new type errors in `canvasController.ts`.
- Manual: before the change, `spaces-read-canvas` on a PUBLIC `#upi` canvas returned `403 Permission denied`; after switching to `requireViewAccess`, a view-access identity resolves canvas content. `updateCanvas` still returns `Edit permission denied` for non-editors.

## 9. Services to which this change is to be deployed
backend (Spaces API)

## 10. Main PR link (if raised against a release branch)
N/A — raised against `main`.