### PR TITLE
fix: XYNE-55416 desk analytics improvement

### DIFF
--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -15,7 +15,7 @@ import {
   type DeskMetricsContribution,
 } from '../services/deskMetricsAggregator.js';
 import { logger } from '../utils/logger.js';
-import { DESK_METRICS_MAX_AGGREGATE_DESKS } from '@xyne/shared';
+import { DESK_METRICS_MAX_AGGREGATE_DESKS, TicketPriority } from '@xyne/shared';
 import type {
   DeskMetricsAggregateResponse,
   DeskMetricsResponse,
@@ -23,11 +23,16 @@ import type {
 } from '@xyne/shared';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const MAX_CUSTOM_RANGE_MS = 31 * DAY_MS;
+const MAX_CUSTOM_RANGE_MS = 90 * DAY_MS;
 
 type CustomFieldFilterArg = {
   keys: string[];
   perKeyFilters?: Record<string, { values?: string[]; textTerms?: string[] }>;
+};
+
+const getStringQueryParam = (req: Request, name: string): string | undefined => {
+  const value = req.query[name];
+  return typeof value === 'string' ? value : undefined;
 };
 
 export class DeskMetricsController {
@@ -45,13 +50,19 @@ export class DeskMetricsController {
   private parseMetricsQuery(
     req: Request,
   ):
-    | { ok: true; timeRange: string; assigneeId: string | null; customFieldFilter?: CustomFieldFilterArg }
+    | {
+        ok: true;
+        timeRange: string;
+        assigneeIds: string[];
+        stageNames: string[];
+        priorities: TicketPriority[];
+        userGroupIds: string[];
+        customFieldFilter?: CustomFieldFilterArg;
+      }
     | { ok: false; error: string } {
       const defaultEndMs = Date.now();
       const rawTimeRange =
-        typeof req.query.timeRange === 'string'
-          ? req.query.timeRange
-          : `${defaultEndMs - 7 * DAY_MS}_${defaultEndMs}`;
+        getStringQueryParam(req, 'timeRange') ?? `${defaultEndMs - 7 * DAY_MS}_${defaultEndMs}`;
       const parts = rawTimeRange.split('_');
       if (parts.length !== 2) {
         return { ok: false, error: 'Invalid timeRange. Use startMs_endMs' };
@@ -64,12 +75,13 @@ export class DeskMetricsController {
         return { ok: false, error: 'Invalid time range' };
       }
       if (toMs - fromMs > MAX_CUSTOM_RANGE_MS) {
-        return { ok: false, error: 'Custom time range cannot exceed 31 days' };
+        return { ok: false, error: 'Custom time range cannot exceed 90 days' };
       }
       const timeRange = rawTimeRange;
-      const assigneeId = typeof req.query.assigneeId === 'string' ? req.query.assigneeId : null;
 
-      const parseJsonStringArray = (raw: string): string[] => {
+      const parseJsonStringArray = (raw?: string): string[] => {
+        if (!raw) return [];
+
         try {
           const parsed: unknown = JSON.parse(raw);
           if (!Array.isArray(parsed)) return [];
@@ -78,12 +90,27 @@ export class DeskMetricsController {
           return [];
         }
       };
-      const rawKeys = typeof req.query.customFieldKeys === 'string' ? req.query.customFieldKeys : '';
-      const customFieldKeys = parseJsonStringArray(rawKeys);
 
-      const parsePerKeyFilters = (raw: string): Record<string, { values?: string[]; textTerms?: string[] }> => {
+      const rawAssigneeIds = getStringQueryParam(req, 'assigneeIds');
+      const legacyAssigneeId = getStringQueryParam(req, 'assigneeId');
+      const assigneeIds = rawAssigneeIds
+        ? parseJsonStringArray(rawAssigneeIds)
+        : legacyAssigneeId
+          ? [legacyAssigneeId]
+          : [];
+      const stageNames = parseJsonStringArray(getStringQueryParam(req, 'stageNames'));
+      const validPriorities = new Set<string>(Object.values(TicketPriority));
+      const priorities = parseJsonStringArray(getStringQueryParam(req, 'priorities')).filter(
+        (priority): priority is TicketPriority => validPriorities.has(priority),
+      );
+      const userGroupIds = parseJsonStringArray(getStringQueryParam(req, 'userGroupIds'));
+      const customFieldKeys = parseJsonStringArray(getStringQueryParam(req, 'customFieldKeys'));
+
+      const parsePerKeyFilters = (
+        raw?: string,
+      ): Record<string, { values?: string[]; textTerms?: string[] }> => {
         try {
-          const parsed = JSON.parse(raw) as Record<string, unknown>;
+          const parsed = JSON.parse(raw ?? '') as Record<string, unknown>;
           if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
           const result: Record<string, { values?: string[]; textTerms?: string[] }> = {};
           for (const [k, v] of Object.entries(parsed)) {
@@ -99,11 +126,14 @@ export class DeskMetricsController {
             result[k] = entry;
           }
           return result;
-        } catch { return {}; }
+        } catch {
+          return {};
+        }
       };
 
-      const rawPerKey = typeof req.query.customFieldPerKeyFilters === 'string' ? req.query.customFieldPerKeyFilters : '';
-      const perKeyFilters = rawPerKey ? parsePerKeyFilters(rawPerKey) : {};
+      const perKeyFilters = parsePerKeyFilters(
+        getStringQueryParam(req, 'customFieldPerKeyFilters'),
+      );
       const customFieldFilter =
         customFieldKeys.length > 0
           ? { keys: customFieldKeys, ...(Object.keys(perKeyFilters).length > 0 ? { perKeyFilters } : {}) }
@@ -112,7 +142,10 @@ export class DeskMetricsController {
       return {
         ok: true,
         timeRange,
-        assigneeId,
+        assigneeIds,
+        stageNames,
+        priorities,
+        userGroupIds,
         ...(customFieldFilter ? { customFieldFilter } : {}),
       };
   }
@@ -120,7 +153,14 @@ export class DeskMetricsController {
   private async metricsForChannel(
     channelId: string,
     preference: { frtStageNames?: string | null },
-    query: { timeRange: string; assigneeId: string | null; customFieldFilter?: CustomFieldFilterArg },
+    query: {
+      timeRange: string;
+      assigneeIds: string[];
+      stageNames: string[];
+      priorities: TicketPriority[];
+      userGroupIds: string[];
+      customFieldFilter?: CustomFieldFilterArg;
+    },
   ): Promise<DeskMetricsResponse> {
     const frtStageNames: string[] = (() => {
       try {
@@ -135,7 +175,10 @@ export class DeskMetricsController {
       channelId,
       timeRange: query.timeRange,
       frtStageNames,
-      assigneeId: query.assigneeId,
+      assigneeIds: query.assigneeIds,
+      stageNames: query.stageNames,
+      priorities: query.priorities,
+      userGroupIds: query.userGroupIds,
       customFieldFilter: query.customFieldFilter,
     });
   }
@@ -171,7 +214,7 @@ export class DeskMetricsController {
   };
 
   getAggregateMetrics = async (req: Request, res: Response): Promise<void> => {
-    const rawIds = typeof req.query.channelIds === 'string' ? req.query.channelIds : '';
+    const rawIds = getStringQueryParam(req, 'channelIds') ?? '';
     const channelIds = [
       ...new Set(
         rawIds

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -75,7 +75,7 @@ export class DeskMetricsController {
         return { ok: false, error: 'Invalid time range' };
       }
       if (toMs - fromMs > MAX_CUSTOM_RANGE_MS) {
-        return { ok: false, error: 'Custom time range cannot exceed 90 days' };
+        return { ok: false, error: 'Custom time range cannot exceed 30 days' };
       }
       const timeRange = rawTimeRange;
 

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -23,7 +23,7 @@ import type {
 } from '@xyne/shared';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const MAX_CUSTOM_RANGE_MS = 90 * DAY_MS;
+const MAX_CUSTOM_RANGE_MS = 31 * DAY_MS;
 
 type CustomFieldFilterArg = {
   keys: string[];

--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -1,6 +1,12 @@
 import { Prisma } from '@prisma/client';
 import { DatabaseClient, readReplicaDb } from '../client';
-import { DeskMetricsAgentRow, DeskMetricsResponse, DeskMetricsTicketRow, TicketStatusV2 } from '@xyne/shared';
+import {
+  DeskMetricsAgentRow,
+  DeskMetricsResponse,
+  DeskMetricsTicketRow,
+  TicketPriority,
+  TicketStatusV2,
+} from '@xyne/shared';
 import { logger } from '@/utils/logger';
 
 /**
@@ -21,10 +27,11 @@ import { logger } from '@/utils/logger';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-const activeTicketFilter = (assigneeId?: string | null): Prisma.Sql => {
-  const assigneeCondition = assigneeId
-    ? Prisma.sql`AND t."assignedTo" = ${assigneeId}`
-    : Prisma.sql``;
+const activeTicketFilter = (assigneeIds: string[] = []): Prisma.Sql => {
+  const assigneeCondition =
+    assigneeIds.length > 0
+      ? Prisma.sql`AND t."assignedTo" IN (${Prisma.join(assigneeIds)})`
+      : Prisma.sql``;
 
   return Prisma.sql`AND EXISTS (
     SELECT 1
@@ -67,18 +74,31 @@ export class DeskMetricsRepository {
     channelId: string;
     timeRange?: string;
     frtStageNames: string[];
-    assigneeId?: string | null;
-    customFieldFilter?: { keys: string[]; perKeyFilters?: Record<string, { values?: string[]; textTerms?: string[] }> };
+    assigneeIds: string[];
+    stageNames: string[];
+    priorities: TicketPriority[];
+    userGroupIds: string[];
+    customFieldFilter?: {
+      keys: string[];
+      perKeyFilters?: Record<string, { values?: string[]; textTerms?: string[] }>;
+    };
   }): Promise<DeskMetricsResponse> {
-    const { channelId, frtStageNames, assigneeId, customFieldFilter } = params;
+    const {
+      channelId,
+      frtStageNames,
+      assigneeIds,
+      stageNames,
+      priorities,
+      userGroupIds,
+      customFieldFilter,
+    } = params;
     const db = this.getDbInstance();
     const { gte, lte } = this.resolveRange(params.timeRange);
 
     // "__emailReply" sentinel: include email-reply arm in FRT stop.
     // When frtStageNames is empty (legacy), treat as email-only (backward compat).
-    const includeEmailReply =
-      frtStageNames.length === 0 || frtStageNames.includes('__emailReply');
-    const stageNames = frtStageNames.filter(n => n !== '__emailReply');
+    const includeEmailReply = frtStageNames.length === 0 || frtStageNames.includes('__emailReply');
+    const frtStopStageNames = frtStageNames.filter((name) => name !== '__emailReply');
 
     const stageEntryPredicate = (names: string[]): Prisma.Sql =>
       Prisma.sql`(
@@ -91,17 +111,18 @@ export class DeskMetricsRepository {
         (SELECT MIN(ta."timestamp") FROM "public"."ticket_activities" ta
           WHERE ta."ticketId" = c."ticketId" AND ta."activityType" = 'EMAIL_SENT'
             AND ta."timestamp" > c.created_at)`;
-      if (!includeEmailReply && stageNames.length === 0) return Prisma.sql`NULL::timestamptz`;
+      if (!includeEmailReply && frtStopStageNames.length === 0)
+        return Prisma.sql`NULL::timestamptz`;
       if (!includeEmailReply) {
         return Prisma.sql`
           (SELECT MIN(ta."timestamp") FROM "public"."ticket_activities" ta
-            WHERE ta."ticketId" = c."ticketId" AND ${stageEntryPredicate(stageNames)}
+            WHERE ta."ticketId" = c."ticketId" AND ${stageEntryPredicate(frtStopStageNames)}
               AND ta."timestamp" > c.created_at)`;
       }
-      if (stageNames.length === 0) return emailArm;
+      if (frtStopStageNames.length === 0) return emailArm;
       return Prisma.sql`LEAST(${emailArm},
         (SELECT MIN(ta."timestamp") FROM "public"."ticket_activities" ta
-          WHERE ta."ticketId" = c."ticketId" AND ${stageEntryPredicate(stageNames)}
+          WHERE ta."ticketId" = c."ticketId" AND ${stageEntryPredicate(frtStopStageNames)}
             AND ta."timestamp" > c.created_at))`;
     };
 
@@ -134,9 +155,7 @@ export class DeskMetricsRepository {
         AND ${reopenedPredicate}
     )`;
 
-    // Cohort: tickets created in range. Optionally filtered by assignee and/or custom field.
-    const ticketFilter = activeTicketFilter(assigneeId);
-
+    // Cohort: active tickets created in range, optionally scoped by the selected filters.
     let customFieldExists: Prisma.Sql = Prisma.sql``;
     if (customFieldFilter && customFieldFilter.keys.length > 0) {
       // Value conditions — OR across keys that have values/terms selected
@@ -151,18 +170,28 @@ export class DeskMetricsRepository {
         let valueCondition: Prisma.Sql;
         if (hasTerms) {
           // OR across all text terms within this field
-          valueCondition = kf!.textTerms!
-            .map(t => Prisma.sql`${fieldCol} ILIKE ${'%' + t + '%'}`)
-            .reduce((or, c, i) => i === 0 ? c : Prisma.sql`${or} OR ${c}`);
+          valueCondition = kf!
+            .textTerms!.map((t) => Prisma.sql`${fieldCol} ILIKE ${'%' + t + '%'}`)
+            .reduce((or, c, i) => (i === 0 ? c : Prisma.sql`${or} OR ${c}`));
         } else {
-          valueCondition = Prisma.sql`${fieldCol} IN (${Prisma.join(kf!.values!)})`;
+          valueCondition = Prisma.sql`(
+            ${fieldCol} IN (${Prisma.join(kf!.values!)})
+            OR (
+              jsonb_typeof(fev."actualFieldValue") = 'array'
+              AND jsonb_exists_any(
+                fev."actualFieldValue",
+                ARRAY[${Prisma.join(kf!.values!)}]::text[]
+              )
+            )
+          )`;
         }
         valueConditions.push(Prisma.sql`(${fieldNameMatch} AND (${valueCondition}))`);
       }
       // Single EXISTS: field-level pre-filter (fieldName IN keys) + optional value-level AND
-      const valueClause = valueConditions.length > 0
-        ? Prisma.sql`AND (${valueConditions.reduce((or, c, i) => i === 0 ? c : Prisma.sql`${or} OR ${c}`)})`
-        : Prisma.sql``;
+      const valueClause =
+        valueConditions.length > 0
+          ? Prisma.sql`AND (${valueConditions.reduce((or, c, i) => (i === 0 ? c : Prisma.sql`${or} OR ${c}`))})`
+          : Prisma.sql``;
       customFieldExists = Prisma.sql`AND EXISTS (
           SELECT 1 FROM "public"."form_entity_values" fev
           LEFT JOIN "public"."global_fields" gf ON gf.id = fev."fieldId"
@@ -174,6 +203,36 @@ export class DeskMetricsRepository {
         )`;
     }
 
+    const ticketAttributeConditions: Prisma.Sql[] = [];
+    if (stageNames.length > 0) {
+      ticketAttributeConditions.push(
+        Prisma.sql`filter_ticket."stageName" IN (${Prisma.join(stageNames)})`
+      );
+    }
+    if (priorities.length > 0) {
+      ticketAttributeConditions.push(
+        Prisma.sql`filter_ticket.priority IN (${Prisma.join(priorities)})`
+      );
+    }
+    if (userGroupIds.length > 0) {
+      ticketAttributeConditions.push(
+        Prisma.sql`filter_ticket."userGroupId" IN (${Prisma.join(userGroupIds)})`
+      );
+    }
+    const ticketAttributeExists =
+      ticketAttributeConditions.length > 0
+        ? Prisma.sql`AND EXISTS (
+            SELECT 1 FROM "public"."tickets" filter_ticket
+            WHERE filter_ticket.id = ta."ticketId"
+              AND ${ticketAttributeConditions.reduce(
+                (condition, next) => Prisma.sql`${condition} AND ${next}`
+              )}
+          )`
+        : Prisma.sql``;
+    const ticketScopeExists = Prisma.sql`${activeTicketFilter(
+      assigneeIds
+    )} ${ticketAttributeExists} ${customFieldExists}`;
+
     const cohortCte = Prisma.sql`
       cohort AS (
         SELECT ta."ticketId", ta."timestamp" AS created_at
@@ -181,19 +240,19 @@ export class DeskMetricsRepository {
         WHERE ta."channelId" = ${channelId}
           AND ta."activityType" = 'TICKET_CREATED'
           AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-          ${ticketFilter}
-          ${customFieldExists}
+          ${ticketScopeExists}
       )`;
 
     const frtStop = frtStopSql();
-    const [aggregates, tickets, emailRepliesInRange, stageCounts, priority, csat, agents] =
+    const [aggregates, tickets, emailRepliesInRange, stageCounts, priority, csat, trend, agents] =
       await Promise.all([
         this.frtRtAggregates(db, cohortCte, frtStop, resolvedAtSql),
         this.ticketRows(db, cohortCte, frtStop, resolvedAtSql),
-        this.emailRepliesCount(db, channelId, gte, lte, assigneeId, customFieldExists),
+        this.emailRepliesCount(db, channelId, gte, lte, ticketScopeExists),
         this.stageCounts(db, cohortCte),
         this.priorityBreakdown(db, cohortCte),
-        this.csatStats(db, channelId, gte, lte, assigneeId, customFieldExists),
+        this.csatStats(db, channelId, gte, lte, ticketScopeExists),
+        this.trendByDay(db, channelId, gte, lte, resolvedPredicate, ticketScopeExists),
         this.agentPerformance(
           db,
           cohortCte,
@@ -203,8 +262,8 @@ export class DeskMetricsRepository {
           channelId,
           gte,
           lte,
-          assigneeId,
-          customFieldExists,
+          assigneeIds,
+          ticketScopeExists
         ),
       ]);
 
@@ -219,7 +278,7 @@ export class DeskMetricsRepository {
         stageCounts,
       },
       priority,
-      trend: [],
+      trend,
       tickets,
       agents,
     };
@@ -233,7 +292,7 @@ export class DeskMetricsRepository {
       where: { boardId, defaultTicketStatusV2: TicketStatusV2.COMPLETED },
       select: { name: true },
     });
-    return stages.map(s => s.name);
+    return stages.map((s) => s.name);
   }
 
   private async boardIdForChannel(channelId: string): Promise<string | null> {
@@ -255,7 +314,7 @@ export class DeskMetricsRepository {
     db: ReturnType<DeskMetricsRepository['getDbInstance']>,
     cohortCte: Prisma.Sql,
     frtStopSql: Prisma.Sql,
-    resolvedAtSql: Prisma.Sql,
+    resolvedAtSql: Prisma.Sql
   ): Promise<{
     opened: number;
     avgFrt: number | null;
@@ -287,7 +346,7 @@ export class DeskMetricsRepository {
             FILTER (WHERE resolved_at IS NOT NULL AND resolved_at >= created_at)::float AS avg_rt,
           COUNT(*) FILTER (WHERE resolved_at IS NOT NULL AND resolved_at >= created_at)::int AS resolved
         FROM per_ticket
-      `,
+      `
     );
     const r = rows[0];
     return {
@@ -303,7 +362,7 @@ export class DeskMetricsRepository {
     db: ReturnType<DeskMetricsRepository['getDbInstance']>,
     cohortCte: Prisma.Sql,
     frtStopSql: Prisma.Sql,
-    resolvedAtSql: Prisma.Sql,
+    resolvedAtSql: Prisma.Sql
   ): Promise<DeskMetricsTicketRow[]> {
     const rows = await db.$queryRaw<
       Array<{
@@ -365,9 +424,9 @@ export class DeskMetricsRepository {
         LEFT JOIN "public"."users" u ON u.id = t."assignedTo"
         LEFT JOIN form_vals fv ON fv.ticket_id = c."ticketId"
         ORDER BY c.created_at DESC
-      `,
+      `
     );
-    return rows.map(r => {
+    return rows.map((r) => {
       const rawScore = r.csat_value?.score;
       const score = typeof rawScore === 'string' ? Number(rawScore) : rawScore;
       return {
@@ -398,14 +457,13 @@ export class DeskMetricsRepository {
     channelId: string,
     gte: Date,
     lte: Date,
-    assigneeId?: string | null,
-    customFieldExists: Prisma.Sql = Prisma.sql``,
+    assigneeIds: string[],
+    customFieldExists: Prisma.Sql = Prisma.sql``
   ): Promise<DeskMetricsAgentRow[]> {
-    const replyActorFilter = assigneeId
-      ? Prisma.sql`AND ta."updatedBy" = ${assigneeId}`
-      : Prisma.sql``;
-    const ticketFilter = activeTicketFilter();
-
+    const replyActorFilter =
+      assigneeIds.length > 0
+        ? Prisma.sql`AND ta."updatedBy" IN (${Prisma.join(assigneeIds)})`
+        : Prisma.sql``;
     const [ownershipRows, replyRows, stageRows] = await Promise.all([
       db.$queryRaw<
         Array<{
@@ -467,7 +525,7 @@ export class DeskMetricsRepository {
             COUNT(*) FILTER (WHERE csat_rating = 'BAD')::int AS csat_bad
           FROM per_ticket
           GROUP BY assignee_id, assignee_name
-        `,
+        `
       ),
       db.$queryRaw<Array<{ user_id: string; user_name: string | null; replies: number }>>(
         Prisma.sql`
@@ -480,11 +538,10 @@ export class DeskMetricsRepository {
           WHERE ta."channelId" = ${channelId}
             AND ta."activityType" = 'EMAIL_SENT'
             AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-            ${ticketFilter}
             ${replyActorFilter}
             ${customFieldExists}
           GROUP BY ta."updatedBy", COALESCE(u."displayName", u.name)
-        `,
+        `
       ),
       db.$queryRaw<Array<{ assignee_id: string | null; stage_name: string; count: number }>>(
         Prisma.sql`
@@ -497,7 +554,7 @@ export class DeskMetricsRepository {
           JOIN "public"."tickets" t ON t.id = c."ticketId"
           WHERE t."isArchived" = false
           GROUP BY t."assignedTo", t."stageName"
-        `,
+        `
       ),
     ]);
 
@@ -557,27 +614,27 @@ export class DeskMetricsRepository {
       });
     }
 
-    const rows = [...byAgent.values()].filter(a => !assigneeId || a.assigneeId === assigneeId);
+    const rows = [...byAgent.values()].filter(
+      (agent) => assigneeIds.length === 0 || assigneeIds.includes(agent.assigneeId ?? '')
+    );
     rows.sort(
       (a, b) =>
         b.assigned - a.assigned ||
         b.resolved - a.resolved ||
         b.emailReplies - a.emailReplies ||
-        (a.assigneeName ?? '').localeCompare(b.assigneeName ?? ''),
+        (a.assigneeName ?? '').localeCompare(b.assigneeName ?? '')
     );
     return rows;
   }
 
-  /** Count email replies sent in range, optionally scoped to tickets assigned to assigneeId and/or matching a custom field. */
+  /** Count email replies sent in range, optionally scoped by assignee and/or ticket filters. */
   private async emailRepliesCount(
     db: ReturnType<DeskMetricsRepository['getDbInstance']>,
     channelId: string,
     gte: Date,
     lte: Date,
-    assigneeId?: string | null,
-    customFieldExists: Prisma.Sql = Prisma.sql``,
+    customFieldExists: Prisma.Sql = Prisma.sql``
   ): Promise<number> {
-    const ticketFilter = activeTicketFilter(assigneeId);
     const rows = await db.$queryRaw<Array<{ count: number }>>(
       Prisma.sql`
         SELECT COUNT(*)::int AS count
@@ -585,9 +642,8 @@ export class DeskMetricsRepository {
         WHERE ta."channelId" = ${channelId}
           AND ta."activityType" = 'EMAIL_SENT'
           AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-          ${ticketFilter}
           ${customFieldExists}
-      `,
+      `
     );
     return rows[0]?.count ?? 0;
   }
@@ -595,7 +651,7 @@ export class DeskMetricsRepository {
   /** Cohort-scoped: current stage of tickets created in the selected range. */
   private async stageCounts(
     db: ReturnType<DeskMetricsRepository['getDbInstance']>,
-    cohortCte: Prisma.Sql,
+    cohortCte: Prisma.Sql
   ): Promise<Array<{ stageName: string; count: number }>> {
     const rows = await db.$queryRaw<Array<{ stage_name: string; count: number }>>(
       Prisma.sql`
@@ -606,14 +662,14 @@ export class DeskMetricsRepository {
         WHERE t."isArchived" = false
         GROUP BY t."stageName"
         ORDER BY count DESC
-      `,
+      `
     );
-    return rows.map(r => ({ stageName: r.stage_name, count: r.count }));
+    return rows.map((r) => ({ stageName: r.stage_name, count: r.count }));
   }
 
   private async priorityBreakdown(
     db: ReturnType<DeskMetricsRepository['getDbInstance']>,
-    cohortCte: Prisma.Sql,
+    cohortCte: Prisma.Sql
   ): Promise<Array<{ priority: string; count: number }>> {
     const rows = await db.$queryRaw<Array<{ priority: string; count: number }>>(
       Prisma.sql`
@@ -623,7 +679,7 @@ export class DeskMetricsRepository {
         JOIN "public"."tickets" t ON t.id = c."ticketId"
         GROUP BY t.priority
         ORDER BY count DESC
-      `,
+      `
     );
     return rows;
   }
@@ -633,10 +689,8 @@ export class DeskMetricsRepository {
     channelId: string,
     gte: Date,
     lte: Date,
-    assigneeId?: string | null,
-    customFieldExists: Prisma.Sql = Prisma.sql``,
+    customFieldExists: Prisma.Sql = Prisma.sql``
   ): Promise<{ avgScore: number | null; scoredResponses: number; good: number; bad: number }> {
-    const ticketFilter = activeTicketFilter(assigneeId);
     const rows = await db.$queryRaw<
       Array<{ avg_score: number | null; scored_responses: number; good: number; bad: number }>
     >(
@@ -650,9 +704,8 @@ export class DeskMetricsRepository {
         WHERE ta."channelId" = ${channelId}
           AND ta."activityType" = 'CSAT_RECEIVED'
           AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
-          ${ticketFilter}
           ${customFieldExists}
-      `,
+      `
     );
     return {
       avgScore: rows[0]?.avg_score ?? null,
@@ -662,6 +715,99 @@ export class DeskMetricsRepository {
     };
   }
 
+  private async trendByDay(
+    db: ReturnType<DeskMetricsRepository['getDbInstance']>,
+    channelId: string,
+    gte: Date,
+    lte: Date,
+    resolvedPredicate: Prisma.Sql,
+    customFieldExists: Prisma.Sql = Prisma.sql``
+  ): Promise<Array<{ date: string; opened: number; closed: number }>> {
+    const rangeDays = (lte.getTime() - gte.getTime()) / DAY_MS;
+    const hourly = rangeDays <= 1;
+    const bucketFn = hourly
+      ? Prisma.sql`to_char(date_trunc('hour', (ta."timestamp" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD HH24:00')`
+      : Prisma.sql`to_char(date_trunc('day',  (ta."timestamp" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD')`;
+    const bucketFnR = hourly
+      ? Prisma.sql`to_char(date_trunc('hour', (r.first_resolved AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD HH24:00')`
+      : Prisma.sql`to_char(date_trunc('day',  (r.first_resolved AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Kolkata'), 'YYYY-MM-DD')`;
+
+    const [openedRows, closedRows] = await Promise.all([
+      db.$queryRaw<Array<{ day: string; count: number }>>(
+        Prisma.sql`
+          SELECT ${bucketFn} AS day, COUNT(*)::int AS count
+          FROM "public"."ticket_activities" ta
+          WHERE ta."channelId" = ${channelId}
+            AND ta."activityType" = 'TICKET_CREATED'
+            AND ta."timestamp" >= ${gte} AND ta."timestamp" <= ${lte}
+            ${customFieldExists}
+          GROUP BY 1
+        `
+      ),
+      db.$queryRaw<Array<{ day: string; count: number }>>(
+        Prisma.sql`
+          SELECT ${bucketFnR} AS day, COUNT(*)::int AS count
+          FROM (
+            SELECT ta."ticketId", MAX(ta."timestamp") AS first_resolved
+            FROM "public"."ticket_activities" ta
+            WHERE ta."channelId" = ${channelId} AND ${resolvedPredicate}
+              ${customFieldExists}
+            GROUP BY ta."ticketId"
+          ) r
+          WHERE r.first_resolved >= ${gte} AND r.first_resolved <= ${lte}
+          GROUP BY 1
+        `
+      ),
+    ]);
+
+    const opened = new Map(openedRows.map((r) => [r.day, r.count]));
+    const closed = new Map(closedRows.map((r) => [r.day, r.count]));
+
+    // Fill all buckets so the chart has no gaps
+    const buckets: string[] = [];
+    const HOUR_MS = 60 * 60 * 1000;
+    const IST_TZ = 'Asia/Kolkata';
+    const toISTDateStr = (ms: number): string =>
+      new Date(ms).toLocaleDateString('en-CA', { timeZone: IST_TZ }); // → 'YYYY-MM-DD'
+    const toISTHourStr = (ms: number): string => {
+      const d = new Date(ms);
+      const date = d.toLocaleDateString('en-CA', { timeZone: IST_TZ });
+      const hour = d
+        .toLocaleTimeString('en-GB', { timeZone: IST_TZ, hour: '2-digit', minute: '2-digit' })
+        .slice(0, 2);
+      return `${date} ${hour}:00`;
+    };
+    const floorToISTDay = (ms: number): number =>
+      new Date(`${toISTDateStr(ms)}T00:00:00+05:30`).getTime();
+    const floorToISTHour = (ms: number): number => {
+      const d = new Date(ms);
+      const date = d.toLocaleDateString('en-CA', { timeZone: IST_TZ });
+      const hour = d
+        .toLocaleTimeString('en-GB', { timeZone: IST_TZ, hour: '2-digit', minute: '2-digit' })
+        .slice(0, 2);
+      return new Date(`${date}T${hour}:00:00+05:30`).getTime();
+    };
+
+    if (hourly) {
+      const startHour = floorToISTHour(gte.getTime());
+      const endHour = floorToISTHour(lte.getTime());
+      for (let t = startHour; t <= endHour; t += HOUR_MS) {
+        buckets.push(toISTHourStr(t));
+      }
+    } else {
+      const startDay = floorToISTDay(gte.getTime());
+      const endDay = floorToISTDay(lte.getTime());
+      for (let t = startDay; t <= endDay; t += DAY_MS) {
+        buckets.push(toISTDateStr(t));
+      }
+    }
+
+    return buckets.map((date) => ({
+      date,
+      opened: opened.get(date) ?? 0,
+      closed: closed.get(date) ?? 0,
+    }));
+  }
 }
 
 export const deskMetricsRepository = new DeskMetricsRepository();

--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -53,7 +53,7 @@ export class DeskMetricsRepository {
   }
 
   /**
-   * Extends the shared analytics presets ('today'/'7d'/'30d'/'90d'/custom)
+   * Extends the shared analytics presets ('today'/'7d'/'30d'/custom)
    * with the ranges the reused dashboard TimeRangePicker emits
    * ('1h'/'24h'/'1y'/'all').
    */

--- a/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDashboard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDashboard.tsx
@@ -1,13 +1,11 @@
-import React, { ReactElement, useMemo, useState, useCallback, useRef, useEffect } from 'react';
-import { useActiveUsers } from '../../../hooks/useUsers';
+import React, { ReactElement, useMemo, useState, useCallback, useEffect } from 'react';
 import { useAuth } from '../../../hooks/useAuth';
 import { usePersistedDeskMetricsFilters } from '../../../hooks/usePersistedDeskMetricsFilters';
-import { useCachedQuery } from '../../../hooks/useCachedQuery';
-import { queries } from '../../../zero/queries';
 import {
   RefreshCw,
   X,
   BarChart3,
+  BarChart4,
   AlertCircle,
   ChevronLeft,
   ChevronRight,
@@ -18,11 +16,21 @@ import {
   Search,
   UserCircle2,
   Users,
-  SlidersHorizontal,
+  ListFilter,
+  Circle,
   Maximize2,
   Layers,
 } from 'lucide-react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { Popover } from '../../ui/Popover';
+import {
+  DynamicFieldSubmenu,
+  PrioritySubmenu,
+  StagesSubmenu,
+  UserSubmenu,
+  UserGroupSubmenu,
+} from '../../Tickets/TicketFilters/Submenus';
+import { getIconForFieldType } from '../../Tickets/TicketFilters/fieldTypeIcons';
 import { DeskMetricsDateRangePicker } from './DeskMetricsDateRangePicker';
 import {
   Bar,
@@ -39,21 +47,18 @@ import {
 } from 'recharts';
 import {
   DESK_METRICS_MAX_AGGREGATE_DESKS,
+  FormFieldType,
+  parseFieldOptionValues,
   type DeskMetricsAgentRow,
   type DeskMetricsPerDeskRow,
   type DeskMetricsSkippedDesk,
   type DeskMetricsTicketRow,
+  type TicketStatusV2,
 } from '@xyne/shared';
+import type { ResolvedDisplayFormField } from '../../../utils/board/resolveDisplayFormFields';
 import { Dialog } from '../../ui/Dialog/Dialog';
 import { cn } from '../../../utils/classNames';
 import { useAggregateDeskMetrics } from '../../../hooks/useDeskMetrics';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '../../ui/Select/Select';
 import { showDownloadCompleteToast } from '../../../utils/downloadToast';
 import { CHART_COLORS as VIZ_CHART_COLORS } from '../../QueryVisualizations/constants';
 
@@ -62,12 +67,24 @@ export interface DeskMetricsSelectableDesk {
   name: string;
 }
 
+interface DeskMetricsStageOption {
+  name: string;
+  status?: TicketStatusV2;
+}
+
+type DeskMetricsCustomFieldDefinition = Pick<
+  ResolvedDisplayFormField,
+  'id' | 'fieldName' | 'fieldType' | 'fieldEnum'
+>;
+
 export interface DeskMetricsDashboardProps {
   open: boolean;
   onClose: () => void;
   channelId: string;
   channelName?: string;
   availableDesks?: DeskMetricsSelectableDesk[];
+  customFieldDefinitions?: readonly ResolvedDisplayFormField[];
+  availableStages?: readonly DeskMetricsStageOption[];
 }
 
 const PRIORITY_COLORS: Record<string, string> = {
@@ -85,6 +102,8 @@ const PRIORITY_BADGE: Record<string, string> = {
 };
 
 const PAGE_SIZE = 15;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 
 const dateTimeMs = (date: Date, time: string, isEnd: boolean): number => {
   const [hour = 0, minute = 0] = time.split(':').map(Number);
@@ -107,6 +126,30 @@ export const formatDuration = (seconds: number | null): string => {
 
 const priorityLabel = (p: string): string =>
   p.charAt(0) + p.slice(1).toLowerCase().replace(/_/g, ' ');
+
+const formatTrendLabel = (dateStr: string, hourly: boolean): string => {
+  if (hourly) {
+    const hour = parseInt(dateStr.slice(11, 13), 10);
+    const suffix = hour >= 12 ? 'pm' : 'am';
+    return `${hour % 12 || 12}${suffix}`;
+  }
+  const [, month, day] = dateStr.split('-').map(Number);
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return `${months[(month ?? 1) - 1]} ${day}`;
+};
 
 const getCustomFieldKeys = (tickets: DeskMetricsTicketRow[]): string[] =>
   [...new Set(tickets.flatMap(t => Object.keys(t.customFields ?? {})))].sort();
@@ -746,18 +789,24 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
   channelId,
   channelName,
   availableDesks = [],
+  customFieldDefinitions = [],
+  availableStages = [],
 }) => {
   const { user } = useAuth();
   const {
     dateRange,
     startTime,
     endTime,
-    selectedAssigneeId,
-    selectedCustomFieldKeys,
+    selectedAssigneeIds,
+    selectedStageNames,
+    selectedPriorities,
+    selectedUserGroupIds,
     selectedCustomFieldValues,
     setDateRange: persistDateRange,
-    setSelectedAssigneeId,
-    setSelectedCustomFieldKeys,
+    setSelectedAssigneeIds,
+    setSelectedStageNames,
+    setSelectedPriorities,
+    setSelectedUserGroupIds,
     setSelectedCustomFieldValues,
     comparedChannelIds,
     setComparedChannelIds,
@@ -793,79 +842,143 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     [channelId, comparedChannelIds, selectedDeskIds.length, setComparedChannelIds],
   );
 
-  const [chartView, setChartView] = useState<'priority' | 'assignee'>('priority');
-  const [expandedChart, setExpandedChart] = useState<'priority' | 'assignee' | null>(null);
+  const [chartView, setChartView] = useState<'priority' | 'trend' | 'assignee'>('priority');
+  const [expandedChart, setExpandedChart] = useState<'priority' | 'trend' | 'assignee' | null>(
+    null,
+  );
   const rangeStartMs = dateTimeMs(dateRange.startDate, startTime, false);
   const rangeEndMs = dateTimeMs(dateRange.endDate, endTime, true);
   const timeRangeParam = `${rangeStartMs}_${rangeEndMs}`;
-  const [ownerSearch, setOwnerSearch] = useState('');
-  const ownerSearchInputRef = useRef<HTMLInputElement>(null);
-  const [fieldKeySearch, setFieldKeySearch] = useState('');
-  const [fieldKeyPopoverOpen, setFieldKeyPopoverOpen] = useState(false);
-  const [fieldValuePopoverOpen, setFieldValuePopoverOpen] = useState(false);
-  const fieldKeySearchInputRef = useRef<HTMLInputElement>(null);
-  const [customFieldTextSearches, setCustomFieldTextSearches] = useState<Record<string, string[]>>(
-    {},
-  );
-  const [textDraftInputs, setTextDraftInputs] = useState<Record<string, string>>({});
-  const [expandedFieldKeys, setExpandedFieldKeys] = useState<Record<string, boolean>>({});
-  const [valueSearches, setValueSearches] = useState<Record<string, string>>({});
-  const FIELD_VALUE_CAP = 100;
-  // Holds selections to re-apply after time range change triggers an unfiltered fetch
-  const pendingReselectRef = useRef<{
-    keys: string[];
-    perKeyValues: Record<string, string[]>;
-  } | null>(null);
-  // Always-current ref so the timeRangeParam effect never reads stale closure values
-  const selectionsRef = useRef({
-    keys: selectedCustomFieldKeys,
-    perKeyValues: selectedCustomFieldValues,
-  });
-  selectionsRef.current = {
-    keys: selectedCustomFieldKeys,
-    perKeyValues: selectedCustomFieldValues,
-  };
-  // Snapshot of field→values from last unfiltered load; used to populate dropdowns even after filter is applied
-  const [allFieldOptions, setAllFieldOptions] = useState<Record<string, string[]>>({});
+  const isHourly = rangeEndMs - rangeStartMs <= DAY_MS;
+  const [assigneePopoverOpen, setAssigneePopoverOpen] = useState(false);
+  const [customFieldPopoverOpen, setCustomFieldPopoverOpen] = useState(false);
+  const [activeSubmenu, setActiveSubmenu] = useState<string | null>(null);
 
-  const activeUsers = useActiveUsers();
-  const [participants] = useCachedQuery(queries.channelParticipants({ channelId }), {
-    enabled: open,
-  });
+  useEffect(() => {
+    setCustomFieldPopoverOpen(false);
+    setActiveSubmenu(null);
+    if (!isMultiDesk) setActiveTab(current => (current === 'desks' ? 'overview' : current));
+  }, [isMultiDesk]);
 
-  // Per-key: whether each selected field is high-cardinality (text search mode)
-  const perKeyIsTextSearch = useMemo(
+  const customFieldDefinitionByName = useMemo(() => {
+    const definitions = new Map<string, ResolvedDisplayFormField>();
+    for (const definition of customFieldDefinitions) {
+      if (!definitions.has(definition.fieldName)) {
+        definitions.set(definition.fieldName, definition);
+      }
+    }
+    return definitions;
+  }, [customFieldDefinitions]);
+
+  const unsupportedCustomFieldNames = useMemo(
     () =>
-      Object.fromEntries(
-        selectedCustomFieldKeys.map(k => [k, (allFieldOptions[k]?.length ?? 0) > FIELD_VALUE_CAP]),
+      new Set(
+        customFieldDefinitions
+          .filter(
+            definition =>
+              definition.fieldType === FormFieldType.DATE ||
+              definition.fieldType === FormFieldType.DOC,
+          )
+          .map(definition => definition.fieldName.trim().toLowerCase()),
       ),
-    [selectedCustomFieldKeys, allFieldOptions],
+    [customFieldDefinitions],
+  );
+
+  const activeCustomFieldKeys = useMemo(
+    () =>
+      Object.keys(selectedCustomFieldValues)
+        .filter(
+          key =>
+            !unsupportedCustomFieldNames.has(key.trim().toLowerCase()) &&
+            (selectedCustomFieldValues[key]?.length ?? 0) > 0,
+        )
+        .sort(),
+    [selectedCustomFieldValues, unsupportedCustomFieldNames],
   );
 
   const customFieldFilter =
-    selectedCustomFieldKeys.length > 0
+    !isMultiDesk && activeCustomFieldKeys.length > 0
       ? {
-          keys: selectedCustomFieldKeys,
+          keys: activeCustomFieldKeys,
           perKeyFilters: Object.fromEntries(
-            selectedCustomFieldKeys.map(k => {
-              if (perKeyIsTextSearch[k]) {
-                const terms = customFieldTextSearches[k] ?? [];
-                return [k, terms.length > 0 ? { textTerms: terms } : {}];
-              }
-              const vals = selectedCustomFieldValues[k] ?? [];
-              return [k, vals.length > 0 ? { values: vals } : {}];
+            activeCustomFieldKeys.map(key => {
+              const values = selectedCustomFieldValues[key] ?? [];
+              const definition = customFieldDefinitionByName.get(key);
+              return [
+                key,
+                definition?.fieldType === FormFieldType.STRING ? { textTerms: values } : { values },
+              ];
             }),
           ) as Record<string, { values?: string[]; textTerms?: string[] }>,
         }
       : undefined;
 
+  const hasMoreFiltersActive =
+    (!isMultiDesk && selectedStageNames.length > 0) ||
+    selectedPriorities.length > 0 ||
+    selectedUserGroupIds.length > 0 ||
+    (!isMultiDesk && activeCustomFieldKeys.length > 0);
+  const hasAnyFiltersActive = selectedAssigneeIds.length > 0 || hasMoreFiltersActive;
+
+  const updateCustomFieldValues = useCallback(
+    (key: string, values: string[]): void => {
+      const next = { ...selectedCustomFieldValues };
+      if (values.length > 0) next[key] = values;
+      else delete next[key];
+      setSelectedCustomFieldValues(next);
+    },
+    [selectedCustomFieldValues, setSelectedCustomFieldValues],
+  );
+
+  const clearAllCustomFieldFilters = useCallback((): void => {
+    setSelectedCustomFieldValues({});
+  }, [setSelectedCustomFieldValues]);
+
   const { data, isLoading, isFetching, isError, refetch } = useAggregateDeskMetrics(
     selectedDeskIds,
     timeRangeParam,
     open,
-    selectedAssigneeId,
+    selectedAssigneeIds,
     customFieldFilter,
+    isMultiDesk ? [] : selectedStageNames,
+    selectedPriorities,
+    selectedUserGroupIds,
   );
+
+  const availableCustomFields = useMemo(() => {
+    const fields = new Map<string, DeskMetricsCustomFieldDefinition>();
+    for (const definition of customFieldDefinitions) {
+      const normalizedName = definition.fieldName.trim().toLowerCase();
+      if (!unsupportedCustomFieldNames.has(normalizedName)) {
+        fields.set(normalizedName, definition);
+      }
+    }
+    for (const ticket of data?.tickets ?? []) {
+      for (const fieldName of Object.keys(ticket.customFields ?? {})) {
+        const normalizedName = fieldName.trim().toLowerCase();
+        if (!unsupportedCustomFieldNames.has(normalizedName) && !fields.has(normalizedName)) {
+          fields.set(normalizedName, {
+            id: fieldName,
+            fieldName,
+            fieldType: FormFieldType.STRING,
+          });
+        }
+      }
+    }
+    for (const fieldName of activeCustomFieldKeys) {
+      const normalizedName = fieldName.trim().toLowerCase();
+      if (!fields.has(normalizedName)) {
+        fields.set(normalizedName, {
+          id: fieldName,
+          fieldName,
+          fieldType: FormFieldType.STRING,
+        });
+      }
+    }
+    return [...fields.values()].sort((a, b) => a.fieldName.localeCompare(b.fieldName));
+  }, [activeCustomFieldKeys, customFieldDefinitions, data?.tickets, unsupportedCustomFieldNames]);
+
+  const stageOptions = availableStages;
 
   const skippedDesks: DeskMetricsSkippedDesk[] = data?.skipped ?? [];
   const perDeskRows: DeskMetricsPerDeskRow[] = data?.perDesk ?? [];
@@ -877,72 +990,6 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     return map;
   }, [channelId, channelName, availableDesks]);
 
-  // When time range changes: save selections, clear filter so unfiltered query fires for new range
-  useEffect(() => {
-    const { keys, perKeyValues } = selectionsRef.current;
-    if (keys.length > 0) {
-      pendingReselectRef.current = { keys: [...keys], perKeyValues: { ...perKeyValues } };
-      setSelectedCustomFieldKeys([]);
-      setSelectedCustomFieldValues({});
-    }
-    setCustomFieldTextSearches({});
-    setTextDraftInputs({});
-    setValueSearches({});
-    setAllFieldOptions({});
-  }, [timeRangeParam]);
-
-  // Rebuild / update snapshot whenever fresh data arrives
-  useEffect(() => {
-    if (!data?.tickets || isFetching) return;
-
-    if (selectedCustomFieldKeys.length === 0) {
-      // No filter active — full replace from current range's unfiltered tickets
-      const seen: Record<string, Set<string>> = {};
-      for (const t of data.tickets) {
-        for (const [k, v] of Object.entries(t.customFields ?? {})) {
-          if (!v) continue;
-          const set = (seen[k] ??= new Set());
-          if (set.size <= FIELD_VALUE_CAP) set.add(v); // cap at FIELD_VALUE_CAP+1 so we know if exceeds
-        }
-      }
-      const opts: Record<string, string[]> = {};
-      for (const [k, s] of Object.entries(seen)) opts[k] = [...s].sort();
-      setAllFieldOptions(opts);
-      const pending = pendingReselectRef.current;
-      if (pending) {
-        pendingReselectRef.current = null;
-        const validKeys = pending.keys.filter(k => k in opts);
-        const newPerKeyValues: Record<string, string[]> = {};
-        for (const k of validKeys) {
-          const validVals = (pending.perKeyValues[k] ?? []).filter(v => opts[k]?.includes(v));
-          if (validVals.length > 0) newPerKeyValues[k] = validVals;
-        }
-        setSelectedCustomFieldKeys(validKeys);
-        setSelectedCustomFieldValues(newPerKeyValues);
-      }
-    } else {
-      // Filter active — merge any new values seen in this response into the snapshot
-      setAllFieldOptions(prev => {
-        let changed = false;
-        const updated = { ...prev };
-        for (const t of data.tickets) {
-          for (const [k, v] of Object.entries(t.customFields ?? {})) {
-            if (!v) continue;
-            const existing = updated[k];
-            if (!existing) {
-              updated[k] = [v];
-              changed = true;
-            } else if (!existing.includes(v) && existing.length <= FIELD_VALUE_CAP) {
-              updated[k] = [...existing, v].sort();
-              changed = true;
-            }
-          }
-        }
-        return changed ? updated : prev;
-      });
-    }
-  }, [data?.tickets, selectedCustomFieldKeys.length, isFetching]);
-
   useEffect(() => {
     if (open) void refetch();
   }, [open, refetch]);
@@ -951,23 +998,16 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     if (!nextOpen) onClose();
   };
 
-  const channelAssignees = useMemo(() => {
-    const memberIds = new Set((participants ?? []).map(p => p.userId));
-    for (const agent of data?.agents ?? []) {
-      if (agent.assigneeId) memberIds.add(agent.assigneeId);
-    }
-    const members = (activeUsers ?? [])
-      .filter(u => memberIds.has(u.id))
-      .map(u => ({ id: u.id, name: u.displayName ?? u.name ?? u.email ?? u.id }));
-    const q = ownerSearch.trim().toLowerCase();
-    return q ? members.filter(a => a.name.toLowerCase().includes(q)) : members;
-  }, [participants, activeUsers, ownerSearch, data?.agents]);
-
   const priorityData = (data?.priority ?? []).map(p => ({
     name: priorityLabel(p.priority),
     value: p.count,
     color: PRIORITY_COLORS[p.priority] ?? '#94a3b8',
   }));
+
+  const trendData = useMemo(
+    () => (data?.trend ?? []).map(d => ({ ...d, label: formatTrendLabel(d.date, isHourly) })),
+    [data?.trend, isHourly],
+  );
 
   const assigneeData = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -986,6 +1026,13 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
+
+  const tickInterval = useMemo(() => {
+    const pointCount = trendData.length;
+    if (pointCount <= 8) return 0;
+    if (pointCount <= 31) return 4;
+    return Math.floor(pointCount / 6);
+  }, [trendData.length]);
 
   const csatTotal = (data?.csat.good ?? 0) + (data?.csat.bad ?? 0);
   const isEmpty = !!data && data.tickets.length === 0 && data.counts.stageCounts.length === 0;
@@ -1034,13 +1081,27 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
       open={open}
       onOpenChange={handleOpenChange}
       title='Desk Metrics'
-      className='max-w-[95vw] w-[1400px] max-h-[95vh] bg-transparent shadow-none rounded-none'
+      className={cn(
+        'left-auto right-0 top-0 bottom-0 h-screen w-[85vw] max-h-none max-w-none translate-x-0 translate-y-0 rounded-l-[16px] rounded-r-none bg-transparent shadow-none',
+        'data-[state=open]:!zoom-in-100 data-[state=open]:!slide-in-from-top-[0%] data-[state=open]:!slide-in-from-right-full',
+        'data-[state=closed]:!zoom-out-100 data-[state=closed]:!slide-out-to-top-[0%] data-[state=closed]:!slide-out-to-right-full',
+      )}
     >
-      <div>
-        <div className='isolate flex h-[92vh] max-h-[92vh] flex-col overflow-hidden rounded-[12px] border border-desk-border bg-popover shadow-lg dark:border-border'>
+      <div className='relative h-full w-full'>
+        <button
+          type='button'
+          onClick={onClose}
+          className='absolute right-6 top-4 z-20 flex h-8 w-8 items-center justify-center rounded-[10px] border border-desk-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground dark:border-border'
+          aria-label='Close desk metrics'
+          data-track-category='DeskMetrics'
+          data-track-name='CloseButton'
+        >
+          <X size={16} />
+        </button>
+        <div className='isolate flex h-full w-full flex-col overflow-hidden rounded-l-[16px] border border-desk-border bg-popover shadow-2xl dark:border-border'>
           {/* Header */}
-          <div className='flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-desk-border px-6 py-4 dark:border-border'>
-            <div className='flex items-center gap-4'>
+          <div className='grid shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-3 border-b border-desk-border px-6 pt-4 dark:border-border'>
+            <div className='flex min-w-0 items-center gap-4 pr-12'>
               <div className='flex items-center gap-2'>
                 <BarChart3 size={18} className='text-desk-accent' />
                 <span className='text-base font-semibold text-foreground'>
@@ -1096,645 +1157,454 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                 ))}
               </div>
             </div>
-            <div className='flex items-center gap-3'>
-              {availableDesks.length > 1 && (
-                <Popover
-                  open={deskPickerOpen}
-                  onOpenChange={openState => {
-                    setDeskPickerOpen(openState);
-                    if (!openState) setDeskSearch('');
-                  }}
-                  align='start'
-                  sideOffset={6}
-                  className='p-0'
-                  trigger={
-                    <button
-                      type='button'
-                      className='flex h-[32px] w-[150px] max-w-[150px] items-center gap-1.5 rounded-[8px] border border-desk-border bg-background px-3 text-sm text-foreground shadow-none hover:bg-accent dark:border-border'
-                      data-track-category='DeskMetrics'
-                      data-track-name='DeskSelector'
-                    >
-                      <Layers size={14} className='shrink-0 text-muted-foreground' />
-                      <span className='flex-1 truncate text-left text-sm'>
-                        {isMultiDesk ? `${selectedDeskIds.length} desks` : '1 desk'}
-                      </span>
-                      {comparedChannelIds.length > 0 ? (
-                        <X
-                          size={12}
-                          className='shrink-0 text-muted-foreground hover:text-foreground'
-                          onClick={e => {
-                            e.stopPropagation();
-                            setComparedChannelIds([]);
-                            setActiveTab(prev => (prev === 'desks' ? 'overview' : prev));
-                          }}
-                        />
-                      ) : (
-                        <ChevronDown size={12} className='shrink-0 text-muted-foreground' />
-                      )}
-                    </button>
-                  }
-                >
-                  <div className='w-[260px]'>
-                    <div className='flex items-center gap-2 border-b border-border px-2 py-1.5'>
-                      <Search size={14} className='shrink-0 text-muted-foreground' />
-                      <input
-                        type='text'
-                        value={deskSearch}
-                        onChange={e => setDeskSearch(e.target.value)}
-                        onKeyDown={e => e.stopPropagation()}
-                        placeholder='Search desks…'
-                        className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
+            <div className='contents'>
+              <div className='col-span-2 row-start-2 -mx-6 flex min-w-0 flex-wrap items-center justify-start gap-3 border-t border-desk-border bg-muted/20 px-6 py-3 dark:border-border'>
+                {availableDesks.length > 1 && (
+                  <Popover
+                    open={deskPickerOpen}
+                    onOpenChange={openState => {
+                      setDeskPickerOpen(openState);
+                      if (!openState) setDeskSearch('');
+                    }}
+                    align='start'
+                    sideOffset={6}
+                    className='p-0'
+                    trigger={
+                      <button
+                        type='button'
+                        className='flex h-[32px] w-[150px] max-w-[150px] items-center gap-1.5 rounded-[8px] border border-desk-border bg-background px-3 text-sm text-foreground shadow-none hover:bg-accent dark:border-border'
                         data-track-category='DeskMetrics'
-                        data-track-name='SearchDesks'
-                      />
-                    </div>
-                    <div
-                      className='max-h-[260px] overflow-y-auto py-1'
-                      onWheel={e => e.stopPropagation()}
-                    >
-                      {(() => {
-                        const query = deskSearch.trim().toLowerCase();
-                        const visible = availableDesks.filter(
-                          d => !query || d.name.toLowerCase().includes(query),
-                        );
-                        if (visible.length === 0) {
-                          return (
-                            <div className='px-3 py-4 text-center text-sm text-muted-foreground'>
-                              No desks match
-                            </div>
-                          );
-                        }
-                        return visible.map(desk => {
-                          const isPrimary = desk.id === channelId;
-                          const isSelected = selectedDeskIds.includes(desk.id);
-                          const isDisabledByLimit = !isSelected && isDeskSelectionAtLimit;
-                          return (
-                            <label
-                              key={desk.id}
-                              className={cn(
-                                'flex items-center gap-2 px-3 py-1.5 text-sm',
-                                isPrimary && 'cursor-default opacity-70',
-                                isDisabledByLimit && 'cursor-not-allowed opacity-50',
-                                !isPrimary &&
-                                  !isDisabledByLimit &&
-                                  'cursor-pointer hover:bg-accent',
-                              )}
-                              title={
-                                isPrimary
-                                  ? 'The desk this dashboard was opened from is always included'
-                                  : isDisabledByLimit
-                                    ? `You can compare up to ${DESK_METRICS_MAX_AGGREGATE_DESKS} desks at once`
-                                    : undefined
-                              }
-                            >
-                              <input
-                                type='checkbox'
-                                checked={isSelected}
-                                disabled={isPrimary || isDisabledByLimit}
-                                onChange={() => toggleDesk(desk.id)}
-                                className='h-3.5 w-3.5 accent-desk-accent'
-                                data-track-category='DeskMetrics'
-                                data-track-name='ToggleDesk'
-                              />
-                              <span className='flex-1 truncate'>{desk.name}</span>
-                              {isPrimary && (
-                                <span className='shrink-0 text-[10px] uppercase text-muted-foreground'>
-                                  current
-                                </span>
-                              )}
-                            </label>
-                          );
-                        });
-                      })()}
-                    </div>
-                    <div
-                      className={cn(
-                        'border-t border-border px-3 py-2 text-xs text-muted-foreground',
-                        isDeskSelectionAtLimit && 'text-amber-600 dark:text-amber-400',
-                      )}
-                    >
-                      {selectedDeskIds.length} of {DESK_METRICS_MAX_AGGREGATE_DESKS} desks selected
-                      {isDeskSelectionAtLimit && ' — limit reached'}
-                    </div>
-                  </div>
-                </Popover>
-              )}
-
-              {/* Assignee filter */}
-              <Select
-                value={selectedAssigneeId ?? '__all__'}
-                onValueChange={v => setSelectedAssigneeId(v === '__all__' ? null : v)}
-                onOpenChange={open => {
-                  if (!open) setOwnerSearch('');
-                }}
-              >
-                <SelectTrigger
-                  className='h-[32px] min-w-[140px] rounded-[8px] border border-desk-border bg-background px-3 text-sm text-foreground shadow-none dark:border-border'
-                  data-track-category='DeskMetrics'
-                  data-track-name='AssigneeFilter'
-                >
-                  <div className='flex items-center gap-1.5'>
-                    <UserCircle2 size={14} className='shrink-0 text-muted-foreground' />
-                    <SelectValue placeholder='All assignees' />
-                  </div>
-                </SelectTrigger>
-                <SelectContent
-                  className='rounded-[10px]'
-                  header={
-                    <div className='flex items-center gap-2 border-b border-border bg-popover px-2 py-1.5'>
-                      <Search size={14} className='shrink-0 text-muted-foreground' />
-                      <input
-                        ref={ownerSearchInputRef}
-                        type='text'
-                        value={ownerSearch}
-                        onChange={e => {
-                          setOwnerSearch(e.target.value);
-                          requestAnimationFrame(() => ownerSearchInputRef.current?.focus());
-                        }}
-                        onKeyDown={e => e.stopPropagation()}
-                        onPointerDown={e => e.stopPropagation()}
-                        placeholder='Search assignees…'
-                        autoFocus
-                        className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
-                        data-track-category='DeskMetrics'
-                        data-track-name='SearchAssignees'
-                      />
-                    </div>
-                  }
-                >
-                  {!ownerSearch && (
-                    <SelectItem value='__all__' className='rounded-[8px]'>
-                      <span className='text-sm'>All assignees</span>
-                    </SelectItem>
-                  )}
-                  {channelAssignees.map(u => (
-                    <SelectItem key={u.id} value={u.id} className='rounded-[8px]'>
-                      <span>{u.name}</span>
-                    </SelectItem>
-                  ))}
-                  {channelAssignees.length === 0 && (
-                    <div className='px-3 py-4 text-center text-sm text-muted-foreground'>
-                      {selectedAssigneeId ? 'Loading…' : 'No assignees in this period'}
-                    </div>
-                  )}
-                </SelectContent>
-              </Select>
-
-              {/* Custom field filter — field key multi-select */}
-              {Object.keys(allFieldOptions).length > 0 && (
-                <Popover
-                  open={fieldKeyPopoverOpen}
-                  onOpenChange={open => {
-                    setFieldKeyPopoverOpen(open);
-                    if (!open) setFieldKeySearch('');
-                  }}
-                  align='start'
-                  sideOffset={6}
-                  className='p-0'
-                  onOpenAutoFocus={e => {
-                    e.preventDefault();
-                    fieldKeySearchInputRef.current?.focus();
-                  }}
-                  trigger={
-                    <button
-                      type='button'
-                      className='flex h-[32px] w-[160px] max-w-[160px] items-center gap-1.5 rounded-[8px] border border-desk-border bg-background px-3 text-sm text-foreground shadow-none hover:bg-accent dark:border-border'
-                      data-track-category='DeskMetrics'
-                      data-track-name='CustomFieldKeyFilter'
-                    >
-                      <SlidersHorizontal size={14} className='shrink-0 text-muted-foreground' />
-                      <span className='flex-1 truncate text-left text-sm'>
-                        {selectedCustomFieldKeys.length === 0 ? (
-                          <span className='text-muted-foreground'>Filter by field</span>
-                        ) : selectedCustomFieldKeys.length === 1 ? (
-                          selectedCustomFieldKeys[0]
+                        data-track-name='DeskSelector'
+                      >
+                        <Layers size={14} className='shrink-0 text-muted-foreground' />
+                        <span className='flex-1 truncate text-left text-sm'>
+                          {isMultiDesk ? `${selectedDeskIds.length} desks` : '1 desk'}
+                        </span>
+                        {comparedChannelIds.length > 0 ? (
+                          <X
+                            size={12}
+                            className='shrink-0 text-muted-foreground hover:text-foreground'
+                            onClick={e => {
+                              e.stopPropagation();
+                              setComparedChannelIds([]);
+                              setActiveTab(prev => (prev === 'desks' ? 'overview' : prev));
+                            }}
+                          />
                         ) : (
-                          `${selectedCustomFieldKeys.length} fields`
+                          <ChevronDown size={12} className='shrink-0 text-muted-foreground' />
                         )}
-                      </span>
-                      {selectedCustomFieldKeys.length > 0 ? (
-                        <X
-                          size={12}
-                          className='shrink-0 text-muted-foreground hover:text-foreground'
-                          onClick={e => {
-                            e.stopPropagation();
-                            setSelectedCustomFieldKeys([]);
-                            setSelectedCustomFieldValues({});
-                          }}
+                      </button>
+                    }
+                  >
+                    <div className='w-[260px]'>
+                      <div className='flex items-center gap-2 border-b border-border px-2 py-1.5'>
+                        <Search size={14} className='shrink-0 text-muted-foreground' />
+                        <input
+                          type='text'
+                          value={deskSearch}
+                          onChange={e => setDeskSearch(e.target.value)}
+                          onKeyDown={e => e.stopPropagation()}
+                          placeholder='Search desks…'
+                          className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
+                          data-track-category='DeskMetrics'
+                          data-track-name='SearchDesks'
                         />
-                      ) : (
-                        <ChevronDown size={12} className='shrink-0 text-muted-foreground' />
-                      )}
-                    </button>
-                  }
-                >
-                  <div className='w-[240px]'>
-                    <div className='flex items-center gap-2 border-b border-border px-2 py-1.5'>
-                      <Search size={14} className='shrink-0 text-muted-foreground' />
-                      <input
-                        ref={fieldKeySearchInputRef}
-                        type='text'
-                        value={fieldKeySearch}
-                        onChange={e => setFieldKeySearch(e.target.value)}
-                        placeholder='Search fields…'
-                        className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
-                        data-track-category='DeskMetrics'
-                        data-track-name='SearchFieldKeys'
-                      />
-                    </div>
-                    <div
-                      className='max-h-[220px] overflow-y-auto py-1'
-                      onWheel={e => e.stopPropagation()}
-                    >
-                      {(() => {
-                        const allKeys = Object.keys(allFieldOptions).sort();
-                        const allSelected =
-                          allKeys.length > 0 &&
-                          allKeys.every(k => selectedCustomFieldKeys.includes(k));
-                        return (
-                          <label className='flex cursor-pointer items-center gap-2 border-b border-border px-3 py-1.5 text-sm font-medium hover:bg-accent'>
-                            <input
-                              type='checkbox'
-                              checked={allSelected}
-                              onChange={() => {
-                                if (allSelected) {
-                                  setSelectedCustomFieldKeys([]);
-                                  setSelectedCustomFieldValues({});
-                                } else {
-                                  setSelectedCustomFieldKeys(allKeys);
+                      </div>
+                      <div
+                        className='max-h-[260px] overflow-y-auto py-1'
+                        onWheel={e => e.stopPropagation()}
+                      >
+                        {((): ReactElement | ReactElement[] => {
+                          const query = deskSearch.trim().toLowerCase();
+                          const visible = availableDesks.filter(
+                            d => !query || d.name.toLowerCase().includes(query),
+                          );
+                          if (visible.length === 0) {
+                            return (
+                              <div className='px-3 py-4 text-center text-sm text-muted-foreground'>
+                                No desks match
+                              </div>
+                            );
+                          }
+                          return visible.map(desk => {
+                            const isPrimary = desk.id === channelId;
+                            const isSelected = selectedDeskIds.includes(desk.id);
+                            const isDisabledByLimit = !isSelected && isDeskSelectionAtLimit;
+                            return (
+                              <label
+                                key={desk.id}
+                                className={cn(
+                                  'flex items-center gap-2 px-3 py-1.5 text-sm',
+                                  isPrimary && 'cursor-default opacity-70',
+                                  isDisabledByLimit && 'cursor-not-allowed opacity-50',
+                                  !isPrimary &&
+                                    !isDisabledByLimit &&
+                                    'cursor-pointer hover:bg-accent',
+                                )}
+                                title={
+                                  isPrimary
+                                    ? 'The desk this dashboard was opened from is always included'
+                                    : isDisabledByLimit
+                                      ? `You can compare up to ${DESK_METRICS_MAX_AGGREGATE_DESKS} desks at once`
+                                      : undefined
                                 }
-                              }}
-                              className='h-3.5 w-3.5 rounded accent-desk-accent'
-                              data-track-category='DeskMetrics'
-                              data-track-name='ToggleAllFieldKeys'
-                            />
-                            All fields
-                          </label>
-                        );
-                      })()}
-                      {Object.keys(allFieldOptions)
-                        .sort()
-                        .filter(
-                          k =>
-                            !fieldKeySearch ||
-                            k.toLowerCase().includes(fieldKeySearch.toLowerCase()),
-                        )
-                        .map(k => (
-                          <label
-                            key={k}
-                            className='flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent'
-                          >
-                            <input
-                              type='checkbox'
-                              checked={selectedCustomFieldKeys.includes(k)}
-                              onChange={() => {
-                                const isSelected = selectedCustomFieldKeys.includes(k);
-                                if (isSelected) {
-                                  const newKeys = selectedCustomFieldKeys.filter(x => x !== k);
-                                  setSelectedCustomFieldKeys(newKeys);
-                                  setSelectedCustomFieldValues(
-                                    Object.fromEntries(
-                                      Object.entries(selectedCustomFieldValues).filter(([key]) =>
-                                        newKeys.includes(key),
-                                      ),
-                                    ) as Record<string, string[]>,
-                                  );
-                                  setCustomFieldTextSearches(prev =>
-                                    Object.fromEntries(
-                                      Object.entries(prev).filter(([key]) => newKeys.includes(key)),
-                                    ),
-                                  );
-                                  setTextDraftInputs(prev =>
-                                    Object.fromEntries(
-                                      Object.entries(prev).filter(([key]) => newKeys.includes(key)),
-                                    ),
-                                  );
-                                  setValueSearches(prev =>
-                                    Object.fromEntries(
-                                      Object.entries(prev).filter(([key]) => newKeys.includes(key)),
-                                    ),
-                                  );
-                                } else {
-                                  setSelectedCustomFieldKeys([...selectedCustomFieldKeys, k]);
-                                }
-                              }}
-                              className='h-3.5 w-3.5 rounded accent-desk-accent'
-                              data-track-category='DeskMetrics'
-                              data-track-name='ToggleFieldKey'
-                            />
-                            <span className='truncate' title={k}>
-                              {k}
-                            </span>
-                          </label>
-                        ))}
-                      {fieldKeySearch &&
-                        Object.keys(allFieldOptions).filter(k =>
-                          k.toLowerCase().includes(fieldKeySearch.toLowerCase()),
-                        ).length === 0 && (
-                          <div className='px-3 py-4 text-center text-sm text-muted-foreground'>
-                            No fields found
-                          </div>
+                              >
+                                <input
+                                  type='checkbox'
+                                  checked={isSelected}
+                                  disabled={isPrimary || isDisabledByLimit}
+                                  onChange={() => toggleDesk(desk.id)}
+                                  className='h-3.5 w-3.5 accent-desk-accent'
+                                  data-track-category='DeskMetrics'
+                                  data-track-name='ToggleDesk'
+                                />
+                                <span className='flex-1 truncate'>{desk.name}</span>
+                                {isPrimary && (
+                                  <span className='shrink-0 text-[10px] uppercase text-muted-foreground'>
+                                    current
+                                  </span>
+                                )}
+                              </label>
+                            );
+                          });
+                        })()}
+                      </div>
+                      <div
+                        className={cn(
+                          'border-t border-border px-3 py-2 text-xs text-muted-foreground',
+                          isDeskSelectionAtLimit && 'text-amber-600 dark:text-amber-400',
                         )}
+                      >
+                        {selectedDeskIds.length} of {DESK_METRICS_MAX_AGGREGATE_DESKS} desks
+                        selected
+                        {isDeskSelectionAtLimit && ' — limit reached'}
+                      </div>
                     </div>
-                  </div>
-                </Popover>
-              )}
+                  </Popover>
+                )}
 
-              {/* Custom field filter — field value multi-select (shown only when keys are selected) */}
-              {selectedCustomFieldKeys.length > 0 && (
+                {/* Assignee filter */}
                 <Popover
-                  open={fieldValuePopoverOpen}
-                  onOpenChange={v => setFieldValuePopoverOpen(v)}
+                  open={assigneePopoverOpen}
+                  onOpenChange={setAssigneePopoverOpen}
                   align='start'
                   sideOffset={6}
-                  className='p-0'
-                  onOpenAutoFocus={e => e.preventDefault()}
+                  collisionPadding={12}
+                  className='border-0 bg-transparent p-0 shadow-none'
                   trigger={
                     <button
                       type='button'
-                      className='flex h-[32px] w-[160px] max-w-[160px] items-center gap-1.5 rounded-[8px] border border-desk-border bg-background px-3 text-sm text-foreground shadow-none hover:bg-accent dark:border-border'
+                      className='flex h-[32px] min-w-[140px] items-center gap-1.5 rounded-[8px] border border-desk-border bg-background px-3 text-sm text-foreground shadow-none hover:bg-accent dark:border-border'
                       data-track-category='DeskMetrics'
-                      data-track-name='CustomFieldValueFilter'
+                      data-track-name='AssigneeFilter'
                     >
-                      <span className='flex-1 truncate text-left text-sm'>
-                        {(() => {
-                          const totalSelected = Object.values(selectedCustomFieldValues).reduce(
-                            (s, a) => s + a.length,
-                            0,
-                          );
-                          const totalSearches = Object.values(customFieldTextSearches).reduce(
-                            (s, a) => s + a.length,
-                            0,
-                          );
-                          const active = totalSelected + totalSearches;
-                          if (active === 0)
-                            return <span className='text-muted-foreground'>Filter values</span>;
-                          if (active === 1) {
-                            const v =
-                              Object.values(selectedCustomFieldValues).flat()[0] ??
-                              Object.values(customFieldTextSearches).flat()[0];
-                            return v ?? 'Filter values';
-                          }
-                          return `${active} filters`;
-                        })()}
-                      </span>
-                      {Object.values(selectedCustomFieldValues).some(a => a.length > 0) ||
-                      Object.values(customFieldTextSearches).some(a => a.length > 0) ? (
-                        <X
-                          size={12}
-                          className='shrink-0 text-muted-foreground hover:text-foreground'
-                          onClick={e => {
-                            e.stopPropagation();
-                            setSelectedCustomFieldValues({});
-                            setCustomFieldTextSearches({});
-                            setTextDraftInputs({});
-                          }}
-                        />
-                      ) : (
-                        <ChevronDown size={12} className='shrink-0 text-muted-foreground' />
+                      <UserCircle2 size={14} className='shrink-0 text-muted-foreground' />
+                      <span className='font-medium'>Assignee</span>
+                      {selectedAssigneeIds.length > 0 && (
+                        <span className='ml-1 rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'>
+                          {selectedAssigneeIds.length}
+                        </span>
                       )}
+                      <ChevronDown
+                        size={12}
+                        className={cn(
+                          'ml-auto shrink-0 text-muted-foreground transition-transform',
+                          assigneePopoverOpen && 'rotate-180',
+                        )}
+                      />
                     </button>
                   }
                 >
-                  {/* Per-key value filter panel — accordion */}
-                  <div
-                    className='w-[300px] max-h-[420px] overflow-y-auto'
-                    onWheel={e => e.stopPropagation()}
+                  <UserSubmenu
+                    selectedUsers={selectedAssigneeIds}
+                    onChange={setSelectedAssigneeIds}
+                    label='Assignee'
+                    channelId={channelId}
+                    demoteDeactivated
+                  />
+                </Popover>
+
+                {/* Kanban-style additional filters */}
+                <>
+                  <Popover
+                    open={customFieldPopoverOpen}
+                    onOpenChange={nextOpen => {
+                      setCustomFieldPopoverOpen(nextOpen);
+                      if (!nextOpen) setActiveSubmenu(null);
+                    }}
+                    align='start'
+                    sideOffset={6}
+                    collisionPadding={12}
+                    className='max-h-[400px] w-56 overflow-y-auto rounded-lg border border-border bg-background p-0 shadow-lg'
+                    onInteractOutside={event => {
+                      const target = event.target;
+                      if (
+                        target instanceof Element &&
+                        target.closest('[data-custom-field-submenu="true"]')
+                      ) {
+                        event.preventDefault();
+                      }
+                    }}
+                    trigger={
+                      <button
+                        type='button'
+                        className='flex h-[32px] items-center gap-1.5 rounded-[10px] border border-border bg-background px-3 text-sm text-foreground shadow-sm hover:bg-muted'
+                        data-track-category='DeskMetrics'
+                        data-track-name='OpenCustomFieldFilters'
+                      >
+                        <ListFilter size={13} className='shrink-0' />
+                        <span className='font-medium'>More Filters</span>
+                        {hasMoreFiltersActive && (
+                          <span className='h-1.5 w-1.5 rounded-full bg-blue-500' />
+                        )}
+                      </button>
+                    }
                   >
-                    {selectedCustomFieldKeys.map((k, ki) => {
-                      const isHighCard = perKeyIsTextSearch[k] ?? false;
-                      const keyValues = allFieldOptions[k] ?? [];
-                      const selectedVals = selectedCustomFieldValues[k] ?? [];
-                      const textSearch = customFieldTextSearches[k] ?? [];
-                      const valueSearch = valueSearches[k] ?? '';
-                      const isExpanded = expandedFieldKeys[k] ?? false;
-                      const allSelected =
-                        keyValues.length > 0 && keyValues.every(v => selectedVals.includes(v));
-                      const filteredValues = valueSearch
-                        ? keyValues.filter(v => v.toLowerCase().includes(valueSearch.toLowerCase()))
-                        : keyValues;
-                      return (
-                        <div key={k} className={ki > 0 ? 'border-t border-border' : ''}>
-                          {/* Accordion header */}
-                          <div className='flex items-center gap-1 px-3 py-2'>
+                    <div className='py-1'>
+                      <PopoverPrimitive.Root
+                        open={activeSubmenu === '__priority'}
+                        onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? '__priority' : null)}
+                      >
+                        <PopoverPrimitive.Trigger asChild>
+                          <button
+                            type='button'
+                            className={cn(
+                              'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                              activeSubmenu === '__priority' && 'bg-muted font-medium',
+                            )}
+                            data-track-category='DeskMetrics'
+                            data-track-name='OpenPriorityFilterSubmenu'
+                          >
+                            <div className='flex min-w-0 items-center gap-3'>
+                              <BarChart4 size={16} className='shrink-0' />
+                              <span>Priority</span>
+                              {selectedPriorities.length > 0 && (
+                                <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
+                              )}
+                            </div>
+                            <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
+                          </button>
+                        </PopoverPrimitive.Trigger>
+                        <PopoverPrimitive.Portal>
+                          <PopoverPrimitive.Content
+                            side='right'
+                            align='start'
+                            sideOffset={4}
+                            collisionPadding={12}
+                            className='z-[70] outline-none'
+                            data-custom-field-submenu='true'
+                            onOpenAutoFocus={event => event.preventDefault()}
+                          >
+                            <PrioritySubmenu
+                              selectedPriorities={selectedPriorities}
+                              onChange={setSelectedPriorities}
+                            />
+                          </PopoverPrimitive.Content>
+                        </PopoverPrimitive.Portal>
+                      </PopoverPrimitive.Root>
+
+                      <PopoverPrimitive.Root
+                        open={activeSubmenu === '__userGroups'}
+                        onOpenChange={nextOpen =>
+                          setActiveSubmenu(nextOpen ? '__userGroups' : null)
+                        }
+                      >
+                        <PopoverPrimitive.Trigger asChild>
+                          <button
+                            type='button'
+                            className={cn(
+                              'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                              activeSubmenu === '__userGroups' && 'bg-muted font-medium',
+                            )}
+                            data-track-category='DeskMetrics'
+                            data-track-name='OpenUserGroupFilterSubmenu'
+                          >
+                            <div className='flex min-w-0 items-center gap-3'>
+                              <Users size={16} className='shrink-0' />
+                              <span>User Groups</span>
+                              {selectedUserGroupIds.length > 0 && (
+                                <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
+                              )}
+                            </div>
+                            <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
+                          </button>
+                        </PopoverPrimitive.Trigger>
+                        <PopoverPrimitive.Portal>
+                          <PopoverPrimitive.Content
+                            side='right'
+                            align='start'
+                            sideOffset={4}
+                            collisionPadding={12}
+                            className='z-[70] outline-none'
+                            data-custom-field-submenu='true'
+                            onOpenAutoFocus={event => event.preventDefault()}
+                          >
+                            <UserGroupSubmenu
+                              selectedGroups={selectedUserGroupIds}
+                              onChange={setSelectedUserGroupIds}
+                              onClose={() => setActiveSubmenu(null)}
+                            />
+                          </PopoverPrimitive.Content>
+                        </PopoverPrimitive.Portal>
+                      </PopoverPrimitive.Root>
+
+                      {!isMultiDesk && stageOptions.length > 0 && (
+                        <PopoverPrimitive.Root
+                          open={activeSubmenu === '__stages'}
+                          onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? '__stages' : null)}
+                        >
+                          <PopoverPrimitive.Trigger asChild>
                             <button
                               type='button'
-                              className='flex flex-1 items-center gap-1.5 text-left'
-                              onClick={() =>
-                                setExpandedFieldKeys(prev => ({ ...prev, [k]: !isExpanded }))
-                              }
+                              className={cn(
+                                'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                                activeSubmenu === '__stages' && 'bg-muted font-medium',
+                              )}
                               data-track-category='DeskMetrics'
-                              data-track-name='ToggleFieldKeyAccordion'
+                              data-track-name='OpenStageFilterSubmenu'
                             >
-                              <ChevronRight
-                                size={13}
-                                className={`shrink-0 text-muted-foreground transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-                              />
-                              <span className='truncate text-sm font-medium'>{k}</span>
-                              {selectedVals.length > 0 && (
-                                <span className='ml-1 shrink-0 text-xs text-muted-foreground'>
-                                  ({selectedVals.length})
-                                </span>
-                              )}
-                              {textSearch.length > 0 && (
-                                <span className='ml-1 shrink-0 text-xs text-muted-foreground'>
-                                  ({textSearch.length})
-                                </span>
-                              )}
-                            </button>
-                            {!isHighCard && keyValues.length > 0 && (
-                              <button
-                                type='button'
-                                className='shrink-0 text-xs text-desk-accent hover:underline'
-                                onClick={() =>
-                                  setSelectedCustomFieldValues({
-                                    ...selectedCustomFieldValues,
-                                    [k]: allSelected ? [] : [...keyValues],
-                                  })
-                                }
-                                data-track-category='DeskMetrics'
-                                data-track-name='ToggleAllFieldValues'
-                              >
-                                {allSelected ? 'Deselect all' : 'Select all'}
-                              </button>
-                            )}
-                          </div>
-
-                          {/* Accordion body */}
-                          {isExpanded &&
-                            (isHighCard ? (
-                              <div className='px-3 pb-3'>
-                                {/* Applied term chips */}
-                                {textSearch.length > 0 && (
-                                  <div className='mb-2 flex flex-wrap gap-1'>
-                                    {textSearch.map(term => (
-                                      <span
-                                        key={term}
-                                        className='flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-foreground'
-                                      >
-                                        {term}
-                                        <X
-                                          size={10}
-                                          className='cursor-pointer text-muted-foreground hover:text-foreground'
-                                          onClick={() =>
-                                            setCustomFieldTextSearches(prev => ({
-                                              ...prev,
-                                              [k]: (prev[k] ?? []).filter(t => t !== term),
-                                            }))
-                                          }
-                                        />
-                                      </span>
-                                    ))}
-                                  </div>
+                              <div className='flex min-w-0 items-center gap-3'>
+                                <Circle size={16} className='shrink-0' />
+                                <span>Stages</span>
+                                {selectedStageNames.length > 0 && (
+                                  <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
                                 )}
-                                {/* Draft input — Enter to apply */}
-                                <div className='flex items-center gap-2 rounded-[6px] border border-border bg-muted/30 px-2 py-1.5'>
-                                  <Search size={12} className='shrink-0 text-muted-foreground' />
-                                  <input
-                                    type='text'
-                                    value={textDraftInputs[k] ?? ''}
-                                    onChange={e =>
-                                      setTextDraftInputs(prev => ({ ...prev, [k]: e.target.value }))
-                                    }
-                                    onKeyDown={e => {
-                                      if (e.key === 'Enter') {
-                                        const term = (textDraftInputs[k] ?? '').trim();
-                                        if (
-                                          term &&
-                                          !(customFieldTextSearches[k] ?? []).includes(term)
-                                        ) {
-                                          setCustomFieldTextSearches(prev => ({
-                                            ...prev,
-                                            [k]: [...(prev[k] ?? []), term],
-                                          }));
-                                        }
-                                        setTextDraftInputs(prev => ({ ...prev, [k]: '' }));
-                                      }
-                                    }}
-                                    placeholder='Type and press Enter…'
-                                    className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
-                                    data-track-category='DeskMetrics'
-                                    data-track-name='CustomFieldTextSearch'
-                                  />
-                                  {(textDraftInputs[k] ?? '') && (
-                                    <X
-                                      size={11}
-                                      className='shrink-0 cursor-pointer text-muted-foreground hover:text-foreground'
-                                      onClick={() =>
-                                        setTextDraftInputs(prev => ({ ...prev, [k]: '' }))
-                                      }
-                                    />
-                                  )}
-                                </div>
-                                <p className='mt-1.5 text-[11px] text-muted-foreground'>
-                                  Press Enter to add — matches any term (OR)
-                                </p>
                               </div>
-                            ) : (
-                              <div className='pb-2'>
-                                {keyValues.length > 1 && (
-                                  <div
-                                    className='flex items-center gap-2 border-b border-border px-3 py-1.5'
-                                    data-track-category='DeskMetrics'
-                                    data-track-name='SearchFieldValues'
-                                  >
-                                    <Search size={12} className='shrink-0 text-muted-foreground' />
-                                    <input
-                                      type='text'
-                                      value={valueSearch}
-                                      onChange={e =>
-                                        setValueSearches(prev => ({ ...prev, [k]: e.target.value }))
-                                      }
-                                      placeholder='Search values…'
-                                      className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
-                                      data-track-category='DeskMetrics'
-                                      data-track-name='SearchFieldValues'
-                                    />
-                                    {valueSearch && (
-                                      <X
-                                        size={11}
-                                        className='shrink-0 cursor-pointer text-muted-foreground hover:text-foreground'
-                                        onClick={() =>
-                                          setValueSearches(prev => ({ ...prev, [k]: '' }))
-                                        }
-                                      />
+                              <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
+                            </button>
+                          </PopoverPrimitive.Trigger>
+                          <PopoverPrimitive.Portal>
+                            <PopoverPrimitive.Content
+                              side='right'
+                              align='start'
+                              sideOffset={4}
+                              collisionPadding={12}
+                              className='z-[70] outline-none'
+                              data-custom-field-submenu='true'
+                              onOpenAutoFocus={event => event.preventDefault()}
+                            >
+                              <StagesSubmenu
+                                selectedStages={selectedStageNames}
+                                onChange={setSelectedStageNames}
+                                availableStages={[...stageOptions]}
+                              />
+                            </PopoverPrimitive.Content>
+                          </PopoverPrimitive.Portal>
+                        </PopoverPrimitive.Root>
+                      )}
+                      {!isMultiDesk &&
+                        availableCustomFields.map(definition => {
+                          const key = definition.fieldName;
+                          const FieldIcon = getIconForFieldType(definition.fieldType);
+                          const isOpen = activeSubmenu === key;
+                          const isActive = activeCustomFieldKeys.includes(key);
+
+                          return (
+                            <PopoverPrimitive.Root
+                              key={key}
+                              open={isOpen}
+                              onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? key : null)}
+                            >
+                              <PopoverPrimitive.Trigger asChild>
+                                <button
+                                  type='button'
+                                  className={cn(
+                                    'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                                    isOpen && 'bg-muted font-medium',
+                                  )}
+                                  data-track-category='DeskMetrics'
+                                  data-track-name='OpenCustomFieldFilterSubmenu'
+                                  data-track-metadata={JSON.stringify({ fieldName: key })}
+                                >
+                                  <div className='flex min-w-0 items-center gap-3'>
+                                    <FieldIcon className='h-4 w-4 shrink-0' />
+                                    <span className='truncate' title={key}>
+                                      {key}
+                                    </span>
+                                    {isActive && (
+                                      <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
                                     )}
                                   </div>
-                                )}
-                                {filteredValues.map(v => (
-                                  <label
-                                    key={v}
-                                    className='flex cursor-pointer items-center gap-2 px-3 py-1 text-sm hover:bg-accent'
-                                  >
-                                    <input
-                                      type='checkbox'
-                                      checked={selectedVals.includes(v)}
-                                      onChange={() => {
-                                        const next = selectedVals.includes(v)
-                                          ? selectedVals.filter(x => x !== v)
-                                          : [...selectedVals, v];
-                                        setSelectedCustomFieldValues({
-                                          ...selectedCustomFieldValues,
-                                          [k]: next,
-                                        });
-                                      }}
-                                      className='h-3.5 w-3.5 rounded accent-desk-accent'
-                                      data-track-category='DeskMetrics'
-                                      data-track-name='ToggleFieldValue'
-                                    />
-                                    <span className='block max-w-[230px] truncate' title={v}>
-                                      {v}
-                                    </span>
-                                  </label>
-                                ))}
-                                {filteredValues.length === 0 && (
-                                  <div className='px-3 py-2 text-xs text-muted-foreground'>
-                                    {valueSearch ? 'No matching values' : 'No values found'}
-                                  </div>
-                                )}
-                              </div>
-                            ))}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </Popover>
-              )}
+                                  <ChevronRight
+                                    size={16}
+                                    className='shrink-0 text-muted-foreground'
+                                  />
+                                </button>
+                              </PopoverPrimitive.Trigger>
+                              <PopoverPrimitive.Portal>
+                                <PopoverPrimitive.Content
+                                  side='right'
+                                  align='start'
+                                  sideOffset={4}
+                                  collisionPadding={12}
+                                  className='z-[70] outline-none'
+                                  data-custom-field-submenu='true'
+                                  onOpenAutoFocus={event => event.preventDefault()}
+                                >
+                                  <DynamicFieldSubmenu
+                                    fieldId={definition.id}
+                                    fieldName={key}
+                                    fieldType={definition.fieldType}
+                                    fieldEnum={parseFieldOptionValues(definition.fieldEnum)}
+                                    selectedValue={selectedCustomFieldValues[key] ?? []}
+                                    onChange={value => {
+                                      if (!Array.isArray(value)) return;
+                                      updateCustomFieldValues(key, value);
+                                    }}
+                                    onClose={() => setActiveSubmenu(null)}
+                                  />
+                                </PopoverPrimitive.Content>
+                              </PopoverPrimitive.Portal>
+                            </PopoverPrimitive.Root>
+                          );
+                        })}
+                    </div>
+                  </Popover>
 
-              <DeskMetricsDateRangePicker
-                dateRange={dateRange}
-                startTime={startTime}
-                endTime={endTime}
-                onChange={(dr, st, et) => {
-                  persistDateRange(dr, st, et);
-                }}
-              />
+                  {hasAnyFiltersActive && (
+                    <button
+                      type='button'
+                      onClick={() => {
+                        setSelectedAssigneeIds([]);
+                        setSelectedStageNames([]);
+                        setSelectedPriorities([]);
+                        setSelectedUserGroupIds([]);
+                        clearAllCustomFieldFilters();
+                      }}
+                      className='flex h-[32px] items-center gap-1.5 rounded-[10px] border border-border bg-background px-3 text-sm text-foreground shadow-sm hover:bg-muted'
+                      data-track-category='DeskMetrics'
+                      data-track-name='ClearDeskMetricsFilters'
+                    >
+                      <X size={14} />
+                      <span>Clear Filters</span>
+                    </button>
+                  )}
+                </>
 
-              <button
-                type='button'
-                onClick={() => void refetch()}
-                disabled={isFetching}
-                className={cn(
-                  'rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground',
-                  isFetching && 'cursor-not-allowed opacity-60',
-                )}
-                title='Refresh metrics'
-                data-track-category='DeskMetrics'
-                data-track-name='Refresh'
-              >
-                <RefreshCw size={16} className={cn(isFetching && 'animate-spin')} />
-              </button>
+                <DeskMetricsDateRangePicker
+                  dateRange={dateRange}
+                  startTime={startTime}
+                  endTime={endTime}
+                  onChange={(dr, st, et) => {
+                    persistDateRange(dr, st, et);
+                  }}
+                />
 
-              {/* Close button */}
-              <button
-                type='button'
-                onClick={onClose}
-                className='flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border border-desk-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground dark:border-border'
-                data-track-category='DeskMetrics'
-                data-track-name='CloseButton'
-              >
-                <X size={16} />
-              </button>
+                <button
+                  type='button'
+                  onClick={() => void refetch()}
+                  disabled={isFetching}
+                  className={cn(
+                    'rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground',
+                    isFetching && 'cursor-not-allowed opacity-60',
+                  )}
+                  title='Refresh metrics'
+                  data-track-category='DeskMetrics'
+                  data-track-name='Refresh'
+                >
+                  <RefreshCw size={16} className={cn(isFetching && 'animate-spin')} />
+                </button>
+              </div>
             </div>
           </div>
 
@@ -2038,6 +1908,8 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                       <div className='mb-3 flex items-center justify-between gap-3'>
                         <div className='text-sm font-medium text-foreground'>
                           {chartView === 'priority' && 'Tickets by priority'}
+                          {chartView === 'trend' &&
+                            `Tickets created vs resolved ${isHourly ? '(hourly)' : '(daily)'}`}
                           {chartView === 'assignee' && 'Tickets by assignee'}
                         </div>
                         <div className='flex items-center gap-2'>
@@ -2055,6 +1927,20 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                               )}
                             >
                               By Priority
+                            </button>
+                            <button
+                              type='button'
+                              onClick={() => setChartView('trend')}
+                              data-track-category='DeskMetrics'
+                              data-track-name='ChartViewTrend'
+                              className={cn(
+                                'rounded-[6px] px-2.5 py-1 text-xs font-medium transition-colors',
+                                chartView === 'trend'
+                                  ? 'bg-background text-foreground shadow-sm'
+                                  : 'text-muted-foreground hover:text-foreground',
+                              )}
+                            >
+                              Created vs Resolved
                             </button>
                             <button
                               type='button'
@@ -2108,6 +1994,41 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                                 <RechartsTooltip cursor={false} />
                                 <Legend />
                               </PieChart>
+                            </ResponsiveContainer>
+                          </div>
+                        ))}
+
+                      {chartView === 'trend' &&
+                        (trendData.length === 0 ? (
+                          <div className='flex h-[280px] items-center justify-center text-xs text-muted-foreground'>
+                            No data in range
+                          </div>
+                        ) : (
+                          <div className='h-[280px]'>
+                            <ResponsiveContainer width='100%' height='100%'>
+                              <BarChart data={trendData} margin={{ left: -16, right: 4 }}>
+                                <CartesianGrid strokeDasharray='3 3' vertical={false} />
+                                <XAxis
+                                  dataKey='label'
+                                  tick={{ fontSize: 11 }}
+                                  interval={tickInterval}
+                                />
+                                <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+                                <RechartsTooltip cursor={false} />
+                                <Legend />
+                                <Bar
+                                  dataKey='opened'
+                                  name='Created'
+                                  fill='#6366f1'
+                                  radius={[4, 4, 0, 0]}
+                                />
+                                <Bar
+                                  dataKey='closed'
+                                  name='Resolved'
+                                  fill='#10b981'
+                                  radius={[4, 4, 0, 0]}
+                                />
+                              </BarChart>
                             </ResponsiveContainer>
                           </div>
                         ))}
@@ -2201,6 +2122,8 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
             <div className='mb-4 flex items-center justify-between'>
               <h2 className='text-base font-semibold text-foreground'>
                 {expandedChart === 'priority' && 'Tickets by priority'}
+                {expandedChart === 'trend' &&
+                  `Tickets created vs resolved ${isHourly ? '(hourly)' : '(daily)'}`}
                 {expandedChart === 'assignee' && 'Tickets by assignee'}
               </h2>
               <button
@@ -2237,6 +2160,24 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                       <RechartsTooltip cursor={false} />
                       <Legend />
                     </PieChart>
+                  </ResponsiveContainer>
+                ))}
+              {expandedChart === 'trend' &&
+                (trendData.length === 0 ? (
+                  <div className='flex h-full items-center justify-center text-sm text-muted-foreground'>
+                    No data in range
+                  </div>
+                ) : (
+                  <ResponsiveContainer width='100%' height='100%'>
+                    <BarChart data={trendData} margin={{ left: -16, right: 8 }}>
+                      <CartesianGrid strokeDasharray='3 3' vertical={false} />
+                      <XAxis dataKey='label' tick={{ fontSize: 12 }} interval={tickInterval} />
+                      <YAxis tick={{ fontSize: 12 }} allowDecimals={false} />
+                      <RechartsTooltip cursor={false} />
+                      <Legend />
+                      <Bar dataKey='opened' name='Created' fill='#6366f1' radius={[4, 4, 0, 0]} />
+                      <Bar dataKey='closed' name='Resolved' fill='#10b981' radius={[4, 4, 0, 0]} />
+                    </BarChart>
                   </ResponsiveContainer>
                 ))}
               {expandedChart === 'assignee' &&

--- a/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDateRangePicker.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDateRangePicker.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 import { cn } from '../../../utils/classNames';
 import { CalendarView, type DateRangeValue } from '../../ui/DateRangeFilter';
 
-const MAX_CUSTOM_DAYS = 31;
+const MAX_CUSTOM_DAYS = 90;
 
 const startOfDay = (d: Date): Date => {
   const r = new Date(d);
@@ -54,6 +54,15 @@ const PRESETS = [
       const e = new Date(),
         s = new Date();
       s.setDate(s.getDate() - 29);
+      return { startDate: startOfDay(s), endDate: endOfDay(e) };
+    },
+  },
+  {
+    label: 'Last 90 days',
+    getValue: () => {
+      const e = new Date(),
+        s = new Date();
+      s.setDate(s.getDate() - 89);
       return { startDate: startOfDay(s), endDate: endOfDay(e) };
     },
   },

--- a/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDateRangePicker.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDateRangePicker.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 import { cn } from '../../../utils/classNames';
 import { CalendarView, type DateRangeValue } from '../../ui/DateRangeFilter';
 
-const MAX_CUSTOM_DAYS = 90;
+const MAX_CUSTOM_DAYS = 30;
 
 const startOfDay = (d: Date): Date => {
   const r = new Date(d);
@@ -54,15 +54,6 @@ const PRESETS = [
       const e = new Date(),
         s = new Date();
       s.setDate(s.getDate() - 29);
-      return { startDate: startOfDay(s), endDate: endOfDay(e) };
-    },
-  },
-  {
-    label: 'Last 90 days',
-    getValue: () => {
-      const e = new Date(),
-        s = new Date();
-      s.setDate(s.getDate() - 89);
       return { startDate: startOfDay(s), endDate: endOfDay(e) };
     },
   },

--- a/apps/dashboard/src/hooks/useDeskMetrics.ts
+++ b/apps/dashboard/src/hooks/useDeskMetrics.ts
@@ -1,5 +1,9 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
-import type { DeskMetricsAggregateResponse, DeskMetricsResponse } from '@xyne/shared';
+import type {
+  DeskMetricsAggregateResponse,
+  DeskMetricsResponse,
+  TicketPriority,
+} from '@xyne/shared';
 import {
   getAggregateDeskMetrics,
   getDeskMetrics,
@@ -10,12 +14,37 @@ export function useDeskMetrics(
   channelId: string | null,
   timeRange: string,
   enabled: boolean,
-  assigneeId?: string | null,
+  assigneeIds?: string[],
   customFieldFilter?: CustomFieldFilter,
+  stageNames?: string[],
+  priorities?: TicketPriority[],
+  userGroupIds?: string[],
 ): UseQueryResult<DeskMetricsResponse> {
+  const sortedStageNames = [...(stageNames ?? [])].sort();
+  const sortedAssigneeIds = [...(assigneeIds ?? [])].sort();
+  const sortedPriorities = [...(priorities ?? [])].sort();
+  const sortedUserGroupIds = [...(userGroupIds ?? [])].sort();
   return useQuery({
-    queryKey: ['desk-metrics', channelId, timeRange, assigneeId ?? null, customFieldFilter ?? null],
-    queryFn: () => getDeskMetrics(channelId as string, timeRange, assigneeId, customFieldFilter),
+    queryKey: [
+      'desk-metrics',
+      channelId,
+      timeRange,
+      sortedAssigneeIds,
+      customFieldFilter ?? null,
+      sortedStageNames,
+      sortedPriorities,
+      sortedUserGroupIds,
+    ],
+    queryFn: () =>
+      getDeskMetrics(
+        channelId as string,
+        timeRange,
+        sortedAssigneeIds,
+        customFieldFilter,
+        sortedStageNames,
+        sortedPriorities,
+        sortedUserGroupIds,
+      ),
     enabled: enabled && !!channelId,
     retry: 1,
   });
@@ -25,20 +54,39 @@ export function useAggregateDeskMetrics(
   channelIds: string[],
   timeRange: string,
   enabled: boolean,
-  assigneeId?: string | null,
+  assigneeIds?: string[],
   customFieldFilter?: CustomFieldFilter,
+  stageNames?: string[],
+  priorities?: TicketPriority[],
+  userGroupIds?: string[],
 ): UseQueryResult<DeskMetricsAggregateResponse> {
   const sortedIds = [...channelIds].sort();
+  const sortedAssigneeIds = [...(assigneeIds ?? [])].sort();
+  const sortedStageNames = [...(stageNames ?? [])].sort();
+  const sortedPriorities = [...(priorities ?? [])].sort();
+  const sortedUserGroupIds = [...(userGroupIds ?? [])].sort();
   const idsKey = sortedIds.join(',');
   return useQuery({
     queryKey: [
       'desk-metrics-aggregate',
       idsKey,
       timeRange,
-      assigneeId ?? null,
+      sortedAssigneeIds,
       customFieldFilter ?? null,
+      sortedStageNames,
+      sortedPriorities,
+      sortedUserGroupIds,
     ],
-    queryFn: () => getAggregateDeskMetrics(sortedIds, timeRange, assigneeId, customFieldFilter),
+    queryFn: () =>
+      getAggregateDeskMetrics(
+        sortedIds,
+        timeRange,
+        sortedAssigneeIds,
+        customFieldFilter,
+        sortedStageNames,
+        sortedPriorities,
+        sortedUserGroupIds,
+      ),
     enabled: enabled && sortedIds.length > 0,
     retry: 1,
   });

--- a/apps/dashboard/src/hooks/usePersistedDeskMetricsFilters.ts
+++ b/apps/dashboard/src/hooks/usePersistedDeskMetricsFilters.ts
@@ -2,13 +2,7 @@ import { useState, useCallback } from 'react';
 import { type DateRangeValue } from '../components/ui/DateRangeFilter';
 import { TicketPriority } from '@xyne/shared';
 
-type RangeLabel =
-  | 'Today'
-  | 'Yesterday'
-  | 'Last 7 days'
-  | 'Last 30 days'
-  | 'Last 90 days'
-  | 'custom';
+type RangeLabel = 'Today' | 'Yesterday' | 'Last 7 days' | 'Last 30 days' | 'custom';
 
 const startOfDay = (d: Date): Date => {
   const r = new Date(d);
@@ -33,13 +27,10 @@ const detectLabel = (dr: DateRangeValue): RangeLabel => {
   s7.setDate(s7.getDate() - 6);
   const s30 = new Date(today);
   s30.setDate(s30.getDate() - 29);
-  const s90 = new Date(today);
-  s90.setDate(s90.getDate() - 89);
   if (isSameDay(dr.startDate, today) && isSameDay(dr.endDate, today)) return 'Today';
   if (isSameDay(dr.startDate, yest) && isSameDay(dr.endDate, yest)) return 'Yesterday';
   if (isSameDay(dr.startDate, s7) && isSameDay(dr.endDate, today)) return 'Last 7 days';
   if (isSameDay(dr.startDate, s30) && isSameDay(dr.endDate, today)) return 'Last 30 days';
-  if (isSameDay(dr.startDate, s90) && isSameDay(dr.endDate, today)) return 'Last 90 days';
   return 'custom';
 };
 
@@ -65,11 +56,6 @@ const rangeFromLabel = (
     case 'Last 30 days': {
       const s = new Date(today);
       s.setDate(s.getDate() - 29);
-      return { startDate: startOfDay(s), endDate: endOfDay(today) };
-    }
-    case 'Last 90 days': {
-      const s = new Date(today);
-      s.setDate(s.getDate() - 89);
       return { startDate: startOfDay(s), endDate: endOfDay(today) };
     }
     case 'custom':
@@ -127,7 +113,6 @@ const readStorage = (key: string): StoredFilters => {
       'Yesterday',
       'Last 7 days',
       'Last 30 days',
-      'Last 90 days',
       'custom',
     ];
     const result: StoredFilters = {

--- a/apps/dashboard/src/hooks/usePersistedDeskMetricsFilters.ts
+++ b/apps/dashboard/src/hooks/usePersistedDeskMetricsFilters.ts
@@ -1,7 +1,14 @@
 import { useState, useCallback } from 'react';
 import { type DateRangeValue } from '../components/ui/DateRangeFilter';
+import { TicketPriority } from '@xyne/shared';
 
-type RangeLabel = 'Today' | 'Yesterday' | 'Last 7 days' | 'Last 30 days' | 'custom';
+type RangeLabel =
+  | 'Today'
+  | 'Yesterday'
+  | 'Last 7 days'
+  | 'Last 30 days'
+  | 'Last 90 days'
+  | 'custom';
 
 const startOfDay = (d: Date): Date => {
   const r = new Date(d);
@@ -26,10 +33,13 @@ const detectLabel = (dr: DateRangeValue): RangeLabel => {
   s7.setDate(s7.getDate() - 6);
   const s30 = new Date(today);
   s30.setDate(s30.getDate() - 29);
+  const s90 = new Date(today);
+  s90.setDate(s90.getDate() - 89);
   if (isSameDay(dr.startDate, today) && isSameDay(dr.endDate, today)) return 'Today';
   if (isSameDay(dr.startDate, yest) && isSameDay(dr.endDate, yest)) return 'Yesterday';
   if (isSameDay(dr.startDate, s7) && isSameDay(dr.endDate, today)) return 'Last 7 days';
   if (isSameDay(dr.startDate, s30) && isSameDay(dr.endDate, today)) return 'Last 30 days';
+  if (isSameDay(dr.startDate, s90) && isSameDay(dr.endDate, today)) return 'Last 90 days';
   return 'custom';
 };
 
@@ -57,6 +67,11 @@ const rangeFromLabel = (
       s.setDate(s.getDate() - 29);
       return { startDate: startOfDay(s), endDate: endOfDay(today) };
     }
+    case 'Last 90 days': {
+      const s = new Date(today);
+      s.setDate(s.getDate() - 89);
+      return { startDate: startOfDay(s), endDate: endOfDay(today) };
+    }
     case 'custom':
       return {
         startDate: customStart ? new Date(customStart) : startOfDay(today),
@@ -68,6 +83,10 @@ const rangeFromLabel = (
 const isStringArray = (v: unknown): v is string[] =>
   Array.isArray(v) && v.every(x => typeof x === 'string');
 
+const isTicketPriorityArray = (v: unknown): v is TicketPriority[] =>
+  isStringArray(v) &&
+  v.every(priority => Object.values(TicketPriority).includes(priority as TicketPriority));
+
 const isPerKeyValues = (v: unknown): v is Record<string, string[]> =>
   typeof v === 'object' && v !== null && !Array.isArray(v) && Object.values(v).every(isStringArray);
 
@@ -77,9 +96,11 @@ interface StoredFilters {
   customEnd?: string;
   startTime: string;
   endTime: string;
-  selectedAssigneeId: string | null;
-  selectedCustomFieldKeys: string[];
-  // Per-key checkbox selections: { Tag: ['EMI', 'UPI'], Tone: ['Neutral'] }
+  selectedAssigneeIds: string[];
+  selectedStageNames: string[];
+  selectedPriorities: TicketPriority[];
+  selectedUserGroupIds: string[];
+  // Per-field selected values or text terms: { Tag: ['EMI', 'UPI'], Tone: ['Neutral'] }
   selectedCustomFieldValues: Record<string, string[]>;
   comparedChannelIds: string[];
 }
@@ -88,8 +109,10 @@ const DEFAULT_STORED: StoredFilters = {
   rangeLabel: 'Last 7 days',
   startTime: '00:00',
   endTime: '23:59',
-  selectedAssigneeId: null,
-  selectedCustomFieldKeys: [],
+  selectedAssigneeIds: [],
+  selectedStageNames: [],
+  selectedPriorities: [],
+  selectedUserGroupIds: [],
   selectedCustomFieldValues: {},
   comparedChannelIds: [],
 };
@@ -104,6 +127,7 @@ const readStorage = (key: string): StoredFilters => {
       'Yesterday',
       'Last 7 days',
       'Last 30 days',
+      'Last 90 days',
       'custom',
     ];
     const result: StoredFilters = {
@@ -112,10 +136,17 @@ const readStorage = (key: string): StoredFilters => {
         : DEFAULT_STORED.rangeLabel,
       startTime: typeof p['startTime'] === 'string' ? p['startTime'] : DEFAULT_STORED.startTime,
       endTime: typeof p['endTime'] === 'string' ? p['endTime'] : DEFAULT_STORED.endTime,
-      selectedAssigneeId:
-        typeof p['selectedAssigneeId'] === 'string' ? p['selectedAssigneeId'] : null,
-      selectedCustomFieldKeys: isStringArray(p['selectedCustomFieldKeys'])
-        ? p['selectedCustomFieldKeys']
+      selectedAssigneeIds: isStringArray(p['selectedAssigneeIds'])
+        ? p['selectedAssigneeIds']
+        : typeof p['selectedAssigneeId'] === 'string'
+          ? [p['selectedAssigneeId']]
+          : [],
+      selectedStageNames: isStringArray(p['selectedStageNames']) ? p['selectedStageNames'] : [],
+      selectedPriorities: isTicketPriorityArray(p['selectedPriorities'])
+        ? p['selectedPriorities']
+        : [],
+      selectedUserGroupIds: isStringArray(p['selectedUserGroupIds'])
+        ? p['selectedUserGroupIds']
         : [],
       // Handle migration from old string[] format → default to empty
       selectedCustomFieldValues: isPerKeyValues(p['selectedCustomFieldValues'])
@@ -143,13 +174,17 @@ export interface PersistedDeskMetricsFilters {
   dateRange: DateRangeValue;
   startTime: string;
   endTime: string;
-  selectedAssigneeId: string | null;
-  selectedCustomFieldKeys: string[];
+  selectedAssigneeIds: string[];
+  selectedStageNames: string[];
+  selectedPriorities: TicketPriority[];
+  selectedUserGroupIds: string[];
   selectedCustomFieldValues: Record<string, string[]>;
   comparedChannelIds: string[];
   setDateRange: (dr: DateRangeValue, st: string, et: string) => void;
-  setSelectedAssigneeId: (id: string | null) => void;
-  setSelectedCustomFieldKeys: (keys: string[]) => void;
+  setSelectedAssigneeIds: (ids: string[]) => void;
+  setSelectedStageNames: (names: string[]) => void;
+  setSelectedPriorities: (priorities: TicketPriority[]) => void;
+  setSelectedUserGroupIds: (ids: string[]) => void;
   setSelectedCustomFieldValues: (vals: Record<string, string[]>) => void;
   setComparedChannelIds: (ids: string[]) => void;
 }
@@ -195,16 +230,30 @@ export const usePersistedDeskMetricsFilters = (
     [persist],
   );
 
-  const setSelectedAssigneeId = useCallback(
-    (id: string | null) => {
-      persist(prev => ({ ...prev, selectedAssigneeId: id }));
+  const setSelectedAssigneeIds = useCallback(
+    (ids: string[]) => {
+      persist(prev => ({ ...prev, selectedAssigneeIds: ids }));
     },
     [persist],
   );
 
-  const setSelectedCustomFieldKeys = useCallback(
-    (keys: string[]) => {
-      persist(prev => ({ ...prev, selectedCustomFieldKeys: keys }));
+  const setSelectedStageNames = useCallback(
+    (names: string[]) => {
+      persist(prev => ({ ...prev, selectedStageNames: names }));
+    },
+    [persist],
+  );
+
+  const setSelectedPriorities = useCallback(
+    (priorities: TicketPriority[]) => {
+      persist(prev => ({ ...prev, selectedPriorities: priorities }));
+    },
+    [persist],
+  );
+
+  const setSelectedUserGroupIds = useCallback(
+    (ids: string[]) => {
+      persist(prev => ({ ...prev, selectedUserGroupIds: ids }));
     },
     [persist],
   );
@@ -228,13 +277,17 @@ export const usePersistedDeskMetricsFilters = (
     dateRange,
     startTime: stored.startTime,
     endTime: stored.endTime,
-    selectedAssigneeId: stored.selectedAssigneeId,
-    selectedCustomFieldKeys: stored.selectedCustomFieldKeys,
+    selectedAssigneeIds: stored.selectedAssigneeIds,
+    selectedStageNames: stored.selectedStageNames,
+    selectedPriorities: stored.selectedPriorities,
+    selectedUserGroupIds: stored.selectedUserGroupIds,
     selectedCustomFieldValues: stored.selectedCustomFieldValues,
     comparedChannelIds: stored.comparedChannelIds,
     setDateRange,
-    setSelectedAssigneeId,
-    setSelectedCustomFieldKeys,
+    setSelectedAssigneeIds,
+    setSelectedStageNames,
+    setSelectedPriorities,
+    setSelectedUserGroupIds,
     setSelectedCustomFieldValues,
     setComparedChannelIds,
   };

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -585,9 +585,23 @@ const SupportScreen = (): ReactElement => {
   // A bare /support visit renders the empty state prompting the user to pick one.
   const selectedChannelId = channelIdParam ?? null;
 
-  const [channelBoardId, setChannelBoardId] = useState<string | null>(null);
+  const [resolvedChannelBoard, setResolvedChannelBoard] = useState<{
+    channelId: string;
+    boardId: string;
+  } | null>(null);
+  const channelBoardId =
+    resolvedChannelBoard?.channelId === selectedChannelId ? resolvedChannelBoard.boardId : null;
+  const handleChannelBoardIdResolved = useCallback(
+    (boardId: string): void => {
+      if (selectedChannelId) {
+        setResolvedChannelBoard({ channelId: selectedChannelId, boardId });
+      }
+    },
+    [selectedChannelId],
+  );
+  const [kanbanTickets, setKanbanTickets] = useState<Ticket[]>([]);
   useEffect(() => {
-    setChannelBoardId(null);
+    setKanbanTickets([]);
   }, [selectedChannelId]);
 
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
@@ -1405,9 +1419,9 @@ const SupportScreen = (): ReactElement => {
   const isDlDesk = channelPreference?.deskType === DeskType.DL;
   useEffect(() => {
     if (channelPreference?.boardId) {
-      setChannelBoardId(channelPreference.boardId);
+      handleChannelBoardIdResolved(channelPreference.boardId);
     }
-  }, [selectedChannelId, channelPreference?.boardId]);
+  }, [channelPreference?.boardId, handleChannelBoardIdResolved]);
   const { data: dlMemberSyncStatus } = useDlMemberSyncStatus(refetchChannelId, isDlDesk);
   const isDlMemberSyncing = dlMemberSyncStatus?.active === true;
   const dlMemberSyncTooltip = isDlMemberSyncing
@@ -1612,11 +1626,6 @@ const SupportScreen = (): ReactElement => {
     () => sortedEmailChannels.find(c => c.id === selectedChannelId),
     [sortedEmailChannels, selectedChannelId],
   );
-
-  // Only the setter is read (onTicketsLoaded callbacks below); the loaded ticket
-  // array itself is not consumed here since the merge dialog is built from the
-  // selection map. See mergeDialogTickets for the rationale.
-  const [kanbanTickets, setKanbanTickets] = useState<Ticket[]>([]);
 
   const [showMergeDialog, setShowMergeDialog] = useState(false);
 
@@ -3019,6 +3028,8 @@ const SupportScreen = (): ReactElement => {
                   channelId={selectedChannelId}
                   channelName={selectedChannelName ?? undefined}
                   availableDesks={metricsSelectableDesks}
+                  customFieldDefinitions={deskDynamicFields}
+                  availableStages={availableStages}
                 />
               )}
               <div className='h-full flex-1 min-h-0 overflow-y-auto no-scrollbar'>
@@ -3099,7 +3110,7 @@ const SupportScreen = (): ReactElement => {
                       <SupportKanbanBoard
                         channelId={selectedChannelId}
                         boardId={channelBoardId}
-                        onBoardIdResolved={setChannelBoardId}
+                        onBoardIdResolved={handleChannelBoardIdResolved}
                         ticketFilter={ticketFilter}
                         dynamicFieldEntries={dynamicFieldEntries}
                         onTicketClick={handleTicketClick}
@@ -3113,7 +3124,7 @@ const SupportScreen = (): ReactElement => {
                         dynamicFieldEntries={dynamicFieldEntries}
                         visibleColumns={tableVisibleColumns}
                         dynamicFieldColumns={tableDynamicFieldColumns}
-                        onBoardIdResolved={setChannelBoardId}
+                        onBoardIdResolved={handleChannelBoardIdResolved}
                         onTicketsLoaded={setKanbanTickets}
                         selectedIds={selectedTicketIds}
                         onSelectionChange={handleTableSelectionChange}
@@ -3139,7 +3150,7 @@ const SupportScreen = (): ReactElement => {
                         activeTicketId={ticketId}
                         selectedIds={selectedTicketIds}
                         onToggleSelect={toggleTicketSelected}
-                        onBoardIdReady={setChannelBoardId}
+                        onBoardIdReady={handleChannelBoardIdResolved}
                         onPageChange={clearTicketSelection}
                         onToggleSelectAll={handleToggleSelectAll}
                         onTicketsLoaded={setKanbanTickets}

--- a/apps/dashboard/src/services/deskMetricsService.ts
+++ b/apps/dashboard/src/services/deskMetricsService.ts
@@ -1,4 +1,8 @@
-import type { DeskMetricsAggregateResponse, DeskMetricsResponse } from '@xyne/shared';
+import type {
+  DeskMetricsAggregateResponse,
+  DeskMetricsResponse,
+  TicketPriority,
+} from '@xyne/shared';
 import { apiInstance } from './clients/apiClient';
 
 export type PerKeyFilter = { values?: string[]; textTerms?: string[] };
@@ -10,11 +14,18 @@ export type CustomFieldFilter = {
 export async function getDeskMetrics(
   channelId: string,
   timeRange: string,
-  assigneeId?: string | null,
+  assigneeIds?: string[],
   customFieldFilter?: CustomFieldFilter,
+  stageNames?: string[],
+  priorities?: TicketPriority[],
+  userGroupIds?: string[],
 ): Promise<DeskMetricsResponse> {
   const params: Record<string, string> = { timeRange };
-  if (assigneeId) params['assigneeId'] = assigneeId;
+  if (assigneeIds && assigneeIds.length > 0) params['assigneeIds'] = JSON.stringify(assigneeIds);
+  if (stageNames && stageNames.length > 0) params['stageNames'] = JSON.stringify(stageNames);
+  if (priorities && priorities.length > 0) params['priorities'] = JSON.stringify(priorities);
+  if (userGroupIds && userGroupIds.length > 0)
+    params['userGroupIds'] = JSON.stringify(userGroupIds);
   if (customFieldFilter && customFieldFilter.keys.length > 0) {
     params['customFieldKeys'] = JSON.stringify(customFieldFilter.keys);
     if (customFieldFilter.perKeyFilters)
@@ -29,14 +40,21 @@ export async function getDeskMetrics(
 export async function getAggregateDeskMetrics(
   channelIds: string[],
   timeRange: string,
-  assigneeId?: string | null,
+  assigneeIds?: string[],
   customFieldFilter?: CustomFieldFilter,
+  stageNames?: string[],
+  priorities?: TicketPriority[],
+  userGroupIds?: string[],
 ): Promise<DeskMetricsAggregateResponse> {
   const params: Record<string, string> = {
     timeRange,
     channelIds: channelIds.join(','),
   };
-  if (assigneeId) params['assigneeId'] = assigneeId;
+  if (assigneeIds && assigneeIds.length > 0) params['assigneeIds'] = JSON.stringify(assigneeIds);
+  if (stageNames && stageNames.length > 0) params['stageNames'] = JSON.stringify(stageNames);
+  if (priorities && priorities.length > 0) params['priorities'] = JSON.stringify(priorities);
+  if (userGroupIds && userGroupIds.length > 0)
+    params['userGroupIds'] = JSON.stringify(userGroupIds);
   if (customFieldFilter && customFieldFilter.keys.length > 0) {
     params['customFieldKeys'] = JSON.stringify(customFieldFilter.keys);
     if (customFieldFilter.perKeyFilters)


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [*] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
Fixed Desk Metrics filtering for multi-select and user custom fields by matching selected values against individual JSON-array elements.
Preserved existing exact-match behavior for scalar custom fields.
Removed unsupported DOC fields from the Desk Metrics filter menu.
Verified with backend/dashboard typechecks, ESLint, and a database array-membership check.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
