### PR TITLE
feat: unify call participant search with @-mention matcher

### DIFF
--- a/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
+++ b/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
@@ -13,7 +13,7 @@ import { usePlatform } from '../../../hooks/usePlatform';
 import { ChannelScopeType } from '@xyne/shared';
 import { useAuth } from '../../../hooks/useAuth';
 import { getUserDisplayName, isUserDeactivated } from '../../../utils/userDisplayName';
-import { searchUsers } from '@xyne/shared/utils';
+import { rankParticipantOptions } from '../../../utils/participantSearch';
 
 interface InstantCallModalProps {
   isOpen: boolean;
@@ -75,20 +75,23 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
     );
   }, [allUsers, channelParticipantUserIds, currentUser?.id]);
 
-  // Filter channel users by search query using the SAME matcher that powers
-  // @-mention search (prefix / word-boundary boost, displayName + old-name +
-  // email matching, deactivated demotion). `channelUsers` is already restricted
-  // to channel members, so non-members stay hidden from this thread modal.
-  const filteredUsers = useMemo(() => {
-    if (!searchQuery.trim()) return channelUsers;
-    return searchUsers(channelUsers, searchQuery, channelUsers.length);
+  // Normalize the channel-member payload before passing it to the shared
+  // participant matcher. Some channel members have no email, which the raw
+  // `searchUsers` matcher assumes is always present.
+  const rankedChannelUsers = useMemo(() => {
+    const options = channelUsers.map(user => ({
+      ...user,
+      label: getUserDisplayName(user),
+      value: `user:${user.id}`,
+    }));
+    return rankParticipantOptions(options, searchQuery);
   }, [channelUsers, searchQuery]);
 
   const inviteUserOptions = useMemo(
     () =>
-      filteredUsers.map(user => ({
-        label: getUserDisplayName(user),
-        value: `user:${user.id}`,
+      rankedChannelUsers.map(user => ({
+        label: user.label,
+        value: user.value,
         icon: (
           <Avatar
             userId={user.id}
@@ -100,7 +103,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
         subtitle: user.email,
         isDeactivated: isUserDeactivated(user),
       })),
-    [filteredUsers],
+    [rankedChannelUsers],
   );
 
   // Get selected users for display

--- a/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
+++ b/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
@@ -85,20 +85,6 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
       value: `user:${user.id}`,
     }));
 
-    const query = searchQuery.trim().toLowerCase();
-    // The shared Fuse matcher deliberately ignores one-character queries. Keep
-    // the previous substring behaviour here so thread members are discoverable
-    // as soon as the user starts typing.
-    if (query.length === 1) {
-      return options.filter(user => {
-        const name = typeof user.name === 'string' ? user.name.toLowerCase() : '';
-        const email = typeof user.email === 'string' ? user.email.toLowerCase() : '';
-        return (
-          user.label.toLowerCase().includes(query) || name.includes(query) || email.includes(query)
-        );
-      });
-    }
-
     return rankParticipantOptions(options, searchQuery);
   }, [channelUsers, searchQuery]);
 

--- a/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
+++ b/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
@@ -84,6 +84,21 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
       label: getUserDisplayName(user),
       value: `user:${user.id}`,
     }));
+
+    const query = searchQuery.trim().toLowerCase();
+    // The shared Fuse matcher deliberately ignores one-character queries. Keep
+    // the previous substring behaviour here so thread members are discoverable
+    // as soon as the user starts typing.
+    if (query.length === 1) {
+      return options.filter(user => {
+        const name = typeof user.name === 'string' ? user.name.toLowerCase() : '';
+        const email = typeof user.email === 'string' ? user.email.toLowerCase() : '';
+        return (
+          user.label.toLowerCase().includes(query) || name.includes(query) || email.includes(query)
+        );
+      });
+    }
+
     return rankParticipantOptions(options, searchQuery);
   }, [channelUsers, searchQuery]);
 

--- a/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
+++ b/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
@@ -13,6 +13,7 @@ import { usePlatform } from '../../../hooks/usePlatform';
 import { ChannelScopeType } from '@xyne/shared';
 import { useAuth } from '../../../hooks/useAuth';
 import { getUserDisplayName, isUserDeactivated } from '../../../utils/userDisplayName';
+import { searchUsers } from '@xyne/shared/utils';
 
 interface InstantCallModalProps {
   isOpen: boolean;
@@ -74,15 +75,13 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
     );
   }, [allUsers, channelParticipantUserIds, currentUser?.id]);
 
-  // Filter channel users by search query
+  // Filter channel users by search query using the SAME matcher that powers
+  // @-mention search (prefix / word-boundary boost, displayName + old-name +
+  // email matching, deactivated demotion). `channelUsers` is already restricted
+  // to channel members, so non-members stay hidden from this thread modal.
   const filteredUsers = useMemo(() => {
     if (!searchQuery.trim()) return channelUsers;
-    const query = searchQuery.toLowerCase();
-    return channelUsers.filter(user => {
-      const name = user.name?.toLowerCase() || '';
-      const email = user.email?.toLowerCase() || '';
-      return name.includes(query) || email.includes(query);
-    });
+    return searchUsers(channelUsers, searchQuery, channelUsers.length);
   }, [channelUsers, searchQuery]);
 
   const inviteUserOptions = useMemo(
@@ -276,6 +275,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                 placeholder='Select participants'
                 searchPlaceholder='Select participants'
                 onSearchChange={setSearchQuery}
+                disableClientFiltering
                 variant='inline'
                 width='100%'
               />

--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -73,7 +73,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
             />
           ),
           children: (
-            <div className='flex items-center gap-2 min-w-0'>
+            <div className='flex flex-1 items-center gap-2 min-w-0'>
               <Avatar
                 userId={user.id}
                 size={'sm'}
@@ -82,7 +82,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
               />
               <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
                 <span
-                  className={`flex-1 truncate text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-foreground'}`}
+                  className={`shrink-0 truncate max-w-[50%] text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-foreground'}`}
                 >
                   {getUserDisplayName(user)}
                 </span>
@@ -92,7 +92,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                   </span>
                 )}
                 {user.email && (
-                  <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
+                  <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>
                     {user.email}
                   </span>
                 )}
@@ -122,12 +122,14 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
       icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
       subtitle: group.alias || group.description,
       children: (
-        <div className='flex items-center gap-2 min-w-0'>
+        <div className='flex flex-1 items-center gap-2 min-w-0'>
           <Users className='size-3.5 text-muted-foreground mx-0.5 shrink-0' strokeWidth={2.3} />
           <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
-            <span className='flex-1 truncate text-sm text-foreground'>{group.name}</span>
+            <span className='shrink-0 truncate max-w-[50%] text-sm text-foreground'>
+              {group.name}
+            </span>
             {(group.alias || group.description) && (
-              <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
+              <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>
                 {group.alias || group.description}
               </span>
             )}

--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -7,7 +7,7 @@ import { useSelf, useActiveUsers, useUsers } from '../../../hooks/useUsers';
 import { useZero } from '../../../hooks/useZero';
 import { queries } from '../../../zero/queries';
 import { SearchParticipants } from '../../../routes/CallHistoryScreen/SearchParticipants';
-import { isUserDeactivated } from '../../../utils/userDisplayName';
+import { getUserDisplayName, isUserDeactivated } from '../../../utils/userDisplayName';
 import {
   parseParticipants,
   matchParticipants,
@@ -73,31 +73,28 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
             />
           ),
           children: (
-            <div className='flex items-center gap-2'>
+            <div className='flex items-center gap-2 min-w-0'>
               <Avatar
                 userId={user.id}
                 size={'sm'}
                 showActiveStatus={false}
                 className='rounded-md size-[18px] flex items-center justify-center bg-background'
               />
-              <div className='flex-1 w-full flex items-center gap-1.5'>
-                <span
-                  className={`text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : ''}`}
-                >
-                  {user.name.split(' ')[0]}
-                </span>
-                {!isUserDeactivated(user) && (
-                  <span className='w-[5px] h-[5px] bg-green-600 rounded-full'></span>
-                )}
-                <span
-                  className={`text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-muted-foreground'}`}
-                >
-                  {user.name}
-                </span>
-                {isUserDeactivated(user) && (
-                  <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
-                    Deactivated
+              <div className='flex-1 min-w-0 text-left'>
+                <div className='flex items-center gap-1.5'>
+                  <span
+                    className={`truncate text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-foreground'}`}
+                  >
+                    {getUserDisplayName(user)}
                   </span>
+                  {isUserDeactivated(user) && (
+                    <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
+                      Deactivated
+                    </span>
+                  )}
+                </div>
+                {user.email && (
+                  <div className='truncate text-xs text-muted-foreground'>{user.email}</div>
                 )}
               </div>
             </div>

--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -17,6 +17,7 @@ import { rankParticipantOptions } from '../../../utils/participantSearch';
 import Avatar from '../../ui/Avatar/Avatar';
 import Button from '../../ui/Button';
 import Dialog from '../../ui/Dialog';
+import { ParticipantOptionContent } from '../ParticipantOptionContent';
 
 interface InstantCallModalProps {
   isOpen: boolean;
@@ -73,31 +74,19 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
             />
           ),
           children: (
-            <div className='flex flex-1 items-center gap-2 min-w-0'>
-              <Avatar
-                userId={user.id}
-                size={'sm'}
-                showActiveStatus={false}
-                className='rounded-md size-[18px] flex items-center justify-center bg-background'
-              />
-              <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
-                <span
-                  className={`shrink-0 truncate max-w-[50%] text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-foreground'}`}
-                >
-                  {getUserDisplayName(user)}
-                </span>
-                {isUserDeactivated(user) && (
-                  <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
-                    Deactivated
-                  </span>
-                )}
-                {user.email && (
-                  <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>
-                    {user.email}
-                  </span>
-                )}
-              </div>
-            </div>
+            <ParticipantOptionContent
+              icon={
+                <Avatar
+                  userId={user.id}
+                  size='sm'
+                  showActiveStatus={false}
+                  className='rounded-md size-[18px] flex items-center justify-center bg-background'
+                />
+              }
+              label={getUserDisplayName(user)}
+              subtitle={user.email}
+              isDeactivated={isUserDeactivated(user)}
+            />
           ),
           type: 'user' as const,
         })) || [];
@@ -122,19 +111,11 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
       icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
       subtitle: group.alias || group.description,
       children: (
-        <div className='flex flex-1 items-center gap-2 min-w-0'>
-          <Users className='size-3.5 text-muted-foreground mx-0.5 shrink-0' strokeWidth={2.3} />
-          <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
-            <span className='shrink-0 truncate max-w-[50%] text-sm text-foreground'>
-              {group.name}
-            </span>
-            {(group.alias || group.description) && (
-              <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>
-                {group.alias || group.description}
-              </span>
-            )}
-          </div>
-        </div>
+        <ParticipantOptionContent
+          icon={<Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />}
+          label={group.name}
+          subtitle={group.alias || group.description}
+        />
       ),
       type: 'user_group' as const,
     }));
@@ -143,6 +124,11 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
       a.label.localeCompare(b.label),
     );
   }, [activeUsers, channels, userGroups, allUsers, user?.id]);
+
+  const rankedParticipantOptions = useMemo(
+    () => rankParticipantOptions(inviteUserOrChannelOptions, searchQuery),
+    [inviteUserOrChannelOptions, searchQuery],
+  );
 
   const handleSubmit = () => {
     onSubmit(selectedParticipants);
@@ -260,7 +246,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
             <div className='space-y-2'>
               <p className='text-muted-foreground text-[13px] leading-5'>{participantLabel}</p>
               <SearchParticipants
-                options={rankParticipantOptions(inviteUserOrChannelOptions, searchQuery)}
+                options={rankedParticipantOptions}
                 selectedValues={selectedParticipants}
                 onMultiSelect={handleMultiSelect}
                 searchQuery={searchQuery}

--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -13,6 +13,7 @@ import {
   matchParticipants,
   looksLikeBulkEntry,
 } from '../../../utils/participantUtils';
+import { rankParticipantOptions } from '../../../utils/participantSearch';
 import Avatar from '../../ui/Avatar/Avatar';
 import Button from '../../ui/Button';
 import Dialog from '../../ui/Dialog';
@@ -247,7 +248,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
             <div className='space-y-2'>
               <p className='text-muted-foreground text-[13px] leading-5'>{participantLabel}</p>
               <SearchParticipants
-                options={inviteUserOrChannelOptions}
+                options={rankParticipantOptions(inviteUserOrChannelOptions, searchQuery)}
                 selectedValues={selectedParticipants}
                 onMultiSelect={handleMultiSelect}
                 searchQuery={searchQuery}
@@ -255,6 +256,7 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                 ref={inputRef}
                 onEnterQuerySubmit={handleBulkUserEntry}
                 helperText={notFoundMessage}
+                disableClientFiltering
               />
             </div>
             <div className='flex items-center justify-between'>

--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -80,21 +80,21 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                 showActiveStatus={false}
                 className='rounded-md size-[18px] flex items-center justify-center bg-background'
               />
-              <div className='flex-1 min-w-0 text-left'>
-                <div className='flex items-center gap-1.5'>
-                  <span
-                    className={`truncate text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-foreground'}`}
-                  >
-                    {getUserDisplayName(user)}
+              <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
+                <span
+                  className={`flex-1 truncate text-sm ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-foreground'}`}
+                >
+                  {getUserDisplayName(user)}
+                </span>
+                {isUserDeactivated(user) && (
+                  <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
+                    Deactivated
                   </span>
-                  {isUserDeactivated(user) && (
-                    <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
-                      Deactivated
-                    </span>
-                  )}
-                </div>
+                )}
                 {user.email && (
-                  <div className='truncate text-xs text-muted-foreground'>{user.email}</div>
+                  <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
+                    {user.email}
+                  </span>
                 )}
               </div>
             </div>
@@ -121,6 +121,19 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
       value: `user_group:${group.id}`,
       icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
       subtitle: group.alias || group.description,
+      children: (
+        <div className='flex items-center gap-2 min-w-0'>
+          <Users className='size-3.5 text-muted-foreground mx-0.5 shrink-0' strokeWidth={2.3} />
+          <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
+            <span className='flex-1 truncate text-sm text-foreground'>{group.name}</span>
+            {(group.alias || group.description) && (
+              <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
+                {group.alias || group.description}
+              </span>
+            )}
+          </div>
+        </div>
+      ),
       type: 'user_group' as const,
     }));
 

--- a/apps/dashboard/src/components/Call/ParticipantOptionContent.tsx
+++ b/apps/dashboard/src/components/Call/ParticipantOptionContent.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+
+interface ParticipantOptionContentProps {
+  icon: ReactNode;
+  label: string;
+  subtitle?: string | null | undefined;
+  isDeactivated?: boolean;
+}
+
+/** Shared full-width participant row used by the call pickers. */
+export function ParticipantOptionContent({
+  icon,
+  label,
+  subtitle,
+  isDeactivated = false,
+}: ParticipantOptionContentProps): ReactNode {
+  return (
+    <div className='flex flex-1 items-center gap-2 min-w-0'>
+      <span className='shrink-0'>{icon}</span>
+      <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
+        <span
+          className={`shrink-0 truncate max-w-[50%] text-sm ${isDeactivated ? 'text-muted-foreground' : 'text-foreground'}`}
+        >
+          {label}
+        </span>
+        {isDeactivated && (
+          <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
+            Deactivated
+          </span>
+        )}
+        {subtitle && (
+          <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>{subtitle}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -344,30 +344,27 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       />
     ),
     children: (
-      <div className='flex items-center gap-2'>
+      <div className='flex items-center gap-2 min-w-0'>
         <Avatar
           userId={u.id}
           size={'sm'}
           showActiveStatus={false}
           className='rounded-md size-[18px] flex items-center justify-center bg-background'
         />
-        <div className='flex-1 w-full flex items-center gap-1.5'>
-          <span className={`text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : ''}`}>
-            {getUserDisplayName(u).split(' ')[0]}
-          </span>
-          {!isUserDeactivated(u) && (
-            <span className='w-[5px] h-[5px] bg-green-600 rounded-full'></span>
-          )}
-          <span
-            className={`text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : 'text-gray-500'}`}
-          >
-            {getUserDisplayName(u)}
-          </span>
-          {isUserDeactivated(u) && (
-            <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
-              Deactivated
+        <div className='flex-1 min-w-0 text-left'>
+          <div className='flex items-center gap-1.5'>
+            <span
+              className={`truncate text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : 'text-foreground'}`}
+            >
+              {getUserDisplayName(u)}
             </span>
-          )}
+            {isUserDeactivated(u) && (
+              <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
+                Deactivated
+              </span>
+            )}
+          </div>
+          {u.email && <div className='truncate text-xs text-muted-foreground'>{u.email}</div>}
         </div>
       </div>
     ),

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -351,20 +351,22 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
           showActiveStatus={false}
           className='rounded-md size-[18px] flex items-center justify-center bg-background'
         />
-        <div className='flex-1 min-w-0 text-left'>
-          <div className='flex items-center gap-1.5'>
-            <span
-              className={`truncate text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : 'text-foreground'}`}
-            >
-              {getUserDisplayName(u)}
+        <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
+          <span
+            className={`flex-1 truncate text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : 'text-foreground'}`}
+          >
+            {getUserDisplayName(u)}
+          </span>
+          {isUserDeactivated(u) && (
+            <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
+              Deactivated
             </span>
-            {isUserDeactivated(u) && (
-              <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
-                Deactivated
-              </span>
-            )}
-          </div>
-          {u.email && <div className='truncate text-xs text-muted-foreground'>{u.email}</div>}
+          )}
+          {u.email && (
+            <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
+              {u.email}
+            </span>
+          )}
         </div>
       </div>
     ),
@@ -437,6 +439,19 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       value: `user_group:${group.id}`,
       icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
       subtitle: group.alias || group.description,
+      children: (
+        <div className='flex items-center gap-2 min-w-0'>
+          <Users className='size-3.5 text-muted-foreground mx-0.5 shrink-0' strokeWidth={2.3} />
+          <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
+            <span className='flex-1 truncate text-sm text-foreground'>{group.name}</span>
+            {(group.alias || group.description) && (
+              <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
+                {group.alias || group.description}
+              </span>
+            )}
+          </div>
+        </div>
+      ),
       type: 'user_group' as const,
     }));
 

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -26,6 +26,7 @@ import { DatePicker } from '../../ui/DatePicker/DatePicker';
 import { TimePicker } from '../../ui/TimePicker/TimePicker';
 import { RadioGroup, Radio } from '../../ui/RadioGroup/RadioGroup';
 import { SearchParticipants } from '../../../routes/CallHistoryScreen/SearchParticipants';
+import { rankParticipantOptions } from '../../../utils/participantSearch';
 import Avatar from '../../ui/Avatar/Avatar';
 import { Controller, useForm } from 'react-hook-form';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
@@ -1806,7 +1807,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                   control={control}
                   render={({ field }) => (
                     <SearchParticipants
-                      options={inviteUserOrChannelOptions}
+                      options={rankParticipantOptions(inviteUserOrChannelOptions, searchQuery)}
+                      disableClientFiltering
                       selectedValues={field.value}
                       onMultiSelect={async (values: string[]) => {
                         const expanded = await expandGroupSelections(values);

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -28,6 +28,7 @@ import { RadioGroup, Radio } from '../../ui/RadioGroup/RadioGroup';
 import { SearchParticipants } from '../../../routes/CallHistoryScreen/SearchParticipants';
 import { rankParticipantOptions } from '../../../utils/participantSearch';
 import Avatar from '../../ui/Avatar/Avatar';
+import { ParticipantOptionContent } from '../ParticipantOptionContent';
 import { Controller, useForm } from 'react-hook-form';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 import {
@@ -344,29 +345,19 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       />
     ),
     children: (
-      <div className='flex flex-1 items-center gap-2 min-w-0'>
-        <Avatar
-          userId={u.id}
-          size={'sm'}
-          showActiveStatus={false}
-          className='rounded-md size-[18px] flex items-center justify-center bg-background'
-        />
-        <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
-          <span
-            className={`shrink-0 truncate max-w-[50%] text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : 'text-foreground'}`}
-          >
-            {getUserDisplayName(u)}
-          </span>
-          {isUserDeactivated(u) && (
-            <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground shrink-0'>
-              Deactivated
-            </span>
-          )}
-          {u.email && (
-            <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>{u.email}</span>
-          )}
-        </div>
-      </div>
+      <ParticipantOptionContent
+        icon={
+          <Avatar
+            userId={u.id}
+            size='sm'
+            showActiveStatus={false}
+            className='rounded-md size-[18px] flex items-center justify-center bg-background'
+          />
+        }
+        label={getUserDisplayName(u)}
+        subtitle={u.email}
+        isDeactivated={isUserDeactivated(u)}
+      />
     ),
     type: 'user' as const,
   });
@@ -438,19 +429,11 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
       subtitle: group.alias || group.description,
       children: (
-        <div className='flex flex-1 items-center gap-2 min-w-0'>
-          <Users className='size-3.5 text-muted-foreground mx-0.5 shrink-0' strokeWidth={2.3} />
-          <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
-            <span className='shrink-0 truncate max-w-[50%] text-sm text-foreground'>
-              {group.name}
-            </span>
-            {(group.alias || group.description) && (
-              <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>
-                {group.alias || group.description}
-              </span>
-            )}
-          </div>
-        </div>
+        <ParticipantOptionContent
+          icon={<Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />}
+          label={group.name}
+          subtitle={group.alias || group.description}
+        />
       ),
       type: 'user_group' as const,
     }));
@@ -520,6 +503,11 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
     userGroups,
     fullUserList,
   ]);
+
+  const rankedParticipantOptions = useMemo(
+    () => rankParticipantOptions(inviteUserOrChannelOptions, searchQuery),
+    [inviteUserOrChannelOptions, searchQuery],
+  );
 
   const handleStartTimeChange = useCallback(
     (timeString: string): void => {
@@ -1819,7 +1807,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                   control={control}
                   render={({ field }) => (
                     <SearchParticipants
-                      options={rankParticipantOptions(inviteUserOrChannelOptions, searchQuery)}
+                      options={rankedParticipantOptions}
                       disableClientFiltering
                       selectedValues={field.value}
                       onMultiSelect={async (values: string[]) => {

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -344,7 +344,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       />
     ),
     children: (
-      <div className='flex items-center gap-2 min-w-0'>
+      <div className='flex flex-1 items-center gap-2 min-w-0'>
         <Avatar
           userId={u.id}
           size={'sm'}
@@ -353,7 +353,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
         />
         <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
           <span
-            className={`flex-1 truncate text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : 'text-foreground'}`}
+            className={`shrink-0 truncate max-w-[50%] text-sm ${isUserDeactivated(u) ? 'text-muted-foreground' : 'text-foreground'}`}
           >
             {getUserDisplayName(u)}
           </span>
@@ -363,9 +363,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
             </span>
           )}
           {u.email && (
-            <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
-              {u.email}
-            </span>
+            <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>{u.email}</span>
           )}
         </div>
       </div>
@@ -440,12 +438,14 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
       subtitle: group.alias || group.description,
       children: (
-        <div className='flex items-center gap-2 min-w-0'>
+        <div className='flex flex-1 items-center gap-2 min-w-0'>
           <Users className='size-3.5 text-muted-foreground mx-0.5 shrink-0' strokeWidth={2.3} />
           <div className='flex flex-1 min-w-0 items-center gap-2 text-left'>
-            <span className='flex-1 truncate text-sm text-foreground'>{group.name}</span>
+            <span className='shrink-0 truncate max-w-[50%] text-sm text-foreground'>
+              {group.name}
+            </span>
             {(group.alias || group.description) && (
-              <span className='shrink-0 truncate text-xs text-muted-foreground max-w-[50%]'>
+              <span className='flex-1 min-w-0 truncate text-xs text-muted-foreground'>
                 {group.alias || group.description}
               </span>
             )}

--- a/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
@@ -27,6 +27,14 @@ interface SearchParticipantsProps {
     allUserIds?: string[],
   ) => void;
   exclusiveSelection?: boolean;
+  /**
+   * Skip the built-in `label.includes(query)` substring filter. Set this when the
+   * caller has already ranked `options` with the shared participant matcher
+   * (`rankParticipantOptions`) so the fuzzy/prefix results are not re-filtered
+   * (and dropped) by substring matching. The exclusive-selection filtering below
+   * still applies.
+   */
+  disableClientFiltering?: boolean;
 }
 
 export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
@@ -43,6 +51,7 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
   hoistSelectedChannelMembers = false,
   toggleExcludedChannelMember,
   exclusiveSelection = true,
+  disableClientFiltering = false,
 }) => {
   const [selectedOptionsMap, setSelectedOptionsMap] = useState<Map<string, ParticipantOptions>>(
     new Map(),
@@ -90,14 +99,21 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
       );
     }
 
-    if (!searchQuery.trim()) return opts;
+    if (disableClientFiltering || !searchQuery.trim()) return opts;
 
     return opts.filter(
       opt =>
         opt.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
         opt.subtitle?.toLowerCase().includes(searchQuery.toLowerCase()),
     );
-  }, [options, searchQuery, hasUserSelected, hasGroupSelected, exclusiveSelection]);
+  }, [
+    options,
+    searchQuery,
+    hasUserSelected,
+    hasGroupSelected,
+    exclusiveSelection,
+    disableClientFiltering,
+  ]);
 
   const selectedOptions = useMemo(() => {
     return selectedValues

--- a/apps/dashboard/src/utils/participantSearch.ts
+++ b/apps/dashboard/src/utils/participantSearch.ts
@@ -1,5 +1,7 @@
 import { searchUsers, searchChannels } from '@xyne/shared/utils';
 
+const MAX_PARTICIPANT_SEARCH_RESULTS = 100;
+
 /**
  * Shared participant-search ranking for the call modals (Instant / Scheduled /
  * thread add-participant).
@@ -66,11 +68,36 @@ export function rankParticipantOptions<T extends RankableOption>(options: T[], q
     else groups.push(opt); // `user_group:` and any future prefixes
   }
 
+  // The shared Fuse matchers intentionally ignore one-character queries. Use
+  // a lightweight substring fallback until there is enough input to rank, so
+  // every participant picker can show matches from the first keystroke.
+  const normalizedQuery = query.trim().toLowerCase();
+  if (normalizedQuery.length === 1) {
+    const matches = (option: T): boolean => {
+      const name = typeof option.name === 'string' ? option.name : '';
+      const email = typeof option.email === 'string' ? option.email : '';
+      const displayName = typeof option.displayName === 'string' ? option.displayName : '';
+      return [option.label, name, email, displayName].some(value =>
+        value.toLowerCase().includes(normalizedQuery),
+      );
+    };
+
+    return [
+      ...users.filter(matches).slice(0, MAX_PARTICIPANT_SEARCH_RESULTS),
+      ...channels.filter(matches).slice(0, MAX_PARTICIPANT_SEARCH_RESULTS),
+      ...groups,
+    ];
+  }
+
   // Some channel-member payloads arrive as `{ id, name }` with no email, while
   // the shared matcher dereferences both fields. Normalize them at this boundary.
   const rankedUsers: T[] =
     users.length > 0
-      ? searchUsers<SearchableUserOption<T>>(users.map(toSearchableUserOption), query, users.length)
+      ? searchUsers<SearchableUserOption<T>>(
+          users.map(toSearchableUserOption),
+          query,
+          Math.min(users.length, MAX_PARTICIPANT_SEARCH_RESULTS),
+        )
       : [];
 
   const rankedChannels: T[] =
@@ -78,7 +105,7 @@ export function rankParticipantOptions<T extends RankableOption>(options: T[], q
       ? searchChannels<T & { name: string }>(
           channels.map(toSearchableChannelOption),
           query,
-          channels.length,
+          Math.min(channels.length, MAX_PARTICIPANT_SEARCH_RESULTS),
         )
       : [];
 

--- a/apps/dashboard/src/utils/participantSearch.ts
+++ b/apps/dashboard/src/utils/participantSearch.ts
@@ -22,14 +22,35 @@ import { searchUsers, searchChannels } from '@xyne/shared/utils';
  * re-filtered (which would drop valid semantic matches).
  */
 export interface RankableOption {
+  [key: string]: unknown;
   value: string;
   label: string;
   subtitle?: string | null;
-  name?: string;
-  email?: string;
+  name?: unknown;
+  email?: unknown;
+  displayName?: unknown;
+  status?: unknown;
+}
+
+type SearchableUserOption<T extends RankableOption> = T & {
+  name: string;
+  email: string;
   displayName?: string | null;
   status?: string | null;
-}
+};
+
+const toSearchableUserOption = <T extends RankableOption>(option: T): SearchableUserOption<T> => ({
+  ...option,
+  name: typeof option.name === 'string' && option.name ? option.name : option.label,
+  email: typeof option.email === 'string' ? option.email : '',
+  displayName: typeof option.displayName === 'string' ? option.displayName : null,
+  status: typeof option.status === 'string' ? option.status : null,
+});
+
+const toSearchableChannelOption = <T extends RankableOption>(option: T): T & { name: string } => ({
+  ...option,
+  name: typeof option.name === 'string' && option.name ? option.name : option.label,
+});
 
 export function rankParticipantOptions<T extends RankableOption>(options: T[], query: string): T[] {
   // Empty query: preserve the caller's existing ordering (already alphabetised).
@@ -45,33 +66,21 @@ export function rankParticipantOptions<T extends RankableOption>(options: T[], q
     else groups.push(opt); // `user_group:` and any future prefixes
   }
 
-  // Coerce name/email to strings before handing options to the matcher — some
-  // channel-member payloads arrive as `{ id, name }` with no email, and the
-  // rescoring step dereferences `.email`.
-  const rankedUsers =
+  // Some channel-member payloads arrive as `{ id, name }` with no email, while
+  // the shared matcher dereferences both fields. Normalize them at this boundary.
+  const rankedUsers: T[] =
     users.length > 0
-      ? searchUsers(
-          users.map(u => ({
-            ...u,
-            name: typeof u.name === 'string' && u.name ? u.name : u.label,
-            email: typeof u.email === 'string' ? u.email : '',
-          })) as unknown as Parameters<typeof searchUsers>[0],
-          query,
-          users.length,
-        )
+      ? searchUsers<SearchableUserOption<T>>(users.map(toSearchableUserOption), query, users.length)
       : [];
 
-  const rankedChannels =
+  const rankedChannels: T[] =
     channels.length > 0
-      ? searchChannels(
-          channels.map(c => ({
-            ...c,
-            name: typeof c.name === 'string' && c.name ? c.name : c.label,
-          })) as unknown as Parameters<typeof searchChannels>[0],
+      ? searchChannels<T & { name: string }>(
+          channels.map(toSearchableChannelOption),
           query,
           channels.length,
         )
       : [];
 
-  return [...rankedUsers, ...rankedChannels, ...groups] as unknown as T[];
+  return [...rankedUsers, ...rankedChannels, ...groups];
 }

--- a/apps/dashboard/src/utils/participantSearch.ts
+++ b/apps/dashboard/src/utils/participantSearch.ts
@@ -1,0 +1,80 @@
+import { searchUsers, searchChannels } from '@xyne/shared/utils';
+
+/**
+ * Shared participant-search ranking for the call modals (Instant / Scheduled /
+ * thread add-participant).
+ *
+ * The call modals historically filtered their option lists with a naive
+ * `label.includes(query)` substring test, which diverges from the `@`-mention
+ * search in the message composer: substring matching misses display-name vs
+ * old-name mismatches (e.g. "@V" -> "Venkatesh"), does not rank prefix / word
+ * boundary hits first, and does not demote deactivated users.
+ *
+ * `rankParticipantOptions` routes each option bucket through the SAME matcher
+ * that powers mention search (`searchUsers` / `searchChannels` from
+ * `@xyne/shared/utils`), so participant search behaves identically everywhere.
+ *
+ * Options carry a prefixed `value` (`user:`, `channel:`, `user_group:`). User and
+ * channel options also spread their raw entity fields (name / email / displayName
+ * / status for users, name for channels) onto the option object, which is what the
+ * matcher keys off. User groups are already query-filtered upstream by
+ * `useUserGroupSearch`, so they are passed through unchanged rather than
+ * re-filtered (which would drop valid semantic matches).
+ */
+export interface RankableOption {
+  value: string;
+  label: string;
+  subtitle?: string | null;
+  name?: string;
+  email?: string;
+  displayName?: string | null;
+  status?: string | null;
+}
+
+export function rankParticipantOptions<T extends RankableOption>(
+  options: T[],
+  query: string,
+): T[] {
+  // Empty query: preserve the caller's existing ordering (already alphabetised).
+  if (!query.trim()) return options;
+
+  const users: T[] = [];
+  const channels: T[] = [];
+  const groups: T[] = [];
+
+  for (const opt of options) {
+    if (opt.value.startsWith('user:')) users.push(opt);
+    else if (opt.value.startsWith('channel:')) channels.push(opt);
+    else groups.push(opt); // `user_group:` and any future prefixes
+  }
+
+  // Coerce name/email to strings before handing options to the matcher — some
+  // channel-member payloads arrive as `{ id, name }` with no email, and the
+  // rescoring step dereferences `.email`.
+  const rankedUsers =
+    users.length > 0
+      ? searchUsers(
+          users.map(u => ({
+            ...u,
+            name: typeof u.name === 'string' && u.name ? u.name : u.label,
+            email: typeof u.email === 'string' ? u.email : '',
+          })) as unknown as Parameters<typeof searchUsers>[0],
+          query,
+          users.length,
+        )
+      : [];
+
+  const rankedChannels =
+    channels.length > 0
+      ? searchChannels(
+          channels.map(c => ({
+            ...c,
+            name: typeof c.name === 'string' && c.name ? c.name : c.label,
+          })) as unknown as Parameters<typeof searchChannels>[0],
+          query,
+          channels.length,
+        )
+      : [];
+
+  return [...rankedUsers, ...rankedChannels, ...groups] as unknown as T[];
+}

--- a/apps/dashboard/src/utils/participantSearch.ts
+++ b/apps/dashboard/src/utils/participantSearch.ts
@@ -31,10 +31,7 @@ export interface RankableOption {
   status?: string | null;
 }
 
-export function rankParticipantOptions<T extends RankableOption>(
-  options: T[],
-  query: string,
-): T[] {
+export function rankParticipantOptions<T extends RankableOption>(options: T[], query: string): T[] {
   // Empty query: preserve the caller's existing ordering (already alphabetised).
   if (!query.trim()) return options;
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/8c742d7e-bc91-4566-a9ee-639589695d0a




## What
Unifies user/participant search across all three call modals (Instant call, Scheduled call, and the thread "add participants" modal) so they use the **same Fuse.js matcher that powers `@`-mention search**, replacing the naive `label.includes(query)` substring filter.

## Why
Users reported call-modal participant search was inferior to `@`-mention search:
- substring matching misses display-name vs old-name mismatches (e.g. typing `@V` should surface "Venkatesh"),
- prefix / word-boundary matches were not ranked first,
- deactivated users were not demoted.

The `@`-mention search already handles all of this via `searchUsers()` in `@xyne/shared/utils`. This PR reuses that matcher instead of maintaining a divergent substring path.

## Changes
- **New** `apps/dashboard/src/utils/participantSearch.ts` — `rankParticipantOptions(options, query)` splits options by `value` prefix and ranks users via `searchUsers()` and channels via `searchChannels()`; user groups pass through unchanged (already query-filtered upstream by `useUserGroupSearch`).
- `SearchParticipants.tsx` — new `disableClientFiltering` prop to skip the built-in substring filter when options are pre-ranked (exclusive-selection filtering still applies).
- `InstantCallModal.tsx` + `ScheduleCallModal.tsx` — wrap options with `rankParticipantOptions(...)` and set `disableClientFiltering`.
- `CallParticipantsSelectionModal.tsx` (thread add-participant) — rank channel members with `searchUsers()`; **non-members remain hidden (members-only)**, and pass `disableClientFiltering` to `EntityMultiSelector`.

## Scope / behavior
- Instant & Scheduled modals still search **all** workspace users + channels + groups (out-of-channel users allowed).
- Thread add-participant modal stays **members-only** — the `channelParticipantUserIds` restriction is retained, so non-channel users are not shown.
- Empty query preserves existing alphabetical ordering.

## Validation
- `tsc --noEmit` on the dashboard: no new errors in any touched file (pre-existing baseline errors are unrelated).
- Manual: search "venktesh" surfaces "V"; "harsha" surfaces both "Sai Harsha" and "Harshvardhan Bahukhandi"; "sk" ranks "Sk Sakil Mostak" first and tags out-of-channel; deactivated users sink.

## Notes
No ticket key was supplied for the branch name — happy to rename/retarget if a XYNE ticket exists.
