### PR TITLE
fix: add flow action security fix to main

### DIFF
--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
 import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
+import { signWebhookPayload } from '@/apps/core/eventSubscriptionUtils';
+import { decrypt } from '@/services/encryptionService';
 import {
   validateActionRequest,
   validateFlowDefinition,
@@ -85,6 +87,17 @@ export class FlowController {
         return;
       }
 
+      // Flow actions are sent to the same app webhook as ordinary Spaces
+      // events, so they must carry the same app-level HMAC. claw-auth treats
+      // fields such as context.userId as authoritative; never forward the
+      // action unsigned when signing material is missing.
+      const app = await repositories.apps.findById(appId);
+      if (!app?.signingSecret) {
+        logger.error('[FLOW-ACTION] App signing secret is missing', { appId, messageId });
+        res.status(502).json({ error: `No signing secret configured for app: ${appId}` });
+        return;
+      }
+
       // 5. Build the payload sent to the app backend
       const appPayload = {
         actionId,
@@ -97,6 +110,9 @@ export class FlowController {
           userId: userId ?? null,
         },
       };
+      // Serialize exactly once: the HMAC must cover the same bytes fetch sends.
+      const body = JSON.stringify(appPayload);
+      const signature = signWebhookPayload(body, decrypt(app.signingSecret));
 
       logger.info('[FLOW-ACTION] Calling app backend', { appId, actionId, type, messageId });
 
@@ -118,8 +134,10 @@ export class FlowController {
         headers: {
           'Content-Type': 'application/json',
           'X-Xyne-Event': 'flow_action',
+          'X-Xyne-Signature': signature,
+          'X-Source': 'XyneSpaces',
         },
-        body: JSON.stringify(appPayload),
+        body,
         redirect: 'manual',
         signal: AbortSignal.timeout(30_000),
       });
@@ -181,4 +199,3 @@ export class FlowController {
     }
   };
 }
-

--- a/apps/backend/src/apps/core/eventSubscriptionUtils.ts
+++ b/apps/backend/src/apps/core/eventSubscriptionUtils.ts
@@ -9,7 +9,7 @@ import crypto from 'crypto';
 const installedAppsRepository = new InstalledAppsRepository();
 
 
-function signWebhookPayload(payload: string, signingSecret: string): string {
+export function signWebhookPayload(payload: string, signingSecret: string): string {
     return crypto
         .createHmac('sha256', signingSecret)
         .update(payload)
@@ -145,4 +145,3 @@ export async function emitEventToWorkspaceApps(
         // Don't throw - event emission failures should not break the main flow
     }
 }
-


### PR DESCRIPTION
Cherry-picks the flow action security fix from PR #296 / commit 337a48abce28e02a0ec7874233a9afe2034d8cd0 onto main.

Notes:
- Original PR #296 targets feature/community_flow_release.
- This PR applies the same security fix to main.
- Cherry-pick conflict in flowController.ts was resolved by preserving the existing SSRF guard and adding the HMAC signing changes.