### PR TITLE
feat: arrow-key message navigation (roving focus)

### DIFF
--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/MessageHoverToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/MessageHoverToolbar.tsx
@@ -6,6 +6,7 @@ import {
   subscribeMessageHoverActions,
 } from './messageHoverActionsRegistry';
 import { useMessageHoverShortcuts } from './useMessageHoverShortcuts';
+import { isProgrammaticScrollActive } from './messageKeyboardNav';
 
 interface MessageHoverToolbarProps {
   /** The positioned (position: relative) list container the overlay lives in. */
@@ -37,7 +38,7 @@ interface ActiveRow {
 export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ containerRef }) => {
   // Keyboard shortcuts for whichever message is hovered — registered once per
   // list here instead of once per mounted ChatBubble (~6 × ~40 effects saved).
-  useMessageHoverShortcuts();
+  useMessageHoverShortcuts(containerRef);
 
   const [activeRow, setActiveRow] = useState<ActiveRow | null>(null);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
@@ -139,6 +140,9 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
 
     const handleScroll = (): void => {
       if (pinnedOpenRef.current) return;
+      // Ignore the scroll our own arrow-key navigation just triggered, so the
+      // row it selected is not immediately cleared.
+      if (isProgrammaticScrollActive()) return;
       hide();
     };
 

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/messageKeyboardNav.ts
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/messageKeyboardNav.ts
@@ -1,0 +1,70 @@
+import { hoveredMessage } from '../ChatBubble/hoveredMessageRef';
+
+/**
+ * Keyboard (arrow-key) navigation across the message list — the "roving focus"
+ * that lets a user walk messages with ↑/↓ and then act on the current one with
+ * the existing per-message shortcuts (e / delete / p / a / l / ⌘⇧C).
+ *
+ * Design: instead of introducing a second, parallel "focused message" concept,
+ * arrow navigation drives the SAME pipeline a real mouse hover drives. Moving
+ * focus dispatches a real `mouseover` on the target row, so the shared
+ * MessageHoverToolbar sets `hoveredMessage.current`, stamps `data-hovered`, and
+ * positions the floating toolbar — exactly as if the pointer had entered the
+ * row. Every message-action shortcut already reads `hoveredMessage.current`, so
+ * they work on the keyboard-selected row with zero changes.
+ */
+
+/**
+ * scrollIntoView() fires an async `scroll` on the list container, and the
+ * MessageHoverToolbar clears the highlight on scroll. This short window tells
+ * that scroll handler to ignore the programmatic scroll we just caused, so the
+ * row we just selected is not immediately cleared.
+ */
+let programmaticScrollUntil = 0;
+
+export const isProgrammaticScrollActive = (): boolean => Date.now() < programmaticScrollUntil;
+
+/**
+ * Move the keyboard selection one row within `container`.
+ *
+ * Rows render oldest→newest top→bottom, so `prev` (↑) moves to the OLDER
+ * message (up the list) and `next` (↓) to the NEWER one. With nothing selected
+ * yet, ↑ selects the newest (bottom) message and ↓ is a no-op (already at the
+ * bottom). Movement clamps at both ends — it never wraps.
+ */
+export const navigateMessageFocus = (container: HTMLElement, direction: 'prev' | 'next'): void => {
+  const rows = Array.from(container.querySelectorAll<HTMLElement>('[data-message-id]'));
+  if (rows.length === 0) return;
+
+  const currentId = hoveredMessage.current?.messageId ?? null;
+  const index = currentId
+    ? rows.findIndex(row => row.getAttribute('data-message-id') === currentId)
+    : -1;
+
+  let target: HTMLElement | undefined;
+  if (index === -1) {
+    // Nothing selected yet: ↑ starts at the newest message; ↓ does nothing.
+    if (direction === 'prev') target = rows[rows.length - 1];
+    else return;
+  } else {
+    const nextIndex = direction === 'prev' ? index - 1 : index + 1;
+    if (nextIndex < 0 || nextIndex >= rows.length) return; // clamp at both ends
+    target = rows[nextIndex];
+  }
+  if (!target) return;
+
+  // Suppress the container's scroll-clear for the programmatic scroll below.
+  programmaticScrollUntil = Date.now() + 300;
+  target.scrollIntoView({ block: 'nearest' });
+
+  // Move DOM focus OUT of the composer onto the row so the message-action
+  // shortcuts (allowInInputs:false) fire instead of typing into the composer.
+  if (target.tabIndex < 0) target.tabIndex = -1;
+  target.focus({ preventScroll: true });
+
+  // Drive the shared hover pipeline exactly like a real pointer hover: sets
+  // hoveredMessage.current, stamps data-hovered, positions the toolbar.
+  target.dispatchEvent(
+    new MouseEvent('mouseover', { bubbles: true, cancelable: true, view: window }),
+  );
+};

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/useMessageHoverShortcuts.ts
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/useMessageHoverShortcuts.ts
@@ -6,6 +6,7 @@ import {
   getMessageHoverActionsByMessageId,
   type MessageHoverToolbarActions,
 } from './messageHoverActionsRegistry';
+import { navigateMessageFocus } from './messageKeyboardNav';
 
 /**
  * Resolve the registry entry for the message currently under the pointer.
@@ -26,6 +27,26 @@ const resolveHoveredEntry = (): MessageHoverToolbarActions | undefined => {
  * is checked lazily in `when`, so it transfers on unmount without any
  * re-registration.
  */
+/**
+ * Arrow navigation must not hijack the caret while the user is actually typing,
+ * and must stay out of the command palette / dialogs / listboxes (which own
+ * their own arrow handling). It IS allowed when focus is on the message list /
+ * body, or in an EMPTY composer (Slack-style: ↑ from an empty field starts
+ * walking messages).
+ */
+const isMessageNavContext = (): boolean => {
+  const el = document.activeElement;
+  if (el instanceof HTMLElement) {
+    if (el.closest('[cmdk-root],[role="dialog"],[role="menu"],[role="listbox"]')) return false;
+    if (el.isContentEditable) return (el.textContent ?? '').trim() === '';
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'input' || tag === 'textarea') {
+      return ((el as HTMLInputElement).value ?? '').trim() === '';
+    }
+  }
+  return true;
+};
+
 const owners: symbol[] = [];
 
 /** One catalog shortcut driven by the hovered message's registry entry. */
@@ -63,7 +84,7 @@ const useHoverShortcut = (
  * entry in the hover-actions registry, checks the relevant capability flag and
  * invokes the entry's handler.
  */
-export const useMessageHoverShortcuts = (): void => {
+export const useMessageHoverShortcuts = (containerRef?: { current: HTMLElement | null }): void => {
   const instanceIdRef = useRef<symbol | null>(null);
   instanceIdRef.current ??= Symbol('messageHoverShortcuts');
 
@@ -78,6 +99,38 @@ export const useMessageHoverShortcuts = (): void => {
   }, []);
 
   const isOwner = (): boolean => owners[0] === instanceIdRef.current;
+
+  // Arrow-key roving focus across the message list. Routed to the list that
+  // actually holds the current selection; with no selection, only the primary
+  // (first-mounted) list handles it. Gated by `isMessageNavContext` so it never
+  // fires while typing or inside a dialog/command palette.
+  const ownsArrowNav = (): boolean => {
+    if (!isMessageNavContext()) return false;
+    const container = containerRef?.current;
+    const currentId = hoveredMessage.current?.messageId;
+    if (currentId && container) {
+      return container.querySelector(`[data-message-id="${CSS.escape(currentId)}"]`) !== null;
+    }
+    return !currentId && isOwner();
+  };
+
+  useShortcutById(
+    'message.focusPrev',
+    () => {
+      const container = containerRef?.current;
+      if (container) navigateMessageFocus(container, 'prev');
+    },
+    { when: ownsArrowNav },
+  );
+
+  useShortcutById(
+    'message.focusNext',
+    () => {
+      const container = containerRef?.current;
+      if (container) navigateMessageFocus(container, 'next');
+    },
+    { when: ownsArrowNav },
+  );
 
   useHoverShortcut(
     'message.edit',

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -262,6 +262,26 @@ export const shortcuts = {
     allowInInputs: false,
     priority: 30,
   },
+  'message.focusPrev': {
+    keys: 'up',
+    scope: 'channel',
+    description: 'Move to previous (older) message',
+    category: 'Messages',
+    // Gated in useMessageHoverShortcuts: only fires on the message list / body or
+    // an EMPTY composer, never while typing or inside a dialog.
+    allowInInputs: true,
+    preventDefault: true,
+    priority: 30,
+  },
+  'message.focusNext': {
+    keys: 'down',
+    scope: 'channel',
+    description: 'Move to next (newer) message',
+    category: 'Messages',
+    allowInInputs: true,
+    preventDefault: true,
+    priority: 30,
+  },
 
   // ===== COMPOSER SHORTCUTS =====
   'composer.attach': {


### PR DESCRIPTION
## What
Adds **Up/Down arrow-key navigation** across the message list. Users can now walk messages with the keyboard and act on the selected one with the existing per-message shortcuts (`e` edit, `Delete` delete, `p` pin, `a`/`b` bookmark, `l` copy link, `⌘⇧C` copy content) — no mouse required. Requested in-thread by Boaz (parity with Slack/Mattermost arrow navigation).

## Why
Today those message shortcuts only fire on the message under the **mouse pointer** (`hoveredMessage.current`). There is no keyboard "cursor", so arrow keys only scroll and there is no way to select-then-edit from the keyboard.

## Approach (reuses the existing hover pipeline — no parallel state)
Instead of a second "focused message" concept, arrow navigation drives the **same** pipeline a real mouse hover drives: moving the selection dispatches a synthetic `mouseover` on the target row, so the shared `MessageHoverToolbar` sets `hoveredMessage.current`, stamps `data-hovered` (existing row highlight), and positions the floating toolbar. Every message-action shortcut already reads `hoveredMessage.current`, so they work on the keyboard-selected row with **zero changes** to those shortcuts.

## Changes
- **new** `apps/dashboard/src/components/Chat/HoverActionsToolbar/messageKeyboardNav.ts` — `navigateMessageFocus(container, dir)` (enumerates `[data-message-id]` rows, moves selection, `scrollIntoView`, moves DOM focus off the composer onto the row, dispatches synthetic `mouseover`) + a short programmatic-scroll guard.
- `useMessageHoverShortcuts.ts` — registers `message.focusPrev` (↑) / `message.focusNext` (↓). Owner-arbitrated (same first-mounted-list ownership as the other hover shortcuts) and routed to the list holding the current selection. Gated by `isMessageNavContext()` so it **never** fires while typing in a non-empty composer or inside a dialog / command palette / listbox.
- `MessageHoverToolbar.tsx` — passes `containerRef` to the hook; its scroll handler ignores the programmatic scroll our own nav triggers (so the just-selected row is not cleared).
- `catalog.ts` — `message.focusPrev` (`up`) and `message.focusNext` (`down`), category Messages, scope `channel`.

## Behavior
- Nothing selected → **↑ selects the newest (bottom) message**; ↓ is a no-op (already at the bottom).
- Then ↑ = older message, ↓ = newer; clamps at both ends (no wrap).
- ↑/↓ in an **empty** composer starts navigation (Slack-style); in a **non-empty** composer they move the caret as normal (shortcut is gated off).
- Selecting a row moves DOM focus off the composer so `e`/`Delete`/`p` (which are `allowInInputs:false`) fire on it.

## Typecheck
`npm run typecheck` reports the same 23 pre-existing errors in 10 files on both `main` and this branch (missing `posthog-js` dep + un-generated Zero mutator types in the sandbox). **This change introduces zero new type errors**; none of the touched files appear in the error list.

## Known limitations / follow-ups
- Manual browser QA still recommended (virtualized list): arrow-by-one only reaches currently-mounted rows (fine with Virtuoso overscan); jumping across a large virtualized gap in one keypress is out of scope.
- No visible focus ring distinct from the hover highlight yet — the selected row reuses the existing `data-[hovered]` background. A dedicated focus ring is a nice follow-up.
- Thread panel vs channel routing follows the existing hover-shortcut ownership model.