### PR TITLE
ci: build images amd64-only to match internal Jenkins and avoid OOM

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,30 +1,12 @@
 name: Build Images
 
-# Build-only, MANUAL-only. Builds the production container images to validate the
-# Dockerfiles build end to end for every supported architecture. It intentionally
-# does NOT push anywhere yet — `push: false`. A destination is decided later; the
-# push wiring is sketched at the bottom of this file.
-#
-# Inputs (chosen in the "Run workflow" dialog):
-#   - branch/tag: GitHub's built-in picker — build from ANY ref you select.
-#   - image: which image to build (all / backend / dashboard / xyne-claw).
-#
-# Access control (only specific team members may build):
-#   Trigger is manual-only, so nothing runs on merges — no approvals pile up.
-#   A run is allowed only if the person who launched it is listed in the
-#   `IMAGE_BUILDERS` Actions variable (comma-separated GitHub usernames). Anyone
-#   else fails instantly — no pending-approval queue, no extra clicks. Edit the
-#   allowed list in Settings → Secrets and variables → Actions → Variables, no
-#   code change needed. (When publishing is enabled later, add an `environment:`
-#   approval gate on top of this — a human "yes" is worth it before pushing.)
-#
-# Multi-arch: images build for linux/amd64 AND linux/arm64 (arm64 via QEMU
-# emulation), so the open-source images run on any system/architecture. A
-# multi-platform build is validated without exporting while push is false.
-#
-# Build context is the REPO ROOT (`.`) for every image — each Dockerfile COPYs
-# the root package.json / pnpm-lock.yaml / workspace packages, so `-f
-# apps/<app>/Dockerfile` with `context: .` is required, not the app dir.
+# Build-only, manual-only: validates the app images build. Does NOT push yet
+# (push: false); publish wiring is sketched at the bottom.
+# - Inputs: ref picker (any branch/tag) + image (all / backend / dashboard / xyne-claw).
+# - Access: only usernames in the IMAGE_BUILDERS Actions variable may run it.
+# - amd64 only, matching the internal Jenkins pipeline (arm64 would need QEMU and
+#   OOMs tsc/vite on the 16 GB runner; amd64 still runs on arm64 via emulation).
+# - Build context is the repo root (.) — Dockerfiles COPY root manifests.
 on:
   workflow_dispatch:
     inputs:
@@ -41,14 +23,12 @@ on:
 permissions:
   contents: read
 
-# One image build at a time.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
-  # Cheap gate job: checks the launcher is allowed AND resolves the matrix from
-  # the chosen `image` input, BEFORE spinning up the heavy multi-arch builds.
+  # Cheap gate: authorize the launcher + resolve the matrix before heavy builds.
   prepare:
     name: Authorize + resolve images
     runs-on: ubuntu-latest
@@ -61,10 +41,10 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: |
           if [ -z "${ALLOWED}" ]; then
-            echo "::error::vars.IMAGE_BUILDERS is not set. Add a repo/org Actions variable listing the comma-separated GitHub usernames allowed to build images."
+            echo "::error::vars.IMAGE_BUILDERS is not set. Add an Actions variable with the comma-separated GitHub usernames allowed to build images."
             exit 1
           fi
-          # Case-insensitive membership check; tolerant of comma/space separators.
+          # Case-insensitive; tolerant of comma/space separators.
           actor_lc="$(printf '%s' "${ACTOR}" | tr 'A-Z' 'a-z')"
           match=0
           IFS=', ' read -r -a list <<< "${ALLOWED}"
@@ -85,7 +65,6 @@ jobs:
         env:
           IMAGE: ${{ inputs.image }}
         run: |
-          # "all" fans out to every image; a specific choice builds just that one.
           case "${IMAGE}" in
             all)                          names='["backend","dashboard","xyne-claw"]' ;;
             backend|dashboard|xyne-claw)  names="[\"${IMAGE}\"]" ;;
@@ -98,39 +77,26 @@ jobs:
     name: Build ${{ matrix.name }} image
     needs: prepare
     runs-on: ubuntu-latest
-    # tsc / vite inside the builder stages need a larger V8 heap (mirrors ci.yml).
+    # tsc / vite need a larger V8 heap (mirrors ci.yml).
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
     strategy:
-      # Build every selected image even if one fails, so one broken Dockerfile
-      # doesn't hide the status of the others.
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v5
 
-      # QEMU registers emulators so linux/arm64 can be built on an amd64 runner.
-      - uses: docker/setup-qemu-action@v3
-
-      # buildx enables multi-platform builds + layer caching (type=gha).
       - uses: docker/setup-buildx-action@v3
 
-      - name: Build ${{ matrix.name }} image (multi-arch, no push)
+      - name: Build ${{ matrix.name }} image (amd64, no push)
         uses: docker/build-push-action@v6
         with:
           context: .
-          # All three Dockerfiles live at apps/<name>/Dockerfile.
           file: apps/${{ matrix.name }}/Dockerfile
-          # BUILD ONLY — do not push. Multi-platform builds cannot be loaded into
-          # the local docker daemon, so nothing is exported; the build itself is
-          # the validation. Flip to true (+ registry login + tags) when a
-          # destination is chosen.
           push: false
-          # Open-source images: build for every supported architecture.
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           # dashboard bakes the commit into the client bundle; others need no args.
           build-args: ${{ matrix.name == 'dashboard' && format('SOURCE_COMMIT={0}', github.sha) || '' }}
-          # Speed up reruns by caching layers in the Actions cache, scoped per image.
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
@@ -141,8 +107,7 @@ jobs:
             echo "### Build ${{ matrix.name }} image"
             echo ""
             echo "- **Dockerfile:** \`apps/${{ matrix.name }}/Dockerfile\`"
-            echo "- **Context:** repo root (\`.\`)"
-            echo "- **Platforms:** linux/amd64, linux/arm64"
+            echo "- **Platform:** linux/amd64"
             echo "- **Pushed:** no (build-only)"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -169,7 +134,8 @@ jobs:
 #         with:
 #           push: true
 #           tags: ${{ steps.meta.outputs.tags }}
-#           platforms: linux/amd64,linux/arm64
+#           platforms: linux/amd64   # add linux/arm64 here (+ setup-qemu) only if
+#                                     # native ARM images are needed at publish time
 #           ...
 # The IMAGE_BUILDERS gate still restricts WHO can run it; the environment adds a
 # human approval step specifically for the push.


### PR DESCRIPTION
ci: build images amd64-only to match internal Jenkins and avoid OOM