### PR TITLE
feat: XYNE-55366 Auto-stop recording when laptop lid closes

### DIFF
--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -16,7 +16,11 @@ import { CallType } from '@xyne/shared';
 import { setupPresenceListeners, cleanupPresenceListeners } from '../../machines/stateMachine';
 import { queryCacheActor, type Conversation } from '../../machines/queryCacheMachine';
 import { MEETING_DETECTION_ENABLED_KEY } from '../../constants/settings';
-import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
+import {
+  sendRecordingEvent,
+  stopRecordingForTeardown,
+  useRecordingStore,
+} from '../../hooks/useRecordingStore';
 import { sendSosAlertEvent } from '../../stores/sosAlertStore';
 
 // Singleton: a fresh Audio element PER NOTIFICATION leaked native listener
@@ -522,15 +526,9 @@ export const NotificationHandler: React.FC = () => {
     });
   }, [isElectron]);
 
-  // macOS freezes the renderer immediately after the Electron main process
-  // receives `powerMonitor.suspend` (including a lid close). Do not use the
-  // normal deferred `requestStop` path here: disconnect LiveKit immediately so
-  // the recording session is finalized before the process is suspended.
   useEffect(() => {
     if (!isElectron || !window.electronAPI?.onRecordingSystemSuspend) return;
-    return window.electronAPI.onRecordingSystemSuspend(() => {
-      sendRecordingEvent({ type: 'stopRecording' });
-    });
+    return window.electronAPI.onRecordingSystemSuspend(stopRecordingForTeardown);
   }, [isElectron]);
 
   const recordingStatus = useRecordingStore(ctx => ctx.status);

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -522,6 +522,17 @@ export const NotificationHandler: React.FC = () => {
     });
   }, [isElectron]);
 
+  // macOS freezes the renderer immediately after the Electron main process
+  // receives `powerMonitor.suspend` (including a lid close). Do not use the
+  // normal deferred `requestStop` path here: disconnect LiveKit immediately so
+  // the recording session is finalized before the process is suspended.
+  useEffect(() => {
+    if (!isElectron || !window.electronAPI?.onRecordingSystemSuspend) return;
+    return window.electronAPI.onRecordingSystemSuspend(() => {
+      sendRecordingEvent({ type: 'stopRecording' });
+    });
+  }, [isElectron]);
+
   const recordingStatus = useRecordingStore(ctx => ctx.status);
   const recordingStartTime = useRecordingStore(ctx => ctx.startTime);
   const wasRecordingActiveRef = useRef<boolean | null>(null);

--- a/apps/dashboard/src/hooks/useRecordingStore.ts
+++ b/apps/dashboard/src/hooks/useRecordingStore.ts
@@ -74,6 +74,16 @@ export function getRecordingStatus(): RecordingState['status'] {
   return store.getSnapshot().context.status;
 }
 
+/** Stop whatever is in flight because the page or the machine is going away. */
+export function stopRecordingForTeardown(): void {
+  const status = getRecordingStatus();
+  if (status === 'starting') {
+    sendRecordingEvent({ type: 'requestStop' });
+  } else if (status === 'recording' || status === 'paused') {
+    sendRecordingEvent({ type: 'stopRecording' });
+  }
+}
+
 export interface UseTranscriptStreamReturn {
   transcripts: TranscriptEntry[];
 }

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -105,6 +105,7 @@ import RecordingsRoute from './RecordingsRoute/RecordingsRoute';
 import RecordingDetailRoute from './RecordingDetailRoute/RecordingDetailRoute';
 import { RecordingOverlay } from '../components/Recording/RecordingOverlay/RecordingOverlay';
 import { useRecordingVersion } from '../hooks/useRecordingVersion';
+import { getRecordingStatus, sendRecordingEvent } from '../hooks/useRecordingStore';
 import { NoteTakerOverlayHost } from './RecordingsV2Screen/components/NoteTakerOverlayHost';
 import FormScreen from './FormScreen/FormScreen';
 import ScheduledMessageScreen from './ScheduledMessageScreen/ScheduledMessageScreen';
@@ -323,6 +324,28 @@ const AppRoot = (): ReactElement => {
     setPendingRecordingFilePath(filePath);
     setIsErrorReportOpen(true);
   });
+
+  // Do not stop an active recording merely because the document becomes hidden:
+  // that also happens when a user locks their screen or switches apps. Browsers
+  // do not expose a reliable lid-close event, so retain only the actual page
+  // unload safeguard below.
+  useEffect(() => {
+    const stopRecordingBeforePageIsFrozen = (): void => {
+      const status = getRecordingStatus();
+      if (status === 'starting') {
+        // Let the start sequence complete and consume the pending stop rather
+        // than allowing its in-flight connection to revive a stopped session.
+        sendRecordingEvent({ type: 'requestStop' });
+      } else if (status === 'recording' || status === 'paused') {
+        sendRecordingEvent({ type: 'stopRecording' });
+      }
+    };
+
+    window.addEventListener('pagehide', stopRecordingBeforePageIsFrozen);
+    return (): void => {
+      window.removeEventListener('pagehide', stopRecordingBeforePageIsFrozen);
+    };
+  }, []);
   useShortcutById('global.openShortcutsHelp', () => setIsShortcutsModalOpen(prev => !prev));
   useShortcutById(
     'global.composeMessage',

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -105,7 +105,7 @@ import RecordingsRoute from './RecordingsRoute/RecordingsRoute';
 import RecordingDetailRoute from './RecordingDetailRoute/RecordingDetailRoute';
 import { RecordingOverlay } from '../components/Recording/RecordingOverlay/RecordingOverlay';
 import { useRecordingVersion } from '../hooks/useRecordingVersion';
-import { getRecordingStatus, sendRecordingEvent } from '../hooks/useRecordingStore';
+import { stopRecordingForTeardown } from '../hooks/useRecordingStore';
 import { NoteTakerOverlayHost } from './RecordingsV2Screen/components/NoteTakerOverlayHost';
 import FormScreen from './FormScreen/FormScreen';
 import ScheduledMessageScreen from './ScheduledMessageScreen/ScheduledMessageScreen';
@@ -330,20 +330,9 @@ const AppRoot = (): ReactElement => {
   // do not expose a reliable lid-close event, so retain only the actual page
   // unload safeguard below.
   useEffect(() => {
-    const stopRecordingBeforePageIsFrozen = (): void => {
-      const status = getRecordingStatus();
-      if (status === 'starting') {
-        // Let the start sequence complete and consume the pending stop rather
-        // than allowing its in-flight connection to revive a stopped session.
-        sendRecordingEvent({ type: 'requestStop' });
-      } else if (status === 'recording' || status === 'paused') {
-        sendRecordingEvent({ type: 'stopRecording' });
-      }
-    };
-
-    window.addEventListener('pagehide', stopRecordingBeforePageIsFrozen);
+    window.addEventListener('pagehide', stopRecordingForTeardown);
     return (): void => {
-      window.removeEventListener('pagehide', stopRecordingBeforePageIsFrozen);
+      window.removeEventListener('pagehide', stopRecordingForTeardown);
     };
   }, []);
   useShortcutById('global.openShortcutsHelp', () => setIsShortcutsModalOpen(prev => !prev));

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -176,6 +176,10 @@ export const recordingStore = createStore({
             startTime: session.startTime,
             defaultLayout,
           });
+
+          if (recordingStore.getSnapshot().context.pendingStop) {
+            recordingStore.send({ type: 'stopRecording' });
+          }
         })
         .catch(error => {
           logger.error(Event.RECORDING_ERROR, {

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -97,6 +97,7 @@ export interface ElectronAPI {
     html: string,
   ) => Promise<{ saved: boolean; filePath?: string }>;
   onWindowModeChanged: (callback: (data: { compact: boolean }) => void) => () => void;
+  onRecordingSystemSuspend: (callback: () => void) => () => void;
   onLog: (callback: (message: { data?: unknown[] }) => void) => () => void;
   getErrorReportNativeLogs?: () => Promise<ErrorReportNativeLog[]>;
   getErrorReportScreenSources?: () => Promise<{

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -149,6 +149,12 @@ const electronAPI = {
     return () => ipcRenderer.removeListener('reload-active-browser-tab', listener);
   },
 
+  onRecordingSystemSuspend: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('recording:system-suspend', listener);
+    return () => ipcRenderer.removeListener('recording:system-suspend', listener);
+  },
+
   onAuthSuccess: (callback: (data?: ElectronAuthData) => void) => {
     const listener = (_event: unknown, data?: ElectronAuthData) => callback(data);
     ipcRenderer.on('auth:success', listener);

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, powerMonitor } from 'electron';
 import log from 'electron-log/main';
 import { getMainWindow, createMainWindow, setWindowReferences } from '../window/manager';
 import { showRecordingPill, hideRecordingPill, isPillWindow } from './recording-pill-window';
@@ -169,11 +169,38 @@ export function initRecordingPillVisibility(): void {
   app.on('browser-window-focus', handleWindowFocus);
   app.on('browser-window-blur', handleWindowBlur);
 
+  // A screen lock is not necessarily a lid close (it can be automatic or
+  // user-initiated), so only react to system suspension. This includes lid
+  // close while leaving an active recording alone when the screen merely locks.
+  const handleSuspend = (): void => {
+    if (!active) return;
+
+    // Clear the main-process state first. The renderer can be frozen before it
+    // has a chance to acknowledge the stop; if we leave `active` set here, the
+    // focus/blur events emitted while macOS sleeps or wakes can recreate the
+    // floating `Recording` pill as a blank BrowserWindow.
+    syncRecordingState(false);
+
+    minimized = false;
+    cancelPendingPillSync();
+    const mainWindow = getMainWindow();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      // This must be a synchronous stop in the renderer. A deferred stop (the
+      // normal tray/pill path) can be overtaken by macOS freezing the renderer
+      // during lid-close suspension, leaving the LiveKit room alive.
+      mainWindow.webContents.send('recording:system-suspend');
+    }
+    hideRecordingPill();
+    log.info('[RecordingController] Stop requested because the system is suspending');
+  };
+  powerMonitor.on('suspend', handleSuspend);
+
   app.once('will-quit', () => {
     cancelPendingPillSync();
     clearFocusRequested();
     app.removeListener('browser-window-focus', handleWindowFocus);
     app.removeListener('browser-window-blur', handleWindowBlur);
+    powerMonitor.removeListener('suspend', handleSuspend);
   });
 }
 

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, powerMonitor } from 'electron';
+import { app, BrowserWindow, powerMonitor, powerSaveBlocker } from 'electron';
 import log from 'electron-log/main';
 import { getMainWindow, createMainWindow, setWindowReferences } from '../window/manager';
 import { showRecordingPill, hideRecordingPill, isPillWindow } from './recording-pill-window';
@@ -23,6 +23,8 @@ let startTime: number | null = null;
 let externalStartExpiry: ReturnType<typeof setTimeout> | null = null;
 
 let minimized = false;
+
+let powerSaveBlockerId: number | null = null;
 
 let rendererReady = false;
 let rendererReadyWaiters: Array<() => void> = [];
@@ -62,6 +64,10 @@ function watchRendererLifecycle(win: BrowserWindow): void {
   watchedRenderers.add(win);
   win.webContents.on('did-start-loading', () => {
     rendererReady = false;
+  });
+  win.webContents.on('render-process-gone', () => {
+    rendererReady = false;
+    syncRecordingState(false);
   });
 }
 
@@ -121,6 +127,15 @@ function isMainWindowFocused(): boolean {
   return !!mainWindow && !mainWindow.isDestroyed() && mainWindow.isFocused();
 }
 
+function syncPowerSaveBlocker(): void {
+  if (active && powerSaveBlockerId === null) {
+    powerSaveBlockerId = powerSaveBlocker.start('prevent-app-suspension');
+  } else if (!active && powerSaveBlockerId !== null) {
+    powerSaveBlocker.stop(powerSaveBlockerId);
+    powerSaveBlockerId = null;
+  }
+}
+
 function cancelPendingPillSync(): void {
   if (pillSyncTimer) {
     clearTimeout(pillSyncTimer);
@@ -173,24 +188,13 @@ export function initRecordingPillVisibility(): void {
   // user-initiated), so only react to system suspension. This includes lid
   // close while leaving an active recording alone when the screen merely locks.
   const handleSuspend = (): void => {
-    if (!active) return;
-
-    // Clear the main-process state first. The renderer can be frozen before it
-    // has a chance to acknowledge the stop; if we leave `active` set here, the
-    // focus/blur events emitted while macOS sleeps or wakes can recreate the
-    // floating `Recording` pill as a blank BrowserWindow.
-    syncRecordingState(false);
-
-    minimized = false;
-    cancelPendingPillSync();
     const mainWindow = getMainWindow();
     if (mainWindow && !mainWindow.isDestroyed()) {
-      // This must be a synchronous stop in the renderer. A deferred stop (the
-      // normal tray/pill path) can be overtaken by macOS freezing the renderer
-      // during lid-close suspension, leaving the LiveKit room alive.
       mainWindow.webContents.send('recording:system-suspend');
     }
-    hideRecordingPill();
+
+    if (!active) return;
+    syncRecordingState(false);
     log.info('[RecordingController] Stop requested because the system is suspending');
   };
   powerMonitor.on('suspend', handleSuspend);
@@ -201,6 +205,10 @@ export function initRecordingPillVisibility(): void {
     app.removeListener('browser-window-focus', handleWindowFocus);
     app.removeListener('browser-window-blur', handleWindowBlur);
     powerMonitor.removeListener('suspend', handleSuspend);
+    if (powerSaveBlockerId !== null) {
+      powerSaveBlocker.stop(powerSaveBlockerId);
+      powerSaveBlockerId = null;
+    }
   });
 }
 
@@ -276,6 +284,7 @@ export function syncRecordingState(nextActive: boolean, nextStartTime?: number):
   }
   if (!nextActive) minimized = false;
 
+  syncPowerSaveBlocker();
   syncPillVisibility();
 
   notifyListeners();


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
