### PR TITLE
fix: clear cookies in 401

### DIFF
--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -106,6 +106,19 @@ export class AuthV2Controller {
     return this.googleClient;
   }
 
+  private clearAuthCookies(req: Request, res: Response): void {
+    res.clearCookie('google_access_token', { path: '/' });
+    res.clearCookie('user_session_id', { path: '/' });
+
+    for (const cookieName of Object.keys(req.cookies || {})) {
+      if (cookieName.startsWith('xyne_ws_') && cookieName.endsWith('_token')) {
+        res.clearCookie(cookieName, { path: '/' });
+      }
+    }
+
+    res.clearCookie('xyne_last_workspace', { path: '/' });
+  }
+
   private async ensureSelfDmForUser(
     userId: string,
     workspaceId: string
@@ -696,6 +709,7 @@ export class AuthV2Controller {
 
       if (!sessionId) {
         logger.warn(`[${requestId}] No session ID cookie found`);
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'No session found',
           message: 'Session ID cookie is missing',
@@ -709,6 +723,7 @@ export class AuthV2Controller {
 
       if (!session || !session.user) {
         logger.warn(`[${requestId}] Session not found in database`);
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid session',
           message: 'Session not found or expired',
@@ -720,6 +735,7 @@ export class AuthV2Controller {
 
       if (session.status !== 'ACTIVE' || new Date() > session.refreshTokenExpiry) {
         logger.warn(`[${requestId}] Session expired or inactive`);
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Session expired',
           message: 'Please re-authenticate',
@@ -1069,6 +1085,10 @@ export class AuthV2Controller {
 
     // Helper to send error response (JSON for mobile, redirect for web)
     const sendError = (errorCode: string, message: string, statusCode = 400) => {
+      if (statusCode === 401) {
+        this.clearAuthCookies(req, res);
+      }
+
       if (isMobileNative) {
         res.status(statusCode).json({
           success: false,
@@ -1416,6 +1436,7 @@ export class AuthV2Controller {
       if (pendingAuthCookie) {
         const parsed = await this.parsePendingAuthCookie(pendingAuthCookie);
         if (!parsed) {
+          this.clearAuthCookies(req, res);
           res.status(401).json({
             error: 'Invalid auth data',
             message: 'Pending auth data is corrupted or expired'
@@ -1432,6 +1453,7 @@ export class AuthV2Controller {
           pendingAccessTokenExpiry = parsed.pendingAccessTokenExpiry;
           pendingTokenKey = parsed.pendingTokenKey;
         } else {
+          this.clearAuthCookies(req, res);
           res.status(401).json({
             error: 'Invalid auth data',
             message: 'Pending auth data is missing provider identity'
@@ -1447,6 +1469,7 @@ export class AuthV2Controller {
         
         const session = await this.userSessionService.getSessionById(existingSessionId);
         if (!session || !session.user || session.status !== 'ACTIVE' || new Date() > session.refreshTokenExpiry) {
+          this.clearAuthCookies(req, res);
           res.status(401).json({
             error: 'Invalid session',
             message: 'Session not found or expired'
@@ -1465,6 +1488,7 @@ export class AuthV2Controller {
         pendingAccessToken = session.accessToken || undefined;
         pendingAccessTokenExpiry = session.accessTokenExpiry || undefined;
       } else {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Unauthorized',
           message: 'Pending auth data not found or expired'
@@ -1473,6 +1497,7 @@ export class AuthV2Controller {
       }
 
       if (!oauthUserData?.email) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid auth data',
           message: 'User data missing from pending auth'
@@ -1651,6 +1676,7 @@ export class AuthV2Controller {
       // Get pending auth data from cookie
       const pendingAuthCookie = req.cookies?.google_access_token;
       if (!pendingAuthCookie) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Unauthorized',
           message: 'Pending auth data not found or expired'
@@ -1660,6 +1686,7 @@ export class AuthV2Controller {
 
       const parsedAuth = await this.parsePendingAuthCookie(pendingAuthCookie);
       if (!parsedAuth) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid auth data',
           message: 'Pending auth data is corrupted or expired'
@@ -1669,6 +1696,7 @@ export class AuthV2Controller {
       const { oauthUserData, provider, pendingRefreshToken, pendingTokenKey } = parsedAuth;
 
       if (!oauthUserData?.email) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid auth data',
           message: 'User data missing from pending auth'
@@ -1977,6 +2005,7 @@ export class AuthV2Controller {
     try {
       const pendingAuthCookie = req.cookies?.google_access_token;
       if (!pendingAuthCookie) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Unauthorized',
           message: 'Pending auth data not found or expired'
@@ -1986,6 +2015,7 @@ export class AuthV2Controller {
 
       const parsedAuth = await this.parsePendingAuthCookie(pendingAuthCookie);
       if (!parsedAuth) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid auth data',
           message: 'Pending auth data is corrupted or expired'
@@ -1994,6 +2024,7 @@ export class AuthV2Controller {
       }
       const { oauthUserData, provider, pendingRefreshToken, pendingTokenKey } = parsedAuth;
         if (!oauthUserData?.email) {
+          this.clearAuthCookies(req, res);
           res.status(401).json({
             error: 'Invalid auth data',
             message: 'User data missing from pending auth'

--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -36,6 +36,19 @@ export class EmailAuthController {
     this.userService = new UserService();
   }
 
+  private clearAuthCookies(req: Request, res: Response): void {
+    res.clearCookie('google_access_token', { path: '/' });
+    res.clearCookie('user_session_id', { path: '/' });
+
+    for (const cookieName of Object.keys(req.cookies || {})) {
+      if (cookieName.startsWith('xyne_ws_') && cookieName.endsWith('_token')) {
+        res.clearCookie(cookieName, { path: '/' });
+      }
+    }
+
+    res.clearCookie('xyne_last_workspace', { path: '/' });
+  }
+
   /**
    * Login with email + password
    * POST /v2/auth/email/login
@@ -89,6 +102,7 @@ export class EmailAuthController {
 
       if (!orgMember || orgMember.leftAt) {
         // Keep this response identical to the wrong-password response below.
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid credentials',
           message: 'Email or password is incorrect',
@@ -97,6 +111,7 @@ export class EmailAuthController {
       }
 
       if (!orgMember.passwordHash) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid credentials',
           message: 'Email or password is incorrect',
@@ -126,6 +141,7 @@ export class EmailAuthController {
           return;
         }
 
+        this.clearAuthCookies(req, res);
         res.status(401).json({
           error: 'Invalid credentials',
           message: 'Email or password is incorrect',
@@ -341,6 +357,7 @@ export class EmailAuthController {
     try {
       const userId = req.user?.id;
       if (!userId) {
+        this.clearAuthCookies(req, res);
         res.status(401).json({ error: 'Authentication required' });
         return;
       }

--- a/apps/backend/src/middleware/authV2Middleware.ts
+++ b/apps/backend/src/middleware/authV2Middleware.ts
@@ -57,6 +57,22 @@ class AuthV2Middleware {
   }
 
   /**
+   * Clear authentication cookies when the request can no longer be authenticated.
+   */
+  private clearAuthCookies(req: Request, res: Response): void {
+    res.clearCookie('google_access_token', { path: '/' });
+    res.clearCookie('user_session_id', { path: '/' });
+
+    for (const cookieName of Object.keys(req.cookies || {})) {
+      if (cookieName.startsWith('xyne_ws_') && cookieName.endsWith('_token')) {
+        res.clearCookie(cookieName, { path: '/' });
+      }
+    }
+
+    res.clearCookie('xyne_last_workspace', { path: '/' });
+  }
+
+  /**
    * Helper to attempt honest refresh using session cookie
    */
   private attemptRefresh = async (req: Request, res: Response, next: NextFunction): Promise<boolean> => {
@@ -369,6 +385,7 @@ class AuthV2Middleware {
                   effectiveWorkspaceId,
                   effectiveMemberId,
                 });
+                this.clearAuthCookies(req, res);
                 res.status(401).json({
                   error: 'Workspace context missing',
                   message: 'Unable to determine workspace for this session. Please log in again.',
@@ -405,6 +422,7 @@ class AuthV2Middleware {
                     userId: user.id,
                     leftAt: user.leftAt,
                   });
+                  this.clearAuthCookies(req, res);
                   res.status(401).json({
                     error: 'User removed from workspace',
                     message: 'You have been removed from this workspace',
@@ -419,6 +437,7 @@ class AuthV2Middleware {
                     userId: user.id,
                     orgMemberLeftAt: orgMember.leftAt,
                   });
+                  this.clearAuthCookies(req, res);
                   res.status(401).json({
                     error: 'User removed from organization',
                     message: 'You have been removed from this organization',
@@ -518,6 +537,7 @@ class AuthV2Middleware {
         tokenSource,
         tokenPreview,
       });
+      this.clearAuthCookies(req, res);
       res.status(401).json({
         error: 'No session found',
         message: 'Session ID cookie is missing',


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
