### PR TITLE
feat(xyne-claw): ingest OpenCode and Codex sessions alongside Claude

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/memory.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/memory.ts
@@ -1410,9 +1410,11 @@ memoryRouter.post("/banks/:agentSlug/upload-md", requireUserAuth, async (req, re
       return;
     }
 
-    const body = (req.body ?? {}) as { filename?: string; content?: string };
+    const body = (req.body ?? {}) as { filename?: string; content?: string; source?: string };
     const filename = (body.filename ?? "").trim();
     const content = (body.content ?? "").trim();
+    const rawSource = (body.source ?? "claude").trim().toLowerCase();
+    const source = ["claude", "opencode", "codex"].includes(rawSource) ? rawSource : "claude";
     if (!filename || !content) {
       res.status(400).json({ success: false, error: "filename and content are required" });
       return;
@@ -2207,9 +2209,9 @@ memoryRouter.delete("/banks/:agentSlug/subsystems/:subsystem", requireUserAuth, 
 /**
  * POST /memory/banks/:agentSlug/upload-session
  *
- * Upload a raw Claude session export (Claude Code JSONL or claude.ai JSON) and
- * distill it into the agent's shared memory. Owner/admin only — the bank is
- * shared across everyone who uses the agent.
+ * Upload a raw session export (Claude Code JSONL, claude.ai JSON, OpenCode bundle,
+ * or Codex rollout JSONL) and distill it into the agent's shared memory.
+ * Owner/admin only — the bank is shared across everyone who uses the agent.
  *
  * The raw export is sent to claw's /internal/curator/distill-session, which
  * parses + normalizes it and runs a chunked map-reduce distill so a large
@@ -2220,7 +2222,7 @@ memoryRouter.delete("/banks/:agentSlug/subsystems/:subsystem", requireUserAuth, 
  *
  * Async: the parse + N-chunk distill is slow (many LLM calls), so the handler
  * responds 202 immediately and does the work in the background (same pattern as
- * batch approve). Uploaded candidates carry a `claude-<ts>-<file>` sessionId so
+ * batch approve). Uploaded candidates carry a `<source>-<ts>-<file>` sessionId so
  * admins can spot upload-sourced proposals in the review queue.
  */
 memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (req, res) => {
@@ -2251,9 +2253,11 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
       return;
     }
 
-    const body = (req.body ?? {}) as { filename?: string; content?: string };
+    const body = (req.body ?? {}) as { filename?: string; content?: string; source?: string };
     const filename = (body.filename ?? "").trim();
     const content = (body.content ?? "").trim();
+    const rawSource = (body.source ?? "claude").trim().toLowerCase();
+    const source = ["claude", "opencode", "codex"].includes(rawSource) ? rawSource : "claude";
     if (!filename || !content) {
       res.status(400).json({ success: false, error: "filename and content are required" });
       return;
@@ -2266,7 +2270,7 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
 
     const now = new Date();
     const reviewDate = now.toISOString().slice(0, 10); // YYYY-MM-DD
-    const sessionId = `claude-${now.getTime()}-${filename}`.slice(0, 200);
+    const sessionId = `${source}-${now.getTime()}-${filename}`.slice(0, 200);
 
     // Respond immediately — the parse + map-reduce distill is slow and must not
     // block the request. Candidates appear in the review queue when done.
@@ -2281,7 +2285,7 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
         // facts. The legacy map-reduce distill (MEMORY_SESSION_INGEST=0)
         // queues per-subsystem review rows instead.
         if (process.env["MEMORY_SESSION_INGEST"] !== "0") {
-          const parsed = await parseSessionFile({ sessionId, agentSlug, userId, filename, rawSession: content });
+          const parsed = await parseSessionFile({ sessionId, agentSlug, userId, filename, source, rawSession: content });
           if (!parsed) {
             logger.warn("[memory] /upload-session parse produced no transcript", { agentSlug, filename, by: userId });
             return;
@@ -2306,7 +2310,7 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
             // without this tag the contributor is unrecoverable. contributor:
             // (not user:) — user: is the twin privacy filter prefix.
             `contributor:${userId}`,
-            "source:claude-upload",
+            `source:${source}-upload`,
             ...(subsystem ? [`subsystem:${subsystem}`] : []),
           ];
           // Retain in generous slices (provider chunks internally at ~3K; the
@@ -2320,7 +2324,7 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
               metadata: {
                 agentSlug,
                 sessionId,
-                source: "claude-upload",
+                source: `${source}-upload`,
                 filename: filename.slice(0, 120),
                 ...(subsystem ? { subsystem } : {}),
               },
@@ -2338,7 +2342,7 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
           return;
         }
 
-        const candidates = await distillSessionFile({ sessionId, agentSlug, userId, filename, rawSession: content });
+        const candidates = await distillSessionFile({ sessionId, agentSlug, userId, filename, source, rawSession: content });
         if (candidates.length === 0) {
           logger.info("[memory] /upload-session produced no candidates", { agentSlug, filename, by: userId });
           return;
@@ -2350,7 +2354,7 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
           orgId: agent.orgId,
           conversationId: null,
           channelId: null,
-          task: `Claude session upload "${filename}"`,
+          task: `${source.charAt(0).toUpperCase() + source.slice(1)} session upload "${filename}"`,
           result: "",
           toolsUsed: [],
           toolInvocations: [],
@@ -2361,7 +2365,7 @@ memoryRouter.post("/banks/:agentSlug/upload-session", requireUserAuth, async (re
           completedAt: new Date(),
         };
         const reviewIds = await persistSubsystemReviews(transcript, candidates, reviewDate);
-        logger.info("[memory] /upload-session curated claude session", {
+        logger.info(`[memory] /upload-session curated ${source} session`, {
           agentSlug, filename, candidatesCreated: reviewIds.length, by: userId,
         });
       } catch (err) {

--- a/apps/xyne-claw-auth/backend/src/services/sessionCurator.ts
+++ b/apps/xyne-claw-auth/backend/src/services/sessionCurator.ts
@@ -179,7 +179,8 @@ export interface DistillSessionFileArgs {
   agentSlug: string;
   userId: string;
   filename: string;
-  /** Raw uploaded Claude export (Claude Code JSONL or claude.ai JSON). */
+  source?: "claude" | "opencode" | "codex" | (string & {});
+  /** Raw uploaded Claude/OpenCode/Codex export. */
   rawSession: string;
 }
 
@@ -212,7 +213,7 @@ export async function parseSessionFile(
     const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json", "x-s2s-key": CONFIG.xyneClawS2sKey },
-      body: JSON.stringify({ ...args, parseOnly: true }),
+      body: JSON.stringify({ ...args, source: args.source, parseOnly: true }),
       signal: AbortSignal.timeout(CURATE_TIMEOUT_MS),
     });
     if (!res.ok) {

--- a/apps/xyne-claw-auth/frontend/src/v2/components/MemoryTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v2/components/MemoryTab.tsx
@@ -285,6 +285,7 @@ export function MemoryTab({ agentSlug, canDelete = false, userTag }: Props) {
   const [showBackfill, setShowBackfill] = useState(false);
   const [showUpload, setShowUpload] = useState(false);
   const [showSessionUpload, setShowSessionUpload] = useState(false);
+  const [sessionUploadSource, setSessionUploadSource] = useState<"claude" | "opencode" | "codex">("claude");
   const [status, setStatus] = useState<MemoryStatusFlags | null>(null);
   const [statusLoading, setStatusLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
@@ -421,13 +422,29 @@ export function MemoryTab({ agentSlug, canDelete = false, userTag }: Props) {
               </button>
             )}
             {canDelete && (
-              <button
-                onClick={() => setShowSessionUpload(true)}
-                title="Upload Claude session exports (.jsonl / .json, or a .zip of them) — parsed and retained as agent memory"
-                className="inline-flex items-center gap-1.5 rounded-full border border-xyne-border-subtle bg-xyne-surface px-3 py-1.5 text-[12px] font-medium text-xyne-fg-secondary hover:text-xyne-fg-primary hover:border-xyne-border"
-              >
-                <Inbox size={12} /> Upload sessions
-              </button>
+              <div className="flex items-center gap-1.5">
+                <button
+                  onClick={() => { setSessionUploadSource("claude"); setShowSessionUpload(true); }}
+                  title="Upload Claude session exports (.jsonl / .json, or a .zip of them) — parsed and retained as agent memory"
+                  className="inline-flex items-center gap-1.5 rounded-full border border-xyne-border-subtle bg-xyne-surface px-3 py-1.5 text-[12px] font-medium text-xyne-fg-secondary hover:text-xyne-fg-primary hover:border-xyne-border"
+                >
+                  <Inbox size={12} /> Claude
+                </button>
+                <button
+                  onClick={() => { setSessionUploadSource("opencode"); setShowSessionUpload(true); }}
+                  title="Upload OpenCode session bundles (.json, or a .zip of them) — parsed and retained as agent memory"
+                  className="inline-flex items-center gap-1.5 rounded-full border border-xyne-border-subtle bg-xyne-surface px-3 py-1.5 text-[12px] font-medium text-xyne-fg-secondary hover:text-xyne-fg-primary hover:border-xyne-border"
+                >
+                  <Inbox size={12} /> OpenCode
+                </button>
+                <button
+                  onClick={() => { setSessionUploadSource("codex"); setShowSessionUpload(true); }}
+                  title="Upload Codex rollout logs (.jsonl / .json, or a .zip of them) — parsed and retained as agent memory"
+                  className="inline-flex items-center gap-1.5 rounded-full border border-xyne-border-subtle bg-xyne-surface px-3 py-1.5 text-[12px] font-medium text-xyne-fg-secondary hover:text-xyne-fg-primary hover:border-xyne-border"
+                >
+                  <Inbox size={12} /> Codex
+                </button>
+              </div>
             )}
             <button
               onClick={loadStats}
@@ -605,6 +622,7 @@ export function MemoryTab({ agentSlug, canDelete = false, userTag }: Props) {
       {showSessionUpload && (
         <UploadSessionModal
           agentSlug={agentSlug}
+          source={sessionUploadSource}
           onClose={() => setShowSessionUpload(false)}
           onDone={() => {
             setShowSessionUpload(false);
@@ -1032,7 +1050,7 @@ function AllMemories({
   const [loading, setLoading] = useState(false);
   const [total, setTotal] = useState(0);
   const [typeFilter, setTypeFilter] = useState<"all" | "world" | "experience" | "observation">("all");
-  const [sourceFilter, setSourceFilter] = useState<"all" | "session-ingest" | "claude-upload" | "other">("all");
+  const [sourceFilter, setSourceFilter] = useState<"all" | "session-ingest" | "claude-upload" | "opencode-upload" | "codex-upload" | "other">("all");
   const [groupBy, setGroupBy] = useState<"none" | "type" | "session" | "subsystem">("none");
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
@@ -1061,7 +1079,8 @@ function AllMemories({
 
     if (sourceFilter !== "all") {
       const source = memory.tags?.find((tag) => tag.startsWith("source:"))?.slice("source:".length);
-      if (sourceFilter === "other" ? source === "session-ingest" || source === "claude-upload" : source !== sourceFilter) {
+      const knownSources = new Set(["session-ingest", "claude-upload", "opencode-upload", "codex-upload"]);
+      if (sourceFilter === "other" ? knownSources.has(source ?? "") : source !== sourceFilter) {
         return false;
       }
     }
@@ -2592,13 +2611,18 @@ function RecallTester({ agentSlug, userTag }: { agentSlug: string; userTag?: str
  */
 function UploadSessionModal({
   agentSlug,
+  source,
   onClose,
   onDone,
 }: {
   agentSlug: string;
+  source: "claude" | "opencode" | "codex";
   onClose: () => void;
   onDone: () => void;
 }) {
+  const sourceLabel = source === "opencode" ? "OpenCode" : source === "codex" ? "Codex" : "Claude";
+  const acceptedExts = source === "opencode" ? /\.(json|zip)$/i : /\.(jsonl|json|zip)$/i;
+  const acceptAttr = source === "opencode" ? ".json,.zip" : ".jsonl,.json,.zip";
   const MAX_SESSION_BYTES = 20_000_000; // backend hard cap
   const [sessions, setSessions] = useState<Array<{ name: string; content: string }>>([]);
   const [skipped, setSkipped] = useState<string[]>([]);
@@ -2625,13 +2649,13 @@ function UploadSessionModal({
             if (entry.dir) continue;
             const base = entry.name.split("/").pop() ?? entry.name;
             if (entry.name.startsWith("__MACOSX/") || base.startsWith(".")) continue;
-            if (!/\.(jsonl|json)$/i.test(base)) continue;
+            if (!acceptedExts.test(base)) continue;
             const content = await entry.async("string");
             if (content.length > MAX_SESSION_BYTES) { skip.push(`${base} (over 20MB)`); continue; }
             if (!content.trim()) { skip.push(`${base} (empty)`); continue; }
             picked.push({ name: base, content });
           }
-        } else if (/\.(jsonl|json)$/i.test(file.name)) {
+        } else if (acceptedExts.test(file.name)) {
           if (file.size > MAX_SESSION_BYTES) { skip.push(`${file.name} (over 20MB)`); continue; }
           picked.push({ name: file.name, content: await file.text() });
         } else {
@@ -2665,7 +2689,7 @@ function UploadSessionModal({
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
-          body: JSON.stringify({ filename: s.name, content: s.content }),
+          body: JSON.stringify({ filename: s.name, content: s.content, source }),
         });
         const data = await res.json().catch(() => ({}));
         if (res.status === 202 && data.success) ok++;
@@ -2687,7 +2711,7 @@ function UploadSessionModal({
       >
         <div className="mb-3 flex items-center gap-2">
           <Inbox size={16} className="text-xyne-fg-secondary" />
-          <h3 className="text-[14px] font-semibold text-xyne-fg-primary">Upload Claude sessions</h3>
+          <h3 className="text-[14px] font-semibold text-xyne-fg-primary">Upload {sourceLabel} sessions</h3>
           <button
             onClick={onClose}
             disabled={uploading}
@@ -2704,7 +2728,7 @@ function UploadSessionModal({
               <Check size={14} /> Uploaded <b>{doneCount}</b> session{doneCount === 1 ? "" : "s"} — parsing and extracting memories in the background.
             </p>
             <p className="text-xyne-fg-tertiary">
-              New facts appear in this agent's bank within a few minutes (source: claude-upload).
+              New facts appear in this agent's bank within a few minutes (source: {source}-upload).
             </p>
             {failures.length > 0 && (
               <div className="rounded-lg border border-xyne-error-fg/30 bg-xyne-error-bg/40 p-2 text-[12px] text-xyne-error-fg">
@@ -2722,13 +2746,15 @@ function UploadSessionModal({
         ) : (
           <div className="space-y-3">
             <p className="text-[12px] text-xyne-fg-tertiary">
-              Pick Claude Code session files (<span className="font-mono">.jsonl</span>), claude.ai exports (<span className="font-mono">.json</span>),
-              or a <span className="font-mono">.zip</span> containing them. Each session is parsed, cleaned of harness noise, and retained as
-              this agent's memory — uploading is the approval.
+              {source === "opencode"
+                ? <>Pick OpenCode session bundles (<span className="font-mono">.json</span>) or a <span className="font-mono">.zip</span> containing them. Each bundle is parsed and retained as this agent's memory — uploading is the approval.</>
+                : source === "codex"
+                  ? <>Pick Codex rollout logs (<span className="font-mono">.jsonl</span> / <span className="font-mono">.json</span>) or a <span className="font-mono">.zip</span> containing them. Each rollout is parsed and retained as this agent's memory — uploading is the approval.</>
+                  : <>Pick Claude Code session files (<span className="font-mono">.jsonl</span>), claude.ai exports (<span className="font-mono">.json</span>), or a <span className="font-mono">.zip</span> containing them. Each session is parsed, cleaned of harness noise, and retained as this agent's memory — uploading is the approval.</>}
             </p>
             <input
               type="file"
-              accept=".jsonl,.json,.zip"
+              accept={acceptAttr}
               multiple
               disabled={reading || uploading}
               onChange={(e) => void onPickFiles(e)}

--- a/apps/xyne-claw/src/routes/curator.ts
+++ b/apps/xyne-claw/src/routes/curator.ts
@@ -12,7 +12,7 @@ import { Router } from "express";
 import type { Request, Response } from "express";
 import { validateS2SKey } from "../middleware/auth.js";
 import { classifyIngestSubsystem, distillSession, distillLargeTranscript } from "../curator.js";
-import { parseClaudeSession } from "../claude-session-parse.js";
+import { parseSession } from "../session-parsers/index.js";
 import type { SessionTranscriptForCurator } from "xyne-claw-shared";
 
 import { createLogger } from "../logger.js";
@@ -90,7 +90,7 @@ curatorRouter.post("/internal/curator/distill", validateS2SKey, async (req: Requ
 });
 
 /**
- * Distill an uploaded Claude session file into subsystem-update candidates.
+ * Distill an uploaded session file (Claude, OpenCode, or Codex) into subsystem-update candidates.
  *
  * Body: { sessionId, agentSlug, userId, filename, rawSession }
  *   rawSession — the raw uploaded export (Claude Code JSONL or claude.ai JSON).
@@ -110,6 +110,7 @@ curatorRouter.post("/internal/curator/distill-session", validateS2SKey, async (r
       agentSlug?: string;
       userId?: string;
       filename?: string;
+      source?: string;
       rawSession?: string;
       bankId?: string;
       parseOnly?: boolean;
@@ -123,7 +124,7 @@ curatorRouter.post("/internal/curator/distill-session", validateS2SKey, async (r
       return;
     }
 
-    const parsed = parseClaudeSession(body.rawSession, body.filename ?? "");
+    const parsed = parseSession(body.rawSession, { source: body.source, filename: body.filename });
     if (parsed.turnCount === 0) {
       res.status(422).json({
         success: false,
@@ -134,6 +135,7 @@ curatorRouter.post("/internal/curator/distill-session", validateS2SKey, async (r
     }
 
     const meta = {
+      source: parsed.source,
       format: parsed.format,
       turnCount: parsed.turnCount,
       conversationCount: parsed.conversationCount,

--- a/apps/xyne-claw/src/session-parsers/codex.ts
+++ b/apps/xyne-claw/src/session-parsers/codex.ts
@@ -1,0 +1,190 @@
+/**
+ * Codex (OpenAI Codex CLI/TUI) rollout parser.
+ *
+ * Input is JSONL. Typical lines:
+ *   {"type":"session_meta","payload":{"session_id":"...",...}}
+ *   {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"..."}]}}
+ *   {"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"..."},{"type":"tool_call","name":"..."}]}}
+ *   {"type":"event_msg","payload":{"type":"task_started"}}
+ *
+ * We treat `session_meta` as the envelope (and reject a file without it),
+ * keep `response_item` messages with role user/assistant, drop developer
+ * instructions and housekeeping `event_msg` lines, and render tool_call /
+ * tool_output content items.
+ */
+
+import { clip, isRecord, safeJson } from "./common.js";
+import type { ParsedSession } from "./types.js";
+
+const MAX_TURN_CHARS = 8_000;
+
+type CodexRole = "user" | "assistant" | "developer" | "system";
+
+function normalizeRole(role: unknown): CodexRole | null {
+  const r = typeof role === "string" ? role.toLowerCase() : "";
+  if (r === "user" || r === "human") return "user";
+  if (r === "assistant" || r === "ai") return "assistant";
+  if (r === "developer" || r === "system") return "developer";
+  return null;
+}
+
+interface ContentItem extends Record<string, unknown> {
+  type?: unknown;
+  text?: unknown;
+}
+
+function isContentItemArray(v: unknown): v is ContentItem[] {
+  return Array.isArray(v);
+}
+
+function renderContentItem(item: ContentItem): { text: string; toolName: string | null; callId: string | null } {
+  const type = typeof item.type === "string" ? item.type : "";
+  switch (type) {
+    case "input_text":
+    case "output_text":
+    case "text": {
+      const text = typeof item.text === "string" ? item.text : "";
+      return { text, toolName: null, callId: null };
+    }
+    case "tool_call": {
+      const name = typeof item.name === "string" ? item.name : "(unnamed tool)";
+      const callId = typeof item.call_id === "string" ? item.call_id : "";
+      const args = safeJson(item.arguments ?? item.args);
+      return { text: `[tool_call ${name}${callId ? ` id=${callId}` : ""}] args: ${clip(args, 800)}`, toolName: name, callId };
+    }
+    case "tool_output": {
+      const callId = typeof item.call_id === "string" ? item.call_id : "";
+      const output = typeof item.output === "string" ? item.output : safeJson(item.output);
+      return { text: `[tool_output${callId ? ` id=${callId}` : ""}] ${output}`, toolName: null, callId };
+    }
+    default:
+      return { text: "", toolName: null, callId: null };
+  }
+}
+
+interface RenderedMessage {
+  text: string;
+  tools: string[];
+}
+
+function renderMessage(role: CodexRole, content: unknown): RenderedMessage | null {
+  if (!isContentItemArray(content)) return null;
+  const parts: string[] = [];
+  const tools: string[] = [];
+  for (const item of content) {
+    const { text, toolName } = renderContentItem(item);
+    if (text) parts.push(text);
+    if (toolName) tools.push(toolName);
+  }
+  if (parts.length === 0 && tools.length === 0) return null;
+  return { text: parts.join("\n"), tools };
+}
+
+interface NormalizedTurn {
+  role: "user" | "assistant";
+  text: string;
+}
+
+function parseMessageFromPayload(payload: Record<string, unknown>): NormalizedTurn | null {
+  const type = typeof payload.type === "string" ? payload.type : "";
+  if (type !== "message") return null;
+
+  const role = normalizeRole(payload.role);
+  if (role !== "user" && role !== "assistant") return null;
+
+  const rendered = renderMessage(role, payload.content);
+  if (!rendered || (!rendered.text && rendered.tools.length === 0)) return null;
+  return { role, text: clip(rendered.text, MAX_TURN_CHARS) };
+}
+
+export function detectCodex(raw: string): boolean {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return false;
+  let hasSessionMeta = false;
+  let hasResponseItem = false;
+  for (const line of trimmed.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const obj = JSON.parse(line) as unknown;
+      if (!isRecord(obj)) continue;
+      if (obj["type"] === "session_meta") hasSessionMeta = true;
+      if (obj["type"] === "response_item") hasResponseItem = true;
+    } catch {
+      // Ignore malformed lines for detection purposes.
+    }
+  }
+  return hasSessionMeta && hasResponseItem;
+}
+
+/**
+ * Parse a Codex rollout JSONL stream into the shared shape.
+ * Never throws.
+ */
+export function parseCodexSession(raw: string, _filename?: string): ParsedSession {
+  const empty = (format: string): ParsedSession => ({
+    task: "",
+    result: "",
+    toolsUsed: [],
+    transcript: "",
+    turnCount: 0,
+    conversationCount: 1,
+    format,
+    source: "codex",
+  });
+
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return empty("unknown");
+
+  const turns: NormalizedTurn[] = [];
+  const tools = new Set<string>();
+  let hasSessionMeta = false;
+
+  for (const line of trimmed.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const obj = JSON.parse(line) as unknown;
+      if (!isRecord(obj)) continue;
+      const type = typeof obj["type"] === "string" ? obj["type"] : "";
+      if (type === "session_meta") {
+        hasSessionMeta = true;
+        continue;
+      }
+      if (type === "response_item" && isRecord(obj["payload"])) {
+        const payload = obj["payload"] as Record<string, unknown>;
+        const content = payload["content"];
+        if (isContentItemArray(content)) {
+          for (const item of content) {
+            const { toolName } = renderContentItem(item);
+            if (toolName) tools.add(toolName);
+          }
+        }
+        const turn = parseMessageFromPayload(payload);
+        if (turn) turns.push(turn);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  if (!hasSessionMeta) return empty("codex-jsonl");
+  if (turns.length === 0) return empty("codex-jsonl");
+
+  const firstUser = turns.find((t) => t.role === "user");
+  const lastAssistant = [...turns].reverse().find((t) => t.role === "assistant");
+
+  const task = firstUser ? clip(firstUser.text, 4_000) : "(no user turn found in session)";
+  const result = lastAssistant ? clip(lastAssistant.text, 4_000) : "(no assistant turn found in session)";
+
+  const transcript = turns.map((t) => `### ${t.role.toUpperCase()}\n${t.text}`).join("\n\n");
+
+  return {
+    task,
+    result,
+    toolsUsed: [...tools],
+    transcript,
+    turnCount: turns.length,
+    conversationCount: 1,
+    format: "codex-jsonl",
+    source: "codex",
+  };
+}

--- a/apps/xyne-claw/src/session-parsers/common.ts
+++ b/apps/xyne-claw/src/session-parsers/common.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared helpers for all session parsers.
+ */
+
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+export function safeJson(v: unknown): string {
+  try {
+    return typeof v === "string" ? v : JSON.stringify(v);
+  } catch {
+    return "";
+  }
+}
+
+export function clip(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}…[truncated]` : s;
+}
+
+export function extractTopLevelString(obj: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const v = obj[key];
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  return "";
+}
+
+export function joinNonEmpty(parts: (string | undefined | null)[], sep = "\n"): string {
+  return parts.filter((p): p is string => typeof p === "string" && p.trim().length > 0).join(sep);
+}

--- a/apps/xyne-claw/src/session-parsers/index.ts
+++ b/apps/xyne-claw/src/session-parsers/index.ts
@@ -1,0 +1,48 @@
+import { parseClaudeSession } from "../claude-session-parse.js";
+import { detectCodex, parseCodexSession } from "./codex.js";
+import { detectOpenCode, parseOpenCodeSession } from "./opencode.js";
+import type { ParsedSession, SessionSource } from "./types.js";
+
+const VALID_SOURCES: readonly SessionSource[] = ["claude", "opencode", "codex"];
+
+function isValidSource(s: string): s is SessionSource {
+  return (VALID_SOURCES as readonly string[]).includes(s);
+}
+
+function detectFormat(raw: string, filename?: string): SessionSource {
+  if (detectOpenCode(raw)) return "opencode";
+  if (detectCodex(raw)) return "codex";
+  return "claude";
+}
+
+/**
+ * Parse a raw session export into a source-agnostic transcript.
+ *
+ * @param raw       Raw file contents (JSON, JSONL, or ZIP bytes handled by caller).
+ * @param options   Optional explicit `source` and original `filename`.
+ *                  If `source` is provided and valid it is trusted; otherwise
+ *                  the payload is sniffed.
+ */
+export function parseSession(
+  raw: string,
+  options?: { source?: string | undefined; filename?: string | undefined },
+): ParsedSession {
+  const requested = options?.source?.trim().toLowerCase() ?? "";
+  const source: SessionSource = isValidSource(requested)
+    ? requested
+    : detectFormat(raw, options?.filename);
+
+  switch (source) {
+    case "opencode":
+      return parseOpenCodeSession(raw, options?.filename);
+    case "codex":
+      return parseCodexSession(raw, options?.filename);
+    case "claude":
+    default: {
+      const parsed = parseClaudeSession(raw, options?.filename ?? "");
+      return { ...parsed, source: "claude" };
+    }
+  }
+}
+
+export type { ParsedSession, SessionSource } from "./types.js";

--- a/apps/xyne-claw/src/session-parsers/opencode.ts
+++ b/apps/xyne-claw/src/session-parsers/opencode.ts
@@ -1,0 +1,206 @@
+/**
+ * OpenCode session parser.
+ *
+ * Targets the OpenCode session bundle export: a JSON object that typically
+ * carries `format: "opencode-session-bundle"`, a top-level `messages` array,
+ * and message parts typed as `text`, `tool`, `step-start`, `step-finish`,
+ * or `file`.
+ *
+ * Detection is heuristic — we prefer the declared format and fall back to a
+ * shape-based check (`info.id` starts with `ses_` plus a messages array whose
+ * items have `role` and `parts`).
+ */
+
+import { clip, extractTopLevelString, isRecord, joinNonEmpty, safeJson } from "./common.js";
+import type { ParsedSession } from "./types.js";
+
+const MAX_TURN_CHARS = 8_000;
+const MAX_FILE_SNIPPET_LEN = 400;
+
+type OpenCodeRole = "user" | "assistant" | "system";
+type OpenCodePart =
+  | { type: "text"; text?: string }
+  | { type: "file"; filename?: string; path?: string }
+  | { type: "tool"; tool?: string; input?: unknown; output?: unknown }
+  | { type: "step-start"; label?: string }
+  | { type: "step-finish"; label?: string }
+  | Record<string, unknown>;
+
+function normalizeRole(role: unknown): OpenCodeRole | null {
+  const r = typeof role === "string" ? role.toLowerCase() : "";
+  if (r === "user" || r === "human") return "user";
+  if (r === "assistant" || r === "ai" || r === "model") return "assistant";
+  if (r === "system" || r === "developer") return "system";
+  return null;
+}
+
+function isOpenCodePartArray(v: unknown): v is OpenCodePart[] {
+  return Array.isArray(v);
+}
+
+function renderFilePart(part: Record<string, unknown>): string {
+  const p = part as Record<string, unknown>;
+  const name =
+    extractTopLevelString(p, ["filename", "name", "file", "path"]) ||
+    (typeof p["path"] === "string" ? (p["path"] as string) : "(unnamed file)");
+  return `[file: ${clip(name, MAX_FILE_SNIPPET_LEN)}]`;
+}
+
+function renderToolPart(part: Record<string, unknown>): { text: string; toolName: string | null } {
+  const p = part as Record<string, unknown>;
+  const toolName = typeof p["tool"] === "string" ? (p["tool"] as string) : "(unnamed tool)";
+  const input = safeJson(p["input"]);
+  const output = safeJson(p["output"]);
+  const pieces: string[] = [`[tool ${toolName}]`];
+  if (input) pieces.push(`input: ${clip(input, 800)}`);
+  if (output) pieces.push(`output: ${clip(output, MAX_TURN_CHARS)}`);
+  return { text: pieces.join(" "), toolName };
+}
+
+function renderPart(part: OpenCodePart): { text: string; toolName: string | null } {
+  if (!isRecord(part)) return { text: "", toolName: null };
+  const p = part as Record<string, unknown>;
+  const type = typeof p["type"] === "string" ? (p["type"] as string) : "";
+  switch (type) {
+    case "text": {
+      const text = typeof p["text"] === "string" ? (p["text"] as string) : "";
+      return { text, toolName: null };
+    }
+    case "file":
+      return { text: renderFilePart(p), toolName: null };
+    case "tool":
+      return renderToolPart(p);
+    case "step-start":
+    case "step-finish":
+      return { text: "", toolName: null };
+    default: {
+      // Unknown part: keep any text but discard the rest.
+      const text = typeof p["text"] === "string" ? (p["text"] as string) : "";
+      return { text, toolName: null };
+    }
+  }
+}
+
+interface NormalizedTurn {
+  role: Exclude<OpenCodeRole, "system">;
+  text: string;
+}
+
+function turnFromMessage(msg: Record<string, unknown>): NormalizedTurn | null {
+  const role = normalizeRole(msg["role"]);
+  if (!role || role === "system") return null;
+
+  const parts = msg["parts"];
+  if (!isOpenCodePartArray(parts)) return null;
+
+  const rendered: string[] = [];
+  for (const part of parts) {
+    const { text } = renderPart(part);
+    if (text.trim()) rendered.push(text.trim());
+  }
+  if (rendered.length === 0) return null;
+
+  return { role, text: rendered.join("\n") };
+}
+
+function extractTaskTitle(envelope: Record<string, unknown>): string {
+  if (isRecord(envelope["info"])) {
+    return extractTopLevelString(envelope["info"] as Record<string, unknown>, ["title", "slug", "description"]);
+  }
+  return "";
+}
+
+export function detectOpenCode(raw: string): boolean {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return false;
+  try {
+    const obj = JSON.parse(trimmed) as unknown;
+    if (!isRecord(obj)) return false;
+
+    // Primary: explicit format declaration.
+    if (obj["format"] === "opencode-session-bundle") return true;
+
+    // Secondary: shape heuristic.
+    if (
+      isRecord(obj["info"]) &&
+      typeof (obj["info"] as Record<string, unknown>)["id"] === "string" &&
+      ((obj["info"] as Record<string, unknown>)["id"] as string).startsWith("ses_") &&
+      Array.isArray(obj["messages"])
+    ) {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse an OpenCode session bundle into the shared shape.
+ * Never throws; returns an empty `unknown` shape when nothing is usable.
+ */
+export function parseOpenCodeSession(raw: string, _filename?: string): ParsedSession {
+  const empty = (format: string): ParsedSession => ({
+    task: "",
+    result: "",
+    toolsUsed: [],
+    transcript: "",
+    turnCount: 0,
+    conversationCount: 1,
+    format,
+    source: "opencode",
+  });
+
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return empty("unknown");
+
+  let envelope: Record<string, unknown>;
+  try {
+    envelope = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return empty("opencode-json");
+  }
+  if (!isRecord(envelope)) return empty("opencode-json");
+
+  const title = extractTaskTitle(envelope);
+  const messages = Array.isArray(envelope["messages"]) ? (envelope["messages"] as unknown[]) : [];
+  const turns: NormalizedTurn[] = [];
+  const tools = new Set<string>();
+
+  for (const m of messages) {
+    if (!isRecord(m)) continue;
+    const parts = m["parts"];
+    if (isOpenCodePartArray(parts)) {
+      for (const part of parts) {
+        if (isRecord(part) && part["type"] === "tool" && typeof part["tool"] === "string") {
+          tools.add(part["tool"] as string);
+        }
+      }
+    }
+    const t = turnFromMessage(m);
+    if (t) turns.push(t);
+  }
+
+  if (turns.length === 0) {
+    return empty("opencode-json");
+  }
+
+  const firstUser = turns.find((t) => t.role === "user");
+  const lastAssistant = [...turns].reverse().find((t) => t.role === "assistant");
+
+  const task = firstUser ? clip(firstUser.text, 4_000) : title || "(no user turn found in session)";
+  const result = lastAssistant ? clip(lastAssistant.text, 4_000) : "(no assistant turn found in session)";
+
+  const transcript = turns.map((t) => `### ${t.role.toUpperCase()}\n${clip(t.text, MAX_TURN_CHARS)}`).join("\n\n");
+
+  return {
+    task,
+    result,
+    toolsUsed: [...tools],
+    transcript,
+    turnCount: turns.length,
+    conversationCount: 1,
+    format: "opencode-json",
+    source: "opencode",
+  };
+}

--- a/apps/xyne-claw/src/session-parsers/types.ts
+++ b/apps/xyne-claw/src/session-parsers/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Source-agnostic output shape for session parsers.
+ *
+ * All parsers (Claude, OpenCode, Codex) normalize to this shape so the curator
+ * and memory ingestion pipeline can stay format-oblivious.
+ */
+
+export type SessionSource = "claude" | "opencode" | "codex";
+
+export interface ParsedSession {
+  /** The user's opening request / task summary. */
+  task: string;
+  /** The final assistant turn — used as the curator's result. */
+  result: string;
+  /** Names of tools referenced anywhere in the session. */
+  toolsUsed: string[];
+  /** Ordered, human-readable transcript for review and distillation. */
+  transcript: string;
+  /** Number of parsed turns (0 means nothing usable was found). */
+  turnCount: number;
+  /** Number of distinct conversations bundled in the export (usually 1). */
+  conversationCount: number;
+  /** Discovered format label, e.g. "jsonl" | "opencode-json" | "codex-jsonl". */
+  format: string;
+  /** Detected or explicit source. */
+  source: SessionSource;
+}

--- a/apps/xyne-claw/test/session-parsers.test.ts
+++ b/apps/xyne-claw/test/session-parsers.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { parseSession } from "../src/session-parsers/index.js";
+import { parseOpenCodeSession, detectOpenCode } from "../src/session-parsers/opencode.js";
+import { parseCodexSession, detectCodex } from "../src/session-parsers/codex.js";
+
+const openCodeFixture = JSON.stringify({
+  format: "opencode-session-bundle",
+  version: "1.0",
+  info: {
+    id: "ses_test_001",
+    slug: "test-session",
+    title: "Test OpenCode Session",
+    directory: "/home/user/project",
+  },
+  messages: [
+    {
+      role: "user",
+      parentID: "root",
+      agent: "user",
+      model: "",
+      finish: "stop",
+      parts: [{ type: "text", text: "Refactor the auth module" }],
+    },
+    {
+      role: "assistant",
+      parentID: "ses_test_001",
+      agent: "opencode",
+      model: "claude-sonnet-4",
+      finish: "stop",
+      parts: [
+        { type: "step-start", label: "plan" },
+        { type: "text", text: "I'll refactor the auth module." },
+        { type: "file", filename: "src/auth.ts" },
+        {
+          type: "tool",
+          tool: "edit_file",
+          input: { path: "src/auth.ts", old: "function login() {}", new: "function login(): User {}" },
+          output: "Applied edit.",
+        },
+        { type: "step-finish", label: "plan" },
+      ],
+    },
+  ],
+});
+
+const codexFixture = [
+  JSON.stringify({
+    type: "session_meta",
+    payload: {
+      session_id: "codex-ses-1",
+      timestamp: "2026-07-31T12:00:00Z",
+      cwd: "/home/user/project",
+      originator: "codex-tui",
+      model_provider: "openai",
+      base_instructions: "You are a helpful coding assistant.",
+    },
+  }),
+  JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "developer",
+      content: [{ type: "text", text: "You are a helpful coding assistant." }],
+    },
+  }),
+  JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Add a health endpoint" }],
+    },
+  }),
+  JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "assistant",
+      content: [
+        { type: "output_text", text: "Adding a /health endpoint." },
+        {
+          type: "tool_call",
+          name: "shell",
+          call_id: "call_1",
+          arguments: { command: "cat > src/routes/health.ts <<'EOF'\nexport function health() {}\nEOF" },
+        },
+      ],
+    },
+  }),
+  JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "tool_output", call_id: "call_1", output: "Wrote src/routes/health.ts" }],
+    },
+  }),
+  JSON.stringify({
+    type: "event_msg",
+    payload: { type: "task_started" },
+  }),
+].join("\n");
+
+describe("parseSession dispatcher", () => {
+  it("trusts an explicit source parameter", () => {
+    const parsed = parseSession(openCodeFixture, { source: "opencode", filename: "session.json" });
+    expect(parsed.source).toBe("opencode");
+    expect(parsed.format).toBe("opencode-json");
+    expect(parsed.turnCount).toBe(2);
+  });
+
+  it("sniffs OpenCode when no source is given", () => {
+    const parsed = parseSession(openCodeFixture);
+    expect(parsed.source).toBe("opencode");
+    expect(parsed.task).toBe("Refactor the auth module");
+  });
+
+  it("sniffs Codex when no source is given", () => {
+    const parsed = parseSession(codexFixture);
+    expect(parsed.source).toBe("codex");
+    expect(parsed.format).toBe("codex-jsonl");
+    expect(parsed.turnCount).toBe(3);
+  });
+
+  it("falls back to Claude for unrecognized payloads", () => {
+    const parsed = parseSession('{"not_a_known_format": true}', { source: "claude" });
+    expect(parsed.source).toBe("claude");
+    expect(parsed.turnCount).toBe(0);
+  });
+});
+
+describe("OpenCode parser", () => {
+  it("detects the OpenCode envelope", () => {
+    expect(detectOpenCode(openCodeFixture)).toBe(true);
+    expect(detectOpenCode('{"foo":"bar"}')).toBe(false);
+  });
+
+  it("extracts text, file, and tool parts and skips scaffolding", () => {
+    const parsed = parseOpenCodeSession(openCodeFixture, "session.json");
+    expect(parsed.source).toBe("opencode");
+    expect(parsed.task).toBe("Refactor the auth module");
+    expect(parsed.result).toContain("I'll refactor the auth module.");
+    expect(parsed.transcript).toContain("### USER");
+    expect(parsed.transcript).toContain("### ASSISTANT");
+    expect(parsed.transcript).toContain("[file: src/auth.ts]");
+    expect(parsed.transcript).toContain("[tool edit_file]");
+    expect(parsed.transcript).not.toContain("step-start");
+    expect(parsed.transcript).not.toContain("step-finish");
+    expect(parsed.toolsUsed).toEqual(["edit_file"]);
+  });
+
+  it("falls back to a source-safe unknown shape when JSON is invalid", () => {
+    const parsed = parseOpenCodeSession("not json", "bad.json");
+    expect(parsed.source).toBe("opencode");
+    expect(parsed.turnCount).toBe(0);
+  });
+});
+
+describe("Codex parser", () => {
+  it("detects the Codex rollout header", () => {
+    expect(detectCodex(codexFixture)).toBe(true);
+    expect(detectCodex('{"foo":"bar"}\n')).toBe(false);
+  });
+
+  it("extracts user and assistant turns and skips developer/housekeeping lines", () => {
+    const parsed = parseCodexSession(codexFixture, "rollout.jsonl");
+    expect(parsed.source).toBe("codex");
+    expect(parsed.task).toBe("Add a health endpoint");
+    expect(parsed.result).toBe("[tool_output id=call_1] Wrote src/routes/health.ts");
+    expect(parsed.transcript).toContain("### USER");
+    expect(parsed.transcript).toContain("### ASSISTANT");
+    expect(parsed.transcript).not.toContain("You are a helpful coding assistant");
+    expect(parsed.transcript).not.toContain("session_meta");
+    expect(parsed.transcript).toContain("[tool_call shell");
+    expect(parsed.toolsUsed).toEqual(["shell"]);
+  });
+
+  it("returns unknown shape when the session_meta header is missing", () => {
+    const parsed = parseCodexSession('{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}');
+    expect(parsed.source).toBe("codex");
+    expect(parsed.turnCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Fresh branch cut from feature/deploy-xyneclaw as requested.

## Changes
- Adds source-agnostic session parser module under apps/xyne-claw/src/session-parsers with Claude/OpenCode/Codex dispatch.
- Parses OpenCode bundles with text/tool/file parts, skipping noisy step-start/step-finish parts.
- Parses Codex JSONL rollout sessions, keeping user/assistant response items and skipping base instructions/housekeeping.
- Wires /internal/curator/distill-session to accept source and return detected source/format metadata.
- Updates claw-auth upload-session path to forward source, generate source-specific session IDs, and tag retained memories as source:<source>-upload.
- Updates MemoryTab UI with separate Claude/OpenCode/Codex upload buttons and expanded source filters.
- Adds focused parser tests.

## Verification
- PASS: cd apps/xyne-claw && npm run test -- test/session-parsers.test.ts (10 tests passed)
- NOTE: cd apps/xyne-claw && npm run typecheck currently fails on pre-existing src/gcs.ts errors only: missing @google-cloud/storage types and implicit any parameters; no errors in changed parser/curator/test files (confirmed by grepping typecheck output).

Branch verification:
- git merge-base --is-ancestor origin/feature/deploy-xyneclaw HEAD returned success.
- git push created origin/feature/session-parsers-opencode-codex-fresh.