### PR TITLE
Feature/build images workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,176 @@
+name: Build Images
+
+# Build-only, MANUAL-only. Builds the production container images to validate the
+# Dockerfiles build end to end for every supported architecture. It intentionally
+# does NOT push anywhere yet — `push: false`. A destination is decided later; the
+# push wiring is sketched at the bottom of this file.
+#
+# Inputs (chosen in the "Run workflow" dialog):
+#   - branch/tag: GitHub's built-in picker — build from ANY ref you select.
+#   - image: which image to build (all / backend / dashboard / xyne-claw).
+#
+# Access control (only specific team members may build):
+#   Trigger is manual-only, so nothing runs on merges — no approvals pile up.
+#   A run is allowed only if the person who launched it is listed in the
+#   `IMAGE_BUILDERS` Actions variable (comma-separated GitHub usernames). Anyone
+#   else fails instantly — no pending-approval queue, no extra clicks. Edit the
+#   allowed list in Settings → Secrets and variables → Actions → Variables, no
+#   code change needed. (When publishing is enabled later, add an `environment:`
+#   approval gate on top of this — a human "yes" is worth it before pushing.)
+#
+# Multi-arch: images build for linux/amd64 AND linux/arm64 (arm64 via QEMU
+# emulation), so the open-source images run on any system/architecture. A
+# multi-platform build is validated without exporting while push is false.
+#
+# Build context is the REPO ROOT (`.`) for every image — each Dockerfile COPYs
+# the root package.json / pnpm-lock.yaml / workspace packages, so `-f
+# apps/<app>/Dockerfile` with `context: .` is required, not the app dir.
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: Which image to build
+        type: choice
+        default: all
+        options:
+          - all
+          - backend
+          - dashboard
+          - xyne-claw
+
+permissions:
+  contents: read
+
+# One image build at a time.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  # Cheap gate job: checks the launcher is allowed AND resolves the matrix from
+  # the chosen `image` input, BEFORE spinning up the heavy multi-arch builds.
+  prepare:
+    name: Authorize + resolve images
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - name: Restrict to allowed image builders
+        env:
+          ALLOWED: ${{ vars.IMAGE_BUILDERS }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [ -z "${ALLOWED}" ]; then
+            echo "::error::vars.IMAGE_BUILDERS is not set. Add a repo/org Actions variable listing the comma-separated GitHub usernames allowed to build images."
+            exit 1
+          fi
+          # Case-insensitive membership check; tolerant of comma/space separators.
+          actor_lc="$(printf '%s' "${ACTOR}" | tr 'A-Z' 'a-z')"
+          match=0
+          IFS=', ' read -r -a list <<< "${ALLOWED}"
+          for u in "${list[@]}"; do
+            [ -z "$u" ] && continue
+            if [ "$(printf '%s' "$u" | tr 'A-Z' 'a-z')" = "${actor_lc}" ]; then
+              match=1; break
+            fi
+          done
+          if [ "$match" -ne 1 ]; then
+            echo "::error::${ACTOR} is not authorized to build images. Allowed: ${ALLOWED}"
+            exit 1
+          fi
+          echo "Authorized: ${ACTOR}"
+
+      - name: Resolve build matrix from input
+        id: set
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          # "all" fans out to every image; a specific choice builds just that one.
+          case "${IMAGE}" in
+            all)                          names='["backend","dashboard","xyne-claw"]' ;;
+            backend|dashboard|xyne-claw)  names="[\"${IMAGE}\"]" ;;
+            *) echo "::error::Unknown image '${IMAGE}'"; exit 1 ;;
+          esac
+          echo "matrix={\"name\":${names}}" >> "$GITHUB_OUTPUT"
+          echo "Building: ${names}"
+
+  build:
+    name: Build ${{ matrix.name }} image
+    needs: prepare
+    runs-on: ubuntu-latest
+    # tsc / vite inside the builder stages need a larger V8 heap (mirrors ci.yml).
+    env:
+      NODE_OPTIONS: "--max-old-space-size=8192"
+    strategy:
+      # Build every selected image even if one fails, so one broken Dockerfile
+      # doesn't hide the status of the others.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      # QEMU registers emulators so linux/arm64 can be built on an amd64 runner.
+      - uses: docker/setup-qemu-action@v3
+
+      # buildx enables multi-platform builds + layer caching (type=gha).
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.name }} image (multi-arch, no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # All three Dockerfiles live at apps/<name>/Dockerfile.
+          file: apps/${{ matrix.name }}/Dockerfile
+          # BUILD ONLY — do not push. Multi-platform builds cannot be loaded into
+          # the local docker daemon, so nothing is exported; the build itself is
+          # the validation. Flip to true (+ registry login + tags) when a
+          # destination is chosen.
+          push: false
+          # Open-source images: build for every supported architecture.
+          platforms: linux/amd64,linux/arm64
+          # dashboard bakes the commit into the client bundle; others need no args.
+          build-args: ${{ matrix.name == 'dashboard' && format('SOURCE_COMMIT={0}', github.sha) || '' }}
+          # Speed up reruns by caching layers in the Actions cache, scoped per image.
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Build ${{ matrix.name }} image"
+            echo ""
+            echo "- **Dockerfile:** \`apps/${{ matrix.name }}/Dockerfile\`"
+            echo "- **Context:** repo root (\`.\`)"
+            echo "- **Platforms:** linux/amd64, linux/arm64"
+            echo "- **Pushed:** no (build-only)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+# ---------------------------------------------------------------------------
+# When you decide WHERE to publish (e.g. ghcr.io), the push wiring is:
+#
+#   permissions:
+#     contents: read
+#     packages: write          # for GHCR
+#
+#   build:
+#     environment: release-publish   # ADD an approval gate for publishing
+#     steps:
+#       - uses: docker/login-action@v3
+#         with:
+#           registry: ghcr.io
+#           username: ${{ github.actor }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
+#       - uses: docker/metadata-action@v5   # generates release-*/sha-*/latest tags
+#         id: meta
+#         with:
+#           images: ghcr.io/${{ github.repository_owner }}/xyne-spaces-${{ matrix.name }}
+#       - uses: docker/build-push-action@v6
+#         with:
+#           push: true
+#           tags: ${{ steps.meta.outputs.tags }}
+#           platforms: linux/amd64,linux/arm64
+#           ...
+# The IMAGE_BUILDERS gate still restricts WHO can run it; the environment adds a
+# human approval step specifically for the push.
+# ---------------------------------------------------------------------------

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,30 +1,12 @@
 name: Build Images
 
-# Build-only, MANUAL-only. Builds the production container images to validate the
-# Dockerfiles build end to end for every supported architecture. It intentionally
-# does NOT push anywhere yet — `push: false`. A destination is decided later; the
-# push wiring is sketched at the bottom of this file.
-#
-# Inputs (chosen in the "Run workflow" dialog):
-#   - branch/tag: GitHub's built-in picker — build from ANY ref you select.
-#   - image: which image to build (all / backend / dashboard / xyne-claw).
-#
-# Access control (only specific team members may build):
-#   Trigger is manual-only, so nothing runs on merges — no approvals pile up.
-#   A run is allowed only if the person who launched it is listed in the
-#   `IMAGE_BUILDERS` Actions variable (comma-separated GitHub usernames). Anyone
-#   else fails instantly — no pending-approval queue, no extra clicks. Edit the
-#   allowed list in Settings → Secrets and variables → Actions → Variables, no
-#   code change needed. (When publishing is enabled later, add an `environment:`
-#   approval gate on top of this — a human "yes" is worth it before pushing.)
-#
-# Multi-arch: images build for linux/amd64 AND linux/arm64 (arm64 via QEMU
-# emulation), so the open-source images run on any system/architecture. A
-# multi-platform build is validated without exporting while push is false.
-#
-# Build context is the REPO ROOT (`.`) for every image — each Dockerfile COPYs
-# the root package.json / pnpm-lock.yaml / workspace packages, so `-f
-# apps/<app>/Dockerfile` with `context: .` is required, not the app dir.
+# Build-only, manual-only: validates the app images build. Does NOT push yet
+# (push: false); publish wiring is sketched at the bottom.
+# - Inputs: ref picker (any branch/tag) + image (all / backend / dashboard / xyne-claw).
+# - Access: only usernames in the IMAGE_BUILDERS Actions variable may run it.
+# - amd64 only, matching the internal Jenkins pipeline (arm64 would need QEMU and
+#   OOMs tsc/vite on the 16 GB runner; amd64 still runs on arm64 via emulation).
+# - Build context is the repo root (.) — Dockerfiles COPY root manifests.
 on:
   workflow_dispatch:
     inputs:
@@ -41,14 +23,12 @@ on:
 permissions:
   contents: read
 
-# One image build at a time.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
-  # Cheap gate job: checks the launcher is allowed AND resolves the matrix from
-  # the chosen `image` input, BEFORE spinning up the heavy multi-arch builds.
+  # Cheap gate: authorize the launcher + resolve the matrix before heavy builds.
   prepare:
     name: Authorize + resolve images
     runs-on: ubuntu-latest
@@ -61,10 +41,10 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: |
           if [ -z "${ALLOWED}" ]; then
-            echo "::error::vars.IMAGE_BUILDERS is not set. Add a repo/org Actions variable listing the comma-separated GitHub usernames allowed to build images."
+            echo "::error::vars.IMAGE_BUILDERS is not set. Add an Actions variable with the comma-separated GitHub usernames allowed to build images."
             exit 1
           fi
-          # Case-insensitive membership check; tolerant of comma/space separators.
+          # Case-insensitive; tolerant of comma/space separators.
           actor_lc="$(printf '%s' "${ACTOR}" | tr 'A-Z' 'a-z')"
           match=0
           IFS=', ' read -r -a list <<< "${ALLOWED}"
@@ -85,7 +65,6 @@ jobs:
         env:
           IMAGE: ${{ inputs.image }}
         run: |
-          # "all" fans out to every image; a specific choice builds just that one.
           case "${IMAGE}" in
             all)                          names='["backend","dashboard","xyne-claw"]' ;;
             backend|dashboard|xyne-claw)  names="[\"${IMAGE}\"]" ;;
@@ -98,39 +77,26 @@ jobs:
     name: Build ${{ matrix.name }} image
     needs: prepare
     runs-on: ubuntu-latest
-    # tsc / vite inside the builder stages need a larger V8 heap (mirrors ci.yml).
+    # tsc / vite need a larger V8 heap (mirrors ci.yml).
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
     strategy:
-      # Build every selected image even if one fails, so one broken Dockerfile
-      # doesn't hide the status of the others.
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v5
 
-      # QEMU registers emulators so linux/arm64 can be built on an amd64 runner.
-      - uses: docker/setup-qemu-action@v3
-
-      # buildx enables multi-platform builds + layer caching (type=gha).
       - uses: docker/setup-buildx-action@v3
 
-      - name: Build ${{ matrix.name }} image (multi-arch, no push)
+      - name: Build ${{ matrix.name }} image (amd64, no push)
         uses: docker/build-push-action@v6
         with:
           context: .
-          # All three Dockerfiles live at apps/<name>/Dockerfile.
           file: apps/${{ matrix.name }}/Dockerfile
-          # BUILD ONLY — do not push. Multi-platform builds cannot be loaded into
-          # the local docker daemon, so nothing is exported; the build itself is
-          # the validation. Flip to true (+ registry login + tags) when a
-          # destination is chosen.
           push: false
-          # Open-source images: build for every supported architecture.
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           # dashboard bakes the commit into the client bundle; others need no args.
           build-args: ${{ matrix.name == 'dashboard' && format('SOURCE_COMMIT={0}', github.sha) || '' }}
-          # Speed up reruns by caching layers in the Actions cache, scoped per image.
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
@@ -141,8 +107,7 @@ jobs:
             echo "### Build ${{ matrix.name }} image"
             echo ""
             echo "- **Dockerfile:** \`apps/${{ matrix.name }}/Dockerfile\`"
-            echo "- **Context:** repo root (\`.\`)"
-            echo "- **Platforms:** linux/amd64, linux/arm64"
+            echo "- **Platform:** linux/amd64"
             echo "- **Pushed:** no (build-only)"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -169,7 +134,8 @@ jobs:
 #         with:
 #           push: true
 #           tags: ${{ steps.meta.outputs.tags }}
-#           platforms: linux/amd64,linux/arm64
+#           platforms: linux/amd64   # add linux/arm64 here (+ setup-qemu) only if
+#                                     # native ARM images are needed at publish time
 #           ...
 # The IMAGE_BUILDERS gate still restricts WHO can run it; the environment adds a
 # human approval step specifically for the push.


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
