### PR TITLE
feat: XYNE-55338 add Cmd+K result actions menu (Message/Call)

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -70,6 +70,8 @@ import { useDeskContacts } from '../../../hooks/useDeskContacts';
 import { useDeskPeople, ALL_DESK } from '../../../hooks/useDeskPeople';
 import { useUsers, useUserSearch, useUser } from '../../../hooks/useUsers';
 import { QuickDmComposer } from './SlashCommands/QuickDmComposer';
+import type { CommandTarget } from './SlashCommands/QuickDmComposer';
+import { ResultActionsMenu } from './ResultActionsMenu';
 import { SlashCommandPalette } from './SlashCommands/SlashCommandPalette';
 import { useSlashCommands, type SlashCommandClickInfo } from './SlashCommands/useSlashCommands';
 import { getCommand, COMMAND_KINDS } from './SlashCommands/commands';
@@ -144,6 +146,8 @@ export const ChannelCommandItem = ({
       key={channel.id}
       value={`channel-${channel.id}-${displayName}`}
       data-item-label={displayName}
+      data-result-id={channel.id}
+      data-result-type='channel'
       onSelect={() => onSelect(displayName)}
       onMouseDownCapture={onItemMouseDown}
       className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer mt-1.5 aria-selected:bg-accent ${!isMobile && 'hover:bg-accent'}`}
@@ -273,7 +277,11 @@ const ChannelCommandMenu = ({
 }: ChannelCommandMenuProps): ReactElement | null => {
   const navigate = useNavigate();
   const channelData = useAllChannels();
-  const commandRef = useRef<HTMLDivElement>(null);
+  const commandRef = useRef<HTMLDivElement | null>(null);
+  // MutationObserver (owned by attachCommandRef) that recomputes the ⌥↵ hint when cmdk adds/removes rows.
+  const rowListObserverRef = useRef<MutationObserver | null>(null);
+  // The highlighted result row the ⌥↵ Actions menu opens above.
+  const actionsAnchorRef = useRef<HTMLElement | null>(null);
   // Tracks whether the most recent activation gesture (mouse or keyboard)
   // carried a Cmd/Ctrl modifier. cmdk's onSelect strips the event and a
   // synthetic .click() strips modifier flags, so we prime this ref from
@@ -594,6 +602,9 @@ const ChannelCommandMenu = ({
   // enterWillOpen = Enter opens the row vs. runs a search; activeItemLabel = its name.
   const [enterWillOpen, setEnterWillOpen] = useState(false);
   const [activeItemLabel, setActiveItemLabel] = useState<string | null>(null);
+  // Whether the highlighted row is a user/channel — the only rows ⌥↵ can act on. Gates the footer
+  // Actions hint so it isn't shown (misleadingly) on messages/tickets/etc. where ⌥↵ does nothing.
+  const [activeItemActionable, setActiveItemActionable] = useState(false);
 
   // Slash-command mode (`/call`, `/chat`, `/askai`). All command state + logic lives in the hook;
   // the parent feeds it the shared cmdk selection (activeItemLabel/hasNavigated) and wires its
@@ -608,6 +619,17 @@ const ChannelCommandMenu = ({
     (info: SlashCommandClickInfo): void => {
       const selectionType = lastSlashSelectionRef.current;
       lastSlashSelectionRef.current = 'unknown';
+      // The ⌥↵ Actions menu dispatches a command WITHOUT first typing `/`, so the commandActive
+      // effect hasn't opened a slash session yet (⌥↵ Call never enters command mode at all) and
+      // onClick would be dropped for want of a session id. Demand-start one here (mirroring the
+      // effect's start branch) so the click — and its `source` — is logged; the effect won't
+      // double-start because slashSessionActiveRef is now set.
+      if (!slashSessionActiveRef.current) {
+        slashSessionActiveRef.current = true;
+        slashInvokedRef.current = false;
+        lastSlashImpressionKeyRef.current = '';
+        slashMetrics.onSessionStart();
+      }
       if (info.terminal) slashInvokedRef.current = true;
       slashMetrics.onClick({
         stage: info.stage,
@@ -616,6 +638,7 @@ const ChannelCommandMenu = ({
         terminal: info.terminal,
         ...(info.targetType && { targetType: info.targetType }),
         ...(info.destination && { destination: info.destination }),
+        ...(info.source && { source: info.source }),
       });
     },
     [slashMetrics],
@@ -653,6 +676,9 @@ const ChannelCommandMenu = ({
     handleEditorText,
   } = slash;
 
+  // ⌥↵ Actions menu: the highlighted user/channel result to act on (Message / Call). Null = closed.
+  const [actionsMenuTarget, setActionsMenuTarget] = useState<CommandTarget | null>(null);
+
   // ── Slash-command funnel: session start / end ────────────────────────────
   // A session spans one entry into command mode (`/`) until a command executes
   // or the box leaves command mode. `commandActive` covers discovery, picker,
@@ -679,7 +705,12 @@ const ChannelCommandMenu = ({
   // command's picker — deduped by a stage+command key so keystrokes within the
   // same view don't re-log.
   useEffect(() => {
-    if (!(commandActive && open && commandText.startsWith('/'))) {
+    // `isComposing` means a target is picked and the composer is on screen — there's no options
+    // view to impress, so bail. This drops the phantom picker impression on the ⌥↵ Message path
+    // (which seeds `/chat ` then jumps straight to compose) and, in the normal `/chat` flow, stops
+    // re-logging the picker once a recipient is chosen. Clearing the key lets the picker re-log if
+    // the user goes back to it.
+    if (!(commandActive && open && commandText.startsWith('/')) || isComposing) {
       lastSlashImpressionKeyRef.current = '';
       return;
     }
@@ -744,6 +775,7 @@ const ChannelCommandMenu = ({
     slash.commandChannelResults,
     slash.commandGroupDmResults,
     slashMetrics,
+    isComposing,
   ]);
 
   // Once the seeded `/` actually lands (command mode is genuinely active), drop the seed flag so
@@ -755,11 +787,40 @@ const ChannelCommandMenu = ({
   }, [seedCommandMode, commandText]);
 
   const syncEnterIntent = useCallback((): void => {
-    const active = commandRef.current?.querySelector('[cmdk-item][aria-selected="true"]');
+    const container = commandRef.current;
+    // The auto-select timer below can fire after the Command unmounts (Escape mid-timer), leaving a
+    // null container — bail before the querySelector.
+    if (!container) return;
+    const active = container.querySelector('[cmdk-item][aria-selected="true"]');
     const willOpen = !!active && active.getAttribute('data-show-results-item') !== 'true';
     setEnterWillOpen(willOpen);
     setActiveItemLabel(willOpen ? (active?.getAttribute('data-item-label') ?? null) : null);
+    // At rest (nothing selected yet) fall back to the first enabled row — the row ⌥↵ acts on
+    // (matching resolveActionTarget) — so the hint is right before any arrow/hover.
+    const actionRow = active ?? container.querySelector('[cmdk-item]:not([aria-disabled="true"])');
+    const resultType = actionRow?.getAttribute('data-result-type');
+    setActiveItemActionable(resultType === 'user' || resultType === 'channel');
   }, []);
+
+  // Callback ref for the <Command> root. Recompute the ⌥↵ hint when rows actually land instead of
+  // guessing with a setTimeout: sync once on mount (browse rows are already children), then observe
+  // the results list for late/streamed rows. Null on unmount/branch swap → disconnect.
+  const attachCommandRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      commandRef.current = node;
+      rowListObserverRef.current?.disconnect();
+      rowListObserverRef.current = null;
+      if (!node) return;
+      syncEnterIntent();
+      // Observe the results list, not the <Command> root: the footer hint syncEnterIntent toggles
+      // sits outside [cmdk-list], so scoping here avoids re-firing on our own hint writes.
+      const listEl = node.querySelector('[cmdk-list]') ?? node;
+      const observer = new MutationObserver((): void => syncEnterIntent());
+      observer.observe(listEl, { childList: true, subtree: true });
+      rowListObserverRef.current = observer;
+    },
+    [syncEnterIntent],
+  );
 
   // Ghost suffix telling the user what Enter does - shown when there's typed text or a filter
   // chip and no mention typeahead is open. getScreenSearchSuffix() picks the text.
@@ -1573,6 +1634,16 @@ const ChannelCommandMenu = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
 
+  // A tab-switch swaps the result set, so reset the navigation flag (new tab re-auto-selects row 0)
+  // and the ghost. activeItemActionable is deliberately NOT reset — syncEnterIntent owns it and the
+  // row-swap MutationObserver recomputes it; forcing false here races that sync and clobbers it.
+  useEffect(() => {
+    hasNavigatedRef.current = false;
+    setHasNavigated(false);
+    setActiveItemLabel(null);
+    setEnterWillOpen(false);
+  }, [activeTab]);
+
   // Reset active tab if the current tab is no longer in the enabled set.
   // In inline mode, fall back to the first enabled tab (never ALL).
   useEffect(() => {
@@ -1618,6 +1689,11 @@ const ChannelCommandMenu = ({
       hasNavigatedRef.current = false;
       setEnterWillOpen(false);
       setActiveItemLabel(null);
+      // Close the ⌥↵ Actions menu on palette close too. It renders as a sibling (survives the
+      // dialog), so a leftover target keeps the popup open over a stale, detached anchor row and
+      // re-surfaces it on the next Cmd+K open.
+      setActionsMenuTarget(null);
+      actionsAnchorRef.current = null;
       setActiveTab(TabType.ALL);
       onTabChange?.(TabType.ALL);
       resetSearchState();
@@ -1762,6 +1838,8 @@ const ChannelCommandMenu = ({
       items.forEach(item => {
         item.setAttribute('aria-selected', item === hovered ? 'true' : 'false');
       });
+      // Hover moves aria-selected (an attribute) — the row-list MutationObserver only watches
+      // childList, so it's blind to this. Recompute the hint here or it freezes while hovering.
       syncEnterIntent();
       markNavigated();
     });
@@ -2063,7 +2141,9 @@ const ChannelCommandMenu = ({
           item.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
         });
       }
-      syncEnterIntent();
+      // No sync here: the results-list observer recomputes actionability whenever rows change
+      // (incl. a re-rank, which reorders keyed rows = a childList mutation), and enterWillOpen/label
+      // stay hidden until the user navigates (arrow/hover re-sync them then).
     }, 50);
     return () => clearTimeout(timer);
   }, [
@@ -2074,12 +2154,14 @@ const ChannelCommandMenu = ({
     filteredLocalUsers.length,
     backendResultOrder,
     mentionSearchType,
-    syncEnterIntent,
     commandActive,
     // `commandText` is a dep (not read in the body) so the first-row auto-select
     // re-fires as the `/` command list / user picker narrows while typing.
     commandText,
   ]);
+
+  // Browse-mode hint sync lives in attachCommandRef's MutationObserver (the auto-select effect above
+  // only runs during an active search).
 
   // Render backend results for the search-active branch (flat list filtered by activeTab)
   const renderSearchBackendResults = () => (
@@ -2614,19 +2696,94 @@ const ChannelCommandMenu = ({
     />
   );
 
+  // ⌥↵ Actions menu, rendered on top of the still-open palette (unlike the confirm dialogs, which
+  // close it first). Running an action dispatches through the slash-command hook; Esc/backdrop just
+  // closes the menu and hands focus back to the search editor.
+  const resultActionsMenu = (
+    <ResultActionsMenu
+      open={actionsMenuTarget !== null}
+      target={actionsMenuTarget}
+      anchorRef={actionsAnchorRef}
+      onRun={kind => {
+        if (actionsMenuTarget) slash.invokeActionOnTarget(kind, actionsMenuTarget);
+        setActionsMenuTarget(null);
+      }}
+      onClose={() => {
+        setActionsMenuTarget(null);
+        // Return focus to the search editor on the NEXT frame — after the DropdownMenu unmounts and
+        // Radix's modal focus-scope finishes its cleanup. Focusing synchronously loses that race
+        // (focus lands on <body>), which leaves cmd+K arrow navigation dead until the user clicks.
+        requestAnimationFrame(() => {
+          (
+            commandRef.current?.querySelector('[contenteditable="true"]') as HTMLElement | null
+          )?.focus();
+        });
+      }}
+    />
+  );
+
   const commandConfirmations = (
     <>
       {channelCallConfirm}
       {recordingActiveDialog}
+      {resultActionsMenu}
     </>
   );
 
   if (inline && !open) return commandConfirmations;
 
+  // Resolve the highlighted Cmd+K row into a chat/call target for the ⌥↵ Actions menu, then map it
+  // to the full user/channel object. Only user & channel results are actionable — chat/call need a
+  // target. Two rows can carry aria-selected at once (cmdk's own value + our manual arrow/hover
+  // setAttribute), so a plain first-match can grab a row the user isn't looking at; prefer the one
+  // whose label matches the visible "– Open" hint (activeItemLabel), then the first selected, then
+  // the first enabled row (mirrors the Enter target fallback).
+  const resolveActionTarget = (): { element: HTMLElement; target: CommandTarget } | null => {
+    const container = commandRef.current;
+    if (!container) return null;
+    const selected = Array.from(
+      container.querySelectorAll<HTMLElement>('[cmdk-item][aria-selected="true"]'),
+    );
+    const byLabel =
+      activeItemLabel !== null
+        ? selected.find(el => el.getAttribute('data-item-label') === activeItemLabel)
+        : undefined;
+    const element =
+      byLabel ??
+      selected[0] ??
+      container.querySelector<HTMLElement>('[cmdk-item]:not([aria-disabled="true"])');
+    if (!element) return null;
+    const resultId = element.getAttribute('data-result-id');
+    const resultType = element.getAttribute('data-result-type');
+    if (!resultId || !resultType) return null;
+    if (resultType === 'user') {
+      const user = usersById.get(resultId);
+      return user ? { element, target: { type: 'user', user } } : null;
+    }
+    if (resultType === 'channel') {
+      const entry = allChannels.find(item => item.channel.id === resultId);
+      if (!entry) return null;
+      return {
+        element,
+        target: {
+          type: 'channel',
+          channel: entry.channel,
+          displayName: getDMDisplayNameWithSelf(entry.channel, entry.searchableNames),
+          isDm: isDMChannel(entry.channel.scopeType),
+        },
+      };
+    }
+    return null;
+  };
+
   const handleCommandKeyDown = (e: React.KeyboardEvent<HTMLElement>): void => {
     // A picked target renders its own UI (composer or confirm modal) — let it own all
     // keys (typing, Enter to send/confirm, its own @/# mention pickers).
     if (commandTarget) return;
+
+    // While the ⌥↵ Actions menu is open it owns the keyboard (via its own document-level capture
+    // handler); the palette must stay inert underneath.
+    if (actionsMenuTarget) return;
 
     // ── Slash-command mode: picker / `/` discovery ───────────────────────
     // Escape is intentionally NOT handled here — it falls through so the menu
@@ -2879,6 +3036,19 @@ const ChannelCommandMenu = ({
 
     // Shift+Enter → allow newline in Lexical
     if (e.shiftKey) return;
+
+    // ⌥↵ → open the Actions menu (Message / Call) for the highlighted user/channel result. If the
+    // row isn't actionable (message/ticket/etc.), fall through to normal Enter navigation.
+    if (e.altKey && mentionSearchType === null) {
+      const resolved = resolveActionTarget();
+      if (resolved) {
+        e.preventDefault();
+        e.stopPropagation();
+        actionsAnchorRef.current = resolved.element;
+        setActionsMenuTarget(resolved.target);
+        return;
+      }
+    }
 
     // If mention search is active, let the mention selection handle Enter
     if (mentionSearchType !== null) {
@@ -4179,8 +4349,10 @@ const ChannelCommandMenu = ({
       </div>
       {/* end body flex row */}
 
-      {/* Footer - outside body flex so TicketPreviewPanel only spans results area */}
-      {!inline && !isMobile && (
+      {/* Footer - outside body flex so TicketPreviewPanel only spans results area. Hidden while the
+          `/chat` composer is open (isComposing): its hints (Open/Navigate/Actions/Ask AI) are about
+          the results list, which the composer replaces — you're typing a message, not navigating. */}
+      {!inline && !isMobile && !isComposing && (
         <div className='relative px-6 py-4 text-sm font-medium text-muted-foreground flex items-center justify-between shrink-0 rounded-b-2xl'>
           {/* Fade the scrolling results into the footer (replaces the hard top border) */}
           <div className='pointer-events-none absolute inset-x-0 bottom-full h-[30px] bg-gradient-to-t from-card to-transparent' />
@@ -4211,18 +4383,34 @@ const ChannelCommandMenu = ({
                 <ArrowTurnDownLeft size={10} />
               </span>
             </span>
-            {/* <span className='text-gray-300'>|</span> */}
-            <span className='flex gap-2.5 items-center'>
-              <span>Navigate </span>
-              <span className='flex gap-1'>
-                <span className='p-1 bg-muted rounded-lg'>
-                  <ArrowUp size={12} />
-                </span>
-                <span className='p-1 bg-muted rounded-lg'>
-                  <ArrowDown size={12} />
+            {/* Navigate hint (↑↓). Shown when the selected row isn't ⌥↵-actionable — a message/
+                ticket/file/desk row, or nothing selected — so the footer always offers a next step.
+                Mutually exclusive with the Actions hint below (which covers user/channel rows). */}
+            {!activeItemActionable && (
+              <span className='flex gap-2.5 items-center'>
+                <span>Navigate</span>
+                <span className='flex items-center gap-1'>
+                  <span className='p-1 bg-muted rounded-lg'>
+                    <ArrowUp size={10} />
+                  </span>
+                  <span className='p-1 bg-muted rounded-lg'>
+                    <ArrowDown size={10} />
+                  </span>
                 </span>
               </span>
-            </span>
+            )}
+            {/* Actions menu hint (⌥↵). Shown whenever the selected row is a user/channel — whether
+                auto-selected on search or arrowed/hovered — since ⌥↵ acts on it. Non-actionable rows
+                (messages/tickets/files/desk) fall to the Navigate hint above. */}
+            {activeItemActionable && (
+              <span className='flex gap-2.5 items-center'>
+                <span>Actions</span>
+                <span className='flex items-center gap-1 px-1.5 py-1 bg-muted rounded-lg leading-none'>
+                  <span>⌥</span>
+                  <ArrowTurnDownLeft size={10} />
+                </span>
+              </span>
+            )}
             {previewTicket ? (
               <span className='flex gap-2.5 items-center'>
                 <span className='flex gap-1'>
@@ -4307,7 +4495,7 @@ const ChannelCommandMenu = ({
   if (inline) {
     return (
       <Command
-        ref={commandRef}
+        ref={attachCommandRef}
         // Selection is managed imperatively (aria-selected via setAttribute) because cmdk's
         // arrow-nav needs a Command.Input we don't use. Pin cmdk's value to a sentinel that
         // matches no item so it never marks one selected too — otherwise it latches a result row
@@ -4366,6 +4554,12 @@ const ChannelCommandMenu = ({
               }
             }}
             onEscapeKeyDown={event => {
+              // While the ⌥↵ Actions menu is open, Escape closes only it — never the palette.
+              if (actionsMenuTarget !== null) {
+                event.preventDefault();
+                setActionsMenuTarget(null);
+                return;
+              }
               // While focus is inside such an overlay, Escape should close only
               // the overlay (it owns that via OverlayPortal), not the palette.
               // Scoped to the focused target — not a global query — so the
@@ -4381,7 +4575,7 @@ const ChannelCommandMenu = ({
             }}
           >
             <Command
-              ref={commandRef}
+              ref={attachCommandRef}
               // See inline <Command> above: pin cmdk's value to a sentinel ('__none__') that matches no
               // item so it never adds a second highlighted row next to the imperatively-managed one.
               value='__none__'

--- a/apps/dashboard/src/components/Chat/ChatDirectory/LexicalSearchInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/LexicalSearchInput.tsx
@@ -261,6 +261,11 @@ function ClearEditorPlugin({ value }: { value: string | undefined }) {
       const hasChip = (node: LexicalNode): boolean =>
         $isFilterChipNode(node) || ($isElementNode(node) && node.getChildren().some(hasChip));
       if (hasChip(root)) return;
+      // Slash-command text ('/chat ', '/call ') lives in this same editor but reports value=''
+      // (the search hook consumes it in command mode). The ⌥↵ Actions → Message path seeds the
+      // editor with '/chat ' AND drives searchText to '' in one go; without this bail we'd clear
+      // that seed, fire onChange(''), drop out of command mode and reset the palette. Keep it.
+      if (root.getTextContent().startsWith('/')) return;
       root.clear();
     });
   }, [value, editor]);

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ResultActionsMenu/ResultActionsMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ResultActionsMenu/ResultActionsMenu.tsx
@@ -1,0 +1,176 @@
+/**
+ * ⌥↵ Actions menu for a highlighted Cmd+K user/channel result (Message / Call).
+ *
+ * Built on Radix DropdownMenu so it gets real popup semantics for free:
+ *  - it PORTALS out of the palette's DOM subtree, so the palette's capture-phase keydown handler
+ *    never intercepts the menu's arrows/Enter, and roving focus gives arrow-key navigation plus
+ *    Enter/Space to select with no manual key handling;
+ *  - click-outside dismisses via Radix. Escape is handled explicitly on `window` (see below): the
+ *    menu renders as a SIBLING of the Cmd+K dialog, so it isn't in the dialog's dismissable-layer
+ *    stack, and the window-capture listener is what keeps Escape from closing the palette.
+ *
+ * Actions come from the registry and dispatch via `onRun` (wired to
+ * `useSlashCommands.invokeActionOnTarget`). Colours are semantic tokens (popover/border/accent/
+ * muted), so the menu tracks the active theme — restyle it by tweaking those CSS variables.
+ */
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { cn } from '../../../../utils/classNames';
+import type { CommandTarget } from '../SlashCommands/QuickDmComposer';
+import { RESULT_ACTIONS, type ResultActionKind } from './actionsRegistry';
+
+interface ResultActionsMenuProps {
+  open: boolean;
+  target: CommandTarget | null;
+  onRun: (kind: ResultActionKind) => void;
+  onClose: () => void;
+  /** The selected result row the menu opens above. */
+  anchorRef?: React.RefObject<HTMLElement | null>;
+}
+
+export const ResultActionsMenu: React.FC<ResultActionsMenuProps> = ({
+  open,
+  target,
+  onRun,
+  onClose,
+  anchorRef,
+}) => {
+  const [anchorRect, setAnchorRect] = useState({ left: 0, top: 0, width: 0, height: 0 });
+  // A select already ran the action; only a real dismiss (Esc / click-outside) should refocus search.
+  const justSelectedRef = useRef(false);
+  // Latest onClose, read by the window-level Escape handler below.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  // First action row — focused on open so it's pre-highlighted (Enter fires it immediately).
+  const firstItemRef = useRef<HTMLDivElement>(null);
+
+  // Mirror the selected row's rect onto the virtual anchor so the menu opens right above that row.
+  // Measured before paint to avoid a first-frame jump.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const anchor = anchorRef?.current;
+    if (anchor) {
+      const rect = anchor.getBoundingClientRect();
+      setAnchorRect({ left: rect.left, top: rect.top, width: rect.width, height: rect.height });
+    } else {
+      setAnchorRect({
+        left: window.innerWidth - 12,
+        top: window.innerHeight - 12,
+        width: 0,
+        height: 0,
+      });
+    }
+  }, [open, anchorRef]);
+
+  // Escape must dismiss ONLY this menu, never the Cmd+K dialog underneath. Radix arms its Escape
+  // listener on `document` in the capture phase and the dialog registered first, so we can't win
+  // that race there. Listen on `window` in capture instead — window is the outermost target in the
+  // capture phase, so this fires before any document-level listener; stopping the event means Radix
+  // (the dialog OR this menu) never sees the Escape, and we close the menu ourselves.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      onCloseRef.current();
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return (): void => {
+      window.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [open]);
+
+  // Radix focuses the menu content on open but doesn't reliably pre-highlight the first item when
+  // opened programmatically. Focus it ourselves on the next frame (after Radix's own open-focus) so
+  // the first action (Message) is highlighted and Enter fires it — matching the palette's
+  // auto-selected first row.
+  useEffect(() => {
+    if (!open) return;
+    const raf = requestAnimationFrame((): void => {
+      firstItemRef.current?.focus();
+    });
+    return (): void => {
+      cancelAnimationFrame(raf);
+    };
+  }, [open]);
+
+  if (!target) return null;
+
+  const actions = RESULT_ACTIONS;
+
+  return (
+    <DropdownMenu.Root
+      open={open}
+      onOpenChange={isOpen => {
+        if (isOpen) return;
+        if (justSelectedRef.current) {
+          justSelectedRef.current = false;
+          return;
+        }
+        onClose();
+      }}
+    >
+      {/* Virtual anchor: a fixed overlay matching the selected row's rect. pointer-events:none so a
+          click on the row still reaches Radix as an outside-click (closing the menu). */}
+      <DropdownMenu.Trigger asChild>
+        <span
+          aria-hidden
+          style={{
+            position: 'fixed',
+            left: anchorRect.left,
+            top: anchorRect.top,
+            width: anchorRect.width,
+            height: anchorRect.height,
+            pointerEvents: 'none',
+          }}
+        />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          side='top'
+          align='start'
+          alignOffset={8}
+          sideOffset={6}
+          onCloseAutoFocus={e => e.preventDefault()}
+          className={cn(
+            // Surface uses ui/Select's popover tokens (rounded-md, border) but a stronger shadow so
+            // this floating menu reads as an elevated layer over the palette instead of bleeding into
+            // it. Narrow width since there's no header. Stays a DropdownMenu for menu semantics.
+            'z-[10051] w-52 overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-2xl outline-none',
+            // Same open/close fade+zoom and side-slide as SelectContent.
+            'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+            'data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-in-from-top-2',
+          )}
+        >
+          {/* No header: the popup is anchored directly above the highlighted row, so repeating the
+              target name would be redundant. The two actions carry their own icons + labels. */}
+          {actions.map((action, index) => {
+            const Icon = action.icon;
+            return (
+              <DropdownMenu.Item
+                key={action.id}
+                ref={index === 0 ? firstItemRef : undefined}
+                data-track-category='CMDK_ACTIONS'
+                data-track-name={`cmdk_action_${action.id}`}
+                onSelect={() => {
+                  justSelectedRef.current = true;
+                  onRun(action.kind);
+                }}
+                className={cn(
+                  // Row shape mirrors ui/Select's SelectItem (minus the value checkmark / pr-8).
+                  'flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground outline-none',
+                  'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
+                )}
+              >
+                <Icon className='h-4 w-4 shrink-0' />
+                <span className='flex-1'>{action.label}</span>
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ResultActionsMenu/actionsRegistry.ts
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ResultActionsMenu/actionsRegistry.ts
@@ -1,0 +1,23 @@
+/**
+ * Registry of secondary actions offered on a highlighted Cmd+K user/channel result (the ⌥↵ Actions
+ * menu). Each entry maps to a `/`-command `kind` that `useSlashCommands.invokeActionOnTarget` runs,
+ * so the menu never re-implements chat/call logic. To add an action (Go to, Copy link, …), add one
+ * entry here — the menu renders from this list, no component changes.
+ */
+import { MessageSquare, Phone, type LucideIcon } from 'lucide-react';
+
+// The slash-command kinds the Actions menu can dispatch (picker commands only).
+export type ResultActionKind = 'chat' | 'call';
+
+export interface ResultAction {
+  id: 'message' | 'call';
+  label: string;
+  icon: LucideIcon;
+  // Which `invokeActionOnTarget` kind to run when picked.
+  kind: ResultActionKind;
+}
+
+export const RESULT_ACTIONS: ResultAction[] = [
+  { id: 'message', label: 'Message', icon: MessageSquare, kind: 'chat' },
+  { id: 'call', label: 'Call', icon: Phone, kind: 'call' },
+];

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ResultActionsMenu/index.ts
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ResultActionsMenu/index.ts
@@ -1,0 +1,2 @@
+export { ResultActionsMenu } from './ResultActionsMenu';
+export { RESULT_ACTIONS, type ResultAction, type ResultActionKind } from './actionsRegistry';

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SlashCommands/useSlashCommands.ts
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SlashCommands/useSlashCommands.ts
@@ -22,7 +22,7 @@ import type { NavigationItem } from '../../../AppSidebar/navigationConfig';
 import { xyneAIActor } from '../../../../machines/xyneAIMachine';
 import { sendRecordingEvent, getRecordingStatus } from '../../../../hooks/useRecordingStore';
 import { getUserDisplayName } from '../../../../utils/userDisplayName';
-import { getDMSearchableNames } from '../ChatDirectory.utils';
+import { getDMSearchableNames, isOneToOneDMChannel } from '../ChatDirectory.utils';
 import type { CommandTarget } from './QuickDmComposer';
 
 /**
@@ -51,6 +51,8 @@ export interface SlashCommandClickInfo {
   terminal: boolean;
   targetType?: 'user' | 'channel';
   destination?: string;
+  /** How a chat/call target was reached: typing the `/`-prefix vs the ⌥↵ Actions menu. */
+  source?: 'slash' | 'actions_menu';
 }
 
 interface UseSlashCommandsParams {
@@ -116,11 +118,13 @@ export interface UseSlashCommandsReturn {
   resetCommand: () => void;
   exitCommandMode: () => void;
   clearTarget: () => void;
-  applyCommand: (word: string) => void;
+  applyCommand: (word: string, options?: { silent?: boolean }) => void;
   runActionCommand: (kind: SearchCommandKind) => void;
   runNavSection: (item: NavigationItem) => void;
   runGotoExtra: (extra: GotoExtra) => void;
   runCommandTarget: (target: CommandTarget) => void;
+  /** Run chat/call on a highlighted Cmd+K result (⌥↵ Actions menu), bypassing the `/`-command step. */
+  invokeActionOnTarget: (kind: 'chat' | 'call', target: CommandTarget) => void;
   startChannelCall: (channelId: string, displayName: string) => void;
   isInCommandMode: () => boolean;
   onSetTextReady: (setText: (text: string) => void) => void;
@@ -399,7 +403,7 @@ export function useSlashCommands({
 
   // Seed the editor with `/call `/`/chat ` when a command is picked from the `/` list.
   const applyCommand = useCallback(
-    (word: string): void => {
+    (word: string, options?: { silent?: boolean }): void => {
       const text = `/${word} `;
       // Mirror the command text into the ref/state synchronously so isInCommandMode() is correct
       // before Lexical's onChange fires — otherwise the mention-trigger guards briefly treat the
@@ -407,8 +411,10 @@ export function useSlashCommands({
       commandTextRef.current = text;
       setCommandText(text);
       setTextRef.current?.(text);
-      // Metrics: command row applied (not terminal — the picker/target step follows).
-      if ((COMMAND_KINDS as string[]).includes(word)) {
+      // Metrics: command row applied (not terminal — the picker/target step follows). Skipped when
+      // `silent`: the ⌥↵ Actions menu seeds `/chat ` here only to reach the composer — the user
+      // never applied a `/chat` command, so a command-stage click would be a phantom event.
+      if (!options?.silent && (COMMAND_KINDS as string[]).includes(word)) {
         onCommandClick?.({ stage: 'command', command: word as SearchCommandKind, terminal: false });
       }
     },
@@ -484,6 +490,45 @@ export function useSlashCommands({
     [exitCommandMode, onOpenChange, onCommandClick],
   );
 
+  // Fire or confirm a call for the picked target. Shared by `/call` (runCommandTarget) and the
+  // Cmd+K result Actions menu (invokeActionOnTarget) so both take the same guarded path: a 1:1 call
+  // fires instantly; a live channel call is joined; a new channel-wide call asks for confirmation.
+  const dispatchCall = useCallback(
+    (target: CommandTarget): void => {
+      if (target.type === 'user') {
+        // A 1:1 call fires instantly, matching the rest of the app.
+        startCall(target.user.id, getUserDisplayName(target.user));
+      } else if (
+        hasActiveChannelCall(target.channel.id) ||
+        isOneToOneDMChannel(target.channel.scopeType)
+      ) {
+        // Start the call directly (no "Start a call in this channel?" confirm) when either: a call
+        // is already live on the channel (you're joining, not broadcasting), OR it's a 1:1 DM —
+        // structurally a channel but really a direct call to one person (e.g. a starred user). Group
+        // DMs pass their friendly label (channel.name is an id list).
+        startChannelCall(target.channel.id, target.displayName ?? target.channel.name);
+      } else if (ensureRoomIdle()) {
+        // No call yet — confirm before starting a new channel-wide call. The modal renders as a
+        // sibling of the Cmd+K dialog, so closing Cmd+K here doesn't tear it down.
+        setPendingChannelCall({
+          id: target.channel.id,
+          name: target.displayName ?? target.channel.name,
+        });
+      }
+      exitCommandMode();
+      onOpenChange(false);
+    },
+    [
+      startCall,
+      startChannelCall,
+      hasActiveChannelCall,
+      ensureRoomIdle,
+      setPendingChannelCall,
+      exitCommandMode,
+      onOpenChange,
+    ],
+  );
+
   const runCommandTarget = useCallback(
     (target: CommandTarget): void => {
       const def = commandKind ? getCommand(commandKind) : null;
@@ -497,42 +542,43 @@ export function useSlashCommands({
         command: commandKind,
         terminal: def.pickerAction === 'call',
         targetType: target.type,
+        source: 'slash',
       });
       if (def.pickerAction === 'call') {
-        if (target.type === 'user') {
-          // A 1:1 call fires instantly, matching the rest of the app.
-          startCall(target.user.id, getUserDisplayName(target.user));
-        } else if (hasActiveChannelCall(target.channel.id)) {
-          // A call is already live on the channel — join it directly, no "start a call?" confirm
-          // (you're joining an existing call, not starting a new channel-wide one). Group DMs pass
-          // their friendly label (channel.name is an id list).
-          startChannelCall(target.channel.id, target.displayName ?? target.channel.name);
-        } else if (ensureRoomIdle()) {
-          // No call yet — confirm before starting a new channel-wide call. The modal renders as a
-          // sibling of the Cmd+K dialog, so closing Cmd+K here doesn't tear it down.
-          setPendingChannelCall({
-            id: target.channel.id,
-            name: target.displayName ?? target.channel.name,
-          });
-        }
-        exitCommandMode();
-        onOpenChange(false);
+        dispatchCall(target);
         return;
       }
       // `compose` (`/chat`): open the composer for the picked user/channel.
       selectTarget(target);
     },
-    [
-      commandKind,
-      startCall,
-      startChannelCall,
-      hasActiveChannelCall,
-      ensureRoomIdle,
-      exitCommandMode,
-      onOpenChange,
-      selectTarget,
-      onCommandClick,
-    ],
+    [commandKind, dispatchCall, selectTarget, onCommandClick],
+  );
+
+  // Cmd+K result Actions menu (⌥↵): run chat/call on a highlighted user/channel result *without*
+  // first typing `/chat`|`/call`. `commandKind` is derived from the editor text, so we can't set it
+  // and reuse runCommandTarget — instead dispatch the call directly, or (for chat) seed the hidden
+  // `/chat ` text via applyCommand then open the composer with selectTarget. The seeded text is what
+  // the composer's "back" button reads, so this path needs no special-casing there.
+  const invokeActionOnTarget = useCallback(
+    (kind: 'chat' | 'call', target: CommandTarget): void => {
+      // Metrics: target picked. `/call` is terminal; `/chat` opens the composer (invoked on send).
+      onCommandClick?.({
+        stage: 'target',
+        command: kind,
+        terminal: kind === 'call',
+        targetType: target.type,
+        source: 'actions_menu',
+      });
+      if (kind === 'call') {
+        dispatchCall(target);
+        return;
+      }
+      // Seed `/chat ` only to open the composer — silent so it doesn't log a phantom command-apply
+      // click (the `stage:'target'` click above already recorded this pick, with `source`).
+      applyCommand('chat', { silent: true });
+      selectTarget(target);
+    },
+    [dispatchCall, applyCommand, selectTarget, onCommandClick],
   );
 
   // Clear command state whenever the menu closes.
@@ -646,6 +692,7 @@ export function useSlashCommands({
     runNavSection,
     runGotoExtra,
     runCommandTarget,
+    invokeActionOnTarget,
     startChannelCall,
     isInCommandMode,
     onSetTextReady,

--- a/apps/dashboard/src/hooks/useSlashCommandMetrics.ts
+++ b/apps/dashboard/src/hooks/useSlashCommandMetrics.ts
@@ -28,6 +28,8 @@ interface SlashClickPayload {
   terminal: boolean;
   targetType?: 'user' | 'channel';
   destination?: string;
+  /** How a chat/call target was reached: typing the `/`-prefix vs the ⌥↵ Actions menu. */
+  source?: 'slash' | 'actions_menu';
 }
 
 export interface UseSlashCommandMetricsReturn {
@@ -113,6 +115,7 @@ export function useSlashCommandMetrics({
         terminal: payload.terminal,
         ...(payload.targetType && { targetType: payload.targetType }),
         ...(payload.destination && { destination: payload.destination }),
+        ...(payload.source && { source: payload.source }),
       });
 
       bumpStage(payload.stage);

--- a/apps/dashboard/src/services/slashCommandMetricsService.ts
+++ b/apps/dashboard/src/services/slashCommandMetricsService.ts
@@ -61,6 +61,7 @@ class SlashCommandMetricsService {
     terminal: boolean;
     targetType?: 'user' | 'channel';
     destination?: string;
+    source?: 'slash' | 'actions_menu';
   }): void {
     const event: SlashCommandClickEvent = {
       slash_session_id: params.slashSessionId,
@@ -72,6 +73,7 @@ class SlashCommandMetricsService {
       // exactOptionalPropertyTypes: only attach the optional keys when present.
       ...(params.targetType && { target_type: params.targetType }),
       ...(params.destination && { destination: params.destination }),
+      ...(params.source && { source: params.source }),
     };
     logger.info(Event.SLASH_COMMAND_CLICK, event as unknown as Record<string, unknown>);
   }

--- a/apps/dashboard/src/types/slashCommandEvents.ts
+++ b/apps/dashboard/src/types/slashCommandEvents.ts
@@ -78,6 +78,11 @@ export interface SlashCommandClickEvent extends CommonSlashEventFields {
   target_type?: 'user' | 'channel';
   /** For `/goto`: the nav path (e.g. `/activity`) or the extra id (`preferences`/`profile`). */
   destination?: string;
+  /**
+   * For `/chat` & `/call` target picks: how the target was reached — `slash` (typed the
+   * `/`-prefix) vs `actions_menu` (the ⌥↵ Cmd+K result Actions menu).
+   */
+  source?: 'slash' | 'actions_menu';
 }
 
 /**


### PR DESCRIPTION
Option+Enter on a highlighted user/channel result opens a small actions popup that dispatches Message/Call through the existing slash-command infrastructure - no new DM/call logic.

- ResultActionsMenu (Radix DropdownMenu styled to match ui/Select) driven by a small action registry
- resolveActionTarget + invokeActionOnTarget/dispatchCall wiring; 1:1 DMs call directly instead of showing the channel-wide confirm
- preserve command text in ClearEditorPlugin so seeding /chat with an active query no longer resets the palette
- reset the menu target on palette close; gate the Actions hint to user/channel rows only
- source=actions_menu dimension on the slash-command click telemetry
<img width="794" height="560" alt="Screenshot 2026-08-07 at 12 25 06 PM" src="https://github.com/user-attachments/assets/7987f987-07be-44f4-aca9-d9cdc3c3377c" />

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [x] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
