### PR TITLE
fix: resolve bare @name/@email mentions in approved Digital Twin replies

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/twin-delivery.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/twin-delivery.ts
@@ -1,5 +1,6 @@
 import { CONFIG } from "../config.js";
-import { expandSpacesMentions } from "./mention-transform.js";
+import { expandSpacesMentions, resolveUnboundMentions } from "./mention-transform.js";
+import { buildSpacesMentionLookupsDb } from "./mention-lookups.js";
 import { createLogger } from "../logger.js";
 import { resolveTwinReplyTarget } from "./twin-reply-target.js";
 
@@ -120,13 +121,31 @@ export async function executeTwinApprovalDelivery(
         destinationConversationId: ctx.destinationConversationId,
       });
     }
+    // Resolve bare `@Name` / `@email` shorthand in the Twin's reply into real,
+    // notifying Spaces mentions BEFORE posting. Every other result-posting path
+    // (webhook, scheduled-jobs, attachments, app-tools) already runs this step;
+    // twin delivery historically ran only the sync expander, so an approved
+    // reply containing a plain `@Anurag Dwivedi` never became a clickable,
+    // notifying mention. Post-as-user is S2S (no user JWT), so resolve via the
+    // Spaces DB scoped to the delivery workspace. Fail-open: on any error, post
+    // the text unchanged so the reply still goes out.
+    let markdownText = finalContent;
+    try {
+      markdownText = await resolveUnboundMentions(finalContent, buildSpacesMentionLookupsDb(ctx.workspaceId));
+    } catch (err) {
+      log.warn(
+        `[twin-delivery] mention resolution failed — posting raw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    markdownText = expandSpacesMentions(markdownText);
+
     const postRes = await fetch(`${CONFIG.spacesInternalUrl}/api/internal/postAsUser`, {
       method: "POST",
       headers: s2sHeaders,
       body: JSON.stringify({
         channelId: target.channelId,
         ...(target.conversationId ? { conversationId: target.conversationId } : {}),
-        markdownText: expandSpacesMentions(finalContent),
+        markdownText,
         userId: ctx.mentionedUserId,
         workspaceId: ctx.workspaceId,
         metadata: { contentFormat: "markdown" },


### PR DESCRIPTION
## What
When a Digital Twin's approved reply contains a plain `@Anurag Dwivedi`, it now becomes a real clickable, **notifying** mention instead of staying as raw text.

## Why (root cause)
`executeTwinApprovalDelivery` (the shared approved-Twin delivery path in `apps/xyne-claw-auth/backend/src/lib/twin-delivery.ts`, used by both the in-thread reply-draft endpoint and the legacy DM approval card) posted `markdownText: expandSpacesMentions(finalContent)` — the **sync expander only**. `expandSpacesMentions` lifts the bracketed `@Name[userId]` shorthand into a mention span but does nothing for a bare `@Name`/`@email`.

Every other result-posting path already resolves bare mentions first via `resolveUnboundMentions()` → then `expandSpacesMentions()`:
- `routes/webhook.ts` (result + pendingResponses paths)
- `routes/scheduled-jobs.ts`
- `surfaces/spaces/attachments.ts`
- `mcp/servers/xyne-spaces-app-tools-server.ts`

Twin delivery was the **one** path that skipped `resolveUnboundMentions`, so an approved reply that mentioned someone by plain name never notified them.

## How
Add the missing `resolveUnboundMentions()` step before `expandSpacesMentions()`, scoped to the delivery workspace via the DB-backed lookups builder `buildSpacesMentionLookupsDb(ctx.workspaceId)`. Post-as-user is S2S (no user JWT), so the DB builder is the correct one — identical to scheduled-jobs' fallback and the app-tools server. Fail-open: on any lookup error the reply still posts with raw text.

## Scope
- 1 file, +21/−2: `apps/xyne-claw-auth/backend/src/lib/twin-delivery.ts`.
- No new typecheck errors introduced.

## Testing (needs a human reviewer)
Trigger the Digital Twin, approve a reply whose text contains `@<a workspace member's name>` and `@<their email>`; confirm the posted message renders a mention pill and the person receives a notification. Confirm `@randomword` (no match) stays plain text and ambiguous duplicate names are left unresolved (existing `resolveUnboundMentions` behavior).
