### PR TITLE
cross-org write-action fix + goal-card fix + multi-encryption key

### DIFF
--- a/apps/xyne-claw-auth/backend/src/config.ts
+++ b/apps/xyne-claw-auth/backend/src/config.ts
@@ -1,8 +1,26 @@
+import { createHmac } from "node:crypto";
+import { derivePurposeKey, registerDecryptionFallback } from "./crypto.js";
+
 const requiredEnv = (name: string): string => {
   const val = process.env[name];
   if (!val) throw new Error(`Missing required env: ${name}`);
   return val;
 };
+
+const rootEncryptionKey = Buffer.from(requiredEnv("ENCRYPTION_KEY"), "hex");
+if (rootEncryptionKey.length !== 32) {
+  throw new Error("ENCRYPTION_KEY must be exactly 32 bytes encoded as 64 hex characters");
+}
+
+const dataEncryptionKey = derivePurposeKey(rootEncryptionKey, "data-encryption/aes-256-gcm/v1");
+const actionSigningKey = derivePurposeKey(rootEncryptionKey, "action-approval/hmac-sha256/v1");
+const sessionSigningKey = derivePurposeKey(rootEncryptionKey, "session-token/hmac-sha256/v1");
+const oauthStateSigningKey = derivePurposeKey(rootEncryptionKey, "oauth-state/hmac-sha256/v1");
+const legacySessionSigningKey = createHmac("sha256", rootEncryptionKey).update("xyne-claw-auth/session-token/v1").digest();
+
+// Existing rows were encrypted directly with ENCRYPTION_KEY. New writes use
+// the derived data key; reads fall back to the legacy root during migration.
+registerDecryptionFallback(dataEncryptionKey, rootEncryptionKey);
 
 export const CONFIG = {
   port: Number(process.env["AUTH_SERVICE_PORT"] ?? 3003),
@@ -13,7 +31,13 @@ export const CONFIG = {
   // traffic off the public ingress (~100k+ progress events/day in prod).
   // Falls back to `selfUrl` so single-node / dev deployments keep working.
   internalUrl: process.env["AUTH_SERVICE_INTERNAL_URL"] ?? process.env["AUTH_SERVICE_URL"] ?? `http://localhost:${process.env["AUTH_SERVICE_PORT"] ?? 3003}`,
-  encryptionKey: Buffer.from(requiredEnv("ENCRYPTION_KEY"), "hex"),
+  encryptionKey: dataEncryptionKey,
+  actionSigningKey,
+  sessionSigningKey,
+  oauthStateSigningKey,
+  legacyActionSigningKey: rootEncryptionKey,
+  legacySessionSigningKey,
+  legacyOauthStateSigningKey: rootEncryptionKey,
   // Spaces' AES-256-CBC key — must equal xyne-spaces backend's ENCRYPTION_KEY
   // value (the two services are independently keyed). Used ONLY to decrypt
   // `installed_apps.signingSecret` read from the Spaces DB during the

--- a/apps/xyne-claw-auth/backend/src/crypto.ts
+++ b/apps/xyne-claw-auth/backend/src/crypto.ts
@@ -1,7 +1,24 @@
-import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+import { randomBytes, createCipheriv, createDecipheriv, hkdfSync } from "node:crypto";
 
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12;
+const HKDF_SALT = Buffer.from("xyne-claw-auth/hkdf-sha256/v1", "utf8");
+const decryptionFallbacks = new Map<string, Buffer[]>();
+
+export function derivePurposeKey(masterKey: Buffer, purpose: string): Buffer {
+  if (masterKey.length !== 32) throw new Error("Master encryption key must be 32 bytes");
+  if (!purpose.trim()) throw new Error("HKDF purpose must not be empty");
+  return Buffer.from(hkdfSync("sha256", masterKey, HKDF_SALT, Buffer.from(purpose, "utf8"), 32));
+}
+
+/** Register a read-only legacy key used only when the primary GCM key fails. */
+export function registerDecryptionFallback(primaryKey: Buffer, legacyKey: Buffer): void {
+  const id = primaryKey.toString("base64");
+  const existing = decryptionFallbacks.get(id) ?? [];
+  if (!existing.some((candidate) => candidate.equals(legacyKey))) {
+    decryptionFallbacks.set(id, [...existing, Buffer.from(legacyKey)]);
+  }
+}
 
 export interface EncryptedPayload {
   ciphertext: string;
@@ -24,15 +41,22 @@ export function encrypt(plaintext: string, key: Buffer): EncryptedPayload {
 }
 
 export function decrypt(ciphertext: string, iv: string, authTag: string, key: Buffer): string {
-  const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(iv, "base64"));
-  decipher.setAuthTag(Buffer.from(authTag, "base64"));
-
-  const decrypted = Buffer.concat([
-    decipher.update(Buffer.from(ciphertext, "base64")),
-    decipher.final(),
-  ]);
-
-  return decrypted.toString("utf8");
+  const candidates = [key, ...(decryptionFallbacks.get(key.toString("base64")) ?? [])];
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    try {
+      const decipher = createDecipheriv(ALGORITHM, candidate, Buffer.from(iv, "base64"));
+      decipher.setAuthTag(Buffer.from(authTag, "base64"));
+      const decrypted = Buffer.concat([
+        decipher.update(Buffer.from(ciphertext, "base64")),
+        decipher.final(),
+      ]);
+      return decrypted.toString("utf8");
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
 }
 
 // Spaces encrypts DB-stored secrets (e.g. installed_apps.signingSecret) with
@@ -57,4 +81,3 @@ export function decryptSpacesCbc(blob: string, key: Buffer): string {
   ]);
   return decrypted.toString("utf8");
 }
-

--- a/apps/xyne-claw-auth/backend/src/lib/oauth-state.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/oauth-state.ts
@@ -23,7 +23,11 @@ interface StateInner {
 }
 
 function hmac(payload: string): string {
-  return createHmac("sha256", CONFIG.encryptionKey).update(payload).digest("hex");
+  return createHmac("sha256", CONFIG.oauthStateSigningKey).update(payload).digest("hex");
+}
+
+function hmacLegacy(payload: string): string {
+  return createHmac("sha256", CONFIG.legacyOauthStateSigningKey).update(payload).digest("hex");
 }
 
 export function signOAuthState(userId: string, extra?: Record<string, unknown>): string {
@@ -56,15 +60,20 @@ export function verifyOAuthState(state: string): VerifiedState {
   const body = state.slice(0, dot);
   const sig = state.slice(dot + 1);
   const expected = hmac(body);
+  const legacyExpected = hmacLegacy(body);
   let sigBuf: Buffer;
   let expectedBuf: Buffer;
+  let legacyExpectedBuf: Buffer;
   try {
     sigBuf = Buffer.from(sig, "hex");
     expectedBuf = Buffer.from(expected, "hex");
+    legacyExpectedBuf = Buffer.from(legacyExpected, "hex");
   } catch {
     throw new OAuthStateError("bad_signature");
   }
-  if (sigBuf.length !== expectedBuf.length || !timingSafeEqual(sigBuf, expectedBuf)) {
+  const matchesCurrent = sigBuf.length === expectedBuf.length && timingSafeEqual(sigBuf, expectedBuf);
+  const matchesLegacy = sigBuf.length === legacyExpectedBuf.length && timingSafeEqual(sigBuf, legacyExpectedBuf);
+  if (!matchesCurrent && !matchesLegacy) {
     throw new OAuthStateError("bad_signature");
   }
 

--- a/apps/xyne-claw-auth/backend/src/lib/session-tokens.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-tokens.ts
@@ -2,9 +2,6 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { CONFIG } from "../config.js";
 
 const TOKEN_VERSION = 1;
-const KEY_LABEL = "xyne-claw-auth/session-token/v1";
-
-const SIGNING_KEY: Buffer = createHmac("sha256", CONFIG.encryptionKey).update(KEY_LABEL).digest();
 
 export interface SessionTokenPayload {
   v: number;
@@ -27,7 +24,12 @@ function fromB64url(input: string): Buffer {
 }
 
 function sign(payloadB64: string): string {
-  const sig = createHmac("sha256", SIGNING_KEY).update(payloadB64).digest();
+  const sig = createHmac("sha256", CONFIG.sessionSigningKey).update(payloadB64).digest();
+  return b64url(sig);
+}
+
+function signLegacy(payloadB64: string): string {
+  const sig = createHmac("sha256", CONFIG.legacySessionSigningKey).update(payloadB64).digest();
   return b64url(sig);
 }
 
@@ -74,11 +76,12 @@ export function verifySessionToken(raw: string | undefined): SessionTokenPayload
   const payloadB64 = raw.slice(0, dot);
   const sigB64 = raw.slice(dot + 1);
 
-  const expected = sign(payloadB64);
-  const expectedBuf = fromB64url(expected);
   const givenBuf = fromB64url(sigB64);
-  if (expectedBuf.length !== givenBuf.length) return "bad-signature";
-  if (!timingSafeEqual(expectedBuf, givenBuf)) return "bad-signature";
+  const expectedBuf = fromB64url(sign(payloadB64));
+  const legacyExpectedBuf = fromB64url(signLegacy(payloadB64));
+  const matchesCurrent = expectedBuf.length === givenBuf.length && timingSafeEqual(expectedBuf, givenBuf);
+  const matchesLegacy = legacyExpectedBuf.length === givenBuf.length && timingSafeEqual(legacyExpectedBuf, givenBuf);
+  if (!matchesCurrent && !matchesLegacy) return "bad-signature";
 
   let payload: SessionTokenPayload;
   try {

--- a/apps/xyne-claw-auth/backend/src/mcpgateway/crypto/index.ts
+++ b/apps/xyne-claw-auth/backend/src/mcpgateway/crypto/index.ts
@@ -3,9 +3,8 @@
  * Encryption and decryption for backend secrets
  */
 
-import crypto from "node:crypto";
 import { CONFIG } from "../../config.js";
-import { ENCRYPTION } from "../config/index.js";
+import { decrypt, encrypt } from "../../crypto.js";
 import type { EncryptedSecretPayload } from "../types/index.js";
 
 /**
@@ -54,16 +53,12 @@ function getEncryptionKey(): Buffer {
  */
 export function encryptSecret(secret: string): EncryptedSecretPayload {
   const key = getEncryptionKey();
-  const iv = crypto.randomBytes(ENCRYPTION.IV_LENGTH);
-  const cipher = crypto.createCipheriv(ENCRYPTION.ALGORITHM, key, iv);
-
-  const encrypted = Buffer.concat([cipher.update(secret, "utf8"), cipher.final()]);
-  const authTag = cipher.getAuthTag();
+  const encrypted = encrypt(secret, key);
 
   return {
-    encryptedSecret: encrypted.toString("base64"),
-    iv: iv.toString("base64"),
-    authTag: authTag.toString("base64"),
+    encryptedSecret: encrypted.ciphertext,
+    iv: encrypted.iv,
+    authTag: encrypted.authTag,
   };
 }
 
@@ -71,19 +66,5 @@ export function encryptSecret(secret: string): EncryptedSecretPayload {
  * Decrypt a secret using AES-256-GCM
  */
 export function decryptSecret(payload: EncryptedSecretPayload): string {
-  const key = getEncryptionKey();
-  const decipher = crypto.createDecipheriv(
-    ENCRYPTION.ALGORITHM,
-    key,
-    Buffer.from(payload.iv, "base64")
-  );
-  decipher.setAuthTag(Buffer.from(payload.authTag, "base64"));
-
-  const decrypted = Buffer.concat([
-    decipher.update(Buffer.from(payload.encryptedSecret, "base64")),
-    decipher.final(),
-  ]);
-
-  return decrypted.toString("utf8");
+  return decrypt(payload.encryptedSecret, payload.iv, payload.authTag, getEncryptionKey());
 }
-

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -127,11 +127,34 @@ function approvalToolFailureMessage(errMsg: string): string {
 }
 
 const AGENT_CALL_CONSUMED_TTL_SEC = 24 * 60 * 60;
+const GOAL_ACTION_TTL_SEC = 24 * 60 * 60;
+const LEGACY_WRITE_CARD_TTL_SEC = 24 * 60 * 60;
+const LEGACY_GOAL_CARD_TTL_SEC = 24 * 60 * 60;
 
 async function consumeAgentCallAction(messageId: string): Promise<boolean> {
   if (!messageId) return true;
   const key = `flow-action:agent-call:${messageId}`;
   const result = await redisService.getConnection().set(key, "1", "EX", AGENT_CALL_CONSUMED_TTL_SEC, "NX");
+  return result === "OK";
+}
+
+async function consumeGoalAction(actionNonce: string): Promise<boolean> {
+  const key = `flow-action:start-goal:${actionNonce}`;
+  const result = await redisService.getConnection().set(key, "1", "EX", GOAL_ACTION_TTL_SEC, "NX");
+  return result === "OK";
+}
+
+async function consumeLegacyWriteCard(messageId: string, actionId: string): Promise<boolean> {
+  if (!messageId || !actionId) return false;
+  const key = `flow-action:legacy-write:${messageId}:${actionId}`;
+  const result = await redisService.getConnection().set(key, "1", "EX", LEGACY_WRITE_CARD_TTL_SEC, "NX");
+  return result === "OK";
+}
+
+async function consumeLegacyGoalCard(messageId: string): Promise<boolean> {
+  if (!messageId) return false;
+  const key = `flow-action:legacy-goal:${messageId}`;
+  const result = await redisService.getConnection().set(key, "1", "EX", LEGACY_GOAL_CARD_TTL_SEC, "NX");
   return result === "OK";
 }
 
@@ -224,7 +247,7 @@ type AppActionResponse =
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-async function findAgentForFlow(agentSlug: string | undefined, spacesAppId?: string): Promise<{
+async function findAgentForFlow(agentSlug: string | undefined, spacesAppId?: string, orgId?: string): Promise<{
   id: string;
   orgId: string;
   slug: string;
@@ -233,13 +256,21 @@ async function findAgentForFlow(agentSlug: string | undefined, spacesAppId?: str
   spacesAppId: string | null;
   config?: unknown;
 } | null> {
-  if (spacesAppId) return prisma.agent.findFirst({ where: { spacesAppId } });
+  if (spacesAppId) {
+    return prisma.agent.findFirst({
+      where: {
+        spacesAppId,
+        ...(orgId ? { orgId } : {}),
+        ...(agentSlug ? { slug: agentSlug } : {}),
+      },
+    });
+  }
   if (!agentSlug) {
     log.error(`[flow-action] org/app context is required; refusing global default-agent lookup spacesAppId=${spacesAppId ?? "none"} agentSlug=default`);
     return null;
   }
   const matches = await prisma.agent.findMany({
-    where: { slug: agentSlug },
+    where: { slug: agentSlug, ...(orgId ? { orgId } : {}) },
     take: 2,
   });
   if (matches.length > 1) {
@@ -377,23 +408,23 @@ async function dispatchContinuationRun(opts: {
 }): Promise<void> {
   try {
     const { setSession } = await import("./webhook.js");
-    const agent = await findAgentForFlow(opts.agentSlug, opts.spacesAppId);
-    const appToken = agent?.spacesAppToken
-      ? decrypt(...(agent.spacesAppToken.split(":") as [string, string, string]), CONFIG.encryptionKey)
-      : "";
     const orgId =
-      agent?.orgId ??
       (await prisma.user.findUnique({ where: { id: opts.writeUserId }, select: { orgId: true } }))?.orgId;
     if (!orgId) {
       log.error(`[flow-action] continuation: no orgId for user=${opts.writeUserId} agent=${opts.agentSlug ?? "(default)"}`);
       return;
     }
+    const agent = await findAgentForFlow(opts.agentSlug, opts.spacesAppId, orgId);
+    const appToken = agent?.spacesAppToken
+      ? decrypt(...(agent.spacesAppToken.split(":") as [string, string, string]), CONFIG.encryptionKey)
+      : "";
     const trimmed = trimForPrompt(opts.resultText);
     const runRes = await fetch(`${CONFIG.internalUrl}/claw/api/v1/internal/run`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+        "x-user-id": opts.writeUserId,
       },
       body: JSON.stringify({
         userId: opts.writeUserId,
@@ -533,6 +564,43 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         return;
       }
 
+      const params = JSON.parse(paramsStr) as Record<string, unknown>;
+
+      // Verify the complete card identity before any approve/decline side
+      // effect. Empty strings give absent routing fields one canonical form.
+      const { verifyActionSignatureAny } = await import("./mcp.js");
+      const actionPayload = {
+        serverType,
+        tool,
+        params,
+        userId: writeUserId,
+        agentSlug: agentSlug ?? "",
+        spacesAppId: spacesAppId ?? "",
+      };
+      const legacyActionPayload = {
+        serverType,
+        tool,
+        params,
+        userId: writeUserId,
+      };
+      const signatureOk = verifyActionSignatureAny([actionPayload, legacyActionPayload], signature);
+      if (!signatureOk) {
+        log.error("[flow-action] HMAC verification failed");
+        res.json({ type: "error", message: "HMAC verification failed — action may have been tampered with" } satisfies AppActionResponse);
+        return;
+      }
+      const legacyWriteCard = !verifyActionSignatureAny([actionPayload], signature);
+
+      const writeUser = await prisma.user.findUnique({ where: { id: writeUserId }, select: { orgId: true } });
+      if (!writeUser?.orgId) {
+        res.status(403).json({ type: "error", message: "Unable to resolve approving user's organization" } satisfies AppActionResponse);
+        return;
+      }
+      if (legacyWriteCard && !(await consumeLegacyWriteCard(messageId, actionId))) {
+        res.status(409).json({ type: "error", message: "This approval card was already used" } satisfies AppActionResponse);
+        return;
+      }
+
       if (actionId === "decline-write") {
         resp = { type: "close_screen", finalMessage: "❌ Action declined." };
         res.json(resp);
@@ -540,21 +608,9 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         return;
       }
 
-      // actionId === "approve-write"
-      const params = JSON.parse(paramsStr) as Record<string, unknown>;
-
-      // Verify HMAC signature
-      const { verifyActionSignature } = await import("./mcp.js");
-      const actionPayload = { serverType, tool, params, userId: writeUserId };
-      if (!verifyActionSignature(actionPayload, signature)) {
-        log.error("[flow-action] HMAC verification failed");
-        res.json({ type: "error", message: "HMAC verification failed — action may have been tampered with" } satisfies AppActionResponse);
-        return;
-      }
-
       // Execute the tool
       if (serverType === "xyne-spaces" && tool === "spaces-send-message") {
-        const agent = await findAgentForFlow(agentSlug, spacesAppId);
+        const agent = await findAgentForFlow(agentSlug, spacesAppId, writeUser.orgId);
         if (!agent?.spacesAppToken) {
           res.json({ type: "error", message: `No spacesAppToken for agent ${agentSlug ?? "(default)"}` } satisfies AppActionResponse);
           return;
@@ -1426,14 +1482,27 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
     }
 
     if (actionType === "start-goal") {
-      const condition = data["condition"] as string | undefined;
+      const rawCondition = data["condition"];
       const goalAgentSlug = data["agentSlug"] as string | undefined;
       const goalSpacesAppId = data["spacesAppId"] as string | undefined;
       const goalChannelId = data["channelId"] as string | undefined;
       const goalConversationId = data["conversationId"] as string | undefined;
       const goalUserId = data["userId"] as string | undefined;
+      const actionNonce = data["actionNonce"] as string | undefined;
+      const issuedAt = data["issuedAt"] as number | undefined;
+      const signature = data["signature"] as string | undefined;
 
-      if (!condition || !goalAgentSlug || !goalChannelId || !goalConversationId || !goalUserId) {
+      const { normalizeGoalCondition } = await import("../services/goalRelooper.js");
+      const condition = normalizeGoalCondition(rawCondition);
+
+      if (
+        actionId !== "start-goal"
+        || !condition
+        || !goalAgentSlug
+        || !goalChannelId
+        || !goalConversationId
+        || !goalUserId
+      ) {
         res.status(400).json({ type: "error", message: "Missing start-goal fields in flowJSON.data" } satisfies AppActionResponse);
         return;
       }
@@ -1444,6 +1513,57 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       if (!callerUserId || callerUserId !== goalUserId) {
         log.error(`[flow-action] start-goal: unauthorized — caller ${callerUserId ?? "(none)"} != expected ${goalUserId}`);
         res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
+        return;
+      }
+
+      const goalUser = await prisma.user.findUnique({ where: { id: goalUserId }, select: { orgId: true } });
+      if (!goalUser?.orgId) {
+        res.status(403).json({ type: "error", message: "Unable to resolve goal user's organization" } satisfies AppActionResponse);
+        return;
+      }
+      const agent = await findAgentForFlow(goalAgentSlug, goalSpacesAppId, goalUser.orgId);
+      if (!agent) {
+        log.error(`[flow-action] start-goal: scoped agent ${goalAgentSlug} not found`);
+        res.status(403).json({ type: "error", message: "Agent is not available in the user's organization" } satisfies AppActionResponse);
+        return;
+      }
+      const hasSignedGoalEnvelope =
+        condition === rawCondition
+        && !!actionNonce
+        && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(actionNonce)
+        && typeof issuedAt === "number"
+        && Number.isSafeInteger(issuedAt)
+        && !!signature;
+      if (hasSignedGoalEnvelope) {
+        const now = Date.now();
+        if (issuedAt > now + 5 * 60_000 || now - issuedAt > GOAL_ACTION_TTL_SEC * 1_000) {
+          res.status(400).json({ type: "error", message: "Goal suggestion has expired" } satisfies AppActionResponse);
+          return;
+        }
+        const { verifyActionSignatureAny } = await import("./mcp.js");
+        const goalActionPayload = {
+          actionType: "start-goal",
+          actionId,
+          condition,
+          agentSlug: goalAgentSlug,
+          spacesAppId: goalSpacesAppId ?? "",
+          channelId: goalChannelId,
+          conversationId: goalConversationId,
+          userId: goalUserId,
+          actionNonce,
+          issuedAt,
+        };
+        if (!verifyActionSignatureAny([goalActionPayload], signature)) {
+          log.error("[flow-action] start-goal: HMAC verification failed");
+          res.status(400).json({ type: "error", message: "Invalid goal suggestion signature" } satisfies AppActionResponse);
+          return;
+        }
+        if (!(await consumeGoalAction(actionNonce))) {
+          res.status(409).json({ type: "error", message: "Goal suggestion was already used" } satisfies AppActionResponse);
+          return;
+        }
+      } else if (!(await consumeLegacyGoalCard(messageId))) {
+        res.status(409).json({ type: "error", message: "Goal suggestion was already used" } satisfies AppActionResponse);
         return;
       }
 
@@ -1466,11 +1586,6 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       // a stuck dispatch is recoverable; a broken UI promise is not.
       (async () => {
         try {
-          const agent = await findAgentForFlow(goalAgentSlug, goalSpacesAppId);
-          if (!agent) {
-            log.error(`[flow-action] start-goal: agent ${goalAgentSlug} not found`);
-            return;
-          }
           const appToken = agent.spacesAppToken
             ? decrypt(...(agent.spacesAppToken.split(":") as [string, string, string]), CONFIG.encryptionKey)
             : "";
@@ -1507,6 +1622,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
             headers: {
               "Content-Type": "application/json",
               ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+              "x-user-id": goalUserId,
             },
             body: JSON.stringify(dispatchPayload),
           });

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -360,7 +360,11 @@ async function resolveServerNameForMcpCall(serverType: string, backendId?: strin
 }
 
 export function signAction(action: Record<string, unknown>): string {
-  return crypto.createHmac("sha256", CONFIG.encryptionKey).update(JSON.stringify(action)).digest("hex");
+  return crypto.createHmac("sha256", CONFIG.actionSigningKey).update(JSON.stringify(action)).digest("hex");
+}
+
+function signLegacyAction(action: Record<string, unknown>): string {
+  return crypto.createHmac("sha256", CONFIG.legacyActionSigningKey).update(JSON.stringify(action)).digest("hex");
 }
 
 /**
@@ -690,6 +694,23 @@ export function verifyActionSignature(action: Record<string, unknown>, signature
   const expected = signAction(action);
   try {
     return crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(signature, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+export function verifyActionSignatureAny(
+  actions: readonly Record<string, unknown>[],
+  signature: string,
+): boolean {
+  try {
+    const given = Buffer.from(signature, "hex");
+    return actions.some((action) => {
+      const current = Buffer.from(signAction(action), "hex");
+      if (current.length === given.length && crypto.timingSafeEqual(current, given)) return true;
+      const legacy = Buffer.from(signLegacyAction(action), "hex");
+      return legacy.length === given.length && crypto.timingSafeEqual(legacy, given);
+    });
   } catch {
     return false;
   }

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -39,7 +39,7 @@ import { resolveAuthForUser } from "../services/userMemoryFetcher.js";
 import { parseExperimentCommand, formatDuration, dispatchExperimentEpoch, dispatchExperimentChecker, EXPERIMENT_PROVIDERS, buildFindingsMarkdown, cancelRunSession } from "../lib/experiment.js";
 import { resolveFastMode, setFastModeOverride } from "../lib/fast-mode.js";
 import { acquireTwinSlot, renameTwinSlot, releaseTwinSlot } from "../lib/twin-limiter.js";
-import { handleSlashCommandBeforeRun, persistGoalStart, recordTurnAndDecide } from "../services/goalRelooper.js";
+import { handleSlashCommandBeforeRun, normalizeGoalCondition, persistGoalStart, recordTurnAndDecide } from "../services/goalRelooper.js";
 import {
   QUEUE_ENABLED,
   QUEUE_CAP,
@@ -1175,16 +1175,33 @@ async function postWriteApprovalAction(args: {
   const params = action["params"] as Record<string, unknown>;
   const actionDesc = formatActionDescription(action["tool"] as string, params, targetValidation);
 
-  const writeFlow = withSpacesAppId(buildWriteApprovalFlow(actionDesc, {
+  // The pending-action signature is minted before the Spaces delivery target is
+  // known. Verify it, then bind the trusted session agent to the card signature
+  // so flow-action cannot be replayed with another org's app credentials.
+  const { signAction, verifyActionSignature } = await import("./mcp.js");
+  const pendingActionPayload = {
     serverType: action["serverType"] as string,
     tool: action["tool"] as string,
     params,
     userId: action["userId"] as string,
-    signature: action["signature"] as string,
-    agentSlug: ctx.agentSlug ?? "",
+  };
+  if (!verifyActionSignature(pendingActionPayload, action["signature"] as string)) {
+    throw new Error("Invalid pending write-action signature");
+  }
+  const agentSlug = ctx.agentSlug ?? "";
+  const spacesAppId = ctx.spacesAppId ?? "";
+  const cardSignature = signAction({ ...pendingActionPayload, agentSlug, spacesAppId });
+
+  const writeFlow = withSpacesAppId(buildWriteApprovalFlow(actionDesc, {
+    serverType: pendingActionPayload.serverType,
+    tool: pendingActionPayload.tool,
+    params,
+    userId: pendingActionPayload.userId,
+    signature: cardSignature,
+    agentSlug,
     channelId: ctx.channelId,
     conversationId: ctx.conversationId,
-  }), ctx.spacesAppId);
+  }), spacesAppId);
 
   // Any attachment is a SEPARATE post from the card. `/files/filesUpload`
   // (filesController.uploadFiles) has no flow handling at all — a `flow` field
@@ -5467,12 +5484,18 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
                 return;
               }
             }
+            const refireUserId = refire["userId"];
+            if (typeof refireUserId !== "string" || !refireUserId) {
+              log.warn("[goal] refire missing userId; refusing to dispatch");
+              return;
+            }
             const runUrl = `${CONFIG.internalUrl}/claw/api/v1/internal/run`;
             void fetch(runUrl, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
                 ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+                "x-user-id": refireUserId,
               },
               body: JSON.stringify(refire),
             }).catch((err) => {
@@ -5612,28 +5635,53 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // collapses to a confirmation line after tap via replaceFlowCardWithText.
     const goalSuggestion = payload.pendingGoalSuggestion;
     if (goalSuggestion && goalSuggestion.condition?.trim() && goalSuggestion.rationale?.trim()) {
-      // Newline-strip + length-cap defensively: matches parseSlashCommand's
-      // cap so manually-typed and button-fired goals behave identically.
-      const safeCondition = goalSuggestion.condition.replace(/\r?\n/g, " ").slice(0, 2_000);
+      const safeCondition = normalizeGoalCondition(goalSuggestion.condition);
       const safeRationale = goalSuggestion.rationale.replace(/\r?\n/g, " ").slice(0, 400);
-      const goalFlow = withSpacesAppId(buildGoalSuggestionFlow(safeRationale, {
-        condition: safeCondition,
-        agentSlug: ctx.agentSlug ?? "",
-        channelId: ctx.channelId,
-        conversationId: ctx.conversationId,
-        userId: ctx.senderId,
-      }), ctx.spacesAppId);
-      await spacesAppFetch("/chat/postMessage", {
-        channelId: ctx.channelId,
-        conversationId: ctx.conversationId,
-        flow: goalFlow,
-        userId: ctx.spacesAppUserId,
-      }, token).catch((err) => {
-        log.warn("Failed to post /goal suggestion FlowUI card", {
-          error: err instanceof Error ? err.message : String(err),
+      if (!safeCondition) {
+        log.warn("Skipped /goal suggestion with invalid condition");
+      } else {
+        const goalAgentSlug = ctx.agentSlug ?? "";
+        const goalSpacesAppId = ctx.spacesAppId ?? "";
+        const actionNonce = crypto.randomUUID();
+        const issuedAt = Date.now();
+        const { signAction } = await import("./mcp.js");
+        const goalActionPayload = {
+          actionType: "start-goal",
+          actionId: "start-goal",
+          condition: safeCondition,
+          agentSlug: goalAgentSlug,
+          spacesAppId: goalSpacesAppId,
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          userId: ctx.senderId,
+          actionNonce,
+          issuedAt,
+        };
+        const goalFlow = withSpacesAppId(buildGoalSuggestionFlow(safeRationale, {
+          condition: safeCondition,
+          agentSlug: goalAgentSlug,
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          userId: ctx.senderId,
+        }), goalSpacesAppId);
+        goalFlow.data = {
+          ...(goalFlow.data ?? {}),
+          actionNonce,
+          issuedAt,
+          signature: signAction(goalActionPayload),
+        };
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow: goalFlow,
+          userId: ctx.spacesAppUserId,
+        }, token).catch((err) => {
+          log.warn("Failed to post /goal suggestion FlowUI card", {
+            error: err instanceof Error ? err.message : String(err),
+          });
         });
-      });
-      log.info(`Posted /goal suggestion in thread ${ctx.conversationId}`);
+        log.info(`Posted /goal suggestion in thread ${ctx.conversationId}`);
+      }
     }
 
     // ── Send approval DMs for pending write actions (HITL) ──

--- a/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
+++ b/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
@@ -17,6 +17,16 @@ import { activeGoalRepository } from "../repositories/activeGoalRepository.js";
 import { judgeGoalViaClaw } from "./goalJudgeClient.js";
 import type { Prisma } from "@prisma/client";
 
+export const GOAL_CONDITION_MAX_LENGTH = 2_000;
+
+/** Canonical, bounded form used by both goal-card signing and execution. */
+export function normalizeGoalCondition(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const normalized = input.replace(/\s+/gu, " ").trim();
+  if (!normalized) return null;
+  return normalized.slice(0, GOAL_CONDITION_MAX_LENGTH);
+}
+
 const NEXT_TURN_TASK_TEMPLATE = (
   condition: string,
   ctx?: { turnCount?: number; maxTurns?: number },


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
