### PR TITLE
Fix/claw fixes

### DIFF
--- a/apps/xyne-claw-auth/backend/src/config.ts
+++ b/apps/xyne-claw-auth/backend/src/config.ts
@@ -1,8 +1,26 @@
+import { createHmac } from "node:crypto";
+import { derivePurposeKey, registerDecryptionFallback } from "./crypto.js";
+
 const requiredEnv = (name: string): string => {
   const val = process.env[name];
   if (!val) throw new Error(`Missing required env: ${name}`);
   return val;
 };
+
+const rootEncryptionKey = Buffer.from(requiredEnv("ENCRYPTION_KEY"), "hex");
+if (rootEncryptionKey.length !== 32) {
+  throw new Error("ENCRYPTION_KEY must be exactly 32 bytes encoded as 64 hex characters");
+}
+
+const dataEncryptionKey = derivePurposeKey(rootEncryptionKey, "data-encryption/aes-256-gcm/v1");
+const actionSigningKey = derivePurposeKey(rootEncryptionKey, "action-approval/hmac-sha256/v1");
+const sessionSigningKey = derivePurposeKey(rootEncryptionKey, "session-token/hmac-sha256/v1");
+const oauthStateSigningKey = derivePurposeKey(rootEncryptionKey, "oauth-state/hmac-sha256/v1");
+const legacySessionSigningKey = createHmac("sha256", rootEncryptionKey).update("xyne-claw-auth/session-token/v1").digest();
+
+// Existing rows were encrypted directly with ENCRYPTION_KEY. New writes use
+// the derived data key; reads fall back to the legacy root during migration.
+registerDecryptionFallback(dataEncryptionKey, rootEncryptionKey);
 
 export const CONFIG = {
   port: Number(process.env["AUTH_SERVICE_PORT"] ?? 3003),
@@ -13,7 +31,13 @@ export const CONFIG = {
   // traffic off the public ingress (~100k+ progress events/day in prod).
   // Falls back to `selfUrl` so single-node / dev deployments keep working.
   internalUrl: process.env["AUTH_SERVICE_INTERNAL_URL"] ?? process.env["AUTH_SERVICE_URL"] ?? `http://localhost:${process.env["AUTH_SERVICE_PORT"] ?? 3003}`,
-  encryptionKey: Buffer.from(requiredEnv("ENCRYPTION_KEY"), "hex"),
+  encryptionKey: dataEncryptionKey,
+  actionSigningKey,
+  sessionSigningKey,
+  oauthStateSigningKey,
+  legacyActionSigningKey: rootEncryptionKey,
+  legacySessionSigningKey,
+  legacyOauthStateSigningKey: rootEncryptionKey,
   // Spaces' AES-256-CBC key — must equal xyne-spaces backend's ENCRYPTION_KEY
   // value (the two services are independently keyed). Used ONLY to decrypt
   // `installed_apps.signingSecret` read from the Spaces DB during the

--- a/apps/xyne-claw-auth/backend/src/crypto.ts
+++ b/apps/xyne-claw-auth/backend/src/crypto.ts
@@ -1,7 +1,24 @@
-import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+import { randomBytes, createCipheriv, createDecipheriv, hkdfSync } from "node:crypto";
 
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12;
+const HKDF_SALT = Buffer.from("xyne-claw-auth/hkdf-sha256/v1", "utf8");
+const decryptionFallbacks = new Map<string, Buffer[]>();
+
+export function derivePurposeKey(masterKey: Buffer, purpose: string): Buffer {
+  if (masterKey.length !== 32) throw new Error("Master encryption key must be 32 bytes");
+  if (!purpose.trim()) throw new Error("HKDF purpose must not be empty");
+  return Buffer.from(hkdfSync("sha256", masterKey, HKDF_SALT, Buffer.from(purpose, "utf8"), 32));
+}
+
+/** Register a read-only legacy key used only when the primary GCM key fails. */
+export function registerDecryptionFallback(primaryKey: Buffer, legacyKey: Buffer): void {
+  const id = primaryKey.toString("base64");
+  const existing = decryptionFallbacks.get(id) ?? [];
+  if (!existing.some((candidate) => candidate.equals(legacyKey))) {
+    decryptionFallbacks.set(id, [...existing, Buffer.from(legacyKey)]);
+  }
+}
 
 export interface EncryptedPayload {
   ciphertext: string;
@@ -24,15 +41,22 @@ export function encrypt(plaintext: string, key: Buffer): EncryptedPayload {
 }
 
 export function decrypt(ciphertext: string, iv: string, authTag: string, key: Buffer): string {
-  const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(iv, "base64"));
-  decipher.setAuthTag(Buffer.from(authTag, "base64"));
-
-  const decrypted = Buffer.concat([
-    decipher.update(Buffer.from(ciphertext, "base64")),
-    decipher.final(),
-  ]);
-
-  return decrypted.toString("utf8");
+  const candidates = [key, ...(decryptionFallbacks.get(key.toString("base64")) ?? [])];
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    try {
+      const decipher = createDecipheriv(ALGORITHM, candidate, Buffer.from(iv, "base64"));
+      decipher.setAuthTag(Buffer.from(authTag, "base64"));
+      const decrypted = Buffer.concat([
+        decipher.update(Buffer.from(ciphertext, "base64")),
+        decipher.final(),
+      ]);
+      return decrypted.toString("utf8");
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
 }
 
 // Spaces encrypts DB-stored secrets (e.g. installed_apps.signingSecret) with
@@ -57,4 +81,3 @@ export function decryptSpacesCbc(blob: string, key: Buffer): string {
   ]);
   return decrypted.toString("utf8");
 }
-

--- a/apps/xyne-claw-auth/backend/src/lib/oauth-state.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/oauth-state.ts
@@ -23,7 +23,11 @@ interface StateInner {
 }
 
 function hmac(payload: string): string {
-  return createHmac("sha256", CONFIG.encryptionKey).update(payload).digest("hex");
+  return createHmac("sha256", CONFIG.oauthStateSigningKey).update(payload).digest("hex");
+}
+
+function hmacLegacy(payload: string): string {
+  return createHmac("sha256", CONFIG.legacyOauthStateSigningKey).update(payload).digest("hex");
 }
 
 export function signOAuthState(userId: string, extra?: Record<string, unknown>): string {
@@ -56,15 +60,20 @@ export function verifyOAuthState(state: string): VerifiedState {
   const body = state.slice(0, dot);
   const sig = state.slice(dot + 1);
   const expected = hmac(body);
+  const legacyExpected = hmacLegacy(body);
   let sigBuf: Buffer;
   let expectedBuf: Buffer;
+  let legacyExpectedBuf: Buffer;
   try {
     sigBuf = Buffer.from(sig, "hex");
     expectedBuf = Buffer.from(expected, "hex");
+    legacyExpectedBuf = Buffer.from(legacyExpected, "hex");
   } catch {
     throw new OAuthStateError("bad_signature");
   }
-  if (sigBuf.length !== expectedBuf.length || !timingSafeEqual(sigBuf, expectedBuf)) {
+  const matchesCurrent = sigBuf.length === expectedBuf.length && timingSafeEqual(sigBuf, expectedBuf);
+  const matchesLegacy = sigBuf.length === legacyExpectedBuf.length && timingSafeEqual(sigBuf, legacyExpectedBuf);
+  if (!matchesCurrent && !matchesLegacy) {
     throw new OAuthStateError("bad_signature");
   }
 

--- a/apps/xyne-claw-auth/backend/src/lib/session-tokens.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-tokens.ts
@@ -2,9 +2,6 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { CONFIG } from "../config.js";
 
 const TOKEN_VERSION = 1;
-const KEY_LABEL = "xyne-claw-auth/session-token/v1";
-
-const SIGNING_KEY: Buffer = createHmac("sha256", CONFIG.encryptionKey).update(KEY_LABEL).digest();
 
 export interface SessionTokenPayload {
   v: number;
@@ -27,7 +24,12 @@ function fromB64url(input: string): Buffer {
 }
 
 function sign(payloadB64: string): string {
-  const sig = createHmac("sha256", SIGNING_KEY).update(payloadB64).digest();
+  const sig = createHmac("sha256", CONFIG.sessionSigningKey).update(payloadB64).digest();
+  return b64url(sig);
+}
+
+function signLegacy(payloadB64: string): string {
+  const sig = createHmac("sha256", CONFIG.legacySessionSigningKey).update(payloadB64).digest();
   return b64url(sig);
 }
 
@@ -74,11 +76,12 @@ export function verifySessionToken(raw: string | undefined): SessionTokenPayload
   const payloadB64 = raw.slice(0, dot);
   const sigB64 = raw.slice(dot + 1);
 
-  const expected = sign(payloadB64);
-  const expectedBuf = fromB64url(expected);
   const givenBuf = fromB64url(sigB64);
-  if (expectedBuf.length !== givenBuf.length) return "bad-signature";
-  if (!timingSafeEqual(expectedBuf, givenBuf)) return "bad-signature";
+  const expectedBuf = fromB64url(sign(payloadB64));
+  const legacyExpectedBuf = fromB64url(signLegacy(payloadB64));
+  const matchesCurrent = expectedBuf.length === givenBuf.length && timingSafeEqual(expectedBuf, givenBuf);
+  const matchesLegacy = legacyExpectedBuf.length === givenBuf.length && timingSafeEqual(legacyExpectedBuf, givenBuf);
+  if (!matchesCurrent && !matchesLegacy) return "bad-signature";
 
   let payload: SessionTokenPayload;
   try {

--- a/apps/xyne-claw-auth/backend/src/mcpgateway/crypto/index.ts
+++ b/apps/xyne-claw-auth/backend/src/mcpgateway/crypto/index.ts
@@ -3,9 +3,8 @@
  * Encryption and decryption for backend secrets
  */
 
-import crypto from "node:crypto";
 import { CONFIG } from "../../config.js";
-import { ENCRYPTION } from "../config/index.js";
+import { decrypt, encrypt } from "../../crypto.js";
 import type { EncryptedSecretPayload } from "../types/index.js";
 
 /**
@@ -54,16 +53,12 @@ function getEncryptionKey(): Buffer {
  */
 export function encryptSecret(secret: string): EncryptedSecretPayload {
   const key = getEncryptionKey();
-  const iv = crypto.randomBytes(ENCRYPTION.IV_LENGTH);
-  const cipher = crypto.createCipheriv(ENCRYPTION.ALGORITHM, key, iv);
-
-  const encrypted = Buffer.concat([cipher.update(secret, "utf8"), cipher.final()]);
-  const authTag = cipher.getAuthTag();
+  const encrypted = encrypt(secret, key);
 
   return {
-    encryptedSecret: encrypted.toString("base64"),
-    iv: iv.toString("base64"),
-    authTag: authTag.toString("base64"),
+    encryptedSecret: encrypted.ciphertext,
+    iv: encrypted.iv,
+    authTag: encrypted.authTag,
   };
 }
 
@@ -71,19 +66,5 @@ export function encryptSecret(secret: string): EncryptedSecretPayload {
  * Decrypt a secret using AES-256-GCM
  */
 export function decryptSecret(payload: EncryptedSecretPayload): string {
-  const key = getEncryptionKey();
-  const decipher = crypto.createDecipheriv(
-    ENCRYPTION.ALGORITHM,
-    key,
-    Buffer.from(payload.iv, "base64")
-  );
-  decipher.setAuthTag(Buffer.from(payload.authTag, "base64"));
-
-  const decrypted = Buffer.concat([
-    decipher.update(Buffer.from(payload.encryptedSecret, "base64")),
-    decipher.final(),
-  ]);
-
-  return decrypted.toString("utf8");
+  return decrypt(payload.encryptedSecret, payload.iv, payload.authTag, getEncryptionKey());
 }
-

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -127,11 +127,34 @@ function approvalToolFailureMessage(errMsg: string): string {
 }
 
 const AGENT_CALL_CONSUMED_TTL_SEC = 24 * 60 * 60;
+const GOAL_ACTION_TTL_SEC = 24 * 60 * 60;
+const LEGACY_WRITE_CARD_TTL_SEC = 24 * 60 * 60;
+const LEGACY_GOAL_CARD_TTL_SEC = 24 * 60 * 60;
 
 async function consumeAgentCallAction(messageId: string): Promise<boolean> {
   if (!messageId) return true;
   const key = `flow-action:agent-call:${messageId}`;
   const result = await redisService.getConnection().set(key, "1", "EX", AGENT_CALL_CONSUMED_TTL_SEC, "NX");
+  return result === "OK";
+}
+
+async function consumeGoalAction(actionNonce: string): Promise<boolean> {
+  const key = `flow-action:start-goal:${actionNonce}`;
+  const result = await redisService.getConnection().set(key, "1", "EX", GOAL_ACTION_TTL_SEC, "NX");
+  return result === "OK";
+}
+
+async function consumeLegacyWriteCard(messageId: string, actionId: string): Promise<boolean> {
+  if (!messageId || !actionId) return false;
+  const key = `flow-action:legacy-write:${messageId}:${actionId}`;
+  const result = await redisService.getConnection().set(key, "1", "EX", LEGACY_WRITE_CARD_TTL_SEC, "NX");
+  return result === "OK";
+}
+
+async function consumeLegacyGoalCard(messageId: string): Promise<boolean> {
+  if (!messageId) return false;
+  const key = `flow-action:legacy-goal:${messageId}`;
+  const result = await redisService.getConnection().set(key, "1", "EX", LEGACY_GOAL_CARD_TTL_SEC, "NX");
   return result === "OK";
 }
 
@@ -224,7 +247,7 @@ type AppActionResponse =
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-async function findAgentForFlow(agentSlug: string | undefined, spacesAppId?: string): Promise<{
+async function findAgentForFlow(agentSlug: string | undefined, spacesAppId?: string, orgId?: string): Promise<{
   id: string;
   orgId: string;
   slug: string;
@@ -233,13 +256,21 @@ async function findAgentForFlow(agentSlug: string | undefined, spacesAppId?: str
   spacesAppId: string | null;
   config?: unknown;
 } | null> {
-  if (spacesAppId) return prisma.agent.findFirst({ where: { spacesAppId } });
+  if (spacesAppId) {
+    return prisma.agent.findFirst({
+      where: {
+        spacesAppId,
+        ...(orgId ? { orgId } : {}),
+        ...(agentSlug ? { slug: agentSlug } : {}),
+      },
+    });
+  }
   if (!agentSlug) {
     log.error(`[flow-action] org/app context is required; refusing global default-agent lookup spacesAppId=${spacesAppId ?? "none"} agentSlug=default`);
     return null;
   }
   const matches = await prisma.agent.findMany({
-    where: { slug: agentSlug },
+    where: { slug: agentSlug, ...(orgId ? { orgId } : {}) },
     take: 2,
   });
   if (matches.length > 1) {
@@ -377,23 +408,23 @@ async function dispatchContinuationRun(opts: {
 }): Promise<void> {
   try {
     const { setSession } = await import("./webhook.js");
-    const agent = await findAgentForFlow(opts.agentSlug, opts.spacesAppId);
-    const appToken = agent?.spacesAppToken
-      ? decrypt(...(agent.spacesAppToken.split(":") as [string, string, string]), CONFIG.encryptionKey)
-      : "";
     const orgId =
-      agent?.orgId ??
       (await prisma.user.findUnique({ where: { id: opts.writeUserId }, select: { orgId: true } }))?.orgId;
     if (!orgId) {
       log.error(`[flow-action] continuation: no orgId for user=${opts.writeUserId} agent=${opts.agentSlug ?? "(default)"}`);
       return;
     }
+    const agent = await findAgentForFlow(opts.agentSlug, opts.spacesAppId, orgId);
+    const appToken = agent?.spacesAppToken
+      ? decrypt(...(agent.spacesAppToken.split(":") as [string, string, string]), CONFIG.encryptionKey)
+      : "";
     const trimmed = trimForPrompt(opts.resultText);
     const runRes = await fetch(`${CONFIG.internalUrl}/claw/api/v1/internal/run`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+        "x-user-id": opts.writeUserId,
       },
       body: JSON.stringify({
         userId: opts.writeUserId,
@@ -533,6 +564,43 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         return;
       }
 
+      const params = JSON.parse(paramsStr) as Record<string, unknown>;
+
+      // Verify the complete card identity before any approve/decline side
+      // effect. Empty strings give absent routing fields one canonical form.
+      const { verifyActionSignatureAny } = await import("./mcp.js");
+      const actionPayload = {
+        serverType,
+        tool,
+        params,
+        userId: writeUserId,
+        agentSlug: agentSlug ?? "",
+        spacesAppId: spacesAppId ?? "",
+      };
+      const legacyActionPayload = {
+        serverType,
+        tool,
+        params,
+        userId: writeUserId,
+      };
+      const signatureOk = verifyActionSignatureAny([actionPayload, legacyActionPayload], signature);
+      if (!signatureOk) {
+        log.error("[flow-action] HMAC verification failed");
+        res.json({ type: "error", message: "HMAC verification failed — action may have been tampered with" } satisfies AppActionResponse);
+        return;
+      }
+      const legacyWriteCard = !verifyActionSignatureAny([actionPayload], signature);
+
+      const writeUser = await prisma.user.findUnique({ where: { id: writeUserId }, select: { orgId: true } });
+      if (!writeUser?.orgId) {
+        res.status(403).json({ type: "error", message: "Unable to resolve approving user's organization" } satisfies AppActionResponse);
+        return;
+      }
+      if (legacyWriteCard && !(await consumeLegacyWriteCard(messageId, actionId))) {
+        res.status(409).json({ type: "error", message: "This approval card was already used" } satisfies AppActionResponse);
+        return;
+      }
+
       if (actionId === "decline-write") {
         resp = { type: "close_screen", finalMessage: "❌ Action declined." };
         res.json(resp);
@@ -540,21 +608,9 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         return;
       }
 
-      // actionId === "approve-write"
-      const params = JSON.parse(paramsStr) as Record<string, unknown>;
-
-      // Verify HMAC signature
-      const { verifyActionSignature } = await import("./mcp.js");
-      const actionPayload = { serverType, tool, params, userId: writeUserId };
-      if (!verifyActionSignature(actionPayload, signature)) {
-        log.error("[flow-action] HMAC verification failed");
-        res.json({ type: "error", message: "HMAC verification failed — action may have been tampered with" } satisfies AppActionResponse);
-        return;
-      }
-
       // Execute the tool
       if (serverType === "xyne-spaces" && tool === "spaces-send-message") {
-        const agent = await findAgentForFlow(agentSlug, spacesAppId);
+        const agent = await findAgentForFlow(agentSlug, spacesAppId, writeUser.orgId);
         if (!agent?.spacesAppToken) {
           res.json({ type: "error", message: `No spacesAppToken for agent ${agentSlug ?? "(default)"}` } satisfies AppActionResponse);
           return;
@@ -1426,14 +1482,27 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
     }
 
     if (actionType === "start-goal") {
-      const condition = data["condition"] as string | undefined;
+      const rawCondition = data["condition"];
       const goalAgentSlug = data["agentSlug"] as string | undefined;
       const goalSpacesAppId = data["spacesAppId"] as string | undefined;
       const goalChannelId = data["channelId"] as string | undefined;
       const goalConversationId = data["conversationId"] as string | undefined;
       const goalUserId = data["userId"] as string | undefined;
+      const actionNonce = data["actionNonce"] as string | undefined;
+      const issuedAt = data["issuedAt"] as number | undefined;
+      const signature = data["signature"] as string | undefined;
 
-      if (!condition || !goalAgentSlug || !goalChannelId || !goalConversationId || !goalUserId) {
+      const { normalizeGoalCondition } = await import("../services/goalRelooper.js");
+      const condition = normalizeGoalCondition(rawCondition);
+
+      if (
+        actionId !== "start-goal"
+        || !condition
+        || !goalAgentSlug
+        || !goalChannelId
+        || !goalConversationId
+        || !goalUserId
+      ) {
         res.status(400).json({ type: "error", message: "Missing start-goal fields in flowJSON.data" } satisfies AppActionResponse);
         return;
       }
@@ -1444,6 +1513,57 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       if (!callerUserId || callerUserId !== goalUserId) {
         log.error(`[flow-action] start-goal: unauthorized — caller ${callerUserId ?? "(none)"} != expected ${goalUserId}`);
         res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
+        return;
+      }
+
+      const goalUser = await prisma.user.findUnique({ where: { id: goalUserId }, select: { orgId: true } });
+      if (!goalUser?.orgId) {
+        res.status(403).json({ type: "error", message: "Unable to resolve goal user's organization" } satisfies AppActionResponse);
+        return;
+      }
+      const agent = await findAgentForFlow(goalAgentSlug, goalSpacesAppId, goalUser.orgId);
+      if (!agent) {
+        log.error(`[flow-action] start-goal: scoped agent ${goalAgentSlug} not found`);
+        res.status(403).json({ type: "error", message: "Agent is not available in the user's organization" } satisfies AppActionResponse);
+        return;
+      }
+      const hasSignedGoalEnvelope =
+        condition === rawCondition
+        && !!actionNonce
+        && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(actionNonce)
+        && typeof issuedAt === "number"
+        && Number.isSafeInteger(issuedAt)
+        && !!signature;
+      if (hasSignedGoalEnvelope) {
+        const now = Date.now();
+        if (issuedAt > now + 5 * 60_000 || now - issuedAt > GOAL_ACTION_TTL_SEC * 1_000) {
+          res.status(400).json({ type: "error", message: "Goal suggestion has expired" } satisfies AppActionResponse);
+          return;
+        }
+        const { verifyActionSignatureAny } = await import("./mcp.js");
+        const goalActionPayload = {
+          actionType: "start-goal",
+          actionId,
+          condition,
+          agentSlug: goalAgentSlug,
+          spacesAppId: goalSpacesAppId ?? "",
+          channelId: goalChannelId,
+          conversationId: goalConversationId,
+          userId: goalUserId,
+          actionNonce,
+          issuedAt,
+        };
+        if (!verifyActionSignatureAny([goalActionPayload], signature)) {
+          log.error("[flow-action] start-goal: HMAC verification failed");
+          res.status(400).json({ type: "error", message: "Invalid goal suggestion signature" } satisfies AppActionResponse);
+          return;
+        }
+        if (!(await consumeGoalAction(actionNonce))) {
+          res.status(409).json({ type: "error", message: "Goal suggestion was already used" } satisfies AppActionResponse);
+          return;
+        }
+      } else if (!(await consumeLegacyGoalCard(messageId))) {
+        res.status(409).json({ type: "error", message: "Goal suggestion was already used" } satisfies AppActionResponse);
         return;
       }
 
@@ -1466,11 +1586,6 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       // a stuck dispatch is recoverable; a broken UI promise is not.
       (async () => {
         try {
-          const agent = await findAgentForFlow(goalAgentSlug, goalSpacesAppId);
-          if (!agent) {
-            log.error(`[flow-action] start-goal: agent ${goalAgentSlug} not found`);
-            return;
-          }
           const appToken = agent.spacesAppToken
             ? decrypt(...(agent.spacesAppToken.split(":") as [string, string, string]), CONFIG.encryptionKey)
             : "";
@@ -1507,6 +1622,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
             headers: {
               "Content-Type": "application/json",
               ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+              "x-user-id": goalUserId,
             },
             body: JSON.stringify(dispatchPayload),
           });

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -360,7 +360,11 @@ async function resolveServerNameForMcpCall(serverType: string, backendId?: strin
 }
 
 export function signAction(action: Record<string, unknown>): string {
-  return crypto.createHmac("sha256", CONFIG.encryptionKey).update(JSON.stringify(action)).digest("hex");
+  return crypto.createHmac("sha256", CONFIG.actionSigningKey).update(JSON.stringify(action)).digest("hex");
+}
+
+function signLegacyAction(action: Record<string, unknown>): string {
+  return crypto.createHmac("sha256", CONFIG.legacyActionSigningKey).update(JSON.stringify(action)).digest("hex");
 }
 
 /**
@@ -690,6 +694,23 @@ export function verifyActionSignature(action: Record<string, unknown>, signature
   const expected = signAction(action);
   try {
     return crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(signature, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+export function verifyActionSignatureAny(
+  actions: readonly Record<string, unknown>[],
+  signature: string,
+): boolean {
+  try {
+    const given = Buffer.from(signature, "hex");
+    return actions.some((action) => {
+      const current = Buffer.from(signAction(action), "hex");
+      if (current.length === given.length && crypto.timingSafeEqual(current, given)) return true;
+      const legacy = Buffer.from(signLegacyAction(action), "hex");
+      return legacy.length === given.length && crypto.timingSafeEqual(legacy, given);
+    });
   } catch {
     return false;
   }

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -39,7 +39,7 @@ import { resolveAuthForUser } from "../services/userMemoryFetcher.js";
 import { parseExperimentCommand, formatDuration, dispatchExperimentEpoch, dispatchExperimentChecker, EXPERIMENT_PROVIDERS, buildFindingsMarkdown, cancelRunSession } from "../lib/experiment.js";
 import { resolveFastMode, setFastModeOverride } from "../lib/fast-mode.js";
 import { acquireTwinSlot, renameTwinSlot, releaseTwinSlot } from "../lib/twin-limiter.js";
-import { handleSlashCommandBeforeRun, persistGoalStart, recordTurnAndDecide } from "../services/goalRelooper.js";
+import { handleSlashCommandBeforeRun, normalizeGoalCondition, persistGoalStart, recordTurnAndDecide } from "../services/goalRelooper.js";
 import {
   QUEUE_ENABLED,
   QUEUE_CAP,
@@ -1175,16 +1175,33 @@ async function postWriteApprovalAction(args: {
   const params = action["params"] as Record<string, unknown>;
   const actionDesc = formatActionDescription(action["tool"] as string, params, targetValidation);
 
-  const writeFlow = withSpacesAppId(buildWriteApprovalFlow(actionDesc, {
+  // The pending-action signature is minted before the Spaces delivery target is
+  // known. Verify it, then bind the trusted session agent to the card signature
+  // so flow-action cannot be replayed with another org's app credentials.
+  const { signAction, verifyActionSignature } = await import("./mcp.js");
+  const pendingActionPayload = {
     serverType: action["serverType"] as string,
     tool: action["tool"] as string,
     params,
     userId: action["userId"] as string,
-    signature: action["signature"] as string,
-    agentSlug: ctx.agentSlug ?? "",
+  };
+  if (!verifyActionSignature(pendingActionPayload, action["signature"] as string)) {
+    throw new Error("Invalid pending write-action signature");
+  }
+  const agentSlug = ctx.agentSlug ?? "";
+  const spacesAppId = ctx.spacesAppId ?? "";
+  const cardSignature = signAction({ ...pendingActionPayload, agentSlug, spacesAppId });
+
+  const writeFlow = withSpacesAppId(buildWriteApprovalFlow(actionDesc, {
+    serverType: pendingActionPayload.serverType,
+    tool: pendingActionPayload.tool,
+    params,
+    userId: pendingActionPayload.userId,
+    signature: cardSignature,
+    agentSlug,
     channelId: ctx.channelId,
     conversationId: ctx.conversationId,
-  }), ctx.spacesAppId);
+  }), spacesAppId);
 
   // Any attachment is a SEPARATE post from the card. `/files/filesUpload`
   // (filesController.uploadFiles) has no flow handling at all — a `flow` field
@@ -5467,12 +5484,18 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
                 return;
               }
             }
+            const refireUserId = refire["userId"];
+            if (typeof refireUserId !== "string" || !refireUserId) {
+              log.warn("[goal] refire missing userId; refusing to dispatch");
+              return;
+            }
             const runUrl = `${CONFIG.internalUrl}/claw/api/v1/internal/run`;
             void fetch(runUrl, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
                 ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+                "x-user-id": refireUserId,
               },
               body: JSON.stringify(refire),
             }).catch((err) => {
@@ -5612,28 +5635,53 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // collapses to a confirmation line after tap via replaceFlowCardWithText.
     const goalSuggestion = payload.pendingGoalSuggestion;
     if (goalSuggestion && goalSuggestion.condition?.trim() && goalSuggestion.rationale?.trim()) {
-      // Newline-strip + length-cap defensively: matches parseSlashCommand's
-      // cap so manually-typed and button-fired goals behave identically.
-      const safeCondition = goalSuggestion.condition.replace(/\r?\n/g, " ").slice(0, 2_000);
+      const safeCondition = normalizeGoalCondition(goalSuggestion.condition);
       const safeRationale = goalSuggestion.rationale.replace(/\r?\n/g, " ").slice(0, 400);
-      const goalFlow = withSpacesAppId(buildGoalSuggestionFlow(safeRationale, {
-        condition: safeCondition,
-        agentSlug: ctx.agentSlug ?? "",
-        channelId: ctx.channelId,
-        conversationId: ctx.conversationId,
-        userId: ctx.senderId,
-      }), ctx.spacesAppId);
-      await spacesAppFetch("/chat/postMessage", {
-        channelId: ctx.channelId,
-        conversationId: ctx.conversationId,
-        flow: goalFlow,
-        userId: ctx.spacesAppUserId,
-      }, token).catch((err) => {
-        log.warn("Failed to post /goal suggestion FlowUI card", {
-          error: err instanceof Error ? err.message : String(err),
+      if (!safeCondition) {
+        log.warn("Skipped /goal suggestion with invalid condition");
+      } else {
+        const goalAgentSlug = ctx.agentSlug ?? "";
+        const goalSpacesAppId = ctx.spacesAppId ?? "";
+        const actionNonce = crypto.randomUUID();
+        const issuedAt = Date.now();
+        const { signAction } = await import("./mcp.js");
+        const goalActionPayload = {
+          actionType: "start-goal",
+          actionId: "start-goal",
+          condition: safeCondition,
+          agentSlug: goalAgentSlug,
+          spacesAppId: goalSpacesAppId,
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          userId: ctx.senderId,
+          actionNonce,
+          issuedAt,
+        };
+        const goalFlow = withSpacesAppId(buildGoalSuggestionFlow(safeRationale, {
+          condition: safeCondition,
+          agentSlug: goalAgentSlug,
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          userId: ctx.senderId,
+        }), goalSpacesAppId);
+        goalFlow.data = {
+          ...(goalFlow.data ?? {}),
+          actionNonce,
+          issuedAt,
+          signature: signAction(goalActionPayload),
+        };
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow: goalFlow,
+          userId: ctx.spacesAppUserId,
+        }, token).catch((err) => {
+          log.warn("Failed to post /goal suggestion FlowUI card", {
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
-      });
-      log.info(`Posted /goal suggestion in thread ${ctx.conversationId}`);
+        log.info(`Posted /goal suggestion in thread ${ctx.conversationId}`);
+      }
     }
 
     // ── Send approval DMs for pending write actions (HITL) ──

--- a/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
+++ b/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
@@ -17,6 +17,16 @@ import { activeGoalRepository } from "../repositories/activeGoalRepository.js";
 import { judgeGoalViaClaw } from "./goalJudgeClient.js";
 import type { Prisma } from "@prisma/client";
 
+export const GOAL_CONDITION_MAX_LENGTH = 2_000;
+
+/** Canonical, bounded form used by both goal-card signing and execution. */
+export function normalizeGoalCondition(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const normalized = input.replace(/\s+/gu, " ").trim();
+  if (!normalized) return null;
+  return normalized.slice(0, GOAL_CONDITION_MAX_LENGTH);
+}
+
 const NEXT_TURN_TASK_TEMPLATE = (
   condition: string,
   ctx?: { turnCount?: number; maxTurns?: number },

--- a/claw-deployments/kata-infra/video-studio/Dockerfile
+++ b/claw-deployments/kata-infra/video-studio/Dockerfile
@@ -1,0 +1,70 @@
+# Video-explainer "studio" renderer image. It extends the standard workspace
+# server image so Kata's /execute, /upload, and /download API stays unchanged,
+# and adds every animation engine the create-video-explainer tool can drive so
+# that ALL scene kinds render in ONE sandbox with no internet at runtime.
+#
+# The base image (agent-workspace) already ships ffmpeg + ffprobe and chromium,
+# which cover the 5 static scene kinds (title, diagram, code, diff, bullets).
+# This image adds the two animated kinds:
+#   - manim  -> Manim Community (Cairo renderer), 1080p/30fps Python scenes.
+#   - d2     -> offline D2 -> SVG (d2) -> PNG (rsvg-convert) -> ffmpeg reveal.
+#
+# Runtime is egress-free (NetworkPolicy egress:[], no SA token, non-root, caps
+# dropped -- see the template YAML). Narration TTS is fetched by the claw pod and
+# injected into the box as an MP3 file, so the S2S key never enters the sandbox
+# and the box needs no network. All package installs below happen at BUILD time
+# (in CI, which has network); nothing is fetched at run time.
+ARG AGENT_WORKSPACE_IMAGE=agent-workspace:local
+FROM ${AGENT_WORKSPACE_IMAGE}
+
+LABEL org.opencontainers.image.title="video-studio" \
+      org.opencontainers.image.description="Single-box multi-engine renderer for create-video-explainer (manim + d2 + rsvg)" \
+      org.opencontainers.image.vendor="Xyne Spaces"
+
+USER root
+
+# --- Manim (Cairo) -------------------------------------------------------------
+# Same toolchain xyne-lens uses. LaTeX is enabled by default because Manim's
+# MathTex/Tex helpers need it; set VIDEO_STUDIO_WITH_TEX=0 for a text-only image.
+ARG VIDEO_STUDIO_WITH_TEX=1
+ARG MANIM_VERSION=0.20.1
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       python3 python3-dev python3-pip \
+       build-essential pkg-config \
+       libcairo2-dev libpango1.0-dev libgl1 \
+       ffmpeg fonts-dejavu-core fontconfig \
+       librsvg2-bin ca-certificates curl \
+  && if [ "${VIDEO_STUDIO_WITH_TEX}" = "1" ]; then \
+       apt-get install -y --no-install-recommends \
+         texlive-latex-base texlive-latex-recommended texlive-latex-extra \
+         texlive-fonts-recommended dvisvgm ghostscript; \
+     fi \
+  && python3 -m pip install --no-cache-dir --break-system-packages "manim==${MANIM_VERSION}" \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# --- D2 (single static Go binary; pinned release) ------------------------------
+# Downloaded at BUILD time only. The runtime box has no network -- d2 runs fully
+# offline (D2_LAYOUT=dagre, the bundled layout engine; no headless browser).
+ARG D2_VERSION=0.7.1
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) d2arch=amd64 ;; \
+      arm64) d2arch=arm64 ;; \
+      *) echo "unsupported arch $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/terrastruct/d2/releases/download/v${D2_VERSION}/d2-v${D2_VERSION}-linux-${d2arch}.tar.gz" \
+      -o /tmp/d2.tar.gz; \
+    tar -C /tmp -xzf /tmp/d2.tar.gz; \
+    install -m 0755 "/tmp/d2-v${D2_VERSION}/bin/d2" /usr/local/bin/d2; \
+    rm -rf /tmp/d2.tar.gz "/tmp/d2-v${D2_VERSION}"; \
+    d2 --version
+
+# Smoke-check every engine is on PATH at build time so a broken image fails CI,
+# not a user's render.
+RUN command -v ffmpeg && command -v ffprobe && command -v manim \
+  && command -v d2 && command -v rsvg-convert
+
+USER 1000:1000

--- a/claw-deployments/kata-infra/video-studio/README.md
+++ b/claw-deployments/kata-infra/video-studio/README.md
@@ -1,0 +1,55 @@
+# video-studio image
+
+A single sandbox image that carries **every** engine the `create-video-explainer`
+tool can drive, so a whole storyboard — static and animated scenes — renders in
+**one** box with **no internet at run time**.
+
+## Why this exists
+
+`create-video-explainer` (`packages/xyne-claw-shared/src/tools/video-explainer/`)
+composes a narrated MP4 from an approved storyboard. Scene kinds:
+
+| Kind | Engine | In base `agent-workspace`? |
+|---|---|---|
+| title, code, diff, bullets | chromium screenshot + ffmpeg | yes |
+| diagram | chromium + bundled mermaid.min.js | yes |
+| **manim** | Manim Community (Cairo) | **added here** |
+| **d2** | d2 → rsvg-convert → ffmpeg | **added here** |
+
+The base workspace image already has `ffmpeg`/`ffprobe` and `chromium`. This
+image only *adds* Manim, D2, and `rsvg-convert` (librsvg2-bin) on top.
+
+## Offline / security model
+
+- **Runtime is egress-free.** The pod template sets `egress: []`, drops the
+  service-account token, runs non-root (uid 1000), and drops capabilities.
+- **No engine needs the network at run time.** Manim (Cairo) and D2
+  (`D2_LAYOUT=dagre`, the bundled layout engine — *not* the browser-based
+  ELK/TALA path) both run fully offline. D2 raster is done by `rsvg-convert`,
+  not a headless Chromium, precisely so no browser download is ever attempted.
+- **TTS never enters the box.** The claw pod calls the S2S-guarded
+  `/internal/tts` endpoint and injects the resulting MP3 into the sandbox as a
+  file (`session.files.write`). The `x-s2s-key` never crosses the VM boundary.
+- **Untrusted model-authored code is sandboxed.** `manim.source` and every
+  `d2.steps[]` string is written to a file and never shelled. Only the Manim
+  `scene` class name is interpolated into a command line, and the validator
+  restricts it to a Python identifier (`storyboard.ts`).
+
+All package installs happen at **build** time (CI has network); the running
+container fetches nothing.
+
+## Build
+
+```bash
+docker build \
+  --build-arg AGENT_WORKSPACE_IMAGE=<the current agent-workspace image> \
+  -t video-studio:local \
+  claw-deployments/kata-infra/video-studio
+```
+
+Pins: `MANIM_VERSION=0.20.1`, `D2_VERSION=0.7.1`. LaTeX is on by default for
+Manim's `MathTex`/`Tex`; set `--build-arg VIDEO_STUDIO_WITH_TEX=0` for a
+text-only image.
+
+> Note: this image is **not** built or run in the dev sandbox (no Docker there).
+> It builds in CI and is validated by the build-time `command -v` smoke check.

--- a/packages/xyne-claw-shared/src/tools/video-explainer/composer.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/composer.ts
@@ -8,11 +8,29 @@ import {
   REPO_CONFIGS,
 } from "../sandbox/index.js";
 import { generateSceneHtml } from "./scene-html.js";
-import type { Storyboard, VideoScene } from "./storyboard.js";
+import {
+  computeSegmentSeconds,
+  isAnimatedScene,
+  type ManimScene,
+  type D2Scene,
+  type Storyboard,
+  type VideoScene,
+} from "./storyboard.js";
 
 const WORK_DIR = "/home/nixuser/workspace/.video-explainer";
 export const OUTPUT_PATH = "/home/nixuser/workspace/results/explainer.mp4";
 const AUTH_URL_DEFAULT = "http://xyne-claw-auth.xyne-apps.svc.cluster.local:3003";
+
+// Canonical output geometry. Every scene — static screenshot, Manim clip, or
+// D2 reveal — is normalized to exactly this before concatenation so the
+// concat demuxer never sees a resolution/SAR/fps mismatch.
+const WIDTH = 1920;
+const HEIGHT = 1080;
+const FPS = 30;
+const CANVAS = "#07111f";
+// Nominal on-screen time per D2 board before the next fades in. Narration
+// still governs the final segment length via computeSegmentSeconds.
+const D2_STEP_SECONDS = 2.4;
 
 interface TtsEnvelope {
   success?: boolean;
@@ -25,6 +43,7 @@ export interface SceneTiming {
   kind: VideoScene["kind"];
   narrationSeconds: number;
   segmentSeconds: number;
+  animationSeconds?: number;
 }
 
 function authUrl(context: ToolExecutionContext): string {
@@ -60,6 +79,19 @@ async function run(session: Session, command: string, timeoutMs = 60_000): Promi
     throw new Error(detail);
   }
   return result.stdout.trim();
+}
+
+async function probeSeconds(session: Session, mediaPath: string, label: string): Promise<number> {
+  const output = await run(
+    session,
+    `ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 '${mediaPath}'`,
+    30_000,
+  );
+  const seconds = Number.parseFloat(output);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error(`ffprobe could not measure ${label}`);
+  }
+  return seconds;
 }
 
 async function requestNarration(
@@ -150,6 +182,13 @@ async function shipMermaidRuntime(session: Session): Promise<boolean> {
   return true;
 }
 
+// ffmpeg filter that fits arbitrary source geometry into the canonical frame
+// without cropping: letterbox onto a CANVAS-colored 1920x1080, square pixels,
+// 30fps.
+const FIT_FILTER =
+  `scale=${WIDTH}:${HEIGHT}:force_original_aspect_ratio=decrease,` +
+  `pad=${WIDTH}:${HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=${CANVAS},setsar=1,fps=${FPS}`;
+
 async function sceneCode(
   session: Session,
   context: ToolExecutionContext,
@@ -215,6 +254,95 @@ async function renderScene(
   );
 }
 
+/**
+ * Render a Manim scene, in THIS sandbox, to a silent clip normalized to the
+ * canonical frame. `source` is written to a file (never shelled); only the
+ * validated `scene` identifier is interpolated into the command line.
+ */
+async function renderManim(session: Session, scene: ManimScene, index: number): Promise<string> {
+  const scriptPath = `${WORK_DIR}/manim-${index}.py`;
+  const mediaDir = `${WORK_DIR}/manim-${index}-media`;
+  const outPath = `${WORK_DIR}/anim-${index}.mp4`;
+  await session.files.write(scriptPath, Buffer.from(scene.source));
+  await run(
+    session,
+    `command -v manim >/dev/null 2>&1 || { echo "manim is missing from the studio image" >&2; exit 44; }; ` +
+      `cd '${WORK_DIR}' && manim --renderer=cairo -r ${WIDTH},${HEIGHT} --fps ${FPS} ` +
+      `--media_dir '${mediaDir}' -o out --format mp4 '${scriptPath}' ${scene.scene}`,
+    600_000,
+  );
+  const raw = await run(session, `find '${mediaDir}' -name 'out.mp4' | head -1`);
+  if (!raw) throw new Error(`manim produced no output for scene ${index + 1}`);
+  await run(
+    session,
+    `ffmpeg -y -i '${raw}' -vf "${FIT_FILTER}" -an -pix_fmt yuv420p '${outPath}'`,
+    180_000,
+  );
+  return outPath;
+}
+
+/**
+ * Render an ordered set of D2 boards to a silent progressive-reveal clip,
+ * entirely offline: d2 (layout+SVG) → rsvg-convert (raster) → ffmpeg. No
+ * headless browser and no network, so it runs in the sealed studio image.
+ */
+async function renderD2(session: Session, scene: D2Scene, index: number): Promise<string> {
+  const clips: string[] = [];
+  for (const [step, source] of scene.steps.entries()) {
+    const d2Path = `${WORK_DIR}/d2-${index}-${step}.d2`;
+    const svgPath = `${WORK_DIR}/d2-${index}-${step}.svg`;
+    const pngPath = `${WORK_DIR}/d2-${index}-${step}.png`;
+    const clipPath = `${WORK_DIR}/d2-${index}-${step}.mp4`;
+    await session.files.write(d2Path, Buffer.from(source));
+    await run(
+      session,
+      `command -v d2 >/dev/null 2>&1 || { echo "d2 is missing from the studio image" >&2; exit 45; }; ` +
+        `D2_LAYOUT=dagre d2 --pad 48 '${d2Path}' '${svgPath}'`,
+      120_000,
+    );
+    await run(
+      session,
+      `command -v rsvg-convert >/dev/null 2>&1 || { echo "rsvg-convert is missing from the studio image" >&2; exit 46; }; ` +
+        `rsvg-convert -w ${WIDTH} -h ${HEIGHT} --keep-aspect-ratio -b '${CANVAS}' '${svgPath}' -o '${pngPath}'`,
+      120_000,
+    );
+    await run(
+      session,
+      `ffmpeg -y -loop 1 -t ${D2_STEP_SECONDS} -i '${pngPath}' ` +
+        `-vf "${FIT_FILTER},fade=t=in:st=0:d=0.4" -an -pix_fmt yuv420p '${clipPath}'`,
+      120_000,
+    );
+    clips.push(clipPath);
+  }
+  const outPath = `${WORK_DIR}/anim-${index}.mp4`;
+  if (clips.length === 1) {
+    await run(session, `cp '${clips[0]}' '${outPath}'`);
+    return outPath;
+  }
+  const concat = clips.map((clip) => `file '${clip}'`).join("\n");
+  await session.files.write(`${WORK_DIR}/d2-${index}-concat.txt`, Buffer.from(`${concat}\n`));
+  await run(
+    session,
+    `ffmpeg -y -f concat -safe 0 -i '${WORK_DIR}/d2-${index}-concat.txt' ` +
+      `-c:v libx264 -preset medium -pix_fmt yuv420p '${outPath}'`,
+    180_000,
+  );
+  return outPath;
+}
+
+async function renderAnimation(
+  session: Session,
+  scene: ManimScene | D2Scene,
+  index: number,
+): Promise<{ clipPath: string; animationSeconds: number }> {
+  const clipPath =
+    scene.kind === "manim"
+      ? await renderManim(session, scene, index)
+      : await renderD2(session, scene, index);
+  const animationSeconds = await probeSeconds(session, clipPath, `animation for scene ${index + 1}`);
+  return { clipPath, animationSeconds };
+}
+
 export async function composeVideo(
   session: Session,
   context: ToolExecutionContext,
@@ -232,37 +360,62 @@ export async function composeVideo(
 
   const timings: SceneTiming[] = [];
   for (const [index, scene] of storyboard.scenes.entries()) {
-    await renderScene(session, context, storyboard, scene, index, mermaidShipped);
+    // Render the visual: a screenshot for static scenes, a silent clip for
+    // animated ones. Both engines run in THIS same sandbox.
+    let animationSeconds = 0;
+    let clipPath: string | undefined;
+    if (isAnimatedScene(scene)) {
+      const animation = await renderAnimation(session, scene, index);
+      clipPath = animation.clipPath;
+      animationSeconds = animation.animationSeconds;
+    } else {
+      await renderScene(session, context, storyboard, scene, index, mermaidShipped);
+    }
+
+    // Narration is fetched by the runtime (not the sandbox) and injected as a
+    // file, so the box never needs network.
     const audioPath = `${WORK_DIR}/scene-${index}.mp3`;
     await session.files.write(
       audioPath,
       await requestNarration(context, scene.narration, storyboard.voice),
     );
-    const durationOutput = await run(
-      session,
-      `ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 '${audioPath}'`,
-      30_000,
-    );
-    const narrationSeconds = Number.parseFloat(durationOutput);
-    if (!Number.isFinite(narrationSeconds) || narrationSeconds <= 0) {
-      throw new Error(`ffprobe could not measure narration for scene ${index + 1}`);
-    }
-    const segmentSeconds = narrationSeconds + 0.8;
+    const narrationSeconds = await probeSeconds(session, audioPath, `narration for scene ${index + 1}`);
+
+    // Narration-first: the longer of narration/animation plus a fixed tail.
+    const segmentSeconds = computeSegmentSeconds(narrationSeconds, animationSeconds);
     const captionPath = `${WORK_DIR}/scene-${index}.ass`;
     await session.files.write(captionPath, Buffer.from(captionFile(scene.narration, segmentSeconds)));
-    await run(
-      session,
-      `ffmpeg -y -loop 1 -i '${WORK_DIR}/scene-${index}.png' -i '${audioPath}' ` +
-        `-vf "subtitles='${captionPath}'" ` +
-        `-af apad -t ${segmentSeconds.toFixed(3)} -r 30 -c:v libx264 -preset medium -pix_fmt yuv420p ` +
-        `-c:a aac -b:a 192k '${WORK_DIR}/segment-${index}.mp4'`,
-      120_000,
-    );
+
+    if (clipPath) {
+      // Animated: freeze the last frame to fill the segment (video never
+      // truncates the voice), pad the audio with trailing silence.
+      const stopDuration = Math.max(0, segmentSeconds - animationSeconds);
+      await run(
+        session,
+        `ffmpeg -y -i '${clipPath}' -i '${audioPath}' ` +
+          `-filter_complex "[0:v]tpad=stop_mode=clone:stop_duration=${stopDuration.toFixed(3)},` +
+          `subtitles='${captionPath}',fps=${FPS}[v];[1:a]apad[a]" ` +
+          `-map "[v]" -map "[a]" -t ${segmentSeconds.toFixed(3)} ` +
+          `-c:v libx264 -preset medium -pix_fmt yuv420p -c:a aac -b:a 192k '${WORK_DIR}/segment-${index}.mp4'`,
+        180_000,
+      );
+    } else {
+      await run(
+        session,
+        `ffmpeg -y -loop 1 -i '${WORK_DIR}/scene-${index}.png' -i '${audioPath}' ` +
+          `-vf "subtitles='${captionPath}'" ` +
+          `-af apad -t ${segmentSeconds.toFixed(3)} -r ${FPS} -c:v libx264 -preset medium -pix_fmt yuv420p ` +
+          `-c:a aac -b:a 192k '${WORK_DIR}/segment-${index}.mp4'`,
+        120_000,
+      );
+    }
+
     timings.push({
       scene: index + 1,
       kind: scene.kind,
       narrationSeconds: Number(narrationSeconds.toFixed(2)),
       segmentSeconds: Number(segmentSeconds.toFixed(2)),
+      ...(animationSeconds > 0 ? { animationSeconds: Number(animationSeconds.toFixed(2)) } : {}),
     });
   }
 

--- a/packages/xyne-claw-shared/src/tools/video-explainer/index.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/index.ts
@@ -1,8 +1,11 @@
 export { createVideoExplainer } from "./tools.js";
 export {
   countWords,
+  computeSegmentSeconds,
+  isAnimatedScene,
   validateStoryboard,
   StoryboardValidationError,
+  SEGMENT_PAD_SECONDS,
   type Storyboard,
   type VideoScene,
 } from "./storyboard.js";

--- a/packages/xyne-claw-shared/src/tools/video-explainer/scene-html.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/scene-html.ts
@@ -55,6 +55,11 @@ function sceneBody(scene: VideoScene, title: string, code?: string, mermaidLive?
       return `<section><div class="eyebrow">BEFORE → AFTER</div><div class="diff-grid"><div><h2 class="before">Before</h2><pre class="code compact">${codeLines(scene.before)}</pre></div><div><h2 class="after">After</h2><pre class="code compact">${codeLines(scene.after)}</pre></div></div></section>`;
     case "bullets":
       return `<section><div class="eyebrow">WHAT THIS MEANS FOR YOU</div><h2>${escapeHtml(title)}</h2><ul>${scene.items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul></section>`;
+    default:
+      // Animated scenes (manim, d2) are rendered by the composer directly and
+      // never reach this HTML rasterizer; this keeps the switch exhaustive and
+      // degrades to a title card if one is ever routed here by mistake.
+      return `<section class="title-scene"><div class="eyebrow">VIDEO EXPLAINER</div><h1>${escapeHtml(title)}</h1><div class="rule"></div></section>`;
   }
 }
 

--- a/packages/xyne-claw-shared/src/tools/video-explainer/storyboard.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/storyboard.ts
@@ -1,6 +1,15 @@
 export const MAX_SCENES = 12;
 export const MAX_NARRATION_WORDS = 4_000;
 export const MAX_SCENE_NARRATION_CHARS = 2_000;
+export const MAX_ANIMATION_SOURCE_CHARS = 20_000;
+export const MAX_D2_STEPS = 8;
+
+/**
+ * Tail padding added to every segment after the narration/animation ends, in
+ * seconds. Kept here (not in the composer) so the timing math is pure and
+ * unit-testable without ffmpeg.
+ */
+export const SEGMENT_PAD_SECONDS = 0.8;
 
 export type TitleScene = { kind: "title"; narration: string };
 export type DiagramScene = { kind: "diagram"; mermaid: string; narration: string };
@@ -17,7 +26,48 @@ export type DiffScene = {
   narration: string;
 };
 export type BulletsScene = { kind: "bullets"; items: string[]; narration: string };
-export type VideoScene = TitleScene | DiagramScene | CodeScene | DiffScene | BulletsScene;
+/**
+ * A Manim animation scene. `source` is a full Manim (Community, Cairo
+ * renderer) Python script; `scene` is the Scene subclass to render. Both run
+ * inside the sealed studio sandbox — no repo, no network, no credentials —
+ * so untrusted model-authored Python never touches a privileged box. `scene`
+ * is interpolated into the manim command line, so it is restricted to a valid
+ * Python identifier; `source` is only ever written to a file, never shelled.
+ */
+export type ManimScene = {
+  kind: "manim";
+  source: string;
+  scene: string;
+  narration: string;
+};
+/**
+ * A D2 architecture/data-flow scene. `steps` is an ordered list of D2 board
+ * snapshots; each is rendered offline (d2 → SVG → rsvg-convert → PNG) and the
+ * boards are faded together into a progressive reveal. One step renders a
+ * single fade-in board. Every source is written to a file, never shelled.
+ */
+export type D2Scene = {
+  kind: "d2";
+  steps: string[];
+  narration: string;
+};
+export type VideoScene =
+  | TitleScene
+  | DiagramScene
+  | CodeScene
+  | DiffScene
+  | BulletsScene
+  | ManimScene
+  | D2Scene;
+
+export const ANIMATED_SCENE_KINDS: ReadonlySet<VideoScene["kind"]> = new Set([
+  "manim",
+  "d2",
+]);
+
+export function isAnimatedScene(scene: VideoScene): scene is ManimScene | D2Scene {
+  return ANIMATED_SCENE_KINDS.has(scene.kind);
+}
 
 export interface Storyboard {
   title: string;
@@ -110,15 +160,58 @@ function parseScene(value: unknown, index: number): VideoScene {
         narration: sceneNarration,
       };
     }
+    case "manim": {
+      const sceneClass = string(scene["scene"], `scenes[${index}].scene`, 200);
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(sceneClass)) {
+        throw new StoryboardValidationError(
+          `scenes[${index}].scene must be a valid Python class name (letters, digits, underscore; not starting with a digit)`,
+        );
+      }
+      return {
+        kind: "manim",
+        source: string(scene["source"], `scenes[${index}].source`, MAX_ANIMATION_SOURCE_CHARS),
+        scene: sceneClass,
+        narration: sceneNarration,
+      };
+    }
+    case "d2": {
+      const steps = scene["steps"];
+      if (!Array.isArray(steps) || steps.length === 0 || steps.length > MAX_D2_STEPS) {
+        throw new StoryboardValidationError(
+          `scenes[${index}].steps must contain between 1 and ${MAX_D2_STEPS} D2 sources`,
+        );
+      }
+      return {
+        kind: "d2",
+        steps: steps.map((step, stepIndex) =>
+          string(step, `scenes[${index}].steps[${stepIndex}]`, MAX_ANIMATION_SOURCE_CHARS),
+        ),
+        narration: sceneNarration,
+      };
+    }
     default:
       throw new StoryboardValidationError(
-        `scenes[${index}].kind must be title, diagram, code, diff, or bullets`,
+        `scenes[${index}].kind must be title, diagram, code, diff, bullets, manim, or d2`,
       );
   }
 }
 
 export function countWords(text: string): number {
   return text.trim() ? text.trim().split(/\s+/).length : 0;
+}
+
+/**
+ * Narration-first timing, unified for static and animated scenes. Narration is
+ * never cut and (for animated scenes) the animation is never cut: the segment
+ * runs for the longer of the two plus a fixed tail. The composer freezes the
+ * animation's last frame and pads the audio with silence to fill this length.
+ */
+export function computeSegmentSeconds(narrationSeconds: number, animationSeconds = 0): number {
+  const base = Math.max(
+    Number.isFinite(narrationSeconds) ? narrationSeconds : 0,
+    Number.isFinite(animationSeconds) ? animationSeconds : 0,
+  );
+  return Number((base + SEGMENT_PAD_SECONDS).toFixed(3));
 }
 
 export function validateStoryboard(value: unknown): Storyboard {

--- a/packages/xyne-claw-shared/src/tools/video-explainer/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/tools.ts
@@ -12,8 +12,12 @@ export const createVideoExplainer: ToolDefinition = {
   name: "Create Video Explainer",
   description:
     "Render an approved storyboard into a narrated MP4 inside the current writable sandbox. " +
-    "Always show the storyboard to the user and obtain approval before calling this tool. " +
-    "After it succeeds, deliver the returned filePath with sandbox-deliver-files.",
+    "Scene kinds: title, diagram (mermaid), code, diff, bullets, and the animated kinds " +
+    "manim (a Manim/Cairo Python scene) and d2 (an ordered list of D2 architecture board " +
+    "snapshots faded into a progressive reveal). Every engine renders in this same sandbox — " +
+    "no separate box — and needs no internet: narration TTS is fetched by the runtime and " +
+    "injected as a file. Always show the storyboard to the user and obtain approval before " +
+    "calling this tool. After it succeeds, deliver the returned filePath with sandbox-deliver-files.",
   source: "custom:sandbox",
   configSchema: SANDBOX_CONFIG_SCHEMA,
   inputSchema: {
@@ -80,6 +84,39 @@ export const createVideoExplainer: ToolDefinition = {
                 narration: { type: "string", maxLength: 2_000 },
               },
               required: ["kind", "items", "narration"],
+            },
+            {
+              type: "object",
+              properties: {
+                kind: { const: "manim" },
+                source: {
+                  type: "string",
+                  description:
+                    "A full Manim Community (Cairo renderer) Python script. Rendered at 1080p/30fps in this sandbox.",
+                },
+                scene: {
+                  type: "string",
+                  description: "The Scene subclass name to render (a valid Python identifier).",
+                },
+                narration: { type: "string", maxLength: 2_000 },
+              },
+              required: ["kind", "source", "scene", "narration"],
+            },
+            {
+              type: "object",
+              properties: {
+                kind: { const: "d2" },
+                steps: {
+                  type: "array",
+                  items: { type: "string" },
+                  minItems: 1,
+                  maxItems: 8,
+                  description:
+                    "Ordered D2 board snapshots. Each is rendered offline and faded into the next as a progressive architecture reveal.",
+                },
+                narration: { type: "string", maxLength: 2_000 },
+              },
+              required: ["kind", "steps", "narration"],
             },
           ],
         },

--- a/packages/xyne-claw-shared/src/tools/video-explainer/video-explainer.test.ts
+++ b/packages/xyne-claw-shared/src/tools/video-explainer/video-explainer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { generateSceneHtml } from "./scene-html.js";
 import {
+  computeSegmentSeconds,
+  isAnimatedScene,
   MAX_NARRATION_WORDS,
+  SEGMENT_PAD_SECONDS,
   validateStoryboard,
 } from "./storyboard.js";
 
@@ -21,6 +24,17 @@ describe("validateStoryboard", () => {
         },
         { kind: "diff", before: "old", after: "new", narration: "The change." },
         { kind: "bullets", items: ["Faster", "Safer"], narration: "The impact." },
+        {
+          kind: "manim",
+          source: "from manim import *\nclass Demo(Scene):\n    def construct(self):\n        pass",
+          scene: "Demo",
+          narration: "The animation.",
+        },
+        {
+          kind: "d2",
+          steps: ["a -> b", "a -> b -> c"],
+          narration: "The architecture.",
+        },
       ],
     });
 
@@ -31,7 +45,51 @@ describe("validateStoryboard", () => {
       "code",
       "diff",
       "bullets",
+      "manim",
+      "d2",
     ]);
+    expect(storyboard.scenes.filter(isAnimatedScene).map((scene) => scene.kind)).toEqual([
+      "manim",
+      "d2",
+    ]);
+  });
+
+  it("rejects a manim scene whose class name is not a valid identifier", () => {
+    expect(() =>
+      validateStoryboard({
+        title: "Injection attempt",
+        scenes: [
+          {
+            kind: "manim",
+            source: "from manim import *",
+            scene: "Demo; rm -rf /",
+            narration: "hello",
+          },
+        ],
+      }),
+    ).toThrow(/valid Python class name/);
+  });
+
+  it("rejects a d2 scene with no steps or too many steps", () => {
+    expect(() =>
+      validateStoryboard({
+        title: "No steps",
+        scenes: [{ kind: "d2", steps: [], narration: "hello" }],
+      }),
+    ).toThrow(/between 1 and 8/);
+
+    expect(() =>
+      validateStoryboard({
+        title: "Too many steps",
+        scenes: [
+          {
+            kind: "d2",
+            steps: Array.from({ length: 9 }, (_, i) => `a -> b${i}`),
+            narration: "hello",
+          },
+        ],
+      }),
+    ).toThrow(/between 1 and 8/);
   });
 
   it("rejects too many scenes, invalid highlights, and oversized narration", () => {
@@ -64,6 +122,25 @@ describe("validateStoryboard", () => {
         })),
       }),
     ).toThrow(/total narration must be at most 4000 words/);
+  });
+});
+
+describe("computeSegmentSeconds", () => {
+  it("uses narration plus the fixed tail for static scenes (no animation)", () => {
+    expect(computeSegmentSeconds(4)).toBe(4 + SEGMENT_PAD_SECONDS);
+    expect(computeSegmentSeconds(4, 0)).toBe(4 + SEGMENT_PAD_SECONDS);
+  });
+
+  it("lets the longer of narration/animation drive, so neither is truncated", () => {
+    // narration longer: animation freezes to fill
+    expect(computeSegmentSeconds(10, 6)).toBe(10 + SEGMENT_PAD_SECONDS);
+    // animation longer: audio pads with silence
+    expect(computeSegmentSeconds(6, 10)).toBe(10 + SEGMENT_PAD_SECONDS);
+  });
+
+  it("is resilient to non-finite ffprobe output", () => {
+    expect(computeSegmentSeconds(Number.NaN, 5)).toBe(5 + SEGMENT_PAD_SECONDS);
+    expect(computeSegmentSeconds(5, Number.POSITIVE_INFINITY)).toBe(5 + SEGMENT_PAD_SECONDS);
   });
 });
 


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
