### PR TITLE
fix: XYNE-55381 analytics query fix

### DIFF
--- a/apps/backend/src/database/repositories/analyticsRepository.ts
+++ b/apps/backend/src/database/repositories/analyticsRepository.ts
@@ -114,7 +114,6 @@ type FilteredMessage = {
   messageId: string;
   senderId: string;
   conversationId: string;
-  metadata: any;
   createdAt: Date;
 };
 
@@ -200,18 +199,49 @@ export class AnalyticsRepository {
     'cmlpgdr0a09rj11uzf3xql7ad', 'cmkmhn5c803k3skfrc836863n','cmlv7gc0a00mrka9fol3ccjrk'
   ];
 
+  /**
+   * Coalesces concurrent identical scans. Every analytics panel calls this
+   * helper with the same (workspace, range) key, and the dashboard fires all
+   * of them in parallel on mount and on every refetch — without this, one
+   * dashboard render issues ~8 copies of the same scan against the replica.
+   */
+  private static readonly inFlightMessageQueries = new Map<string, Promise<FilteredMessage[]>>();
+
   private async getFilteredMessages(dateCondition: { gte?: Date; lte?: Date }, workspaceId: string): Promise<FilteredMessage[]> {
-    const excludedChannels = AnalyticsRepository.EXCLUDED_CHANNEL_IDS;
+    const scopedWorkspaceId = this.requireWorkspaceId(workspaceId);
     const gte = dateCondition.gte ? dateCondition.gte.toISOString() : null;
     const lte = dateCondition.lte ? dateCondition.lte.toISOString() : null;
-    const scopedWorkspaceId = this.requireWorkspaceId(workspaceId);
+
+    const key = `${scopedWorkspaceId}|${gte ?? ''}|${lte ?? ''}`;
+    const inFlight = AnalyticsRepository.inFlightMessageQueries.get(key);
+    if (inFlight) return inFlight;
+
+    const query = this.queryFilteredMessages(gte, lte, scopedWorkspaceId)
+      .finally(() => AnalyticsRepository.inFlightMessageQueries.delete(key));
+
+    AnalyticsRepository.inFlightMessageQueries.set(key, query);
+    return query;
+  }
+
+  private async queryFilteredMessages(gte: string | null, lte: string | null, scopedWorkspaceId: string): Promise<FilteredMessage[]> {
+    const excludedChannels = AnalyticsRepository.EXCLUDED_CHANNEL_IDS;
+
+    // Emit the date bounds as plain comparisons instead of
+    // `($1::timestamp IS NULL OR m."createdAt" >= $1::timestamp)`. That OR form
+    // is non-sargable: Postgres can only fold the IS NULL branch away while it
+    // still builds custom plans, so once a pooled connection's prepared
+    // statement flips to a generic plan it stops using (msgType, createdAt) and
+    // sequential-scans `messages` regardless of how narrow the range is. That is
+    // what makes the same request succeed on one connection and hit
+    // statement_timeout on the next.
+    const gteClause = gte ? Prisma.sql`AND m."createdAt" >= ${gte}::timestamp` : Prisma.empty;
+    const lteClause = lte ? Prisma.sql`AND m."createdAt" <= ${lte}::timestamp` : Prisma.empty;
 
     const messages = await this.prisma.$queryRaw<FilteredMessage[]>(Prisma.sql`
       SELECT 
         m."messageId", 
         m."senderId", 
         m."conversationId", 
-        m."metadata", 
         m."createdAt"
       FROM "public"."messages_without_content" m
       INNER JOIN "public"."conversations" c 
@@ -220,8 +250,8 @@ export class AnalyticsRepository {
         ON ch."id" = c."channelId"
       WHERE 
         m."msgType" = 'USER'
-        AND (${gte}::timestamp IS NULL OR m."createdAt" >= ${gte}::timestamp)
-        AND (${lte}::timestamp IS NULL OR m."createdAt" <= ${lte}::timestamp)
+        ${gteClause}
+        ${lteClause}
         AND ch."workspaceId" = ${scopedWorkspaceId}
         AND c."channelId" NOT IN (${Prisma.join(excludedChannels)})
         AND NOT EXISTS (

--- a/apps/backend/src/database/repositories/analyticsRepository.ts
+++ b/apps/backend/src/database/repositories/analyticsRepository.ts
@@ -116,13 +116,20 @@ type FilteredMessage = {
   conversationId: string;
   createdAt: Date;
 };
+const MINUTE_MS = 60 * 1000;
+/**
+ * Quantizes "now" to a whole minute so the ~8 panels of one dashboard resolve and share identical [gte, lte]
+ */
+function floorToMinute(date: Date): Date {
+  return new Date(Math.floor(date.getTime() / MINUTE_MS) * MINUTE_MS);
+}
 
 /**
  * Helper method to get date filter SQL condition
  * ALL DATE OPERATIONS USE UTC TO AVOID TIMEZONE ISSUES
  */
 export function getDateFilter(filters: AnalyticsFilters): Date | { gte: Date; lte?: Date } {
-  const now = new Date();
+  const now = floorToMinute(new Date());
 
   // Handle custom date range
   if (filters.timeRange === 'custom' && filters.startDate) {
@@ -204,10 +211,13 @@ export class AnalyticsRepository {
    * helper with the same (workspace, range) key, and the dashboard fires all
    * of them in parallel on mount and on every refetch — without this, one
    * dashboard render issues ~8 copies of the same scan against the replica.
+   *
+   * Relies on ranges being minute-quantized (see floorToMinute) so that panels
+   * resolving their range moments apart still produce the same key.
    */
   private static readonly inFlightMessageQueries = new Map<string, Promise<FilteredMessage[]>>();
 
-  private async getFilteredMessages(dateCondition: { gte?: Date; lte?: Date }, workspaceId: string): Promise<FilteredMessage[]> {
+  private async getFilteredMessages(dateCondition: { gte?: Date; lte?: Date }, workspaceId: string): Promise<readonly FilteredMessage[]> {
     const scopedWorkspaceId = this.requireWorkspaceId(workspaceId);
     const gte = dateCondition.gte ? dateCondition.gte.toISOString() : null;
     const lte = dateCondition.lte ? dateCondition.lte.toISOString() : null;
@@ -2169,8 +2179,9 @@ export class AnalyticsRepository {
    */
   async getMessagesToday(workspaceId?: string): Promise<number> {
     const scopedWorkspaceId = this.requireWorkspaceId(workspaceId);
-    // Get current time in IST (UTC+5:30)
-    const now = new Date();
+    // Get current time in IST (UTC+5:30), quantized so this range matches the
+    // one getMessagesTodayTimeSeries resolves and the two can share a scan.
+    const now = floorToMinute(new Date());
     const istTime = new Date(now.getTime() + IST_OFFSET_MS);
     
     // Get start of today in IST
@@ -2193,8 +2204,9 @@ export class AnalyticsRepository {
    */
   async getMessagesTodayTimeSeries(workspaceId?: string): Promise<{ date: string; value: number }[]> {
     const scopedWorkspaceId = this.requireWorkspaceId(workspaceId);
-    // Get current time in IST (UTC+5:30)
-    const now = new Date();
+    // Get current time in IST (UTC+5:30), quantized so this range matches the
+    // one getMessagesToday resolves and the two can share a scan.
+    const now = floorToMinute(new Date());
     const istTime = new Date(now.getTime() + IST_OFFSET_MS);
 
     // Get start of today in IST


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

**Description**
 The date filter was written as an optional-filter idiom:
 AND (${gte}::timestamp IS NULL OR m."createdAt" >= ${gte}::timestamp)

That predicate is non-sargable. Postgres can only fold the IS NULL branch away while it builds custom plans; once a pooled connection's prepared statement flips to a generic plan, the OR has to stay, the (msgType, createdAt) index becomes unusable, and it sequential-scans the entire messages table.


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
