### PR TITLE
fix: block workspace guests from Context, Knowledge Base and channel creation

### DIFF
--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -29,7 +29,7 @@ import {
   AppPermissionStatus,
   AppPermissionType,
   ActivityClassification,
-  ActivityClassificationJobType, ChannelType, ChannelRole,
+  ActivityClassificationJobType, ChannelType, ChannelRole, WorkspaceRole,
 } from '@xyne/shared';
 import '../types/express'; // Import to enable Express types augmentation
 import { unreadService } from '../services/unreadService';
@@ -798,6 +798,20 @@ export class ChannelController {
       } = req.body;
 
       const userId = req.user!.id;
+
+      // Guests are invited to specific channels only and have read-only
+      // resource access; they must not create workspace channels. The Zero
+      // ChannelsACL already blocks guest channel inserts, but channel
+      // creation via this REST endpoint bypasses that ACL, so enforce the
+      // same restriction here. DM creation has its own endpoint and is not
+      // affected.
+      if (req.user!.role === WorkspaceRole.GUEST && scopeType !== ChannelScopeType.DM) {
+        res.status(403).json({
+          error: 'Guests cannot create channels',
+          message: 'Your role does not permit creating channels in this workspace',
+        });
+        return;
+      }
 
       // Validate required fields
       if (!scopeType || !projectId) {

--- a/apps/dashboard/src/components/Auth/GuestBlockedRoute.tsx
+++ b/apps/dashboard/src/components/Auth/GuestBlockedRoute.tsx
@@ -1,0 +1,29 @@
+import { ReactElement } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+import { WorkspaceRole } from '@xyne/shared';
+import { useAuth } from '../../hooks/useAuth';
+
+interface GuestBlockedRouteProps {
+  children: ReactElement;
+}
+
+/**
+ * Route guard that blocks workspace GUEST users from a whole section.
+ *
+ * Guests are invited to specific channels / canvases only; they must never
+ * reach workspace-wide surfaces (Claw Agents, Context, Knowledge Base, etc.)
+ * even by typing the URL directly. Non-guest roles pass through unchanged.
+ *
+ * Redirects denied guests to the workspace home instead of rendering the
+ * protected subtree.
+ */
+export const GuestBlockedRoute = ({ children }: GuestBlockedRouteProps): ReactElement => {
+  const { user } = useAuth();
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
+
+  if (user?.role === WorkspaceRole.GUEST) {
+    return <Navigate to={workspaceId ? `/${workspaceId}` : '/'} replace />;
+  }
+
+  return children;
+};

--- a/apps/dashboard/src/hooks/useVisibleNavigationItems.ts
+++ b/apps/dashboard/src/hooks/useVisibleNavigationItems.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { usePermissions } from './usePermissions';
 import { useAuth } from './useAuth';
+import { WorkspaceRole } from '@xyne/shared';
 import { useUserGroups } from './useUserGroup';
 import {
   NAVIGATION_ITEMS,
@@ -18,6 +19,7 @@ export const useVisibleNavigationItems = (): NavigationItem[] => {
     group => group.createdBy === user?.id && group.workspaceId === user?.workspaceId,
   );
   const { showClawDashboard } = useClawDashboardVisibility();
+  const isGuest = user?.role === WorkspaceRole.GUEST;
 
   return useMemo(() => {
     const permittedItems = filterNavItemsByPermission(
@@ -25,7 +27,15 @@ export const useVisibleNavigationItems = (): NavigationItem[] => {
       permissions,
       canManageOwnUserGroups,
     );
-    if (showClawDashboard) return permittedItems;
-    return permittedItems.filter(item => item.path !== '/claw-agents');
-  }, [permissions, canManageOwnUserGroups, showClawDashboard]);
+    // Guests are scoped to specific channels / canvases; Context (/memory)
+    // and Knowledge Base are workspace-wide surfaces they must not see. The
+    // Knowledge Base item is already resource-gated, but we hide it here too
+    // as defense in depth alongside the route guard.
+    const guestBlockedPaths = new Set(['/memory', '/knowledge-base']);
+    const withoutGuestBlocked = isGuest
+      ? permittedItems.filter(item => !guestBlockedPaths.has(item.path))
+      : permittedItems;
+    if (showClawDashboard) return withoutGuestBlocked;
+    return withoutGuestBlocked.filter(item => item.path !== '/claw-agents');
+  }, [permissions, canManageOwnUserGroups, showClawDashboard, isGuest]);
 };

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -188,6 +188,7 @@ import { sharedChatRoutes } from './SharedChatRoutes';
 import { ResourceAccessScreen } from './ResourceAccessScreen/ResourceAccessScreen';
 import { RoleManagementScreen } from './RoleManagementScreen';
 import { ResourceProtectedRoute } from '../components/Auth/ResourceProtectedRoute';
+import { GuestBlockedRoute } from '../components/Auth/GuestBlockedRoute';
 import { WorkspaceManagementScreen } from './WorkspaceManagementScreen';
 import OrganisationsScreen from './OrganisationsScreen/OrganisationsScreen';
 import { AcceptInvitation } from './InvitationScreen/AcceptInvitation';
@@ -1169,7 +1170,11 @@ export const router = createBrowserRouter([
               },
               {
                 path: 'knowledge-base',
-                element: <KnowledgeBaseV2Layout />,
+                element: (
+                  <GuestBlockedRoute>
+                    <KnowledgeBaseV2Layout />
+                  </GuestBlockedRoute>
+                ),
                 children: [
                   {
                     index: true,
@@ -1198,7 +1203,11 @@ export const router = createBrowserRouter([
               },
               {
                 path: 'memory',
-                element: <MemoryScreen />,
+                element: (
+                  <GuestBlockedRoute>
+                    <MemoryScreen />
+                  </GuestBlockedRoute>
+                ),
               },
               {
                 path: 'analytics',


### PR DESCRIPTION
## Problem
A workspace GUEST (invited only to specific shared canvases / channels) can:
1. Open the **Context** (`/memory`) and **Knowledge Base** (`/knowledge-base`) sections and read workspace knowledge-base docs and SOPs. These routes had no role guard, and the Context nav item was not permission-gated at all.
2. **Create channels** via `POST /channels` even though their channel resource access is read-only. The Zero `ChannelsACL` already blocks guest channel inserts, but the REST channel-create endpoint bypasses that ACL entirely.

## Fix
Frontend (client guard):
- Add reusable `GuestBlockedRoute` guard (`apps/dashboard/src/components/Auth/GuestBlockedRoute.tsx`) that redirects `WorkspaceRole.GUEST` to workspace home.
- Wrap the `/memory` (Context) and `/knowledge-base` routes in `GuestBlockedRoute` (`apps/dashboard/src/routes/AppRoot.tsx`).
- Hide the Context and Knowledge Base nav items for guests (`useVisibleNavigationItems.ts`).

Backend (real authorization fix):
- Reject `WorkspaceRole.GUEST` in `channelController.createChannel` for non-DM channels (`apps/backend/src/controllers/channelController.ts`), closing the REST bypass of the Zero `ChannelsACL` guest block. DM creation uses a separate endpoint and is unaffected.

## Note on overlap with the Claw-agents PR
This PR introduces the same small `GuestBlockedRoute` component as the companion Claw-agents guest-restriction PR (they share one guard by design). If that PR merges first, resolve the trivial add/add on `GuestBlockedRoute.tsx` by keeping the existing file.

## Residual risk / follow-up
The Context memory API (`/api/memory/*`) is workspace-scoped with no guest guard, so a guest could still reach that data via direct API calls; this PR closes the UI surface. Adding a guest guard on the memory read endpoints is a recommended backend follow-up for defense in depth.

## Testing
- Backend `tsc --noEmit` and dashboard `typecheck` pass for the changed files (pre-existing unrelated sandbox errors remain).
- Manual: as GUEST, `/memory` and `/knowledge-base` redirect home, their nav items are hidden, and `POST /channels` returns 403; other roles unchanged.