### PR TITLE
fix: XYNE-54830 fix secops issues

### DIFF
--- a/apps/backend/src/controllers/invitationController.ts
+++ b/apps/backend/src/controllers/invitationController.ts
@@ -274,11 +274,12 @@ export class InvitationController {
       }
 
       // Invitation is valid
+      // Note: invitee email is intentionally omitted — this endpoint is unauthenticated,
+      // and the actual email match is enforced server-side at accept time.
       res.status(200).json({
         valid: true,
         invitation: {
           id: invitation.id,
-          email: invitation.email,
           role: invitation.role,
           workspaceName: invitation.workspace?.name,
           organizationName: invitation.organization?.name,

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -765,7 +765,15 @@ export class InvitationService {
         redirectPath = guestResult.redirectPath;
         logger.info(`[DEBUG] [acceptInvitation] Granted existing guest user id=${newWorkspaceUser.id} access to invitation entity`);
       } else {
-        // User exists - reactivate them if they were removed (leftAt is set)
+        // A currently-active member of this workspace must not have their role
+        // silently overwritten by accepting a fresh invitation — that's a role
+        // escalation/downgrade vector for whoever created the invitation, not a
+        // legitimate edit path. Only a genuinely departed member (leftAt was
+        // already set) gets reactivated with the new invitation's role.
+        if (!existingWorkspaceUser.leftAt) {
+          throw new Error('You are already a member of this workspace.');
+        }
+
         newWorkspaceUser = await this.prisma.user.update({
           where: { id: existingWorkspaceUser.id },
           data: {
@@ -784,7 +792,7 @@ export class InvitationService {
       // Fetch existing orgMember by email
       const existingOrgMember = await this.prisma.orgMember.findUnique({
         where: { email: userData.email.toLowerCase() },
-        select: { memberId: true, role: true }
+        select: { memberId: true, orgId: true, leftAt: true, role: true }
       });
 
       let orgMember: { memberId: string };
@@ -800,9 +808,18 @@ export class InvitationService {
             email: userData.email.toLowerCase(),
             role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
           },
-          select: { memberId: true },
+          select: { memberId: true, orgId: true, leftAt: true },
         });
       } else if (resolvedOrgId) {
+        // An email that's already an active OrgMember of a *different* org must
+        // not be silently relocated into this org just because someone there
+        // sent them an invitation — that's a cross-org account-hijack vector.
+        // A departed member (leftAt already set) can still be picked up here;
+        // that's a legitimate rejoin-elsewhere case, not a hijack.
+        if (existingOrgMember.orgId !== resolvedOrgId && !existingOrgMember.leftAt) {
+          throw new Error('This email is already an active member of a different organization.');
+        }
+
         const wasCommunityMember = existingOrgMember.role === 'COMMUNITY_MEMBER';
         orgMember = await this.prisma.orgMember.update({
           where: { memberId: existingOrgMember.memberId },
@@ -811,7 +828,7 @@ export class InvitationService {
             orgId: resolvedOrgId,
             role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
           },
-          select: { memberId: true },
+          select: { memberId: true, orgId: true, leftAt: true },
         });
 
         if (wasCommunityMember) {

--- a/apps/dashboard/src/routes/InvitationScreen/AcceptInvitation.tsx
+++ b/apps/dashboard/src/routes/InvitationScreen/AcceptInvitation.tsx
@@ -14,7 +14,6 @@ import {
 
 interface InvitationDetails {
   id: string;
-  email: string;
   role: string;
   workspaceName?: string;
   organizationName?: string;
@@ -57,7 +56,6 @@ interface ApiErrorResponse {
 type PageState =
   | { status: 'redirecting' }
   | { status: 'verifying' }
-  | { status: 'email_mismatch'; loggedInEmail: string; invitedEmail: string }
   | { status: 'ready'; invitation: InvitationDetails }
   | { status: 'accepting' }
   | {
@@ -75,7 +73,6 @@ export const AcceptInvitation = (): ReactElement => {
 
   const invitationId = searchParams.get('invitationId');
   const loginComplete = searchParams.get('loginComplete') === 'true';
-  const loggedInEmail = searchParams.get('loggedInEmail') ?? '';
 
   const [state, setState] = useState<PageState>(
     loginComplete ? { status: 'verifying' } : { status: 'redirecting' },
@@ -99,7 +96,7 @@ export const AcceptInvitation = (): ReactElement => {
     void navigate(`/auth?invitationId=${invitationId}`);
   }, [loginComplete, invitationId, navigate]);
 
-  // Post-OAuth return: verify invitation and check logged-in email matches
+  // Post-OAuth return: verify invitation (email match is enforced server-side at accept time)
   useEffect(() => {
     if (!loginComplete) return;
 
@@ -115,14 +112,7 @@ export const AcceptInvitation = (): ReactElement => {
         );
 
         if (response.data.valid && response.data.invitation) {
-          const inv = response.data.invitation;
-
-          // Frontend email-match guard (backend also validates this on accept)
-          if (loggedInEmail && inv.email.toLowerCase() !== loggedInEmail.toLowerCase()) {
-            setState({ status: 'email_mismatch', loggedInEmail, invitedEmail: inv.email });
-          } else {
-            setState({ status: 'ready', invitation: inv });
-          }
+          setState({ status: 'ready', invitation: response.data.invitation });
         }
       } catch (error) {
         if (axios.isAxiosError<ApiErrorResponse>(error)) {
@@ -144,7 +134,7 @@ export const AcceptInvitation = (): ReactElement => {
     };
 
     void verify();
-  }, [loginComplete, invitationId, loggedInEmail]);
+  }, [loginComplete, invitationId]);
 
   const handleAccept = async (): Promise<void> => {
     if (!invitationId || state.status !== 'ready') return;
@@ -231,24 +221,6 @@ export const AcceptInvitation = (): ReactElement => {
                 ? 'Verifying invitation...'
                 : 'Accepting invitation...'}
           </p>
-        </div>
-      </div>
-    );
-  }
-
-  if (state.status === 'email_mismatch') {
-    return (
-      <div className='min-h-screen bg-background flex items-center justify-center p-4'>
-        <div className='max-w-md w-full bg-card border border-border rounded-lg p-8 text-center'>
-          <div className='w-16 h-16 bg-destructive/10 rounded-full flex items-center justify-center mx-auto mb-4'>
-            <XCircle className='w-8 h-8 text-destructive' />
-          </div>
-          <h1 className='text-2xl font-semibold text-foreground mb-2'>
-            You are not supposed to access this invitation
-          </h1>
-          <Button onClick={handleGoHome} className='w-full'>
-            Go to Home
-          </Button>
         </div>
       </div>
     );
@@ -377,9 +349,6 @@ export const AcceptInvitation = (): ReactElement => {
             <CheckCircle className='w-5 h-5 text-green-500' />
             <span className='text-sm text-foreground'>Invitation verified</span>
           </div>
-          <p className='text-sm text-muted-foreground'>
-            Email: <span className='text-foreground'>{invitation.email}</span>
-          </p>
           <p className='text-sm text-muted-foreground'>
             Role:{' '}
             <span className='text-foreground capitalize'>{invitation.role?.toLowerCase()}</span>


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

fix: XYNE-54830 block invitation-accept role overwrite and cross-org member move

acceptInvitation silently overwrote an existing active member's role and could relocate an already-active OrgMember into a different org just by having them accept a new invitation. Both are now rejected outright unless the existing record had already left (leftAt set), which is a legitimate rejoin rather than a hijack/escalation path.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

fix: enforce ACL on classification_mappings desk-config writes (M2)

Zero writes to classification_mappings fell through to the permissive DenyGuestsACL default, so any non-guest workspace member could create/update/delete another channel's desk routing config (the client canManage check was the only gate). Add ClassificationMappingsACL mirroring EmailChannelPreferencesACL: allow only the desk owner (email_channel_preferences.ownerUserId) or a channel admin, scoped to the caller's workspace; update/delete resolve the row's channelId first. Register it in ACLFactory. All writes to this table go through Zero (verified: no REST/Prisma/raw-SQL path), so the ACL fully covers it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

fix: XYNE-54830 typecheck

Services-Requiring-Redeployment:
  - backend

fix: XYNE-54830 resolved comments

fix: XYNE-54830 minor fix

Services-Requiring-Redeployment:
  - backend

fix: XYNE-54830 resolving comment

fix: XYNE-54830 remove jwtid

fix: XYNE-54830 remove temp

fix: XYNE-54830 remove unnecessary

Services-Requiring-Redeployment:
  - backend

fix: XYNE-54830 remove all

Services-Requiring-Redeployment:
  - backend

fix: XYNE-54830 add jwt in email only

Services-Requiring-Redeployment:
  - backend

fix: XYNE-54830 minor change

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
