### PR TITLE
fix: XYNE-55411 fixing workspace creation, switching, and invitaiton …

### DIFF
--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -15,6 +15,7 @@ import type { WorkspaceJoinPolicy as WorkspaceJoinPolicyValue, WorkspaceType as 
 import '../types/express';
 import { config } from '@/config/env';
 import { DatabaseClient } from '@/database/client';
+import { runAsSystem } from '@/database/tenant/context';
 import { getFrontendUrl, resolveConfiguredOAuthRedirectUrl } from '@/utils/publicUrls';
 import {
   OrganizationDomainConflictError,
@@ -1879,77 +1880,85 @@ export class AuthV2Controller {
 
       const currentUser = req.user!;
 
-      // Find the User record scoped to the target workspace
-      const targetUser = await this.userService.findUserByEmail(currentUser.email, workspaceId);
-      if (!targetUser) {
-        res.status(403).json({
-          error: 'Forbidden',
-          message: 'You do not have access to this workspace',
-        });
-        return;
-      }
-
-      await this.userService.ensureUserPresence(targetUser.id, workspaceId);
-      const selfDmChannelId = await this.ensureSelfDmForUser(targetUser.id, workspaceId);
-
-      const workspace = await this.prisma.workspace.findUnique({
-        where: { id: workspaceId },
-        select: { landingChannelId: true },
-      });
-
-      // Get existing session from global session cookie
-      // We reuse the same session across workspaces (session belongs to user, not workspace)
-      const sessionId = req.cookies?.user_session_id;
-      
-      // Verify session exists and is valid
-      let validSessionId: string | null = null;
-      if (sessionId) {
-        const currentSession = await this.userSessionService.getSessionById(sessionId);
-        if (currentSession && currentSession.status === 'ACTIVE') {
-          validSessionId = currentSession.id;
-          logger.info(`[SWITCH-WORKSPACE] Reusing existing session: ${validSessionId}`);
+      // Switching workspaces is inherently cross-tenant: everything below acts on the
+      // TARGET workspace while the ambient session context is still the caller's current
+      // (old) one — the per-model ACLs' "must match your current workspace" rule can never
+      // be satisfied by definition. Safe to bypass because every lookup here is keyed off
+      // `currentUser.email` (the caller's own verified session), never attacker-supplied —
+      // this can only ever act on the caller's own identity in the target workspace.
+      await runAsSystem(async () => {
+        // Find the User record scoped to the target workspace
+        const targetUser = await this.userService.findUserByEmail(currentUser.email, workspaceId);
+        if (!targetUser) {
+          res.status(403).json({
+            error: 'Forbidden',
+            message: 'You do not have access to this workspace',
+          });
+          return;
         }
-      }
-      
-      if (!validSessionId) {
-        logger.warn(`[SWITCH-WORKSPACE] No valid session found for workspace switch`);
-      }
 
-      const token = jwtService.generateToken({
-        sub: targetUser.id,
-        email: targetUser.email,
-        name: targetUser.name,
-        picture: targetUser.picture || undefined,
-        workspaceId: targetUser.workspaceId ?? undefined,
-        memberId: targetUser.orgMemberId,
-      });
+        await this.userService.ensureUserPresence(targetUser.id, workspaceId);
+        const selfDmChannelId = await this.ensureSelfDmForUser(targetUser.id, workspaceId);
 
-      const isProduction = process.env.NODE_ENV === 'production';
-      const cookieBase = { httpOnly: true, secure: isProduction, sameSite: 'strict' as const, path: '/' };
+        const workspace = await this.prisma.workspace.findUnique({
+          where: { id: workspaceId },
+          select: { landingChannelId: true },
+        });
 
-      // Set workspace-specific cookies
-      res.cookie(`xyne_ws_${workspaceId}_token`, token, { ...cookieBase, maxAge: config.jwt.expirationSeconds * 1000 });
-      res.cookie('xyne_last_workspace', workspaceId, { ...cookieBase, maxAge: 30 * 24 * 60 * 60 * 1000 });
-      
-      // Set global session cookie (reusing existing session)
-      if (validSessionId) {
-        res.cookie('user_session_id', validSessionId, { ...cookieBase, maxAge: 30 * 24 * 60 * 60 * 1000 });
-      }
+        // Get existing session from global session cookie
+        // We reuse the same session across workspaces (session belongs to user, not workspace)
+        const sessionId = req.cookies?.user_session_id;
 
-      logger.info(`[SWITCH-WORKSPACE] User ${currentUser.email} switched to workspace ${workspaceId}`);
+        // Verify session exists and is valid
+        let validSessionId: string | null = null;
+        if (sessionId) {
+          const currentSession = await this.userSessionService.getSessionById(sessionId);
+          if (currentSession && currentSession.status === 'ACTIVE') {
+            validSessionId = currentSession.id;
+            logger.info(`[SWITCH-WORKSPACE] Reusing existing session: ${validSessionId}`);
+          }
+        }
 
-      res.status(200).json({
-        user: {
-          id: targetUser.id,
+        if (!validSessionId) {
+          logger.warn(`[SWITCH-WORKSPACE] No valid session found for workspace switch`);
+        }
+
+        const token = jwtService.generateToken({
+          sub: targetUser.id,
           email: targetUser.email,
           name: targetUser.name,
-          picture: targetUser.picture,
-          workspaceId: targetUser.workspaceId,
-          role: targetUser.role,
+          picture: targetUser.picture || undefined,
+          workspaceId: targetUser.workspaceId ?? undefined,
           memberId: targetUser.orgMemberId,
-        },
-        selfDmChannelId,
-        landingChannelId: workspace?.landingChannelId ?? null,
+        });
+
+        const isProduction = process.env.NODE_ENV === 'production';
+        const cookieBase = { httpOnly: true, secure: isProduction, sameSite: 'strict' as const, path: '/' };
+
+        // Set workspace-specific cookies
+        res.cookie(`xyne_ws_${workspaceId}_token`, token, { ...cookieBase, maxAge: config.jwt.expirationSeconds * 1000 });
+        res.cookie('xyne_last_workspace', workspaceId, { ...cookieBase, maxAge: 30 * 24 * 60 * 60 * 1000 });
+
+        // Set global session cookie (reusing existing session)
+        if (validSessionId) {
+          res.cookie('user_session_id', validSessionId, { ...cookieBase, maxAge: 30 * 24 * 60 * 60 * 1000 });
+        }
+
+        logger.info(`[SWITCH-WORKSPACE] User ${currentUser.email} switched to workspace ${workspaceId}`);
+
+        res.status(200).json({
+          user: {
+            id: targetUser.id,
+            email: targetUser.email,
+            name: targetUser.name,
+            picture: targetUser.picture,
+            workspaceId: targetUser.workspaceId,
+            role: targetUser.role,
+            memberId: targetUser.orgMemberId,
+          },
+          selfDmChannelId,
+          landingChannelId: workspace?.landingChannelId ?? null,
+        });
       });
     } catch (error) {
       logger.error('Error switching workspace:', error);

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -96,11 +96,14 @@ export class InvitationService {
       // Ensure the invitee exists in the org_members table (any org)
       if (role !== 'GUEST') {
         // Looks the invitee up across any org, not just the caller's, so it runs above the caller's own scope.
-        const inviteeInOrg = await withWorkspaceScope(() =>
-          this.prisma.orgMember.findFirst({
+        // The query MUST be awaited inside the closure: Prisma promises are lazy, so awaiting
+        // outside would execute the query after withWorkspaceScope has exited — back in the
+        // request context where OrgMembersACL scopes it to the caller's own membership.
+        const inviteeInOrg = await withWorkspaceScope(async () => {
+          return await this.prisma.orgMember.findFirst({
             where: { email, leftAt: null },
-          }),
-        );
+          });
+        });
 
         if (!inviteeInOrg) {
           throw new Error(
@@ -111,11 +114,11 @@ export class InvitationService {
     }
 
     if (role === 'GUEST') {
-      const inviteeOrgMember = await withWorkspaceScope(() =>
-        this.prisma.orgMember.findUnique({
+      const inviteeOrgMember = await withWorkspaceScope(async () => {
+        return await this.prisma.orgMember.findUnique({
           where: { email },
-        }),
-      );
+        });
+      });
       if (inviteeOrgMember && inviteeOrgMember.leftAt) {
         throw new Error(
           `${email} is no longer part of an organization and cannot be invited as a guest`

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -3,6 +3,7 @@ import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { logger } from '../utils/logger';
 import { repositories } from '../database/repositories/index';
 import { DatabaseClient } from '@/database/client';
+import { runAsSystem } from '@/database/tenant/context';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { grantPermissionsForRole, syncOrgResourceAdminAccess } from './permissionMatrix';
 import { USER_PREFERENCE_NOTIFICATION_DEFAULTS } from '@/constants/userPreferenceDefaults';
@@ -604,109 +605,111 @@ export class UserService {
     memberCount: number;
   }>> {
     try {
-      logger.info(`[getWorkspacesByEmail] Querying workspaces for email: ${email}`);
-      const workspaceUsers = await this.prisma.user.findMany({
-        where: {
-          email,
-          status: UserStatus.ACTIVE,
-          leftAt: null,
-        },
-        include: {
-          workspace: {
-            include: {
-              organization: true
+      return await runAsSystem(async () => {
+        logger.info(`[getWorkspacesByEmail] Querying workspaces for email: ${email}`);
+        const workspaceUsers = await this.prisma.user.findMany({
+          where: {
+            email,
+            status: UserStatus.ACTIVE,
+            leftAt: null,
+          },
+          include: {
+            workspace: {
+              include: {
+                organization: true
+              }
             }
           }
-        }
-      });
+        });
 
-      const visibleWorkspaceUsers = workspaceUsers;
+        const visibleWorkspaceUsers = workspaceUsers;
 
-      logger.info(`[getWorkspacesByEmail] Found ${visibleWorkspaceUsers.length} active workspace users for email: ${email}`);
-      visibleWorkspaceUsers.forEach(u => {
-        logger.info(`[getWorkspacesByEmail] - User ${u.id} in workspace ${u.workspace?.id}`);
-      });
+        logger.info(`[getWorkspacesByEmail] Found ${visibleWorkspaceUsers.length} active workspace users for email: ${email}`);
+        visibleWorkspaceUsers.forEach(u => {
+          logger.info(`[getWorkspacesByEmail] - User ${u.id} in workspace ${u.workspace?.id}`);
+        });
 
-      const existingWorkspaceIds = new Set(
-        visibleWorkspaceUsers
-          .map(wsUser => wsUser.workspaceId)
-          .filter((workspaceId): workspaceId is string => Boolean(workspaceId)),
-      );
+        const existingWorkspaceIds = new Set(
+          visibleWorkspaceUsers
+            .map(wsUser => wsUser.workspaceId)
+            .filter((workspaceId): workspaceId is string => Boolean(workspaceId)),
+        );
 
-      const approvedJoinRequests = await this.prisma.workspaceJoinRequest.findMany({
-        where: {
-          email: email,
-          status: 'APPROVED',
-        },
-        orderBy: { updatedAt: 'desc' },
-      });
+        const approvedJoinRequests = await this.prisma.workspaceJoinRequest.findMany({
+          where: {
+            email: email,
+            status: 'APPROVED',
+          },
+          orderBy: { updatedAt: 'desc' },
+        });
 
-      const approvedJoinRequestWorkspaces = approvedJoinRequests.length > 0
-        ? await this.prisma.workspace.findMany({
-            where: {
-              id: { in: approvedJoinRequests.map(request => request.workspaceId) },
-              status: Status.ACTIVE,
-              OR: [{ workspaceType: WorkspaceType.ENTERPRISE }, { workspaceType: null }],
-            },
-            include: {
-              organization: true,
-            },
-          })
-        : [];
-      const approvedJoinRequestWorkspacesById = new Map(
-        approvedJoinRequestWorkspaces.map(workspace => [workspace.id, workspace]),
-      );
+        const approvedJoinRequestWorkspaces = approvedJoinRequests.length > 0
+          ? await this.prisma.workspace.findMany({
+              where: {
+                id: { in: approvedJoinRequests.map(request => request.workspaceId) },
+                status: Status.ACTIVE,
+                OR: [{ workspaceType: WorkspaceType.ENTERPRISE }, { workspaceType: null }],
+              },
+              include: {
+                organization: true,
+              },
+            })
+          : [];
+        const approvedJoinRequestWorkspacesById = new Map(
+          approvedJoinRequestWorkspaces.map(workspace => [workspace.id, workspace]),
+        );
 
-      const workspaceIds = [
-        ...new Set([
-          ...visibleWorkspaceUsers.map(wsUser => wsUser.workspaceId),
-          ...approvedJoinRequestWorkspaces.map(ws => ws.id),
-        ].filter((id): id is string => Boolean(id))),
-      ];
+        const workspaceIds = [
+          ...new Set([
+            ...visibleWorkspaceUsers.map(wsUser => wsUser.workspaceId),
+            ...approvedJoinRequestWorkspaces.map(ws => ws.id),
+          ].filter((id): id is string => Boolean(id))),
+        ];
 
-      const memberCounts = await this.prisma.user.groupBy({
-        by: ['workspaceId'],
-        where: {
-          workspaceId: { in: workspaceIds },
-          status: UserStatus.ACTIVE,
-          leftAt: null,
-        },
-        _count: { workspaceId: true },
-      });
+        const memberCounts = await this.prisma.user.groupBy({
+          by: ['workspaceId'],
+          where: {
+            workspaceId: { in: workspaceIds },
+            status: UserStatus.ACTIVE,
+            leftAt: null,
+          },
+          _count: { workspaceId: true },
+        });
 
-      const memberCountByWorkspaceId = new Map(
-        memberCounts.map(group => [group.workspaceId, group._count.workspaceId]),
-      );
+        const memberCountByWorkspaceId = new Map(
+          memberCounts.map(group => [group.workspaceId, group._count.workspaceId]),
+        );
 
-      // Return flat list of workspaces for frontend
-      const activeWorkspaces = visibleWorkspaceUsers.map(wsUser => ({
-        id: wsUser.workspace!.id,
-        name: wsUser.workspace!.name,
-        role: wsUser.role || 'MEMBER',
-        orgId: wsUser.workspace!.organization.orgId,
-        orgName: wsUser.workspace!.organization.name,
-        workspaceType: wsUser.workspace!.workspaceType,
-        memberCount: memberCountByWorkspaceId.get(wsUser.workspace!.id) ?? 0,
-      }));
-
-      const approvedRequestWorkspaces = approvedJoinRequests
-        .filter(request => !existingWorkspaceIds.has(request.workspaceId))
-        .map(request => approvedJoinRequestWorkspacesById.get(request.workspaceId))
-        .filter(
-          (workspace): workspace is (typeof approvedJoinRequestWorkspaces)[number] =>
-            Boolean(workspace),
-        )
-        .map(workspace => ({
-          id: workspace.id,
-          name: workspace.name,
-          role: 'MEMBER',
-          orgId: workspace.organization.orgId,
-          orgName: workspace.organization.name,
-          workspaceType: workspace.workspaceType,
-          memberCount: memberCountByWorkspaceId.get(workspace.id) ?? 0,
+        // Return flat list of workspaces for frontend
+        const activeWorkspaces = visibleWorkspaceUsers.map(wsUser => ({
+          id: wsUser.workspace!.id,
+          name: wsUser.workspace!.name,
+          role: wsUser.role || 'MEMBER',
+          orgId: wsUser.workspace!.organization.orgId,
+          orgName: wsUser.workspace!.organization.name,
+          workspaceType: wsUser.workspace!.workspaceType,
+          memberCount: memberCountByWorkspaceId.get(wsUser.workspace!.id) ?? 0,
         }));
 
-      return [...activeWorkspaces, ...approvedRequestWorkspaces];
+        const approvedRequestWorkspaces = approvedJoinRequests
+          .filter(request => !existingWorkspaceIds.has(request.workspaceId))
+          .map(request => approvedJoinRequestWorkspacesById.get(request.workspaceId))
+          .filter(
+            (workspace): workspace is (typeof approvedJoinRequestWorkspaces)[number] =>
+              Boolean(workspace),
+          )
+          .map(workspace => ({
+            id: workspace.id,
+            name: workspace.name,
+            role: 'MEMBER',
+            orgId: workspace.organization.orgId,
+            orgName: workspace.organization.name,
+            workspaceType: workspace.workspaceType,
+            memberCount: memberCountByWorkspaceId.get(workspace.id) ?? 0,
+          }));
+
+        return [...activeWorkspaces, ...approvedRequestWorkspaces];
+      });
     } catch (error) {
       logger.error('Error getting workspaces by email:', error);
       throw new Error('Failed to get workspaces');
@@ -1138,107 +1141,114 @@ export class UserService {
       }
     }
 
-    // Step 1: Create workspace under existing org with temporary createdBy
-    let workspace;
-    try {
-      workspace = await this.prisma.workspace.create({
+    // Creating a workspace is inherently cross-tenant: the row being created/updated can
+    // never satisfy "must belong to the caller's current workspace" (there is no current
+    // workspace for something that doesn't exist yet). Bootstrap it as `system` — every
+    // write below already carries its own workspaceId explicitly, so nothing relies on the
+    // ambient-context stamper this bypasses. See WorkspacesACL.getMutateWhere / runAsSystem.
+    return runAsSystem(async () => {
+      // Step 1: Create workspace under existing org with temporary createdBy
+      let workspace;
+      try {
+        workspace = await this.prisma.workspace.create({
+          data: {
+            orgId: org.orgId,
+            name: workspaceName,
+            createdBy: userData.providerUserId, // Temporary: will update after user creation
+            status: Status.ACTIVE,
+            workspaceType,
+            joinPolicy,
+          },
+        });
+      } catch (error) {
+        if (error instanceof PrismaClientKnownRequestError && error.code === 'P2002') {
+          this.raiseWorkspaceCreateError('A workspace with this name already exists. Please choose a different name.', 409);
+        }
+        throw error;
+      }
+
+      // Step 2: Link workspace to organization
+      await this.prisma.workspaceOrganization.create({
         data: {
           orgId: org.orgId,
-          name: workspaceName,
-          createdBy: userData.providerUserId, // Temporary: will update after user creation
-          status: 'ACTIVE',
-          workspaceType,
-          joinPolicy,
+          workspaceId: workspace.id,
+          role: WorkspaceRole.ADMIN,
         },
       });
-    } catch (error) {
-      if (error instanceof PrismaClientKnownRequestError && error.code === 'P2002') {
-        this.raiseWorkspaceCreateError('A workspace with this name already exists. Please choose a different name.', 409);
-      }
-      throw error;
-    }
 
-    // Step 2: Link workspace to organization
-    await this.prisma.workspaceOrganization.create({
-      data: {
-        orgId: org.orgId,
-        workspaceId: workspace.id,
-        role: 'ADMIN',
-      },
-    });
-
-    // Step 3: Fetch orgMember for the user (reuse existing orgMember if available)
-    const userOrgMember = orgMember || await this.prisma.orgMember.findUnique({
-      where: { email: userData.email },
-      select: { memberId: true }
-    });
-
-    if (!userOrgMember) {
-      throw new Error(`orgMember not found for email ${userData.email}. User must be added to the organization first.`);
-    }
-
-    // Step 4: Create workspace-scoped user as OWNER
-    const workspaceUser = await this.prisma.user.create({
-      data: {
-        providerUserId: userData.providerUserId,
-        email: userData.email,
-        name: userData.name,
-        picture: userData.picture,
-        authProvider: 'GOOGLE',
-        workspace: { connect: { id: workspace.id } },
-        role: 'OWNER',
-        orgMember: { connect: { memberId: orgMember.memberId } },
-      },
-    });
-
-    // Step 5: Update workspace with correct createdBy (actual user ID)
-    await this.prisma.workspace.update({
-      where: { id: workspace.id },
-      data: { createdBy: workspaceUser.id }
-    });
-
-    // Step 6: Create DM project for the workspace with correct createdBy
-    await this.prisma.project.create({
-      data: {
-        name: 'Direct Messages',
-        code: 'DM',
-        description: 'DM project for direct message channels',
-        type: ProjectType.DM,
-        workspaceId: workspace.id,
-        createdBy: workspaceUser.id,
-      }
-    });
-
-    const defaults = await createCommunityWorkspaceDefaults({
-      db: this.prisma,
-      workspaceId: workspace.id,
-      workspaceName,
-      createdBy: workspaceUser.id,
-    });
-
-    workspace = { ...workspace, landingChannelId: defaults.workspace.landingChannelId };
-    await repositories.channelParticipants.addParticipant(defaults.channel.id, workspaceUser.id, ChannelRole.ADMIN);
-
-    // Grant full admin resource access to the workspace owner
-    await grantPermissionsForRole(workspaceUser.id, workspaceUser.email, WorkspaceRole.OWNER, workspace.id);
-
-    // Sync all hardcoded bots into the new workspace
-    await unifiedBotUserService.syncAllBotUsers(workspace.id);
-
-    try {
-      await aiProvisioningService.enqueueWorkspaceSync(workspace.id);
-      await aiProvisioningService.enqueueUserSync(workspaceUser.orgMemberId);
-    } catch (error) {
-      logger.error('[UserService] Failed to enqueue AI provisioning jobs for new workspace', {
-        orgId: org.orgId,
-        workspaceId: workspace.id,
-        userId: workspaceUser.id,
-        error,
+      // Step 3: Fetch orgMember for the user (reuse existing orgMember if available)
+      const userOrgMember = orgMember || await this.prisma.orgMember.findUnique({
+        where: { email: userData.email },
+        select: { memberId: true }
       });
-    }
 
-    logger.info(`Created workspace "${workspaceName}" under org "${org.name}" for ${userData.email}`);
-    return { organization: org, workspace, workspaceUser };
+      if (!userOrgMember) {
+        throw new Error(`orgMember not found for email ${userData.email}. User must be added to the organization first.`);
+      }
+
+      // Step 4: Create workspace-scoped user as OWNER
+      const workspaceUser = await this.prisma.user.create({
+        data: {
+          providerUserId: userData.providerUserId,
+          email: userData.email,
+          name: userData.name,
+          picture: userData.picture,
+          authProvider: AuthProvider.GOOGLE,
+          workspace: { connect: { id: workspace.id } },
+          role: WorkspaceRole.OWNER,
+          orgMember: { connect: { memberId: orgMember.memberId } },
+        },
+      });
+
+      // Step 5: Update workspace with correct createdBy (actual user ID)
+      await this.prisma.workspace.update({
+        where: { id: workspace.id },
+        data: { createdBy: workspaceUser.id }
+      });
+
+      // Step 6: Create DM project for the workspace with correct createdBy
+      await this.prisma.project.create({
+        data: {
+          name: 'Direct Messages',
+          code: 'DM',
+          description: 'DM project for direct message channels',
+          type: ProjectType.DM,
+          workspaceId: workspace.id,
+          createdBy: workspaceUser.id,
+        }
+      });
+
+      const defaults = await createCommunityWorkspaceDefaults({
+        db: this.prisma,
+        workspaceId: workspace.id,
+        workspaceName,
+        createdBy: workspaceUser.id,
+      });
+
+      workspace = { ...workspace, landingChannelId: defaults.workspace.landingChannelId };
+      await repositories.channelParticipants.addParticipant(defaults.channel.id, workspaceUser.id, ChannelRole.ADMIN);
+
+      // Grant full admin resource access to the workspace owner
+      await grantPermissionsForRole(workspaceUser.id, workspaceUser.email, WorkspaceRole.OWNER, workspace.id);
+
+      // Sync all hardcoded bots into the new workspace
+      await unifiedBotUserService.syncAllBotUsers(workspace.id);
+
+      try {
+        await aiProvisioningService.enqueueWorkspaceSync(workspace.id);
+        await aiProvisioningService.enqueueUserSync(workspaceUser.id);
+      } catch (error) {
+        logger.error('[UserService] Failed to enqueue AI provisioning jobs for new workspace', {
+          orgId: org.orgId,
+          workspaceId: workspace.id,
+          userId: workspaceUser.id,
+          error,
+        });
+      }
+
+      logger.info(`Created workspace "${workspaceName}" under org "${org.name}" for ${userData.email}`);
+      return { organization: org, workspace, workspaceUser };
+    });
   }
 
   /**


### PR DESCRIPTION
…flow

Services-Requiring-Redeployment:
  - backend

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
