### PR TITLE
fix: speed up Cmd+K typing for users with many DMs

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -2477,32 +2477,56 @@ const ChannelCommandMenu = ({
       {/* 2. Group DMs (from local channels) */}
       {(activeTab === TabType.ALL || activeTab === TabType.CHANNELS) &&
         showGroupedLocalResults &&
-        localGroupDMs.length > 0 && (
-          <div className='mb-4'>
-            <Command.Group
-              heading={getCategoryLabel(ChannelCategory.GROUP_DMS)}
-              className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-            >
-              {localGroupDMs.map(({ channel }, index) => {
-                const unreadCount = unreadCounts[channel.id] ?? 0;
-                return (
-                  <ChannelCommandItem
-                    key={channel.id}
-                    channel={channel}
-                    currentUserID={currentUserID}
-                    unreadCount={unreadCount}
-                    onSelect={displayName => {
-                      void handleChannelSelect(channel, displayName, index + 1);
-                    }}
-                    onItemMouseDown={handleItemMouseDown}
-                    getChannelIcon={getChannelIcon}
-                    isSelected={contextItems.some(c => c.id === `channel-${channel.id}`)}
+        localGroupDMs.length > 0 &&
+        (() => {
+          // Cap the number of mounted rows (with an inline expand) the same way
+          // the Starred / Channels sections do. A short query can match
+          // thousands of DMs; mounting them all as cmdk items is what drove the
+          // per-keystroke render + cmdk bookkeeping cost.
+          const category = ChannelCategory.GROUP_DMS;
+          const isExpanded = expandedCategories.has(category);
+          const hasMore = localGroupDMs.length > DISPLAY_LIMIT;
+          const displayItems =
+            !isExpanded && hasMore ? localGroupDMs.slice(0, DISPLAY_LIMIT) : localGroupDMs;
+          const hiddenCount = localGroupDMs.length - DISPLAY_LIMIT;
+          return (
+            <div className='mb-4'>
+              <Command.Group
+                heading={getCategoryLabel(category)}
+                className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
+              >
+                {displayItems.map(({ channel }, index) => {
+                  const unreadCount = unreadCounts[channel.id] ?? 0;
+                  return (
+                    <ChannelCommandItem
+                      key={channel.id}
+                      channel={channel}
+                      currentUserID={currentUserID}
+                      unreadCount={unreadCount}
+                      onSelect={displayName => {
+                        void handleChannelSelect(channel, displayName, index + 1);
+                      }}
+                      onItemMouseDown={handleItemMouseDown}
+                      getChannelIcon={getChannelIcon}
+                      isSelected={contextItems.some(c => c.id === `channel-${channel.id}`)}
+                    />
+                  );
+                })}
+                {hasMore && (
+                  <SeeMoreItem
+                    value={`__see-more-group-dm-${category as string}__`}
+                    label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
+                    onSelect={() => toggleCategoryExpansion(category)}
+                    hoverable={!isMobile}
+                    trackCategory='CHANNEL_SEARCH'
+                    trackName='TOGGLE_GROUP_DM_CATEGORY_EXPANSION'
+                    trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
                   />
-                );
-              })}
-            </Command.Group>
-          </div>
-        )}
+                )}
+              </Command.Group>
+            </div>
+          );
+        })()}
 
       {/* 3. Channels (from local channels) */}
       {includeChannels && renderSearchChannelsSection()}

--- a/apps/dashboard/src/hooks/useChannelDisplayName.ts
+++ b/apps/dashboard/src/hooks/useChannelDisplayName.ts
@@ -5,7 +5,8 @@ import {
   getDMParticipantIdsToFetch,
   parseDMParticipantIds,
 } from '../components/Chat/ChatDirectory/ChatDirectory.utils';
-import { useUsers } from './useUsers';
+import { useUsersById } from './useUsers';
+import type { User } from '../machines/stateMachine';
 import { getUserDisplayName } from '../utils/userDisplayName';
 import { useAuthContextValues } from './useAuth';
 
@@ -50,19 +51,20 @@ export const useChannelDisplayName = (
     [safeChannel, currentUserId],
   );
 
-  const allUsers = useUsers();
-  // Memoized: unmemoized `.filter()` produced a fresh `users` array every
-  // render, which busted the displayInfo memo below — so the full
-  // display-name computation re-ran on every render of every caller
-  // (profiled in the activity list trace).
+  // O(1) id -> User Map for the whole workspace (shared reference-keyed cache).
+  // Replaces the previous `allUsers.filter(...)` full-workspace scan that ran
+  // once per participant lookup per rendered item — with thousands of items
+  // mounting per Cmd+K keystroke that scan dominated render time.
+  const usersById = useUsersById();
+  // Look up the handful of participants by id. Order follows the channel's
+  // stored participant order (getDMParticipantIdsToFetch) rather than the
+  // workspace-array order the old scan produced; for 1:1 DMs (one participant)
+  // this is identical, and for group DMs it is a deterministic, stable order.
   const users = useMemo(
-    () => allUsers.filter(v => userIdsToFetch.some(u => u === v.id)),
-    [allUsers, userIdsToFetch],
+    () => userIdsToFetch.map(id => usersById.get(id)).filter((u): u is User => Boolean(u)),
+    [usersById, userIdsToFetch],
   );
-  const currentUser = useMemo(
-    () => allUsers.find(u => u.id === currentUserId),
-    [allUsers, currentUserId],
-  );
+  const currentUser = useMemo(() => usersById.get(currentUserId), [usersById, currentUserId]);
 
   const totalOtherParticipants = useMemo(() => {
     if (!isDMChannel(safeChannel.scopeType)) return 0;

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo, useDeferredValue } from 'react';
 import Fuse from 'fuse.js';
 import { searchMetricsService } from '../services/searchMetricsService';
 import { useAuthContextValues } from './useAuth';
@@ -38,27 +38,34 @@ import { useCmdkAllDefaultRankProfile } from './useCmdkSearchConfig';
 // At affinity=50 → sat=0.5; at affinity=200 → sat≈0.9.
 const sat = (x: number): number => (2 / Math.PI) * Math.atan(x / 50);
 
-// Fuse instances are expensive to construct — cache by searchableNames content
-// so the same instance is reused across keystrokes for the same DM channel.
-// Bounded LRU: evict oldest entry when the map grows beyond MAX_FUSE_CACHE_SIZE.
-const MAX_FUSE_CACHE_SIZE = 50;
-const fuseCache = new Map<string, Fuse<string>>();
-function getFuseInstance(searchableNames: string[]): Fuse<string> {
-  const key = searchableNames.join('\0');
-  let instance = fuseCache.get(key);
-  if (!instance) {
-    if (fuseCache.size >= MAX_FUSE_CACHE_SIZE) {
-      fuseCache.delete(fuseCache.keys().next().value!);
-    }
-    instance = new Fuse(searchableNames, {
-      threshold: 0.35,
-      includeScore: true,
-      ignoreLocation: true,
-      minMatchCharLength: 1,
-    });
-    fuseCache.set(key, instance);
+// A single Fuse doc: one participant name tagged with the DM channel it belongs
+// to. We index every DM participant name into ONE Fuse instance instead of
+// building a separate Fuse per DM channel.
+type DmParticipantDoc = { channelId: string; name: string };
+
+const DM_FUSE_OPTIONS = {
+  threshold: 0.35,
+  includeScore: true,
+  ignoreLocation: true,
+  minMatchCharLength: 1,
+  keys: ['name'],
+};
+
+// Single-slot memo for the combined DM Fuse index. The set of DMs (and their
+// participant names) is stable across keystrokes within a typing session, so
+// we build the index once and reuse it for every keystroke — the previous
+// per-DM approach constructed one Fuse per DM on EVERY keystroke and, with an
+// LRU capped at 50, provided zero reuse for users with more than 50 DMs.
+// Fuse computes a per-item (query, string) score independently of the rest of
+// the corpus, so grouping the best match per channel out of one shared index
+// yields the SAME score per DM as a per-DM index did.
+let _dmFuse: { sig: string; fuse: Fuse<DmParticipantDoc> } | null = null;
+
+function getDmFuse(docs: DmParticipantDoc[], sig: string): Fuse<DmParticipantDoc> {
+  if (!_dmFuse || _dmFuse.sig !== sig) {
+    _dmFuse = { sig, fuse: new Fuse(docs, DM_FUSE_OPTIONS) };
   }
-  return instance;
+  return _dmFuse.fuse;
 }
 
 // Affinity weight for DM ranking. Fuse scores are [0, 1]; 0.5 means peak
@@ -241,35 +248,62 @@ export function filterChannelsBySearchableNames<
     .map(p => p.trim())
     .filter(Boolean);
 
-  const matchedDms = dmItems
-    .flatMap(item => {
-      const { searchableNames } = item;
-      if (!searchableNames || searchableNames.length === 0 || queryParts.length === 0) return [];
+  // Build ONE Fuse index over every DM participant name (tagged with its
+  // channel) and search it once per query token, instead of building a fresh
+  // Fuse per DM and searching each one per token. For P tokens and N DMs this
+  // turns O(N) index constructions + O(N*P) searches per keystroke into a
+  // cached single construction + O(P) searches.
+  const dmDocs: DmParticipantDoc[] = [];
+  for (const item of dmItems) {
+    const names = item.searchableNames;
+    if (!names) continue;
+    for (const name of names) dmDocs.push({ channelId: item.channel.id, name });
+  }
 
-      const fuse = getFuseInstance(searchableNames);
+  let matchedDms: T[] = [];
+  if (dmItems.length > 0 && queryParts.length > 0 && dmDocs.length > 0) {
+    // Signature is stable across keystrokes for a fixed DM set, so the index is
+    // constructed once per session and reused. Keyed on channel id + names.
+    const sig = dmDocs.map(d => d.channelId + '\x1f' + d.name).join('\x1e');
+    const fuse = getDmFuse(dmDocs, sig);
 
-      let totalFuseScore = 0;
-      for (const part of queryParts) {
-        const results = fuse.search(part);
-        if (results.length === 0) return []; // AND: every token must match some participant
-        const best = results[0]!;
-        const score = best.score ?? 1;
-        const matched = best.item.toLowerCase();
-        totalFuseScore += matched.startsWith(part) ? score - 0.5 : score;
+    // For each token, record the best (lowest) Fuse score per channel plus the
+    // matched name. Fuse returns results sorted ascending by score, so the FIRST
+    // result seen for a channel is that channel's best match for the token —
+    // identical to `results[0]` from the old per-DM search.
+    const bestPerChannelPerPart = queryParts.map(part => {
+      const perChannel = new Map<string, { score: number; matched: string }>();
+      for (const { item: doc, score } of fuse.search(part)) {
+        if (perChannel.has(doc.channelId)) continue;
+        perChannel.set(doc.channelId, { score: score ?? 1, matched: doc.name.toLowerCase() });
       }
+      return perChannel;
+    });
 
-      // Fuse scores are [0, 1] (0 = perfect). Prefix boost subtracts 0.5, making
-      // per-part scores potentially negative. Subtraction (not division) is critical:
-      // division would make negative scores less negative with high affinity, inverting
-      // the ranking. Lower finalScore = better rank.
-      const fuseScore = totalFuseScore / queryParts.length;
-      const affinity = affinityService.getChannelWeight(item.channel.id);
-      const finalScore = fuseScore - sat(affinity) * AFFINITY_WEIGHT;
+    matchedDms = dmItems
+      .flatMap(item => {
+        const channelId = item.channel.id;
 
-      return [{ item, score: finalScore }];
-    })
-    .sort((a, b) => a.score - b.score) // lower = better
-    .map(({ item }) => item);
+        let totalFuseScore = 0;
+        for (let i = 0; i < queryParts.length; i++) {
+          const best = bestPerChannelPerPart[i]!.get(channelId);
+          if (!best) return []; // AND: every token must match some participant
+          totalFuseScore += best.matched.startsWith(queryParts[i]!) ? best.score - 0.5 : best.score;
+        }
+
+        // Fuse scores are [0, 1] (0 = perfect). Prefix boost subtracts 0.5, making
+        // per-part scores potentially negative. Subtraction (not division) is critical:
+        // division would make negative scores less negative with high affinity, inverting
+        // the ranking. Lower finalScore = better rank.
+        const fuseScore = totalFuseScore / queryParts.length;
+        const affinity = affinityService.getChannelWeight(channelId);
+        const finalScore = fuseScore - sat(affinity) * AFFINITY_WEIGHT;
+
+        return [{ item, score: finalScore }];
+      })
+      .sort((a, b) => a.score - b.score) // lower = better
+      .map(({ item }) => item);
+  }
 
   const regularChannels = regularItems.map(item => item.channel);
   const regularItemsById = new Map(regularItems.map(item => [item.channel.id, item]));
@@ -344,14 +378,21 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
   // Filter local users using the search hook - use cleaned searchText
   const filteredLocalUsers = useUserSearch(cleanedSearchText, CMDK_USER_LIMIT);
 
-  // Filter local channels - use cleaned searchText
+  // Decouple the (potentially expensive) local channel filter from the keystroke
+  // that triggered it. The input value is bound to `text`, so it always echoes
+  // instantly; deferring the value fed to the filter lets React keep the input
+  // responsive and render the previous channel results until the new filter pass
+  // is ready, instead of blocking each keystroke on the full DM Fuse pass.
+  const deferredCleanedSearchText = useDeferredValue(cleanedSearchText);
+
+  // Filter local channels - use the deferred cleaned searchText
   const filteredLocalChannels: Array<{
     channel: Channel;
     category: ChannelCategory;
     searchableNames?: string[];
   }> = useMemo(
-    () => filterChannelsBySearchableNames(options.allChannels ?? [], cleanedSearchText),
-    [options.allChannels, cleanedSearchText],
+    () => filterChannelsBySearchableNames(options.allChannels ?? [], deferredCleanedSearchText),
+    [options.allChannels, deferredCleanedSearchText],
   );
 
   const [currentSearchContext, setCurrentSearchContext] = useState<{

--- a/apps/dashboard/src/hooks/useUsers.ts
+++ b/apps/dashboard/src/hooks/useUsers.ts
@@ -1,6 +1,7 @@
 export {
   searchUsers,
   useUsers,
+  useUsersById,
   useUser,
   useSelf,
   useUserSearch,

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -1,43 +1,48 @@
-export { SharedAuthProvider, useSharedAuthContext } from './context.js';
-export type { SharedAuthContext } from './context.js';
+export { SharedAuthProvider, useSharedAuthContext } from "./context.js";
+export type { SharedAuthContext } from "./context.js";
 
-export { HttpClientProvider, useHttpClient, useOptionalHttpClient } from './HttpClientContext.js';
-export type { HttpClient } from './HttpClientContext.js';
+export {
+  HttpClientProvider,
+  useHttpClient,
+  useOptionalHttpClient,
+} from "./HttpClientContext.js";
+export type { HttpClient } from "./HttpClientContext.js";
 
-export { useAffinityService } from './useAffinityService.js';
-export { AffinityService } from '../services/affinityService.js';
-export type { AffinityWeights } from '../services/affinityService.js';
+export { useAffinityService } from "./useAffinityService.js";
+export { AffinityService } from "../services/affinityService.js";
+export type { AffinityWeights } from "../services/affinityService.js";
 
-export { useCacConfig } from './useCacConfig.js';
+export { useCacConfig } from "./useCacConfig.js";
 
-export { useChannelRecentSenders } from './useChannelRecentSenders.js';
-export { useDmAffinityRank } from './useDmAffinityRank.js';
+export { useChannelRecentSenders } from "./useChannelRecentSenders.js";
+export { useDmAffinityRank } from "./useDmAffinityRank.js";
 export {
   useVespaChannelParticipants,
   ChannelServiceProvider,
-} from './useVespaChannelParticipants.js';
-export type { FetchVespaChannelParticipants } from './useVespaChannelParticipants.js';
+} from "./useVespaChannelParticipants.js";
+export type { FetchVespaChannelParticipants } from "./useVespaChannelParticipants.js";
 
-export { useUserGroupSearch } from './useUserGroupSearch.js';
-export type { UserGroupLike } from './useUserGroupSearch.js';
+export { useUserGroupSearch } from "./useUserGroupSearch.js";
+export type { UserGroupLike } from "./useUserGroupSearch.js";
 
-export { useMentionSearch } from './useMentionSearch.js';
+export { useMentionSearch } from "./useMentionSearch.js";
 export type {
   UseMentionSearchResult,
   UseMentionSearchOptions,
-} from './useMentionSearch.js';
-export type { MentionResult } from '../types/mention.js';
+} from "./useMentionSearch.js";
+export type { MentionResult } from "../types/mention.js";
 
 export {
   searchUsers,
   useUsers,
+  useUsersById,
   useUser,
   useSelf,
   useUserSearch,
   useActiveUsers,
   useActiveUserSearch,
   invalidateUsersMapCache,
-} from './useUsers.js';
+} from "./useUsers.js";
 
 export {
   searchChannels,
@@ -59,8 +64,8 @@ export {
   useGetChannelConversations,
   getChannelConversationsSnapshot,
   useGetLatestConversation,
-} from './useChannels.js';
-export type { VisibleChannel, VisibleProject } from './useChannels.js';
+} from "./useChannels.js";
+export type { VisibleChannel, VisibleProject } from "./useChannels.js";
 
 export {
   usePermissions,
@@ -70,36 +75,54 @@ export {
   useCanViewAnalytics,
   useHasResourceAccess,
   useCanManageUserActivity,
-} from './usePermissions.js';
+} from "./usePermissions.js";
 
-export { useZero, InstrumentationProvider, useInstrumentation } from './useZero.js';
-export type { Instrumentation } from './useZero.js';
-export { getPendingMutationCount, subscribePendingMutations } from './pendingMutations.js';
+export {
+  useZero,
+  InstrumentationProvider,
+  useInstrumentation,
+} from "./useZero.js";
+export type { Instrumentation } from "./useZero.js";
+export {
+  getPendingMutationCount,
+  subscribePendingMutations,
+} from "./pendingMutations.js";
 
-export { useQuery, useRawQuery } from './useQuery.js';
+export { useQuery, useRawQuery } from "./useQuery.js";
 
-export { useCachedQuery } from './useCachedQuery.js';
-export type { UseCachedQueryOptions } from './useCachedQuery.js';
+export { useCachedQuery } from "./useCachedQuery.js";
+export type { UseCachedQueryOptions } from "./useCachedQuery.js";
 
-export { useCurrentUserRoleIds } from './useRoles.js';
-export type { Role } from './useRoles.js';
+export { useCurrentUserRoleIds } from "./useRoles.js";
+export type { Role } from "./useRoles.js";
 
 export {
   ZeroFallbackProvider,
   useZeroFallbackConfig,
   ZeroFallbackContext,
   DEFAULT_ZERO_FALLBACK_CONFIG,
-} from './ZeroFallbackContext.js';
-export type { ZeroFallbackConfig, FallbackPlatformServices } from './ZeroFallbackContext.js';
+} from "./ZeroFallbackContext.js";
+export type {
+  ZeroFallbackConfig,
+  FallbackPlatformServices,
+} from "./ZeroFallbackContext.js";
 
-export { useFallbackQuery, FallbackExecutorProvider, useFallbackExecutor } from './useFallbackQuery.js';
-export type { FallbackQueryExecutor } from './useFallbackQuery.js';
+export {
+  useFallbackQuery,
+  FallbackExecutorProvider,
+  useFallbackExecutor,
+} from "./useFallbackQuery.js";
+export type { FallbackQueryExecutor } from "./useFallbackQuery.js";
 
-export { useFallbackHydratedQuery } from './useFallbackHydratedQuery.js';
+export { useFallbackHydratedQuery } from "./useFallbackHydratedQuery.js";
 
-export { useZeroConnectionInfo } from './useZeroConnectionState.js';
-export type { ZeroConnectionInfo } from './useZeroConnectionState.js';
+export { useZeroConnectionInfo } from "./useZeroConnectionState.js";
+export type { ZeroConnectionInfo } from "./useZeroConnectionState.js";
 
-export { useZeroOfflineState } from './useZeroOfflineState.js';
+export { useZeroOfflineState } from "./useZeroOfflineState.js";
 
-export { wasInterrupted, recordConnectionChange, recordConnectionConnected } from './metricValidity.js';
+export {
+  wasInterrupted,
+  recordConnectionChange,
+  recordConnectionConnected,
+} from "./metricValidity.js";

--- a/packages/shared/src/hooks/useUsers.ts
+++ b/packages/shared/src/hooks/useUsers.ts
@@ -1,12 +1,12 @@
-import { useSelector } from '@xstate/react';
-import { useMemo } from 'react';
-import { stateMachineActor } from '../machines/stateMachine.js';
-import type { User } from '../machines/stateMachine.js';
-import { useSharedAuthContext } from './context.js';
-import { searchUsers as _searchUsers } from '../utils/search.js';
-import { UserStatus } from '../zero/schema.js';
+import { useSelector } from "@xstate/react";
+import { useMemo } from "react";
+import { stateMachineActor } from "../machines/stateMachine.js";
+import type { User } from "../machines/stateMachine.js";
+import { useSharedAuthContext } from "./context.js";
+import { searchUsers as _searchUsers } from "../utils/search.js";
+import { UserStatus } from "../zero/schema.js";
 
-export { type User } from '../machines/stateMachine.js';
+export { type User } from "../machines/stateMachine.js";
 
 export function searchUsers(users: User[], query: string, limit = 10): User[] {
   return _searchUsers(users, query, limit);
@@ -27,20 +27,33 @@ export function invalidateUsersMapCache(): void {
 function getUsersMap(users: User[]): Map<string, User> {
   if (_usersMapRef !== users) {
     _usersMapRef = users;
-    _usersMap = new Map(users.map(u => [u.id, u]));
+    _usersMap = new Map(users.map((u) => [u.id, u]));
   }
   return _usersMap;
 }
 
 export const useUsers = (): User[] => {
-  const users = useSelector(stateMachineActor, state => state.context.users);
+  const users = useSelector(stateMachineActor, (state) => state.context.users);
   return useMemo(() => users, [users]);
+};
+
+/**
+ * Returns a stable id -> User Map for the whole workspace. Backed by the same
+ * reference-keyed `getUsersMap` cache as `useUser`, so it is built once per
+ * users-array reference and reused across all callers. Use this instead of
+ * `useUsers().filter(...)` when you need to look participants up by id — an O(1)
+ * Map lookup per id instead of an O(users) scan per lookup.
+ */
+export const useUsersById = (): Map<string, User> => {
+  return useSelector(stateMachineActor, (state) =>
+    getUsersMap(state.context.users),
+  );
 };
 
 export const useUser = (userId: string): User | undefined => {
   // O(1) Map lookup inside selector. Re-renders only when this specific user
   // object changes (=== check on the returned User object, not the entire array).
-  return useSelector(stateMachineActor, state =>
+  return useSelector(stateMachineActor, (state) =>
     getUsersMap(state.context.users).get(userId),
   );
 };
@@ -62,7 +75,10 @@ export const useUserSearch = (query: string, limit: number): User[] => {
  */
 export const useActiveUsers = (): User[] => {
   const users = useUsers();
-  return useMemo(() => users.filter(u => u.status === UserStatus.ACTIVE), [users]);
+  return useMemo(
+    () => users.filter((u) => u.status === UserStatus.ACTIVE),
+    [users],
+  );
 };
 
 /**


### PR DESCRIPTION
## What & why
Typing in Cmd+K was multi-second-slow for users with high DM volume. Every keystroke synchronously rebuilt a Fuse index **per DM channel** and mounted **every** matched result into cmdk. This PR makes four targeted fixes.

## Changes
1. **`useSearchMetrics.ts` — single cached DM Fuse index.** `filterChannelsBySearchableNames` now indexes all DM participant names into ONE Fuse instance (cached across keystrokes via a stable signature) and searches it once per query token, grouping the best match per channel. Replaces N per-DM index constructions + N×P searches per keystroke — the old 50-entry LRU gave **zero** reuse above 50 DMs. Fuse scores a (query, string) pair independently of the rest of the corpus, so per-DM ranking is **unchanged** (verified with an equivalence harness across single-token, AND-multi-token, prefix, and no-match queries — identical order and membership on every case).
2. **`ChannelCommandMenu.tsx` — cap the Group DMs search section** at `DISPLAY_LIMIT` with an inline "See more", matching the Starred/Users/Channels sections. Previously it mounted every matched group DM; a 1–2 char query matches thousands.
3. **`useChannelDisplayName.ts` — Map lookup instead of workspace scan.** Participants are now looked up in the shared id→User Map (`useUsersById`) instead of `allUsers.filter(...)` scanning the entire workspace user list per rendered item.
4. **`useSearchMetrics.ts` — `useDeferredValue`** on the text fed to the local channel filter, so the input echoes instantly even when a filter pass is expensive.

Also adds `useUsersById` to `@xyne/shared/hooks`, backed by the existing reference-keyed users Map cache.

## Behavior notes
- DM/group-DM search ranking is byte-for-byte identical (equivalence-verified).
- One minor, intentional change: `useChannelDisplayName` now orders group-DM participant names by the channel's stored participant order rather than workspace-array order. 1:1 DMs (single participant) are unaffected.

## Validation
- `dashboard` `tsc --noEmit` passes for all changed files (the only remaining error is a pre-existing `posthog-js` missing-module error in an untouched file, present on clean `main`).
- `packages/shared` `tsc` build passes.
- DM-filter ranking equivalence proven with a standalone harness.
