### PR TITLE
fix: omit empty conversationId on channel-bound result + approval-card posts

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -1219,7 +1219,11 @@ async function postWriteApprovalAction(args: {
 
   await spacesAppFetch("/chat/postMessage", {
     channelId: ctx.channelId,
-    conversationId: ctx.conversationId,
+    // Same empty-conversationId guard as the result post: an API/event-triggered
+    // run has no thread, so posting the approval card with conversationId: ""
+    // 400s in Spaces' channel-validation middleware and the card silently never
+    // appears. Omit when empty → the card posts as a top-level channel message.
+    ...(ctx.conversationId ? { conversationId: ctx.conversationId } : {}),
     flow: writeFlow,
     userId: ctx.spacesAppUserId,
   }, token);
@@ -5386,7 +5390,13 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
           log.info(`Posting result: channelId=${ctx.channelId} conversationId=${ctx.conversationId} resultLen=${prepared.text.length} userId=${ctx.spacesAppUserId}`);
           await spacesAppFetch("/chat/postMessage", {
             channelId: ctx.channelId,
-            conversationId: ctx.conversationId,
+            // Channel-bound, thread-less runs (API/event-triggered) carry an
+            // empty conversationId. Sending "" explicitly fails Spaces'
+            // ChannelValidationSchema (conversationId is .min(1).optional() —
+            // "" is a string, not undefined, so it trips .min(1) → 400
+            // "Validation error"). Omit it when empty so Spaces treats the post
+            // as a top-level channel message and creates a fresh thread.
+            ...(ctx.conversationId ? { conversationId: ctx.conversationId } : {}),
             markdownText: prepared.text,
             userId: ctx.spacesAppUserId,
             metadata: convMetadata,


### PR DESCRIPTION
## Summary
Follow-up to PR #219. API/event-triggered runs of channel-bound agents (e.g. `npci-program-management-agent`) are **thread-less**, so `ctx.conversationId` is the empty string. claw-auth posted both the final result and the HITL write-approval card to Spaces `/chat/postMessage` with `conversationId: ""` explicitly in the body. Spaces' `validateChannelAccessForPost` middleware validates it with `z.string().min(1).trim().optional()` — `.optional()` permits `undefined` but **not** `""`, so the empty string trips `.min(1)` and returns `400 {"error":"Bad Request","message":"Validation error"}`. The result POST has no local try/catch, so the throw propagates to the outer catch (`"Failed to send result"`) and aborts the `/webhook/result` handler **before** the approval-card block runs — neither the result nor the card is ever posted. This is why the PR #219 card still wasn't visible in prod: #219's card logic lives in the `if (externalResultCallback)` branch, which these runs never enter (they carry no external callbackUrl), so they fall through to the normal channel path, which dies here.

## 1. Problem Description
HITL write-approval cards (and final results) never appear in the bound channel for API-triggered runs. Root cause: an empty `conversationId` sent as `""` (not omitted) fails Spaces channel-validation → 400, which aborts the whole result handler before the card is posted.

## 2. How the issue was identified
Prod claw-auth logs for 6+ npci runs (sessions `69b28b7a`, `7b228494`, `3ffe0e1e`, `d18a12c4`, `97fc34f2`, `8fc699dc`) all show `Posting result: channelId=cms6363ip1mtunk2t8co0z5rd conversationId=` immediately followed by `Failed to send result … Spaces app API 400 {"error":"Bad Request","message":"Validation error"}`. Zero `external-callback …` log lines exist, confirming PR #219's branch never executes for these runs. Traced the 400 to `apps/backend/src/apps/middelware/channelValidation.ts:171` (`ChannelValidationSchema`, conversationId `.min(1).optional()`).

## 3. Solution implemented
In `apps/xyne-claw-auth/backend/src/routes/webhook.ts`, at both `/chat/postMessage` call sites on the channel-bound path — the result post (~L5390) and the write-approval card post in `postWriteApprovalAction` (~L1219) — omit `conversationId` from the body when it is empty, via the idiomatic conditional spread `...(ctx.conversationId ? { conversationId: ctx.conversationId } : {})`. With channelId-only, Spaces' `findOrCreateConversation` creates a fresh top-level thread in the bound channel and posts there; the participant check (the agent's app user must be a member of the channel — already satisfied, since `apps-send-message` works) still gates it. Existing conversation-mode runs (non-empty `conversationId`) are byte-for-byte unchanged.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A

## 8. Testing
- Verified against prod logs that the failing path is the empty-`conversationId` 400.
- claw-auth backend `tsc --noEmit`: no new type errors at the edited lines (repo has a pre-existing implicit-any baseline unrelated to this change).
- Manual: an API-triggered run with a gated write tool now posts the result and the Approve/Decline card as top-level messages in the bound channel.

## 9. Services to which this change is to be deployed
xyne-claw-auth (claw-auth backend).

## 10. Main PR link
N/A — targets the claw deploy line `feature/deploy-xyneclaw`.

## Known follow-up (not in this PR)
The result and the card currently land as two separate top-level channel messages. Threading the card under the result's newly created conversation (capture the conversationId returned by the result post and reuse it) is a small UX refinement left for a follow-up.