### PR TITLE
fix: render FlowJSON activity notifications as compact one-line preview

### DIFF
--- a/apps/dashboard/src/components/Activity/ActivityMessagePreview.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityMessagePreview.tsx
@@ -1,0 +1,57 @@
+import { ReactElement, ReactNode } from 'react';
+import type { ActivityWithRelated } from '../../types/activity';
+import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
+import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
+
+type ActivityMessage = NonNullable<ActivityWithRelated['message']>;
+
+/**
+ * Shared renderer for the message preview inside an activity row.
+ *
+ * FlowJSON messages (Plan cards etc.) are collapsed to a single-line text
+ * preview in BOTH expanded and collapsed modes. Otherwise the message content
+ * would flow into RenderMessageWithHTML, which mounts the full interactive
+ * FlowScreenManager card and dominates the activity feed. Collapsing keeps flow
+ * notifications consistent with mentions/replies (a one-line preview).
+ *
+ * Non-flow messages keep the previous behavior:
+ *  - expanded  -> full MessageBubble
+ *  - collapsed -> a truncated single line (or the provided `collapsedContent`,
+ *                 e.g. the reaction preview used by the reaction activities).
+ */
+export const ActivityMessagePreview = ({
+  message,
+  isExpanded,
+  collapsedContent,
+}: {
+  message: ActivityMessage;
+  isExpanded: boolean;
+  collapsedContent?: ReactNode;
+}): ReactElement => {
+  const flowPreview = getFlowJsonPreviewText(message.content);
+
+  if (flowPreview) {
+    return (
+      <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
+        {flowPreview}
+      </div>
+    );
+  }
+
+  if (isExpanded) {
+    return (
+      <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
+    );
+  }
+
+  if (collapsedContent !== undefined) {
+    return <>{collapsedContent}</>;
+  }
+
+  return (
+    <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
+      <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
+++ b/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
@@ -1,8 +1,7 @@
 import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
-import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { ActivityMessagePreview } from './ActivityMessagePreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -44,13 +43,7 @@ export const DirectMessageActivity = ({
       isExpanded={isExpanded}
       className='flex items-start'
     >
-      {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
-      ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-        </div>
-      )}
+      <ActivityMessagePreview message={message} isExpanded={isExpanded} />
     </ActivityItemCard>
   );
 };

--- a/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
+++ b/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
@@ -1,8 +1,7 @@
 import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
-import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { ActivityMessagePreview } from './ActivityMessagePreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { Hashtag } from '@xyne/icons';
@@ -47,13 +46,7 @@ export const KeywordMatchActivity = ({
       showUnreadDot
       className='flex items-start'
     >
-      {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
-      ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-        </div>
-      )}
+      <ActivityMessagePreview message={message} isExpanded={isExpanded} />
     </ActivityItemCard>
   );
 };

--- a/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
@@ -1,9 +1,8 @@
 import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
-import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { AtMark } from '@xyne/icons';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { ActivityMessagePreview } from './ActivityMessagePreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -48,13 +47,7 @@ export const MessageMentionActivity = ({
       showUnreadDot
       className='flex items-start'
     >
-      {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
-      ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-        </div>
-      )}
+      <ActivityMessagePreview message={message} isExpanded={isExpanded} />
     </ActivityItemCard>
   );
 };

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
@@ -1,8 +1,7 @@
 import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
-import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { ActivityMessagePreview } from './ActivityMessagePreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -42,13 +41,7 @@ export const MessageRepliedActivity = ({
       useActivityCutoff
       isExpanded={isExpanded}
     >
-      {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
-      ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-        </div>
-      )}
+      <ActivityMessagePreview message={message} isExpanded={isExpanded} />
     </ActivityItemCard>
   );
 };

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
@@ -1,8 +1,7 @@
 import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
-import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { ActivityMessagePreview } from './ActivityMessagePreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -94,21 +93,7 @@ export const MessageRepliedActivityV2 = ({
       useActivityCutoff
       isExpanded={isExpanded}
     >
-      {isExpanded ? (
-        <MessageBubble
-          message={latestReplyMessage}
-          showAvatar={false}
-          variant='default'
-          contentOnly={true}
-        />
-      ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML
-            message={latestReplyMessage.content}
-            showEdited={latestReplyMessage.edited}
-          />
-        </div>
-      )}
+      <ActivityMessagePreview message={latestReplyMessage} isExpanded={isExpanded} />
     </ActivityItemCard>
   );
 };

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
-import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
+import { ActivityMessagePreview } from './ActivityMessagePreview';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -47,14 +47,16 @@ export const ReactionAddedActivity = ({
       useActivityCutoff
       isExpanded={isExpanded}
     >
-      {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
-      ) : (
-        <RenderMessageWithHTML
-          message={getReactionMessagePreview(message.content)}
-          showEdited={message.edited}
-        />
-      )}
+      <ActivityMessagePreview
+        message={message}
+        isExpanded={isExpanded}
+        collapsedContent={
+          <RenderMessageWithHTML
+            message={getReactionMessagePreview(message.content)}
+            showEdited={message.edited}
+          />
+        }
+      />
     </ActivityItemCard>
   );
 };

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
-import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
+import { ActivityMessagePreview } from './ActivityMessagePreview';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -78,14 +78,16 @@ export const ReactionAddedActivityV2 = ({
       useActivityCutoff
       isExpanded={isExpanded}
     >
-      {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
-      ) : (
-        <RenderMessageWithHTML
-          message={getReactionMessagePreview(message.content)}
-          showEdited={message.edited}
-        />
-      )}
+      <ActivityMessagePreview
+        message={message}
+        isExpanded={isExpanded}
+        collapsedContent={
+          <RenderMessageWithHTML
+            message={getReactionMessagePreview(message.content)}
+            showEdited={message.edited}
+          />
+        }
+      />
     </ActivityItemCard>
   );
 };

--- a/apps/dashboard/src/utils/flowPreview.ts
+++ b/apps/dashboard/src/utils/flowPreview.ts
@@ -29,7 +29,8 @@ function stripFlowMarkup(raw: string): string {
 /**
  * Returns a clean single-line preview string for a FlowJSON message, or null if
  * the content is not a FlowJSON message. Joins the flow title with every text
- * `content` prop in the component tree.
+ * `content` prop in the component tree, plus plan `desc` and each plan todo's
+ * `text`, so plan cards preview their actual steps instead of just the title.
  */
 export function getFlowJsonPreviewText(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
@@ -56,6 +57,23 @@ export function getFlowJsonPreviewText(content: string): string | null {
         const p = c['props'] as Record<string, unknown> | undefined;
         if (p && typeof p['content'] === 'string' && p['content'].trim()) {
           texts.push(p['content'].trim());
+        }
+        // Plan cards store their prose in `desc` and each step in `todos[].text`
+        // (schema: planComponentSchema) rather than a `content` prop, so pull
+        // those out too — otherwise a plan collapses to just the flow title.
+        if (c['type'] === 'plan' && p) {
+          if (typeof p['desc'] === 'string' && p['desc'].trim()) {
+            texts.push(p['desc'].trim());
+          }
+          const todos = p['todos'];
+          if (Array.isArray(todos)) {
+            for (const t of todos) {
+              if (t && typeof t === 'object') {
+                const tt = (t as Record<string, unknown>)['text'];
+                if (typeof tt === 'string' && tt.trim()) texts.push(tt.trim());
+              }
+            }
+          }
         }
         if (Array.isArray(c['children'])) walk(c['children'] as unknown[]);
       }


### PR DESCRIPTION
## What & why

Activity feed rows fed message content straight into `RenderMessageWithHTML`, which mounts the full interactive `FlowScreenManager` for `Data-flow-json` messages. As a result, Plan/flow notifications rendered as a large interactive card that dominated the Activity feed instead of showing a one-line preview like mentions and replies.

## Change

- New shared `apps/dashboard/src/components/Activity/ActivityMessagePreview.tsx` that collapses FlowJSON messages to a single-line text preview (via the existing `getFlowJsonPreviewText` helper — already used for DM list rows) in **both** expanded and collapsed modes.
- Non-flow messages keep existing behavior: full `MessageBubble` when expanded, truncated HTML line when collapsed, and the reaction preview for reaction activities (`collapsedContent` prop).
- Routed all 7 activity components through it, removing the duplicated `isExpanded` ternary block (avoids future drift): `DirectMessageActivity`, `KeywordMatchActivity`, `MessageMentionActivity`, `MessageRepliedActivity`, `MessageRepliedActivityV2`, `ReactionAddedActivity`, `ReactionAddedActivityV2`.

Frontend render-only change — no backend, schema, or contract changes.

## Validation

- `tsc --noEmit` on `apps/dashboard` passes clean.
- Manual: seeded a FlowJSON (Plan) activity plus a normal mention; in **detailed** mode (worst case) the Plan activity now renders as a single line ("Plan — Get user identity and thread context — Locat…") consistent with the normal mention, instead of the full Plan card. POT video attached in the thread.

Diff: 8 files, +32 / −71.