### PR TITLE
feat: thread agent auto-continuation for BOT and APP agents

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -197,6 +197,8 @@ const envSchema = Joi.object({
   WORKING_HOUR_END: Joi.number().default(19),
   ENABLE_NOTIFICATION_WORKER: Joi.boolean().default(false),
   ENABLE_MESSAGE_CLASSIFICATION: Joi.boolean().default(false),
+  // Auto-invoke a chat-enabled agent on a same-initiator no-mention thread reply.
+  THREAD_AGENT_CONTINUATION_ENABLED: Joi.boolean().default(false),
   ENABLE_TICKET_CLEANUP_WORKER: Joi.boolean().default(false),
   ENABLE_WORKER_SCHEDULER: Joi.boolean().default(true),
   ENABLE_RECAP_SCHEDULER: Joi.boolean().default(true),
@@ -784,6 +786,7 @@ export const config = {
   ticketCleanupWorkerEnabled: envVars.ENABLE_TICKET_CLEANUP_WORKER,
   notificationWorkerEnabled: envVars.ENABLE_NOTIFICATION_WORKER,
   messageClassificationEnabled: envVars.ENABLE_MESSAGE_CLASSIFICATION,
+  threadAgentContinuationEnabled: envVars.THREAD_AGENT_CONTINUATION_ENABLED,
   runWorkerInBackend: envVars.RUN_WORKER_IN_BACKEND,
   recapScheduler: {
     enabled: envVars.ENABLE_RECAP_SCHEDULER,

--- a/apps/backend/src/services/bots/index.ts
+++ b/apps/backend/src/services/bots/index.ts
@@ -5,3 +5,4 @@ export * from './botExecutionSession';
 export * from './botCommandParser';
 export * from './botMentionHandler';
 export * from './chat-enabled-bots';
+export * from './threadContinuation';

--- a/apps/backend/src/services/bots/threadContinuation.test.ts
+++ b/apps/backend/src/services/bots/threadContinuation.test.ts
@@ -1,0 +1,230 @@
+import {
+  resolveThreadContinuation,
+  isAcknowledgementText,
+  DEFAULT_CONTINUATION_RECENCY_MS,
+  type ContinuationConfig,
+  type CurrentMessageForContinuation,
+  type ThreadMessageForContinuation,
+} from './threadContinuation';
+
+// --- fixtures -------------------------------------------------------------
+
+const H1 = 'human-1';
+const H2 = 'human-2';
+const BOT_A = 'bot-ask-ai';
+const APP_B = 'app-architect';
+const NON_CHAT_BOT = 'bot-varys';
+
+const T0 = 1_000_000_000_000; // arbitrary epoch ms
+const min = (n: number) => n * 60_000;
+
+const eligible = new Set<string>([BOT_A, APP_B]);
+
+function msg(
+  over: Partial<ThreadMessageForContinuation> & Pick<ThreadMessageForContinuation, 'senderId' | 'senderType' | 'createdAtMs'>,
+): ThreadMessageForContinuation {
+  return {
+    messageId: `m-${over.createdAtMs}`,
+    mentionedAgentUserIds: [],
+    ...over,
+  };
+}
+
+function cfg(over: Partial<ContinuationConfig>): ContinuationConfig {
+  return {
+    nowMs: T0 + min(35),
+    isThreadReply: true,
+    chatEnabledAgentUserIds: eligible,
+    recencyWindowMs: DEFAULT_CONTINUATION_RECENCY_MS,
+    priorMessages: [],
+    ...over,
+  };
+}
+
+const humanReply: CurrentMessageForContinuation = {
+  senderId: H1,
+  senderType: 'USER',
+  hasAnyMention: false,
+  isAcknowledgement: false,
+};
+
+/** Canonical happy-path thread: H1 tags BOT_A, BOT_A replies, now H1 follows up. */
+function happyThread(lastReplyMs = T0 + min(10)): ThreadMessageForContinuation[] {
+  return [
+    msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [BOT_A] }),
+    msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: lastReplyMs }),
+  ];
+}
+
+// --- resolveThreadContinuation -------------------------------------------
+
+describe('resolveThreadContinuation', () => {
+  it('invokes the anchored agent on a same-initiator no-mention follow-up (happy path)', () => {
+    const d = resolveThreadContinuation(
+      humanReply,
+      cfg({ nowMs: T0 + min(12), priorMessages: happyThread(T0 + min(10)) }),
+    );
+    expect(d.invoke).toBe(true);
+    expect(d.reason).toBe('ok');
+    expect(d.agentUserIds).toEqual([BOT_A]);
+  });
+
+  it('skips when the message is not a thread reply', () => {
+    const d = resolveThreadContinuation(humanReply, cfg({ isThreadReply: false, priorMessages: happyThread() }));
+    expect(d).toEqual({ invoke: false, agentUserIds: [], reason: 'not_thread_reply' });
+  });
+
+  it('skips when the sender is an agent (loop safety)', () => {
+    const d = resolveThreadContinuation(
+      { ...humanReply, senderId: BOT_A, senderType: 'BOT' },
+      cfg({ priorMessages: happyThread() }),
+    );
+    expect(d.reason).toBe('sender_not_human');
+  });
+
+  it('skips when the reply explicitly mentions someone', () => {
+    const d = resolveThreadContinuation({ ...humanReply, hasAnyMention: true }, cfg({ priorMessages: happyThread() }));
+    expect(d.reason).toBe('has_explicit_mention');
+  });
+
+  it('skips a bare acknowledgement', () => {
+    const d = resolveThreadContinuation({ ...humanReply, isAcknowledgement: true }, cfg({ priorMessages: happyThread() }));
+    expect(d.reason).toBe('acknowledgement');
+  });
+
+  it('skips when no prior human ever tagged an agent (e.g. bare bot-started thread)', () => {
+    const prior = [
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 }), // scheduled report, no human tag yet
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ priorMessages: prior }));
+    expect(d.reason).toBe('no_prior_agent_invocation');
+  });
+
+  it('skips when a DIFFERENT human is the current sender (only the invoker auto-continues)', () => {
+    const d = resolveThreadContinuation(
+      { ...humanReply, senderId: H2 },
+      cfg({ nowMs: T0 + min(12), priorMessages: happyThread(T0 + min(10)) }),
+    );
+    expect(d.reason).toBe('sender_not_invoker');
+  });
+
+  it('re-anchors to the most recent invoker: H2 tags after H1, so H2 (not H1) continues', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [BOT_A] }),
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 + min(1) }),
+      msg({ senderId: H2, senderType: 'USER', createdAtMs: T0 + min(2), mentionedAgentUserIds: [BOT_A] }),
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 + min(3) }),
+    ];
+    const h2Follow = resolveThreadContinuation(
+      { ...humanReply, senderId: H2 },
+      cfg({ nowMs: T0 + min(5), priorMessages: prior }),
+    );
+    expect(h2Follow).toMatchObject({ invoke: true, reason: 'ok', agentUserIds: [BOT_A] });
+
+    const h1Follow = resolveThreadContinuation(
+      { ...humanReply, senderId: H1 },
+      cfg({ nowMs: T0 + min(5), priorMessages: prior }),
+    );
+    expect(h1Follow.reason).toBe('sender_not_invoker');
+  });
+
+  it('skips when the agent has not replied since the anchor (run still pending)', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [BOT_A] }),
+      // no agent reply yet
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ nowMs: T0 + min(1), priorMessages: prior }));
+    expect(d.reason).toBe('agent_response_pending');
+  });
+
+  it('skips when another human posted AFTER the agent reply (no-human-between guard)', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [BOT_A] }),
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 + min(1) }),
+      msg({ senderId: H2, senderType: 'USER', createdAtMs: T0 + min(2) }), // interjection
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ nowMs: T0 + min(3), priorMessages: prior }));
+    expect(d.reason).toBe('other_human_interjected');
+  });
+
+  it('allows the invoker to post multiple follow-ups (own messages after reply are fine)', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [BOT_A] }),
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 + min(1) }),
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0 + min(2) }), // invoker's own earlier follow-up
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 + min(3) }),
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ nowMs: T0 + min(4), priorMessages: prior }));
+    expect(d).toMatchObject({ invoke: true, reason: 'ok' });
+  });
+
+  it('skips when the agent reply is older than the recency window', () => {
+    const d = resolveThreadContinuation(
+      humanReply,
+      cfg({ nowMs: T0 + min(120), priorMessages: happyThread(T0 + min(10)) }),
+    );
+    expect(d.reason).toBe('stale_thread');
+  });
+
+  it('routes to BOTH agents when two eligible agents are active and none is explicitly tagged', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [BOT_A, APP_B] }),
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 + min(1) }),
+      msg({ senderId: APP_B, senderType: 'APP', createdAtMs: T0 + min(2) }),
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ nowMs: T0 + min(3), priorMessages: prior }));
+    expect(d.invoke).toBe(true);
+    expect(new Set(d.agentUserIds)).toEqual(new Set([BOT_A, APP_B]));
+  });
+
+  it('drops non-chat-eligible agents from the target set', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [BOT_A, NON_CHAT_BOT] }),
+      msg({ senderId: BOT_A, senderType: 'BOT', createdAtMs: T0 + min(1) }),
+      msg({ senderId: NON_CHAT_BOT, senderType: 'BOT', createdAtMs: T0 + min(2) }),
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ nowMs: T0 + min(3), priorMessages: prior }));
+    expect(d).toMatchObject({ invoke: true, reason: 'ok' });
+    expect(d.agentUserIds).toEqual([BOT_A]); // NON_CHAT_BOT excluded
+  });
+
+  it('skips when the only anchored agent is not chat-eligible', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [NON_CHAT_BOT] }),
+      msg({ senderId: NON_CHAT_BOT, senderType: 'BOT', createdAtMs: T0 + min(1) }),
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ nowMs: T0 + min(2), priorMessages: prior }));
+    expect(d.reason).toBe('no_eligible_agent');
+  });
+
+  it('continues an APP agent (claw) the same way as a BOT', () => {
+    const prior = [
+      msg({ senderId: H1, senderType: 'USER', createdAtMs: T0, mentionedAgentUserIds: [APP_B] }),
+      msg({ senderId: APP_B, senderType: 'APP', createdAtMs: T0 + min(1) }),
+    ];
+    const d = resolveThreadContinuation(humanReply, cfg({ nowMs: T0 + min(2), priorMessages: prior }));
+    expect(d).toMatchObject({ invoke: true, reason: 'ok', agentUserIds: [APP_B] });
+  });
+});
+
+// --- isAcknowledgementText ------------------------------------------------
+
+describe('isAcknowledgementText', () => {
+  it.each([
+    'thanks', 'Thanks!', 'thank you', 'ok', 'okay', 'k', 'got it', 'great, thanks',
+    'noted thanks', 'perfect', 'cool', 'lgtm', '👍', '🙏🙏', '  ', '...', 'yes',
+  ])('treats %p as an acknowledgement', (t) => {
+    expect(isAcknowledgementText(t)).toBe(true);
+  });
+
+  it.each([
+    'can you also add tests?',
+    'what about the APP path',
+    'now do the same for staging',
+    'thanks — but why did it skip the second agent',
+    'ok so what happens on retry',
+    'summarize the thread',
+  ])('treats %p as a real request', (t) => {
+    expect(isAcknowledgementText(t)).toBe(false);
+  });
+});

--- a/apps/backend/src/services/bots/threadContinuation.ts
+++ b/apps/backend/src/services/bots/threadContinuation.ts
@@ -1,0 +1,202 @@
+/**
+ * Thread agent auto-continuation resolver.
+ *
+ * Problem: once an agent (a chat-enabled BOT like `ask-ai`, or an installed APP
+ * agent) is @mentioned in a channel thread, users currently have to re-tag it on
+ * every follow-up. This module decides whether a *no-mention* thread reply should
+ * auto-invoke the agent(s) the initiator is already talking to.
+ *
+ * The decision is a PURE function of already-fetched thread state so it can be
+ * unit-tested exhaustively without a database. The side-effect handler
+ * (`messages-handler.ts`) is responsible for fetching thread history, resolving
+ * agent-ness / chat-eligibility, and executing the returned targets.
+ *
+ * Agreed rules (all must hold to auto-invoke):
+ *   1. The message is a thread reply.
+ *   2. The sender is a human (loop safety — never continue on an agent's own post).
+ *   3. The reply mentions NO ONE (no human, BOT, APP, group, or @channel/@here).
+ *      Any explicit mention routes through the normal explicit path instead.
+ *   4. The reply is a real request, not a bare acknowledgement ("thanks", "ok", …).
+ *   5. There is a prior "anchor": the most recent human message that explicitly
+ *      tagged >= 1 agent. The sender of the current reply MUST be that anchor's
+ *      author (the "agent invoker"). Re-tagging re-anchors to the new invoker.
+ *   6. At least one anchored agent is chat-eligible.
+ *   7. That agent has actually replied since the anchor (else a run is pending).
+ *   8. No OTHER human has posted since the agent's last reply.
+ *   9. The agent's last reply is within the recency window (not a stale thread).
+ *
+ * When >1 eligible agent is active in the thread, ALL of them are returned
+ * (route-to-both), matching the product decision.
+ */
+
+export type ParticipantType = 'USER' | 'BOT' | 'APP';
+
+export interface ThreadMessageForContinuation {
+  messageId: string;
+  senderId: string;
+  senderType: ParticipantType;
+  createdAtMs: number;
+  /** Agent (BOT/APP) user ids explicitly @mentioned in THIS message. */
+  mentionedAgentUserIds: string[];
+}
+
+export interface CurrentMessageForContinuation {
+  senderId: string;
+  senderType: ParticipantType;
+  /** True if the reply @mentions ANY user (human/bot/app), group, or @channel/@here. */
+  hasAnyMention: boolean;
+  /** True if the reply is a bare acknowledgement ("thanks", "ok", emoji-only, …). */
+  isAcknowledgement: boolean;
+}
+
+export interface ContinuationConfig {
+  nowMs: number;
+  isThreadReply: boolean;
+  /** Agent user ids eligible to be auto-continued (chat-enabled BOTs + installed APP agents). */
+  chatEnabledAgentUserIds: ReadonlySet<string>;
+  /** Skip if the agent's last reply is older than this. */
+  recencyWindowMs: number;
+  /** Prior thread messages in chronological (oldest→newest) order, excluding the current message. */
+  priorMessages: ThreadMessageForContinuation[];
+}
+
+export type ContinuationReason =
+  | 'ok'
+  | 'not_thread_reply'
+  | 'sender_not_human'
+  | 'has_explicit_mention'
+  | 'acknowledgement'
+  | 'no_prior_agent_invocation'
+  | 'sender_not_invoker'
+  | 'no_eligible_agent'
+  | 'agent_response_pending'
+  | 'other_human_interjected'
+  | 'stale_thread';
+
+export interface ContinuationDecision {
+  invoke: boolean;
+  /** Agent user ids to auto-invoke (BOT and/or APP). Empty unless invoke === true. */
+  agentUserIds: string[];
+  reason: ContinuationReason;
+}
+
+/** Default: auto-continue only within 30 minutes of the agent's last reply. */
+export const DEFAULT_CONTINUATION_RECENCY_MS = 30 * 60 * 1000;
+
+const isAgent = (t: ParticipantType): boolean => t === 'BOT' || t === 'APP';
+
+/**
+ * Decide whether a no-mention thread reply should auto-invoke the agent(s) the
+ * sender is already conversing with. Pure — no I/O.
+ */
+export function resolveThreadContinuation(
+  current: CurrentMessageForContinuation,
+  config: ContinuationConfig,
+): ContinuationDecision {
+  const skip = (reason: ContinuationReason): ContinuationDecision => ({
+    invoke: false,
+    agentUserIds: [],
+    reason,
+  });
+
+  if (!config.isThreadReply) return skip('not_thread_reply');
+  if (current.senderType !== 'USER') return skip('sender_not_human');
+  if (current.hasAnyMention) return skip('has_explicit_mention');
+  if (current.isAcknowledgement) return skip('acknowledgement');
+
+  const prior = config.priorMessages;
+
+  // (5) Anchor = most recent prior HUMAN message that explicitly tagged >= 1 agent.
+  let anchorIndex = -1;
+  for (let i = prior.length - 1; i >= 0; i--) {
+    const m = prior[i];
+    if (m.senderType === 'USER' && m.mentionedAgentUserIds.length > 0) {
+      anchorIndex = i;
+      break;
+    }
+  }
+  if (anchorIndex === -1) return skip('no_prior_agent_invocation');
+
+  const anchor = prior[anchorIndex];
+  if (anchor.senderId !== current.senderId) return skip('sender_not_invoker');
+
+  // Active agents = tagged at the anchor UNION any agent that posted after it.
+  const active = new Set<string>(anchor.mentionedAgentUserIds);
+  for (let i = anchorIndex + 1; i < prior.length; i++) {
+    const m = prior[i];
+    if (isAgent(m.senderType)) active.add(m.senderId);
+  }
+
+  // (6) Keep only chat-eligible agents.
+  const eligible = [...active].filter(id => config.chatEnabledAgentUserIds.has(id));
+  if (eligible.length === 0) return skip('no_eligible_agent');
+  const eligibleSet = new Set(eligible);
+
+  // (7) An eligible agent must have actually replied since the anchor.
+  let lastAgentReplyMs = -1;
+  for (let i = anchorIndex + 1; i < prior.length; i++) {
+    const m = prior[i];
+    if (isAgent(m.senderType) && eligibleSet.has(m.senderId) && m.createdAtMs > lastAgentReplyMs) {
+      lastAgentReplyMs = m.createdAtMs;
+    }
+  }
+  if (lastAgentReplyMs === -1) return skip('agent_response_pending');
+
+  // (8) No OTHER human may have posted since the agent's last reply.
+  for (let i = anchorIndex + 1; i < prior.length; i++) {
+    const m = prior[i];
+    if (m.senderType === 'USER' && m.senderId !== current.senderId && m.createdAtMs > lastAgentReplyMs) {
+      return skip('other_human_interjected');
+    }
+  }
+
+  // (9) Recency window.
+  if (config.nowMs - lastAgentReplyMs > config.recencyWindowMs) return skip('stale_thread');
+
+  return { invoke: true, agentUserIds: eligible, reason: 'ok' };
+}
+
+/**
+ * Deterministic acknowledgement filter (rule 4). Zero added latency/cost — no LLM.
+ * Returns true when a reply carries no actionable request: empty, emoji/punctuation
+ * only, or a short courtesy phrase like "thanks" / "ok, got it".
+ *
+ * Intentionally conservative: only clear acknowledgements are suppressed. Anything
+ * with a question mark, or more than a couple of non-courtesy words, is treated as
+ * a real request and allowed through.
+ */
+const ACK_TOKENS = new Set([
+  'thanks', 'thank', 'thankyou', 'thx', 'ty', 'tysm', 'cheers',
+  'ok', 'okay', 'k', 'kk', 'okey',
+  'great', 'cool', 'nice', 'perfect', 'awesome', 'lovely', 'good', 'fine',
+  'done', 'noted', 'sure', 'yes', 'yeah', 'yep', 'yup', 'no', 'nope', 'nah',
+  'got', 'it', 'understood', 'gotcha', 'roger', 'ack', 'acknowledged',
+  'makes', 'sense', 'sounds', 'brilliant', 'superb', 'excellent',
+]);
+
+const ACK_PHRASES = new Set([
+  'got it', 'makes sense', 'sounds good', 'thank you', 'thanks a lot',
+  'thanks a ton', 'many thanks', 'ok thanks', 'okay thanks', 'ok thank you',
+  'got it thanks', 'great thanks', 'cool thanks', 'noted thanks', 'all good',
+  'sounds great', 'looks good', 'lgtm',
+]);
+
+export function isAcknowledgementText(plain: string): boolean {
+  const lowered = plain.trim().toLowerCase();
+  if (lowered.length === 0) return true;
+
+  // Strip everything except letters, numbers, spaces and apostrophes (drops emoji & punctuation).
+  const stripped = lowered.replace(/[^\p{L}\p{N}\s']/gu, ' ').replace(/\s+/g, ' ').trim();
+  if (stripped.length === 0) return true; // emoji-only / punctuation-only
+
+  // A question is always a real request.
+  if (lowered.includes('?')) return false;
+
+  if (ACK_PHRASES.has(stripped)) return true;
+
+  const words = stripped.split(' ').filter(Boolean);
+  // Up to 3 words AND every word is a courtesy token → acknowledgement.
+  if (words.length <= 3 && words.every(w => ACK_TOKENS.has(w))) return true;
+
+  return false;
+}

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -16,6 +16,7 @@ import {
   getChannelParticipantsForMention,
   getOnlineChannelParticipants,
   extractSpecialMentions,
+  hasAnyMentionsToNotify,
 } from '@/utils/mentionUtils';
 import { userActivityTrackingService } from '@/services/userActivityTrackingService';
 import { logger } from '@/utils/logger';
@@ -44,9 +45,12 @@ import { InstalledAppsRepository } from '@/database/repositories/installedAppsRe
 import { extractInternalUrl, parseInternalUrl, extractFirstUrl } from '@/utils/urlUtils';
 import { linkPreviewService, type ExternalLinkMetadata } from '@/services/linkPreviewService';
 import { botCatalog } from '@/bots/unified/catalog/bot-catalog';
-import { extractBotMentions, executeBotForMention, CHAT_ENABLED_BOT_IDS } from '@/services/bots';
+import { extractBotMentions, executeBotForMention, CHAT_ENABLED_BOT_IDS,
+  resolveThreadContinuation, isAcknowledgementText, DEFAULT_CONTINUATION_RECENCY_MS,
+  type ParticipantType } from '@/services/bots';
 import { getSlackRecipientEmails } from '@/utils/notificationHelper';
 import { extractPlainTextFromHtml } from '@/utils/contentUtils';
+import { extractUserMentions } from '@/utils/mentionParser';
 import { matchKeywordsForUsers } from '@/utils/keywordMatchUtils';
 import type { BotDefinition } from '@/bots/unified/types/unified-bot';
 import { messageMetadataService } from '@/services/messageMetadataService';
@@ -825,6 +829,22 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       channel,
       sender,
       channelParticipants
+    );
+
+    // Thread agent auto-continuation: a same-initiator, no-mention follow-up in a
+    // thread where the initiator already @mentioned a chat-enabled agent re-invokes
+    // that agent (BOT and/or APP) without an explicit re-tag. Feature-flagged;
+    // shadow-logs its decision even when disabled. See services/bots/threadContinuation.
+    await this.handleAgentThreadContinuation(
+      message,
+      conversation,
+      channel,
+      sender,
+      channelParticipants,
+      appUserIds,
+      channelName,
+      senderName,
+      channelProject?.name ?? null,
     );
 
     if (isReply && conversationId) {
@@ -2375,6 +2395,216 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       logger.error('[BOT-MENTION] Error handling bot mentions', {
         messageId: message.messageId,
         error: error,
+      });
+    }
+  }
+
+  /**
+   * Thread agent auto-continuation.
+   *
+   * When a human posts a no-mention reply in a channel thread where they had
+   * previously @mentioned a chat-enabled agent (BOT like ask-ai, or an installed
+   * APP/claw agent) and that agent already replied with no other human speaking
+   * since, re-invoke the SAME agent(s) without requiring a re-tag. The pure guard
+   * logic lives in `resolveThreadContinuation`; this method only fetches thread
+   * state, resolves chat-eligibility, and dispatches the returned targets.
+   *
+   * Feature-flagged via config.threadAgentContinuationEnabled — the decision is
+   * always logged (shadow mode) so the guard can be tuned on real traffic before
+   * execution is turned on.
+   */
+  private async handleAgentThreadContinuation(
+    message: {
+      messageId: string;
+      senderId: string;
+      content: string;
+      conversationId: string;
+      createdAt: Date;
+      hasAttachment: boolean;
+    },
+    conversation: { channelId: string; initialMessageId: string | null },
+    channel: { id?: string; name: string | null; scopeType: string | null; projectId?: string | null } | null,
+    sender: { name: string; userType?: string } | null,
+    channelParticipants: Array<{ userId: string; user: { email: string; name: string } }>,
+    appUserIds: string[],
+    channelName: string,
+    senderName: string,
+    projectName: string | null,
+  ): Promise<void> {
+    try {
+      // DMs already auto-respond via the mutator path.
+      if (
+        channel?.scopeType === ChannelScopeType.DM ||
+        channel?.scopeType === ChannelScopeType.GROUP_DM
+      ) {
+        return;
+      }
+
+      // Loop safety: never continue on an agent's own post.
+      if (sender?.userType === UserType.BOT || sender?.userType === UserType.APP) {
+        return;
+      }
+
+      const isThreadReply = !!(
+        conversation.initialMessageId && conversation.initialMessageId !== message.messageId
+      );
+      if (!isThreadReply) return;
+
+      // ACL: sender must be a channel participant.
+      if (!channelParticipants.some(p => p.userId === message.senderId)) return;
+
+      // Build the chat-eligible agent set: chat-enabled BOTs (by DB user id) plus
+      // installed APP agents present in this channel.
+      const chatEnabledAgentUserIds = new Set<string>();
+      const botEntriesByUserId = new Map<string, { botId: string; def: BotDefinition }>();
+      for (const entry of botCatalog.getAll()) {
+        const uid = botCatalog.getDbUserId(entry.definition.id);
+        if (!uid) continue;
+        botEntriesByUserId.set(uid, { botId: entry.definition.id, def: entry.definition });
+        if (CHAT_ENABLED_BOT_IDS.has(entry.definition.id)) {
+          chatEnabledAgentUserIds.add(uid);
+        }
+      }
+      for (const id of appUserIds) chatEnabledAgentUserIds.add(id);
+      if (chatEnabledAgentUserIds.size === 0) return;
+
+      // Fetch recent thread history (excluding the current message).
+      const recent = await db.message.findMany({
+        where: { conversationId: message.conversationId, messageId: { not: message.messageId } },
+        orderBy: { createdAt: 'asc' },
+        take: 100,
+        select: {
+          messageId: true,
+          senderId: true,
+          content: true,
+          createdAt: true,
+          sender: { select: { userType: true } },
+        },
+      });
+
+      // Resolve which mentioned user ids are agents (BOT/APP) in one query.
+      const allMentioned = new Set<string>();
+      for (const m of recent) {
+        for (const id of extractUserMentions(m.content ?? '')) allMentioned.add(id);
+      }
+      let agentIdSet = new Set<string>();
+      if (allMentioned.size > 0) {
+        const agentUsers = await db.user.findMany({
+          where: { id: { in: [...allMentioned] }, userType: { in: [UserType.BOT, UserType.APP] } },
+          select: { id: true },
+        });
+        agentIdSet = new Set(agentUsers.map(u => u.id));
+      }
+
+      const priorMessages = recent.map(m => ({
+        messageId: m.messageId,
+        senderId: m.senderId,
+        senderType: (m.sender?.userType ?? UserType.USER) as ParticipantType,
+        createdAtMs: m.createdAt.getTime(),
+        mentionedAgentUserIds: extractUserMentions(m.content ?? '').filter(id => agentIdSet.has(id)),
+      }));
+
+      const plain = extractPlainTextFromHtml(message.content);
+      const decision = resolveThreadContinuation(
+        {
+          senderId: message.senderId,
+          senderType: (sender?.userType ?? UserType.USER) as ParticipantType,
+          hasAnyMention: hasAnyMentionsToNotify(message.content),
+          isAcknowledgement: isAcknowledgementText(plain),
+        },
+        {
+          nowMs: message.createdAt.getTime(),
+          isThreadReply,
+          chatEnabledAgentUserIds,
+          recencyWindowMs: DEFAULT_CONTINUATION_RECENCY_MS,
+          priorMessages,
+        },
+      );
+
+      logger.info('[THREAD-CONTINUATION] decision', {
+        messageId: message.messageId,
+        conversationId: message.conversationId,
+        enabled: config.threadAgentContinuationEnabled,
+        invoke: decision.invoke,
+        reason: decision.reason,
+        targets: decision.agentUserIds,
+      });
+
+      if (!decision.invoke || !config.threadAgentContinuationEnabled) return;
+
+      // De-dupe: a BOT that authored the thread's initial message is already handled
+      // by handleBotMentions' legacy bot-started continuation. Skip it here.
+      let initialAuthorId: string | null = null;
+      if (conversation.initialMessageId) {
+        const initial = await db.message.findUnique({
+          where: { messageId: conversation.initialMessageId },
+          select: { senderId: true },
+        });
+        initialAuthorId = initial?.senderId ?? null;
+      }
+
+      const question = plain.trim() || 'What happened in this thread until now?';
+      const appTargets: string[] = [];
+
+      for (const agentUserId of decision.agentUserIds) {
+        const botEntry = botEntriesByUserId.get(agentUserId);
+        if (botEntry) {
+          if (agentUserId === initialAuthorId) continue; // legacy path owns this
+          await executeBotForMention({
+            bot: { botUserId: agentUserId, botId: botEntry.botId, botDefinition: botEntry.def },
+            message: {
+              messageId: message.messageId,
+              senderId: message.senderId,
+              content: message.content,
+              conversationId: message.conversationId,
+            },
+            conversation,
+            question,
+            sender,
+            channelParticipants,
+          }).catch(err =>
+            logger.error('[THREAD-CONTINUATION] BOT execution failed', { agentUserId, error: err }),
+          );
+        } else if (appUserIds.includes(agentUserId)) {
+          appTargets.push(agentUserId);
+        }
+      }
+
+      if (appTargets.length > 0) {
+        const attachments = message.hasAttachment
+          ? await messageAttachmentRepository.findByMessageId(message.messageId)
+          : [];
+        void this.handlleMessageAppEvents(
+          AppEventType.APP_MENTION,
+          {
+            conversationId: message.conversationId,
+            messageId: message.messageId,
+            content: message.content,
+            cleanContent: plain,
+            createdAt: message.createdAt,
+            userId: message.senderId,
+            senderName,
+            channelId: conversation.channelId,
+            channelName,
+            ...(channel?.projectId ? { projectId: channel.projectId } : {}),
+            ...(projectName ? { projectName } : {}),
+            ...(attachments.length > 0 && {
+              attachments: attachments.map(att => ({
+                attachmentId: att.id,
+                fileName: att.originalFilename,
+                fileSize: att.size,
+                mimeType: att.mimetype,
+                fileUrl: att.url,
+              })),
+            }),
+          } as AppMentionEventPayload,
+          appTargets,
+        );
+      }
+    } catch (error) {
+      logger.error('[THREAD-CONTINUATION] Error handling thread continuation', {
+        messageId: message.messageId,
+        error,
       });
     }
   }


### PR DESCRIPTION
## What & why
Once an agent (a chat-enabled BOT like ask-ai/Genius, or an installed APP/claw agent) is @mentioned in a channel thread, users currently have to re-tag it on every follow-up. This adds **thread agent auto-continuation**: a same-initiator, no-mention follow-up in that thread re-invokes the same agent(s) automatically. Applies to **both** BOT and APP agents.

## Guard logic (pure, unit-tested)
All in `resolveThreadContinuation` (`apps/backend/src/services/bots/threadContinuation.ts`). Auto-invoke only when ALL hold:
- message is a thread reply
- sender is a human (loop safety — never continue on an agent's own post)
- reply mentions **no one** (any user/group/@channel/@here routes to the normal explicit path)
- reply is not a bare acknowledgement ("thanks", "ok", emoji-only, …) — deterministic filter, no LLM cost
- there is an **anchor**: the most recent human message that explicitly tagged ≥1 agent; the current sender must be that anchor's author (the "agent invoker"). Re-tagging re-anchors to the new invoker.
- an eligible agent has actually replied since the anchor (else a run is still pending)
- no **other** human has posted since the agent's last reply
- the agent's last reply is within a 30-minute recency window

When several eligible agents are active, **all** of them are re-invoked (route-to-both).

## Wiring
Single decision point `handleAgentThreadContinuation` in `messages-handler.ts`, called right after `handleBotMentions`. It covers both sinks: `executeBotForMention` for BOTs and an `APP_MENTION` emission for APP agents. A BOT that authored the thread's initial message is skipped here to avoid double-invoke with the existing legacy bot-started continuation.

## Rollout
Gated behind `THREAD_AGENT_CONTINUATION_ENABLED` (default **off**). The decision is **always logged** (`[THREAD-CONTINUATION] decision`, shadow mode) so we can tune the guard on real traffic before enabling execution.

## Tests / proof
- `apps/backend/src/services/bots/threadContinuation.test.ts` — **39 tests, all passing** (`jest`), covering the full guard truth-table (happy path, non-thread-reply, agent-sender loop-safety, explicit-mention, acknowledgement, no-prior-anchor, wrong-invoker, invoker re-anchor, pending-run, other-human-interjection, invoker multi-follow-up, stale window, route-to-both, non-chat-eligible filtering, APP parity) plus the acknowledgement filter.
- `tsc --noEmit`: no new type errors in any touched file.

## Files changed
- `apps/backend/src/services/bots/threadContinuation.ts` (new — pure resolver + ack filter)
- `apps/backend/src/services/bots/threadContinuation.test.ts` (new — 39 tests)
- `apps/backend/src/zero/side-effects/tables/messages-handler.ts` (wiring both sinks + feature flag)
- `apps/backend/src/config/env.ts` (`THREAD_AGENT_CONTINUATION_ENABLED`)
- `apps/backend/src/services/bots/index.ts` (export)