### PR TITLE
fix: XYNE-55365 slack, jira, backfill, system msg, bot trigger fixes …

### DIFF
--- a/apps/backend/src/bots/unified/orchestrator/execution-orchestrator.ts
+++ b/apps/backend/src/bots/unified/orchestrator/execution-orchestrator.ts
@@ -111,7 +111,7 @@ class ExecutionOrchestrator {
     const context = await this.buildContext(request, entry);
 
     // 3. Update conversation activity
-    await this.updateConversationActivity(request);
+    await this.updateConversationActivity(request, context.triggerMessage);
 
     // 4. Delegate to appropriate runtime
     if (isInternalBot(entry.definition)) {
@@ -366,8 +366,16 @@ class ExecutionOrchestrator {
   /**
    * Update conversation activity counts
    */
-  private async updateConversationActivity(request: ExecutionRequest): Promise<void> {
-    await conversationRepository.incrementReplyCount(request.conversationId);
+  private async updateConversationActivity(
+    request: ExecutionRequest,
+    triggerMessage: BotExecutionContext['triggerMessage'],
+  ): Promise<void> {
+    const conversation = await conversationRepository.findById(request.conversationId);
+    const replyCreatedAt =
+      triggerMessage && triggerMessage.messageId !== conversation?.initialMessageId
+        ? triggerMessage.createdAt
+        : null;
+    await conversationRepository.incrementReplyCount(request.conversationId, replyCreatedAt);
     await channelRepository.updateLastActivity(request.channelId);
   }
 

--- a/apps/backend/src/database/repositories/conversationRepository.ts
+++ b/apps/backend/src/database/repositories/conversationRepository.ts
@@ -146,6 +146,7 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
   async incrementReplyCount(
     conversationId: string,
     replyCreatedAt?: Date | null,
+    markParticipantsRead = false,
   ): Promise<Conversation> {
     const conversation = await this.findById(conversationId);
     if (!conversation) {
@@ -167,6 +168,16 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
         },
         data: { lastReplyAt: effectiveReplyCreatedAt },
       });
+
+      if (markParticipantsRead) {
+        await this.db.conversationParticipant.updateMany({
+          where: {
+            conversationId,
+            OR: [{ lastReadAt: null }, { lastReadAt: { lt: effectiveReplyCreatedAt } }],
+          },
+          data: { lastReadAt: effectiveReplyCreatedAt },
+        });
+      }
     }
 
     return result;

--- a/apps/backend/src/database/repositories/conversationRepository.ts
+++ b/apps/backend/src/database/repositories/conversationRepository.ts
@@ -143,25 +143,29 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
     return await this.findMany({ channelId, pinned: true });
   }
 
-  async incrementReplyCount(conversationId: string, skipParticipantUpdate = false): Promise<Conversation> {
+  async incrementReplyCount(
+    conversationId: string,
+    replyCreatedAt?: Date | null,
+  ): Promise<Conversation> {
     const conversation = await this.findById(conversationId);
     if (!conversation) {
       throw new Error('Conversation not found');
     }
 
     const now = new Date();
+    const effectiveReplyCreatedAt = replyCreatedAt === undefined ? now : replyCreatedAt;
     const result = await this.update(conversationId, {
       replyCount: conversation.replyCount + 1,
       lastActivityAt: now,
     });
 
-    // Update lastReplyAt on all participants (denormalized for userConversationsPaginatedV2).
-    // Skipped during migration — the value would be the migration run time, not the
-    // historical Slack timestamp, so it is incorrect anyway.
-    if (!skipParticipantUpdate) {
+    if (effectiveReplyCreatedAt) {
       await this.db.conversationParticipant.updateMany({
-        where: { conversationId },
-        data: { lastReplyAt: now },
+        where: {
+          conversationId,
+          OR: [{ lastReplyAt: null }, { lastReplyAt: { lt: effectiveReplyCreatedAt } }],
+        },
+        data: { lastReplyAt: effectiveReplyCreatedAt },
       });
     }
 

--- a/apps/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -491,6 +491,7 @@ export async function ingestConversationSlack(
           lastActivityAt: createdAt,
           createdAt,
           isAddingParticipant: false,
+          markParticipantsRead: true,
         });
 
         message = result.message;

--- a/apps/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -491,7 +491,6 @@ export async function ingestConversationSlack(
           lastActivityAt: createdAt,
           createdAt,
           isAddingParticipant: false,
-          isMigration: true,
         });
 
         message = result.message;

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -101,6 +101,8 @@ export interface AddMessageToConversationParams {
   createdAt?: Date;
   isAddingParticipant?: boolean;
   isMarkdown?: boolean;
+  /** Migration-only: advance participant read state to the imported reply timestamp. */
+  markParticipantsRead?: boolean;
 }
 
 export interface UpdateMessageParams {
@@ -568,6 +570,7 @@ export class ConversationService {
       isMarkdown,
       createdAt,
       isAddingParticipant = true,
+      markParticipantsRead = false,
     } = params;
 
     const conversation = await this.conversationRepository.findById(conversationId);
@@ -748,6 +751,7 @@ export class ConversationService {
     await this.conversationRepository.incrementReplyCount(
       conversationId,
       createdAt === undefined ? undefined : message.createdAt,
+      markParticipantsRead,
     );
     await messageMetadataService.addReply(conversationId, userId);
 

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -101,13 +101,6 @@ export interface AddMessageToConversationParams {
   createdAt?: Date;
   isAddingParticipant?: boolean;
   isMarkdown?: boolean;
-  /**
-   * When true, skips the `conversationParticipant.updateMany` inside
-   * `incrementReplyCount`. During migration the value written would be the
-   * migration run time (not the historical Slack timestamp), so it is
-   * incorrect regardless. Skipping it avoids unnecessary DB writes.
-   */
-  isMigration?: boolean;
 }
 
 export interface UpdateMessageParams {
@@ -575,7 +568,6 @@ export class ConversationService {
       isMarkdown,
       createdAt,
       isAddingParticipant = true,
-      isMigration = false,
     } = params;
 
     const conversation = await this.conversationRepository.findById(conversationId);
@@ -753,10 +745,10 @@ export class ConversationService {
       await messageMetadataService.syncParentMessageMd(childConversationId);
     }
 
-    // Update conversation reply count and last activity.
-    // Pass isMigration to skip the conversationParticipant.updateMany — during
-    // migration the timestamp would be wrong (run time, not Slack ts) anyway.
-    await this.conversationRepository.incrementReplyCount(conversationId, isMigration);
+    await this.conversationRepository.incrementReplyCount(
+      conversationId,
+      createdAt === undefined ? undefined : message.createdAt,
+    );
     await messageMetadataService.addReply(conversationId, userId);
 
     // Update reply count for previous message's child conversation if it exists

--- a/apps/backend/src/services/jiraMigrationImportService.ts
+++ b/apps/backend/src/services/jiraMigrationImportService.ts
@@ -1848,10 +1848,12 @@ export class JiraMigrationImportService {
         },
       });
 
-      // Update lastReplyAt on all participants (denormalized for userConversationsPaginatedV2)
       if (lastCommentAt) {
         await db.conversationParticipant.updateMany({
-          where: { conversationId },
+          where: {
+            conversationId,
+            OR: [{ lastReplyAt: null }, { lastReplyAt: { lt: lastCommentAt } }],
+          },
           data: { lastReplyAt: lastCommentAt },
         });
       }

--- a/apps/backend/src/services/jiraMigrationImportService.ts
+++ b/apps/backend/src/services/jiraMigrationImportService.ts
@@ -1856,6 +1856,14 @@ export class JiraMigrationImportService {
           },
           data: { lastReplyAt: lastCommentAt },
         });
+
+        await db.conversationParticipant.updateMany({
+          where: {
+            conversationId,
+            OR: [{ lastReadAt: null }, { lastReadAt: { lt: lastCommentAt } }],
+          },
+          data: { lastReadAt: lastCommentAt },
+        });
       }
     }
 

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -248,11 +248,43 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
         conversationId: true,
         msgType: true,
         hasAttachment: true,
-        createdAt: true
+        createdAt: true,
+        isDeleted: true,
       },
     });
 
-    if (!message || message.msgType === "SYSTEM" ) {
+    if (!message) {
+      return;
+    }
+
+    if (message.msgType === MessageType.SYSTEM) {
+      const conversation = await db.conversation.findUnique({
+        where: { conversationId: message.conversationId },
+        select: { initialMessageId: true },
+      });
+      const isReply =
+        !message.isDeleted &&
+        conversation?.initialMessageId != null &&
+        conversation.initialMessageId !== message.messageId;
+      if (isReply) {
+        try {
+          await db.conversationParticipant.updateMany({
+            where: {
+              conversationId: message.conversationId,
+              OR: [{ lastReplyAt: null }, { lastReplyAt: { lt: message.createdAt } }],
+            },
+            data: { lastReplyAt: message.createdAt },
+          });
+          logger.info('[MessagesSideEffect] Updated lastReplyAt for SYSTEM reply', {
+            conversationId: message.conversationId,
+          });
+        } catch (error) {
+          logger.error('[MessagesSideEffect] Failed to update lastReplyAt for SYSTEM reply:', {
+            conversationId: message.conversationId,
+            error,
+          });
+        }
+      }
       return;
     }
 
@@ -1985,7 +2017,7 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       activityService.deleteActivitiesBySource('message', messageId),
     ]);
 
-    if (!previousValue?.conversationId || previousValue.msgType === MessageType.SYSTEM) {
+    if (!previousValue?.conversationId) {
       return;
     }
 
@@ -1994,7 +2026,7 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       select: { initialMessageId: true, channelId: true },
     });
 
-    if (!conversation?.initialMessageId || !conversation.channelId) {
+    if (!conversation?.initialMessageId) {
       return;
     }
 
@@ -2030,6 +2062,14 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       logger.error('[MessagesSideEffectHandler] Failed to roll back lastReplyAt on delete', {
         error: error
       });
+    }
+
+    if (previousValue.msgType === MessageType.SYSTEM) {
+      return;
+    }
+
+    if (!conversation.channelId) {
+      return;
     }
 
     let repliers: string[] = [];


### PR DESCRIPTION
**Why**
conversation_participants.lastReplyAt should be:
The latest createdAt among live, non-root messages in the conversation, or null when no live replies exist.

_Some code paths were producing day-scale incorrect values:_
Bot triggers used execution time, including root messages that were not replies.
Slack migration skipped participant updates to avoid writing migration runtime.
Jira imports could move timestamps backward.
SYSTEM inserts and deletions returned before updating participants.
The existing backfill handled only null rows and used lastActivityAt, which is not necessarily a reply timestamp.