### PR TITLE
Feature/readme context first rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,32 +47,17 @@ with each read and write filtered through the same permission model.
 
 ## Why Xyne Spaces?
 
-Start with the context. In the age of AI, what your organization knows — its
-conversations, decisions, tickets, documents, calls — is the raw material for everything
-else: answers, automation, agents. Each of those is only as good as the context it can
-reach, so **the context has to live in one place** — normalised, indexed, and served
-through one API — rather than pieced together from a dozen tools every time someone,
-or something, asks.
+**Context is the foundation.** Every conversation, decision, ticket, document, and call adds to your organization’s understanding of what it knows, how it works, and where it’s going. Query responses, automation, and agents are only as good as the context they can reach.
 
-The apps are there for the same reason. Instead of bolting AI onto the old ways of
-working and waiting out one slow migration after another, they are built **agent-first
-and collaboration-first** from the start: real-time and shared by default, with agents
-in the same threads, tickets and canvases as people — producing context the moment the
-work happens.
+That context has to live in one place — normalized, indexed, and served through one interface — rather than pieced together from a dozen tools every time a person or agent needs it.
 
-Centralizing context creates an access problem: most of it is not safe to show to
-everyone. Search results and agent answers both have to respect who is allowed to see
-what, so **access control is enforced in the data layer**:
+**The apps build the context as work happens.** They are agent-first and collaboration-first: real-time and shared by default, with people and agents working together in the same threads, tickets, and canvases.
 
-- **Synced reads are scoped per user.** Every table carries a policy that rewrites the
-  query for the acting user, so a query only selects rows that user is allowed to see.
-- **Writes are checked centrally.** Sync mutations are ACL-wrapped in one place, and
-  REST routes resolve a permission matrix of resource × access level per user and
-  group. Since both paths are enforced centrally, new features get the same checks by
-  default.
-- **Agents operate within the same boundary.** An agent acts *as the person who invoked
-  it* and has that person's access — including for search and context lookups. There is
-  no privileged system token that bypasses this.
+Accessing context — through search or agents — must respect the permissions of the underlying work, so **access control is enforced at the data layer**:
+
+* **Reads respect user permissions.** Queries are scoped to the acting user, returning only the context they’re allowed to access.
+* **Writes are enforced centrally.** Mutations go through the same permission layer, so access rules apply consistently across apps and features.
+* **Agents inherit the user’s access.** Agents act as the person invoking them, so they can only search, read, and act on context that person can access. There is no privileged bypass.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,19 @@
 
 # Xyne Spaces
 
-**The org OS — a collaborative workspace that is your organization's context layer.
-Real-time by default, permission-aware by default, and built for agents.**
+**The org OS — your organization's context layer, with collaborative apps built
+around it. Real-time, permission-aware and built for agents.**
 
-Chat, threads, tickets, boards, calls and shared canvases — where your team actually does
-the work. And because the work happens here, every conversation, ticket, call, document and
-calendar is already in one place, indexed and served back to your people *and* your
-agents — with each read and write filtered through the same permission model.
+**At the center: your org's context.** Connectors bring in what your organization
+already knows — Slack, Google Workspace, Microsoft 365 and [more](#connectors) —
+normalised into a store built for records *and* retrieval, and served back to your
+people and your agents through permission-aware org-context APIs, so every caller
+gets exactly the slice they're allowed to see.
+
+Around that core sit the [org apps](#org-apps) — Call · Claw · Agentic Search ·
+Automations · Customer Support Desk · Chat · Canvas · Tickets — adopted as you
+choose, where your team can do the work directly. Work done in them lands straight in the same context store —
+with each read and write filtered through the same permission model.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![CI](https://github.com/juspay/xyne-spaces/actions/workflows/ci.yml/badge.svg)](https://github.com/juspay/xyne-spaces/actions/workflows/ci.yml)
@@ -26,6 +32,7 @@ agents — with each read and write filtered through the same permission model.
 - [Agents and the sandbox](#agents-and-the-sandbox)
 - [Quickstart](#quickstart)
 - [Connectors](#connectors)
+- [Org apps](#org-apps)
 - [MCP tools](#mcp-tools)
 - [Demos](#demos)
 - [Repository map](#repository-map)
@@ -40,36 +47,46 @@ agents — with each read and write filtered through the same permission model.
 
 ## Why Xyne Spaces?
 
-Most "context platforms" are a layer bolted onto tools people work in somewhere else, which
-means the context is always a stale copy of the real thing. Xyne Spaces inverts that: **it
-is the place the work happens.** Teams chat, run calls, file tickets, draft on canvases and
-review each other's work here — collaboratively and in real time — and the context is simply
-the exhaust of that, current by construction rather than by sync schedule.
+Start with the context. In the age of AI, what your organization knows — its
+conversations, decisions, tickets, documents, calls — is the raw material for everything
+else: answers, automation, agents. Each of those is only as good as the context it can
+reach, so **the context has to live in one place** — normalised, indexed, and served
+through one API — rather than pieced together from a dozen tools every time someone,
+or something, asks.
 
-Which leads to the wall everyone hits next. An organization's context is scattered across a
-dozen tools, and the moment you gather it somewhere useful: **most of it is not safe to show
-to everyone.** Search that ignores permissions is a leak. An assistant that ignores them is
-a worse one.
+The apps are there for the same reason. Instead of bolting AI onto the old ways of
+working and waiting out one slow migration after another, they are built **agent-first
+and collaboration-first** from the start: real-time and shared by default, with agents
+in the same threads, tickets and canvases as people — producing context the moment the
+work happens.
 
-Xyne Spaces starts from the opposite end. Context is centralized, but **access control
-lives in the data layer, not in a filter bolted on top**:
+Centralizing context creates an access problem: most of it is not safe to show to
+everyone. Search results and agent answers both have to respect who is allowed to see
+what, so **access control is enforced in the data layer**:
 
-- **Synced reads are narrowed before they run.** Every table carries a policy that rewrites
-  the query for the acting user, so rows they may not see are never selected — not fetched
-  and then hidden.
-- **Writes are wrapped, not trusted.** Sync mutations are ACL-wrapped centrally, and REST
-  routes go through a permission matrix of resource × access level resolved per user and
-  group. Both paths are enforced in one place each, so a new feature is guarded by default
-  rather than by someone remembering to add a check.
-- **Agents inherit the same boundary.** An agent acts *as the person who invoked it*. It
-  reaches exactly their slice of the org, and there is no system-token back door around it.
-
-That last point is what makes it worth pointing an agent at your company's context at all.
-It can use everything that person could have found themselves — no more, and no less.
+- **Synced reads are scoped per user.** Every table carries a policy that rewrites the
+  query for the acting user, so a query only selects rows that user is allowed to see.
+- **Writes are checked centrally.** Sync mutations are ACL-wrapped in one place, and
+  REST routes resolve a permission matrix of resource × access level per user and
+  group. Since both paths are enforced centrally, new features get the same checks by
+  default.
+- **Agents operate within the same boundary.** An agent acts *as the person who invoked
+  it* and has that person's access — including for search and context lookups. There is
+  no privileged system token that bypasses this.
 
 ---
 
 ## What can I do with Xyne Spaces?
+
+Xyne Spaces breaks down into four stacks:
+
+- **Context** — the store at the center: connectors bring in what the org knows, and
+  permission-aware APIs serve it back.
+- **Collaboration** — real-time work with your team: Chat, Call, Canvas.
+- **Agentic workflows** — Claw agents, Agentic Search and Automations, all working
+  from the same context.
+- **Org productivity apps** — Customer Support Desk and Tickets for the day-to-day
+  running of the org.
 
 <details>
 <summary><b>Bring your org's context into one place</b></summary>
@@ -82,12 +99,12 @@ threaded and indexed for hybrid search.
 </details>
 
 <details>
-<summary><b>Work in real time, together</b></summary>
+<summary><b>Search across everything you're allowed to see</b></summary>
 <br>
 
-Channels, threads, tickets, boards, calls and collaborative canvases. The client keeps a
-live local replica rather than polling, so edits appear instantly, keep working offline,
-and replay on reconnect.
+Hybrid retrieval over the full corpus — conversations, documents, tickets, call
+transcripts — scoped to the person asking. The same index backs both the search box and an
+agent's context lookups.
 
 </details>
 
@@ -103,12 +120,11 @@ connected systems.
 </details>
 
 <details>
-<summary><b>Search across everything you're allowed to see</b></summary>
+<summary><b>Work in real time, collaboratively</b></summary>
 <br>
 
-Hybrid retrieval over the full corpus — conversations, documents, tickets, call
-transcripts — scoped to the person asking. The same index backs both the search box and an
-agent's context lookups.
+Channels, threads, tickets, boards, calls and collaborative canvases. The client keeps a
+live local replica rather than polling, so edits appear instantly.
 
 </details>
 
@@ -243,6 +259,24 @@ adapter, not touching the pipeline. Credentials are stored encrypted and decrypt
 the moment of use.
 
 → Adapter contract: [`apps/backend/src/integrations/README.md`](apps/backend/src/integrations/README.md)
+
+---
+
+## Org apps
+
+Eight apps, adopted independently. All of them read and write through the same context
+store and permission model.
+
+| App | What it does |
+| --- | --- |
+| **Call** | Team calls with recordings; transcripts are indexed into the context store. |
+| **Claw** | Sandboxed agents that read repositories, run code and call tools on connected systems; actions taken as you require approval. |
+| **Agentic Search** | Search across conversations, documents, tickets and call transcripts, scoped to the person asking; the same retrieval backs agents' context lookups. |
+| **Automations** | Scheduled agent runs and background jobs: ticket triage and classification, entity extraction, draft replies, SLA tracking, recaps. |
+| **Customer Support Desk** | Ticket intake, queues and triage. |
+| **Chat** | Channels, threads and DMs, live-synced. |
+| **Canvas** | Collaborative documents, drafted and reviewed together in real time. |
+| **Tickets** | Tickets and boards for planning and tracking work. |
 
 ---
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
