### PR TITLE
fix: XYNE-55337 agent creation via chat

### DIFF
--- a/apps/dashboard/src/components/flowUI/nodes/AgentNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/AgentNode.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import type { AgentProps, FlowComponent } from '@xyne/shared';
+import { DraftAgentCard } from './agent/DraftAgentCard';
+import { ProfileAgentCard } from './agent/ProfileAgentCard';
+
+/**
+ * Agent artifact — ONE node type for every agent surface.
+ *
+ * `props.variant` is the discriminant. It selects the chrome and the
+ * affordances; the identity block underneath is the same component in every
+ * branch (see agent/AgentIdentityBlock.tsx), which is what keeps a drafted
+ * agent, a created agent and a described agent recognisably the same object.
+ *
+ *   draft   → pending: capability chips toggle, Approve/Decline footer.
+ *             created | rejected: the same identity, chip + audit, no buttons.
+ *   profile → a live agent, read-only.
+ *
+ * ── Wire contract (backend emits this) ──────────────────────────────────────
+ * Source of truth + zod validation: shared/src/validation/flowSchema.ts
+ * (`agentComponentSchema`). Built by xyne-claw-shared's `buildAgentCardFlow`.
+ * The whole FlowDefinition is JSON-stringified, `"`→`&quot;` escaped, and stored
+ * in messages.content as `<div data-flow-json="…">Flow JSON</div>`. Post once,
+ * then `updateMessage` the SAME screenId to advance phases.
+ *
+ *   { version: '2.0', screenId: 'agent-card-<requestId>', title: 'Agent',
+ *     state: { … },                                 // always empty at emit
+ *     data: { actionType: 'agent-card', requestId, agentSlug, userId, … },
+ *     components: [{ id: 'agent', type: 'agent', props: <AgentProps> }] }
+ *
+ * `id` must stay 'agent' — it is both the reconciliation key and the flow-state
+ * key the backend reads the capability selection from. props is `.strict()`:
+ * unknown keys are rejected, and a NEW surface is a new `variant` branch rather
+ * than a new field on an existing one.
+ *
+ * Everything actionable (which request, which user may decide, where to post)
+ * travels in `flowJSON.data`, never in props — the whole flowJSON round-trips
+ * through the browser, so props are display data and nothing else.
+ */
+export const AgentNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as AgentProps | undefined;
+  if (!props) {
+    return null;
+  }
+
+  if (props.variant === 'draft') {
+    return <DraftAgentCard node={node} props={props} />;
+  }
+  return <ProfileAgentCard node={node} props={props} />;
+};

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -16,6 +16,7 @@ import { LinkNode } from './LinkNode';
 import { PlanNode } from './PlanNode';
 import { PrNode } from './PrNode';
 import { CallScheduleNode } from './CallScheduleNode';
+import { AgentNode } from './AgentNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
 // is kept in ./PrApprovalNode.tsx but unlinked so 'pr_approval' isn't a live artifact.
 
@@ -64,6 +65,7 @@ NodeRegistry.register('plan', PlanNode);
 NodeRegistry.register('pr', PrNode);
 // NodeRegistry.register('pr_approval', PrApprovalNode); // unlinked for now
 NodeRegistry.register('call_schedule', CallScheduleNode);
+NodeRegistry.register('agent', AgentNode);
 
 /**
  * Kept for backward compatibility with existing callers/imports.

--- a/apps/dashboard/src/components/flowUI/nodes/PlanNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/PlanNode.tsx
@@ -463,13 +463,9 @@ const Header: React.FC<{ chip?: React.ReactNode; onExpand?: (() => void) | undef
   onExpand,
 }) => (
   <div className='flex items-center justify-between'>
-    <div className='flex items-center gap-2'>
-      <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
-        Plan
-      </span>
-      {chip}
-    </div>
-    {/* No Maximize when the card is rendered inside a widget preview's own thread
+    {/* No "Plan" label — the card's own title says what it is. */}
+    <div className='flex items-center gap-2'>{chip}</div>
+    {/* No Maximize when the card is rendered inside a PlanPreview's own thread
         panel (onExpand omitted) — prevents stacking a second full-screen preview. */}
     {onExpand && (
       <button

--- a/apps/dashboard/src/components/flowUI/nodes/agent/AgentIdentityBlock.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/AgentIdentityBlock.tsx
@@ -1,0 +1,436 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
+import type { AgentCapability, AgentIdentity } from '@xyne/shared';
+import { cn } from '../../../../utils/classNames';
+import useMeasure from '../../../../hooks/useMeasure';
+import { useNavigate } from 'react-router-dom';
+import { CapabilityIcon } from './CapabilityIcon';
+
+/**
+ * The agent identity — the INVARIANT core of every `agent` artifact variant.
+ *
+ * A draft awaiting approval, a live agent's profile and (later) an editor all
+ * render this exact block; only the surrounding chrome differs. Keeping it in
+ * one component is what makes "show me this agent" and "approve this draft"
+ * look like the same object rather than two cards that happen to share fields.
+ *
+ * Interactivity is injected, not branched on: pass `interactive` and the
+ * capability chips become toggles whose state the caller owns (it lives in
+ * flow-state, so the backend reads it back on submit). Omit it and the same
+ * chips render read-only.
+ */
+
+/**
+ * Capability chip — two states, exactly as the design draws them:
+ *
+ *   granted → filled pill, SOLID border, `×` to drop it.
+ *   dropped → the "suggestion" look: card-coloured pill, DASHED border, `+` to
+ *             put it back.
+ *
+ * Both states apply to MCP-backed subagents and built-in tools alike; only the
+ * brand logo is subagent-only. Read-only cards (a live agent's profile) render
+ * the granted pill as a static span with no trailing control.
+ */
+const CapabilityChip: React.FC<{
+  capability: AgentCapability;
+  selected: boolean;
+  onToggle?: (() => void) | undefined;
+  disabled?: boolean;
+}> = ({ capability, selected, onToggle, disabled }) => {
+  const interactive = Boolean(onToggle);
+  // Subagents wrap an integration and get its brand tile; built-in tools are
+  // label-only pills with roomier leading padding, exactly as the design splits
+  // its "MCP" and "Built in tools" rows.
+  const withIcon = capability.kind === 'subagent';
+
+  const content = (
+    <>
+      {withIcon && <CapabilityIcon iconKey={capability.iconKey} label={capability.label} />}
+      <span
+        className={cn(
+          'truncate text-sm font-medium leading-none',
+          selected ? 'text-foreground' : 'text-foreground/60',
+        )}
+      >
+        {capability.label}
+      </span>
+      {interactive &&
+        (selected ? (
+          <MultipleCrossCancelDefault size={12} className='shrink-0 text-muted-foreground' />
+        ) : (
+          <PlusDefault size={16} className='shrink-0 text-muted-foreground' />
+        ))}
+    </>
+  );
+
+  const className = cn(
+    'inline-flex max-w-full items-center gap-1.5 overflow-hidden rounded-[10px]',
+    'border-[0.8px] border-border py-1',
+    selected ? 'bg-foreground/[0.06]' : 'border-dashed bg-card',
+    withIcon ? 'pl-1 pr-2' : 'h-9 pl-3 pr-2',
+    interactive && !disabled && 'hover:bg-foreground/[0.09]',
+    disabled && 'cursor-not-allowed opacity-60',
+  );
+
+  if (!interactive) {
+    return <span className={className}>{content}</span>;
+  }
+  return (
+    <button
+      type='button'
+      onClick={onToggle}
+      aria-pressed={selected}
+      disabled={disabled}
+      title={selected ? `Remove ${capability.label}` : `Add ${capability.label} back`}
+      className={className}
+      data-track-category='AGENT_ARTIFACT'
+      data-track-name='TOGGLE_CAPABILITY'
+    >
+      {content}
+    </button>
+  );
+};
+
+/** Selection wiring for the capability chips. Owned by the caller so the compact
+ *  card and the expanded dialog drive ONE state — a chip toggled in either place
+ *  is the same edit, because both write the same flow-state key. */
+export interface AgentCapabilityInteraction {
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  disabled?: boolean;
+}
+
+/** Section title row — the design's 14px label with room for a trailing control. */
+const SectionHeader: React.FC<{ label: string; trailing?: React.ReactNode }> = ({
+  label,
+  trailing,
+}) => (
+  <div className='flex items-center justify-between gap-2'>
+    <p className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>{label}</p>
+    {trailing}
+  </div>
+);
+
+/** Horizontal gap between chips, in px. Must match the `gap-x-*` utility on the
+ *  chip row — the fit maths measures widths itself and has to add the gaps. */
+const CHIP_GAP = 10;
+
+/**
+ * One capability group, collapsed to a SINGLE row by default.
+ *
+ * An agent with every integration attached produced a wall of ~35 chips that
+ * pushed the card's own controls off-screen. So the row shows as many chips as
+ * actually fit on one line and hides the rest behind "Show all N tools".
+ *
+ * Fit is measured, not guessed: an off-screen twin renders every chip at its
+ * natural width plus a worst-case toggle, and we walk it counting what fits in
+ * the live track — the approach ContextPillRow uses for the composer's context
+ * pills. That is what makes the "do they all fit?" answer correct, so a group
+ * that fits on one line shows no toggle at all.
+ */
+const CapabilityGroup: React.FC<{
+  label: string;
+  items: AgentCapability[];
+  interactive?: AgentCapabilityInteraction | undefined;
+}> = ({ label, items, interactive }) => {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const { width: trackWidth } = useMeasure({ ref: trackRef, observeResize: true });
+  // The twin is `w-max`, so its width changes whenever a label does — using it
+  // as a dep re-runs the maths on content changes, not just container resizes.
+  const { width: measuredWidth } = useMeasure({ ref: measureRef, observeResize: true });
+
+  const [visibleCount, setVisibleCount] = useState(items.length);
+  const [expanded, setExpanded] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = measureRef.current;
+    if (!el || trackWidth <= 0) {
+      return;
+    }
+    const widths = (Array.from(el.children) as HTMLElement[]).map(
+      child => child.getBoundingClientRect().width,
+    );
+
+    // The toggle lives in the header, not the row, so every pixel of the track is
+    // available to chips and no reserve has to be subtracted.
+    let used = 0;
+    let count = 0;
+    for (const width of widths) {
+      const next = used + width + (count > 0 ? CHIP_GAP : 0);
+      if (next > trackWidth) {
+        break;
+      }
+      used = next;
+      count += 1;
+    }
+
+    setVisibleCount(count);
+  }, [trackWidth, measuredWidth, items.length]);
+
+  const shownCount = expanded ? items.length : Math.min(visibleCount, items.length);
+  const overflowing = shownCount < items.length;
+  const kept = interactive
+    ? items.filter(item => interactive.selected.has(item.id)).length
+    : items.length;
+
+  const chip = (capability: AgentCapability): React.ReactNode => (
+    <CapabilityChip
+      key={capability.id}
+      capability={capability}
+      selected={interactive ? interactive.selected.has(capability.id) : true}
+      {...(interactive ? { onToggle: (): void => interactive.onToggle(capability.id) } : {})}
+      {...(interactive?.disabled ? { disabled: true } : {})}
+    />
+  );
+
+  const toggle = (text: string): React.ReactElement => (
+    <button
+      type='button'
+      onClick={(): void => setExpanded(!expanded)}
+      className='shrink-0 whitespace-nowrap text-xs font-medium leading-[1.2] text-muted-foreground underline underline-offset-2 hover:text-foreground'
+      aria-expanded={expanded}
+      data-track-category='AGENT_ARTIFACT'
+      data-track-name='TOGGLE_CAPABILITY_OVERFLOW'
+    >
+      {text}
+    </button>
+  );
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      {/* The toggle replaces the count in the header row, so the chip row itself
+          stays purely chips — nothing steals width from what fits. */}
+      <SectionHeader
+        label={label}
+        trailing={
+          overflowing || expanded ? (
+            toggle(expanded ? 'Show less' : `Show all ${items.length} tools`)
+          ) : (
+            <span className='text-xs leading-[1.2] text-muted-foreground tabular-nums'>
+              {interactive ? `${kept} of ${items.length}` : String(items.length)}
+            </span>
+          )
+        }
+      />
+      <div
+        ref={trackRef}
+        className={cn(
+          'relative flex min-w-0 items-center gap-x-2.5',
+          expanded ? 'flex-wrap gap-y-2.5' : 'flex-nowrap overflow-hidden',
+        )}
+      >
+        {/* Off-screen twin: every chip at natural width plus a worst-case toggle,
+            so the reserve is never under-measured. `invisible` rather than
+            `hidden` — it still needs layout to be measurable — and absolute so it
+            contributes nothing to the track's size. */}
+        <div
+          ref={measureRef}
+          aria-hidden
+          className='pointer-events-none invisible absolute left-0 top-0 flex w-max flex-nowrap items-center gap-x-2.5'
+        >
+          {items.map(chip)}
+        </div>
+
+        {items.slice(0, shownCount).map(chip)}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * The capability list, grouped the way the agent design groups them: integration
+ * -backed subagents under "MCP" (brand tile + name), custom tools under
+ * "Built in tools" (label-only pills). Exported so the expanded view
+ * (AgentPreview) renders the SAME chips with the SAME selection rather than a
+ * roomier lookalike that drifts.
+ */
+export const AgentCapabilities: React.FC<{
+  capabilities: AgentCapability[];
+  interactive?: AgentCapabilityInteraction | undefined;
+}> = ({ capabilities, interactive }) => {
+  if (capabilities.length === 0) {
+    return null;
+  }
+
+  const groups: Array<{ key: string; label: string; items: AgentCapability[] }> = [
+    { key: 'mcp', label: 'MCP', items: capabilities.filter(c => c.kind === 'subagent') },
+    { key: 'builtin', label: 'Built in tools', items: capabilities.filter(c => c.kind === 'tool') },
+  ].filter(group => group.items.length > 0);
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {groups.map(group => (
+        <CapabilityGroup
+          key={group.key}
+          label={group.label}
+          items={group.items}
+          interactive={interactive}
+        />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Footer prompt for capabilities whose integration the viewer hasn't connected.
+ *
+ * `requiresConnection` is computed per-viewer from their user_mcp_connections, so
+ * this counts what YOU would need to connect for the agent's tools to actually
+ * run. Clicking goes to where that's fixed:
+ *
+ *   created / profile → that agent's Connections tab
+ *   pending draft     → the MCP list, because the agent does not exist yet and
+ *                       its detail route would 404
+ *
+ * Renders nothing when everything is connected, so a fully-wired agent shows no
+ * footer noise.
+ */
+export const AgentConnectPrompt: React.FC<{
+  agent: AgentIdentity;
+  /** True once the agent exists and has a detail screen to link to. */
+  agentExists?: boolean;
+  className?: string;
+}> = ({ agent, agentExists = false, className }) => {
+  const navigate = useNavigate();
+  const unconnected = (agent.capabilities ?? []).filter(c => c.requiresConnection);
+  if (unconnected.length === 0) {
+    return null;
+  }
+  const target = agentExists
+    ? `/claw-agents/agents/${agent.slug}?tab=connections`
+    : '/claw-agents/mcp';
+
+  return (
+    <div className={cn('min-w-0 shrink-0', className)}>
+      <button
+        type='button'
+        onClick={(): void => void navigate(target)}
+        className='whitespace-nowrap text-xs font-medium leading-[1.2] text-blue-500 underline underline-offset-2 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300'
+        data-track-category='AGENT_ARTIFACT'
+        data-track-name='CLICK_CONNECT_UNCONNECTED'
+      >
+        Connect {unconnected.length} unconnected {unconnected.length === 1 ? 'tool' : 'tools'}
+      </button>
+    </div>
+  );
+};
+
+/** Connect-account links for capabilities whose integration isn't wired up yet. */
+export const AgentConnectLinks: React.FC<{ agent: AgentIdentity }> = ({ agent }) => {
+  const links = agent.connectLinks ?? [];
+  if (links.length === 0) {
+    return null;
+  }
+  return (
+    <div className='flex flex-wrap gap-2'>
+      {links.map(link => (
+        <a
+          key={link.serverType}
+          href={link.authUrl}
+          target='_blank'
+          rel='noreferrer'
+          className='text-xs font-medium leading-[1.3] text-foreground underline underline-offset-2 hover:text-foreground/80'
+          data-track-category='AGENT_ARTIFACT'
+          data-track-name='CLICK_CONNECT'
+        >
+          Connect {link.displayName}
+        </a>
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Name row + the agent's identifiers — the header block that replaces the old
+ * "Agent" header bar. `trailing` carries whatever chrome the card needs on the
+ * right (the expand control), so no separate row exists just to hold it.
+ *
+ * The sub-line is the slug and the model together: the two things that identify
+ * WHICH agent this is and what runs it. Both are already in `details`, but a
+ * key/value row buries them — here they read at a glance.
+ */
+export const AgentIdentityHeader: React.FC<{
+  agent: AgentIdentity;
+  statePill?: React.ReactNode;
+  trailing?: React.ReactNode;
+}> = ({ agent, statePill, trailing }) => (
+  <div className='flex items-start gap-3'>
+    <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+      <div className='flex items-center gap-2'>
+        <p className='truncate text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+          {agent.name}
+        </p>
+        {statePill}
+      </div>
+      {/* `@slug` in the mention colour — it IS the handle you type to reach this
+          agent, so it reads the same here as it does in a message. */}
+      <p className='flex min-w-0 items-center gap-2 text-sm leading-[22px]'>
+        <span className='truncate text-blue-500 dark:text-blue-400'>@{agent.slug}</span>
+        {agent.modelId && (
+          <>
+            <span aria-hidden className='shrink-0 text-foreground/30'>
+              ·
+            </span>
+            <span className='truncate text-foreground/70'>{agent.modelId}</span>
+          </>
+        )}
+      </p>
+    </div>
+    {trailing}
+  </div>
+);
+
+/** "What it does" — the design's labelled description block. */
+export const AgentDescription: React.FC<{ description?: string | undefined }> = ({
+  description,
+}) => {
+  if (!description) {
+    return null;
+  }
+  return (
+    <div className='flex flex-col gap-1'>
+      <p className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+        What it does
+      </p>
+      <p className='text-sm leading-[22px] text-foreground/70'>{description}</p>
+    </div>
+  );
+};
+
+export const AgentIdentityBlock: React.FC<{
+  agent: AgentIdentity;
+  /** Present ⇒ capability chips are toggles. Absent ⇒ read-only. */
+  interactive?: AgentCapabilityInteraction;
+  note?: string | undefined;
+  statePill?: React.ReactNode;
+  trailing?: React.ReactNode;
+}> = ({ agent, interactive, note, statePill, trailing }) => {
+  const capabilities = agent.capabilities ?? [];
+  const details = agent.details ?? [];
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <AgentIdentityHeader agent={agent} statePill={statePill} trailing={trailing} />
+
+      <AgentDescription description={agent.description} />
+
+      {details.length > 0 && (
+        <div className='flex flex-col gap-1'>
+          {details.map(detail => (
+            <div key={detail.label} className='flex items-baseline gap-2 text-xs leading-[1.4]'>
+              <span className='w-20 shrink-0 text-muted-foreground'>{detail.label}</span>
+              <span className='truncate text-foreground/80'>{detail.value || '—'}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <AgentCapabilities capabilities={capabilities} interactive={interactive} />
+
+      <AgentConnectLinks agent={agent} />
+
+      {note && <p className='text-xs leading-[1.4] text-muted-foreground'>{note}</p>}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/agent/AgentPreview.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/AgentPreview.tsx
@@ -1,0 +1,238 @@
+import React, { createContext, useMemo } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { useParams } from 'react-router-dom';
+import { MultipleCrossCancelDefault } from '@xyne/icons';
+import type { AgentIdentity } from '@xyne/shared';
+import { PreviewSplitDialog, PreviewThreadPanel } from '../../../ui/PreviewSplitDialog';
+import { MarkdownMessageRenderer } from '../../../ui/MessageBubble/MarkdownMessageRenderer';
+import { createMarkdownComponents } from '../../../../utils/markdownComponents';
+import { usePlatform } from '../../../../hooks/usePlatform';
+import {
+  AgentCapabilities,
+  AgentConnectLinks,
+  type AgentCapabilityInteraction,
+} from './AgentIdentityBlock';
+
+/**
+ * True inside AgentPreview's right-hand thread panel. The thread re-renders the
+ * SAME agent message as a live card, which would otherwise show its own expand
+ * button and let the user stack a second full-screen preview on top. The agent
+ * cards read this and hide their expand control when set.
+ */
+export const InsideAgentPreviewContext = createContext(false);
+
+/**
+ * AgentPreview — the EXPANDED agent view.
+ *
+ * The compact card only BRIEFS the agent (name, description, capability chips).
+ * Expanding opens this split screen on the same shell the plan preview and the
+ * attachment viewer use:
+ *
+ *   LEFT  → the whole agent: name, @slug, description, details, capabilities
+ *           (the SAME selection state as the card — toggling here is the same
+ *           edit), and the full system prompt rendered with the canonical
+ *           MarkdownMessageRenderer chat uses.
+ *   RIGHT → the live thread the card sits in.
+ *
+ * Rendered INSIDE the card, so it shares live flow props and the flow-action
+ * round-trip; `footer` carries the phase-specific controls (pending →
+ * Approve/Decline, decided → audit). On a decision the card closes this view so
+ * the user drops back to the thread. On mobile the thread panel is dropped.
+ */
+interface AgentPreviewProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Stable id for markdown code-block keys (the card's message id). */
+  messageId: string;
+  agent: AgentIdentity;
+  /** Present ⇒ capability chips are toggles here too. */
+  interactive?: AgentCapabilityInteraction | undefined;
+  note?: string | undefined;
+  /** State pill shown beside the name (the card's own "Draft"/"Created" chip). */
+  statePill?: React.ReactNode;
+  /** Thread the card belongs to — rendered on the right. */
+  conversationId?: string | undefined;
+  /** Phase-specific controls shown in the left panel footer (actions / audit). */
+  footer?: React.ReactNode;
+}
+
+const PanelHeader: React.FC<{ label: string; onClose?: (() => void) | undefined }> = ({
+  label,
+  onClose,
+}) => (
+  <div className='flex h-14 flex-shrink-0 items-center justify-between border-b border-border px-5'>
+    <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+      {label}
+    </span>
+    {onClose && (
+      <button
+        type='button'
+        onClick={onClose}
+        aria-label='Close'
+        className='rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        data-track-category='AGENT_ARTIFACT'
+        data-track-name='CLOSE_AGENT_PREVIEW'
+      >
+        <MultipleCrossCancelDefault size={18} />
+      </button>
+    )}
+  </div>
+);
+
+const DetailPanel: React.FC<{
+  messageId: string;
+  agent: AgentIdentity;
+  interactive?: AgentCapabilityInteraction | undefined;
+  note?: string | undefined;
+  statePill?: React.ReactNode;
+  footer?: React.ReactNode;
+  onClose?: () => void;
+}> = ({ messageId, agent, interactive, note, statePill, footer, onClose }) => {
+  const markdownComponents = useMemo(
+    () => createMarkdownComponents(messageId || 'agent-detail'),
+    [messageId],
+  );
+  const details = agent.details ?? [];
+
+  return (
+    <div className='flex h-full flex-col bg-background'>
+      <PanelHeader label='Agent' onClose={onClose} />
+      <div className='flex-1 overflow-y-auto px-6 py-5'>
+        <div className='mx-auto flex max-w-3xl flex-col gap-5'>
+          <div className='flex min-w-0 flex-col gap-1'>
+            <div className='flex items-center gap-2'>
+              <h1 className='text-2xl font-medium leading-[1.2] text-foreground'>{agent.name}</h1>
+              {statePill}
+            </div>
+            {/* Slug + model, matching the card's sub-line. */}
+            <p className='flex min-w-0 items-center gap-2 text-sm leading-[22px]'>
+              <span className='truncate text-blue-500 dark:text-blue-400'>@{agent.slug}</span>
+              {agent.modelId && (
+                <>
+                  <span aria-hidden className='shrink-0 text-foreground/30'>
+                    ·
+                  </span>
+                  <span className='truncate text-foreground/70'>{agent.modelId}</span>
+                </>
+              )}
+            </p>
+          </div>
+
+          {/* Same "What it does" block as the card, one size up. */}
+          {agent.description && (
+            <div className='flex flex-col gap-1'>
+              <h2 className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+                What it does
+              </h2>
+              <p className='text-sm leading-[22px] text-foreground/70'>{agent.description}</p>
+            </div>
+          )}
+
+          {details.length > 0 && (
+            <div className='flex flex-col gap-1.5 rounded-lg border border-border bg-muted/30 p-3'>
+              {details.map(detail => (
+                <div key={detail.label} className='flex items-baseline gap-3 text-sm leading-[1.4]'>
+                  <span className='w-32 shrink-0 text-muted-foreground'>{detail.label}</span>
+                  <span className='text-foreground/80'>{detail.value || '—'}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Same chips, same selection state as the compact card — a toggle here
+              and a toggle there are one edit, not two views of it. */}
+          <AgentCapabilities capabilities={agent.capabilities ?? []} interactive={interactive} />
+          <AgentConnectLinks agent={agent} />
+          {note && <p className='text-xs leading-[1.4] text-muted-foreground'>{note}</p>}
+
+          {agent.systemPrompt && (
+            <>
+              <div className='h-px w-full bg-border' />
+              <div className='flex flex-col gap-2'>
+                <h2 className='text-sm font-medium leading-[1.2] text-foreground'>Instructions</h2>
+                {/* The full prompt — this view is the reason the card doesn't
+                    carry it inline. Same renderer the plan document uses. */}
+                <MarkdownMessageRenderer
+                  content={agent.systemPrompt}
+                  markdownComponents={markdownComponents}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+      {footer && (
+        <div className='flex-shrink-0 border-t border-border bg-foreground/[0.03] px-6 py-3'>
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const AgentPreview: React.FC<AgentPreviewProps> = ({
+  open,
+  onOpenChange,
+  messageId,
+  agent,
+  interactive,
+  note,
+  statePill,
+  conversationId,
+  footer,
+}) => {
+  const { channelId } = useParams<{ channelId?: string }>();
+  const { isMobile } = usePlatform();
+  const close = (): void => onOpenChange(false);
+
+  const detailPanel = (
+    <>
+      {/* Radix needs a Title/Description descendant of Dialog.Content (which the
+          shared shell renders); keep them screen-reader only. */}
+      <Dialog.Title className='sr-only'>{agent.name}</Dialog.Title>
+      <Dialog.Description className='sr-only'>
+        {agent.description ?? 'Agent details'}
+      </Dialog.Description>
+      <DetailPanel
+        messageId={messageId}
+        agent={agent}
+        interactive={interactive}
+        note={note}
+        statePill={statePill}
+        footer={footer}
+        // Close button lives on the detail panel only when there is no thread
+        // panel to carry it (mobile / no conversation) — matching the viewer.
+        {...(isMobile || !conversationId ? { onClose: close } : {})}
+      />
+    </>
+  );
+
+  const threadPanel =
+    isMobile || !conversationId ? undefined : (
+      // Mark the thread subtree so the nested (same) agent card hides its own
+      // expand button — no second full-screen preview stacked on top.
+      <InsideAgentPreviewContext.Provider value={true}>
+        <PreviewThreadPanel
+          {...(channelId ? { channelId } : {})}
+          conversationId={conversationId}
+          onClose={close}
+        />
+      </InsideAgentPreviewContext.Provider>
+    );
+
+  // Same shell as the plan preview and the attachment viewer — only the left
+  // panel's content differs.
+  return (
+    <PreviewSplitDialog
+      open={open}
+      onClose={close}
+      idPrefix='agent-preview'
+      isMobile={isMobile}
+      left={detailPanel}
+      right={threadPanel}
+      overlayClassName='bg-black/80'
+      contentClassName='bg-black data-[state=closed]:fade-out transition-all ease-in-out duration-300 data-[state=open]:fade-in'
+      bodyClassName='bg-background'
+    />
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/agent/CapabilityIcon.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/CapabilityIcon.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { cn } from '../../../../utils/classNames';
+
+/**
+ * Brand tile for a capability chip — the 28px dashed-outline square the agent
+ * design puts in front of an integration's name.
+ *
+ * Reuses the icon assets the dashboard already ships at /assets/mcp (same files
+ * McpServerIcon draws from), keyed by the capability's `iconKey` (an MCP
+ * serverType). That component isn't reused directly because its tile is a fixed
+ * solid-border, shadowed frame and this design calls for a dashed 28px one; the
+ * asset convention is what matters and that is shared.
+ *
+ * Falls back png → svg → initials, so a capability with no brand asset (custom
+ * tools, new connectors) still renders something stable rather than a broken
+ * image.
+ */
+
+type Stage = 'png' | 'svg' | 'initials';
+
+const initialsFor = (label: string): string => {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return '?';
+  }
+  if (words.length === 1) {
+    return (words[0] ?? '').slice(0, 2).toUpperCase();
+  }
+  return `${words[0]?.[0] ?? ''}${words[1]?.[0] ?? ''}`.toUpperCase();
+};
+
+export const CapabilityIcon: React.FC<{
+  iconKey?: string | undefined;
+  label: string;
+  className?: string;
+}> = ({ iconKey, label, className }) => {
+  const [stage, setStage] = useState<Stage>(iconKey ? 'png' : 'initials');
+
+  // No fill, no border: the logo sits directly on the chip. Brand marks carry
+  // their own colour and shape, and a framed tile around them was a second
+  // surface inside an already bordered pill.
+  const tile = cn(
+    'flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-lg',
+    className,
+  );
+
+  if (!iconKey || stage === 'initials') {
+    return (
+      <span aria-hidden className={cn(tile, 'text-[10px] font-medium text-muted-foreground')}>
+        {initialsFor(label)}
+      </span>
+    );
+  }
+
+  return (
+    <span aria-hidden className={tile}>
+      <img
+        src={`/assets/mcp/${iconKey}.${stage}`}
+        alt=''
+        aria-hidden='true'
+        // png first (most integrations), then svg (gmail, google-drive,
+        // xyne-spaces…), then give up and show initials.
+        onError={(): void => setStage(stage === 'png' ? 'svg' : 'initials')}
+        className='size-full object-contain p-1'
+      />
+    </span>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
@@ -1,0 +1,227 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { MaximizeFourArrow, Spinner } from '@xyne/icons';
+import type { AgentDraftProps, FlowComponent } from '@xyne/shared';
+import { useFlow } from '../../FlowContext';
+import { useAgentProgress } from '../../../../hooks/useAgentProgress';
+import { cn } from '../../../../utils/classNames';
+import { AuditLine, CardShell, Mention, StatusChip, formatDecisionTime } from '../cardPrimitives';
+import Avatar from '../../../ui/Avatar/Avatar';
+import { AgentIdentityBlock, AgentConnectPrompt } from './AgentIdentityBlock';
+import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
+
+/**
+ * The `agent` artifact's DRAFT variant — an agent an agent proposed, awaiting
+ * the requester's decision.
+ *
+ *   pending  → capability chips are toggles; Approve / Decline in the footer.
+ *   created  → Created chip, identity read-only, audit footer.
+ *   rejected → Rejected chip, identity read-only, audit footer.
+ *
+ * All three render the SAME identity block; the backend updates this card in
+ * place (same screenId + component id) rather than posting a new message, so
+ * the thread keeps one card per draft.
+ *
+ * Selection lives in flow-state under this component's id, which is what the
+ * server reads on submit. It can only NARROW the grant — the backend intersects
+ * whatever arrives with the capabilities it resolved itself.
+ */
+export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftProps }> = ({
+  node,
+  props,
+}) => {
+  const { state, updateFieldValue, executeAction, conversationId, messageId } = useFlow();
+  const [pending, setPending] = useState<'approve' | 'reject' | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  // A copy of this card lives inside its own AgentPreview thread panel; hide the
+  // expand control there so it can't open a nested preview.
+  const insidePreview = useContext(InsideAgentPreviewContext);
+
+  const capabilities = props.agent.capabilities ?? [];
+  const decided = props.phase !== 'pending';
+
+  // Seed once from props, then flow-state owns it (the plan card's pattern) —
+  // props stay the server's view, state stays the user's edits.
+  const stored = state.values[node.id];
+  const seeded = Array.isArray(stored);
+  const selected = new Set<string>(
+    seeded ? (stored as string[]) : (props.selected ?? capabilities.map(c => c.id)),
+  );
+
+  useEffect(() => {
+    if (state.values[node.id] === undefined) {
+      updateFieldValue(node.id, props.selected ?? capabilities.map(c => c.id));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [node.id]);
+
+  // Approving mid-run dispatches work that collides with the active run at the
+  // runtime session lock. The server also fails this closed; disabling the
+  // button is just the clearer signal.
+  const { agents } = useAgentProgress(conversationId || undefined);
+  const agentRunning = agents.length > 0;
+  const locked = state.submitting || decided || pending !== null;
+
+  const toggle = (id: string): void => {
+    if (locked) {
+      return;
+    }
+    const next = new Set(selected);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    updateFieldValue(node.id, Array.from(next));
+  };
+
+  const submit = async (actionId: 'agent-draft-approve' | 'agent-draft-decline'): Promise<void> => {
+    if (locked || (actionId === 'agent-draft-approve' && agentRunning)) {
+      return;
+    }
+    setPending(actionId === 'agent-draft-approve' ? 'approve' : 'reject');
+    try {
+      await executeAction({ type: 'submit', actionId });
+      // On a decision, drop the expanded view back to the thread.
+      setExpanded(false);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  // The artifact's state rides beside the agent's name (the design's "Beta"
+  // pill position), which is what lets the card drop its header bar entirely.
+  // The chip itself is the plan card's StatusChip, tone for tone, so the two
+  // artifacts label their state identically.
+  const statePill =
+    props.phase === 'created' ? (
+      <StatusChip label='Created' />
+    ) : props.phase === 'rejected' ? (
+      <StatusChip label='Declined' tone='rejected' />
+    ) : (
+      <StatusChip label='Draft' tone='muted' />
+    );
+
+  // Built as nodes, not a string, so the actor renders as a mention.
+  const decidedAtLabel = formatDecisionTime(props.decidedAt);
+  const auditNode = (
+    <div className='flex min-w-0 items-center gap-1.5'>
+      {/* Same avatar treatment as the reply tray — the decider is a person, so
+          they read as one rather than as a name in prose. */}
+      {props.decidedById && (
+        <Avatar userId={props.decidedById} size='xs' rounded showActiveStatus={false} />
+      )}
+      <AuditLine>
+        {props.phase === 'created' ? 'Created' : 'Declined'}
+        {props.decidedBy && (
+          <>
+            {' by '}
+            <Mention handle={props.decidedBy} />
+          </>
+        )}
+        {decidedAtLabel && ` · ${decidedAtLabel}`}
+      </AuditLine>
+    </div>
+  );
+
+  const approveLabel =
+    pending === 'approve' ? 'Creating…' : agentRunning ? 'Agent is working…' : 'Create agent';
+
+  const interactive = decided ? undefined : { selected, onToggle: toggle, disabled: locked };
+
+  // Approve / Decline controls, shared by the compact card footer AND the
+  // expanded preview footer (submit() closes the preview on a decision).
+  const actionControls = (
+    <div className='flex shrink-0 items-center gap-2'>
+      {agentRunning && (
+        <span className='hidden text-xs text-muted-foreground sm:inline'>
+          Approve once it finishes.
+        </span>
+      )}
+      <button
+        type='button'
+        onClick={() => void submit('agent-draft-decline')}
+        disabled={locked}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2 py-1.5',
+          'text-sm font-medium leading-[1.2] text-muted-foreground',
+          'hover:bg-foreground/[0.04] hover:text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='AGENT_ARTIFACT'
+        data-track-name='CLICK_DECLINE'
+      >
+        {pending === 'reject' && <Spinner size={14} className='animate-spin' />}
+        {pending === 'reject' ? 'Declining…' : 'Decline'}
+      </button>
+      <button
+        type='button'
+        onClick={() => void submit('agent-draft-approve')}
+        disabled={locked || agentRunning}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1.5',
+          'text-sm font-medium leading-[1.2] text-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+        data-track-category='AGENT_ARTIFACT'
+        data-track-name='CLICK_APPROVE'
+      >
+        {(pending === 'approve' || agentRunning) && <Spinner size={14} className='animate-spin' />}
+        {approveLabel}
+      </button>
+    </div>
+  );
+
+  return (
+    <CardShell style={node.style}>
+      <div className={cn('flex flex-col p-4', props.phase === 'rejected' && 'opacity-60')}>
+        {/* No header bar: the state pill sits beside the name and the expand
+            control rides in the same row, so nothing exists purely as chrome. */}
+        <AgentIdentityBlock
+          agent={props.agent}
+          {...(interactive ? { interactive } : {})}
+          note={props.note}
+          statePill={statePill}
+          trailing={
+            insidePreview ? undefined : (
+              <button
+                type='button'
+                onClick={(): void => setExpanded(true)}
+                aria-label='Expand agent'
+                className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+                data-track-category='AGENT_ARTIFACT'
+                data-track-name='EXPAND_ARTIFACT'
+              >
+                <MaximizeFourArrow size={16} className='shrink-0' />
+              </button>
+            )
+          }
+        />
+      </div>
+
+      {/* One row: the connect prompt (or audit) reads from the left, the decision
+          buttons sit at the right end. `justify-between` with the prompt allowed
+          to shrink keeps the buttons anchored even when there is no prompt. */}
+      <div className='flex items-center justify-between gap-3 border-t border-border bg-foreground/[0.03] px-4 py-3'>
+        <div className='flex min-w-0 items-center gap-3'>
+          {decided && auditNode}
+          {/* Only a CREATED draft has an agent to link to; a pending one goes to
+              the MCP list instead. */}
+          <AgentConnectPrompt agent={props.agent} agentExists={props.phase === 'created'} />
+        </div>
+        {!decided && actionControls}
+      </div>
+
+      <AgentPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        messageId={messageId ?? ''}
+        agent={props.agent}
+        interactive={interactive}
+        note={props.note}
+        statePill={statePill}
+        conversationId={conversationId ?? undefined}
+        footer={decided ? auditNode : actionControls}
+      />
+    </CardShell>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
@@ -1,29 +1,33 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { MaximizeFourArrow, Spinner } from '@xyne/icons';
+import { MaximizeTwoArrow, Spinner } from '@xyne/icons';
 import type { AgentDraftProps, FlowComponent } from '@xyne/shared';
 import { useFlow } from '../../FlowContext';
 import { useAgentProgress } from '../../../../hooks/useAgentProgress';
 import { cn } from '../../../../utils/classNames';
-import { AuditLine, CardShell, Mention, StatusChip, formatDecisionTime } from '../cardPrimitives';
+import { AuditLine, CardShell, Mention, StatusChip } from '../cardPrimitives';
 import Avatar from '../../../ui/Avatar/Avatar';
-import { AgentIdentityBlock, AgentConnectPrompt } from './AgentIdentityBlock';
 import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
 
 /**
  * The `agent` artifact's DRAFT variant — an agent an agent proposed, awaiting
  * the requester's decision.
  *
- *   pending  → capability chips are toggles; Approve / Decline in the footer.
- *   created  → Created chip, identity read-only, audit footer.
- *   rejected → Rejected chip, identity read-only, audit footer.
+ *   pending  → Decline / Edit / Create Agent in the footer.
+ *   created  → Created chip, audit footer.
+ *   rejected → Declined chip, audit footer.
  *
- * All three render the SAME identity block; the backend updates this card in
- * place (same screenId + component id) rather than posting a new message, so
- * the thread keeps one card per draft.
+ * Laid out to the "Agent Create" frame: a white inset panel carrying the
+ * identity (kind + state, name, @slug, description) over a flat footer of
+ * controls. The identity here is deliberately INLINE rather than the shared
+ * AgentIdentityBlock — that block is the richer profile/preview presentation
+ * (blue mention slug, model, capability chips, detail rows), and this frame
+ * draws a plainer subset. AgentIdentityBlock still backs the expanded preview,
+ * so the detailed view stays in one place.
  *
- * Selection lives in flow-state under this component's id, which is what the
- * server reads on submit. It can only NARROW the grant — the backend intersects
- * whatever arrives with the capabilities it resolved itself.
+ * Capability chips are NOT rendered on the card for now (see AgentPreview for
+ * the full list). Selection state is still seeded into flow-state below so the
+ * server receives the complete capability set on approve — hiding the chips
+ * must not silently narrow the grant.
  */
 export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftProps }> = ({
   node,
@@ -88,10 +92,6 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
     }
   };
 
-  // The artifact's state rides beside the agent's name (the design's "Beta"
-  // pill position), which is what lets the card drop its header bar entirely.
-  // The chip itself is the plan card's StatusChip, tone for tone, so the two
-  // artifacts label their state identically.
   const statePill =
     props.phase === 'created' ? (
       <StatusChip label='Created' />
@@ -101,8 +101,9 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
       <StatusChip label='Draft' tone='muted' />
     );
 
-  // Built as nodes, not a string, so the actor renders as a mention.
-  const decidedAtLabel = formatDecisionTime(props.decidedAt);
+  // Built as nodes, not a string, so the actor renders as a mention. No decision
+  // time — the chin names who decided, not when; the message's own timestamp in
+  // the thread already places it.
   const auditNode = (
     <div className='flex min-w-0 items-center gap-1.5'>
       {/* Same avatar treatment as the reply tray — the decider is a person, so
@@ -118,97 +119,155 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
             <Mention handle={props.decidedBy} />
           </>
         )}
-        {decidedAtLabel && ` · ${decidedAtLabel}`}
       </AuditLine>
     </div>
   );
 
   const approveLabel =
-    pending === 'approve' ? 'Creating…' : agentRunning ? 'Agent is working…' : 'Create agent';
+    pending === 'approve' ? 'Creating…' : agentRunning ? 'Agent is working…' : 'Create Agent';
 
   const interactive = decided ? undefined : { selected, onToggle: toggle, disabled: locked };
 
-  // Approve / Decline controls, shared by the compact card footer AND the
+  // Footer button shapes from the frame: text-only for the secondary actions, a
+  // bordered surface for the primary one.
+  const ghostButton = cn(
+    'inline-flex h-7 items-center gap-1.5 rounded-[10px] px-1.5',
+    'text-sm font-semibold leading-5 text-foreground',
+    'hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-60',
+  );
+  const primaryButton = cn(
+    'inline-flex h-7 items-center gap-1.5 rounded-lg border border-border bg-background px-1.5',
+    'text-sm font-semibold leading-5 text-foreground',
+    'hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-60',
+  );
+
+  // Decline / Edit / Create Agent — shared by the compact footer AND the
   // expanded preview footer (submit() closes the preview on a decision).
   const actionControls = (
-    <div className='flex shrink-0 items-center gap-2'>
-      {agentRunning && (
-        <span className='hidden text-xs text-muted-foreground sm:inline'>
-          Approve once it finishes.
-        </span>
-      )}
+    <div className='flex w-full items-center justify-between gap-3'>
       <button
         type='button'
         onClick={() => void submit('agent-draft-decline')}
         disabled={locked}
-        className={cn(
-          'inline-flex items-center gap-1.5 rounded-lg border border-transparent px-2 py-1.5',
-          'text-sm font-medium leading-[1.2] text-muted-foreground',
-          'hover:bg-foreground/[0.04] hover:text-foreground',
-          'disabled:cursor-not-allowed disabled:opacity-60',
-        )}
+        className={cn(ghostButton, 'px-2.5')}
         data-track-category='AGENT_ARTIFACT'
         data-track-name='CLICK_DECLINE'
       >
         {pending === 'reject' && <Spinner size={14} className='animate-spin' />}
         {pending === 'reject' ? 'Declining…' : 'Decline'}
       </button>
-      <button
-        type='button'
-        onClick={() => void submit('agent-draft-approve')}
-        disabled={locked || agentRunning}
-        className={cn(
-          'inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1.5',
-          'text-sm font-medium leading-[1.2] text-foreground',
-          'disabled:cursor-not-allowed disabled:opacity-60',
+
+      <div className='flex shrink-0 items-center gap-2'>
+        {agentRunning && (
+          <span className='hidden text-xs text-muted-foreground sm:inline'>
+            Approve once it finishes.
+          </span>
         )}
-        data-track-category='AGENT_ARTIFACT'
-        data-track-name='CLICK_APPROVE'
-      >
-        {(pending === 'approve' || agentRunning) && <Spinner size={14} className='animate-spin' />}
-        {approveLabel}
-      </button>
+        {/* Placeholder from the frame — no edit flow exists yet. Rendered so the
+            layout matches the design; wire it up when the behaviour is decided. */}
+        <button
+          type='button'
+          onClick={() => {
+            /* TODO: no edit flow yet — see the Agent Create frame. */
+          }}
+          disabled={locked}
+          className={cn(ghostButton, 'px-2.5')}
+          data-track-category='AGENT_ARTIFACT'
+          data-track-name='CLICK_EDIT'
+        >
+          Edit
+        </button>
+        <button
+          type='button'
+          onClick={() => void submit('agent-draft-approve')}
+          disabled={locked || agentRunning}
+          className={cn(primaryButton, 'px-2.5')}
+          data-track-category='AGENT_ARTIFACT'
+          data-track-name='CLICK_APPROVE'
+        >
+          {(pending === 'approve' || agentRunning) && (
+            <Spinner size={14} className='animate-spin' />
+          )}
+          {approveLabel}
+        </button>
+      </div>
     </div>
   );
 
   return (
     <CardShell style={node.style}>
-      <div className={cn('flex flex-col p-4', props.phase === 'rejected' && 'opacity-60')}>
-        {/* No header bar: the state pill sits beside the name and the expand
-            control rides in the same row, so nothing exists purely as chrome. */}
-        <AgentIdentityBlock
-          agent={props.agent}
-          {...(interactive ? { interactive } : {})}
-          note={props.note}
-          statePill={statePill}
-          trailing={
-            insidePreview ? undefined : (
-              <button
-                type='button'
-                onClick={(): void => setExpanded(true)}
-                aria-label='Expand agent'
-                className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-                data-track-category='AGENT_ARTIFACT'
-                data-track-name='EXPAND_ARTIFACT'
-              >
-                <MaximizeFourArrow size={16} className='shrink-0' />
-              </button>
-            )
-          }
-        />
+      {/* Inset panel — the frame's white card sitting on the shell's fill.
+          Radius is 11px, not the shell's 12px (`rounded-xl`): the panel sits
+          flush inside the shell's 1px border, so the radius it has to follow is
+          12 − 1. Matching the shell's 12px instead makes the two curves fight at
+          the top corners — concentric radii differ by the inset. */}
+      {/* Identical in every phase — the state reads from the chip and the chin
+          (footer) alone, so a declined agent is presented exactly as a pending
+          one rather than dimmed into a different-looking card. */}
+      <div className='flex flex-col gap-4 rounded-[11px] border border-border bg-card/80 p-3'>
+        <div className='flex h-6 items-center gap-1.5 pl-1'>
+          <div className='flex min-w-0 flex-1 items-center gap-1.5'>
+            <span className='text-sm font-semibold leading-5 tracking-[-0.5px] text-muted-foreground'>
+              Agent
+            </span>
+            {statePill}
+          </div>
+          {!insidePreview && (
+            <button
+              type='button'
+              onClick={(): void => setExpanded(true)}
+              aria-label='Expand agent'
+              className='shrink-0 rounded-[10px] p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='AGENT_ARTIFACT'
+              data-track-name='EXPAND_ARTIFACT'
+            >
+              <MaximizeTwoArrow size={16} className='shrink-0' />
+            </button>
+          )}
+        </div>
+
+        <div className='flex flex-col gap-3'>
+          <div className='flex min-w-0 flex-col pl-1 gap-1'>
+            <p className='break-words text-sm font-semibold leading-5 text-foreground'>
+              {props.agent.name}
+            </p>
+            <span className='block truncate text-sm font-normal leading-5 tracking-[-0.07px] text-foreground'>
+              @{props.agent.slug}
+            </span>
+          </div>
+
+          {/* gap-1.5 is the frame's 6px. The body below is a <span>, not a second
+              <p>, for the same reason as the slug above: `.jp-message-html p + p`
+              (global.css) would add its own 8px on top of this gap and win, since
+              the card renders inside the message-content root. */}
+          {props.agent.description && (
+            <div className='flex min-w-0 flex-col gap-1 px-1'>
+              <p className='truncate text-sm font-semibold leading-5 text-foreground'>
+                Description
+              </p>
+              <span className='block break-words text-sm font-normal leading-5 tracking-[-0.07px] text-foreground'>
+                {props.agent.description}
+              </span>
+            </div>
+          )}
+
+          {/* `props.note` (the server's "not granted — no such tool" footnote) is
+              intentionally NOT rendered here for now, alongside the hidden
+              capability chips. The server still sends it and the expanded
+              preview still shows it — this is a display choice, not a change to
+              the wire contract. */}
+        </div>
       </div>
 
-      {/* One row: the connect prompt (or audit) reads from the left, the decision
-          buttons sit at the right end. `justify-between` with the prompt allowed
-          to shrink keeps the buttons anchored even when there is no prompt. */}
-      <div className='flex items-center justify-between gap-3 border-t border-border bg-foreground/[0.03] px-4 py-3'>
-        <div className='flex min-w-0 items-center gap-3'>
-          {decided && auditNode}
-          {/* Only a CREATED draft has an agent to link to; a pending one goes to
-              the MCP list instead. */}
-          <AgentConnectPrompt agent={props.agent} agentExists={props.phase === 'created'} />
-        </div>
-        {!decided && actionControls}
+      {/* min-h pins the chin to its tallest state — the pending buttons (h-7 + the
+          16px of py-2). Without it the card contracts by ~12px the moment a
+          decision lands (an audit line is shorter than a button row, and shorter
+          again when there is no decider avatar), reflowing the thread under it. */}
+      <div className='flex min-h-[44px] items-center justify-between gap-3 px-3 py-2'>
+        {/* A decided card shows the audit line only. No connect prompt in either
+            phase — it belongs with the capability chips, which this card no
+            longer renders; the expanded preview still surfaces both. */}
+        {decided ? auditNode : actionControls}
       </div>
 
       <AgentPreview

--- a/apps/dashboard/src/components/flowUI/nodes/agent/ProfileAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/ProfileAgentCard.tsx
@@ -1,0 +1,68 @@
+import React, { useContext, useState } from 'react';
+import { MaximizeFourArrow } from '@xyne/icons';
+import type { AgentProfileProps, FlowComponent } from '@xyne/shared';
+import { useFlow } from '../../FlowContext';
+import { CardShell } from '../cardPrimitives';
+import { AgentIdentityBlock, AgentConnectPrompt } from './AgentIdentityBlock';
+import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
+
+/**
+ * The `agent` artifact's PROFILE variant — a live agent described back to the
+ * user ("what can this agent do?"). Read-only: no selection, no footer, and no
+ * state pill (a live agent isn't in a state worth calling out).
+ *
+ * Same identity block and the same expanded view as the draft card, so an agent
+ * looks and reads the same before and after it exists — only the affordances
+ * differ. Its content is built server-side from the agent's row, never from text
+ * a model supplied.
+ */
+export const ProfileAgentCard: React.FC<{ node: FlowComponent; props: AgentProfileProps }> = ({
+  node,
+  props,
+}) => {
+  const { conversationId, messageId } = useFlow();
+  const insidePreview = useContext(InsideAgentPreviewContext);
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <CardShell style={node.style}>
+      <div className='flex flex-col p-4'>
+        <AgentIdentityBlock
+          agent={props.agent}
+          note={props.note}
+          trailing={
+            insidePreview ? undefined : (
+              <button
+                type='button'
+                onClick={(): void => setExpanded(true)}
+                aria-label='Expand agent'
+                className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+                data-track-category='AGENT_ARTIFACT'
+                data-track-name='EXPAND_ARTIFACT'
+              >
+                <MaximizeFourArrow size={16} className='shrink-0' />
+              </button>
+            )
+          }
+        />
+      </div>
+
+      {/* A profile card always describes a live agent, so its link goes straight
+          to that agent's Connections tab. */}
+      <AgentConnectPrompt
+        agent={props.agent}
+        agentExists
+        className='border-t border-border bg-foreground/[0.03] px-4 py-3'
+      />
+
+      <AgentPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        messageId={messageId ?? ''}
+        agent={props.agent}
+        note={props.note}
+        conversationId={conversationId ?? undefined}
+      />
+    </CardShell>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/cardPrimitives.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/cardPrimitives.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { MaximizeFourArrow } from '@xyne/icons';
+import { cn } from '../../../utils/classNames';
+
+/**
+ * Shell + chrome for the agent artifact, and for artifact cards added after it.
+ *
+ * The measurements and tokens deliberately match the plan card so the two read
+ * as one visual system (same 450px shell, same chip treatment, same audit
+ * footer). PlanNode keeps its own copy of these on purpose — it is live and
+ * working, and rewiring it to a shared module would be a refactor of a shipped
+ * artifact for a new one's benefit. If a third card arrives, folding PlanNode
+ * in here is the natural moment; it is not this change's job.
+ */
+
+export const CardShell: React.FC<{
+  children: React.ReactNode;
+  style?: React.CSSProperties | undefined;
+}> = ({ children, style }) => (
+  <div
+    // Fills its container up to 700px. Width tracks the thread rather than being
+    // pinned like the plan card's 450px: this artifact carries capability chips
+    // that wrap, so the extra room keeps a row like "MCP" on one line instead of
+    // stacking, and it still narrows cleanly on mobile. Height stays auto — it
+    // grows with content. Border, fill and radius stay identical to the plan card
+    // so the two read as one system in the thread.
+    className='flex w-full max-w-[700px] flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+    style={style}
+  >
+    {children}
+  </div>
+);
+
+/** Card header: the artifact's kind on the left, optional chip, optional expand. */
+export const CardHeader: React.FC<{
+  label: string;
+  chip?: React.ReactNode;
+  onExpand?: (() => void) | undefined;
+  expandAriaLabel?: string;
+  trackCategory?: string;
+}> = ({ label, chip, onExpand, expandAriaLabel = 'Expand', trackCategory = 'ARTIFACT_CARD' }) => (
+  <div className='flex items-center justify-between'>
+    <div className='flex items-center gap-2'>
+      <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+        {label}
+      </span>
+      {chip}
+    </div>
+    {/* Omitted when the card is rendered inside its own preview panel — that
+        would stack a second full-screen preview on top of the first. */}
+    {onExpand && (
+      <button
+        type='button'
+        onClick={onExpand}
+        aria-label={expandAriaLabel}
+        className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        data-track-category={trackCategory}
+        data-track-name='EXPAND_ARTIFACT'
+      >
+        <MaximizeFourArrow size={16} className='shrink-0' />
+      </button>
+    )}
+  </div>
+);
+
+export type StatusChipTone = 'approved' | 'muted' | 'rejected';
+
+export const StatusChip: React.FC<{ label: string; tone?: StatusChipTone }> = ({
+  label,
+  tone = 'approved',
+}) => (
+  <span className='flex h-[18px] items-center'>
+    <span
+      className={cn(
+        'rounded px-1 py-px text-xs font-medium leading-[18px] tracking-[0.2px]',
+        tone === 'muted' && 'bg-muted text-muted-foreground',
+        tone === 'rejected' && 'bg-destructive/10 text-destructive',
+        tone === 'approved' &&
+          'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]',
+      )}
+    >
+      {label}
+    </span>
+  </span>
+);
+
+/**
+ * Small muted audit line for a card footer — "Created by @name · 2 mins ago".
+ *
+ * Takes children rather than a string so the actor can render as a mention
+ * (styled `@handle`) inside otherwise-muted prose. `truncate` keeps a long name
+ * on one line instead of wrapping the footer.
+ */
+export const AuditLine: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <span className='truncate text-xs leading-[1.2] text-muted-foreground'>{children}</span>
+);
+
+/** An `@handle` in the mention colour — the same treatment the agent's slug gets. */
+export const Mention: React.FC<{ handle: string }> = ({ handle }) => (
+  <span className='text-blue-500 dark:text-blue-400'>@{handle.replace(/^@+/, '')}</span>
+);
+
+export const TitleBlock: React.FC<{ title: string; desc?: string | undefined }> = ({
+  title,
+  desc,
+}) => (
+  <div className='flex flex-col'>
+    <p className='text-lg font-medium leading-[1.2] text-foreground'>{title}</p>
+    {desc && <p className='text-sm leading-[1.5] tracking-[-0.15px] text-foreground/80'>{desc}</p>}
+  </div>
+);
+
+/**
+ * Format an ISO decision timestamp for an audit footer. Relative within the
+ * first day ("just now", "5 mins ago", "1 hr ago"); absolute after 24h, e.g.
+ * "Jul 26, 2:34 PM". Returns null for a missing/invalid value so callers omit
+ * the "· <time>" suffix.
+ */
+export const formatDecisionTime = (iso?: string): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+
+  // Relative for the first day; a future timestamp (clock skew) falls through
+  // to the absolute format rather than showing a negative "ago".
+  const diffMs = Date.now() - d.getTime();
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  if (diffMs >= 0 && diffMs < ONE_DAY_MS) {
+    const mins = Math.floor(diffMs / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} ${mins === 1 ? 'min' : 'mins'} ago`;
+    const hrs = Math.floor(mins / 60);
+    return `${hrs} ${hrs === 1 ? 'hr' : 'hrs'} ago`;
+  }
+
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+/** Join an audit label with its (optional) decision time. */
+export const withDecisionTime = (label: string, iso?: string): string => {
+  const t = formatDecisionTime(iso);
+  return t ? `${label} · ${t}` : label;
+};

--- a/apps/dashboard/src/components/flowUI/nodes/cardPrimitives.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/cardPrimitives.tsx
@@ -18,13 +18,12 @@ export const CardShell: React.FC<{
   style?: React.CSSProperties | undefined;
 }> = ({ children, style }) => (
   <div
-    // Fills its container up to 700px. Width tracks the thread rather than being
-    // pinned like the plan card's 450px: this artifact carries capability chips
-    // that wrap, so the extra room keeps a row like "MCP" on one line instead of
-    // stacking, and it still narrows cleanly on mobile. Height stays auto — it
-    // grows with content. Border, fill and radius stay identical to the plan card
-    // so the two read as one system in the thread.
-    className='flex w-full max-w-[700px] flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+    // Same fixed 450px as the plan card (PlanNode's own CardShell), so the two
+    // artifacts sit at one width in the thread instead of the agent card running
+    // ~250px wider. `max-w-full` caps it on containers narrower than 450px
+    // (mobile). Height stays auto — it grows with content. Border, fill and
+    // radius already matched the plan card; now the width does too.
+    className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
     style={style}
   >
     {children}

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -491,6 +491,25 @@
     filter: brightness(0) invert(1);
     opacity: 0.85;
   }
+
+  /* Text selection — app-wide, themed.
+     Without a rule here the browser falls back to the OS highlight colour, so
+     the selection changed with each user's macOS accent and looked different
+     from page to page. A light blue reads as selection without competing with
+     summer_breeze's coral --primary.
+     Rich-text and code surfaces (BlockNote, CodeMirror) keep their own selection
+     styling on purpose — they need range semantics this flat fill can't express. */
+  ::selection {
+    background-color: hsl(211 100% 86%);
+    color: hsl(var(--foreground));
+  }
+
+  /* Same hue, but light-on-dark: an 86%-lightness fill would blow out against
+     midnight's surfaces and swallow the text. */
+  [data-theme="midnight"] ::selection {
+    background-color: hsl(211 90% 58% / 0.4);
+    color: hsl(var(--foreground));
+  }
 }
 
 * {

--- a/apps/xyne-claw-auth/backend/src/lib/agent-card.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-card.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import {
+  identityFromAgentRow,
+  identityFromDraftSpec,
+  isConnectorServerType,
+  isValidAgentSlug,
+  resolveAgentCapabilities,
+  toConfigTools,
+  toolIdsFromConfig,
+  unknownToolsNote,
+} from "./agent-card.js";
+import type { AvailableToolsCatalog } from "../routes/tools.js";
+
+// Minimal catalog shaped like buildAvailableToolsCatalog's output. Only the two
+// buckets the resolver reads are populated — everything else is irrelevant here
+// and deliberately stays unmatched (see the "gateway/MCP tokens" test).
+const catalog = {
+  subagents: [
+    { name: "spaces", description: "", serverType: "xyne-spaces", progressLabel: "", progressLabels: [], source: "builtin" },
+    { name: "google", description: "", serverType: "google", progressLabel: "", progressLabels: [], source: "builtin" },
+  ],
+  mcpServers: [],
+  writeTools: [],
+  customGroups: [
+    { source: "custom:web", tools: [{ slug: "web-search", name: "Web Search" }] },
+    { source: "custom:report", tools: [{ slug: "create-html-report", name: "Create Report" }] },
+  ],
+  serverTools: {},
+  integrations: [],
+} as unknown as AvailableToolsCatalog;
+
+describe("resolveAgentCapabilities", () => {
+  it("buckets exact subagent names and custom tool slugs", async () => {
+    const resolved = await resolveAgentCapabilities(["spaces", "web-search"], catalog);
+    expect(resolved.subagents).toEqual(["spaces"]);
+    expect(resolved.custom).toEqual(["web-search"]);
+    expect(resolved.unknown).toEqual([]);
+    expect(resolved.capabilities).toEqual([
+      // iconKey is the subagent's serverType, NOT its name — the brand asset for
+      // "spaces" lives under "xyne-spaces", so the renderer must be told which
+      // key to use rather than guessing from the label.
+      { id: "spaces", label: "spaces", kind: "subagent", iconKey: "xyne-spaces" },
+      { id: "web-search", label: "Web Search", kind: "tool" },
+    ]);
+  });
+
+  it("reports unmatched tokens instead of guessing a bucket", async () => {
+    // An MCP/gateway token needs a source-scoped selection key whose bucket
+    // depends on integration state; mis-bucketing it would silently mis-wire the
+    // agent, so it must surface on the card rather than be dropped or assumed.
+    const resolved = await resolveAgentCapabilities(
+      ["spaces", "Bitbucket__create_pull_request", "invented-tool"],
+      catalog,
+    );
+    expect(resolved.subagents).toEqual(["spaces"]);
+    expect(resolved.custom).toEqual([]);
+    expect(resolved.unknown).toEqual(["Bitbucket__create_pull_request", "invented-tool"]);
+    expect(unknownToolsNote(resolved.unknown)).toContain("Bitbucket__create_pull_request");
+  });
+
+  it("is case- and whitespace-exact (a near miss is reported, never silently matched)", async () => {
+    const resolved = await resolveAgentCapabilities(["Spaces", " web-search "], catalog);
+    // Trimmed, but not case-folded: "Spaces" is not the subagent "spaces".
+    expect(resolved.custom).toEqual(["web-search"]);
+    expect(resolved.unknown).toEqual(["Spaces"]);
+  });
+
+  it("dedupes and drops blanks", async () => {
+    const resolved = await resolveAgentCapabilities(["spaces", "spaces", "", "  "], catalog);
+    expect(resolved.subagents).toEqual(["spaces"]);
+    expect(resolved.capabilities).toHaveLength(1);
+  });
+
+  it("omits the connection hint when no user is given", async () => {
+    // The hint is about a specific person's account; without one there is
+    // nothing truthful to say, so no chip is flagged.
+    const resolved = await resolveAgentCapabilities(["google"], catalog);
+    expect(resolved.capabilities[0]).toEqual({
+      id: "google",
+      label: "google",
+      kind: "subagent",
+      iconKey: "google",
+    });
+  });
+});
+
+describe("toolIdsFromConfig", () => {
+  it("flattens the two capability buckets back into a flat id list", () => {
+    // The profile card round-trips: config.tools → ids → resolved capabilities,
+    // so a live agent's card shows exactly what it was granted.
+    expect(
+      toolIdsFromConfig({ tools: { subagents: ["spaces", "google"], custom: ["web-search"] } }),
+    ).toEqual(["spaces", "google", "web-search"]);
+  });
+
+  it("ignores buckets this card does not own, and malformed config", () => {
+    // gateway/direct use a different addressing scheme; reading them here would
+    // render chips whose ids the resolver can never match.
+    expect(toolIdsFromConfig({ tools: { gateway: ["x"], direct: ["y"] } })).toEqual([]);
+    expect(toolIdsFromConfig({ tools: { subagents: "not-an-array" } })).toEqual([]);
+    expect(toolIdsFromConfig(null)).toEqual([]);
+    expect(toolIdsFromConfig({})).toEqual([]);
+  });
+});
+
+describe("toConfigTools", () => {
+  it("omits empty buckets so a tool-less agent gets {}", () => {
+    expect(toConfigTools({ subagents: [], custom: [] })).toEqual({});
+    expect(toConfigTools({ subagents: ["spaces"], custom: [] })).toEqual({ subagents: ["spaces"] });
+  });
+});
+
+describe("unknownToolsNote", () => {
+  it("says nothing when everything matched", () => {
+    expect(unknownToolsNote([])).toBeUndefined();
+  });
+
+  it("caps the list rather than spilling a wall of text onto the card", () => {
+    const note = unknownToolsNote(["a", "b", "c", "d", "e", "f", "g", "h"]);
+    expect(note).toContain("+2 more");
+  });
+});
+
+describe("isValidAgentSlug", () => {
+  it.each(["a", "ticket-triage", "pr-report-2"])("accepts %s", slug => {
+    expect(isValidAgentSlug(slug)).toBe(true);
+  });
+
+  it.each(["", "-lead", "trail-", "double--dash", "Upper", "has space", "a".repeat(81)])(
+    "rejects %s",
+    slug => {
+      expect(isValidAgentSlug(slug)).toBe(false);
+    },
+  );
+});
+
+describe("identity builders", () => {
+  const resolved = {
+    capabilities: [{ id: "spaces", label: "spaces", kind: "subagent" as const }],
+    subagents: ["spaces"],
+    custom: [],
+    unknown: [],
+  };
+
+  it("produce the SAME shape from a draft spec and from a persisted row", () => {
+    // The reuse invariant: the card a user approves and the card that later
+    // describes the created agent must be built from one shape, or the two
+    // surfaces drift apart field by field.
+    const fromDraft = identityFromDraftSpec(
+      {
+        name: "Ticket Triage",
+        slug: "ticket-triage",
+        description: "Triages tickets",
+        systemPrompt: "You are a triage agent.",
+        modelId: "claude-sonnet-5",
+        tools: ["spaces"],
+      },
+      resolved,
+    );
+    const fromRow = identityFromAgentRow(
+      {
+        name: "Ticket Triage",
+        slug: "ticket-triage",
+        description: "Triages tickets",
+        systemPrompt: "You are a triage agent.",
+        modelId: "claude-sonnet-5",
+      },
+      resolved,
+    );
+    expect(fromDraft).toEqual(fromRow);
+  });
+
+  it("emits no detail rows — slug and model render in the card header", () => {
+    // The card shows "@slug · model" in its header, so repeating them as
+    // key/value rows under the description showed the same two facts twice.
+    // `details` stays available for rows that have nowhere else to go.
+    const identity = identityFromAgentRow(
+      { name: "A", slug: "a", systemPrompt: "p", modelId: "claude-sonnet-5" },
+      resolved,
+    );
+    expect(identity.details).toBeUndefined();
+    // The model is still on the identity — the header reads it directly.
+    expect(identity.modelId).toBe("claude-sonnet-5");
+  });
+});
+
+describe("isConnectorServerType", () => {
+  it("accepts real MCP connector types", () => {
+    expect(isConnectorServerType("github")).toBe(true);
+    expect(isConnectorServerType("xyne-spaces")).toBe(true);
+  });
+
+  it("rejects custom-tool sources and blanks", () => {
+    // The artifacts subagent reports "custom:create-ppt" as its serverType. It
+    // has no brand asset and can never match a user_mcp_connections row, so
+    // treating it as a connector flagged that chip unconnected forever and gave
+    // it an icon key that 404s into a meaningless monogram.
+    expect(isConnectorServerType("custom:create-ppt")).toBe(false);
+    expect(isConnectorServerType("")).toBe(false);
+    expect(isConnectorServerType(undefined)).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/agent-card.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-card.ts
@@ -1,0 +1,441 @@
+/**
+ * Agent-card server helpers — the ONE place that turns identifiers into the
+ * `agent` artifact's identity block, shared by every surface that renders it.
+ *
+ *   draft   (webhook /result, flow-action decisions) → identityFromDraftSpec
+ *   profile (a live agent described back to the user) → identityFromAgentRow
+ *
+ * Both funnel through xyne-claw-shared's `agentIdentity()` normalizer, so the
+ * two surfaces cannot drift: the card a user approves and the card that later
+ * describes the created agent are built from the same shape.
+ *
+ * Capability resolution is deliberately CONSERVATIVE. A flat token is accepted
+ * only as an exact match on a catalog subagent NAME or a custom tool SLUG —
+ * the two buckets whose meaning does not depend on integration state. MCP-server
+ * and gateway tokens need a source-scoped selection key, and guessing their
+ * bucket would silently mis-wire the agent, so they come back as `unknown` and
+ * are reported on the card instead of being dropped in silence.
+ */
+
+import { agentIdentity, type AgentCapability, type AgentIdentity } from "xyne-claw-shared";
+import type { AvailableToolsCatalog } from "../routes/tools.js";
+import { agentRepository, agentRequestRepository } from "../repositories/index.js";
+import { prisma } from "../db.js";
+import { writeAuditLog } from "./audit.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("agent-card");
+
+/** Slug rule enforced everywhere an agent slug is accepted (tool → card → create). */
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function isValidAgentSlug(slug: string): boolean {
+  return slug.length > 0 && slug.length <= 80 && SLUG_RE.test(slug);
+}
+
+/**
+ * Is this serverType a real MCP connector — something a user can hold a
+ * connection to and that ships a brand asset?
+ *
+ * A subagent's `serverType` is not always one: the artifacts subagent reports
+ * "custom:create-ppt", a custom-tool source. Those have no icon file and no
+ * possible row in user_mcp_connections, so both the icon key and the
+ * needs-connecting hint must skip them.
+ */
+export function isConnectorServerType(serverType: string | undefined): serverType is string {
+  return typeof serverType === "string" && serverType.length > 0 && !serverType.includes(":");
+}
+
+export interface ResolvedCapabilities {
+  /** Card-facing capability chips, in catalog order (subagents first). */
+  capabilities: AgentCapability[];
+  /** config.tools.subagents — matched subagent names. */
+  subagents: string[];
+  /** config.tools.custom — matched custom tool slugs. */
+  custom: string[];
+  /** Tokens that matched nothing. Reported on the card, never persisted. */
+  unknown: string[];
+}
+
+/**
+ * Resolve requested tool identifiers against the org catalog.
+ *
+ * `connectedFor` (optional) is the user whose connections decide the
+ * "needs connecting" hint on a capability — pass the person who will approve
+ * the card, since it is their account the created agent runs against.
+ */
+export async function resolveAgentCapabilities(
+  requested: string[],
+  catalog: AvailableToolsCatalog,
+  connectedFor?: string,
+): Promise<ResolvedCapabilities> {
+  const subagentByName = new Map(catalog.subagents.map((s) => [s.name, s]));
+  const customBySlug = new Map(
+    catalog.customGroups.flatMap((g) => g.tools.map((t) => [t.slug, t] as const)),
+  );
+
+  const subagents: string[] = [];
+  const custom: string[] = [];
+  const unknown: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of requested) {
+    const token = raw.trim();
+    if (!token || seen.has(token)) continue;
+    seen.add(token);
+    if (subagentByName.has(token)) subagents.push(token);
+    else if (customBySlug.has(token)) custom.push(token);
+    else unknown.push(token);
+  }
+
+  // Which serverTypes does the approver still need to connect? Only asked when
+  // a matched subagent actually depends on one — this is a display hint, so a
+  // lookup failure degrades to "no hint" rather than failing the card.
+  //
+  // `custom:*` serverTypes (e.g. the artifacts subagent's "custom:create-ppt")
+  // are custom-tool sources, not MCP connectors: they can never match a
+  // user_mcp_connections row, so treating them as connectable flagged EVERY such
+  // chip as unconnected forever. They have no brand asset either — see
+  // isConnectorServerType at the icon assignment below.
+  const wantedServerTypes = subagents
+    .map((name) => subagentByName.get(name)?.serverType)
+    .filter((t): t is string => isConnectorServerType(t));
+  const unconnected = new Set<string>(wantedServerTypes);
+  if (connectedFor && unconnected.size > 0) {
+    try {
+      const connections = await prisma.userMcpConnection.findMany({
+        where: { userId: connectedFor, mcpServer: { type: { in: [...unconnected] } } },
+        select: { mcpServer: { select: { type: true } } },
+      });
+      for (const c of connections) unconnected.delete(c.mcpServer.type);
+    } catch (err) {
+      unconnected.clear();
+      log.warn(
+        `[agent-card] connection lookup failed for ${connectedFor}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  } else {
+    unconnected.clear();
+  }
+
+  const capabilities: AgentCapability[] = [
+    ...subagents.map((name) => {
+      const def = subagentByName.get(name);
+      const serverType = def?.serverType;
+      return {
+        id: name,
+        label: name,
+        kind: "subagent" as const,
+        // The brand icon is keyed by serverType, which is NOT always the
+        // subagent name ("spaces" is served by "xyne-spaces") — resolve it here
+        // so the renderer never guesses an asset filename. Non-connector types
+        // have no asset, so omitting the key lets the chip render label-only
+        // rather than falling through two 404s to a meaningless monogram.
+        ...(isConnectorServerType(serverType) ? { iconKey: serverType } : {}),
+        ...(isConnectorServerType(serverType) && unconnected.has(serverType)
+          ? { requiresConnection: serverType }
+          : {}),
+      };
+    }),
+    ...custom.map((slug) => ({
+      id: slug,
+      label: customBySlug.get(slug)?.name ?? slug,
+      kind: "tool" as const,
+    })),
+  ];
+
+  return { capabilities, subagents, custom, unknown };
+}
+
+/**
+ * Flatten a persisted agent's `config.tools` back into the flat identifier list
+ * `resolveAgentCapabilities` takes. Only the two buckets the resolver owns are
+ * read; gateway/direct selections are a different addressing scheme and are not
+ * capabilities in this card's sense.
+ */
+export function toolIdsFromConfig(config: unknown): string[] {
+  const record = (config ?? {}) as Record<string, unknown>;
+  const tools = (record["tools"] ?? {}) as Record<string, unknown>;
+  const read = (key: string): string[] =>
+    Array.isArray(tools[key])
+      ? (tools[key] as unknown[]).filter((v): v is string => typeof v === "string")
+      : [];
+  return [...read("subagents"), ...read("custom")];
+}
+
+/** The `config.tools` object, omitting empty buckets so a tool-less agent gets `{}`. */
+export function toConfigTools(resolved: Pick<ResolvedCapabilities, "subagents" | "custom">): {
+  subagents?: string[];
+  custom?: string[];
+} {
+  return {
+    ...(resolved.subagents.length > 0 ? { subagents: resolved.subagents } : {}),
+    ...(resolved.custom.length > 0 ? { custom: resolved.custom } : {}),
+  };
+}
+
+/** Muted card footnote naming what could not be granted. */
+export function unknownToolsNote(unknown: string[]): string | undefined {
+  if (unknown.length === 0) return undefined;
+  const shown = unknown.slice(0, 6).join(", ");
+  const more = unknown.length > 6 ? ` (+${unknown.length - 6} more)` : "";
+  return `Not granted — no such tool in this workspace: ${shown}${more}. Add them from the agent's settings.`;
+}
+
+/** The draft spec the pod ships on `pendingAgentCard`. */
+export interface DraftAgentSpec {
+  name: string;
+  slug: string;
+  description: string;
+  systemPrompt: string;
+  modelId?: string;
+  color?: string;
+  tools: string[];
+  /** The agent's own line for the thread, posted next to the card. Chat text
+   *  only — deliberately NOT part of the identity, so it never renders on a
+   *  re-drawn card after the decision. */
+  summary?: string;
+}
+
+/**
+ * Identity for a DRAFTED (not yet persisted) agent.
+ *
+ * `builtBy` credits the agent that authored the draft — the card says "Built by
+ * @<slug>" so a user reading it later knows the agent didn't come from a human.
+ */
+export function identityFromDraftSpec(
+  spec: DraftAgentSpec,
+  resolved: ResolvedCapabilities,
+  builtBy?: string,
+): AgentIdentity {
+  return agentIdentity({
+    name: spec.name,
+    slug: spec.slug,
+    ...(builtBy ? { builtBy } : {}),
+    description: spec.description,
+    systemPrompt: spec.systemPrompt,
+    ...(spec.modelId ? { modelId: spec.modelId } : {}),
+    ...(spec.color ? { color: spec.color } : {}),
+    capabilities: resolved.capabilities,
+    // No Identifier/Model rows: the card renders slug + model in its header line,
+    // and repeating them here showed the same two facts twice. `details` stays as
+    // the extension point for rows that have nowhere else to go.
+  });
+}
+
+/** Structural view of the agent row the profile surface renders. */
+export interface AgentRowLike {
+  name: string;
+  slug: string;
+  description?: string | null;
+  systemPrompt: string;
+  modelId?: string | null;
+  color?: string | null;
+}
+
+/**
+ * Identity for a LIVE agent, read from its row.
+ *
+ * Authority note: a profile card is built from the DB, never from text an agent
+ * supplied — an agent must not be able to narrate capabilities it does not have
+ * onto an official-looking card. The caller passes the row; the agent only ever
+ * names which one.
+ */
+export function identityFromAgentRow(
+  row: AgentRowLike,
+  resolved: ResolvedCapabilities,
+  builtBy?: string,
+): AgentIdentity {
+  return agentIdentity({
+    name: row.name,
+    slug: row.slug,
+    ...(builtBy ? { builtBy } : {}),
+    description: row.description ?? "",
+    systemPrompt: row.systemPrompt,
+    ...(row.modelId ? { modelId: row.modelId } : {}),
+    ...(row.color ? { color: row.color } : {}),
+    capabilities: resolved.capabilities,
+    // Same as the draft path — slug + model live in the card header.
+  });
+}
+
+// ── Decision path ────────────────────────────────────────────────────────────
+
+export type AgentDraftResolution =
+  | {
+      ok: true;
+      status: "approved" | "rejected";
+      /** Re-rendered identity for the decided card (approved = what was granted). */
+      identity: AgentIdentity;
+      note?: string;
+      /** True when someone/something already decided this draft (replay, race). */
+      alreadyResolved: boolean;
+    }
+  | { ok: false; code: 400 | 403 | 404 | 409 | 500; error: string };
+
+function parseDraftSpec(raw: string | null): DraftAgentSpec | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<DraftAgentSpec>;
+    if (!parsed || typeof parsed.name !== "string" || typeof parsed.slug !== "string") return null;
+    if (typeof parsed.systemPrompt !== "string" || parsed.systemPrompt.trim().length === 0) return null;
+    return {
+      name: parsed.name,
+      slug: parsed.slug,
+      description: typeof parsed.description === "string" ? parsed.description : "",
+      systemPrompt: parsed.systemPrompt,
+      ...(typeof parsed.modelId === "string" ? { modelId: parsed.modelId } : {}),
+      ...(typeof parsed.color === "string" ? { color: parsed.color } : {}),
+      tools: Array.isArray(parsed.tools) ? parsed.tools.filter((t): t is string => typeof t === "string") : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Approve or reject a drafted agent.
+ *
+ * Everything authoritative is re-read here: the spec comes from the AgentRequest
+ * row (never the card), the catalog is re-resolved (it may have changed since
+ * the draft), and the slug is re-checked for collisions (another agent may have
+ * taken it meanwhile). `keptCapabilityIds` — the user's chip selection, which
+ * arrives from the browser — can only NARROW the server-resolved set, never add
+ * to it.
+ *
+ * Concurrency: the pending→decided flip is an atomic compare-and-set, so a
+ * double-click or two open tabs produce exactly one agent; the loser gets
+ * `alreadyResolved`. A failure after the claim rolls the row back to pending so
+ * the user can retry rather than being stuck approved-with-no-agent.
+ */
+export async function resolveAgentDraft(
+  requestId: string,
+  callerUserId: string,
+  decision: "approve" | "reject",
+  keptCapabilityIds?: string[],
+  /** Drafting agent's slug, so the decided card keeps its "Built by" credit. */
+  builtBy?: string,
+): Promise<AgentDraftResolution> {
+  const request = await agentRequestRepository.findById(requestId);
+  if (!request || request.requestType !== "agent_create") {
+    return { ok: false, code: 404, error: "This agent draft no longer exists." };
+  }
+
+  // Self-approval (the drafter's own request), re-checked against the row and
+  // not just the card — the card is client-supplied.
+  if (request.requesterId !== callerUserId) {
+    return { ok: false, code: 403, error: "Only the person who requested this agent can decide it." };
+  }
+
+  const spec = parseDraftSpec(request.proposedContent);
+  if (!spec) {
+    return { ok: false, code: 400, error: "This draft is unreadable and can't be created. Ask for the agent again." };
+  }
+
+  const catalog = await buildCatalogFor(request.orgId);
+  const buildIdentity = async (grantedIds?: string[]): Promise<{ identity: AgentIdentity; resolved: ResolvedCapabilities }> => {
+    const resolved = await resolveAgentCapabilities(
+      grantedIds ?? spec.tools,
+      catalog,
+      request.requesterId,
+    );
+    return { identity: identityFromDraftSpec(spec, resolved, builtBy), resolved };
+  };
+
+  // Already decided (replay, or the other tab won): report the settled state
+  // with a re-rendered card instead of creating anything.
+  if (request.status !== "pending") {
+    const { identity } = await buildIdentity();
+    return {
+      ok: true,
+      status: request.status === "approved" ? "approved" : "rejected",
+      identity,
+      alreadyResolved: true,
+      ...(request.reviewNote ? { note: request.reviewNote } : {}),
+    };
+  }
+
+  const claimed = await agentRequestRepository.claimPendingAgentCreate(
+    requestId,
+    decision === "approve" ? "approved" : "rejected",
+    callerUserId,
+  );
+  if (claimed.count !== 1) {
+    const fresh = await agentRequestRepository.findById(requestId);
+    const { identity } = await buildIdentity();
+    return {
+      ok: true,
+      status: fresh?.status === "approved" ? "approved" : "rejected",
+      identity,
+      alreadyResolved: true,
+      ...(fresh?.reviewNote ? { note: fresh.reviewNote } : {}),
+    };
+  }
+
+  if (decision === "reject") {
+    const { identity } = await buildIdentity();
+    log.info(`[agent-card] draft ${spec.slug} rejected by ${callerUserId} (request=${requestId})`);
+    return { ok: true, status: "rejected", identity, alreadyResolved: false };
+  }
+
+  // ── Approve: create the agent ──────────────────────────────────────────────
+  try {
+    const existing = await agentRepository.findBySlug(spec.slug, request.orgId);
+    if (existing) {
+      await agentRequestRepository.revertAgentCreateToPending(requestId).catch(() => {});
+      return {
+        ok: false,
+        code: 409,
+        error: `An agent with the identifier "${spec.slug}" now exists — nothing was created.`,
+      };
+    }
+
+    // The user's chip selection can only remove capabilities: intersect it with
+    // what the catalog actually grants rather than trusting it as the source.
+    const grantedIds = keptCapabilityIds
+      ? spec.tools.filter((t) => keptCapabilityIds.includes(t))
+      : spec.tools;
+    const { identity, resolved } = await buildIdentity(grantedIds);
+
+    const created = await agentRepository.create({
+      slug: spec.slug,
+      name: spec.name,
+      description: spec.description ?? "",
+      systemPrompt: spec.systemPrompt,
+      scope: "personal",
+      color: spec.color?.trim() || "#6366f1",
+      modelId: spec.modelId?.trim() ?? "",
+      config: { tools: toConfigTools(resolved) },
+      owner: { connect: { id: request.requesterId } },
+      org: { connect: { id: request.orgId } },
+    });
+
+    await agentRequestRepository.recordAgentCreateResult(requestId, created.id).catch(() => {});
+    await writeAuditLog({
+      actorUserId: callerUserId,
+      eventType: "AGENT_CREATED",
+      targetId: created.id,
+      description: `agent-authored agent "${spec.name}" (${spec.slug}) approved from a draft card`,
+      metadata: { requestId, subagents: resolved.subagents, custom: resolved.custom },
+    });
+    log.info(
+      `[agent-card] created agent ${spec.slug} (id=${created.id}) owner=${request.requesterId} org=${request.orgId} tools=${resolved.subagents.length + resolved.custom.length}`,
+    );
+
+    const note = unknownToolsNote(resolved.unknown);
+    return { ok: true, status: "approved", identity, alreadyResolved: false, ...(note ? { note } : {}) };
+  } catch (err) {
+    // Roll the claim back so the card stays approvable instead of dead.
+    await agentRequestRepository.revertAgentCreateToPending(requestId).catch(() => {});
+    log.error(
+      `[agent-card] create failed for ${spec.slug} (request=${requestId}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: false, code: 500, error: "Couldn't create the agent just now — please try approving again." };
+  }
+}
+
+/** Catalog fetch isolated so the resolver stays testable and the import stays lazy. */
+async function buildCatalogFor(orgId: string): Promise<AvailableToolsCatalog> {
+  const { buildAvailableToolsCatalog } = await import("../routes/tools.js");
+  return buildAvailableToolsCatalog(undefined, orgId);
+}

--- a/apps/xyne-claw-auth/backend/src/repositories/agentRequestRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRequestRepository.ts
@@ -172,4 +172,97 @@ export const agentRequestRepository = {
       where: { id },
       data: { status: "pending", reviewerId: null, reviewNote: null },
     }),
+
+  // ── Agent-create drafts (propose-agent → agent card) ──────────────────────
+  // An "agent_create" request is raised when an agent calls propose-agent. The
+  // DRAFT lives here, not on the card: the card only carries the requestId, so
+  // the spec cannot be edited client-side between draft and approval, and the
+  // approve path re-reads what was actually reviewed. `agentSlug` holds the
+  // PROPOSED slug (no agent row exists yet); `resultAgentId` records the agent
+  // created on approval, which makes replay idempotent.
+
+  /** This proposer's pending draft for the same slug (dedupe / supersede). */
+  findPendingAgentCreate: (agentSlug: string, requesterId: string) =>
+    prisma.agentRequest.findFirst({
+      where: { targetType: "agent", agentSlug, requesterId, requestType: "agent_create", status: "pending" },
+    }),
+
+  /** Every pending draft this proposer has in the org — used to retire stale
+   *  cards when a NEW draft supersedes them (an agent that re-drafts after
+   *  feedback leaves an approvable ghost card behind otherwise). */
+  listPendingAgentCreates: (requesterId: string, orgId: string) =>
+    prisma.agentRequest.findMany({
+      where: { targetType: "agent", requesterId, orgId, requestType: "agent_create", status: "pending" },
+      orderBy: { createdAt: "desc" },
+    }),
+
+  /**
+   * A proposer's NEW draft replaces their pending drafts for the SAME slug. The
+   * old rows close as rejected with a supersede note, so their cards resolve to
+   * "already handled" (claimPendingAgentCreate only claims pending rows) instead
+   * of staying independently approvable — two live cards for one slug means the
+   * second approval always fails the duplicate-slug guard. Transactional so no
+   * window exists where both are pending.
+   */
+  supersedeAndCreateAgentCreate: (data: {
+    agentSlug: string;
+    requesterId: string;
+    orgId: string;
+    proposedContent: string;
+    proposedContentHash: string;
+    requestNote?: string | null;
+  }) =>
+    prisma.$transaction(async (tx) => {
+      const superseded = await tx.agentRequest.updateMany({
+        where: {
+          targetType: "agent",
+          agentSlug: data.agentSlug,
+          requesterId: data.requesterId,
+          requestType: "agent_create",
+          status: "pending",
+        },
+        data: {
+          status: "rejected",
+          reviewerId: data.requesterId,
+          reviewNote: "Superseded by a newer draft from the same proposer",
+        },
+      });
+      const request = await tx.agentRequest.create({
+        data: {
+          targetType: "agent",
+          requestType: "agent_create",
+          agentSlug: data.agentSlug,
+          requesterId: data.requesterId,
+          orgId: data.orgId,
+          proposedContent: data.proposedContent,
+          proposedContentHash: data.proposedContentHash,
+          requestNote: data.requestNote ?? null,
+        },
+      });
+      return { request, supersededCount: superseded.count };
+    }),
+
+  /**
+   * Atomically claim a pending draft, flipping pending→status only if it is
+   * still pending. count===1 → this caller won and owns creating the agent;
+   * count===0 → someone else already decided it (double-click, two tabs).
+   * Scoped to requestType="agent_create" so it can never claim another row type.
+   */
+  claimPendingAgentCreate: (id: string, status: "approved" | "rejected", reviewerId: string, reviewNote?: string | null) =>
+    prisma.agentRequest.updateMany({
+      where: { id, requestType: "agent_create", status: "pending" },
+      data: { status, reviewerId, reviewNote: reviewNote ?? null },
+    }),
+
+  /** Roll a claimed draft back to pending when creating the agent fails, so the
+   *  user can retry instead of being stuck "approved" with no agent. */
+  revertAgentCreateToPending: (id: string) =>
+    prisma.agentRequest.update({
+      where: { id },
+      data: { status: "pending", reviewerId: null, reviewNote: null, resultAgentId: null },
+    }),
+
+  /** Record the agent an approved draft produced (audit + idempotent replay). */
+  recordAgentCreateResult: (id: string, resultAgentId: string) =>
+    prisma.agentRequest.update({ where: { id }, data: { resultAgentId } }),
 };

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -21,7 +21,7 @@ import { verifySpacesSignature } from "../middleware/verify-spaces-signature.js"
 import { agentRunRepository } from "../repositories/index.js";
 import { recordTwinApprovalOutcome } from "../services/twinResponseFeedback.js";
 import type { FlowDefinition } from "xyne-claw-shared";
-import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
+import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, PLAN_COMPONENT_ID, buildAgentCardFlow, AGENT_COMPONENT_ID } from "xyne-claw-shared";
 import { clearActivePlanCard, setPlanExecMeta, clearPlanExecMeta, normalizePlanTitle } from "../lib/session-context.js";
 import { executeTool as executeGatewayTool } from "../mcpgateway/services/execution.js";
 import { GATEWAY_KEY_PREFIX, parseGatewayCatalogSource } from "../mcpgateway/key-format.js";
@@ -1385,6 +1385,116 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       resp = { type: "close_screen", finalMessage: finalText };
       res.json(resp);
       void replaceFlowCardWithText(messageId, skillAgentSlug, finalText, conversationId, undefined, skillSpacesAppId);
+      return;
+    }
+
+    // ── Agent card ────────────────────────────────────────────────────────────
+    // The single dispatch site for the `agent` artifact. Today it decides a DRAFT
+    // (variant "draft"): the requester approves or declines the agent an agent
+    // drafted for them. New variants (a live agent's editor, …) add an actionId
+    // here — the envelope, the authz shape and the in-place card update stay put.
+    //
+    // The card carries only the requestId; the spec lives in its AgentRequest row
+    // (resolveAgentDraft re-reads it), so what the user approved is what gets
+    // created. The only thing taken from the client is the capability selection,
+    // and that can only narrow the grant.
+    if (actionType === "agent-card") {
+      const requestId = data["requestId"] as string | undefined;
+      const cardUserId = data["userId"] as string | undefined;
+      const cardAgentSlug = data["agentSlug"] as string | undefined;
+      const cardSpacesAppId = data["spacesAppId"] as string | undefined;
+      const cardChannelId = data["channelId"] as string | undefined;
+      const cardConversationId = (data["conversationId"] as string | undefined) ?? conversationId;
+
+      if (!requestId || !cardUserId) {
+        res.status(400).json({ type: "error", message: "Missing agent-card fields in flowJSON.data" } satisfies AppActionResponse);
+        return;
+      }
+      // Fail closed: a missing callerUserId must never skip the check.
+      if (!callerUserId || callerUserId !== cardUserId) {
+        log.error(`[flow-action] agent-card: unauthorized — caller ${callerUserId ?? "(none)"} != expected ${cardUserId}`);
+        res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
+        return;
+      }
+      if (actionId !== "agent-draft-approve" && actionId !== "agent-draft-decline") {
+        res.status(400).json({ type: "error", message: `Unknown agent-card action: ${actionId}` } satisfies AppActionResponse);
+        return;
+      }
+
+      const decision = actionId === "agent-draft-approve" ? "approve" : "reject";
+      // The chips the user kept, from the node's own flow-state key.
+      const keptCapabilityIds = Array.isArray(values[AGENT_COMPONENT_ID])
+        ? (values[AGENT_COMPONENT_ID] as unknown[]).filter((v): v is string => typeof v === "string")
+        : undefined;
+
+      const { resolveAgentDraft } = await import("../lib/agent-card.js");
+      const result = await resolveAgentDraft(
+        requestId,
+        callerUserId,
+        decision,
+        keptCapabilityIds,
+        cardAgentSlug,
+      );
+
+      if (!result.ok) {
+        resp = { type: "close_screen", finalMessage: result.error };
+        res.json(resp);
+        void replaceFlowCardWithText(messageId, cardAgentSlug, `⚠️ ${result.error}`, cardConversationId, cardChannelId, cardSpacesAppId);
+        return;
+      }
+
+      // Stamp the audit ONLY for a decision made right now. On a replay (the
+      // other tab already decided it, or the draft was superseded) this click
+      // decided nothing, and stamping it would write a false "Created by X ·
+      // just now" over a decision someone else made earlier.
+      const decidedNow = !result.alreadyResolved;
+      const deciderName = decidedNow
+        ? await prisma.user
+            .findUnique({ where: { id: callerUserId }, select: { name: true } })
+            .then((u) => u?.name?.trim() ?? "")
+            .catch(() => "")
+        : "";
+      const phase = result.status === "approved" ? "created" : "rejected";
+      const finalText =
+        result.status === "approved"
+          ? result.alreadyResolved
+            ? `✅ Agent "${result.identity.name}" was already created.`
+            : `✅ Agent "${result.identity.name}" created.`
+          : result.alreadyResolved
+            ? "❌ This draft was already declined."
+            : "❌ Agent draft declined.";
+
+      resp = { type: "close_screen", finalMessage: finalText };
+      res.json(resp);
+      // Update the SAME card in place — the identity stays visible, the chip and
+      // footer flip to the decided state. Falls back to text if the card can't
+      // be rebuilt, so the buttons never survive a decision either way.
+      void replaceFlowCardWithFlow(
+        messageId,
+        cardAgentSlug,
+        buildAgentCardFlow(
+          {
+            variant: "draft",
+            phase,
+            agent: result.identity,
+            ...(result.note ? { note: result.note } : {}),
+            ...(deciderName ? { decidedBy: deciderName } : {}),
+            ...(decidedNow ? { decidedById: callerUserId } : {}),
+            ...(decidedNow ? { decidedAt: new Date().toISOString() } : {}),
+          },
+          {
+            requestId,
+            agentSlug: cardAgentSlug ?? "",
+            userId: cardUserId,
+            ...(cardConversationId ? { conversationId: cardConversationId } : {}),
+            ...(cardChannelId ? { channelId: cardChannelId } : {}),
+          },
+        ),
+        cardConversationId,
+        cardChannelId,
+        cardSpacesAppId,
+      );
+      log.info(`[flow-action] agent-card ${decision} request=${requestId} by=${callerUserId} phase=${phase}`);
       return;
     }
 

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -20,7 +20,18 @@ import {
   chatMessageRepository,
   agentChainWorkflowRepository,
   activeGoalRepository,
+  agentRequestRepository,
 } from "../repositories/index.js";
+import { buildAvailableToolsCatalog } from "./tools.js";
+import {
+  identityFromAgentRow,
+  identityFromDraftSpec,
+  isValidAgentSlug,
+  resolveAgentCapabilities,
+  toolIdsFromConfig,
+  unknownToolsNote,
+  type DraftAgentSpec,
+} from "../lib/agent-card.js";
 import { getValidClaudeBearer } from "../lib/claude-oauth-refresh.js";
 import { getValidCodexBearer } from "../lib/codex-oauth-refresh.js";
 import { resolveAgentProviderConfigs, resolveSubagentProviderMode, KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget } from "../lib/agent-provider-config.js";
@@ -88,7 +99,7 @@ import {
 } from "../lib/session-context.js";
 import { emitAgentWorkingSignal } from "../surfaces/spaces/client.js";
 import JSZip from "jszip";
-import { buildWriteApprovalFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, buildPrFlow, prScreenId, isTwinDelivery, type PrProvider, type PrStatus } from "xyne-claw-shared";
+import { buildWriteApprovalFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, buildAgentCardFlow, hashSkillContent, buildPrFlow, prScreenId, isTwinDelivery, type PrProvider, type PrStatus } from "xyne-claw-shared";
 import type { TwinDelivery } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 
@@ -3229,6 +3240,13 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // Turn 1 finishes. Renders the plan card in the thread (proposed → Approve
     // gate, or trivial → auto-execute Turn 2). Wire contract, never for twin.
     pendingPlan?: { title: string; desc?: string; document?: string; todos: Array<{ id: string; title: string }>; trivial: boolean };
+    // Agent authoring: set by claw's propose-agent terminal tool. Renders the
+    // `agent` artifact card (variant "draft", phase "pending") and awaits the
+    // user's approval — nothing is created until they approve. A union because
+    // the same card serves other agent surfaces (a read-only profile next).
+    pendingAgentCard?:
+      | { variant: "draft"; agent: DraftAgentSpec }
+      | { variant: "profile"; slug?: string };
   };
 
   const sessionId = payload.sessionId ?? "";
@@ -4268,8 +4286,248 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     return;
   }
 
-  // Notify user if result is empty (but not if copilot has pendingResponses)
-  if (!resultWithCitations.trim() && !payload.pendingResponses?.length) {
+  // ── Agent authoring: propose-agent drafted an agent ────────────────────────
+  // Handled HERE — before the empty-result notice below (propose-agent ships
+  // result: "" because the CARD is the deliverable) and before the normal
+  // text-posting path. Conversation mode only: a draft needs a human to approve
+  // it, and the twin flow has its own approval surface.
+  //
+  // Nothing is created here. The draft is persisted as an AgentRequest row and
+  // the card carries only its requestId, so the spec the user approves is the
+  // spec that gets created — it never round-trips through the browser.
+  const pendingAgentCard = payload.pendingAgentCard;
+  const agentCardDeliverable =
+    ctx.responseMode === "conversation" && !!ctx.agentSlug && !!ctx.agentOrgId;
+  if (pendingAgentCard && !agentCardDeliverable) {
+    // The card can't be posted without a thread and an org. Falling through
+    // lands on the empty-result notice ("Sorry…"), which is honest but says
+    // nothing about why — log the real reason so this is one grep away instead
+    // of a mystery.
+    log.warn(
+      `[agent-card] dropping ${pendingAgentCard.variant} card — responseMode=${ctx.responseMode} agentSlug=${ctx.agentSlug ?? "(none)"} orgId=${ctx.agentOrgId ?? "(none)"}`,
+    );
+  }
+
+  // ── Capability card: the agent describing itself ───────────────────────────
+  // Emitted by describe-agent ("what can you do?"). Unlike the draft, this does
+  // NOT short-circuit: the card accompanies the reply, so we post it and let the
+  // normal text path run. `postedAgentProfileCard` then stops the empty-result
+  // notice from firing when the card WAS the whole answer.
+  //
+  // Authority: the identity is read from the target agent's own row. The pod
+  // only names a slug — nothing the model wrote reaches this card, so an agent
+  // cannot advertise a capability it was never granted.
+  let postedAgentProfileCard = false;
+  if (pendingAgentCard?.variant === "profile" && agentCardDeliverable && ctx.agentOrgId) {
+    try {
+      const targetSlug = pendingAgentCard.slug?.trim() || ctx.agentSlug!;
+      const row = await agentRepository.findBySlug(targetSlug, ctx.agentOrgId);
+      if (!row) {
+        log.info(`[agent-card] profile card skipped — no agent "${targetSlug}" in org ${ctx.agentOrgId}`);
+      } else {
+        const catalog = await buildAvailableToolsCatalog(undefined, ctx.agentOrgId);
+        const resolved = await resolveAgentCapabilities(
+          toolIdsFromConfig(row.config),
+          catalog,
+          ctx.senderId,
+        );
+        const flow = withSpacesAppId(
+          buildAgentCardFlow(
+            { variant: "profile", agent: identityFromAgentRow(row, resolved) },
+            {
+              agentSlug: ctx.agentSlug!,
+              targetSlug,
+              userId: ctx.senderId,
+              conversationId: ctx.conversationId,
+              channelId: ctx.channelId,
+            },
+          ),
+          ctx.spacesAppId,
+        );
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow,
+          userId: ctx.spacesAppUserId,
+        }, ctx.appToken);
+        postedAgentProfileCard = true;
+        log.info(`[agent-card] posted profile card for ${targetSlug} conv=${ctx.conversationId}`);
+      }
+    } catch (err) {
+      // Non-fatal: the reply itself still posts below.
+      log.warn("Failed to post agent profile card (non-fatal)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  if (
+    pendingAgentCard?.variant === "draft" &&
+    ctx.responseMode === "conversation" &&
+    ctx.agentSlug &&
+    ctx.agentOrgId
+  ) {
+    const token = ctx.appToken;
+    const spec = pendingAgentCard.agent;
+    try {
+      const orgId = ctx.agentOrgId;
+      const requesterId = ctx.senderId;
+
+      // Fail loudly on the card rather than silently creating a mis-slugged
+      // agent: the pod normalizes, so an invalid slug here means drift.
+      if (!isValidAgentSlug(spec.slug)) {
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          markdownText: `⚠️ I drafted an agent but \`${spec.slug}\` isn't a usable identifier. Ask me again with a simple name like "ticket triage".`,
+          userId: ctx.spacesAppUserId,
+          metadata: { contentFormat: "markdown" },
+        }, token);
+        log.warn(`[agent-card] rejected draft with invalid slug "${spec.slug}" conv=${ctx.conversationId}`);
+        await deleteSession(sessionId).catch(() => {});
+        return;
+      }
+
+      // Duplicate slug: catch it NOW, while the agent can still be re-asked,
+      // instead of at approval time when the user has already committed.
+      const existing = await agentRepository.findBySlug(spec.slug, orgId);
+      if (existing) {
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          markdownText: `⚠️ An agent called **${existing.name}** (\`${spec.slug}\`) already exists here, so I didn't create a draft. Ask me again with a different name, or edit the existing agent.`,
+          userId: ctx.spacesAppUserId,
+          metadata: { contentFormat: "markdown" },
+        }, token);
+        log.info(`[agent-card] draft dropped — slug ${spec.slug} already exists in org ${orgId}`);
+        await deleteSession(sessionId).catch(() => {});
+        return;
+      }
+
+      // Resolve the requested tools against THIS org's catalog. Unmatched
+      // tokens are reported on the card and never persisted.
+      const catalog = await buildAvailableToolsCatalog(undefined, orgId);
+      const resolved = await resolveAgentCapabilities(spec.tools ?? [], catalog, requesterId);
+      const note = unknownToolsNote(resolved.unknown);
+      if (resolved.unknown.length > 0) {
+        log.info(`[agent-card] draft ${spec.slug}: unmatched tools [${resolved.unknown.join(", ")}]`);
+      }
+
+      // The draft itself lives server-side. proposedContent is what the approve
+      // path re-reads and creates — the card is display only.
+      const proposedContent = JSON.stringify(spec);
+      const outcome = await agentRequestRepository.supersedeAndCreateAgentCreate({
+        agentSlug: spec.slug,
+        requesterId,
+        orgId,
+        proposedContent,
+        proposedContentHash: hashSkillContent(proposedContent),
+      });
+      if (outcome.supersededCount > 0) {
+        log.info(`[agent-card] superseded ${outcome.supersededCount} stale draft(s) for ${spec.slug} by ${requesterId}`);
+      }
+
+      // A lead-in line so the card isn't dropped into the thread wordlessly. The
+      // agent's own `summary` (why it made these calls) when it wrote one;
+      // otherwise a neutral line — never a restatement of the card, which would
+      // just be the same content twice.
+      const leadIn =
+        spec.summary?.trim() ||
+        `I've drafted an agent for this — have a look and approve it below if it's right.`;
+      try {
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          markdownText: leadIn,
+          userId: ctx.spacesAppUserId,
+          metadata: { contentFormat: "markdown" },
+        }, token);
+      } catch (e) {
+        // Non-fatal: the card is the deliverable and still posts below.
+        log.warn("Failed to post agent-draft lead-in (non-fatal)", {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+
+      const identity = identityFromDraftSpec(spec, resolved, ctx.agentSlug);
+      const flow = withSpacesAppId(
+        buildAgentCardFlow(
+          {
+            variant: "draft",
+            phase: "pending",
+            agent: identity,
+            ...(note ? { note } : {}),
+          },
+          {
+            requestId: outcome.request.id,
+            agentSlug: ctx.agentSlug,
+            userId: requesterId,
+            conversationId: ctx.conversationId,
+            channelId: ctx.channelId,
+          },
+        ),
+        ctx.spacesAppId,
+      );
+
+      await spacesAppFetch("/chat/postMessage", {
+        channelId: ctx.channelId,
+        conversationId: ctx.conversationId,
+        flow,
+        userId: ctx.spacesAppUserId,
+      }, token);
+      log.info(`[agent-card] posted draft card slug=${spec.slug} request=${outcome.request.id} conv=${ctx.conversationId}`);
+
+      // Persist an assistant transcript row: the interactive card exists only in
+      // Spaces, so without this the claw chat shows nothing for this turn and the
+      // next user message groups as a sibling branch. Same reasoning as the plan
+      // card's transcript row above.
+      try {
+        const capabilityLine = identity.capabilities?.length
+          ? `\n\n**Capabilities:** ${identity.capabilities.map((c) => c.label).join(", ")}`
+          : "";
+        const parentId = await chatMessageRepository
+          .latestMessageId(ctx.conversationId, ctx.agentSlug)
+          .catch(() => null);
+        await chatMessageRepository.create({
+          conversationId: ctx.conversationId,
+          agentSlug: ctx.agentSlug,
+          userId: runOwnerId,
+          orgId,
+          ...(parentId ? { parentId } : {}),
+          role: "assistant",
+          content: `**🤖 Drafted an agent — ${identity.name}** (\`${identity.slug}\`)\n\n${identity.description ?? ""}${capabilityLine}\n\n_Approve the card to create it._`,
+          status: "completed",
+          ...(payload.reasoning ? { reasoning: payload.reasoning } : {}),
+        });
+      } catch (e) {
+        log.warn("Failed to persist agent-draft assistant transcript row (non-fatal)", {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    } catch (err) {
+      log.error("Failed to post agent draft card", {
+        error: err instanceof Error ? err.message : String(err),
+        slug: spec.slug,
+      });
+      try {
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          markdownText: "⚠️ I drafted the agent but couldn't post it for approval. Please try again.",
+          userId: ctx.spacesAppUserId,
+          metadata: { contentFormat: "markdown" },
+        }, token);
+      } catch {
+        // The user already lost this turn; don't compound it with a throw.
+      }
+    }
+    await deleteSession(sessionId).catch(() => {});
+    return;
+  }
+
+  // Notify user if result is empty (but not if copilot has pendingResponses, and
+  // not when a capability card was just posted — there the card IS the answer
+  // and an apology under it would be nonsense).
+  if (!resultWithCitations.trim() && !payload.pendingResponses?.length && !postedAgentProfileCard) {
     if (ctx.responseMode === "approval") {
       log.warn("Empty result in approval mode — skipping (no thread message)");
       await deleteSession(sessionId);

--- a/apps/xyne-claw/src/describe-agent.ts
+++ b/apps/xyne-claw/src/describe-agent.ts
@@ -1,0 +1,94 @@
+/**
+ * describe-agent — the tool behind "what can you do?" / "tell me about yourself".
+ *
+ * Available to EVERY agent, on every interactive run, with no config: being able
+ * to say what you are is table stakes, not a feature to switch on. The agent
+ * calls it and claw-auth posts the `agent` artifact (variant "profile") — a
+ * capability card built from the agent's OWN row.
+ *
+ * Deliberately NOT terminal (unlike propose-plan / propose-agent): the card is an
+ * attachment to the reply, not the whole reply. "What can you do, and can you
+ * help me with X?" should get the card AND the answer to X, so the tool records
+ * and returns, letting the turn continue.
+ *
+ * The tool takes no content — only, optionally, which agent to describe. The
+ * agent names a target; the SERVER describes it. Nothing the model writes here
+ * reaches the card, so it cannot advertise a tool it wasn't granted.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { PendingAgentCard } from "./propose-agent.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("describe-agent");
+
+export const DESCRIBE_AGENT_TOOL_NAME = "describe-agent";
+
+/** Shared ref the tool writes into; read back by run.ts. */
+export interface DescribeAgentRef {
+  value?: Extract<PendingAgentCard, { variant: "profile" }>;
+  /** Repeat calls after the first — telemetry only, the first target stands. */
+  duplicates?: number;
+}
+
+export function buildDescribeAgentTool(ref: DescribeAgentRef): ToolDefinition {
+  return {
+    name: DESCRIBE_AGENT_TOOL_NAME,
+    label: "Describe Agent",
+    description: [
+      "Show a capability card for an agent — use this whenever someone asks what you",
+      "are, what you can do, what tools or integrations you have, or to introduce",
+      "yourself. Call it INSTEAD of listing your tools in prose: the card is built from",
+      "your actual configuration, so it is always accurate, while a written list drifts.",
+      "",
+      "Omit `slug` to describe YOURSELF (the usual case). Pass a slug only when the user",
+      "asked about a DIFFERENT agent by name.",
+      "",
+      "This does not end your turn — if the user asked something else as well, answer it",
+      "normally in the same reply. Do not also describe your tools in text; the card",
+      "covers that. Call it at most once per reply.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        slug: {
+          type: "string",
+          description:
+            "Optional. The agent to describe, e.g. 'ticket-triage'. Omit to describe yourself.",
+        },
+      },
+      required: [],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      if (ref.value !== undefined) {
+        ref.duplicates = (ref.duplicates ?? 0) + 1;
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "A capability card is already queued for this reply — it will be shown to the user. Do not call describe-agent again; continue with the rest of your answer.",
+            },
+          ],
+          details: { duplicate: true },
+        };
+      }
+
+      const p = (params as Record<string, unknown> | undefined) ?? {};
+      const slug = typeof p["slug"] === "string" ? p["slug"].trim().slice(0, 80) : "";
+      ref.value = { variant: "profile", ...(slug ? { slug } : {}) };
+      log.info(`[describe-agent] queued profile card for ${slug || "self"}`);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `A capability card for ${slug || "you"} will be shown to the user with your reply. It lists the tools and integrations from the real configuration — do NOT repeat that list in your text. Keep any remaining answer brief, or say nothing more if the card is the whole answer.`,
+          },
+        ],
+        details: { slug: slug || "self" },
+      };
+    },
+  };
+}

--- a/apps/xyne-claw/src/propose-agent.ts
+++ b/apps/xyne-claw/src/propose-agent.ts
@@ -1,0 +1,266 @@
+/**
+ * propose-agent — the terminal tool for AGENT AUTHORING (agent.config.agentAuthoring).
+ *
+ * An agent asked to "build me an agent" investigates (list_available_tools /
+ * list_agents), then calls propose-agent exactly ONCE with the full draft, which:
+ *   1. captures the spec into a closure ref (read back by run.ts), and
+ *   2. HARD-STOPS the turn via abortRun — nothing is created yet, so there is
+ *      nothing further to say and the model must not narrate a created agent.
+ *
+ * run.ts recovers ref.value in its catch block (the abort lands there) and puts
+ * it on the /webhook/result callback as `pendingAgentCard`. claw-auth validates
+ * the requested tools against the org catalog, persists the draft as an
+ * AgentRequest row, and posts the `agent` artifact card (variant "draft", phase
+ * "pending"). The agent is created only when the user approves that card.
+ *
+ * Structurally identical to propose-plan.ts (ref + idempotency + abortRun) —
+ * that pattern is the repo's established "agent authors an artifact, human
+ * decides" shape, and reusing it keeps the abort/recovery wiring in one style.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("propose-agent");
+
+export const PROPOSE_AGENT_TOOL_NAME = "propose-agent";
+const MAX_NAME = 80;
+const MAX_SLUG = 80;
+const MAX_DESC = 300;
+/** The pod's cap. claw-auth persists this verbatim; the card truncates for display. */
+const MAX_SYSTEM_PROMPT = 20000;
+const MAX_TOOLS = 40;
+const MIN_SYSTEM_PROMPT = 40;
+/** One or two sentences — this is a chat line, not a second description. */
+const MAX_SUMMARY = 400;
+
+/** The drafted agent — read back by run.ts and shipped as `pendingAgentCard`. */
+export interface ProposedAgentSpec {
+  name: string;
+  /** Kebab-case; derived from `name` when the model omits it. */
+  slug: string;
+  description: string;
+  systemPrompt: string;
+  modelId?: string;
+  color?: string;
+  /** Flat tool slugs / subagent names. claw-auth resolves these against the org
+   *  catalog and reports back anything it could not match — the pod deliberately
+   *  does NOT guess, because only claw-auth knows what this org has. */
+  tools: string[];
+  /** One line the agent says in the thread alongside the card. The card can only
+   *  show WHAT was drafted; this is where the agent says why it made the calls it
+   *  did. Optional — claw-auth falls back to a neutral line. */
+  summary?: string;
+}
+
+/**
+ * The run-result payload for the `agent` artifact.
+ *
+ * A union so every agent surface travels on ONE transport: the draft carries the
+ * proposed spec, the profile carries only a slug — claw-auth reads that agent's
+ * real row and describes it, because an agent must not be able to narrate
+ * capabilities it doesn't have onto an official-looking card.
+ */
+export type PendingAgentCard =
+  | { variant: "draft"; agent: ProposedAgentSpec }
+  | { variant: "profile"; slug?: string };
+
+/** Shared ref the tool writes the accepted draft into (mirrors ProposePlanRef). */
+export interface ProposeAgentRef {
+  /** Narrowed to the draft member — this ref never holds a profile card. */
+  value?: Extract<PendingAgentCard, { variant: "draft" }>;
+  /** How many duplicate calls arrived after the first accepted draft. */
+  duplicates?: number;
+  /** How many times the tool rejected a call — telemetry / fail-open backstop. */
+  rejections?: number;
+}
+
+/** Kebab-case slug, matching the validator claw-auth applies before persisting. */
+export function normalizeAgentSlug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG);
+}
+
+export function buildProposeAgentTool(
+  ref: ProposeAgentRef,
+  abortRun?: () => void,
+): ToolDefinition {
+  return {
+    name: PROPOSE_AGENT_TOOL_NAME,
+    label: "Propose Agent",
+    description: [
+      "Draft a NEW agent and STOP. Calling this ENDS your turn immediately — the user",
+      "gets an agent card showing exactly what you drafted, and the agent is created",
+      "ONLY if they approve it. Nothing is saved by this call.",
+      "",
+      "BEFORE calling: run `list_available_tools` (and `list_agents` if you need to see",
+      "what already exists). `tools` must contain EXACT identifiers from that catalog —",
+      "subagent names or custom tool slugs, one per entry, no prose. Anything that does",
+      "not match is dropped and reported on the card, so guessing costs the user a tool.",
+      "",
+      "Write `systemPrompt` as the agent's real operating instructions, in the second",
+      "person ('You are …', 'When asked to …'): its role, what it should do step by step,",
+      "which tools to reach for and when, the output format it should produce, and what it",
+      "must NOT do. A one-line prompt makes a useless agent — be specific and concrete.",
+      "",
+      "`description` is the single line shown in the agent picker — what it does, not how.",
+      "",
+      "ALSO write `summary`: one or two sentences you say to the user next to the card,",
+      "explaining what you built and WHY you made the key calls — which tools you granted",
+      "and anything you deliberately left out. The card already lists the name, description",
+      "and tools, so do NOT restate them; this is your reasoning, in your own voice.",
+      "",
+      "Call this exactly ONCE, and do not call any other tool after it.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        name: {
+          type: "string",
+          description: "Human-readable agent title, e.g. 'Ticket Triage'.",
+        },
+        slug: {
+          type: "string",
+          description:
+            "Optional kebab-case identifier, e.g. 'ticket-triage'. Derived from `name` when omitted.",
+        },
+        description: {
+          type: "string",
+          description: "One line shown in the agent picker — what this agent does.",
+        },
+        systemPrompt: {
+          type: "string",
+          description:
+            "The agent's full operating instructions (role, procedure, tool usage, output format, limits). Second person.",
+        },
+        modelId: {
+          type: "string",
+          description:
+            "Optional model id. Omit unless the user asked for a specific model — the org default is used otherwise.",
+        },
+        color: {
+          type: "string",
+          description: "Optional hex tint for the agent avatar, e.g. '#6366f1'.",
+        },
+        tools: {
+          type: "array",
+          description:
+            "Exact tool slugs / subagent names from list_available_tools. Grant only what the agent's job needs.",
+          items: { type: "string" },
+        },
+        summary: {
+          type: "string",
+          description:
+            "One or two sentences you say in the thread next to the card — what you built and WHY you made the key calls (which tools you granted and what you left out). Do NOT restate the name, description or tool list: the card already shows those. Write it as yourself, to the user.",
+        },
+      },
+      required: ["name", "description", "systemPrompt"],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const reject = (text: string) => {
+        ref.rejections = (ref.rejections ?? 0) + 1;
+        return { content: [{ type: "text" as const, text }], details: { error: true } };
+      };
+
+      // Idempotency: the draft is proposed EXACTLY ONCE per turn. Repeat calls
+      // (some models re-emit after the abort) are a no-op — the first draft stands.
+      if (ref.value !== undefined) {
+        ref.duplicates = (ref.duplicates ?? 0) + 1;
+        log.info(`[propose-agent] duplicate call #${ref.duplicates} ignored — first draft stands`);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "You have ALREADY proposed this agent — that first call is final and is queued for the user's approval. Do NOT call propose-agent again. Stop here and produce no further output.",
+            },
+          ],
+          details: { duplicate: true },
+        };
+      }
+
+      const p = (params as Record<string, unknown> | undefined) ?? {};
+      const name = typeof p["name"] === "string" ? p["name"].trim().slice(0, MAX_NAME) : "";
+      if (!name) {
+        return reject("Rejected: `name` is required. Call propose-agent again with the agent's title.");
+      }
+
+      const description =
+        typeof p["description"] === "string" ? p["description"].trim().slice(0, MAX_DESC) : "";
+      if (!description) {
+        return reject(
+          "Rejected: `description` is required — one line describing what this agent does, shown in the agent picker.",
+        );
+      }
+
+      const systemPrompt =
+        typeof p["systemPrompt"] === "string" ? p["systemPrompt"].trim().slice(0, MAX_SYSTEM_PROMPT) : "";
+      if (systemPrompt.length < MIN_SYSTEM_PROMPT) {
+        return reject(
+          `Rejected: \`systemPrompt\` is too short (${systemPrompt.length} chars). Write the agent's real operating instructions — role, procedure, which tools to use when, output format, and limits — then call propose-agent again.`,
+        );
+      }
+
+      const slug = normalizeAgentSlug(
+        typeof p["slug"] === "string" && p["slug"].trim() ? p["slug"] : name,
+      );
+      if (!slug) {
+        return reject(
+          "Rejected: could not derive a slug from `name`. Provide `slug` explicitly as lowercase words separated by hyphens.",
+        );
+      }
+
+      // Tools are passed through as-authored: claw-auth owns the org catalog and
+      // reports unmatched entries on the card. Only shape is enforced here.
+      const tools = (Array.isArray(p["tools"]) ? (p["tools"] as unknown[]) : [])
+        .filter((t): t is string => typeof t === "string" && t.trim().length > 0)
+        .map((t) => t.trim())
+        .filter((t, i, arr) => arr.indexOf(t) === i)
+        .slice(0, MAX_TOOLS);
+
+      const modelId = typeof p["modelId"] === "string" ? p["modelId"].trim().slice(0, 120) : "";
+      const color = typeof p["color"] === "string" ? p["color"].trim().slice(0, 32) : "";
+      const summary = typeof p["summary"] === "string" ? p["summary"].trim().slice(0, MAX_SUMMARY) : "";
+
+      ref.value = {
+        variant: "draft",
+        agent: {
+          name,
+          slug,
+          description,
+          systemPrompt,
+          tools,
+          ...(modelId ? { modelId } : {}),
+          ...(color ? { color } : {}),
+          ...(summary ? { summary } : {}),
+        },
+      };
+      log.info(
+        `[propose-agent] accepted name="${name}" slug=${slug} promptLen=${systemPrompt.length} tools=${tools.length}`,
+      );
+
+      // Hard-stop the turn — nothing exists yet and nothing further can be done
+      // until the user approves. Wired by run.ts to AbortController.abort().
+      try {
+        abortRun?.();
+      } catch {
+        // Never let an abort-wiring bug poison the draft path.
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "STOP — the agent draft was sent to the user for approval. Do NOT continue, do NOT call any more tools, and do NOT tell the user the agent exists: it is created only if they approve the card.",
+          },
+        ],
+        details: { slug, tools: tools.length },
+      };
+    },
+  };
+}

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -106,6 +106,8 @@ import { buildMemoryWriteTool } from "../memory-write.js";
 import { buildMemoryFileTools } from "../memory-file-tools.js";
 import { buildTwinDeliverTool, buildTwinDeliverMandate, type TwinDeliverRef } from "../twin-deliver.js";
 import { buildProposePlanTool, PROPOSE_PLAN_TOOL_NAME, type ProposePlanRef } from "../propose-plan.js";
+import { buildProposeAgentTool, type ProposeAgentRef } from "../propose-agent.js";
+import { buildDescribeAgentTool, type DescribeAgentRef } from "../describe-agent.js";
 import { buildEmitBriefTool, EMIT_BRIEF_TOOL_NAME, type EmitBriefRef } from "../daily-brief.js";
 import {
   buildSuggestGoalTool,
@@ -1453,6 +1455,14 @@ async function processTask(
   // — never the success path — and the plan is read from ref.value there and
   // shipped as `pendingPlan` on the callback.
   const proposePlanRef: ProposePlanRef = {};
+  // Hoisted for the same reason: propose-agent (agent-authoring's terminal tool)
+  // fires abortRun, so the drafted agent is recovered from ref.value in the catch
+  // block and shipped as `pendingAgentCard` on the callback.
+  const proposeAgentRef: ProposeAgentRef = {};
+  // describe-agent is NOT terminal, so this is read on the success path; hoisted
+  // alongside the others so the catch handler can still ship a queued card when
+  // the turn ends some other way.
+  const describeAgentRef: DescribeAgentRef = {};
   // Hoisted for the same reason: emit_brief (daily-brief mode's terminal tool)
   // fires abortRun, so the brief is recovered from ref.value in the catch block
   // and shipped as `dailyBrief` on the callback.
@@ -2492,6 +2502,42 @@ async function processTask(
     if (isDailyBrief) {
       allTools.push(buildEmitBriefTool(emitBriefRef, abortRun));
       log("Daily brief mode — injected terminal emit_brief tool");
+    }
+
+    // Agent authoring (agent.config.agentAuthoring): inject the terminal
+    // propose-agent tool so this agent can DRAFT another agent. Gated on the same
+    // interactive-surface conditions as the plan tools — a draft is worthless
+    // without a human to approve its card, so a scheduled/automation run (no one
+    // watching) must never get the tool. Never alongside the other terminal tools
+    // (plan / daily brief own turn termination in their modes).
+    const agentAuthoringEnabled =
+      agentConfig?.["agentAuthoring"] === true &&
+      (!!channelId || (progressUrl && typeof progressUrl !== "string")) &&
+      !isScheduledOrAutomationRun(eventType, conversationId) &&
+      !isTwinMentionFlow &&
+      !isPlanMode &&
+      !isDailyBrief;
+    if (agentAuthoringEnabled) {
+      allTools.push(buildProposeAgentTool(proposeAgentRef, abortRun));
+      log("Agent authoring enabled — injected terminal propose-agent tool");
+    }
+
+    // describe-agent: EVERY agent gets this, no config. "What can you do?" is a
+    // question any agent should answer from its real configuration rather than
+    // from prose the model invents. Gated only on there being somewhere to post
+    // the card — a scheduled/automation run has no one to show it to.
+    //
+    // Deliberately NOT excluded in plan mode: the tool writes nothing (plan
+    // mode's read-only filter passes it through untouched), and an agent
+    // configured to plan first should still be able to say what it is. Twin is
+    // excluded because that flow delivers through its own approval surface.
+    const describeAgentAvailable =
+      (!!channelId || (progressUrl && typeof progressUrl !== "string")) &&
+      !isScheduledOrAutomationRun(eventType, conversationId) &&
+      !isTwinMentionFlow &&
+      !isDailyBrief;
+    if (describeAgentAvailable) {
+      allTools.push(buildDescribeAgentTool(describeAgentRef));
     }
 
     // Inject copilot respond-to-user tool if provider is copilot.
@@ -3765,6 +3811,11 @@ async function processTask(
         `[daily-brief] emit_brief was called but the run reached the SUCCESS path (abortRun did not terminate the loop) — shipping the brief anyway; investigate abort wiring. session=${sessionId}`,
       );
     }
+    if (proposeAgentRef.value) {
+      logErr(
+        `[agent-authoring] propose-agent was called but the run reached the SUCCESS path (abortRun did not terminate the loop) — shipping the draft anyway; investigate abort wiring. session=${sessionId}`,
+      );
+    }
 
     clog.info(
       `[follow-ups] callback sessionId=${sessionId} pendingQuestions=${pendingQuestions.length} followUpCount=${pendingQuestions.find((question) => question.purpose === "follow_up_suggestions")?.options.length ?? 0}`,
@@ -3812,6 +3863,15 @@ async function processTask(
       // claw-auth's /webhook/result posts the plan card and (if trivial)
       // auto-continues into the auto-mode execution turn.
       ...(proposePlanRef.value ? { pendingPlan: proposePlanRef.value } : {}),
+      // Agent authoring: propose-agent normally aborts (→ catch branch below),
+      // but if the run finished cleanly with a draft proposed, carry it here too.
+      // claw-auth validates it, persists the AgentRequest and posts the agent card.
+      // A draft (terminal, normally recovered in the catch) wins over a profile
+      // card if a turn somehow produced both — the decision surface matters more
+      // than the description.
+      ...(proposeAgentRef.value || describeAgentRef.value
+        ? { pendingAgentCard: proposeAgentRef.value ?? describeAgentRef.value }
+        : {}),
       // Daily brief: emit_brief normally aborts (→ catch branch below), but if the
       // run finished cleanly with a brief emitted, carry it here too. claw-auth
       // persists it to GeneratedContent and (on the SSE regenerate path) forwards
@@ -3970,6 +4030,9 @@ async function processTask(
           ? { automationResult: automationResultAtError }
           : {}),
         pendingResponses: pendingResponsesAtError,
+        // A queued capability card must survive the copilot terminal path too,
+        // or "what can you do?" silently loses its card on those agents.
+        ...(describeAgentRef.value ? { pendingAgentCard: describeAgentRef.value } : {}),
         ...(pendingGoalSuggestion ? { pendingGoalSuggestion } : {}),
         ...(dedupedPendingActionsAtError.length > 0 ? { pendingActions: dedupedPendingActionsAtError } : {}),
         ...(attachmentsAtError.length > 0 ? { attachments: attachmentsAtError } : {}),
@@ -4004,6 +4067,36 @@ async function processTask(
         status: "completed",
         result: "",
         pendingPlan: proposePlanRef.value,
+        ...(err instanceof RunCancelledError && err.toolsUsed.length > 0 ? { toolsUsed: err.toolsUsed } : {}),
+        ...(err instanceof RunCancelledError && err.toolInvocations.length > 0 ? { toolInvocations: err.toolInvocations } : {}),
+        ...(err instanceof RunCancelledError ? { tokenUsage: err.tokenUsage } : {}),
+        provider: callbackProvider,
+        model: callbackModel,
+      });
+    } else if (
+      proposeAgentRef.value &&
+      !isUserCancel &&
+      (err instanceof RunCancelledError || abortSignal?.aborted)
+    ) {
+      // Agent authoring: propose-agent fired abortRun to end the turn, so the run
+      // lands HERE (RunCancelledError), not the success path — the SAME pattern as
+      // propose-plan above. This is a normal, successful draft, NOT a cancellation:
+      // emit status="completed" carrying it. claw-auth validates the requested
+      // tools, persists the draft as an AgentRequest and posts the agent card. The
+      // card is the deliverable, so there is no chat text on this turn — and the
+      // agent must not narrate a creation that has not been approved yet.
+      log(
+        `Session terminated by propose-agent (slug=${proposeAgentRef.value.agent.slug}, ${proposeAgentRef.value.agent.tools.length} tool(s)): ${sessionId}`,
+      );
+      await sendCallback(callbackUrl, sessionToken, {
+        sessionId,
+        userId,
+        conversationId: conversationId ?? null,
+        agentSlug: agentSlug ?? null,
+        fastMode: fastModeForCallback,
+        status: "completed",
+        result: "",
+        pendingAgentCard: proposeAgentRef.value,
         ...(err instanceof RunCancelledError && err.toolsUsed.length > 0 ? { toolsUsed: err.toolsUsed } : {}),
         ...(err instanceof RunCancelledError && err.toolInvocations.length > 0 ? { toolInvocations: err.toolInvocations } : {}),
         ...(err instanceof RunCancelledError ? { tokenUsage: err.tokenUsage } : {}),

--- a/apps/xyne-claw/test/describe-agent.test.ts
+++ b/apps/xyne-claw/test/describe-agent.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "vitest";
+import {
+  buildDescribeAgentTool,
+  DESCRIBE_AGENT_TOOL_NAME,
+  type DescribeAgentRef,
+} from "../src/describe-agent.js";
+
+async function callTool(ref: DescribeAgentRef, params: unknown) {
+  const tool = buildDescribeAgentTool(ref);
+  expect(tool.name).toBe(DESCRIBE_AGENT_TOOL_NAME);
+  return (
+    tool as unknown as {
+      execute: (
+        id: string,
+        p: unknown,
+      ) => Promise<{ content: { text: string }[]; details?: Record<string, unknown> }>;
+    }
+  ).execute("tc-1", params);
+}
+
+test("queues a self-description when no slug is given", async () => {
+  const ref: DescribeAgentRef = {};
+  await callTool(ref, {});
+  expect(ref.value).toEqual({ variant: "profile" });
+});
+
+test("queues another agent when a slug is given", async () => {
+  const ref: DescribeAgentRef = {};
+  await callTool(ref, { slug: "  ticket-triage  " });
+  expect(ref.value).toEqual({ variant: "profile", slug: "ticket-triage" });
+});
+
+test("takes no content from the model — only a target", async () => {
+  // The card is built server-side from the agent's row. If the tool ever accepted
+  // a description or a tool list, an agent could advertise capabilities it does
+  // not have on an official-looking card.
+  const ref: DescribeAgentRef = {};
+  await callTool(ref, {
+    slug: "ticket-triage",
+    description: "I can do anything",
+    tools: ["admin-delete-everything"],
+  });
+  expect(ref.value).toEqual({ variant: "profile", slug: "ticket-triage" });
+});
+
+test("is idempotent — the first target stands", async () => {
+  const ref: DescribeAgentRef = {};
+  await callTool(ref, {});
+  const second = await callTool(ref, { slug: "someone-else" });
+  expect(ref.value).toEqual({ variant: "profile" });
+  expect(ref.duplicates).toBe(1);
+  expect(second.details?.["duplicate"]).toBe(true);
+});
+
+test("does not end the turn — the card accompanies the reply", async () => {
+  // No abortRun is even accepted: "what can you do, and also help me with X"
+  // must still get an answer to X.
+  const ref: DescribeAgentRef = {};
+  const res = await callTool(ref, {});
+  expect(res.content[0]!.text).toMatch(/do NOT repeat that list/i);
+  expect(buildDescribeAgentTool(ref).description).not.toMatch(/STOP/);
+});

--- a/apps/xyne-claw/test/propose-agent.test.ts
+++ b/apps/xyne-claw/test/propose-agent.test.ts
@@ -1,0 +1,133 @@
+import { test, expect, vi, describe } from "vitest";
+import {
+  buildProposeAgentTool,
+  normalizeAgentSlug,
+  type ProposeAgentRef,
+  PROPOSE_AGENT_TOOL_NAME,
+} from "../src/propose-agent.js";
+
+async function callTool(ref: ProposeAgentRef, abortRun: (() => void) | undefined, params: unknown) {
+  const tool = buildProposeAgentTool(ref, abortRun);
+  expect(tool.name).toBe(PROPOSE_AGENT_TOOL_NAME);
+  // Pi SDK tool shape: execute(toolCallId, params).
+  return (
+    tool as unknown as {
+      execute: (
+        id: string,
+        p: unknown,
+      ) => Promise<{ content: { text: string }[]; details?: Record<string, unknown> }>;
+    }
+  ).execute("tc-1", params);
+}
+
+const validDraft = {
+  name: "Ticket Triage",
+  description: "Triages incoming tickets",
+  systemPrompt:
+    "You are a triage agent. Read each ticket, classify it, and route it to the right owner.",
+  tools: ["spaces", "web-search"],
+};
+
+test("captures the draft into ref and fires abortRun to end the turn", async () => {
+  const ref: ProposeAgentRef = {};
+  const abortRun = vi.fn();
+  const res = await callTool(ref, abortRun, validDraft);
+
+  expect(abortRun).toHaveBeenCalledOnce();
+  expect(ref.value).toMatchObject({
+    variant: "draft",
+    agent: {
+      name: "Ticket Triage",
+      slug: "ticket-triage",
+      description: "Triages incoming tickets",
+      tools: ["spaces", "web-search"],
+    },
+  });
+  // The model must not be left thinking the agent exists.
+  expect(res.content[0]!.text).toContain("STOP");
+  expect(res.content[0]!.text).toMatch(/only if they approve/i);
+});
+
+test("derives a slug from the name and honours an explicit one", async () => {
+  const derived: ProposeAgentRef = {};
+  await callTool(derived, undefined, { ...validDraft, name: "Weekly  PR Report!" });
+  expect(derived.value?.agent.slug).toBe("weekly-pr-report");
+
+  const explicit: ProposeAgentRef = {};
+  await callTool(explicit, undefined, { ...validDraft, slug: "My_Custom Slug" });
+  expect(explicit.value?.agent.slug).toBe("my-custom-slug");
+});
+
+describe("rejections keep the turn alive so the model can retry", () => {
+  test.each([
+    ["missing name", { ...validDraft, name: "  " }, /name/i],
+    ["missing description", { ...validDraft, description: "" }, /description/i],
+    ["stub system prompt", { ...validDraft, systemPrompt: "be helpful" }, /systemPrompt/i],
+  ])("%s", async (_label, params, pattern) => {
+    const ref: ProposeAgentRef = {};
+    const abortRun = vi.fn();
+    const res = await callTool(ref, abortRun, params);
+
+    expect(ref.value).toBeUndefined();
+    // A rejected draft must NOT end the turn — the model has to be able to fix it.
+    expect(abortRun).not.toHaveBeenCalled();
+    expect(res.details?.["error"]).toBe(true);
+    expect(res.content[0]!.text).toMatch(pattern);
+  });
+});
+
+test("is idempotent — the first draft stands and repeats are no-ops", async () => {
+  const ref: ProposeAgentRef = {};
+  const abortRun = vi.fn();
+  await callTool(ref, abortRun, validDraft);
+  const second = await callTool(ref, abortRun, { ...validDraft, name: "Something Else" });
+
+  expect(ref.value?.agent.name).toBe("Ticket Triage");
+  expect(ref.duplicates).toBe(1);
+  expect(second.details?.["duplicate"]).toBe(true);
+});
+
+test("carries the agent's own summary line, and omits it when absent", async () => {
+  // The card can only show WHAT was drafted; the summary is where the agent says
+  // why. claw-auth posts it beside the card and falls back when it's missing.
+  const withSummary: ProposeAgentRef = {};
+  await callTool(withSummary, undefined, {
+    ...validDraft,
+    summary: "Granted it GitHub and Spaces; left out anything that can write.",
+  });
+  expect(withSummary.value?.agent.summary).toBe(
+    "Granted it GitHub and Spaces; left out anything that can write.",
+  );
+
+  const without: ProposeAgentRef = {};
+  await callTool(without, undefined, { ...validDraft, summary: "   " });
+  expect(without.value?.agent).not.toHaveProperty("summary");
+});
+
+test("normalizes the tool list without inventing or dropping identifiers", async () => {
+  const ref: ProposeAgentRef = {};
+  await callTool(ref, undefined, {
+    ...validDraft,
+    // Duplicates, padding and non-strings — but unknown slugs pass through
+    // untouched: only claw-auth knows this org's catalog, and silently dropping
+    // one here would hide it from the card's "not granted" note.
+    tools: [" spaces ", "spaces", "", 42, "totally-made-up"],
+  });
+  expect(ref.value?.agent.tools).toEqual(["spaces", "totally-made-up"]);
+});
+
+test("survives a throwing abortRun rather than losing the draft", async () => {
+  const ref: ProposeAgentRef = {};
+  const abortRun = vi.fn(() => {
+    throw new Error("abort wiring broken");
+  });
+  await expect(callTool(ref, abortRun, validDraft)).resolves.toBeDefined();
+  expect(ref.value).toBeDefined();
+});
+
+test("normalizeAgentSlug matches the slug rule the server enforces", () => {
+  expect(normalizeAgentSlug("  Ticket   Triage  ")).toBe("ticket-triage");
+  expect(normalizeAgentSlug("--weird--")).toBe("weird");
+  expect(normalizeAgentSlug("!!!")).toBe("");
+  expect(normalizeAgentSlug("a".repeat(200)).length).toBe(80);
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -84,6 +84,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
+    "test": "tsc && node --test \"test/*.test.mjs\"",
     "prepare": "pnpm run build"
   },
   "dependencies": {

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -26,7 +26,8 @@ export type FlowComponentType =
   | 'plan'
   | 'pr'
   | 'pr_approval'
-  | 'call_schedule';
+  | 'call_schedule'
+  | 'agent';
 
 export interface FlowComponent {
   id: string;

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -520,6 +520,128 @@ export type DurationMinutes = z.infer<typeof durationMinutesSchema>;
 export type CallScheduleProps = z.infer<typeof callSchedulePropsSchema>;
 export type CallSchedulePhase = CallScheduleProps['phase'];
 
+// ── Agent artifact ────────────────────────────────────────────────────────────
+// ONE node renders every agent surface. The identity block (name / slug /
+// description / model / capabilities / system prompt) is INVARIANT across
+// variants — that identity IS the artifact. `variant` discriminates only the
+// chrome: which header chip, which footer affordances, and whether the
+// capability chips are interactive.
+//
+//   draft   → the agent does NOT exist yet. `phase` walks pending → created |
+//             rejected on the SAME message (post once, then updateMessage the
+//             same screenId), exactly like the plan card.
+//   profile → a live agent, read-only ("tell me about this agent").
+//
+// Extension rule: a new surface is a NEW UNION BRANCH, never a new field on an
+// existing one — existing emitters keep validating unchanged. Presentational
+// key/value rows (model settings, limits, quotas) go in `agent.details` and need
+// no schema change at all; only making a field EDITABLE earns a new branch.
+//
+// INVARIANT: props are PRESENTATION ONLY. Every identifier the server acts on
+// (requestId, agentSlug, the acting userId, routing) lives in flowJSON.data —
+// the whole flowJSON round-trips through the client, so props are untrusted.
+export const agentCapabilitySchema = z
+  .object({
+    /** Subagent name or custom tool slug — the identifier config.tools stores. */
+    id: z.string().min(1),
+    label: z.string().min(1),
+    kind: z.enum(['subagent', 'tool']),
+    /**
+     * MCP serverType whose brand icon represents this capability, e.g. "github".
+     * Set server-side (the subagent name and the icon key differ — "spaces" is
+     * served by "xyne-spaces"), so the renderer never has to guess a filename.
+     */
+    iconKey: z.string().optional(),
+    /** serverType whose account/credentials this capability needs, when unconnected. */
+    requiresConnection: z.string().optional(),
+  })
+  .strict();
+
+/** Presentational label/value row (model, thinking level, limits, …). */
+export const agentDetailRowSchema = z
+  .object({
+    label: z.string().min(1),
+    value: z.string(),
+  })
+  .strict();
+
+export const agentIdentitySchema = z
+  .object({
+    name: z.string().min(1),
+    slug: z.string().min(1),
+    /** Handle credited under the name ("Built by @fractal-agent") — who authored it. */
+    builtBy: z.string().optional(),
+    description: z.string().optional(),
+    /** Full system prompt — revealed in the expanded view, never the card body. */
+    systemPrompt: z.string().optional(),
+    modelId: z.string().optional(),
+    /**
+     * Hex tint the agent is created with, e.g. '#6366f1'. Carried so the card
+     * reflects what gets persisted; no current surface paints with it (the cards
+     * render no avatar).
+     */
+    color: z.string().optional(),
+    capabilities: z.array(agentCapabilitySchema).optional(),
+    details: z.array(agentDetailRowSchema).optional(),
+    connectLinks: z
+      .array(
+        z
+          .object({
+            serverType: z.string().min(1),
+            displayName: z.string().min(1),
+            authUrl: z.string().url(),
+          })
+          .strict(),
+      )
+      .optional(),
+  })
+  .strict();
+
+export const agentDraftPhaseSchema = z.enum(['pending', 'created', 'rejected']);
+
+export const agentPropsSchema = z.discriminatedUnion('variant', [
+  z
+    .object({
+      variant: z.literal('draft'),
+      phase: agentDraftPhaseSchema,
+      agent: agentIdentitySchema,
+      // Seeds state.values[node.id] — the capability ids kept by the user. The
+      // live selection then lives in flow state (the plan card's pattern), so
+      // `capabilities` stays byte-identical across variants.
+      selected: z.array(z.string()).optional(),
+      // Muted footnote, e.g. "skipped unknown tools: foo, bar".
+      note: z.string().optional(),
+      // Audit for the decided phases.
+      decidedBy: z.string().optional(),
+      /** User id of the decider — renders their avatar beside the audit line. */
+      decidedById: z.string().optional(),
+      decidedAt: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      variant: z.literal('profile'),
+      agent: agentIdentitySchema,
+      note: z.string().optional(),
+    })
+    .strict(),
+]);
+
+export const agentComponentSchema = baseComponentSchema.extend({
+  type: z.literal('agent'),
+  props: agentPropsSchema,
+});
+
+// TS mirrors inferred from the schema so the two can't drift.
+export type AgentCapability = z.infer<typeof agentCapabilitySchema>;
+export type AgentDetailRow = z.infer<typeof agentDetailRowSchema>;
+export type AgentIdentity = z.infer<typeof agentIdentitySchema>;
+export type AgentProps = z.infer<typeof agentPropsSchema>;
+export type AgentVariant = AgentProps['variant'];
+export type AgentDraftProps = Extract<AgentProps, { variant: 'draft' }>;
+export type AgentDraftPhase = AgentDraftProps['phase'];
+export type AgentProfileProps = Extract<AgentProps, { variant: 'profile' }>;
+
 // Recursive container schemas need z.lazy
 export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
   z.discriminatedUnion('type', [
@@ -540,6 +662,7 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     prComponentSchema,
     prApprovalComponentSchema,
     callScheduleComponentSchema,
+    agentComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema
     baseComponentSchema.extend({
       type: z.literal('row'),

--- a/packages/shared/test/agentCardFlowSchema.test.mjs
+++ b/packages/shared/test/agentCardFlowSchema.test.mjs
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Imports the BUILT output on purpose: this is exactly the module consumers
+// resolve, so a mismatch between src and the published dist shows up here too.
+// Run via `pnpm --filter @xyne/shared test` (builds first).
+import { validateFlowDefinition } from '../dist/validation/flowSchema.js';
+
+/**
+ * Schema-side half of the agent-card contract.
+ *
+ * apps/backend runs `validateFlowDefinition` over every flow an app posts
+ * (apps/controllers/flowController.ts, apps/controllers/chatController.ts)
+ * before storing it, so a card whose shape drifts from this schema fails as an
+ * HTTP 400 at postMessage — not as a blank card noticed days later.
+ *
+ * The payloads below mirror what xyne-claw-shared's `buildAgentCardFlow` emits;
+ * packages/xyne-claw-shared/src/flow/agent-card.test.ts pins the same prop keys
+ * from the emitting side. The two packages can't import each other (claw-shared
+ * deliberately avoids a runtime dep on this one), so they move together by
+ * convention — change one, change the other.
+ */
+
+const identity = {
+  name: 'Ticket Triage',
+  slug: 'ticket-triage',
+  description: 'Triages incoming tickets',
+  systemPrompt: 'You are a triage agent.',
+  modelId: 'claude-sonnet-5',
+  capabilities: [
+    { id: 'spaces', label: 'spaces', kind: 'subagent', iconKey: 'xyne-spaces' },
+    { id: 'web-search', label: 'Web Search', kind: 'tool', requiresConnection: 'google' },
+  ],
+  details: [{ label: 'Model', value: 'claude-sonnet-5' }],
+};
+
+const flowWith = props => ({
+  version: '2.0',
+  screenId: 'agent-card-req-1',
+  title: 'Agent',
+  components: [{ id: 'agent', type: 'agent', props }],
+  data: {
+    actionType: 'agent-card',
+    variant: 'draft',
+    requestId: 'req-1',
+    agentSlug: 'architect',
+    userId: 'user-1',
+  },
+  state: {
+    values: {},
+    touched: {},
+    errors: {},
+    submitting: false,
+    submitted: false,
+    history: [],
+    loadingComponentIds: [],
+  },
+});
+
+const accepts = props => assert.equal(validateFlowDefinition(flowWith(props)).success, true);
+const rejects = props => assert.equal(validateFlowDefinition(flowWith(props)).success, false);
+
+test('accepts a draft card in every phase', () => {
+  for (const phase of ['pending', 'created', 'rejected']) {
+    accepts({
+      variant: 'draft',
+      phase,
+      agent: identity,
+      selected: ['spaces'],
+      note: 'skipped unknown tools: foo',
+      decidedBy: 'Harsh',
+      decidedById: 'usr_1',
+      decidedAt: '2026-08-05T10:00:00.000Z',
+    });
+  }
+});
+
+test('accepts a profile card carrying the same identity', () => {
+  accepts({ variant: 'profile', agent: identity });
+});
+
+test('accepts a minimal identity (name + slug only)', () => {
+  accepts({ variant: 'draft', phase: 'pending', agent: { name: 'A', slug: 'a' } });
+});
+
+test('rejects an unknown prop key so emitter drift fails loudly', () => {
+  rejects({ variant: 'draft', phase: 'pending', agent: identity, todos: [] });
+});
+
+test('rejects draft-only fields on a profile card', () => {
+  // The variants are a discriminated union precisely so a read-only card can
+  // never carry a decision affordance.
+  rejects({ variant: 'profile', agent: identity, phase: 'pending' });
+  rejects({ variant: 'profile', agent: identity, selected: ['spaces'] });
+});
+
+test('rejects unknown variants and phases', () => {
+  rejects({ variant: 'editor', agent: identity });
+  rejects({ variant: 'draft', phase: 'approved', agent: identity });
+});
+
+test('rejects a nameless identity', () => {
+  rejects({ variant: 'draft', phase: 'pending', agent: { name: '', slug: 'a' } });
+});
+
+test('rejects a capability with an unknown kind', () => {
+  rejects({
+    variant: 'draft',
+    phase: 'pending',
+    agent: { name: 'A', slug: 'a', capabilities: [{ id: 'x', label: 'X', kind: 'gateway' }] },
+  });
+});
+
+test('rejects a non-URL connect link', () => {
+  rejects({
+    variant: 'draft',
+    phase: 'pending',
+    agent: {
+      name: 'A',
+      slug: 'a',
+      connectLinks: [{ serverType: 'google', displayName: 'Google', authUrl: 'not-a-url' }],
+    },
+  });
+});

--- a/packages/xyne-claw-shared/src/flow/agent-card.test.ts
+++ b/packages/xyne-claw-shared/src/flow/agent-card.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { buildAgentCardFlow, agentIdentity, AGENT_COMPONENT_ID } from "./agent-card.js";
+
+/**
+ * Builder-side half of the agent-card contract. The zod half lives in
+ * apps/backend (`src/test/agentCardFlowSchema.test.ts`) because the validator
+ * that actually gates a posted card is @xyne/shared's, and this package
+ * deliberately does not depend on it. The two tests assert the SAME prop keys —
+ * change one and change the other, or the card 400s at postMessage.
+ */
+
+const identity = agentIdentity({
+  name: "Ticket Triage",
+  slug: "ticket-triage",
+  description: "Triages incoming tickets",
+  systemPrompt: "You are a triage agent. Read the ticket and route it.",
+  modelId: "claude-sonnet-5",
+  capabilities: [
+    { id: "spaces", label: "spaces", kind: "subagent" },
+    { id: "web-search", label: "Web Search", kind: "tool" },
+  ],
+  details: [{ label: "Model", value: "claude-sonnet-5" }],
+});
+
+const data = {
+  requestId: "req-1",
+  agentSlug: "architect",
+  userId: "user-1",
+  conversationId: "conv-1",
+  channelId: "chan-1",
+};
+
+describe("buildAgentCardFlow — draft", () => {
+  const flow = buildAgentCardFlow({ variant: "draft", phase: "pending", agent: identity }, data);
+  const component = flow.components[0]!;
+
+  it("emits ONE agent component under the stable id the backend reads state from", () => {
+    expect(flow.components).toHaveLength(1);
+    expect(component.id).toBe(AGENT_COMPONENT_ID);
+    expect(component.type).toBe("agent");
+  });
+
+  it("keeps every actionable identifier in data, never in props", () => {
+    expect(flow.data).toMatchObject({
+      actionType: "agent-card",
+      variant: "draft",
+      requestId: "req-1",
+      agentSlug: "architect",
+      userId: "user-1",
+    });
+    // props are display-only: no request id, no acting user, nothing routable.
+    const props = component.props as Record<string, unknown>;
+    expect(props["requestId"]).toBeUndefined();
+    expect(props["userId"]).toBeUndefined();
+  });
+
+  it("does not leak the system prompt into data (it rides in props for display only)", () => {
+    expect(JSON.stringify(flow.data)).not.toContain("You are a triage agent");
+    expect((component.props as Record<string, unknown>)["agent"]).toMatchObject({
+      systemPrompt: expect.stringContaining("You are a triage agent"),
+    });
+  });
+
+  it("defaults the selection to every capability", () => {
+    // An absent seed must not read as "the user deselected everything" — an
+    // unchecked chip is a removal, so the default has to be all-selected.
+    expect((component.props as Record<string, unknown>)["selected"]).toEqual([
+      "spaces",
+      "web-search",
+    ]);
+  });
+
+  it("honours an explicit selection", () => {
+    const narrowed = buildAgentCardFlow(
+      { variant: "draft", phase: "pending", agent: identity, selected: ["spaces"] },
+      data,
+    );
+    expect((narrowed.components[0]!.props as Record<string, unknown>)["selected"]).toEqual(["spaces"]);
+  });
+
+  it("keys the screen on the request so every phase updates the SAME card", () => {
+    const created = buildAgentCardFlow(
+      { variant: "draft", phase: "created", agent: identity, decidedBy: "Harsh", decidedAt: "2026-08-05T10:00:00.000Z" },
+      data,
+    );
+    expect(created.screenId).toBe(flow.screenId);
+    expect((created.components[0]!.props as Record<string, unknown>)["phase"]).toBe("created");
+  });
+
+  it("omits absent optional props rather than emitting empties (props are .strict())", () => {
+    const props = component.props as Record<string, unknown>;
+    expect(props).not.toHaveProperty("note");
+    expect(props).not.toHaveProperty("decidedBy");
+    expect(props).not.toHaveProperty("decidedAt");
+  });
+});
+
+describe("buildAgentCardFlow — profile", () => {
+  const flow = buildAgentCardFlow({ variant: "profile", agent: identity }, { ...data, targetSlug: "ticket-triage" });
+  const props = flow.components[0]!.props as Record<string, unknown>;
+
+  it("renders the same identity with no draft-only fields", () => {
+    expect(props["variant"]).toBe("profile");
+    expect(props["agent"]).toEqual(identity);
+    expect(props).not.toHaveProperty("phase");
+    expect(props).not.toHaveProperty("selected");
+  });
+
+  it("carries the described agent separately from the posting agent", () => {
+    // `agentSlug` resolves the Spaces token that updates the message; the card's
+    // SUBJECT is targetSlug. Conflating them posts as the wrong identity.
+    expect(flow.data).toMatchObject({ agentSlug: "architect", targetSlug: "ticket-triage" });
+  });
+});
+
+describe("agentIdentity — the reuse hinge", () => {
+  it("drops blank fields instead of emitting empty strings", () => {
+    const result = agentIdentity({ name: "A", slug: "a", description: "   ", modelId: "" });
+    expect(result).toEqual({ name: "A", slug: "a" });
+  });
+
+  it("falls back rather than emitting an empty name/slug", () => {
+    expect(agentIdentity({ name: "  ", slug: "  " })).toEqual({ name: "Agent", slug: "agent" });
+  });
+
+  it("truncates a very long system prompt for display", () => {
+    const long = "x".repeat(25_000);
+    const result = agentIdentity({ name: "A", slug: "a", systemPrompt: long });
+    // Display cap only — the full prompt is persisted server-side and is what
+    // actually gets created.
+    expect(result.systemPrompt!.length).toBeLessThan(long.length);
+    expect(result.systemPrompt).toContain("truncated for display");
+  });
+
+  it("drops capabilities with empty ids/labels and preserves kind", () => {
+    const result = agentIdentity({
+      name: "A",
+      slug: "a",
+      capabilities: [
+        { id: " ", label: "ghost", kind: "tool" },
+        { id: "spaces", label: "spaces", kind: "subagent", requiresConnection: "google" },
+      ],
+    });
+    expect(result.capabilities).toEqual([
+      { id: "spaces", label: "spaces", kind: "subagent", requiresConnection: "google" },
+    ]);
+  });
+
+  it("produces the same shape from a draft spec and from a stored row", () => {
+    // The invariant that makes one node serve both surfaces.
+    const fromDraft = agentIdentity({ name: "A", slug: "a", description: "d", systemPrompt: "p" });
+    const fromRow = agentIdentity({ name: "A", slug: "a", description: "d", systemPrompt: "p" });
+    expect(Object.keys(fromDraft).sort()).toEqual(Object.keys(fromRow).sort());
+  });
+});

--- a/packages/xyne-claw-shared/src/flow/agent-card.ts
+++ b/packages/xyne-claw-shared/src/flow/agent-card.ts
@@ -1,0 +1,235 @@
+/**
+ * Agent card — ONE FlowUI v2.0 `agent` component that renders every agent
+ * surface (dashboard: components/flowUI/nodes/AgentNode.tsx).
+ *
+ * The identity block (name / slug / description / model / capabilities / system
+ * prompt) is INVARIANT across variants — that identity IS the artifact. The
+ * `variant` discriminates only the chrome:
+ *
+ *   draft   → the agent does NOT exist yet. `phase` walks pending → created |
+ *             rejected on the SAME message: post once via Spaces
+ *             postMessage({ flow }), then updateMessage({ flowJSON }) with the
+ *             same screenId + component id, exactly like the plan card.
+ *   profile → a live agent, read-only.
+ *
+ * Adding a surface = adding a UNION BRANCH (existing emitters keep validating).
+ * Presentational key/value rows go in `identity.details` and need no schema
+ * change at all; only making a field EDITABLE earns a new branch.
+ *
+ * ── The props/data split (load-bearing) ──────────────────────────────────────
+ * `props` is PRESENTATION ONLY. Every identifier the server acts on — requestId,
+ * agentSlug, the user allowed to act, routing — lives in `flowJSON.data`, which
+ * flow-action.ts reads. The whole flowJSON round-trips through the browser on
+ * every action, so props are untrusted input: the approve path re-reads the
+ * draft from its AgentRequest row and never persists what the card carried.
+ *
+ * Source-of-truth schema + zod validation: @xyne/shared
+ * shared/src/validation/flowSchema.ts (`agentComponentSchema`). Both must ship
+ * before an emitter goes live — apps/backend validates every posted flow, so an
+ * unknown component type is a 400 at postMessage, not a blank card.
+ */
+
+import { FlowBuilder, type FlowComponent, type FlowDefinition } from './builder.js';
+
+/** Stable component id — the `state.values` key the node reads/writes and the
+ *  key flow-action.ts reads the user's capability selection from. Do NOT change
+ *  without updating both consumers. */
+export const AGENT_COMPONENT_ID = 'agent';
+
+/** Display cap for the system prompt carried on the card. The card copy is for
+ *  the expanded view only — the FULL prompt lives in the AgentRequest row and is
+ *  what actually gets created, so truncating here is purely cosmetic. */
+const MAX_CARD_PROMPT = 20_000;
+const MAX_DESC = 500;
+const MAX_CAPABILITIES = 60;
+const MAX_DETAILS = 12;
+
+export interface AgentCapability {
+  /** Subagent name or custom tool slug — the identifier config.tools stores. */
+  id: string;
+  label: string;
+  kind: 'subagent' | 'tool';
+  /** MCP serverType whose brand icon represents this capability, e.g. "github". */
+  iconKey?: string;
+  /** serverType whose account/credentials this capability needs, when unconnected. */
+  requiresConnection?: string;
+}
+
+export interface AgentDetailRow {
+  label: string;
+  value: string;
+}
+
+export interface AgentConnectLink {
+  serverType: string;
+  displayName: string;
+  authUrl: string;
+}
+
+export interface AgentIdentity {
+  name: string;
+  slug: string;
+  /** Handle credited under the name ("Built by @fractal-agent"). */
+  builtBy?: string;
+  description?: string;
+  systemPrompt?: string;
+  modelId?: string;
+  color?: string;
+  capabilities?: AgentCapability[];
+  details?: AgentDetailRow[];
+  connectLinks?: AgentConnectLink[];
+}
+
+export type AgentDraftPhase = 'pending' | 'created' | 'rejected';
+
+export type AgentCardProps =
+  | {
+      variant: 'draft';
+      phase: AgentDraftPhase;
+      agent: AgentIdentity;
+      /** Seeds state.values[AGENT_COMPONENT_ID] — capability ids kept by the user. */
+      selected?: string[];
+      note?: string;
+      decidedBy?: string;
+      /** User id of the decider — the card renders their avatar. */
+      decidedById?: string;
+      decidedAt?: string;
+    }
+  | { variant: 'profile'; agent: AgentIdentity; note?: string };
+
+/** Routing + server-truth identifiers. Read by flow-action.ts; never by the node. */
+export interface AgentCardData {
+  /** Draft cards: the AgentRequest row this card decides. */
+  requestId?: string;
+  /**
+   * The agent that POSTED this card — its Spaces app token is what updates the
+   * message. Keyed `agentSlug` because every flow-action branch resolves the
+   * poster from exactly that key; the card's SUBJECT is `targetSlug`.
+   */
+  agentSlug: string;
+  /** Profile cards: the live agent this card describes. */
+  targetSlug?: string;
+  /** The ONLY user allowed to act on this card (fail-closed in flow-action). */
+  userId: string;
+  conversationId?: string;
+  channelId?: string;
+}
+
+const trimmed = (value: unknown, max: number): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const t = value.trim();
+  if (!t) return undefined;
+  return t.length > max ? `${t.slice(0, max)}\n\n…(truncated for display)` : t;
+};
+
+/**
+ * Normalize an identity into the exact shape `agentIdentitySchema` accepts.
+ *
+ * THE reuse hinge: the draft path (from a propose-agent spec) and the profile
+ * path (from a persisted row) both funnel through here, so the two surfaces can
+ * never drift. Empty/blank fields are DROPPED rather than emitted as "" — the
+ * zod props schema is .strict() and blank strings render as empty rows.
+ */
+export function agentIdentity(input: {
+  name: string;
+  slug: string;
+  builtBy?: string | null;
+  description?: string | null;
+  systemPrompt?: string | null;
+  modelId?: string | null;
+  color?: string | null;
+  capabilities?: AgentCapability[];
+  details?: AgentDetailRow[];
+  connectLinks?: AgentConnectLink[];
+}): AgentIdentity {
+  const identity: AgentIdentity = {
+    name: trimmed(input.name, 120) ?? 'Agent',
+    slug: trimmed(input.slug, 80) ?? 'agent',
+  };
+
+  // Stored without the leading "@" — the renderer adds it, so the value stays a
+  // plain handle wherever else it is used.
+  const builtBy = trimmed(input.builtBy, 80)?.replace(/^@+/, "");
+  if (builtBy) identity.builtBy = builtBy;
+  const description = trimmed(input.description, MAX_DESC);
+  if (description) identity.description = description;
+  const systemPrompt = trimmed(input.systemPrompt, MAX_CARD_PROMPT);
+  if (systemPrompt) identity.systemPrompt = systemPrompt;
+  const modelId = trimmed(input.modelId, 120);
+  if (modelId) identity.modelId = modelId;
+  const color = trimmed(input.color, 32);
+  if (color) identity.color = color;
+
+  const capabilities = (input.capabilities ?? [])
+    .filter((c) => c.id.trim().length > 0 && c.label.trim().length > 0)
+    .slice(0, MAX_CAPABILITIES)
+    .map((c) => ({
+      id: c.id.trim(),
+      label: c.label.trim(),
+      kind: c.kind,
+      ...(c.iconKey ? { iconKey: c.iconKey } : {}),
+      ...(c.requiresConnection ? { requiresConnection: c.requiresConnection } : {}),
+    }));
+  if (capabilities.length > 0) identity.capabilities = capabilities;
+
+  const details = (input.details ?? [])
+    .filter((d) => d.label.trim().length > 0)
+    .slice(0, MAX_DETAILS)
+    .map((d) => ({ label: d.label.trim(), value: d.value.trim() }));
+  if (details.length > 0) identity.details = details;
+
+  if (input.connectLinks && input.connectLinks.length > 0) {
+    identity.connectLinks = input.connectLinks;
+  }
+
+  return identity;
+}
+
+/**
+ * Build the agent card as a single `agent` component. Deterministic (pure) so
+ * every phase/variant re-render produces a byte-stable card the client can
+ * reconcile in place. screenId is keyed on the card's server identity so phase
+ * updates for the same draft land on the same screen.
+ */
+export function buildAgentCardFlow(props: AgentCardProps, data: AgentCardData): FlowDefinition {
+  const componentProps: Record<string, unknown> =
+    props.variant === 'draft'
+      ? {
+          variant: 'draft',
+          phase: props.phase,
+          agent: props.agent,
+          // Default the selection to EVERY capability: an unchecked chip means
+          // "the user removed it", so an absent seed must not read as "user
+          // deselected everything".
+          selected: props.selected ?? (props.agent.capabilities ?? []).map((c) => c.id),
+          ...(props.note ? { note: props.note } : {}),
+          ...(props.decidedBy ? { decidedBy: props.decidedBy } : {}),
+          ...(props.decidedById ? { decidedById: props.decidedById } : {}),
+          ...(props.decidedAt ? { decidedAt: props.decidedAt } : {}),
+        }
+      : {
+          variant: 'profile',
+          agent: props.agent,
+          ...(props.note ? { note: props.note } : {}),
+        };
+
+  const component: FlowComponent = { id: AGENT_COMPONENT_ID, type: 'agent', props: componentProps };
+  const screenKey = data.requestId ?? data.targetSlug ?? props.agent.slug;
+
+  // No title: FlowRenderer paints `flowJSON.title` as an <h2> ABOVE the card, and
+  // a bare "Agent" heading over a card whose first line is the agent's name is
+  // pure duplication. The card names itself.
+  return new FlowBuilder(`agent-card-${screenKey}`)
+    .addComponent(component)
+    .setData({
+      actionType: 'agent-card',
+      variant: props.variant,
+      ...(data.requestId ? { requestId: data.requestId } : {}),
+      agentSlug: data.agentSlug,
+      ...(data.targetSlug ? { targetSlug: data.targetSlug } : {}),
+      userId: data.userId,
+      ...(data.conversationId ? { conversationId: data.conversationId } : {}),
+      ...(data.channelId ? { channelId: data.channelId } : {}),
+    })
+    .build();
+}

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -28,6 +28,7 @@ type FlowComponentType =
   | 'image'
   | 'link'
   | 'plan'
+  | 'agent'
   | 'pr';
 
 interface FlowComponentStyle {

--- a/packages/xyne-claw-shared/src/flow/plan-flow.ts
+++ b/packages/xyne-claw-shared/src/flow/plan-flow.ts
@@ -133,8 +133,10 @@ export function buildPlanFlow(
 
   const planComponent: FlowComponent = { id: PLAN_COMPONENT_ID, type: 'plan', props };
 
+  // No flow title: FlowRenderer paints `flowJSON.title` as an <h2> ABOVE the
+  // card, and the card's own TitleBlock already shows `props.title` — the same
+  // string twice, once outside the artifact and once inside it.
   return new FlowBuilder(screenId)
-    .setTitle(title)
     .addComponent(planComponent)
     .setData({ kind: 'plan', ...(opts?.data ?? {}) })
     .build();

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -23,6 +23,16 @@ export { createSkillTool, updateSkillTool } from "./tools/skill-management/index
 export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
+export { buildAgentCardFlow, agentIdentity, AGENT_COMPONENT_ID } from "./flow/agent-card.js";
+export type {
+  AgentCardProps,
+  AgentCardData,
+  AgentIdentity,
+  AgentCapability,
+  AgentDetailRow,
+  AgentConnectLink,
+  AgentDraftPhase,
+} from "./flow/agent-card.js";
 export type { Todo, TodoStatus, PlanPhase, PlanTodoInput } from "./flow/plan-flow.js";
 export { buildPrFlow, prScreenId, PR_COMPONENT_ID } from "./flow/pr-flow.js";
 export type { PrProvider, PrStatus, PrCardInput, PrIdentity } from "./flow/pr-flow.js";


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-55337 — lets an agent **create another agent from chat**, with the human approving before anything is written.

Ask an agent to build you an agent and it drafts one, then posts an interactive card in the thread. Nothing is persisted until you approve. Also ships the read-only half of the same surface: ask any agent *"what can you do?"* and it answers with a capability card built from its real configuration instead of prose it invents.

### One generic `agent` artifact, not two cards

The deliverable is a single new FlowJSON node type (`agent`), discriminated by `variant` so it can serve every agent surface as they arrive:

| variant | states | emitter |
| --- | --- | --- |
| `draft` | `pending` → `created` \| `rejected` | `propose-agent` |
| `profile` | read-only | `describe-agent` |

Both branches embed the **same** `agentIdentitySchema`, and one normalizer (`agentIdentity()`) builds it from either a proposed spec or a persisted row — so a drafted agent and a described agent are the same object visually and structurally. A future surface (an editor, say) is a new union branch, not a new node type.

### How safety is arranged

- **The card carries only a `requestId`.** The draft itself lives in an `AgentRequest` row. The whole FlowJSON round-trips through the browser on every click, so `props` is display data and nothing else — the approve path re-reads the spec server-side and never persists what the card carried.
- **Capability selection can only narrow.** The user's kept-chip list arrives from the client and is *intersected* with what the server resolved (`spec.tools.filter(...)`), so a tampered payload can't add a capability.
- **Tool names are resolved against the org catalog**, not trusted. Unmatched tokens are reported on the card rather than silently dropped or guessed into a bucket.
- **Approval is a compare-and-set** (`claimPendingAgentCreate`), so a double-click or two open tabs produce exactly one agent; failures roll the row back to `pending` so the card stays retryable.
- **A profile card is built from the agent's DB row**, never from model output — an agent can't advertise a capability it wasn't granted on an official-looking card.

### Enablement

- `propose-agent` is gated per agent on `config.agentAuthoring === true`.
- `describe-agent` is **on for every agent, no config** — answering "what are you" from real configuration is table stakes. It's non-terminal, so the card accompanies the reply rather than replacing it.

### Also in here

- `plan-flow.ts` / `agent-card.ts` no longer call `setTitle()`. `FlowRenderer` paints `flowJSON.title` as an `<h2>` *above* the card, which duplicated the title the card already renders. Side effect: artifact messages now have a thinner channel-list preview (`flowPreview.ts` reads that title).
- Removed the hardcoded `Plan` label from the plan card header — the card's own title says what it is.
- **Themed text selection** (`global.css`). There was no `::selection` rule anywhere, so selection fell back to the OS highlight colour — it differed per machine and per page, and clashed with the palette. Now a light blue on `classic` / `summer_breeze`, and the same hue at lower lightness on `midnight` (an 86%-lightness fill washes out on dark surfaces). Editor surfaces (BlockNote, CodeMirror) keep their own selection styling on purpose.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

Deliberately reuses the existing `AgentRequest` table with a new `requestType` value (`agent_create`) rather than adding a table — the clone/skill-update rows already model propose→claim→resolve, and the new repository methods scope every query by `requestType` so they can never claim another row type.

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed**
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [x] Feature flag or runtime config changed

No env vars. The one flag is `agentAuthoring`, a per-agent key inside `agents.config` (JSON, DB) — nothing to add to `.env` files, and it defaults off, so no existing agent changes behaviour.

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [x] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots

Both additive, no removals:
- `/webhook/result` payload gains optional `pendingAgentCard` (claw → claw-auth).
- `/flow/action` gains `actionType: 'agent-card'` with `agent-draft-approve` / `agent-draft-decline`.

### ⚠️ Deploy ordering (matters)

`apps/backend` validates every posted flow against its copy of `@xyne/shared`, and the artifact's props schemas are `.strict()` — an unknown key is a **400 at postMessage**, not a blank card. Ship in this order:

1. `packages/shared` built
2. **`apps/backend` restarted** (it holds the compiled schema in memory)
3. `apps/dashboard`
4. `claw-auth` / claw pod

Deploying claw-auth before the backend produces `Invalid flow definition: Unrecognized key(s)`.

---

## How did you test it?

End-to-end on local dev: enabled `agentAuthoring` on the `fractal-agent` row, asked it in a Xyne Spaces channel to create an agent, and drove the draft card through approve and decline. Verified the created agent lands with the expected `config.tools`, that de-selecting chips narrows the grant, and that the card updates in place rather than posting a second message.

### Automated

- [ ] Backend unit tests — no `apps/backend` changes
- [x] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite
- [x] Added / updated tests for this change
- [ ] Not covered by tests

**46 new/updated tests across four packages:**

| Package | Covers |
| --- | --- |
| `packages/shared` (9) | zod round-trip per variant; `.strict()` rejection so emitter drift fails loudly |
| `packages/xyne-claw-shared` (14) | builder output; that no identifier leaks into `props`; the identity normalizer |
| `apps/xyne-claw` (14) | `propose-agent` capture/abort/idempotency; `describe-agent` takes no model-authored content |
| `apps/xyne-claw-auth` (24) | capability bucketing, unknown-token reporting, connector-type filtering, identity parity |

Note: `apps/xyne-claw`'s suite has 5 pre-existing failures on `main` (`memory-search`, `session-freshness`, `mid-turn-compaction`, `user-memory-curator-trace`) unrelated to this branch — verified by stashing and re-running.

### Manual

**Users**
- [x] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [x] Narrow viewport, dark + light theme — **dark only**
- [x] Empty state — agent with no matched tools renders without capability sections
- [x] Large / realistic data volume — 40-capability agent; drove the one-row collapse
- [ ] Error paths

**Not yet exercised — worth a reviewer's attention:**
- Two users racing the same card (the compare-and-set claim is unit-tested, not manually raced).
- The decline path's in-place card update on a superseded draft.
- Light theme.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass — not run, no backend changes
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] No new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

`claw-auth` typecheck has 2 pre-existing express-typing errors in `agent-chat.ts` / `agents.ts`, untouched by this branch.
