### PR TITLE
feat: bulk view-gated channel canvas export with folder placement

### DIFF
--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -453,6 +453,130 @@ export class CanvasController {
     }
   };
 
+  // Bulk-export every canvas in a channel that the caller can VIEW, together
+  // with each canvas's folder placement, so callers (e.g. the export/KB-import
+  // tooling) can reconstruct the channel's folder structure in a single pass
+  // instead of issuing one read per canvas.
+  //
+  // Security: this endpoint does NOT bypass canvas-level ACL. Each candidate
+  // canvas is individually gated by canvasAuthService.checkCanvasAccess and is
+  // omitted unless the caller has VIEW access. Only view access is required —
+  // this is a read/export, never an edit.
+  exportChannelCanvases = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        res.status(403).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const { channelId } = req.params;
+      if (!channelId) {
+        res.status(400).json({ error: 'channelId is required' });
+        return;
+      }
+
+      // Optional visibility filter (PUBLIC / PRIVATE); omit for everything the
+      // caller can view.
+      const visibilityParam = String(req.query.visibility ?? '').toUpperCase();
+      const visibility: 'PUBLIC' | 'PRIVATE' | undefined =
+        visibilityParam === 'PUBLIC' ? 'PUBLIC' : visibilityParam === 'PRIVATE' ? 'PRIVATE' : undefined;
+
+      // Content reads hit Y-Sweet per canvas, so the response is paginated and
+      // content can be skipped for a fast structure-only listing.
+      const includeContent = String(req.query.includeContent ?? 'true') !== 'false';
+      const rawLimit = parseInt(String(req.query.limit ?? '25'), 10);
+      const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 100) : 25;
+      const rawOffset = parseInt(String(req.query.offset ?? '0'), 10);
+      const offset = Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0;
+
+      const prisma = DatabaseClient.getInstance();
+
+      const where: { channelId: string; visibility?: 'PUBLIC' | 'PRIVATE' } = { channelId };
+      if (visibility) where.visibility = visibility;
+
+      // Count of canvases matching the filter (pre-ACL) so the caller can page.
+      const totalMatching = await prisma.canvas.count({ where });
+
+      const canvases = await prisma.canvas.findMany({
+        where,
+        select: { id: true, title: true, visibility: true, folderId: true, updatedAt: true },
+        orderBy: { updatedAt: 'desc' },
+        skip: offset,
+        take: limit,
+      });
+
+      // Resolve folder names for this channel once. CanvasFolder is a flat,
+      // channel-scoped set (no nested hierarchy), so a single id->name map is
+      // sufficient to reconstruct placement.
+      const folders = await prisma.canvasFolder.findMany({
+        where: { channelId },
+        select: { id: true, name: true },
+      });
+      const folderNameById = new Map(folders.map((f) => [f.id, f.name]));
+
+      const { readFromYSweet } = await import('../utils/ysweetUtils.js');
+
+      type ExportItem = {
+        id: string;
+        title: string;
+        visibility: string;
+        folderId: string | null;
+        folderName: string | null;
+        url: string;
+        markdown?: string;
+      };
+      const items: ExportItem[] = [];
+
+      for (const c of canvases) {
+        // Per-canvas ACL — skip anything the caller cannot view.
+        const auth = await canvasAuthService.checkCanvasAccess(c.id, userId);
+        if (!auth.hasAccess || !auth.canView) {
+          continue;
+        }
+
+        const item: ExportItem = {
+          id: c.id,
+          title: c.title,
+          visibility: c.visibility,
+          folderId: c.folderId ?? null,
+          folderName: c.folderId ? folderNameById.get(c.folderId) ?? null : null,
+          url: getCanvasUrl(c.id, req.user?.workspaceId),
+        };
+
+        if (includeContent) {
+          try {
+            const blocks = await readFromYSweet(c.id);
+            item.markdown = blocks.length > 0 ? await convertBlockNoteToMarkdown(blocks) : '';
+          } catch (readError) {
+            logger.warn(
+              `[CANVAS-EXPORT] Failed to read content for canvas ${c.id}: ${
+                readError instanceof Error ? readError.message : String(readError)
+              }`,
+            );
+            item.markdown = '';
+          }
+        }
+
+        items.push(item);
+      }
+
+      res.status(200).json({
+        channelId,
+        visibility: visibility ?? 'ALL',
+        totalMatching,
+        offset,
+        limit,
+        returned: items.length,
+        hasMore: offset + canvases.length < totalMatching,
+        canvases: items,
+      });
+    } catch (error) {
+      logger.error('[CANVAS-EXPORT] Error:', error);
+      res.status(500).json({ error: 'Failed to export channel canvases' });
+    }
+  };
+
   updateCanvas = async (req: Request, res: Response): Promise<void> => {
     try {
       const userId = req.user?.id;

--- a/apps/backend/src/routes/internalCanvas.ts
+++ b/apps/backend/src/routes/internalCanvas.ts
@@ -24,4 +24,13 @@ function attachInternalUser(req: Request, _res: Response, next: NextFunction): v
 router.get('/view/:canvasId', validateS2SKey, attachInternalUser, canvasController.readCanvas);
 router.patch('/view/:canvasId', validateS2SKey, attachInternalUser, canvasController.updateCanvas);
 
+// Bulk export of a channel's canvases (view-gated per canvas). See
+// CanvasController.exportChannelCanvases.
+router.get(
+  '/channel/:channelId/export',
+  validateS2SKey,
+  attachInternalUser,
+  canvasController.exportChannelCanvases,
+);
+
 export default router;

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -3660,6 +3660,112 @@ const spacesReadCanvas: ToolDef = {
 
 // ── spaces-edit-canvas ───────────────────────────────────────────────
 
+// ── spaces-export-channel-canvases ───────────────────────────────────
+// Bulk-export a channel's canvases (folder placement + markdown) in one
+// paginated, view-gated call, so callers can reconstruct the channel's
+// folder structure without one read per canvas.
+const spacesExportChannelCanvases: ToolDef = {
+  name: "spaces-export-channel-canvases",
+  description:
+    "Bulk-export the canvases in a channel together with their FOLDER placement, for archiving or KB import. " +
+    "Returns each canvas the caller can VIEW as { id, title, folderName, visibility, markdown } so the channel's " +
+    "folder structure can be reconstructed in one pass (no per-canvas reads). Filter with visibility (e.g. PUBLIC). " +
+    "Content reads are heavy, so results are PAGINATED — use limit/offset to page large channels, and set " +
+    "includeContent=false for a fast structure-only listing (folders + titles, no bodies). " +
+    "Canvases the caller cannot view are silently omitted.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      channelId: {
+        type: "string",
+        description: "Channel ID to export canvases from.",
+      },
+      visibility: {
+        type: "string",
+        enum: ["PUBLIC", "PRIVATE"],
+        description: "Only export canvases with this visibility. Omit to include everything the caller can view.",
+      },
+      includeContent: {
+        type: "boolean",
+        description: "Include full markdown body per canvas (default true). Set false for a fast id/title/folder-only listing.",
+      },
+      limit: {
+        type: "number",
+        description: "Max canvases per page (default 25, max 100).",
+      },
+      offset: {
+        type: "number",
+        description: "Pagination offset (default 0). Increase to page through a large channel.",
+      },
+    },
+    required: ["channelId"],
+  },
+  async handler(params, ctx) {
+    try {
+      const channelId = String(params["channelId"] ?? "").trim();
+      if (!channelId) return err("channelId is required");
+
+      const qs = new URLSearchParams();
+      if (params["visibility"]) qs.set("visibility", String(params["visibility"]));
+      if (params["includeContent"] === false) qs.set("includeContent", "false");
+      if (params["limit"] != null) qs.set("limit", String(params["limit"]));
+      if (params["offset"] != null) qs.set("offset", String(params["offset"]));
+
+      const s2sKey = process.env["INTERNAL_S2S_KEY"] ?? "";
+      const result = (await spacesFetch(
+        `/api/internal/canvas/channel/${encodeURIComponent(channelId)}/export?${qs.toString()}`,
+        {
+          method: "GET",
+          headers: { "x-user-id": ctx.userId },
+        },
+        { s2sKey },
+      )) as {
+        error?: string;
+        totalMatching?: number;
+        returned?: number;
+        offset?: number;
+        limit?: number;
+        hasMore?: boolean;
+        canvases?: Array<{
+          id: string;
+          title: string;
+          folderName: string | null;
+          visibility: string;
+          markdown?: string;
+          url?: string;
+        }>;
+      };
+
+      if (result.error) return err(result.error);
+      const canvases = result.canvases ?? [];
+      if (canvases.length === 0) {
+        return ok("No viewable canvases found for that channel/filter.");
+      }
+
+      const chunks = canvases.map((c, idx) => {
+        const folder = c.folderName ? c.folderName : "(root)";
+        const lines = [
+          `Folder: ${folder}`,
+          `Visibility: ${c.visibility}`,
+          c.url ? `URL: ${c.url}` : "",
+          "",
+          c.markdown ?? "(content not included)",
+        ];
+        return prefixChunk(idx + 1, `# ${c.title}`, lines);
+      });
+
+      const footer =
+        `\n\n(${result.returned ?? canvases.length} of ${result.totalMatching ?? "?"} canvases` +
+        `; offset ${result.offset ?? 0}` +
+        (result.hasMore ? " — more available, increase offset to page)" : ")");
+
+      return ok(`${chunks.join("\n\n")}${footer}`);
+    } catch (e) {
+      return err(`Export channel canvases error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  },
+};
+
 const spacesEditCanvas: ToolDef = {
   name: "spaces-edit-canvas",
   description:
@@ -5855,6 +5961,7 @@ export const tools: ToolDef[] = [
   spacesUpdateTicket,
   spacesScheduleCall,
   spacesReadCanvas,
+  spacesExportChannelCanvases,
   spacesEditCanvas,
   spacesTriggerAgent,
   spacesCreateCanvas,


### PR DESCRIPTION
Follow-up to #271 (Fix A — canvas read requires view not edit). This PR is **Fix B** and is independent of #271; it branches from `main`. Opened as a draft for review.

## 1. Problem Description
Exporting/archiving all public canvases of a channel (e.g. to a knowledge base) currently isn't feasible through the tooling for two reasons: (a) there is no way to retrieve a canvas's folder placement — the `spaces-canvases` tool never returns `folderId`/folder name, and no folder-listing tool exists — so the channel's folder structure can't be reconstructed; and (b) reading canvases one-by-one does not scale (a real channel had 481 public canvases), and each `spaces-read-canvas` call is a separate Y-Sweet round-trip.

## 2. How the issue was identified
While trying to export all public canvases of the `#upi` channel (481 public canvases) preserving folder structure: the folder placement was not obtainable via any MCP tool, and per-canvas reads were both permission-gated (see #271) and impractical at that scale.

## 3. Explain the solution implemented in the PR
Adds a single view-gated bulk export path:

- **Endpoint:** `GET /api/internal/canvas/channel/:channelId/export` (internal — `validateS2SKey` + `x-user-id` via `attachInternalUser`), in `apps/backend/src/routes/internalCanvas.ts`.
- **Controller:** `CanvasController.exportChannelCanvases` in `apps/backend/src/controllers/canvasController.ts`. Lists canvases in the channel (optional `visibility` filter), resolves folder names once from `CanvasFolder` (a flat, channel-scoped set — no nesting), reads markdown from Y-Sweet, and returns `{ id, title, folderId, folderName, visibility, markdown, url }` per canvas plus pagination metadata (`totalMatching`, `returned`, `offset`, `limit`, `hasMore`).
- **MCP tool:** `spaces-export-channel-canvases` in `apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts`, which calls the endpoint and formats results so callers can rebuild the folder tree.

**Security properties:**
- The bulk endpoint does **not** bypass canvas-level ACL. Each candidate canvas is individually gated by `canvasAuthService.checkCanvasAccess`; canvases the caller cannot view are silently omitted. It requires only VIEW access (read/export, never edit).
- Same S2S + `x-user-id` trust model as the existing `/view/:canvasId` read/update endpoints — no new auth surface.

**Scale/performance:**
- Content reads hit Y-Sweet per canvas, so responses are **paginated** (`limit` default 25, max 100) and content can be skipped with `includeContent=false` for a fast structure-only (folders + titles) listing.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A — no schema changes. Reads existing `Canvas` and `CanvasFolder` tables only.

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A — reuses `INTERNAL_S2S_KEY` already used by `spaces-read-canvas`.

## 8. Testing
- `tsc --noEmit` on `apps/backend` and `apps/xyne-claw-auth/backend` — no new type errors in the changed files (`canvasController.ts`, `internalCanvas.ts`, `xyne-spaces-tools.ts`).
- Still to do before un-drafting: integration test of the endpoint against a seeded channel (public + private + foldered + root canvases) asserting (a) private/unauthorized canvases are omitted, (b) `folderName` matches `CanvasFolder.name`, (c) pagination `hasMore`/`offset` behave, (d) `includeContent=false` returns no bodies.

## 9. Services to which this change is to be deployed
backend (Spaces API) and the Claw MCP tools service (xyne-claw-auth).

## 10. Main PR link (if this PR is raised against a release branch)
N/A — raised against `main`. Related: #271.