### PR TITLE
adding flow action security fix

### DIFF
--- a/backend/src/apps/controllers/flowController.ts
+++ b/backend/src/apps/controllers/flowController.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
+import { signWebhookPayload } from '@/apps/core/eventSubscriptionUtils';
+import { decrypt } from '@/services/encryptionService';
 import {
   validateActionRequest,
   validateFlowDefinition,
@@ -72,6 +74,17 @@ export class FlowController {
         return;
       }
 
+      // Flow actions are sent to the same app webhook as ordinary Spaces
+      // events, so they must carry the same app-level HMAC. claw-auth treats
+      // fields such as context.userId as authoritative; never forward the
+      // action unsigned when signing material is missing.
+      const app = await repositories.apps.findById(appId);
+      if (!app?.signingSecret) {
+        logger.error('[FLOW-ACTION] App signing secret is missing', { appId, messageId });
+        res.status(502).json({ error: `No signing secret configured for app: ${appId}` });
+        return;
+      }
+
       // 5. Build the payload sent to the app backend
       const appPayload = {
         actionId,
@@ -84,6 +97,9 @@ export class FlowController {
           userId: userId ?? null,
         },
       };
+      // Serialize exactly once: the HMAC must cover the same bytes fetch sends.
+      const body = JSON.stringify(appPayload);
+      const signature = signWebhookPayload(body, decrypt(app.signingSecret));
 
       logger.info('[FLOW-ACTION] Calling app backend', { appId, actionId, type, messageId });
 
@@ -93,8 +109,10 @@ export class FlowController {
         headers: {
           'Content-Type': 'application/json',
           'X-Xyne-Event': 'flow_action',
+          'X-Xyne-Signature': signature,
+          'X-Source': 'XyneSpaces',
         },
-        body: JSON.stringify(appPayload),
+        body,
         signal: AbortSignal.timeout(30_000),
       });
 
@@ -155,4 +173,3 @@ export class FlowController {
     }
   };
 }
-

--- a/backend/src/apps/core/eventSubscriptionUtils.ts
+++ b/backend/src/apps/core/eventSubscriptionUtils.ts
@@ -8,7 +8,7 @@ import crypto from 'crypto';
 const installedAppsRepository = new InstalledAppsRepository();
 
 
-function signWebhookPayload(payload: string, signingSecret: string): string {
+export function signWebhookPayload(payload: string, signingSecret: string): string {
     return crypto
         .createHmac('sha256', signingSecret)
         .update(payload)
@@ -138,4 +138,3 @@ export async function emitEventToWorkspaceApps(
         // Don't throw - event emission failures should not break the main flow
     }
 }
-


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
