### PR TITLE
Fix/lastreply at migration

### DIFF
--- a/backend/src/bots/unified/orchestrator/execution-orchestrator.ts
+++ b/backend/src/bots/unified/orchestrator/execution-orchestrator.ts
@@ -111,7 +111,7 @@ class ExecutionOrchestrator {
     const context = await this.buildContext(request, entry);
 
     // 3. Update conversation activity
-    await this.updateConversationActivity(request);
+    await this.updateConversationActivity(request, context.triggerMessage);
 
     // 4. Delegate to appropriate runtime
     if (isInternalBot(entry.definition)) {
@@ -366,8 +366,16 @@ class ExecutionOrchestrator {
   /**
    * Update conversation activity counts
    */
-  private async updateConversationActivity(request: ExecutionRequest): Promise<void> {
-    await conversationRepository.incrementReplyCount(request.conversationId);
+  private async updateConversationActivity(
+    request: ExecutionRequest,
+    triggerMessage: BotExecutionContext['triggerMessage'],
+  ): Promise<void> {
+    const conversation = await conversationRepository.findById(request.conversationId);
+    const replyCreatedAt =
+      triggerMessage && triggerMessage.messageId !== conversation?.initialMessageId
+        ? triggerMessage.createdAt
+        : null;
+    await conversationRepository.incrementReplyCount(request.conversationId, replyCreatedAt);
     await channelRepository.updateLastActivity(request.channelId);
   }
 

--- a/backend/src/database/repositories/conversationRepository.ts
+++ b/backend/src/database/repositories/conversationRepository.ts
@@ -146,6 +146,7 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
   async incrementReplyCount(
     conversationId: string,
     replyCreatedAt?: Date | null,
+    markParticipantsRead = false,
   ): Promise<Conversation> {
     const conversation = await this.findById(conversationId);
     if (!conversation) {
@@ -167,6 +168,16 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
         },
         data: { lastReplyAt: effectiveReplyCreatedAt },
       });
+
+      if (markParticipantsRead) {
+        await this.db.conversationParticipant.updateMany({
+          where: {
+            conversationId,
+            OR: [{ lastReadAt: null }, { lastReadAt: { lt: effectiveReplyCreatedAt } }],
+          },
+          data: { lastReadAt: effectiveReplyCreatedAt },
+        });
+      }
     }
 
     return result;

--- a/backend/src/database/repositories/conversationRepository.ts
+++ b/backend/src/database/repositories/conversationRepository.ts
@@ -143,25 +143,29 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
     return await this.findMany({ channelId, pinned: true });
   }
 
-  async incrementReplyCount(conversationId: string, skipParticipantUpdate = false): Promise<Conversation> {
+  async incrementReplyCount(
+    conversationId: string,
+    replyCreatedAt?: Date | null,
+  ): Promise<Conversation> {
     const conversation = await this.findById(conversationId);
     if (!conversation) {
       throw new Error('Conversation not found');
     }
 
     const now = new Date();
+    const effectiveReplyCreatedAt = replyCreatedAt === undefined ? now : replyCreatedAt;
     const result = await this.update(conversationId, {
       replyCount: conversation.replyCount + 1,
       lastActivityAt: now,
     });
 
-    // Update lastReplyAt on all participants (denormalized for userConversationsPaginatedV2).
-    // Skipped during migration — the value would be the migration run time, not the
-    // historical Slack timestamp, so it is incorrect anyway.
-    if (!skipParticipantUpdate) {
+    if (effectiveReplyCreatedAt) {
       await this.db.conversationParticipant.updateMany({
-        where: { conversationId },
-        data: { lastReplyAt: now },
+        where: {
+          conversationId,
+          OR: [{ lastReplyAt: null }, { lastReplyAt: { lt: effectiveReplyCreatedAt } }],
+        },
+        data: { lastReplyAt: effectiveReplyCreatedAt },
       });
     }
 

--- a/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -491,6 +491,7 @@ export async function ingestConversationSlack(
           lastActivityAt: createdAt,
           createdAt,
           isAddingParticipant: false,
+          markParticipantsRead: true,
         });
 
         message = result.message;

--- a/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -491,7 +491,6 @@ export async function ingestConversationSlack(
           lastActivityAt: createdAt,
           createdAt,
           isAddingParticipant: false,
-          isMigration: true,
         });
 
         message = result.message;

--- a/backend/src/services/conversationService.ts
+++ b/backend/src/services/conversationService.ts
@@ -107,6 +107,8 @@ export interface AddMessageToConversationParams {
   createdAt?: Date;
   isAddingParticipant?: boolean;
   isMarkdown?: boolean;
+  /** Migration-only: advance participant read state to the imported reply timestamp. */
+  markParticipantsRead?: boolean;
 }
 
 export interface UpdateMessageParams {
@@ -571,6 +573,7 @@ export class ConversationService {
       isMarkdown,
       createdAt,
       isAddingParticipant = true,
+      markParticipantsRead = false,
     } = params;
 
     const conversation = await this.conversationRepository.findById(conversationId);
@@ -748,6 +751,7 @@ export class ConversationService {
     await this.conversationRepository.incrementReplyCount(
       conversationId,
       createdAt === undefined ? undefined : message.createdAt,
+      markParticipantsRead,
     );
     await messageMetadataService.addReply(conversationId, userId);
 

--- a/backend/src/services/conversationService.ts
+++ b/backend/src/services/conversationService.ts
@@ -107,13 +107,6 @@ export interface AddMessageToConversationParams {
   createdAt?: Date;
   isAddingParticipant?: boolean;
   isMarkdown?: boolean;
-  /**
-   * When true, skips the `conversationParticipant.updateMany` inside
-   * `incrementReplyCount`. During migration the value written would be the
-   * migration run time (not the historical Slack timestamp), so it is
-   * incorrect regardless. Skipping it avoids unnecessary DB writes.
-   */
-  isMigration?: boolean;
 }
 
 export interface UpdateMessageParams {
@@ -578,7 +571,6 @@ export class ConversationService {
       isMarkdown,
       createdAt,
       isAddingParticipant = true,
-      isMigration = false,
     } = params;
 
     const conversation = await this.conversationRepository.findById(conversationId);
@@ -753,10 +745,10 @@ export class ConversationService {
       await messageMetadataService.syncParentMessageMd(childConversationId);
     }
 
-    // Update conversation reply count and last activity.
-    // Pass isMigration to skip the conversationParticipant.updateMany — during
-    // migration the timestamp would be wrong (run time, not Slack ts) anyway.
-    await this.conversationRepository.incrementReplyCount(conversationId, isMigration);
+    await this.conversationRepository.incrementReplyCount(
+      conversationId,
+      createdAt === undefined ? undefined : message.createdAt,
+    );
     await messageMetadataService.addReply(conversationId, userId);
 
     // Update reply count for previous message's child conversation if it exists

--- a/backend/src/services/jiraMigrationImportService.ts
+++ b/backend/src/services/jiraMigrationImportService.ts
@@ -1858,6 +1858,14 @@ export class JiraMigrationImportService {
           },
           data: { lastReplyAt: lastCommentAt },
         });
+
+        await db.conversationParticipant.updateMany({
+          where: {
+            conversationId,
+            OR: [{ lastReadAt: null }, { lastReadAt: { lt: lastCommentAt } }],
+          },
+          data: { lastReadAt: lastCommentAt },
+        });
       }
     }
 

--- a/backend/src/services/jiraMigrationImportService.ts
+++ b/backend/src/services/jiraMigrationImportService.ts
@@ -1850,10 +1850,12 @@ export class JiraMigrationImportService {
         },
       });
 
-      // Update lastReplyAt on all participants (denormalized for userConversationsPaginatedV2)
       if (lastCommentAt) {
         await db.conversationParticipant.updateMany({
-          where: { conversationId },
+          where: {
+            conversationId,
+            OR: [{ lastReplyAt: null }, { lastReplyAt: { lt: lastCommentAt } }],
+          },
           data: { lastReplyAt: lastCommentAt },
         });
       }

--- a/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { ActivityClassification, ActivityClassificationJobType, AttachmentEntityType, ChannelScopeType, NotificationDeliveryMethod, NotificationType, UserStatus, UserType } from '@prisma/client';
+import { ActivityClassification, ActivityClassificationJobType, AttachmentEntityType, ChannelScopeType, MessageType, NotificationDeliveryMethod, NotificationType, UserStatus, UserType } from '@prisma/client';
 import { BaseSideEffectHandler } from '../base-handler';
 import type { SideEffectJobConfig, MessagePreviousValue } from '../types';
 import { db } from '@/database/client';

--- a/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -233,11 +233,43 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
         conversationId: true,
         msgType: true,
         hasAttachment: true,
-        createdAt: true
+        createdAt: true,
+        isDeleted: true,
       },
     });
 
-    if (!message || message.msgType === "SYSTEM" ) {
+    if (!message) {
+      return;
+    }
+
+    if (message.msgType === MessageType.SYSTEM) {
+      const conversation = await db.conversation.findUnique({
+        where: { conversationId: message.conversationId },
+        select: { initialMessageId: true },
+      });
+      const isReply =
+        !message.isDeleted &&
+        conversation?.initialMessageId != null &&
+        conversation.initialMessageId !== message.messageId;
+      if (isReply) {
+        try {
+          await db.conversationParticipant.updateMany({
+            where: {
+              conversationId: message.conversationId,
+              OR: [{ lastReplyAt: null }, { lastReplyAt: { lt: message.createdAt } }],
+            },
+            data: { lastReplyAt: message.createdAt },
+          });
+          logger.info('[MessagesSideEffect] Updated lastReplyAt for SYSTEM reply', {
+            conversationId: message.conversationId,
+          });
+        } catch (error) {
+          logger.error('[MessagesSideEffect] Failed to update lastReplyAt for SYSTEM reply:', {
+            conversationId: message.conversationId,
+            error,
+          });
+        }
+      }
       return;
     }
 
@@ -1951,7 +1983,7 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       activityService.deleteActivitiesBySource('message', messageId),
     ]);
 
-    if (!previousValue?.conversationId || previousValue.msgType === 'SYSTEM') {
+    if (!previousValue?.conversationId) {
       return;
     }
 
@@ -1960,7 +1992,7 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       select: { initialMessageId: true, channelId: true },
     });
 
-    if (!conversation?.initialMessageId || !conversation.channelId) {
+    if (!conversation?.initialMessageId) {
       return;
     }
 
@@ -1996,6 +2028,14 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       logger.error('[MessagesSideEffectHandler] Failed to roll back lastReplyAt on delete', {
         error: error
       });
+    }
+
+    if (previousValue.msgType === MessageType.SYSTEM) {
+      return;
+    }
+
+    if (!conversation.channelId) {
+      return;
     }
 
     let repliers: string[] = [];


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
