### PR TITLE
fix: improve activity read item contrast

### DIFF
--- a/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
@@ -275,7 +275,9 @@ export const ActivityItemCard = ({
               // Sets the color the truncation ellipsis is drawn in (text-overflow
               // paints the "…" from THIS element's color, not the clipped child's),
               // so the ellipsis matches the muted/foreground title state.
-              activity.isRead ? 'text-muted-foreground' : 'text-foreground',
+              // Read activity is secondary, but still used for navigation/context recall.
+              // Keep it comfortably scannable instead of making it look disabled.
+              activity.isRead ? 'text-foreground/80' : 'text-foreground',
             )}
           >
             {isMobile ? (
@@ -297,7 +299,12 @@ export const ActivityItemCard = ({
             {/* Description children (the `description` prop) set their own
                 text-muted-foreground; on unread we override them to foreground via
                 the child selector. Read + the container's color handle the rest. */}
-            <span className={cn('ml-1.5', activity.isRead ? '' : '*:text-foreground')}>
+            <span
+              className={cn(
+                'ml-1.5',
+                activity.isRead ? '*:text-foreground/70' : '*:text-foreground',
+              )}
+            >
               {description}
             </span>
 
@@ -345,7 +352,12 @@ export const ActivityItemCard = ({
               ))}
           </div>
 
-          <span className='flex-shrink-0 flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground ml-auto sm:ml-2'>
+          <span
+            className={cn(
+              'flex-shrink-0 flex items-center gap-1.5 whitespace-nowrap text-xs ml-auto sm:ml-2',
+              activity.isRead ? 'text-foreground/60' : 'text-muted-foreground',
+            )}
+          >
             {!isMobile &&
               !['reacted', 'removed'].includes(activity.actorAction) &&
               !isDeskChannelType(channel?.type) &&
@@ -401,7 +413,7 @@ export const ActivityItemCard = ({
           className={cn(
             'mt-px w-full',
             activity.isRead
-              ? 'text-muted-foreground [&_.jp-message-html]:text-muted-foreground'
+              ? 'text-foreground/70 [&_.jp-message-html]:text-foreground/70'
               : 'text-foreground',
             isExpanded
               ? 'whitespace-normal break-normal'


### PR DESCRIPTION
## Summary
- Improves scanability of read Activity feed rows without changing layout, row surfaces, or unread hierarchy.
- Raises read title/description/body/timestamp contrast using existing foreground alpha utilities.
- Keeps unread rows visually stronger via existing fill/dot treatment.

## Testing
- PASS: `pnpm --filter xyne-spaces-dashboard exec eslint src/components/Activity/ActivityItemCard.tsx` (0 errors, existing warnings only for pre-existing explicit-return-type rules in this file)
- KNOWN BASELINE FAILURE: `pnpm --filter xyne-spaces-dashboard run typecheck` currently fails on unrelated generated/shared type drift (`threadType`, `THREAD_TYPES`, `posthog-js`, support mailbox folder); no errors in `ActivityItemCard.tsx`.
- PASS: Playwright screenshots captured for classic, summer_breeze, and midnight themes under `screenshots/activity-read-contrast/`.
- PASS: POT verifier passed with real video `/tmp/videos/activity-read-contrast-pot.webm` (480607 bytes).

## Screenshots
Attached in Spaces delivery report: classic, summer_breeze, midnight activity sidebar screenshots.