### PR TITLE
fix: enforcing workspaceId in transaction blocks

### DIFF
--- a/apps/backend/src/apps/core/ticketutils.ts
+++ b/apps/backend/src/apps/core/ticketutils.ts
@@ -174,7 +174,7 @@ export async function createTicketWithConversation(
     // Generate xyneId and create ticket in a transaction
     const ticket = await prisma.$transaction(async (tx) => {
       // Generate xyneId using project-scoped format
-      const xyneId = await TicketIdService.generateTicketId(tx, projectId);
+      const xyneId = await TicketIdService.generateTicketId(tx, projectId, workspaceId);
       // Create ticket using repository
       const createdTicket = await ticketRepository.createTicket({
         title,

--- a/apps/backend/src/automations/steps/make-call.step.ts
+++ b/apps/backend/src/automations/steps/make-call.step.ts
@@ -11,6 +11,7 @@ import { CallType, CallOrigin, CallStatus, ProjectType, UserType } from '@xyne/s
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { getAutomationsBotUserId } from './automations-bot';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 const MAX_CALL_INVITEES = 499;
 
@@ -327,7 +328,7 @@ export class MakeCallStep extends BaseActionStep<typeof MakeCallConfigSchema, Ma
       });
       const cancelledAt = new Date();
       const cleanupResults = await Promise.allSettled([
-        db.$transaction([
+        runAsServiceActor('automation-make-call', workspaceId, () => db.$transaction([
           db.callParticipant.deleteMany({ where: { callId } }),
           db.message.updateMany({
             where: { messageId, conversationId },
@@ -363,7 +364,7 @@ export class MakeCallStep extends BaseActionStep<typeof MakeCallConfigSchema, Ma
               lastActivityAt: cancelledAt,
             },
           }),
-        ]),
+        ])),
         livekitService.deleteRoom(externalId),
       ]);
       cleanupResults.forEach((cleanupResult, index) => {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -477,8 +477,14 @@ const envSchema = Joi.object({
 
   // Tenant-enforcement switches. Default true (refuse); only an explicit false relaxes,
   // so a permissive deployment says so in its own config. Reported either way.
+  // A write naming a workspace other than the enforced one: refused when on, corrected to
+  // the enforced workspace and reported when off. The boundary holds either way.
   ACL_ENFORCE_WORKSPACE_IMMUTABLE: Joi.boolean().default(true),
-  ACL_ENFORCE_GUEST_WRITES: Joi.boolean().default(true),
+  // A query on a workspace-scoped table with no workspace resolved. Covers INTERACTIVE AND
+  // BATCH TRANSACTIONS ONLY — deliberately not the ordinary query path, because
+  // authentication resolves a session before it knows a workspace and user_sessions carries
+  // one, so enforcing there would make it impossible to log in. Widening this needs those
+  // callers named from the `[acl] query ran with no tenant scope` line first.
   ACL_ENFORCE_NO_CONTEXT: Joi.boolean().default(true),
 }).unknown();
 
@@ -1012,7 +1018,6 @@ export const config = {
   },
   aclEnforcement: {
     workspaceImmutable: envVars.ACL_ENFORCE_WORKSPACE_IMMUTABLE as boolean,
-    guestWrites: envVars.ACL_ENFORCE_GUEST_WRITES as boolean,
     noContext: envVars.ACL_ENFORCE_NO_CONTEXT as boolean,
   },
 };

--- a/apps/backend/src/controllers/commitAnalysisController.ts
+++ b/apps/backend/src/controllers/commitAnalysisController.ts
@@ -121,6 +121,7 @@ export class CommitAnalysisController {
 
   private async deriveReleaseContext(
     releaseTicketId: string,
+    initiatorWorkspaceId: string,
   ): Promise<{
     projectId: string;
     mainReleaseBoardId: string;
@@ -129,7 +130,7 @@ export class CommitAnalysisController {
     code: string | null;
   } | null> {
     const ticket = await db.ticket.findUnique({
-      where: { id: releaseTicketId },
+      where: { id: releaseTicketId, workspaceId: initiatorWorkspaceId },
       select: {
         projectId: true,
         boardId: true,
@@ -211,7 +212,7 @@ export class CommitAnalysisController {
     let loadingMessageId: string | null = null;
 
     try {
-      const derived = await this.deriveReleaseContext(currentTicketId);
+      const derived = await this.deriveReleaseContext(currentTicketId, params.workspaceId);
 
       if (!derived) {
         logger.warn('[ReleaseTrigger] skipped: no workspace/repoSlug available');
@@ -255,6 +256,7 @@ export class CommitAnalysisController {
         const releaseResult = await this.releaseService!.release(
           analysisRequest,
           {
+            workspaceId: params.workspaceId,
             workspace: derivedProjectKey,
             repoSlug: derivedRepoSlug,
             projectId,

--- a/apps/backend/src/controllers/deskTagsConfigController.ts
+++ b/apps/backend/src/controllers/deskTagsConfigController.ts
@@ -13,6 +13,7 @@ import { EmailClassificationRepository } from '@/database/repositories/emailClas
 import { EmailRepository } from '@/database/repositories/emailRepository';
 import { generateLlmTags } from '@/tags/generators/llm';
 import { tagRepository } from '@/database/repositories/tagRepository';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 export class DeskTagsConfigController {
   private channelParticipantRepo = new ChannelParticipantRepository();
@@ -288,7 +289,11 @@ export class DeskTagsConfigController {
     const userId = await this.assertAccess(req, res, channelId, true);
     if (!userId) return;
 
-    const workspaceId = req.user?.workspaceId!;
+    const workspaceId = req.user?.workspaceId;
+    if (!workspaceId) {
+      res.status(401).json({ error: 'Workspace context is required' });
+      return;
+    }
     const configKey = deskEmailConfigKey(channelId);
 
     try {
@@ -310,7 +315,7 @@ export class DeskTagsConfigController {
 
       // Advisory lock scoped to (sourceType, sourceId, category) serializes concurrent
       // manual tag adds for the same entity+category without requiring serializable isolation.
-      await db.$transaction(async (tx) => {
+      await runAsServiceActor('desk-tag-write', workspaceId, () => db.$transaction(async (tx) => {
         await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`tag-add:${DESK_EMAIL_SOURCE_TYPE}:${emailId}:${category}`}))`;
 
         const existing = await tx.tag.findFirst({
@@ -351,7 +356,7 @@ export class DeskTagsConfigController {
             isDeleted: false,
           },
         });
-      });
+      }));
 
       res.status(201).json({ success: true });
     } catch (error: any) {

--- a/apps/backend/src/controllers/invitationController.ts
+++ b/apps/backend/src/controllers/invitationController.ts
@@ -8,7 +8,7 @@ import { Request, Response } from 'express';
 import { invitationService } from '@/services/invitationService';
 import { redisService } from '@/services/redisService';
 import { DatabaseClient } from '@/database/client';
-import { withWorkspaceScope } from '@/database/tenant/context';
+import { runAsSystem, withWorkspaceScope } from '@/database/tenant/context';
 import { logger } from '@/utils/logger';
 import { config } from '@/config/env';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
@@ -479,7 +479,9 @@ export class InvitationController {
       }
 
       // All creation steps in one transaction — rollback automatically on any failure
-      const { org, workspace } = await prisma.$transaction(async tx => {
+      // The authorized admin is provisioning a brand-new workspace, so no existing
+      // workspace can be the tenant scope for these creation-only writes.
+      const { org, workspace } = await runAsSystem(() => prisma.$transaction(async tx => {
         const org = await tx.organization.create({
           data: {
             name: orgName.trim(),
@@ -531,7 +533,7 @@ export class InvitationController {
         });
 
         return { org, workspace };
-      });
+      }));
 
       await organizationDomainService.createDomainMappingForOrg({
         orgId: org.orgId,

--- a/apps/backend/src/controllers/ticketController.ts
+++ b/apps/backend/src/controllers/ticketController.ts
@@ -258,7 +258,7 @@ export class TicketController {
       const channelWorkspaceId = await this.channelRepository.getWorkspaceId(channelId);
 
       // Generate xyneId using project-scoped format
-      const xyneId = await TicketIdService.generateTicketId(tx, projectId);
+      const xyneId = await TicketIdService.generateTicketId(tx, projectId, channelWorkspaceId);
 
       // Create ticket
       const ticket = await this.ticketRepository.createTicket({
@@ -716,7 +716,11 @@ export class TicketController {
       // Wrap all database operations in a transaction for data integrity
       const { ticket } = await prisma.$transaction(async (tx) => {
         // Generate xyneId using project-scoped format
-        const xyneId = await TicketIdService.generateTicketId(tx, projectId);
+        const xyneId = await TicketIdService.generateTicketId(
+          tx,
+          projectId,
+          req.user!.workspaceId,
+        );
 
         let conversationId: string;
         let ticket: Ticket;
@@ -1137,7 +1141,7 @@ export class TicketController {
               });
               logger.info(`[Ticket Creation] Created ${formEntityValuesData.length} form entity values for ticket ${ticket.id}`);
               if (Object.prototype.hasOwnProperty.call(dynamicFields, 'releaseVersion')) {
-                versionReleaseMappingService.syncTicketById(ticket.id).catch(error => {
+                versionReleaseMappingService.syncTicketById(ticket.id, req.user!.workspaceId).catch(error => {
                   logger.error(`[Ticket Creation] Version release mapping failed for ticket ${ticket.xyneId}:`, error);
                 });
               }

--- a/apps/backend/src/database/repositories/applicationRepository.ts
+++ b/apps/backend/src/database/repositories/applicationRepository.ts
@@ -1,5 +1,4 @@
 import { DatabaseClient } from '@/database/client';
-import { resolveWorkspaceIdFromModel } from '@/database/tenant/workspace-utils';
 import { logger } from '@framework';
 import { TicketIdService } from '@/services/ticketIdService';
 
@@ -7,6 +6,7 @@ const prisma = DatabaseClient.getInstance();
 import { Application } from '@prisma/client';
 import { ActivityType, TicketPriority } from '@xyne/shared';
 import { dualWriteTicketTag } from '@/services/ticketTagDualWriteService';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 export class ApplicationRepository {
 
@@ -48,22 +48,37 @@ export class ApplicationRepository {
    * snapshot those here. Dedup is handled by the @@unique([applicationReleaseId,
    * ticketId]) constraint via skipDuplicates.
    */
-  async createApplicationReleaseTicketMappings(records: Array<{
-    applicationReleaseId: string;
-    releaseId: string;
-    devTicketId: string;
-  }>): Promise<{ count: number }> {
+  async createApplicationReleaseTicketMappings(
+    records: Array<{
+      applicationReleaseId: string;
+      releaseId: string;
+      devTicketId: string;
+    }>,
+    initiatorWorkspaceId: string,
+  ): Promise<{ count: number }> {
     if (records.length === 0) return { count: 0 };
 
-    // All ART rows for a release share the release's workspace; the dev ticket
-    // carries the denormalized tenant key, so resolve it once and stamp it.
-    const artWorkspaceId = await resolveWorkspaceIdFromModel(prisma, 'ticket', { id: records[0].devTicketId });
+    const devTicketIds = [...new Set(records.map(record => record.devTicketId))];
+    const releaseIds = [...new Set(records.map(record => record.releaseId))];
+    const subTicketIds = [...new Set(records.map(record => record.applicationReleaseId))];
+    const [devTicketCount, releaseCount, subTicketCount] = await Promise.all([
+      prisma.ticket.count({ where: { id: { in: devTicketIds }, workspaceId: initiatorWorkspaceId } }),
+      prisma.ticket.count({ where: { id: { in: releaseIds }, workspaceId: initiatorWorkspaceId } }),
+      prisma.subTicket.count({ where: { id: { in: subTicketIds }, workspaceId: initiatorWorkspaceId } }),
+    ]);
+    if (
+      devTicketCount !== devTicketIds.length
+      || releaseCount !== releaseIds.length
+      || subTicketCount !== subTicketIds.length
+    ) {
+      throw new Error('Application release mappings contain targets outside the initiator workspace');
+    }
 
     const data = records.map(r => ({
       applicationReleaseId: r.applicationReleaseId,
       releaseId: r.releaseId,
       ticketId: r.devTicketId,
-      workspaceId: artWorkspaceId,
+      workspaceId: initiatorWorkspaceId,
     }));
 
     const result = await prisma.applicationReleaseTicket.createMany({
@@ -109,6 +124,7 @@ export class ApplicationRepository {
     channelId: string;
     conversationId: string;
     createdBy: string;
+    initiatorWorkspaceId: string;
     affectedApplications: (Application & { matchedFiles: string[] })[];
     prLinksByApplication: Map<string, string[]>;
     isHotFix?: boolean;
@@ -120,26 +136,46 @@ export class ApplicationRepository {
       channelId,
       conversationId,
       createdBy,
+      initiatorWorkspaceId,
       affectedApplications,
       prLinksByApplication,
       isHotFix,
     } = opts;
     logger.info(`Creating sub-tickets for ${affectedApplications.length} affected applications`);
 
-    // Project workspace doesn't change per-app; resolve once outside the loop.
-    const ticketWorkspaceId = await resolveWorkspaceIdFromModel(prisma, 'project', { id: projectId });
+    // Authorize every parent supplied to the transaction against the initiator. Resolving the
+    // workspace from a target id would only describe the target and would permit IDOR.
+    const [project, parentTicket, channel, conversation] = await Promise.all([
+      prisma.project.findFirst({ where: { id: projectId, workspaceId: initiatorWorkspaceId }, select: { id: true } }),
+      prisma.ticket.findFirst({ where: { id: parentTicketId, workspaceId: initiatorWorkspaceId }, select: { id: true } }),
+      prisma.channel.findFirst({ where: { id: channelId, workspaceId: initiatorWorkspaceId }, select: { id: true } }),
+      prisma.conversation.findFirst({
+        where: { conversationId, workspaceId: initiatorWorkspaceId },
+        select: { conversationId: true },
+      }),
+    ]);
+    if (!project || !parentTicket || !channel || !conversation) {
+      throw new Error('Release targets are not accessible in the initiator workspace');
+    }
 
     const result = new Map<string, { subTicketId: string; mappedTicketId: string; xyneId: string }>();
 
     for (const application of affectedApplications) {
+      if (application.workspaceId !== initiatorWorkspaceId) {
+        throw new Error(`Application ${application.id} is not accessible in the initiator workspace`);
+      }
       if (!application.boardId) {
         logger.warn(`Application ${application.name} has no boardId, skipping ticket creation`);
         continue;
       }
 
       try {
-        const txResult = await prisma.$transaction(async (tx) => {
-          const xyneId = await TicketIdService.generateTicketId(tx, projectId);
+        const txResult = await runAsServiceActor(createdBy, initiatorWorkspaceId, () => prisma.$transaction(async (tx) => {
+          const xyneId = await TicketIdService.generateTicketId(
+            tx,
+            projectId,
+            initiatorWorkspaceId,
+          );
 
           const prLinks = prLinksByApplication.get(application.id) || [];
           const prLinksSection = prLinks.length > 0
@@ -151,7 +187,7 @@ export class ApplicationRepository {
           // configured first column instead of a hardcoded 'Release' label
           // that may not exist on the board.
           const firstStage = await tx.stage.findFirst({
-            where: { boardId: application.boardId! },
+            where: { boardId: application.boardId!, workspaceId: initiatorWorkspaceId },
             orderBy: { sequenceNumber: 'asc' },
             select: { name: true, defaultTicketStatusV2: true },
           });
@@ -166,7 +202,7 @@ export class ApplicationRepository {
               channelId,
               xyneId,
               projectId,
-              workspaceId: ticketWorkspaceId,
+              workspaceId: initiatorWorkspaceId,
               boardId: application.boardId,
               statusV2: firstStage?.defaultTicketStatusV2 ?? 'TODO',
               priority: TicketPriority.LOW,
@@ -180,7 +216,7 @@ export class ApplicationRepository {
               data: {
                 ticketId: ticket.id,
                 name: 'HotFix',
-                workspaceId: ticketWorkspaceId,
+                workspaceId: initiatorWorkspaceId,
               }
             })
             await dualWriteTicketTag(ticket.id, 'HotFix', tx);
@@ -195,18 +231,18 @@ export class ApplicationRepository {
               conversationId,
               mappedTicketId: ticket.id,
               assignedTo: null,
-              workspaceId: ticketWorkspaceId,
+              workspaceId: initiatorWorkspaceId,
             },
           });
 
           await tx.ticketSubTicketMapping.create({
-            data: { ticketId: parentTicketId, subTicketId: subTicket.id, workspaceId: ticketWorkspaceId },
+            data: { ticketId: parentTicketId, subTicketId: subTicket.id, workspaceId: initiatorWorkspaceId },
           });
 
           await tx.ticketActivity.create({
             data: {
               ticketId: parentTicketId,
-              workspaceId: ticketWorkspaceId,
+              workspaceId: initiatorWorkspaceId,
               updatedBy: createdBy,
               activityType: ActivityType.SUBTICKET_CREATED,
               value: {
@@ -221,7 +257,7 @@ export class ApplicationRepository {
           });
 
           return { subTicketId: subTicket.id, mappedTicketId: ticket.id, xyneId };
-        });
+        }));
 
         result.set(application.id, txResult);
         logger.info(`Created sub-ticket ${txResult.subTicketId}, ticket ${txResult.xyneId} (${txResult.mappedTicketId}) for application ${application.name}`);

--- a/apps/backend/src/database/repositories/callWhiteboardRepository.ts
+++ b/apps/backend/src/database/repositories/callWhiteboardRepository.ts
@@ -7,6 +7,7 @@ import {
   AttachmentEntityType,
   MessageType,
 } from '@xyne/shared';
+import { runAsServiceActor } from '../tenant/context';
 
 export interface SaveCallWhiteboardAttachmentInput {
   callId: string;
@@ -42,8 +43,8 @@ export class CallWhiteboardRepository {
   ): Promise<SaveCallWhiteboardAttachmentResult> {
     const lockKey = `whiteboard:${data.callId}:${data.pageId ?? 'call'}`;
 
-    return await this.db.$transaction(
-      async tx => {
+    return await runAsServiceActor('call-whiteboard', data.workspaceId, () =>
+      this.db.$transaction(async tx => {
         await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
 
         const existing = await tx.messageAttachment.findFirst({
@@ -147,8 +148,7 @@ export class CallWhiteboardRepository {
           alreadyExists: false,
           whiteboardMessageId: whiteboardMessage.messageId,
         };
-      },
-      { maxWait: 10_000, timeout: 30_000 },
+      }, { maxWait: 10_000, timeout: 30_000 }),
     );
   }
 }

--- a/apps/backend/src/database/repositories/workflowExecutionStateUtils.ts
+++ b/apps/backend/src/database/repositories/workflowExecutionStateUtils.ts
@@ -5,6 +5,7 @@
  */
 
 import { DatabaseClient } from '@/database/client';
+import { runAsServiceActor } from '@/database/tenant/context';
 import { WorkflowExecution } from '@/types/database';
 
 const prisma = DatabaseClient.getInstance();
@@ -230,7 +231,7 @@ export async function markAutomationFailed(
     chain: existingMeta.chain ?? [],
   };
 
-  await prisma.$transaction([
+  await runAsServiceActor('workflow-execution-state', execution.workspaceId, () => prisma.$transaction([
     prisma.workflowExecution.update({
       where: { id: workflowExecutionId },
       data: { status: 'FAILED' },
@@ -240,7 +241,7 @@ export async function markAutomationFailed(
       create: { workflowExecutionId, workspaceId: execution.workspaceId, context: JSON.stringify(mergedContext) },
       update: { context: JSON.stringify(mergedContext) },
     }),
-  ]);
+  ]));
   return 'marked';
 }
 

--- a/apps/backend/src/database/tenant/acl-extension.test.ts
+++ b/apps/backend/src/database/tenant/acl-extension.test.ts
@@ -34,6 +34,10 @@ jest.mock('@/database/tenant/context', () => ({
 const getACL = jest.fn();
 jest.mock('@/database/acl', () => ({ ACLFactory: { getACL: () => getACL() } }));
 
+// The real env.ts validates the whole schema on import and needs JWT_SECRET.
+const enforce = { noContext: false, workspaceImmutable: false };
+jest.mock('@/config/env', () => ({ config: { aclEnforcement: enforce } }));
+
 const warn = jest.fn();
 jest.mock('@/utils/logger', () => ({ logger: { warn: (...a: unknown[]) => warn(...a), info: jest.fn() } }));
 
@@ -71,6 +75,8 @@ function asUser(role = 'MEMBER') {
 
 beforeEach(() => {
   warn.mockReset();
+  enforce.noContext = false;
+  enforce.workspaceImmutable = false;
   getACL.mockReset();
   ctxState.ctx = null;
   ctxState.ws = null;
@@ -81,20 +87,89 @@ beforeEach(() => {
 const tags = (): string[] => warn.mock.calls.map((c) => c[0] as string);
 
 describe('gates before any scoping', () => {
-  it('passes through untouched inside an interactive transaction', async () => {
+  /** Run an operation from inside the transaction wrapper, as $transaction(fn) would. */
+  const inTransaction = (txWrapper: unknown, fn: () => unknown) =>
+    (txWrapper as (f: unknown) => Promise<unknown>).call({}, fn);
+
+  it('bounds the query by workspace inside an interactive transaction', async () => {
     asUser();
     const { hook, txWrapper } = build();
     const query = jest.fn().mockResolvedValue('row');
 
-    // Run the operation from inside the transaction wrapper, as $transaction(fn) would.
-    const result = await (txWrapper as (fn: unknown) => Promise<unknown>).call(
-      { }, // `this` is unused
-      () => hook({ model: 'Message', operation: 'findMany', args: { where: { id: 'm' } }, query }),
+    const result = await inTransaction(txWrapper, () =>
+      hook({ model: 'Message', operation: 'findMany', args: { where: { id: 'm' } }, query }),
     );
 
-    expect(query).toHaveBeenCalledWith({ where: { id: 'm' } });
+    // The normal path's pre-query reads would escape the transaction, so the boundary is
+    // applied to the arguments instead.
+    expect(query).toHaveBeenCalledWith({ where: { AND: [{ id: 'm' }, { workspaceId: WS }] } });
     expect(result).toBe('row');
     expect(tags()).toContain('[acl] ran inside a transaction');
+  });
+
+  it('passes through in a transaction with no workspace while enforcement is off', async () => {
+    ctxState.ctx = { actor: 'user', userId: 'u-1', workspaceId: null };
+    ctxState.ws = null;
+    enforce.noContext = false;
+    const { hook, txWrapper } = build();
+    const query = jest.fn().mockResolvedValue(null);
+
+    await inTransaction(txWrapper, () =>
+      hook({ model: 'Message', operation: 'findMany', args: {}, query }),
+    );
+
+    expect(query).toHaveBeenCalledWith({});
+    expect(tags()).toContain('[acl] query ran with no tenant scope');
+  });
+
+  it('refuses a tenant table in a transaction with no workspace once enforcement is on', async () => {
+    ctxState.ctx = { actor: 'user', userId: 'u-1', workspaceId: null };
+    ctxState.ws = null;
+    enforce.noContext = true;
+    const { hook, txWrapper } = build();
+    const query = jest.fn();
+
+    await expect(
+      inTransaction(txWrapper, () =>
+        hook({ model: 'Message', operation: 'findMany', args: {}, query }),
+      ),
+    ).rejects.toThrow(/workspaceId required for Message.findMany/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('lets a model with no workspaceId column through even with enforcement on', async () => {
+    ctxState.ctx = { actor: 'user', userId: 'u-1', workspaceId: null };
+    ctxState.ws = null;
+    enforce.noContext = true;
+    const { hook, txWrapper } = build();
+    const query = jest.fn().mockResolvedValue([]);
+
+    await inTransaction(txWrapper, () =>
+      hook({ model: 'Workspace', operation: 'findMany', args: {}, query }),
+    );
+
+    expect(query).toHaveBeenCalledWith({});
+  });
+
+  // Authentication resolves the session before it knows a workspace, and UserSession is a
+  // workspace-scoped table. It runs outside a transaction, so the switch must not reach it —
+  // enforcing here would make it impossible to log in.
+  it('lets a workspace-scoped read through outside a transaction even with enforcement on', async () => {
+    ctxState.ctx = { actor: 'user', userId: 'u-1', workspaceId: null };
+    ctxState.ws = null;
+    enforce.noContext = true;
+    const { hook } = build();
+    const query = jest.fn().mockResolvedValue({ id: 's-1' });
+
+    const row = await hook({
+      model: 'UserSession',
+      operation: 'findUnique',
+      args: { where: { id: 's-1' } },
+      query,
+    });
+
+    expect(query).toHaveBeenCalledWith({ where: { id: 's-1' } });
+    expect(row).toEqual({ id: 's-1' });
   });
 
   it('passes through when no workspace is resolved, and says why', async () => {

--- a/apps/backend/src/database/tenant/acl-extension.ts
+++ b/apps/backend/src/database/tenant/acl-extension.ts
@@ -12,6 +12,8 @@ import { AsyncLocalStorage } from 'async_hooks';
 import { getContextOrNull, currentWorkspaceId, isRequestContext } from './context';
 import { ACLFactory } from '@/database/acl';
 import { logger } from '@/utils/logger';
+import { config } from '@/config/env';
+import { stampArgsForWorkspace } from './stamp';
 
 const txStorage = new AsyncLocalStorage<boolean>();
 
@@ -44,6 +46,11 @@ function isWorkspaceOnly(where: Record<string, unknown>, ws: string): boolean {
   const keys = Object.keys(where);
   return keys.length === 1 && keys[0] === 'workspaceId' && where.workspaceId === ws;
 }
+
+/** Whether a check refuses or only reports. Read once; echoed at startup. */
+const ENFORCE = { noContext: config.aclEnforcement.noContext } as const;
+
+logger.info('[acl] enforcement mode', ENFORCE);
 
 const SEEN_CAP = 1000;
 const seen = new Set<string>();
@@ -141,6 +148,49 @@ const WHERE_OPS = new Set(['findFirst', 'findFirstOrThrow', 'findMany', 'count',
 const UNIQUE_OPS = new Set(['findUnique', 'findUniqueOrThrow']);
 const BULK_MUTATE_OPS = new Set(['updateMany', 'updateManyAndReturn', 'deleteMany']);
 const UNIQUE_MUTATE_OPS = new Set(['update', 'delete']);
+
+/**
+ * Transaction-safe tenant boundary.
+ *
+ * Prisma gives an interactive transaction callback a transaction client rather than the
+ * fully extended application client. The normal ACL implementation below cannot safely do
+ * its authorization pre-queries through `base`, because those queries would run outside the
+ * transaction. Inside an interactive transaction we therefore enforce the non-negotiable
+ * workspace boundary directly in the operation arguments. This layer prevents an id from
+ * another workspace being read or mutated inside it; per-user/table policies continue to be
+ * enforced by the normal path outside interactive transactions.
+ */
+function scopeTransactionArgs(
+  model: string,
+  operation: string,
+  args: unknown,
+  workspaceId: string,
+): unknown {
+  let scoped = stampArgsForWorkspace(model, operation, args, workspaceId, true);
+  if (!isWorkspaceScopedModel(model)) return scoped;
+
+  const op = operation;
+  const isRead = WHERE_OPS.has(op) || UNIQUE_OPS.has(op);
+  const isBulkMutate = BULK_MUTATE_OPS.has(op);
+  const isUniqueMutate = UNIQUE_MUTATE_OPS.has(op);
+  const isUpsert = op === 'upsert';
+  if (!isRead && !isBulkMutate && !isUniqueMutate && !isUpsert) return scoped;
+
+  const a = (scoped ?? {}) as Record<string, unknown> & {
+    where?: Record<string, unknown>;
+  };
+  const workspaceWhere = { workspaceId };
+  // Prisma 5's extended WhereUniqueInput permits additional non-unique fields, but still
+  // requires its unique selector at the top level (putting it only inside AND is invalid).
+  // Bulk/read operations accept an arbitrary WhereInput, so compose those with AND.
+  const where = UNIQUE_OPS.has(op) || isUniqueMutate || isUpsert
+    ? { ...(a.where ?? {}), workspaceId }
+    : a.where
+      ? { AND: [a.where, workspaceWhere] }
+      : workspaceWhere;
+  scoped = { ...a, where };
+  return scoped;
+}
 
 /**
  * Per-model set of compound unique/PK accessor names (e.g. 'channelId_userId'). Their value is
@@ -366,9 +416,31 @@ export function withAclExtension<T extends PrismaClient>(prisma: T): T {
       $allModels: {
         async $allOperations({ model, operation, args, query }) {
           if (txStorage.getStore() === true) {
-            // Interactive transactions run on the base client; record what goes through.
+            // The normal path's pre-query reads go through `base` and would escape the
+            // transaction, so the workspace boundary is enforced in the operation arguments
+            // instead. Per-table and per-user policy still only applies outside a transaction.
             warnLogOnce('[acl] ran inside a transaction', model, operation);
-            return query(args);
+            const ctx = getContextOrNull();
+            const ws = currentWorkspaceId();
+            if (!ws || !model) {
+              if (ctx?.actor !== 'system') {
+                warnLogOnce('[acl] query ran with no tenant scope', model, operation, {
+                  reason: ctx ? 'transaction-no-workspace' : 'transaction-no-context',
+                });
+              }
+              // A typed operation on a tenant table must never silently become cross-workspace.
+              // Background jobs open runAsServiceActor with their parent entity's workspace;
+              // intentional cross-workspace maintenance uses runAsSystem. Refused only where
+              // ACL_ENFORCE_NO_CONTEXT is on, so the log above can name the callers first.
+              if (ENFORCE.noContext && model && isWorkspaceScopedModel(model) && ctx?.actor !== 'system') {
+                throw new Error(
+                  `workspaceId required for ${model}.${operation} inside an interactive transaction`,
+                );
+              }
+              return query(args);
+            }
+            const scoped = scopeTransactionArgs(model, operation, args, ws);
+            return scoped === args ? query(args) : query(scoped as typeof args);
           }
           const ctx = getContextOrNull();
           const ws = currentWorkspaceId();
@@ -437,6 +509,14 @@ export function withAclExtension<T extends PrismaClient>(prisma: T): T {
         if (typeof args[0] === 'function') {
           const fn = args[0] as (tx: unknown) => unknown;
           return runTransaction((tx: unknown) => txStorage.run(true, () => fn(tx)), ...args.slice(1));
+        }
+        if (Array.isArray(args[0])) {
+          const ctx = getContextOrNull();
+          if (!currentWorkspaceId() && ctx?.actor !== 'system') {
+            throw new Error(
+              'workspaceId required for a batch Prisma transaction; use runAsSystem for intentional global work',
+            );
+          }
         }
         return runTransaction(...args);
       },

--- a/apps/backend/src/database/tenant/acl-extension.ts
+++ b/apps/backend/src/database/tenant/acl-extension.ts
@@ -47,10 +47,10 @@ function isWorkspaceOnly(where: Record<string, unknown>, ws: string): boolean {
   return keys.length === 1 && keys[0] === 'workspaceId' && where.workspaceId === ws;
 }
 
-/** Whether a check refuses or only reports. Read once; echoed at startup. */
-const ENFORCE = { noContext: config.aclEnforcement.noContext } as const;
-
-logger.info('[acl] enforcement mode', ENFORCE);
+logger.info('[acl] enforcement mode', {
+  workspaceImmutable: config.aclEnforcement.workspaceImmutable,
+  noContext: config.aclEnforcement.noContext,
+});
 
 const SEEN_CAP = 1000;
 const seen = new Set<string>();
@@ -166,7 +166,13 @@ function scopeTransactionArgs(
   args: unknown,
   workspaceId: string,
 ): unknown {
-  let scoped = stampArgsForWorkspace(model, operation, args, workspaceId, true);
+  let scoped = stampArgsForWorkspace(
+    model,
+    operation,
+    args,
+    workspaceId,
+    config.aclEnforcement.workspaceImmutable,
+  );
   if (!isWorkspaceScopedModel(model)) return scoped;
 
   const op = operation;
@@ -432,7 +438,7 @@ export function withAclExtension<T extends PrismaClient>(prisma: T): T {
               // Background jobs open runAsServiceActor with their parent entity's workspace;
               // intentional cross-workspace maintenance uses runAsSystem. Refused only where
               // ACL_ENFORCE_NO_CONTEXT is on, so the log above can name the callers first.
-              if (ENFORCE.noContext && model && isWorkspaceScopedModel(model) && ctx?.actor !== 'system') {
+              if (config.aclEnforcement.noContext && model && isWorkspaceScopedModel(model) && ctx?.actor !== 'system') {
                 throw new Error(
                   `workspaceId required for ${model}.${operation} inside an interactive transaction`,
                 );
@@ -513,9 +519,14 @@ export function withAclExtension<T extends PrismaClient>(prisma: T): T {
         if (Array.isArray(args[0])) {
           const ctx = getContextOrNull();
           if (!currentWorkspaceId() && ctx?.actor !== 'system') {
-            throw new Error(
-              'workspaceId required for a batch Prisma transaction; use runAsSystem for intentional global work',
-            );
+            warnLogOnce('[acl] query ran with no tenant scope', undefined, '$transaction', {
+              reason: 'batch-transaction-no-workspace',
+            });
+            if (config.aclEnforcement.noContext) {
+              throw new Error(
+                'workspaceId required for a batch Prisma transaction; use runAsSystem for intentional global work',
+              );
+            }
           }
         }
         return runTransaction(...args);

--- a/apps/backend/src/database/tenant/stamp.test.ts
+++ b/apps/backend/src/database/tenant/stamp.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Behavioural lock on the workspace stamper.
+ *
+ * `stampArgsForWorkspace` decides what happens to the tenant key on a write. The fifth
+ * argument is the enforcement switch: refuse a payload naming another workspace, or correct
+ * it. Both positions must keep the boundary — they differ only in whether the caller is told.
+ *
+ * Models are real (Prisma.dmmf, no connection): Message carries workspaceId and has stampable
+ * relations; Workspace does not carry one.
+ */
+
+const warn = jest.fn();
+jest.mock('@/utils/logger', () => ({ logger: { warn: (...a: unknown[]) => warn(...a), info: jest.fn() } }));
+
+// eslint-disable-next-line import/first
+import { stampArgsForWorkspace } from './stamp';
+
+const WS = 'ws-1';
+const OTHER = 'ws-2';
+
+const REFUSE = true;
+const CORRECT = false;
+
+beforeEach(() => warn.mockReset());
+
+/** Tags emitted during a test. */
+const tags = (): string[] => warn.mock.calls.map((c) => c[0] as string);
+const foreignWarnings = () =>
+  warn.mock.calls.filter((c) => c[0] === '[acl] create names a different workspace').map((c) => c[1]);
+
+describe('create', () => {
+  it('leaves a payload that already names the caller workspace untouched', () => {
+    const args = { data: { id: 'm', workspaceId: WS } };
+    const out = stampArgsForWorkspace('Message', 'create', args, WS, REFUSE);
+
+    expect(out).toBe(args); // same reference: nothing needed changing
+    expect(tags()).toHaveLength(0);
+  });
+
+  it('fills a missing workspaceId', () => {
+    const out = stampArgsForWorkspace('Message', 'create', { data: { id: 'm' } }, WS, REFUSE);
+
+    expect(out).toEqual({ data: { id: 'm', workspaceId: WS } });
+    expect(tags()).toContain('[STAMP] filled a missing workspaceId — caller should pass it explicitly');
+  });
+
+  it('refuses a payload naming another workspace when the switch is on', () => {
+    expect(() =>
+      stampArgsForWorkspace('Message', 'create', { data: { id: 'm', workspaceId: OTHER } }, WS, REFUSE),
+    ).toThrow(/Cannot write Message for a different workspace/);
+
+    // Reported before refusing, so the log is complete in both positions.
+    expect(foreignWarnings()[0]).toMatchObject({ given: OTHER, enforced: WS, refused: true });
+  });
+
+  it('corrects a payload naming another workspace when the switch is off', () => {
+    const out = stampArgsForWorkspace('Message', 'create', { data: { id: 'm', workspaceId: OTHER } }, WS, CORRECT);
+
+    // The boundary holds either way — off means "corrected and reported", not "allowed".
+    expect(out).toEqual({ data: { id: 'm', workspaceId: WS } });
+    expect(foreignWarnings()[0]).toMatchObject({ given: OTHER, enforced: WS, refused: false });
+  });
+
+  it('does not mutate the caller\'s object when correcting', () => {
+    const data = { id: 'm', workspaceId: OTHER };
+    stampArgsForWorkspace('Message', 'create', { data }, WS, CORRECT);
+
+    expect(data.workspaceId).toBe(OTHER); // copy-on-write
+  });
+
+  it('checks every row of a createMany', () => {
+    const out = stampArgsForWorkspace(
+      'Message',
+      'createMany',
+      { data: [{ id: 'a' }, { id: 'b', workspaceId: OTHER }] },
+      WS,
+      CORRECT,
+    );
+
+    expect(out).toEqual({ data: [{ id: 'a', workspaceId: WS }, { id: 'b', workspaceId: WS }] });
+  });
+});
+
+describe('the workspace relation, not just the scalar', () => {
+  it('refuses a connect to another workspace when the switch is on', () => {
+    expect(() =>
+      stampArgsForWorkspace(
+        'Message',
+        'create',
+        { data: { id: 'm', workspace: { connect: { id: OTHER } } } },
+        WS,
+        REFUSE,
+      ),
+    ).toThrow(/Cannot connect Message to a different workspace/);
+  });
+
+  it('corrects a foreign connect when the switch is off', () => {
+    const out = stampArgsForWorkspace(
+      'Message',
+      'create',
+      { data: { id: 'm', workspace: { connect: { id: OTHER } } } },
+      WS,
+      CORRECT,
+    );
+
+    expect(out).toEqual({ data: { id: 'm', workspace: { connect: { id: WS } } } });
+  });
+
+  it('leaves a connect to the caller workspace alone', () => {
+    const args = { data: { id: 'm', workspace: { connect: { id: WS } } } };
+    const out = stampArgsForWorkspace('Message', 'create', args, WS, REFUSE);
+
+    expect(out).toBe(args);
+  });
+});
+
+describe('update', () => {
+  it('does not stamp the existing row', () => {
+    const args = { where: { id: 'm' }, data: { content: 'hi' } };
+    const out = stampArgsForWorkspace('Message', 'update', args, WS, REFUSE);
+
+    // A live row never acquires a tenant key it did not have.
+    expect(out).toBe(args);
+  });
+
+  it('still refuses an update that moves the row to another workspace', () => {
+    expect(() =>
+      stampArgsForWorkspace('Message', 'update', { where: { id: 'm' }, data: { workspaceId: OTHER } }, WS, REFUSE),
+    ).toThrow(/Cannot write Message for a different workspace/);
+  });
+
+  it('stamps a nested create inside an update', () => {
+    const out = stampArgsForWorkspace(
+      'Message',
+      'update',
+      { where: { id: 'm' }, data: { reactions: { create: [{ id: 'r' }] } } },
+      WS,
+      REFUSE,
+    ) as { data: { reactions: { create: Array<{ workspaceId?: string }> } } };
+
+    expect(out.data.reactions.create[0].workspaceId).toBe(WS);
+  });
+});
+
+describe('upsert', () => {
+  it('stamps the create half and leaves the update half alone', () => {
+    const out = stampArgsForWorkspace(
+      'Message',
+      'upsert',
+      { where: { id: 'm' }, create: { id: 'm' }, update: { content: 'hi' } },
+      WS,
+      REFUSE,
+    );
+
+    expect(out).toEqual({
+      where: { id: 'm' },
+      create: { id: 'm', workspaceId: WS },
+      update: { content: 'hi' },
+    });
+  });
+
+  it('refuses a foreign workspace in the create half', () => {
+    expect(() =>
+      stampArgsForWorkspace(
+        'Message',
+        'upsert',
+        { where: { id: 'm' }, create: { id: 'm', workspaceId: OTHER }, update: {} },
+        WS,
+        REFUSE,
+      ),
+    ).toThrow(/Cannot write Message for a different workspace/);
+  });
+});
+
+describe('what it leaves alone', () => {
+  it('ignores reads', () => {
+    const args = { where: { id: 'm' } };
+    expect(stampArgsForWorkspace('Message', 'findMany', args, WS, REFUSE)).toBe(args);
+  });
+
+  it('ignores delete, which carries no payload to stamp', () => {
+    const args = { where: { id: 'm' } };
+    expect(stampArgsForWorkspace('Message', 'delete', args, WS, REFUSE)).toBe(args);
+  });
+
+  it('ignores a model with no workspaceId column', () => {
+    const args = { data: { name: 'w' } };
+    expect(stampArgsForWorkspace('Workspace', 'create', args, WS, REFUSE)).toBe(args);
+  });
+});

--- a/apps/backend/src/database/tenant/stamp.ts
+++ b/apps/backend/src/database/tenant/stamp.ts
@@ -123,6 +123,23 @@ function stampField(entry: Row, key: string, stamp: (row: Row) => Row): Row {
 
 // ── recursive stamping ───────────────────────────────────────────────────────
 
+/** Every occurrence: a repeat is itself the signal, and the count decides when to enforce. */
+function logForeignWorkspace(
+  model: string,
+  op: string,
+  given: string,
+  ws: string,
+  refused: boolean,
+): void {
+  logger.warn('[acl] create names a different workspace', {
+    model,
+    operation: op,
+    given,
+    enforced: ws,
+    refused,
+  });
+}
+
 /**
  * Stamp one write payload for `model`.
  *  - isInsert=true  → the row is being INSERTED: add its own workspaceId (if stampable),
@@ -142,27 +159,46 @@ function stampPayload(
 ): Row {
   if (!isObject(row)) return row;
 
-  if (rejectForeignWorkspace && STAMPABLE.has(model)) {
-    if (row.workspaceId !== undefined && row.workspaceId !== ws) {
-      throw new Error(
-        `Cannot write ${model} for a different workspace inside a scoped transaction`,
-      );
-    }
-    if (isObject(row.workspace)) {
-      const connect = row.workspace.connect;
-      if (isObject(connect) && connect.id !== undefined && connect.id !== ws) {
-        throw new Error(
-          `Cannot connect ${model} to a different workspace inside a scoped transaction`,
-        );
-      }
-    }
-  }
-  let out = isInsert && STAMPABLE.has(model)
-    ? addWorkspaceId(row, ws, model, op)
-    : row;
+  let out: Row = row;
   const copyBeforeEdit = (): void => {
     if (out === row) out = { ...row };
   };
+
+  // A payload naming another workspace. Reported every time in both positions: refused when
+  // the switch is on, corrected to the enforced workspace when it is off — so the boundary
+  // holds either way, and the log says how much is relying on the correction.
+  if (STAMPABLE.has(model)) {
+    const given = row.workspaceId;
+    if (typeof given === 'string' && given !== ws) {
+      logForeignWorkspace(model, op, given, ws, rejectForeignWorkspace);
+      if (rejectForeignWorkspace) {
+        throw new Error(
+          `Cannot write ${model} for a different workspace inside a scoped transaction`,
+        );
+      }
+      copyBeforeEdit();
+      out.workspaceId = ws;
+    }
+    const relation = row.workspace;
+    if (isObject(relation)) {
+      const connect = relation.connect;
+      if (isObject(connect) && typeof connect.id === 'string' && connect.id !== ws) {
+        logForeignWorkspace(model, op, connect.id, ws, rejectForeignWorkspace);
+        if (rejectForeignWorkspace) {
+          throw new Error(
+            `Cannot connect ${model} to a different workspace inside a scoped transaction`,
+          );
+        }
+        copyBeforeEdit();
+        out.workspace = { ...relation, connect: { ...connect, id: ws } };
+      }
+    }
+  }
+
+  if (isInsert && STAMPABLE.has(model)) {
+    // Fills only when absent, so a value corrected above is left alone.
+    out = addWorkspaceId(out, ws, model, op);
+  }
 
   for (const { field, child, isList } of RELATIONS.get(model) ?? []) {
     const nestedWrite = row[field];

--- a/apps/backend/src/database/tenant/stamp.ts
+++ b/apps/backend/src/database/tenant/stamp.ts
@@ -95,7 +95,12 @@ function stampObjectOrArray(value: unknown, stamp: (row: Row) => Row): unknown {
  * an explicit `null` for a deliberate cross-workspace row) or set a `workspace` relation
  * (setting the scalar too would trigger Prisma's scalar-plus-relation conflict).
  */
-function addWorkspaceId(row: Row, workspaceId: string, model: string, op: string): Row {
+function addWorkspaceId(
+  row: Row,
+  workspaceId: string,
+  model: string,
+  op: string,
+): Row {
   if (row.workspaceId !== undefined || 'workspace' in row) return row;
   const key = `${model}:${op}`;
   if (!stamped.has(key) && stamped.size < 500) {
@@ -127,10 +132,34 @@ function stampField(entry: Row, key: string, stamp: (row: Row) => Row): Row {
  *                     themselves insert new rows.
  * Copy-on-write: returns `row` unchanged (same reference) when nothing needed stamping.
  */
-function stampPayload(model: string, row: Row, ws: string, isInsert: boolean, op: string): Row {
+function stampPayload(
+  model: string,
+  row: Row,
+  ws: string,
+  isInsert: boolean,
+  op: string,
+  rejectForeignWorkspace: boolean,
+): Row {
   if (!isObject(row)) return row;
 
-  let out = isInsert && STAMPABLE.has(model) ? addWorkspaceId(row, ws, model, op) : row;
+  if (rejectForeignWorkspace && STAMPABLE.has(model)) {
+    if (row.workspaceId !== undefined && row.workspaceId !== ws) {
+      throw new Error(
+        `Cannot write ${model} for a different workspace inside a scoped transaction`,
+      );
+    }
+    if (isObject(row.workspace)) {
+      const connect = row.workspace.connect;
+      if (isObject(connect) && connect.id !== undefined && connect.id !== ws) {
+        throw new Error(
+          `Cannot connect ${model} to a different workspace inside a scoped transaction`,
+        );
+      }
+    }
+  }
+  let out = isInsert && STAMPABLE.has(model)
+    ? addWorkspaceId(row, ws, model, op)
+    : row;
   const copyBeforeEdit = (): void => {
     if (out === row) out = { ...row };
   };
@@ -139,7 +168,7 @@ function stampPayload(model: string, row: Row, ws: string, isInsert: boolean, op
     const nestedWrite = row[field];
     if (!isObject(nestedWrite)) continue;
 
-    const stamped = stampNestedWrite(child, isList, nestedWrite, ws, op);
+    const stamped = stampNestedWrite(child, isList, nestedWrite, ws, op, rejectForeignWorkspace);
     if (stamped !== nestedWrite) {
       copyBeforeEdit();
       out[field] = stamped;
@@ -155,15 +184,24 @@ function stampPayload(model: string, row: Row, ws: string, isInsert: boolean, op
  * recursed for their own nested creates but never self-stamped. `isList` tells us the
  * shape of `update` (to-one vs to-many). Copy-on-write.
  */
-function stampNestedWrite(child: string, isList: boolean, write: Row, ws: string, op: string): Row {
+function stampNestedWrite(
+  child: string,
+  isList: boolean,
+  write: Row,
+  ws: string,
+  op: string,
+  rejectForeignWorkspace: boolean,
+): Row {
   let out = write;
   const replace = (key: string, value: unknown): void => {
     if (value === write[key]) return;
     if (out === write) out = { ...write };
     out[key] = value;
   };
-  const asInsert = (row: Row): Row => stampPayload(child, row, ws, true, op);
-  const asUpdate = (row: Row): Row => stampPayload(child, row, ws, false, op);
+  const asInsert = (row: Row): Row =>
+    stampPayload(child, row, ws, true, op, rejectForeignWorkspace);
+  const asUpdate = (row: Row): Row =>
+    stampPayload(child, row, ws, false, op, rejectForeignWorkspace);
 
   // create: {…} | [{…}]  → new row(s)
   if ('create' in write) replace('create', stampObjectOrArray(write.create, asInsert));
@@ -205,6 +243,51 @@ function isWriteOp(op: string): boolean {
   return op.startsWith('create') || op.startsWith('update') || op === 'upsert';
 }
 
+/**
+ * Apply the workspace stamper to one Prisma operation.
+ *
+ * Kept separate from the client extension so the interactive-transaction guard can apply
+ * exactly the same top-level and nested-create rules to Prisma's transaction client. Prisma
+ * does not return the outer extended client to an interactive transaction callback.
+ */
+export function stampArgsForWorkspace(
+  model: string,
+  operation: string,
+  args: unknown,
+  workspaceId: string,
+  rejectForeignWorkspace = false,
+): unknown {
+  if (!isWriteOp(operation) || !isObject(args)) return args;
+
+  // create* → every row in `data` is a new insert (plus its nested creates).
+  if (operation.startsWith('create')) {
+    const data = stampObjectOrArray(args.data, (row) =>
+      stampPayload(model, row, workspaceId, true, operation, rejectForeignWorkspace),
+    );
+    return data === args.data ? args : { ...args, data };
+  }
+
+  // upsert → `create` inserts (self + nested); `update` touches an existing row
+  // and therefore only its nested creates are stamped.
+  if (operation === 'upsert') {
+    const create = isObject(args.create)
+      ? stampPayload(model, args.create, workspaceId, true, operation, rejectForeignWorkspace)
+      : args.create;
+    const update = isObject(args.update)
+      ? stampPayload(model, args.update, workspaceId, false, operation, rejectForeignWorkspace)
+      : args.update;
+    return create === args.create && update === args.update
+      ? args
+      : { ...args, create, update };
+  }
+
+  // update* → do not stamp the existing row; only stamp nested creates.
+  const data = isObject(args.data)
+    ? stampPayload(model, args.data, workspaceId, false, operation, rejectForeignWorkspace)
+    : args.data;
+  return data === args.data ? args : { ...args, data };
+}
+
 /** Wrap a Prisma client so every write stamps workspaceId onto the rows it inserts, from context. */
 export function withWorkspaceStamp<T extends PrismaClient>(prisma: T): T {
   logger.info('[STAMP] withWorkspaceStamp extension, registered');
@@ -217,25 +300,8 @@ export function withWorkspaceStamp<T extends PrismaClient>(prisma: T): T {
           const ws = isWriteOp(op) ? currentWorkspaceId() : null;
           if (!ws) return query(args); // reads/deletes, or no tenant context → untouched
 
-          const a = args as Row;
-
-          // create* → every row in `data` is a new insert (plus its nested creates).
-          if (op.startsWith('create')) {
-            const data = stampObjectOrArray(a.data, (row) => stampPayload(model, row, ws, true, op));
-            return data === a.data ? query(args) : query({ ...a, data } as typeof args);
-          }
-
-          // upsert → `create` inserts (self + nested); `update` touches an existing row (nested only).
-          if (op === 'upsert') {
-            const create = isObject(a.create) ? stampPayload(model, a.create, ws, true, op) : a.create;
-            const update = isObject(a.update) ? stampPayload(model, a.update, ws, false, op) : a.update;
-            return create === a.create && update === a.update ? query(args) : query({ ...a, create, update } as typeof args);
-          }
-
-          // update / updateMany / updateManyAndReturn → existing rows: never stamp the row's
-          // own key; recurse `data` only for nested creates.
-          const data = isObject(a.data) ? stampPayload(model, a.data, ws, false, op) : a.data;
-          return data === a.data ? query(args) : query({ ...a, data } as typeof args);
+          const stamped = stampArgsForWorkspace(model, op, args, ws);
+          return stamped === args ? query(args) : query(stamped as typeof args);
         },
       },
     },

--- a/apps/backend/src/migration/slack/slackJiraffeService.ts
+++ b/apps/backend/src/migration/slack/slackJiraffeService.ts
@@ -416,6 +416,11 @@ async function ingestTicket(
     createdAt: new Date(ticket.created_at),
   });
 
+  const channel = await channelRepo.findById(channelId);
+  if (!channel?.workspaceId) {
+    throw new Error(`workspaceId required: channel ${channelId} not found or has no workspace`);
+  }
+
   // Build description: add JIRA link if title was AI-generated (not fallback)
   let description = ticket.task_description || '';
   if (titleText !== fallbackTitle) {
@@ -426,8 +431,7 @@ async function ingestTicket(
   // Generate xyneId and create ticket
   const { TicketIdService } = await import('../../services/ticketIdService');
   const createdTicket = await db.$transaction(async (tx) => {
-    const xyneId = await TicketIdService.generateTicketId(tx, projectId);
-    const channel = await channelRepo.findById(channelId);
+    const xyneId = await TicketIdService.generateTicketId(tx, projectId, channel.workspaceId);
 
     const newTicket = await tx.ticket.create({
       data: {
@@ -438,7 +442,7 @@ async function ingestTicket(
         conversationId: conversation.conversation.conversationId,
         channelId: channelId,
         projectId: projectId,
-        workspaceId: channel?.workspaceId ?? '',
+        workspaceId: channel.workspaceId,
         boardId: boardId,
         ...(resolvedUserGroupId && { userGroupId: resolvedUserGroupId }),
         stageName: resolvedStageName,

--- a/apps/backend/src/queues/delayedMessageQueue.ts
+++ b/apps/backend/src/queues/delayedMessageQueue.ts
@@ -4,6 +4,7 @@ import { redisService } from '@/services/redisService';
 
 export interface DelayedMessageJobData {
   delayedMessageId: string;
+  workspaceId: string;
   channelId: string;
   conversationId?: string | null;
   senderId: string;

--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -6,7 +6,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { DatabaseClient } from '@/database/client';
-import { withWorkspaceScope } from '@/database/tenant/context';
+import { runAsServiceActor, withWorkspaceScope } from '@/database/tenant/context';
 import { repositories } from '@/database/repositories';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { DEFAULT_SUMMARY_FIELDS, MessageType, CanvasRole, CanvasVisibility } from '@xyne/shared';
@@ -1770,7 +1770,7 @@ A comprehensive detailed summary has been generated from this call.
       });
 
       if (callMessage) {
-        await prisma.$transaction(async (tx) => {
+        await runAsServiceActor('call-document', callMessage.workspaceId, () => prisma.$transaction(async (tx) => {
           // Title generation and first-chunk Canvas publication can now update
           // this message concurrently. Lock the row and merge from the latest
           // metadata so neither write erases the other's key.
@@ -1778,6 +1778,7 @@ A comprehensive detailed summary has been generated from this call.
             SELECT "metadata"
             FROM "messages"
             WHERE "messageId" = ${callMessage.messageId}
+              AND "workspaceId" = ${callMessage.workspaceId}
             FOR UPDATE
           `;
           if (!lockedMessage) {
@@ -1793,10 +1794,10 @@ A comprehensive detailed summary has been generated from this call.
             nextMetadata[metadataKey] = canvasUrl;
           }
           await tx.message.update({
-            where: { messageId: callMessage.messageId },
+            where: { messageId: callMessage.messageId, workspaceId: callMessage.workspaceId },
             data: { metadata: nextMetadata },
           });
-        });
+        }));
         logger.info(`[CallDocumentService] Updated call message ${callMessage.messageId} with ${metadataKey}`);
       } else {
         logger.warn(`[CallDocumentService] Call message not found for callId ${callId}`);
@@ -1819,6 +1820,7 @@ A comprehensive detailed summary has been generated from this call.
     canvasId: string,
     conversationId: string,
     callId: string,
+    workspaceId: string,
   ): Promise<void> {
     logger.warn(`[CallDocumentService] Cleaning up failed detailed summary canvas ${canvasId} for call ${callId}`);
 
@@ -1856,12 +1858,14 @@ A comprehensive detailed summary has been generated from this call.
       // CanvasParticipant and CanvasUserStatus do not declare cascading deletes
       // in relationMode="prisma", so remove dependent rows explicitly. deleteMany
       // also keeps this cleanup idempotent if a previous attempt partially ran.
-      await prisma.$transaction([
-        prisma.canvasVersion.deleteMany({ where: { canvasId } }),
-        prisma.canvasParticipant.deleteMany({ where: { canvasId } }),
-        prisma.canvasUserStatus.deleteMany({ where: { canvasId } }),
-        prisma.canvas.deleteMany({ where: { id: canvasId } }),
-      ]);
+      await runAsServiceActor('call-document-cleanup', workspaceId, () =>
+        prisma.$transaction([
+          prisma.canvasVersion.deleteMany({ where: { canvasId } }),
+          prisma.canvasParticipant.deleteMany({ where: { canvasId } }),
+          prisma.canvasUserStatus.deleteMany({ where: { canvasId } }),
+          prisma.canvas.deleteMany({ where: { id: canvasId } }),
+        ]),
+      );
     } catch (error) {
       logger.error('[CallDocumentService] Cleanup: failed to delete canvas database rows:', error);
     }
@@ -1964,6 +1968,7 @@ A comprehensive detailed summary has been generated from this call.
     // Tracks a brand-new, lazily-created streaming canvas so any failure after
     // its first chunk can tear down the canvas and published message.
     let newCanvasId: string | null = null;
+    let cleanupWorkspaceId: string | null = null;
     try {
       const call = await repositories.calls.findByExternalId(callId);
       if (!call) {
@@ -1982,6 +1987,7 @@ A comprehensive detailed summary has been generated from this call.
       if (!channel?.workspaceId) {
         return { success: false, error: 'Channel workspace not found' };
       }
+      cleanupWorkspaceId = channel.workspaceId;
 
       // Number the transcript segments so the LLM can cite them, and build the
       // token→segment map used to turn `[clf-n]` tokens into canvas citation chips.
@@ -2242,7 +2248,7 @@ A comprehensive detailed summary has been generated from this call.
 
       if (!detailedSummaryMarkdown) {
         if (newCanvasId) {
-          await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId);
+          await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId, channel.workspaceId);
         }
         return { success: false, error: 'Failed to generate detailed summary' };
       }
@@ -2256,7 +2262,7 @@ A comprehensive detailed summary has been generated from this call.
       const initializationFailure = getCanvasInitializationError();
       if (initializationFailure || !newCanvasId || !canvasUrl) {
         if (newCanvasId) {
-          await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId);
+          await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId, channel.workspaceId);
         }
         return {
           success: false,
@@ -2283,7 +2289,7 @@ A comprehensive detailed summary has been generated from this call.
         sideEffectContextPromise ?? undefined,
       );
       if (!finalized) {
-        await this.cleanupFailedDetailedSummaryCanvas(finalizedCanvasId, conversationId, callId);
+        await this.cleanupFailedDetailedSummaryCanvas(finalizedCanvasId, conversationId, callId, channel.workspaceId);
         return { success: false, error: 'Failed to write final detailed summary content' };
       }
 
@@ -2313,8 +2319,8 @@ A comprehensive detailed summary has been generated from this call.
       logger.error('[CallDocumentService] Error in generateAndPostDetailedSummary:', error);
       // If a brand-new canvas + link was already published before the throw,
       // tear it down so an exception doesn't leave a dangling canvas/message.
-      if (newCanvasId) {
-        await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId);
+      if (newCanvasId && cleanupWorkspaceId) {
+        await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId, cleanupWorkspaceId);
       }
       return {
         success: false,

--- a/apps/backend/src/services/communityWorkspaceService.ts
+++ b/apps/backend/src/services/communityWorkspaceService.ts
@@ -22,7 +22,7 @@ import { aiProvisioningService } from '@/services/aiProvisioningService';
 import { organizationDomainService } from '@/services/organizationDomainService';
 import { repositories } from '@/database/repositories';
 import { ensureUserInGeneralChannel as joinUserToGeneralChannel } from '@/utils/workspaceGeneralChannel';
-import { withWorkspaceScope } from '@/database/tenant/context';
+import { runAsServiceActor, withWorkspaceScope } from '@/database/tenant/context';
 
 const COMMUNITY_MEMBER_WORKSPACE_ROLE = 'COMMUNITY_MEMBER' as WorkspaceRole;
 const TEMPLATE_TOKEN_PATTERN = /{{\s*(workspaceName|workspaceId|joinLink|email)\s*}}/g;
@@ -311,7 +311,10 @@ export class CommunityWorkspaceService {
 
     const landingChannelId = requestedChannel?.id ?? params.workspace.landingChannelId ?? null;
 
-    const result = await this.prisma.$transaction(async (tx) => {
+    // This public onboarding flow has no existing workspace principal. The validated OPEN
+    // join policy is the authority to enter the selected workspace scope.
+    const result = await runAsServiceActor('community-workspace-join', params.workspace.id, () =>
+      this.prisma.$transaction(async (tx) => {
       let orgMember = await tx.orgMember.findUnique({
         where: { email },
         select: { memberId: true },
@@ -367,7 +370,8 @@ export class CommunityWorkspaceService {
       }
 
       return { workspaceUser, isNewUser };
-    });
+      }),
+    );
 
     if (landingChannelId) {
       try {

--- a/apps/backend/src/services/confluence/confluenceImportService.ts
+++ b/apps/backend/src/services/confluence/confluenceImportService.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import type { Prisma } from '@prisma/client';
 import { DatabaseClient } from '@/database/client';
+import { runAsServiceActor } from '@/database/tenant/context';
 import { logger } from '@/utils/logger';
 import { convertMarkdownToBlockNote } from '@/services/canvasService';
 import type { BlockNoteBlock } from '@/types/blockNoteTypes';
@@ -1257,7 +1258,7 @@ export class ConfluenceImportService {
       throw new Error('workspaceId required: Confluence import config missing workspaceId');
     }
     const ownerUserIds = uniqueIds([creatorUserId, lastEditorUserId, actorUserId]);
-    await db.$transaction([
+    await runAsServiceActor(actorUserId, workspaceId, () => db.$transaction([
       db.canvas.create({
         data: {
           id: canvasId,
@@ -1293,7 +1294,7 @@ export class ConfluenceImportService {
         })),
         skipDuplicates: true,
       }),
-    ]);
+    ]));
 
     await initializeYSweetDoc(canvasId, safeContent as unknown as BlockNoteBlock[]);
   }

--- a/apps/backend/src/services/dynamicDashboard/dataSource/DataSourceService.ts
+++ b/apps/backend/src/services/dynamicDashboard/dataSource/DataSourceService.ts
@@ -5,6 +5,7 @@ import type { DataSource } from '@/types/database';
 import { logger } from '@/utils/logger';
 import { dataSourceIngestQueue } from '@/queues/dataSourceIngestQueue';
 import { ConnectorFactory } from './connectors/ConnectorFactory';
+import { runAsServiceActor } from '@/database/tenant/context';
 import type {
   ConnectionConfig,
   DiscoveredTable,
@@ -273,7 +274,7 @@ export class DataSourceService {
   async remove(id: string, workspaceId: string, actorUserId: string): Promise<boolean> {
     const ds = await this.findWorkspace(id, workspaceId);
     if (!ds) return false;
-    await db.$transaction([
+    await runAsServiceActor(actorUserId, workspaceId, () => db.$transaction([
       db.dataSource.delete({ where: { id } }),
       db.dashboardActivity.create({
         data: {
@@ -285,7 +286,7 @@ export class DataSourceService {
           details: JSON.stringify({ name: ds.name }),
         },
       }),
-    ]);
+    ]));
     return true;
   }
 

--- a/apps/backend/src/services/emailService.ts
+++ b/apps/backend/src/services/emailService.ts
@@ -1089,7 +1089,7 @@ export class EmailService {
       });
 
       // Generate xyneId and create ticket
-      const xyneId = await TicketIdService.generateTicketId(tx, projectId);
+      const xyneId = await TicketIdService.generateTicketId(tx, projectId, channel.workspaceId);
       const ticketTitle = (emailSubject ?? '').replace(SUBJECT_PREFIX_REGEX, '').trim() || emailSubject;
       const ticketPriority = derivePriorityFromSubject(emailSubject);
       const createdTicket = await tx.ticket.create({
@@ -1537,7 +1537,7 @@ export class EmailService {
     const slaResolutionDue = await this.getSlaResolutionDue(boardId, ticketPriority, new Date());
     const ticket = await this.prisma.$transaction(async (tx) => {
       // Generate xyneId using project-scoped format
-      const xyneId = await TicketIdService.generateTicketId(tx, projectId);
+      const xyneId = await TicketIdService.generateTicketId(tx, projectId, channel.workspaceId);
 
       return await tx.ticket.create({
         data: {
@@ -2056,7 +2056,7 @@ export class EmailService {
             },
           });
 
-          const xyneId = await TicketIdService.generateTicketId(tx, projectId);
+          const xyneId = await TicketIdService.generateTicketId(tx, projectId, channel.workspaceId);
           const createdTicket = await tx.ticket.create({
             data: {
               title: firstEmail.subject,

--- a/apps/backend/src/services/entitySequenceService.ts
+++ b/apps/backend/src/services/entitySequenceService.ts
@@ -48,7 +48,8 @@ export class EntitySequenceService {
 
   static async getNextProjectTicketSequence(
     tx: MainPrismaTransaction,
-    projectId: string
+    projectId: string,
+    workspaceId: string,
   ): Promise<number> {
     if (this.isCommonProjectTicketSequenceEnabled()) {
       try {
@@ -62,7 +63,7 @@ export class EntitySequenceService {
     }
 
     const project = await tx.project.update({
-      where: { id: projectId },
+      where: { id: projectId, workspaceId },
       data: { ticketSequence: { increment: 1 } },
       select: { ticketSequence: true },
     });

--- a/apps/backend/src/services/ingestion/docling/scheduler/store.ts
+++ b/apps/backend/src/services/ingestion/docling/scheduler/store.ts
@@ -15,7 +15,7 @@ import { randomUUID } from 'node:crypto';
 import { resolveWorkspaceIdFromModel } from '@/database/tenant/workspace-utils';
 import { db } from '@/database/client';
 import { config } from '@/config/env';
-import { currentWorkspaceId } from '@/database/tenant/context';
+import { currentWorkspaceId, runAsServiceActor } from '@/database/tenant/context';
 import { Prisma } from '@prisma/client';
 import { IngestionStatus } from '@xyne/shared';
 import {
@@ -39,7 +39,7 @@ const numberValue = (value: unknown, fallback = 0): number => {
 
 const fileFromRow = (row: RawRow): DoclingFile => ({
   fileId: String(row.file_id),
-  workspaceId: row.workspace_id ? String(row.workspace_id) : null,
+  workspaceId: row.workspaceId ? String(row.workspaceId) : null,
   collectionId: String(row.collection_id),
   sourcePath: String(row.source_path),
   sourceStorageKey: row.source_storage_key ? String(row.source_storage_key) : null,
@@ -70,6 +70,7 @@ const fileFromRow = (row: RawRow): DoclingFile => ({
 
 const partFromRow = (row: RawRow): DoclingPart => ({
   fileId: String(row.file_id),
+  workspaceId: row.workspaceId ? String(row.workspaceId) : null,
   partIndex: numberValue(row.part_index),
   docId: String(row.doc_id),
   currentJobId: row.current_job_id ? String(row.current_job_id) : null,
@@ -97,10 +98,11 @@ const partFromRow = (row: RawRow): DoclingPart => ({
 const setCollectionItemStatus = async (
   tx: Prisma.TransactionClient,
   fileId: string,
+  workspaceId: string,
   status: IngestionStatus,
 ): Promise<void> => {
   await tx.collectionItem.updateMany({
-    where: { fileId, isLatest: true },
+    where: { fileId, workspaceId, isLatest: true },
     data: { ingestionStatus: status },
   });
 };
@@ -181,7 +183,8 @@ export const markDoclingFileSplitComplete = async (
   stagedParts: DoclingStagedParts,
   resultsDir: string,
 ): Promise<boolean> => {
-  return await db.$transaction(async (tx) => {
+  if (!file.workspaceId) throw new Error(`workspaceId missing for Docling file ${file.fileId}`);
+  return await runAsServiceActor('docling-splitter', file.workspaceId, () => db.$transaction(async (tx) => {
     const claimed = await tx.$queryRaw<RawRow[]>`
       UPDATE non_zero.docling_async_files
       SET status = ${DOCLING_FILE_STATUS.QueuedForOcr},
@@ -197,6 +200,7 @@ export const markDoclingFileSplitComplete = async (
           available_at = NOW(),
           updated_at = NOW()
       WHERE file_id = ${file.fileId}
+        AND "workspaceId" = ${file.workspaceId}
         AND status = ${DOCLING_FILE_STATUS.Splitting}
         AND lease_owner = ${file.leaseOwner}
         AND lease_token = ${file.leaseToken}
@@ -207,9 +211,9 @@ export const markDoclingFileSplitComplete = async (
       return false;
     }
 
-    const workspaceId = await resolveWorkspaceIdFromModel(tx, 'doclingAsyncFile', { fileId: file.fileId });
+    const workspaceId = file.workspaceId;
 
-    await tx.doclingAsyncPart.deleteMany({ where: { fileId: file.fileId } });
+    await tx.doclingAsyncPart.deleteMany({ where: { fileId: file.fileId, workspaceId } });
     await tx.doclingAsyncPart.createMany({
       data: stagedParts.parts.map((part) => ({
         fileId: file.fileId,
@@ -226,7 +230,7 @@ export const markDoclingFileSplitComplete = async (
       })),
     });
     return true;
-  });
+  }));
 };
 
 export const markDoclingFileSplitRetry = async (
@@ -426,11 +430,12 @@ export const getDoclingPartsForFile = async (
 
 export const markDoclingPartReady = async (input: {
   fileId: string;
+  workspaceId: string;
   partIndex: number;
   jobId: string;
   resultPath: string;
 }): Promise<void> => {
-  await db.$transaction(async (tx) => {
+  await runAsServiceActor('docling-result', input.workspaceId, () => db.$transaction(async (tx) => {
     const ready = await tx.$queryRaw<RawRow[]>`
       UPDATE non_zero.docling_async_parts
       SET status = ${DOCLING_PART_STATUS.Ready},
@@ -440,6 +445,7 @@ export const markDoclingPartReady = async (input: {
           lease_until = NULL,
           updated_at = NOW()
       WHERE file_id = ${input.fileId}
+        AND "workspaceId" = ${input.workspaceId}
         AND part_index = ${input.partIndex}
         AND current_job_id = ${input.jobId}
         AND status IN (${DOCLING_PART_STATUS.Submitting}, ${DOCLING_PART_STATUS.Submitted})
@@ -453,7 +459,8 @@ export const markDoclingPartReady = async (input: {
       UPDATE non_zero.docling_async_files
       SET ready_parts_count = ready_parts_count + 1,
           updated_at = NOW()
-      WHERE file_id = ${input.fileId}`;
+      WHERE file_id = ${input.fileId}
+        AND "workspaceId" = ${input.workspaceId}`;
 
     await tx.$executeRaw`
       UPDATE non_zero.docling_async_files
@@ -461,30 +468,34 @@ export const markDoclingPartReady = async (input: {
           available_at = NOW(),
           updated_at = NOW()
       WHERE file_id = ${input.fileId}
+        AND "workspaceId" = ${input.workspaceId}
         AND status = ${DOCLING_FILE_STATUS.OcrActive}
         AND ready_parts_count >= total_parts`;
-  });
+  }));
 };
 
 export const failDoclingFile = async (
   fileId: string,
   errorMessage: string,
 ): Promise<void> => {
-  await db.$transaction(async (tx) => {
+  const workspaceId = await resolveWorkspaceIdFromModel(db, 'doclingAsyncFile', { fileId });
+  await runAsServiceActor('docling-failure', workspaceId, () => db.$transaction(async (tx) => {
     await tx.$executeRaw`
       UPDATE non_zero.docling_async_files
       SET status = ${DOCLING_FILE_STATUS.Failed},
           lease_owner = NULL, lease_token = NULL, lease_until = NULL,
           error_message = ${errorMessage}, updated_at = NOW()
-      WHERE file_id = ${fileId}`;
+      WHERE file_id = ${fileId}
+        AND "workspaceId" = ${workspaceId}`;
     await tx.$executeRaw`
       UPDATE non_zero.docling_async_parts
       SET status = ${DOCLING_PART_STATUS.Failed},
           error_message = ${errorMessage},
           lease_owner = NULL, lease_until = NULL, updated_at = NOW()
-      WHERE file_id = ${fileId}`;
-    await setCollectionItemStatus(tx, fileId, IngestionStatus.FAILED);
-  });
+      WHERE file_id = ${fileId}
+        AND "workspaceId" = ${workspaceId}`;
+    await setCollectionItemStatus(tx, fileId, workspaceId, IngestionStatus.FAILED);
+  }));
 };
 
 export const failDoclingFileIfOwned = async (
@@ -492,13 +503,16 @@ export const failDoclingFileIfOwned = async (
   expectedStatus: string,
   errorMessage: string,
 ): Promise<boolean> => {
-  return await db.$transaction(async (tx) => {
+  if (!file.workspaceId) throw new Error(`workspaceId missing for Docling file ${file.fileId}`);
+  const workspaceId = file.workspaceId;
+  return await runAsServiceActor('docling-failure', workspaceId, () => db.$transaction(async (tx) => {
     const claimed = await tx.$queryRaw<RawRow[]>`
       UPDATE non_zero.docling_async_files
       SET status = ${DOCLING_FILE_STATUS.Failed},
           lease_owner = NULL, lease_token = NULL, lease_until = NULL,
           error_message = ${errorMessage}, updated_at = NOW()
       WHERE file_id = ${file.fileId}
+        AND "workspaceId" = ${workspaceId}
         AND status = ${expectedStatus}
         AND lease_owner = ${file.leaseOwner}
         AND lease_token = ${file.leaseToken}
@@ -514,10 +528,11 @@ export const failDoclingFileIfOwned = async (
       SET status = ${DOCLING_PART_STATUS.Failed},
           error_message = ${errorMessage},
           lease_owner = NULL, lease_until = NULL, updated_at = NOW()
-      WHERE file_id = ${file.fileId}`;
-    await setCollectionItemStatus(tx, file.fileId, IngestionStatus.FAILED);
+      WHERE file_id = ${file.fileId}
+        AND "workspaceId" = ${workspaceId}`;
+    await setCollectionItemStatus(tx, file.fileId, workspaceId, IngestionStatus.FAILED);
     return true;
-  });
+  }));
 };
 
 export const claimNextDoclingFileToWrite = async (
@@ -568,11 +583,12 @@ export const markDoclingFileWriteRetry = async (
 
 export const markDoclingFileCompleted = async (input: {
   fileId: string;
+  workspaceId: string;
   statusMessage: string;
   leaseOwner?: string | null;
   leaseToken?: string | null;
 }): Promise<boolean> => {
-  return await db.$transaction(async (tx) => {
+  return await runAsServiceActor('docling-writer', input.workspaceId, () => db.$transaction(async (tx) => {
     const claimed = await tx.$queryRaw<RawRow[]>`
       UPDATE non_zero.docling_async_files
       SET status = ${DOCLING_FILE_STATUS.Completed},
@@ -580,6 +596,7 @@ export const markDoclingFileCompleted = async (input: {
           lease_owner = NULL, lease_token = NULL, lease_until = NULL,
           error_message = NULL, updated_at = NOW()
       WHERE file_id = ${input.fileId}
+        AND "workspaceId" = ${input.workspaceId}
         AND status = ${DOCLING_FILE_STATUS.Writing}
         AND lease_owner = ${input.leaseOwner}
         AND lease_token = ${input.leaseToken}
@@ -590,13 +607,14 @@ export const markDoclingFileCompleted = async (input: {
       return false;
     }
 
-    await setCollectionItemStatus(tx, input.fileId, IngestionStatus.COMPLETED);
+    await setCollectionItemStatus(tx, input.fileId, input.workspaceId, IngestionStatus.COMPLETED);
     await tx.$executeRaw`
       UPDATE non_zero.docling_async_parts
       SET status = ${DOCLING_PART_STATUS.Written}, written_at = NOW(), updated_at = NOW()
-      WHERE file_id = ${input.fileId}`;
+      WHERE file_id = ${input.fileId}
+        AND "workspaceId" = ${input.workspaceId}`;
     return true;
-  });
+  }));
 };
 
 /**
@@ -610,20 +628,23 @@ export const completeDoclingFileViaSyncFallback = async (
   fileId: string,
   statusMessage: string,
 ): Promise<void> => {
-  await db.$transaction(async (tx) => {
+  const workspaceId = await resolveWorkspaceIdFromModel(db, 'doclingAsyncFile', { fileId });
+  await runAsServiceActor('docling-fallback', workspaceId, () => db.$transaction(async (tx) => {
     await tx.$executeRaw`
       UPDATE non_zero.docling_async_files
       SET status = ${DOCLING_FILE_STATUS.Completed},
           completed_at = NOW(),
           lease_owner = NULL, lease_token = NULL, lease_until = NULL,
           error_message = ${statusMessage}, updated_at = NOW()
-      WHERE file_id = ${fileId}`;
+      WHERE file_id = ${fileId}
+        AND "workspaceId" = ${workspaceId}`;
     await tx.$executeRaw`
       UPDATE non_zero.docling_async_parts
       SET status = ${DOCLING_PART_STATUS.Written}, written_at = NOW(), updated_at = NOW()
-      WHERE file_id = ${fileId}`;
-    await setCollectionItemStatus(tx, fileId, IngestionStatus.COMPLETED);
-  });
+      WHERE file_id = ${fileId}
+        AND "workspaceId" = ${workspaceId}`;
+    await setCollectionItemStatus(tx, fileId, workspaceId, IngestionStatus.COMPLETED);
+  }));
 };
 
 export const requeueExpiredDoclingLeases = async (now = new Date()): Promise<void> => {

--- a/apps/backend/src/services/ingestion/docling/types.ts
+++ b/apps/backend/src/services/ingestion/docling/types.ts
@@ -54,6 +54,7 @@ export interface DoclingFile {
 
 export interface DoclingPart {
   fileId: string
+  workspaceId: string | null
   partIndex: number
   docId: string
   currentJobId: string | null

--- a/apps/backend/src/services/ingestion/docling/workers/result.ts
+++ b/apps/backend/src/services/ingestion/docling/workers/result.ts
@@ -65,6 +65,7 @@ const handleResultEvent = async (event: DoclingResultEvent) => {
   if (!jobId) return
   const part = await getDoclingPartByJobId(jobId)
   if (!part) return
+  if (!part.workspaceId) throw new Error(`workspaceId missing for Docling part ${part.fileId}/${part.partIndex}`)
   const t1 = part.submittedAt ? part.submittedAt.getTime() : null
   const t2 = Date.now()
   const ocrMs = t1 !== null ? t2 - t1 : null
@@ -126,6 +127,7 @@ const handleResultEvent = async (event: DoclingResultEvent) => {
   await writeJson(path, result)
   await markDoclingPartReady({
     fileId: part.fileId,
+    workspaceId: part.workspaceId,
     partIndex: part.partIndex,
     jobId,
     resultPath: path,

--- a/apps/backend/src/services/ingestion/docling/workers/scheduler.ts
+++ b/apps/backend/src/services/ingestion/docling/workers/scheduler.ts
@@ -1032,8 +1032,12 @@ const runWriterWorker = async (id: string, shouldStop: () => boolean) => {
       await releasePermit(permit);
       permit = null;
 
+      if (!file.workspaceId) {
+        throw new TerminalDoclingSchedulerError(`workspaceId missing for Docling file ${file.fileId}`);
+      }
       const completed = await markDoclingFileCompleted({
         fileId: file.fileId,
+        workspaceId: file.workspaceId,
         statusMessage: `OCR complete: ${aggregate.chunks.length + aggregate.image_chunks.length} chunks from ${fileName}`,
         leaseOwner: file.leaseOwner,
         leaseToken: file.leaseToken,

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -12,7 +12,7 @@ import {
   CanvasRole,
   ChannelScopeType, OrgRole, UserStatus } from '@xyne/shared';
 import { DatabaseClient } from '@/database/client';
-import { withWorkspaceScope } from '@/database/tenant/context';
+import { runAsServiceActor, withWorkspaceScope } from '@/database/tenant/context';
 import { logger } from '@/utils/logger';
 import { emailService } from './email/factory';
 import { grantPermissionsForRole } from './permissionMatrix';
@@ -622,7 +622,9 @@ export class InvitationService {
       authProvider: string;
     }
   ): Promise<{ user: User; redirectPath: string | null }> {
-    return this.prisma.$transaction(async (tx) => {
+    // A verified invitation authorizes the not-yet-member user to enter its target workspace.
+    return runAsServiceActor(userData.id, invitation.workspaceId!, () =>
+      this.prisma.$transaction(async (tx) => {
       const orgMember = await tx.orgMember.findUnique({
         where: { email: userData.email.toLowerCase() },
       });
@@ -660,7 +662,8 @@ export class InvitationService {
       const redirectPath = await this.grantGuestEntityAccess(newWorkspaceUser.id, invitation, tx);
 
       return { user: newWorkspaceUser, redirectPath };
-    });
+      }),
+    );
   }
 
   /**
@@ -747,7 +750,8 @@ export class InvitationService {
           throw new Error(`Cannot accept invitation — ${userData.email} is no longer part of the organization`);
         }
 
-        const guestResult = await this.prisma.$transaction(async (tx) => {
+        const guestResult = await runAsServiceActor(userData.id, invitation.workspaceId!, () =>
+          this.prisma.$transaction(async (tx) => {
           const reactivatedUser = await tx.user.update({
             where: { id: existingWorkspaceUser.id },
             data: {
@@ -757,7 +761,8 @@ export class InvitationService {
           });
           const path = await this.grantGuestEntityAccess(reactivatedUser.id, invitation, tx);
           return { user: reactivatedUser, redirectPath: path };
-        });
+          }),
+        );
         newWorkspaceUser = guestResult.user;
         redirectPath = guestResult.redirectPath;
         logger.info(`[DEBUG] [acceptInvitation] Granted existing guest user id=${newWorkspaceUser.id} access to invitation entity`);

--- a/apps/backend/src/services/jiraMigrationImportService.ts
+++ b/apps/backend/src/services/jiraMigrationImportService.ts
@@ -3351,7 +3351,11 @@ export class JiraMigrationImportService {
                 },
               });
 
-              const xyneId = await TicketIdService.generateTicketId(tx as any, project.id);
+              const xyneId = await TicketIdService.generateTicketId(
+                tx as any,
+                project.id,
+                workspaceId,
+              );
 
               const dueDateRaw = issue.fields.duedate;
               const eta =

--- a/apps/backend/src/services/prCheckApprovalService.ts
+++ b/apps/backend/src/services/prCheckApprovalService.ts
@@ -5,6 +5,7 @@ import { config } from '@/config/env';
 import { randomUUID } from 'crypto';
 import { MessageType } from '@xyne/shared';
 import { parseBitbucketPrUrl } from '@/utils/repoUrlParser';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 const VARYS_BOT_EMAIL = 'varys@app.xyne.ai';
 const PR_CHECK_MESSAGE_SUBTYPE = 'pr_check_approval';
@@ -150,7 +151,7 @@ async function createButtonMessage(params: {
   const messageId = randomUUID();
   const replyNow = new Date();
 
-  await db.$transaction([
+  await runAsServiceActor('pr-check-approval', params.workspaceId, () => db.$transaction([
     db.message.create({
       data: {
         messageId,
@@ -198,7 +199,7 @@ async function createButtonMessage(params: {
           }),
         ]
       : []),
-  ]);
+  ]));
 
   return messageId;
 }
@@ -239,7 +240,7 @@ async function postNoTicketNotice(params: {
 Make sure the PR title starts with a valid ticket ID (e.g. \`XYNE-1234: your title\`), then post the PR link again.`;
 
   const replyNow = new Date();
-  await db.$transaction([
+  await runAsServiceActor('pr-check-approval', params.workspaceId, () => db.$transaction([
     db.message.create({
       data: {
         messageId: randomUUID(),
@@ -268,7 +269,7 @@ Make sure the PR title starts with a valid ticket ID (e.g. \`XYNE-1234: your tit
       where: { conversationId: params.conversationId },
       data: { lastReplyAt: replyNow },
     }),
-  ]);
+  ]));
 }
 
 /**

--- a/apps/backend/src/services/prThreadNotificationService.ts
+++ b/apps/backend/src/services/prThreadNotificationService.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Prisma } from '@prisma/client';
 import { MessageType } from '@xyne/shared';
 import { db } from '@/database/client';
+import { runAsServiceActor } from '@/database/tenant/context';
 import { logger } from '@/utils/logger';
 import { parseBitbucketPrUrl } from '@/utils/repoUrlParser';
 
@@ -52,43 +53,47 @@ async function broadcastPRUpdate(params: BroadcastPRUpdateParams): Promise<void>
     // concurrently; within one conversation the message and the reply-count
     // bump commit atomically so a failure can't leave a phantom message.
     const results = await Promise.all(
-      links.map(async ({ conversationId, workspaceId }): Promise<boolean> => {
+      links.map(async (
+        { conversationId, workspaceId }: { conversationId: string; workspaceId: string },
+      ): Promise<boolean> => {
         try {
           const now = new Date();
-          await db.$transaction([
-            db.message.create({
-              data: {
-                messageId: uuidv4(),
-                conversationId,
-                workspaceId,
-                senderId: params.senderId,
-                content: params.content,
-                msgType: MessageType.SYSTEM,
-                hasAttachment: false,
-                edited: false,
-                isDeleted: false,
-                isSent: true,
-                showInChannel: false,
-                createdAt: now,
-                ...(params.metadata !== undefined ? { metadata: params.metadata } : {}),
-              },
+          await runAsServiceActor('pr-thread-notification', workspaceId, () =>
+            db.$transaction(async (tx) => {
+              await tx.message.create({
+                data: {
+                  messageId: uuidv4(),
+                  conversationId,
+                  workspaceId,
+                  senderId: params.senderId,
+                  content: params.content,
+                  msgType: MessageType.SYSTEM,
+                  hasAttachment: false,
+                  edited: false,
+                  isDeleted: false,
+                  isSent: true,
+                  showInChannel: false,
+                  createdAt: now,
+                  ...(params.metadata !== undefined ? { metadata: params.metadata } : {}),
+                },
+              });
+              // Surface the update in the thread: bump reply count / activity so
+              // the merge-channel thread visibly moves when the PR progresses.
+              await tx.conversation.update({
+                where: { conversationId, workspaceId },
+                data: {
+                  replyCount: { increment: 1 },
+                  lastActivityAt: now,
+                },
+              });
+              // Bump each participant's lastReplyAt so the thread rises in the
+              // sidebar — userConversationsPaginatedV2 orders by this field.
+              await tx.conversationParticipant.updateMany({
+                where: { conversationId, workspaceId },
+                data: { lastReplyAt: now },
+              });
             }),
-            // Surface the update in the thread: bump reply count / activity so
-            // the merge-channel thread visibly moves when the PR progresses.
-            db.conversation.update({
-              where: { conversationId },
-              data: {
-                replyCount: { increment: 1 },
-                lastActivityAt: now,
-              },
-            }),
-            // Bump each participant's lastReplyAt so the thread rises in the
-            // sidebar — userConversationsPaginatedV2 orders by this field.
-            db.conversationParticipant.updateMany({
-              where: { conversationId },
-              data: { lastReplyAt: now },
-            }),
-          ]);
+          );
           return true;
         } catch (error) {
           logger.error(

--- a/apps/backend/src/services/release/core/releaseService.ts
+++ b/apps/backend/src/services/release/core/releaseService.ts
@@ -15,6 +15,7 @@ import { Prisma } from '@prisma/client';
 // `ReleaseEventContext` in ./types.ts (per-event payload threaded through
 // commit-analysis and form-save paths).
 export interface ReleaseContext {
+	workspaceId: string;
 	workspace: string;
 	repoSlug: string;
 	projectId: string;
@@ -117,6 +118,7 @@ export class ReleaseService {
 			channelId,
 			conversationId,
 			createdBy: userId,
+			initiatorWorkspaceId: context.workspaceId,
 			affectedApplications: apps,
 			prLinksByApplication,
 			isHotFix,
@@ -145,7 +147,10 @@ export class ReleaseService {
 		const recordsToCreate = buildApplicationReleaseTicketMappings(results, affectedApplications, currentTicketId);
 		if (recordsToCreate.length > 0) {
 			try {
-				const createResult = await this.applicationRepository.createApplicationReleaseTicketMappings(recordsToCreate);
+				const createResult = await this.applicationRepository.createApplicationReleaseTicketMappings(
+					recordsToCreate,
+					context.workspaceId,
+				);
 				logger.info(
 					`[Release] ART rows persisted: attempted=${recordsToCreate.length}, inserted=${createResult.count}, releaseId=${currentTicketId}`,
 				);

--- a/apps/backend/src/services/release/versionReleaseMappingService.ts
+++ b/apps/backend/src/services/release/versionReleaseMappingService.ts
@@ -14,6 +14,7 @@ import {
   FormEntityType,
   ReleaseTrackingMode,
   isReleaseTicket, PRStatus, TicketStatusV2 } from '@xyne/shared';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 const prisma = DatabaseClient.getInstance();
 
@@ -61,23 +62,28 @@ class VersionReleaseMappingService {
   // re-reads the current version, so the latest edit always wins.
   private readonly pendingSyncs = new Map<string, Promise<void>>();
 
-  async syncTicketById(ticketId: string): Promise<void> {
-    const previous = this.pendingSyncs.get(ticketId) ?? Promise.resolve();
-    const run = previous.then(() => this.runSyncTicketById(ticketId));
-    this.pendingSyncs.set(ticketId, run);
+  async syncTicketById(ticketId: string, initiatorWorkspaceId: string): Promise<void> {
+    const syncKey = `${initiatorWorkspaceId}:${ticketId}`;
+    const previous = this.pendingSyncs.get(syncKey) ?? Promise.resolve();
+    const run = previous.then(() =>
+      runAsServiceActor('version-release-mapping', initiatorWorkspaceId, () =>
+        this.runSyncTicketById(ticketId, initiatorWorkspaceId),
+      ),
+    );
+    this.pendingSyncs.set(syncKey, run);
     try {
       await run;
     } finally {
-      if (this.pendingSyncs.get(ticketId) === run) {
-        this.pendingSyncs.delete(ticketId);
+      if (this.pendingSyncs.get(syncKey) === run) {
+        this.pendingSyncs.delete(syncKey);
       }
     }
   }
 
-  private async runSyncTicketById(ticketId: string): Promise<void> {
+  private async runSyncTicketById(ticketId: string, initiatorWorkspaceId: string): Promise<void> {
     try {
       const ticket = await prisma.ticket.findUnique({
-        where: { id: ticketId },
+        where: { id: ticketId, workspaceId: initiatorWorkspaceId },
         include: { project: true, board: true },
       });
       if (!ticket) {
@@ -87,9 +93,9 @@ class VersionReleaseMappingService {
 
       const releaseVersion = await this.getTicketReleaseVersion(ticket.id);
       if (isReleaseTicket(ticket.ticketType as BaseTicketType)) {
-        await this.syncReleaseTicket(ticket, releaseVersion);
+        await this.syncReleaseTicket(ticket, releaseVersion, initiatorWorkspaceId);
       } else {
-        await this.syncDevTicket(ticket, releaseVersion);
+        await this.syncDevTicket(ticket, releaseVersion, initiatorWorkspaceId);
       }
     } catch (error) {
       logger.error(`[VersionReleaseMapping] failed for ticket ${ticketId}:`, error);
@@ -99,6 +105,7 @@ class VersionReleaseMappingService {
   private async syncReleaseTicket(
     releaseTicket: TicketWithReleaseBoard,
     releaseVersion: string | null,
+    initiatorWorkspaceId: string,
   ): Promise<void> {
     if (releaseTicket.board?.releaseTrackingMode !== ReleaseTrackingMode.VERSION) {
       return;
@@ -112,13 +119,14 @@ class VersionReleaseMappingService {
 
     const devTickets = await this.findDevTicketsByVersion(releaseTicket.projectId, releaseVersion);
     for (const devTicket of devTickets) {
-      await this.mapDevTicketToRelease(devTicket, releaseTicket);
+      await this.mapDevTicketToRelease(devTicket, releaseTicket, initiatorWorkspaceId);
     }
   }
 
   private async syncDevTicket(
     devTicket: TicketWithReleaseBoard,
     releaseVersion: string | null,
+    initiatorWorkspaceId: string,
   ): Promise<void> {
     await this.cleanupDevRowsForCurrentVersion(devTicket, releaseVersion);
     if (!releaseVersion) {
@@ -128,13 +136,14 @@ class VersionReleaseMappingService {
 
     const releases = await this.findReleaseTicketsByVersion(devTicket.projectId, releaseVersion);
     for (const releaseTicket of releases) {
-      await this.mapDevTicketToRelease(devTicket, releaseTicket);
+      await this.mapDevTicketToRelease(devTicket, releaseTicket, initiatorWorkspaceId);
     }
   }
 
   private async mapDevTicketToRelease(
     devTicket: TicketWithReleaseBoard,
     releaseTicket: TicketWithReleaseBoard,
+    initiatorWorkspaceId: string,
   ): Promise<void> {
     if (
       !releaseTicket.boardId
@@ -169,6 +178,7 @@ class VersionReleaseMappingService {
       releaseTicket,
       affectedApps,
       prLinksByApplication,
+      initiatorWorkspaceId,
     );
 
     const records = affectedApps
@@ -188,7 +198,10 @@ class VersionReleaseMappingService {
       return;
     }
 
-    const result = await this.applicationRepository.createApplicationReleaseTicketMappings(records);
+    const result = await this.applicationRepository.createApplicationReleaseTicketMappings(
+      records,
+      initiatorWorkspaceId,
+    );
     logger.info(
       `[VersionReleaseMapping] mapped dev ticket ${devTicket.xyneId} to release ${releaseTicket.xyneId}: ` +
       `attempted=${records.length}, inserted=${result.count}`,
@@ -404,6 +417,7 @@ class VersionReleaseMappingService {
     releaseTicket: TicketWithReleaseBoard,
     affectedApps: AffectedApplication[],
     prLinksByApplication: Map<string, string[]>,
+    initiatorWorkspaceId: string,
   ): Promise<Map<string, { subTicketId: string; mappedTicketId: string; xyneId: string }>> {
     const existing = await this.findExistingApplicationReleaseSubTickets(releaseTicket.id, affectedApps);
     const missingApps = affectedApps.filter(app => !existing.has(app.id));
@@ -416,6 +430,7 @@ class VersionReleaseMappingService {
         channelId: releaseTicket.channelId,
         conversationId: releaseTicket.conversationId,
         createdBy: releaseTicket.createdBy,
+        initiatorWorkspaceId,
         affectedApplications: missingApps,
         prLinksByApplication,
         isHotFix: releaseTicket.ticketType === BaseTicketType.Hotfix,

--- a/apps/backend/src/services/releaseReports/releaseReportService.ts
+++ b/apps/backend/src/services/releaseReports/releaseReportService.ts
@@ -16,6 +16,7 @@ import { unifiedBotUserService } from '@/bots/unified';
 import { userActivityTrackingService } from '@/services/userActivityTrackingService';
 import { logger } from '@/utils/logger';
 import { ReleaseReportCanvasService } from './releaseReportCanvas';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 interface ReleaseReportTicketMetadata {
   releaseReportCanvasId?: string;
@@ -283,12 +284,14 @@ export class ReleaseReportService {
   }: PublishReleaseReportInput): Promise<PublishReleaseReportResponse> {
     const report = await this.gatherReleaseReport(ticketId);
 
-    return db.$transaction(
-      async (tx) => {
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${'release-report:' + ticketId}))`;
-        return this.publishLocked(ticketId, publisher, report);
-      },
-      { maxWait: 10_000, timeout: 60_000 }
+    return runAsServiceActor('release-report', report.release.workspaceId, () =>
+      db.$transaction(
+        async (tx) => {
+          await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${'release-report:' + ticketId}))`;
+          return this.publishLocked(ticketId, publisher, report);
+        },
+        { maxWait: 10_000, timeout: 60_000 },
+      ),
     );
   }
 

--- a/apps/backend/src/services/stageTransition/stageEntryApproval.ts
+++ b/apps/backend/src/services/stageTransition/stageEntryApproval.ts
@@ -13,6 +13,7 @@ import { db } from '@/database/client';
 import { activityService } from '@/services/activity/activityService';
 import { notificationService } from '@/services/notificationService';
 import { logger } from '@/utils/logger';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 const LOG_PREFIX = '[StageApprovalNotify]';
 
@@ -104,15 +105,17 @@ export async function maybeCreateEntryApprovalRequest(
 
     let claimed: boolean;
     try {
-      claimed = await db.$transaction(tx =>
-        claimEntryApprovalRequest(
-          tx,
-          ticket,
-          targetStageId,
-          landedStageName,
-          targetStageName,
-          actorId,
-          actorName,
+      claimed = await runAsServiceActor('stage-entry-approval', ticket.workspaceId, () =>
+        db.$transaction(tx =>
+          claimEntryApprovalRequest(
+            tx,
+            ticket,
+            targetStageId,
+            landedStageName,
+            targetStageName,
+            actorId,
+            actorName,
+          ),
         ),
       );
     } catch (error) {
@@ -178,12 +181,14 @@ async function claimEntryApprovalRequest(
   actorName: string,
 ): Promise<boolean> {
   const [row] = await tx.$queryRaw<{ stageName: string }[]>`
-    SELECT "stageName" FROM "tickets" WHERE "id" = ${ticket.id} FOR UPDATE
+    SELECT "stageName" FROM "tickets"
+    WHERE "id" = ${ticket.id} AND "workspaceId" = ${ticket.workspaceId}
+    FOR UPDATE
   `;
   if (!row || row.stageName !== landedStageName) return false;
 
   const existing = await tx.ticketStageRequest.findUnique({
-    where: { ticketId_stageId: { ticketId: ticket.id, stageId } },
+    where: { ticketId_stageId: { ticketId: ticket.id, stageId }, workspaceId: ticket.workspaceId },
     select: { status: true },
   });
 
@@ -207,7 +212,12 @@ async function claimEntryApprovalRequest(
     // means at most one concurrent updateMany can affect the row: the loser's
     // WHERE no longer matches once the winner's UPDATE commits.
     const { count } = await tx.ticketStageRequest.updateMany({
-      where: { ticketId: ticket.id, stageId, status: { not: TicketStageRequestStatus.SUBMITTED } },
+      where: {
+        ticketId: ticket.id,
+        stageId,
+        workspaceId: ticket.workspaceId,
+        status: { not: TicketStageRequestStatus.SUBMITTED },
+      },
       data: {
         status: TicketStageRequestStatus.SUBMITTED,
         submittedBy: actorId,

--- a/apps/backend/src/services/ticketIdService.ts
+++ b/apps/backend/src/services/ticketIdService.ts
@@ -18,10 +18,11 @@ export class TicketIdService {
    */
   static async generateTicketId(
     tx: PrismaTransaction,
-    projectId: string
+    projectId: string,
+    workspaceId: string,
   ): Promise<string> {
     const project = await tx.project.findUnique({
-      where: { id: projectId },
+      where: { id: projectId, workspaceId },
       select: { code: true },
     });
 
@@ -29,7 +30,11 @@ export class TicketIdService {
       throw new Error(`Project not found: ${projectId}`);
     }
 
-    const sequenceNumber = await EntitySequenceService.getNextProjectTicketSequence(tx, projectId);
+    const sequenceNumber = await EntitySequenceService.getNextProjectTicketSequence(
+      tx,
+      projectId,
+      workspaceId,
+    );
 
     return this.formatProjectScopedId(project.code, sequenceNumber);
   }

--- a/apps/backend/src/services/tickets/descriptionCleaner/ticketCleanupWorkerService.ts
+++ b/apps/backend/src/services/tickets/descriptionCleaner/ticketCleanupWorkerService.ts
@@ -6,6 +6,7 @@ import { config } from '@/config/env';
 import vespaClient from '@/vespa/client';
 import { ticketSchema } from '@/vespa/src/types';
 import { descCleaner } from './index';
+import { runAsSystem } from '@/database/tenant/context';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const MIN_INTERVAL_MS = 5000;
@@ -105,7 +106,8 @@ class TicketCleanupWorkerService {
   }
 
   private async claimFailedCleanupLogs(): Promise<VespaInsertionLogs[]> {
-    return db.$transaction(async tx => {
+    // This worker intentionally claims across workspaces; keep that privilege explicit.
+    return runAsSystem(() => db.$transaction(async tx => {
       const logs = await tx.vespaInsertionLogs.findMany({
         where: {
           type: VespaOperationType.POST_INGEST_CLEAN,
@@ -142,7 +144,7 @@ class TicketCleanupWorkerService {
         ...log,
         status: VespaInsertionStatus.PENDING,
       }));
-    });
+    }));
   }
 
   private async processLog(log: VespaInsertionLogs): Promise<void> {

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -22,6 +22,7 @@ import { callRecordingService } from '@/services/callRecordingService';
 import { callDocumentService } from '@/services/callDocumentService';
 import { acquireLock, releaseLock } from '@/utils/distributedLock';
 import { orgLLMCredentialService } from '@/services/orgLLMCredentialService';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 const SPEAKER_IDENTIFICATION_CAC_KEY = 'speaker_identification_config';
 
@@ -1931,18 +1932,19 @@ Output ONLY the processed transcript, nothing else.`;
             // Serialize with first-chunk Canvas URL attachment. Both operations
             // merge message metadata, so the row lock prevents either concurrent
             // writer from replacing the other's newly-added keys.
-            await db.$transaction(async (tx) => {
+            await runAsServiceActor('transcript-summary', callMessage.workspaceId, () => db.$transaction(async (tx) => {
               const [message] = await tx.$queryRaw<Array<{ content: string; metadata: unknown }>>`
                 SELECT "content", "metadata"
                 FROM "messages"
                 WHERE "messageId" = ${messageId}
+                  AND "workspaceId" = ${callMessage.workspaceId}
                 FOR UPDATE
               `;
 
               if (message) {
                 // Swap storage: message.content = AI description, metadata.callEndedText = original call text
                 await tx.message.update({
-                  where: { messageId },
+                  where: { messageId, workspaceId: callMessage.workspaceId },
                   data: {
                     content: title,
                     metadata: {
@@ -1957,7 +1959,7 @@ Output ONLY the processed transcript, nothing else.`;
               } else {
                 logger.warn(`Call message ${messageId} not found for title update`);
               }
-            });
+            }));
           } catch (error) {
             logger.error(`Failed to update call message with title:`, error);
             // Don't fail the whole process if message update fails

--- a/apps/backend/src/team-intelligence/repositories/team-intelligence.repository.ts
+++ b/apps/backend/src/team-intelligence/repositories/team-intelligence.repository.ts
@@ -7,6 +7,7 @@ import {
   TeamIntelligenceUserIngestionV2,
 } from '@prisma/client';
 import { db } from '@/database/client';
+import { runAsSystem } from '@/database/tenant/context';
 import { TeamIntelligenceBatchStatus, TeamIntelligenceUserIngestionStatus } from '@xyne/shared';
 
 export interface CreateTeamIntelligenceBatchData {
@@ -126,7 +127,8 @@ class TeamIntelligenceRepository {
     batchData: CreateTeamIntelligenceBatchData,
     usersData: CreateTeamIntelligenceUserData[]
   ): Promise<TeamIntelligenceBatchWithUsers> {
-    return await this.prisma.$transaction(async (transaction) => {
+    // S2S-authenticated global ingestion: these models intentionally opt out of workspace ACL.
+    return await runAsSystem(() => this.prisma.$transaction(async (transaction) => {
       const batch = await transaction.teamIntelligenceIngestionBatchV2.create({
         data: {
           ...batchData,
@@ -147,7 +149,7 @@ class TeamIntelligenceRepository {
       );
 
       return { batch, users };
-    });
+    }));
   }
 
   async updateBatchStatus(
@@ -470,7 +472,7 @@ class TeamIntelligenceRepository {
   }
 
   async getTeamProgress(batchId: string, teamId: string): Promise<TeamIntelligenceTeamProgress> {
-    const [totalUsers, completedUsers, failedUsers] = await this.prisma.$transaction([
+    const [totalUsers, completedUsers, failedUsers] = await runAsSystem(() => this.prisma.$transaction([
       this.prisma.teamIntelligenceUserIngestionV2.count({
         where: { batchId, teamId },
       }),
@@ -488,7 +490,7 @@ class TeamIntelligenceRepository {
           processingStatus: TeamIntelligenceUserIngestionStatus.FAILED,
         },
       }),
-    ]);
+    ]));
 
     return {
       totalUsers,
@@ -504,7 +506,7 @@ class TeamIntelligenceRepository {
       failedUsers,
       processingUsers,
       queuedUsers,
-    ] = await this.prisma.$transaction([
+    ] = await runAsSystem(() => this.prisma.$transaction([
       this.prisma.teamIntelligenceUserIngestionV2.count({ where: { batchId } }),
       this.prisma.teamIntelligenceUserIngestionV2.count({
         where: {
@@ -530,7 +532,7 @@ class TeamIntelligenceRepository {
           processingStatus: TeamIntelligenceUserIngestionStatus.QUEUED,
         },
       }),
-    ]);
+    ]));
 
     return {
       totalUsers,
@@ -542,7 +544,7 @@ class TeamIntelligenceRepository {
   }
 
   async getOrgProgress(batchId: string): Promise<TeamIntelligenceOrgProgress> {
-    const [totalTeams, completedTeams, failedTeams] = await this.prisma.$transaction([
+    const [totalTeams, completedTeams, failedTeams] = await runAsSystem(() => this.prisma.$transaction([
       this.prisma.teamIntelligenceTeamSummaryV2.count({
         where: { batchId },
       }),
@@ -558,7 +560,7 @@ class TeamIntelligenceRepository {
           status: TeamIntelligenceBatchStatus.FAILED,
         },
       }),
-    ]);
+    ]));
 
     return {
       totalTeams,

--- a/apps/backend/src/workers/callValidationWorker.ts
+++ b/apps/backend/src/workers/callValidationWorker.ts
@@ -7,6 +7,7 @@ import { repositories } from '@/database/repositories';
 import { updateCallSystemMessageIfNeeded } from '@/zero/utils/systemMessagesUtils';
 import { recurringCallService } from '@/services/recurringCallService';
 import { callSideEffectService } from '@/services/callSideEffectService';
+import { runAsServiceActor } from '@/database/tenant/context';
 
 const POLL_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -225,7 +226,7 @@ export class CallValidationWorker {
         const endedAt = new Date();
 
         // Use transaction to atomically update call and system message
-        await db.$transaction(async (tx) => {
+        await runAsServiceActor('call-validation', call.workspaceId, () => db.$transaction(async (tx) => {
           // End the call
           await repositories.calls.endCall(callId, endedAt, tx);
 
@@ -244,7 +245,7 @@ export class CallValidationWorker {
           if (messageUpdated) {
             logger.info(`[CallValidationWorker] Updated system message for call ${externalId}`);
           }
-        });
+        }));
 
         logger.info('[CallValidationWorker] Transcript will be processed when user views the ended call message');
 

--- a/apps/backend/src/workers/delayedMessageWorker.ts
+++ b/apps/backend/src/workers/delayedMessageWorker.ts
@@ -7,6 +7,8 @@ import { deliverDelayedMessage } from '@/zero/utils/delayedMessageDelivery';
 import { cleanupDelayedMessageAttachmentsPrisma } from '@/zero/utils/attachmentEntityCleanup';
 import { activityService } from '@/services/activity/activityService';
 import type { DelayedMessageJobData } from '@/queues/delayedMessageQueue';
+import { runAsServiceActor } from '@/database/tenant/context';
+import { resolveWorkspaceIdFromModel } from '@/database/tenant/workspace-utils';
 
 const QUEUE_NAME = 'delayed-messages';
 
@@ -102,6 +104,7 @@ class DelayedMessageWorker {
         await queue.add(
           {
             delayedMessageId: record.id,
+            workspaceId: record.workspaceId,
             channelId: record.channelId,
             conversationId: record.conversationId,
             senderId: record.senderId,
@@ -117,6 +120,7 @@ class DelayedMessageWorker {
         await queue.add(
           {
             delayedMessageId: record.id,
+            workspaceId: record.workspaceId,
             channelId: record.channelId,
             conversationId: record.conversationId,
             senderId: record.senderId,
@@ -167,6 +171,19 @@ class DelayedMessageWorker {
   }
 
   private async processJob(job: Bull.Job<DelayedMessageJobData>): Promise<void> {
+    // New jobs carry workspaceId. Resolve from the parent for jobs queued before rollout.
+    const queuedWorkspaceId = (job.data as Partial<DelayedMessageJobData>).workspaceId;
+    const workspaceId = queuedWorkspaceId ?? await resolveWorkspaceIdFromModel(
+      DatabaseClient.getInstance(),
+      'delayedMessage',
+      { id: job.data.delayedMessageId },
+    );
+    return runAsServiceActor('delayed-message-delivery', workspaceId, () =>
+      this.processScopedJob(job),
+    );
+  }
+
+  private async processScopedJob(job: Bull.Job<DelayedMessageJobData>): Promise<void> {
     const { delayedMessageId, channelId, conversationId, senderId, content } = job.data;
 
     logger.info(

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -10908,7 +10908,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           if (entityType === FormEntityType.TICKET && fieldName === 'releaseVersion') {
             asyncTasks.push(async () => {
               try {
-                await versionReleaseMappingService.syncTicketById(entityId);
+                await versionReleaseMappingService.syncTicketById(entityId, authData.workspaceId);
               } catch (error) {
                 logger.error('release_mapping_sync_failed', { entityId, error });
               }
@@ -11027,7 +11027,7 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           if (entityType === FormEntityType.TICKET && fieldName === 'releaseVersion') {
             asyncTasks.push(async () => {
               try {
-                await versionReleaseMappingService.syncTicketById(entityId);
+                await versionReleaseMappingService.syncTicketById(entityId, authData.workspaceId);
               } catch (error) {
                 logger.error('release_mapping_sync_failed', { entityId, error });
               }
@@ -11139,7 +11139,10 @@ export function createMutators(authData: AuthData, asyncTasks: Array<() => Promi
           ) {
             asyncTasks.push(async () => {
               try {
-                await versionReleaseMappingService.syncTicketById(formEntityValue.entityId);
+                await versionReleaseMappingService.syncTicketById(
+                  formEntityValue.entityId,
+                  authData.workspaceId,
+                );
               } catch (error) {
                 logger.error('release_mapping_sync_failed', { entityId: formEntityValue.entityId, error });
               }

--- a/apps/backend/src/zero/side-effects/tables/delayed-messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/delayed-messages-handler.ts
@@ -15,6 +15,7 @@ export class DelayedMessagesSideEffectHandler extends BaseSideEffectHandler {
       where: { id: delayedMessageId },
       select: {
         id: true,
+        workspaceId: true,
         channelId: true,
         conversationId: true,
         senderId: true,
@@ -31,6 +32,7 @@ export class DelayedMessagesSideEffectHandler extends BaseSideEffectHandler {
 
     await delayedMessageQueue.scheduleMessage({
       delayedMessageId: record.id,
+      workspaceId: record.workspaceId,
       channelId: record.channelId,
       conversationId: record.conversationId,
       senderId: record.senderId,
@@ -52,6 +54,7 @@ export class DelayedMessagesSideEffectHandler extends BaseSideEffectHandler {
       where: { id: delayedMessageId },
       select: {
         id: true,
+        workspaceId: true,
         channelId: true,
         conversationId: true,
         senderId: true,
@@ -92,6 +95,7 @@ export class DelayedMessagesSideEffectHandler extends BaseSideEffectHandler {
       try {
         await delayedMessageQueue.scheduleMessage({
           delayedMessageId: record.id,
+          workspaceId: record.workspaceId,
           channelId: record.channelId,
           conversationId: record.conversationId,
           senderId: record.senderId,


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
