### PR TITLE
feat: reuse shared pending-message framework in dashboard channel sends

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -42,6 +42,7 @@ import {
 import type { FocusPosition } from '@tiptap/react';
 import { createWorkflow, CreateWorkflowRequest } from '../../../services/Workflow/workflowService';
 import type { MentionResult } from '@xyne/shared';
+import { sendMessage, type ConversationRef } from '@xyne/shared/messages';
 import { useCanCreateTicket } from '../../../hooks/usePermissions';
 import { mutators } from '../../../zero/mutators';
 import { useShortcutById } from '../../../shortcuts';
@@ -563,11 +564,14 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
           twinEdit.onApprove(edited);
           return;
         }
-        if (isOffline) {
+        // Edits and thread replies still require a live connection. New
+        // top-level channel messages are allowed offline: the pending-message
+        // framework queues them and auto-retries on reconnect.
+        if (isOffline && (messageId || conversationId)) {
           toast.warning("You're offline", {
             description: messageId
               ? "Edits can't be saved until you reconnect."
-              : 'Your message has been saved as a draft. It will be ready to send when you reconnect.',
+              : "Thread replies can't be sent until you reconnect.",
           });
           throw new Error('offline');
         }
@@ -784,28 +788,23 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
             // Scope the agent-progress spinner to this new conversation right away,
             // before the `conversationId` prop catches up (see pendingConversationId).
             setPendingConversationId(newConversationId);
-            const result = zero.mutate(
-              mutators.conversations.send({
-                channelId,
-                content: processedHtml,
-                type: MessageType.USER,
-                conversationId: newConversationId,
-                messageId: newMessageId,
-                timestamp: messageCreatedAt,
-              }),
-            );
+            // Route top-level channel sends through the shared pending-message
+            // framework. sendMessage writes a durable pending entry, fires
+            // mutators.conversations.send when Zero is connected (and queues it
+            // for auto-retry when it is not), and clears the entry once the
+            // server confirms the write. Failed sends stay queued and surface a
+            // retry/delete affordance instead of being restored to the composer.
+            const channelRef: ConversationRef = { kind: 'channel', channelId };
+            sendMessage(zero, channelRef, {
+              content: processedHtml,
+              type: MessageType.USER,
+              conversationId: newConversationId,
+              messageId: newMessageId,
+              timestamp: messageCreatedAt,
+            });
 
             saveDraft(lookupId, '', '');
-            handleMutationResult(
-              result,
-              restoreDraft,
-              () => dispatchChatMessageSentEvent(channelId),
-              undefined,
-              {
-                channelId,
-                isNewConversation: true,
-              },
-            );
+            dispatchChatMessageSentEvent(channelId);
 
             logger.info(Event.MESSAGE_SENT, {
               channelId,

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -795,7 +795,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
             // server confirms the write. Failed sends stay queued and surface a
             // retry/delete affordance instead of being restored to the composer.
             const channelRef: ConversationRef = { kind: 'channel', channelId };
-            sendMessage(zero, channelRef, {
+            sendMessage(zero as Parameters<typeof sendMessage>[0], channelRef, {
               content: processedHtml,
               type: MessageType.USER,
               conversationId: newConversationId,

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -36,6 +36,7 @@ import { getDraft } from '../../../hooks/useDraft';
 import { v4 as uuidv4 } from 'uuid';
 import { withProfiler } from '../../../utils/withProfiler';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
+import { usePendingForChannel, buildPendingChannelConversation } from '@xyne/shared/messages';
 import { MessageHoverToolbar } from '../HoverActionsToolbar/MessageHoverToolbar';
 
 export type ChatListProps = {
@@ -300,8 +301,26 @@ const ChatListV4: React.FC<ChatListProps> = ({
   const topVisibleConvIdRef = useRef<string | undefined>(undefined);
   const { isMobile } = usePlatform();
 
+  // Merge durable pending sends (queued while offline, awaiting server
+  // confirmation, or failed) into the render list. Any conversation whose
+  // initial message is still pending is dropped first so Zero's optimistic row
+  // and the pending row never collide on the same key; the pending rows carry
+  // the newest timestamps, so appending sorts them to the tail.
+  const pendingForChannel = usePendingForChannel(channelId);
+  const conversationsWithPending = useMemo(() => {
+    if (pendingForChannel.length === 0) return conversations;
+    const pendingIds = new Set(pendingForChannel.map(p => p.messageId));
+    const base = conversations.filter(
+      c => !c.initialMessageId || !pendingIds.has(c.initialMessageId),
+    );
+    const pendingRows = pendingForChannel.map(
+      p => buildPendingChannelConversation(p) as unknown as Conversation,
+    );
+    return [...base, ...pendingRows];
+  }, [conversations, pendingForChannel]);
+
   const { combinedMessages, itemHeights } = useCombinedMesseges(
-    conversations,
+    conversationsWithPending,
     isMobile,
     newConversationBoundary?.index ?? -1,
   );

--- a/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
@@ -122,18 +122,22 @@ const ChatListItemComponent = ({
         {...(linkedConversationId !== null && { linkedConversationId })}
       />
       {pendingStatus === 'failed' && pendingEntry && (
-        <div className="flex items-center gap-3 pl-12 pt-1 text-xs text-red-500">
+        <div className='flex items-center gap-3 pl-12 pt-1 text-xs text-red-500'>
           <span>Failed to send.</span>
           <button
-            type="button"
-            className="font-medium underline hover:opacity-80"
+            type='button'
+            data-track-category='PENDING_MESSAGE'
+            data-track-name='retry_failed_send'
+            className='font-medium underline hover:opacity-80'
             onClick={() => firePendingMutator(zero, pendingEntry)}
           >
             Retry
           </button>
           <button
-            type="button"
-            className="font-medium underline hover:opacity-80"
+            type='button'
+            data-track-category='PENDING_MESSAGE'
+            data-track-name='delete_failed_send'
+            className='font-medium underline hover:opacity-80'
             onClick={() => removePending(pendingEntry.messageId)}
           >
             Delete

--- a/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
@@ -9,6 +9,13 @@ import { useDraft, useDraftFromDB } from '../../../hooks/useDraft';
 import { ChannelScopeType, MessageAttachment } from '@xyne/shared';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
 import { useAuth } from '../../../hooks/useAuth';
+import { useZero } from '../../../hooks/useZero';
+import {
+  usePendingStatusByMessageId,
+  usePendingByMessageId,
+  firePendingMutator,
+  removePending,
+} from '@xyne/shared/messages';
 
 type ChatListItemProps = {
   item: ChatListItemWithSeparator;
@@ -48,6 +55,10 @@ const ChatListItemComponent = ({
   const draft = useDraft(channelId, conversation?.conversationId ?? '');
   const draftFromDB = useDraftFromDB(channelId, conversation?.conversationId ?? '');
   const hasDraftAttachments = draftFromDB?.attachments && draftFromDB.attachments?.length > 0;
+  const zero = useZero();
+  const pendingMessageId = conversation?.initialMessageId ?? '';
+  const pendingStatus = usePendingStatusByMessageId(pendingMessageId);
+  const pendingEntry = usePendingByMessageId(pendingMessageId);
 
   // Render date separator
   if (item.type === 'date-separator') {
@@ -110,6 +121,25 @@ const ChatListItemComponent = ({
         {...(onEmojiPickerOpenChange && { onEmojiPickerOpenChange })}
         {...(linkedConversationId !== null && { linkedConversationId })}
       />
+      {pendingStatus === 'failed' && pendingEntry && (
+        <div className="flex items-center gap-3 pl-12 pt-1 text-xs text-red-500">
+          <span>Failed to send.</span>
+          <button
+            type="button"
+            className="font-medium underline hover:opacity-80"
+            onClick={() => firePendingMutator(zero, pendingEntry)}
+          >
+            Retry
+          </button>
+          <button
+            type="button"
+            className="font-medium underline hover:opacity-80"
+            onClick={() => removePending(pendingEntry.messageId)}
+          >
+            Delete
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -30,6 +30,7 @@ import { useZeroConnectionLogger } from '../services/zeroConnectionLogger';
 import { useCachedQuery } from '../hooks/useCachedQuery';
 import { authRefreshDuration, authRefreshTotal, safeRecordMetric } from '../services/otel';
 import { SharedAuthProvider, HttpClientProvider, ChannelServiceProvider } from '@xyne/shared/hooks';
+import { usePendingQueue } from '@xyne/shared/messages';
 import { axiosHttpClient } from '../services/affinityService';
 import { channelService } from '../services/Chat/channelService';
 
@@ -90,6 +91,10 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
   logger.setZeroClientGroupId(zero.clientGroupID);
 
   useZeroConnectionLogger(state);
+
+  // Durable pending-message queue: reconciles server-confirmed sends and
+  // auto-retries messages queued while the socket was reconnecting.
+  usePendingQueue();
 
   // Connection failure modal state — in-memory only
   const [showModal, setShowModal] = useState(false);


### PR DESCRIPTION
## Summary
Adopts the existing platform-agnostic pending-message framework (`@xyne/shared/messages`) inside the Dashboard for **top-level channel sends**. Messages now get a durable pending entry, queue while offline/reconnecting, auto-retry on reconnect, reconcile against server confirmation, and surface a Retry/Delete affordance on failure instead of silently restoring the composer draft.

Scope is intentionally limited to the channel (new-conversation) send path. Edit and thread-reply paths are unchanged; thread-reply adoption is a planned follow-up.

1. **Problem Description:** The Dashboard hand-rolled its send path (`zero.mutate(...send)` + `handleMutationResult`/`restoreDraft`). It had no durable queue: offline sends were blocked with a toast, in-flight sends weren't persisted across reload, and failures were surfaced by restoring the draft rather than as a retryable message. The shared `@xyne/shared/messages` framework already solves all of this and is platform-agnostic (localStorage fallback on web) but was unused by the Dashboard.
2. **How the issue was identified:** Architecture review of the shared pending-messages framework and the Dashboard send path; confirmed every framework dependency (shared instrumented `useZero`/`useQuery`, `InstrumentationProvider` + `ZeroFallbackProvider`, shared `mutators`, draft state machine, `queryCacheMachine` Conversation type) is already satisfied by the Dashboard.
3. **Solution implemented:**
   - `InitialStateLoader`: mount `usePendingQueue()` once — reconciles server-confirmed sends (`messagesByIds`, `isSent`) and auto-retries entries queued while reconnecting.
   - `ChatInput`: route the new-conversation (top-level channel) send through `sendMessage(zero, {kind:'channel',channelId}, ...)`; relax the offline guard so top-level channel messages queue and auto-retry (edits and thread replies still require a live connection).
   - `ChatListV4`: inject pending channel rows into the render list, deduped against Zero's optimistic insert (byte-matched builder → no flicker on swap).
   - `ChatListItem`: failed-send affordance (Retry → `firePendingMutator`, Delete → `removePending`) driven by `usePendingStatusByMessageId`.
4. **Documentation:** N/A
5. **DB Alter Details:** N/A
6. **Data fix Details:** N/A
7. **Environment variable Changes:** N/A
8. **Testing:** `tsc --noEmit` (dashboard `tsconfig.app.json`) — no new type errors introduced (total error count unchanged vs `main` baseline; the 23 pre-existing `threadType`/`THREAD_TYPES` errors are unrelated to this PR). **Manual QA still required** (could not be visually verified in this environment): send online; send while offline/reconnecting (queues → auto-fires on reconnect → survives reload); force an app-level mutator error (failed bubble appears, composer text not lost); multi-tab behavior (see Known limitation).
9. **Services to which this change is to be deployed:** dashboard (frontend only).
10. **Main PR link (if against a release branch):** N/A — targets `main`.

### Known limitation (multi-tab, web-only)
`currentSessionId` is generated per browser-tab module load while pending state lives in shared `localStorage`. An in-flight message sent from tab A can briefly render as `failed` in tab B (different session), offering a false Retry. Cosmetic — auto-retry is session-scoped and the entry clears on reconcile once `isSent`. Follow-up: treat `connected` + `mutatorFired` cross-session entries as "sending" rather than "failed".

If the API supports it, please add reviewers: Nikunj Gupta, Naman Kalkhuria, Devesh Rastogi, Aravind Sethuraj.