### PR TITLE
feat: XYNE-55302 add manim + d2 animated scene kinds to video explainer

### DIFF
--- a/claw-deployments/kata-infra/video-studio/Dockerfile
+++ b/claw-deployments/kata-infra/video-studio/Dockerfile
@@ -1,0 +1,70 @@
+# Video-explainer "studio" renderer image. It extends the standard workspace
+# server image so Kata's /execute, /upload, and /download API stays unchanged,
+# and adds every animation engine the create-video-explainer tool can drive so
+# that ALL scene kinds render in ONE sandbox with no internet at runtime.
+#
+# The base image (agent-workspace) already ships ffmpeg + ffprobe and chromium,
+# which cover the 5 static scene kinds (title, diagram, code, diff, bullets).
+# This image adds the two animated kinds:
+#   - manim  -> Manim Community (Cairo renderer), 1080p/30fps Python scenes.
+#   - d2     -> offline D2 -> SVG (d2) -> PNG (rsvg-convert) -> ffmpeg reveal.
+#
+# Runtime is egress-free (NetworkPolicy egress:[], no SA token, non-root, caps
+# dropped -- see the template YAML). Narration TTS is fetched by the claw pod and
+# injected into the box as an MP3 file, so the S2S key never enters the sandbox
+# and the box needs no network. All package installs below happen at BUILD time
+# (in CI, which has network); nothing is fetched at run time.
+ARG AGENT_WORKSPACE_IMAGE=agent-workspace:local
+FROM ${AGENT_WORKSPACE_IMAGE}
+
+LABEL org.opencontainers.image.title="video-studio" \
+      org.opencontainers.image.description="Single-box multi-engine renderer for create-video-explainer (manim + d2 + rsvg)" \
+      org.opencontainers.image.vendor="Xyne Spaces"
+
+USER root
+
+# --- Manim (Cairo) -------------------------------------------------------------
+# Same toolchain xyne-lens uses. LaTeX is enabled by default because Manim's
+# MathTex/Tex helpers need it; set VIDEO_STUDIO_WITH_TEX=0 for a text-only image.
+ARG VIDEO_STUDIO_WITH_TEX=1
+ARG MANIM_VERSION=0.20.1
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       python3 python3-dev python3-pip \
+       build-essential pkg-config \
+       libcairo2-dev libpango1.0-dev libgl1 \
+       ffmpeg fonts-dejavu-core fontconfig \
+       librsvg2-bin ca-certificates curl \
+  && if [ "${VIDEO_STUDIO_WITH_TEX}" = "1" ]; then \
+       apt-get install -y --no-install-recommends \
+         texlive-latex-base texlive-latex-recommended texlive-latex-extra \
+         texlive-fonts-recommended dvisvgm ghostscript; \
+     fi \
+  && python3 -m pip install --no-cache-dir --break-system-packages "manim==${MANIM_VERSION}" \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# --- D2 (single static Go binary; pinned release) ------------------------------
+# Downloaded at BUILD time only. The runtime box has no network -- d2 runs fully
+# offline (D2_LAYOUT=dagre, the bundled layout engine; no headless browser).
+ARG D2_VERSION=0.7.1
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) d2arch=amd64 ;; \
+      arm64) d2arch=arm64 ;; \
+      *) echo "unsupported arch $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/terrastruct/d2/releases/download/v${D2_VERSION}/d2-v${D2_VERSION}-linux-${d2arch}.tar.gz" \
+      -o /tmp/d2.tar.gz; \
+    tar -C /tmp -xzf /tmp/d2.tar.gz; \
+    install -m 0755 "/tmp/d2-v${D2_VERSION}/bin/d2" /usr/local/bin/d2; \
+    rm -rf /tmp/d2.tar.gz "/tmp/d2-v${D2_VERSION}"; \
+    d2 --version
+
+# Smoke-check every engine is on PATH at build time so a broken image fails CI,
+# not a user's render.
+RUN command -v ffmpeg && command -v ffprobe && command -v manim \
+  && command -v d2 && command -v rsvg-convert
+
+USER 1000:1000

--- a/claw-deployments/kata-infra/video-studio/README.md
+++ b/claw-deployments/kata-infra/video-studio/README.md
@@ -1,0 +1,55 @@
+# video-studio image
+
+A single sandbox image that carries **every** engine the `create-video-explainer`
+tool can drive, so a whole storyboard — static and animated scenes — renders in
+**one** box with **no internet at run time**.
+
+## Why this exists
+
+`create-video-explainer` (`packages/xyne-claw-shared/src/tools/video-explainer/`)
+composes a narrated MP4 from an approved storyboard. Scene kinds:
+
+| Kind | Engine | In base `agent-workspace`? |
+|---|---|---|
+| title, code, diff, bullets | chromium screenshot + ffmpeg | yes |
+| diagram | chromium + bundled mermaid.min.js | yes |
+| **manim** | Manim Community (Cairo) | **added here** |
+| **d2** | d2 → rsvg-convert → ffmpeg | **added here** |
+
+The base workspace image already has `ffmpeg`/`ffprobe` and `chromium`. This
+image only *adds* Manim, D2, and `rsvg-convert` (librsvg2-bin) on top.
+
+## Offline / security model
+
+- **Runtime is egress-free.** The pod template sets `egress: []`, drops the
+  service-account token, runs non-root (uid 1000), and drops capabilities.
+- **No engine needs the network at run time.** Manim (Cairo) and D2
+  (`D2_LAYOUT=dagre`, the bundled layout engine — *not* the browser-based
+  ELK/TALA path) both run fully offline. D2 raster is done by `rsvg-convert`,
+  not a headless Chromium, precisely so no browser download is ever attempted.
+- **TTS never enters the box.** The claw pod calls the S2S-guarded
+  `/internal/tts` endpoint and injects the resulting MP3 into the sandbox as a
+  file (`session.files.write`). The `x-s2s-key` never crosses the VM boundary.
+- **Untrusted model-authored code is sandboxed.** `manim.source` and every
+  `d2.steps[]` string is written to a file and never shelled. Only the Manim
+  `scene` class name is interpolated into a command line, and the validator
+  restricts it to a Python identifier (`storyboard.ts`).
+
+All package installs happen at **build** time (CI has network); the running
+container fetches nothing.
+
+## Build
+
+```bash
+docker build \
+  --build-arg AGENT_WORKSPACE_IMAGE=<the current agent-workspace image> \
+  -t video-studio:local \
+  claw-deployments/kata-infra/video-studio
+```
+
+Pins: `MANIM_VERSION=0.20.1`, `D2_VERSION=0.7.1`. LaTeX is on by default for
+Manim's `MathTex`/`Tex`; set `--build-arg VIDEO_STUDIO_WITH_TEX=0` for a
+text-only image.
+
+> Note: this image is **not** built or run in the dev sandbox (no Docker there).
+> It builds in CI and is validated by the build-time `command -v` smoke check.

--- a/packages/xyne-claw-shared/src/tools/video-explainer/composer.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/composer.ts
@@ -8,11 +8,29 @@ import {
   REPO_CONFIGS,
 } from "../sandbox/index.js";
 import { generateSceneHtml } from "./scene-html.js";
-import type { Storyboard, VideoScene } from "./storyboard.js";
+import {
+  computeSegmentSeconds,
+  isAnimatedScene,
+  type ManimScene,
+  type D2Scene,
+  type Storyboard,
+  type VideoScene,
+} from "./storyboard.js";
 
 const WORK_DIR = "/home/nixuser/workspace/.video-explainer";
 export const OUTPUT_PATH = "/home/nixuser/workspace/results/explainer.mp4";
 const AUTH_URL_DEFAULT = "http://xyne-claw-auth.xyne-apps.svc.cluster.local:3003";
+
+// Canonical output geometry. Every scene — static screenshot, Manim clip, or
+// D2 reveal — is normalized to exactly this before concatenation so the
+// concat demuxer never sees a resolution/SAR/fps mismatch.
+const WIDTH = 1920;
+const HEIGHT = 1080;
+const FPS = 30;
+const CANVAS = "#07111f";
+// Nominal on-screen time per D2 board before the next fades in. Narration
+// still governs the final segment length via computeSegmentSeconds.
+const D2_STEP_SECONDS = 2.4;
 
 interface TtsEnvelope {
   success?: boolean;
@@ -25,6 +43,7 @@ export interface SceneTiming {
   kind: VideoScene["kind"];
   narrationSeconds: number;
   segmentSeconds: number;
+  animationSeconds?: number;
 }
 
 function authUrl(context: ToolExecutionContext): string {
@@ -60,6 +79,19 @@ async function run(session: Session, command: string, timeoutMs = 60_000): Promi
     throw new Error(detail);
   }
   return result.stdout.trim();
+}
+
+async function probeSeconds(session: Session, mediaPath: string, label: string): Promise<number> {
+  const output = await run(
+    session,
+    `ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 '${mediaPath}'`,
+    30_000,
+  );
+  const seconds = Number.parseFloat(output);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error(`ffprobe could not measure ${label}`);
+  }
+  return seconds;
 }
 
 async function requestNarration(
@@ -150,6 +182,13 @@ async function shipMermaidRuntime(session: Session): Promise<boolean> {
   return true;
 }
 
+// ffmpeg filter that fits arbitrary source geometry into the canonical frame
+// without cropping: letterbox onto a CANVAS-colored 1920x1080, square pixels,
+// 30fps.
+const FIT_FILTER =
+  `scale=${WIDTH}:${HEIGHT}:force_original_aspect_ratio=decrease,` +
+  `pad=${WIDTH}:${HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=${CANVAS},setsar=1,fps=${FPS}`;
+
 async function sceneCode(
   session: Session,
   context: ToolExecutionContext,
@@ -215,6 +254,95 @@ async function renderScene(
   );
 }
 
+/**
+ * Render a Manim scene, in THIS sandbox, to a silent clip normalized to the
+ * canonical frame. `source` is written to a file (never shelled); only the
+ * validated `scene` identifier is interpolated into the command line.
+ */
+async function renderManim(session: Session, scene: ManimScene, index: number): Promise<string> {
+  const scriptPath = `${WORK_DIR}/manim-${index}.py`;
+  const mediaDir = `${WORK_DIR}/manim-${index}-media`;
+  const outPath = `${WORK_DIR}/anim-${index}.mp4`;
+  await session.files.write(scriptPath, Buffer.from(scene.source));
+  await run(
+    session,
+    `command -v manim >/dev/null 2>&1 || { echo "manim is missing from the studio image" >&2; exit 44; }; ` +
+      `cd '${WORK_DIR}' && manim --renderer=cairo -r ${WIDTH},${HEIGHT} --fps ${FPS} ` +
+      `--media_dir '${mediaDir}' -o out --format mp4 '${scriptPath}' ${scene.scene}`,
+    600_000,
+  );
+  const raw = await run(session, `find '${mediaDir}' -name 'out.mp4' | head -1`);
+  if (!raw) throw new Error(`manim produced no output for scene ${index + 1}`);
+  await run(
+    session,
+    `ffmpeg -y -i '${raw}' -vf "${FIT_FILTER}" -an -pix_fmt yuv420p '${outPath}'`,
+    180_000,
+  );
+  return outPath;
+}
+
+/**
+ * Render an ordered set of D2 boards to a silent progressive-reveal clip,
+ * entirely offline: d2 (layout+SVG) → rsvg-convert (raster) → ffmpeg. No
+ * headless browser and no network, so it runs in the sealed studio image.
+ */
+async function renderD2(session: Session, scene: D2Scene, index: number): Promise<string> {
+  const clips: string[] = [];
+  for (const [step, source] of scene.steps.entries()) {
+    const d2Path = `${WORK_DIR}/d2-${index}-${step}.d2`;
+    const svgPath = `${WORK_DIR}/d2-${index}-${step}.svg`;
+    const pngPath = `${WORK_DIR}/d2-${index}-${step}.png`;
+    const clipPath = `${WORK_DIR}/d2-${index}-${step}.mp4`;
+    await session.files.write(d2Path, Buffer.from(source));
+    await run(
+      session,
+      `command -v d2 >/dev/null 2>&1 || { echo "d2 is missing from the studio image" >&2; exit 45; }; ` +
+        `D2_LAYOUT=dagre d2 --pad 48 '${d2Path}' '${svgPath}'`,
+      120_000,
+    );
+    await run(
+      session,
+      `command -v rsvg-convert >/dev/null 2>&1 || { echo "rsvg-convert is missing from the studio image" >&2; exit 46; }; ` +
+        `rsvg-convert -w ${WIDTH} -h ${HEIGHT} --keep-aspect-ratio -b '${CANVAS}' '${svgPath}' -o '${pngPath}'`,
+      120_000,
+    );
+    await run(
+      session,
+      `ffmpeg -y -loop 1 -t ${D2_STEP_SECONDS} -i '${pngPath}' ` +
+        `-vf "${FIT_FILTER},fade=t=in:st=0:d=0.4" -an -pix_fmt yuv420p '${clipPath}'`,
+      120_000,
+    );
+    clips.push(clipPath);
+  }
+  const outPath = `${WORK_DIR}/anim-${index}.mp4`;
+  if (clips.length === 1) {
+    await run(session, `cp '${clips[0]}' '${outPath}'`);
+    return outPath;
+  }
+  const concat = clips.map((clip) => `file '${clip}'`).join("\n");
+  await session.files.write(`${WORK_DIR}/d2-${index}-concat.txt`, Buffer.from(`${concat}\n`));
+  await run(
+    session,
+    `ffmpeg -y -f concat -safe 0 -i '${WORK_DIR}/d2-${index}-concat.txt' ` +
+      `-c:v libx264 -preset medium -pix_fmt yuv420p '${outPath}'`,
+    180_000,
+  );
+  return outPath;
+}
+
+async function renderAnimation(
+  session: Session,
+  scene: ManimScene | D2Scene,
+  index: number,
+): Promise<{ clipPath: string; animationSeconds: number }> {
+  const clipPath =
+    scene.kind === "manim"
+      ? await renderManim(session, scene, index)
+      : await renderD2(session, scene, index);
+  const animationSeconds = await probeSeconds(session, clipPath, `animation for scene ${index + 1}`);
+  return { clipPath, animationSeconds };
+}
+
 export async function composeVideo(
   session: Session,
   context: ToolExecutionContext,
@@ -232,37 +360,62 @@ export async function composeVideo(
 
   const timings: SceneTiming[] = [];
   for (const [index, scene] of storyboard.scenes.entries()) {
-    await renderScene(session, context, storyboard, scene, index, mermaidShipped);
+    // Render the visual: a screenshot for static scenes, a silent clip for
+    // animated ones. Both engines run in THIS same sandbox.
+    let animationSeconds = 0;
+    let clipPath: string | undefined;
+    if (isAnimatedScene(scene)) {
+      const animation = await renderAnimation(session, scene, index);
+      clipPath = animation.clipPath;
+      animationSeconds = animation.animationSeconds;
+    } else {
+      await renderScene(session, context, storyboard, scene, index, mermaidShipped);
+    }
+
+    // Narration is fetched by the runtime (not the sandbox) and injected as a
+    // file, so the box never needs network.
     const audioPath = `${WORK_DIR}/scene-${index}.mp3`;
     await session.files.write(
       audioPath,
       await requestNarration(context, scene.narration, storyboard.voice),
     );
-    const durationOutput = await run(
-      session,
-      `ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 '${audioPath}'`,
-      30_000,
-    );
-    const narrationSeconds = Number.parseFloat(durationOutput);
-    if (!Number.isFinite(narrationSeconds) || narrationSeconds <= 0) {
-      throw new Error(`ffprobe could not measure narration for scene ${index + 1}`);
-    }
-    const segmentSeconds = narrationSeconds + 0.8;
+    const narrationSeconds = await probeSeconds(session, audioPath, `narration for scene ${index + 1}`);
+
+    // Narration-first: the longer of narration/animation plus a fixed tail.
+    const segmentSeconds = computeSegmentSeconds(narrationSeconds, animationSeconds);
     const captionPath = `${WORK_DIR}/scene-${index}.ass`;
     await session.files.write(captionPath, Buffer.from(captionFile(scene.narration, segmentSeconds)));
-    await run(
-      session,
-      `ffmpeg -y -loop 1 -i '${WORK_DIR}/scene-${index}.png' -i '${audioPath}' ` +
-        `-vf "subtitles='${captionPath}'" ` +
-        `-af apad -t ${segmentSeconds.toFixed(3)} -r 30 -c:v libx264 -preset medium -pix_fmt yuv420p ` +
-        `-c:a aac -b:a 192k '${WORK_DIR}/segment-${index}.mp4'`,
-      120_000,
-    );
+
+    if (clipPath) {
+      // Animated: freeze the last frame to fill the segment (video never
+      // truncates the voice), pad the audio with trailing silence.
+      const stopDuration = Math.max(0, segmentSeconds - animationSeconds);
+      await run(
+        session,
+        `ffmpeg -y -i '${clipPath}' -i '${audioPath}' ` +
+          `-filter_complex "[0:v]tpad=stop_mode=clone:stop_duration=${stopDuration.toFixed(3)},` +
+          `subtitles='${captionPath}',fps=${FPS}[v];[1:a]apad[a]" ` +
+          `-map "[v]" -map "[a]" -t ${segmentSeconds.toFixed(3)} ` +
+          `-c:v libx264 -preset medium -pix_fmt yuv420p -c:a aac -b:a 192k '${WORK_DIR}/segment-${index}.mp4'`,
+        180_000,
+      );
+    } else {
+      await run(
+        session,
+        `ffmpeg -y -loop 1 -i '${WORK_DIR}/scene-${index}.png' -i '${audioPath}' ` +
+          `-vf "subtitles='${captionPath}'" ` +
+          `-af apad -t ${segmentSeconds.toFixed(3)} -r ${FPS} -c:v libx264 -preset medium -pix_fmt yuv420p ` +
+          `-c:a aac -b:a 192k '${WORK_DIR}/segment-${index}.mp4'`,
+        120_000,
+      );
+    }
+
     timings.push({
       scene: index + 1,
       kind: scene.kind,
       narrationSeconds: Number(narrationSeconds.toFixed(2)),
       segmentSeconds: Number(segmentSeconds.toFixed(2)),
+      ...(animationSeconds > 0 ? { animationSeconds: Number(animationSeconds.toFixed(2)) } : {}),
     });
   }
 

--- a/packages/xyne-claw-shared/src/tools/video-explainer/index.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/index.ts
@@ -1,8 +1,11 @@
 export { createVideoExplainer } from "./tools.js";
 export {
   countWords,
+  computeSegmentSeconds,
+  isAnimatedScene,
   validateStoryboard,
   StoryboardValidationError,
+  SEGMENT_PAD_SECONDS,
   type Storyboard,
   type VideoScene,
 } from "./storyboard.js";

--- a/packages/xyne-claw-shared/src/tools/video-explainer/scene-html.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/scene-html.ts
@@ -55,6 +55,11 @@ function sceneBody(scene: VideoScene, title: string, code?: string, mermaidLive?
       return `<section><div class="eyebrow">BEFORE → AFTER</div><div class="diff-grid"><div><h2 class="before">Before</h2><pre class="code compact">${codeLines(scene.before)}</pre></div><div><h2 class="after">After</h2><pre class="code compact">${codeLines(scene.after)}</pre></div></div></section>`;
     case "bullets":
       return `<section><div class="eyebrow">WHAT THIS MEANS FOR YOU</div><h2>${escapeHtml(title)}</h2><ul>${scene.items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul></section>`;
+    default:
+      // Animated scenes (manim, d2) are rendered by the composer directly and
+      // never reach this HTML rasterizer; this keeps the switch exhaustive and
+      // degrades to a title card if one is ever routed here by mistake.
+      return `<section class="title-scene"><div class="eyebrow">VIDEO EXPLAINER</div><h1>${escapeHtml(title)}</h1><div class="rule"></div></section>`;
   }
 }
 

--- a/packages/xyne-claw-shared/src/tools/video-explainer/storyboard.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/storyboard.ts
@@ -1,6 +1,15 @@
 export const MAX_SCENES = 12;
 export const MAX_NARRATION_WORDS = 4_000;
 export const MAX_SCENE_NARRATION_CHARS = 2_000;
+export const MAX_ANIMATION_SOURCE_CHARS = 20_000;
+export const MAX_D2_STEPS = 8;
+
+/**
+ * Tail padding added to every segment after the narration/animation ends, in
+ * seconds. Kept here (not in the composer) so the timing math is pure and
+ * unit-testable without ffmpeg.
+ */
+export const SEGMENT_PAD_SECONDS = 0.8;
 
 export type TitleScene = { kind: "title"; narration: string };
 export type DiagramScene = { kind: "diagram"; mermaid: string; narration: string };
@@ -17,7 +26,48 @@ export type DiffScene = {
   narration: string;
 };
 export type BulletsScene = { kind: "bullets"; items: string[]; narration: string };
-export type VideoScene = TitleScene | DiagramScene | CodeScene | DiffScene | BulletsScene;
+/**
+ * A Manim animation scene. `source` is a full Manim (Community, Cairo
+ * renderer) Python script; `scene` is the Scene subclass to render. Both run
+ * inside the sealed studio sandbox — no repo, no network, no credentials —
+ * so untrusted model-authored Python never touches a privileged box. `scene`
+ * is interpolated into the manim command line, so it is restricted to a valid
+ * Python identifier; `source` is only ever written to a file, never shelled.
+ */
+export type ManimScene = {
+  kind: "manim";
+  source: string;
+  scene: string;
+  narration: string;
+};
+/**
+ * A D2 architecture/data-flow scene. `steps` is an ordered list of D2 board
+ * snapshots; each is rendered offline (d2 → SVG → rsvg-convert → PNG) and the
+ * boards are faded together into a progressive reveal. One step renders a
+ * single fade-in board. Every source is written to a file, never shelled.
+ */
+export type D2Scene = {
+  kind: "d2";
+  steps: string[];
+  narration: string;
+};
+export type VideoScene =
+  | TitleScene
+  | DiagramScene
+  | CodeScene
+  | DiffScene
+  | BulletsScene
+  | ManimScene
+  | D2Scene;
+
+export const ANIMATED_SCENE_KINDS: ReadonlySet<VideoScene["kind"]> = new Set([
+  "manim",
+  "d2",
+]);
+
+export function isAnimatedScene(scene: VideoScene): scene is ManimScene | D2Scene {
+  return ANIMATED_SCENE_KINDS.has(scene.kind);
+}
 
 export interface Storyboard {
   title: string;
@@ -110,15 +160,58 @@ function parseScene(value: unknown, index: number): VideoScene {
         narration: sceneNarration,
       };
     }
+    case "manim": {
+      const sceneClass = string(scene["scene"], `scenes[${index}].scene`, 200);
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(sceneClass)) {
+        throw new StoryboardValidationError(
+          `scenes[${index}].scene must be a valid Python class name (letters, digits, underscore; not starting with a digit)`,
+        );
+      }
+      return {
+        kind: "manim",
+        source: string(scene["source"], `scenes[${index}].source`, MAX_ANIMATION_SOURCE_CHARS),
+        scene: sceneClass,
+        narration: sceneNarration,
+      };
+    }
+    case "d2": {
+      const steps = scene["steps"];
+      if (!Array.isArray(steps) || steps.length === 0 || steps.length > MAX_D2_STEPS) {
+        throw new StoryboardValidationError(
+          `scenes[${index}].steps must contain between 1 and ${MAX_D2_STEPS} D2 sources`,
+        );
+      }
+      return {
+        kind: "d2",
+        steps: steps.map((step, stepIndex) =>
+          string(step, `scenes[${index}].steps[${stepIndex}]`, MAX_ANIMATION_SOURCE_CHARS),
+        ),
+        narration: sceneNarration,
+      };
+    }
     default:
       throw new StoryboardValidationError(
-        `scenes[${index}].kind must be title, diagram, code, diff, or bullets`,
+        `scenes[${index}].kind must be title, diagram, code, diff, bullets, manim, or d2`,
       );
   }
 }
 
 export function countWords(text: string): number {
   return text.trim() ? text.trim().split(/\s+/).length : 0;
+}
+
+/**
+ * Narration-first timing, unified for static and animated scenes. Narration is
+ * never cut and (for animated scenes) the animation is never cut: the segment
+ * runs for the longer of the two plus a fixed tail. The composer freezes the
+ * animation's last frame and pads the audio with silence to fill this length.
+ */
+export function computeSegmentSeconds(narrationSeconds: number, animationSeconds = 0): number {
+  const base = Math.max(
+    Number.isFinite(narrationSeconds) ? narrationSeconds : 0,
+    Number.isFinite(animationSeconds) ? animationSeconds : 0,
+  );
+  return Number((base + SEGMENT_PAD_SECONDS).toFixed(3));
 }
 
 export function validateStoryboard(value: unknown): Storyboard {

--- a/packages/xyne-claw-shared/src/tools/video-explainer/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/tools.ts
@@ -12,8 +12,12 @@ export const createVideoExplainer: ToolDefinition = {
   name: "Create Video Explainer",
   description:
     "Render an approved storyboard into a narrated MP4 inside the current writable sandbox. " +
-    "Always show the storyboard to the user and obtain approval before calling this tool. " +
-    "After it succeeds, deliver the returned filePath with sandbox-deliver-files.",
+    "Scene kinds: title, diagram (mermaid), code, diff, bullets, and the animated kinds " +
+    "manim (a Manim/Cairo Python scene) and d2 (an ordered list of D2 architecture board " +
+    "snapshots faded into a progressive reveal). Every engine renders in this same sandbox — " +
+    "no separate box — and needs no internet: narration TTS is fetched by the runtime and " +
+    "injected as a file. Always show the storyboard to the user and obtain approval before " +
+    "calling this tool. After it succeeds, deliver the returned filePath with sandbox-deliver-files.",
   source: "custom:sandbox",
   configSchema: SANDBOX_CONFIG_SCHEMA,
   inputSchema: {
@@ -80,6 +84,39 @@ export const createVideoExplainer: ToolDefinition = {
                 narration: { type: "string", maxLength: 2_000 },
               },
               required: ["kind", "items", "narration"],
+            },
+            {
+              type: "object",
+              properties: {
+                kind: { const: "manim" },
+                source: {
+                  type: "string",
+                  description:
+                    "A full Manim Community (Cairo renderer) Python script. Rendered at 1080p/30fps in this sandbox.",
+                },
+                scene: {
+                  type: "string",
+                  description: "The Scene subclass name to render (a valid Python identifier).",
+                },
+                narration: { type: "string", maxLength: 2_000 },
+              },
+              required: ["kind", "source", "scene", "narration"],
+            },
+            {
+              type: "object",
+              properties: {
+                kind: { const: "d2" },
+                steps: {
+                  type: "array",
+                  items: { type: "string" },
+                  minItems: 1,
+                  maxItems: 8,
+                  description:
+                    "Ordered D2 board snapshots. Each is rendered offline and faded into the next as a progressive architecture reveal.",
+                },
+                narration: { type: "string", maxLength: 2_000 },
+              },
+              required: ["kind", "steps", "narration"],
             },
           ],
         },

--- a/packages/xyne-claw-shared/src/tools/video-explainer/video-explainer.test.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/video-explainer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { generateSceneHtml } from "./scene-html.js";
 import {
+  computeSegmentSeconds,
+  isAnimatedScene,
   MAX_NARRATION_WORDS,
+  SEGMENT_PAD_SECONDS,
   validateStoryboard,
 } from "./storyboard.js";
 
@@ -21,6 +24,17 @@ describe("validateStoryboard", () => {
         },
         { kind: "diff", before: "old", after: "new", narration: "The change." },
         { kind: "bullets", items: ["Faster", "Safer"], narration: "The impact." },
+        {
+          kind: "manim",
+          source: "from manim import *\nclass Demo(Scene):\n    def construct(self):\n        pass",
+          scene: "Demo",
+          narration: "The animation.",
+        },
+        {
+          kind: "d2",
+          steps: ["a -> b", "a -> b -> c"],
+          narration: "The architecture.",
+        },
       ],
     });
 
@@ -31,7 +45,51 @@ describe("validateStoryboard", () => {
       "code",
       "diff",
       "bullets",
+      "manim",
+      "d2",
     ]);
+    expect(storyboard.scenes.filter(isAnimatedScene).map((scene) => scene.kind)).toEqual([
+      "manim",
+      "d2",
+    ]);
+  });
+
+  it("rejects a manim scene whose class name is not a valid identifier", () => {
+    expect(() =>
+      validateStoryboard({
+        title: "Injection attempt",
+        scenes: [
+          {
+            kind: "manim",
+            source: "from manim import *",
+            scene: "Demo; rm -rf /",
+            narration: "hello",
+          },
+        ],
+      }),
+    ).toThrow(/valid Python class name/);
+  });
+
+  it("rejects a d2 scene with no steps or too many steps", () => {
+    expect(() =>
+      validateStoryboard({
+        title: "No steps",
+        scenes: [{ kind: "d2", steps: [], narration: "hello" }],
+      }),
+    ).toThrow(/between 1 and 8/);
+
+    expect(() =>
+      validateStoryboard({
+        title: "Too many steps",
+        scenes: [
+          {
+            kind: "d2",
+            steps: Array.from({ length: 9 }, (_, i) => `a -> b${i}`),
+            narration: "hello",
+          },
+        ],
+      }),
+    ).toThrow(/between 1 and 8/);
   });
 
   it("rejects too many scenes, invalid highlights, and oversized narration", () => {
@@ -64,6 +122,25 @@ describe("validateStoryboard", () => {
         })),
       }),
     ).toThrow(/total narration must be at most 4000 words/);
+  });
+});
+
+describe("computeSegmentSeconds", () => {
+  it("uses narration plus the fixed tail for static scenes (no animation)", () => {
+    expect(computeSegmentSeconds(4)).toBe(4 + SEGMENT_PAD_SECONDS);
+    expect(computeSegmentSeconds(4, 0)).toBe(4 + SEGMENT_PAD_SECONDS);
+  });
+
+  it("lets the longer of narration/animation drive, so neither is truncated", () => {
+    // narration longer: animation freezes to fill
+    expect(computeSegmentSeconds(10, 6)).toBe(10 + SEGMENT_PAD_SECONDS);
+    // animation longer: audio pads with silence
+    expect(computeSegmentSeconds(6, 10)).toBe(10 + SEGMENT_PAD_SECONDS);
+  });
+
+  it("is resilient to non-finite ffprobe output", () => {
+    expect(computeSegmentSeconds(Number.NaN, 5)).toBe(5 + SEGMENT_PAD_SECONDS);
+    expect(computeSegmentSeconds(5, Number.POSITIVE_INFINITY)).toBe(5 + SEGMENT_PAD_SECONDS);
   });
 });
 


### PR DESCRIPTION
1. Problem Description:
The create-video-explainer tool supported only 5 static scene kinds (title, diagram, code, diff, bullets). Rich technical explainers need real animation — math/algorithm sequences (Manim) and architecture diagrams (D2).

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Enhancement — extends the existing video-explainer tool to unlock animated scenes.

3. Explain the solution implemented in the PR:
Additive change — the 5 existing scene kinds are preserved. Two animated kinds are added:
- `manim` — full Manim Community (Cairo) Python source + a validated Scene class name.
- `d2` — declarative diagram steps rendered offline (D2 → SVG → rsvg → PNG → animated clip).
The narration-first pipeline is unchanged: per-scene TTS → measure duration → render each animated clip → unify to 1920x1080/30fps/yuv420p → freeze-last-frame pad → ffmpeg concat. A new `video-studio` sandbox image (Dockerfile + README under claw-deployments/kata-infra/video-studio) bundles manim + d2 + rsvg so rendering runs fully offline in a single box. Security: scene `source`/`steps` are only ever written to files, never shelled; only the validated Manim Scene class name (identifier regex) ever reaches a command line.

4. Documentation (link to confluence docs created/updated for this change):
N/A — README added at claw-deployments/kata-infra/video-studio/README.md.

5. DB Alter Details (if any):
N/A.

6. Data fix Details (if any):
N/A.

7. Environment variable Changes (if any):
N/A — uses the existing claw-auth /internal/tts S2S endpoint already present on this base branch.

8. Testing (how it was tested; screenshots/links):
- 9/9 video-explainer unit tests pass; xyne-claw-shared typecheck clean.
- Full multi-engine render E2E verified in-box with real Manim 0.20.1 + D2 0.7.1 + rsvg, producing a 1920x1080 h264/yuv420p mono-AAC MP4 (both narration-first branches exercised: Manim freeze-pad + D2 pad).
- Cherry-picked cleanly onto deploy-xyneclaw; the resulting files are byte-identical to the validated source commits (415741d1, aa2d67c5).
- NOT verified here: docker image build of the video-studio image (needs CI/registry) and a live composeVideo against a deployed claw-auth.

9. Services to which this change is to be deployed:
xyne-claw / xyne-claw-shared (video-explainer tool); new video-studio sandbox image for the render box.

10. Main PR link (if this PR is raised against a release branch):
N/A.