### PR TITLE
feat: move MCP file-input forwarding allowlist from env to DB flag

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260807180000_add_forward_file_inputs/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260807180000_add_forward_file_inputs/migration.sql
@@ -1,0 +1,6 @@
+-- Inbound file forwarding (user workspace file -> MCP tool as base64) toggle.
+-- Mirrors mcp_servers.forwardFiles (the reverse, MCP -> user direction).
+-- Replaces the CLAW_FILE_INPUT_FORWARDING_SERVERS env allowlist as the source of
+-- truth; off by default so no server gains the capability implicitly.
+ALTER TABLE "mcp_servers"
+  ADD COLUMN "forwardFileInputs" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1360,6 +1360,15 @@ model McpServer {
   /// and is unaffected. Admin-toggleable; surfaced via the resolved connector
   /// definition so the runner reads it without a per-tool catalog query.
   forwardFiles         Boolean                   @default(false)
+  /// When true, the xyne-claw runtime is allowed to expand a `{{file:<path>}}`
+  /// marker in this server's outbound tool arguments into the base64 of a
+  /// workspace file BEFORE the MCP call leaves the pod (inbound file → MCP).
+  /// Server-level admin toggle, mirroring forwardFiles (which governs the
+  /// reverse, MCP → user direction). Off by default; surfaced via the resolved
+  /// connector definition and the /mcp/tools payload so the pod reads it
+  /// without a per-tool catalog query. Replaces the CLAW_FILE_INPUT_FORWARDING_SERVERS
+  /// env allowlist (kept only as a deprecated rollout fallback in the pod).
+  forwardFileInputs    Boolean                   @default(false)
   createdAt            DateTime                  @default(now())
   updatedAt            DateTime                  @updatedAt
   connections          UserMcpConnection[]

--- a/apps/xyne-claw-auth/backend/src/mcp/connector-definitions.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/connector-definitions.ts
@@ -97,6 +97,7 @@ function buildDynamicDefinition(row: McpServer): ResolvedConnectorDefinition {
     writeTools: writeToolsFromPolicy(writePolicy),
     staticTools: [],
     forwardFiles: row.forwardFiles === true,
+    forwardFileInputs: row.forwardFileInputs === true,
     buildStdioCommand(credentials) {
       const envTemplate = asRecord(launch["env"]);
       const args = Array.isArray(launch["args"]) ? launch["args"].map((a) => applyTemplate(String(a), credentials)) : [];
@@ -133,6 +134,10 @@ function fromStaticAdapter(serverType: string): ResolvedConnectorDefinition | un
     // Code-defined adapters don't forward files (none return binary today). Add
     // a flag to StdioMcpAdapter if one ever needs it.
     forwardFiles: false,
+    // Base value only. The file-forwarding toggles are overlaid from the DB row
+    // in resolveConnectorDefinition() so static HTTP adapters (e.g. jusbiz-mcp,
+    // whose row has no httpConfigTemplate) can still be enabled by an admin.
+    forwardFileInputs: false,
     buildStdioCommand(credentials): StdioLaunchConfig {
       if (adapter.transport !== "stdio") return { cmd: "", args: [], env: {} };
       const cmd = adapter.buildCommand(credentials);
@@ -161,13 +166,15 @@ function fromStaticAdapter(serverType: string): ResolvedConnectorDefinition | un
  */
 const STATIC_FIRST_TYPES = new Set<string>(["rapidapi-linkedin"]);
 
-export async function resolveConnectorDefinition(serverType: string): Promise<ResolvedConnectorDefinition | undefined> {
+async function resolveBaseConnectorDefinition(
+  serverType: string,
+  row: McpServer | null,
+): Promise<ResolvedConnectorDefinition | undefined> {
   if (STATIC_FIRST_TYPES.has(serverType)) {
     const staticDef = fromStaticAdapter(serverType);
     if (staticDef) return staticDef;
   }
 
-  const row = await prisma.mcpServer.findUnique({ where: { type: serverType } });
   if (row && row.enabled) {
     // Only use the dynamic (DB-driven) path when the row has an actual launch
     // config — launchConfigTemplate for stdio or httpConfigTemplate for http.
@@ -195,6 +202,31 @@ export async function resolveConnectorDefinition(serverType: string): Promise<Re
     }
   }
   return fromStaticAdapter(serverType);
+}
+
+/**
+ * Resolve a connector definition and overlay the DB-driven admin file-forwarding
+ * toggles (forwardFiles = MCP -> user, forwardFileInputs = user -> MCP) onto it.
+ *
+ * The overlay is applied for EVERY connector — including static adapters whose
+ * row has no launchConfigTemplate/httpConfigTemplate and therefore never reaches
+ * buildDynamicDefinition() (e.g. jusbiz-mcp). These two booleans do not affect
+ * the launch/spawn command (the security-sensitive part gated by STATIC_FIRST_TYPES
+ * and the stdio rules in resolveBaseConnectorDefinition), so DB-driving them for
+ * static adapters does not weaken the "never spawn from a DB row" guarantee.
+ */
+export async function resolveConnectorDefinition(serverType: string): Promise<ResolvedConnectorDefinition | undefined> {
+  const row = await prisma.mcpServer.findUnique({ where: { type: serverType } });
+  const base = await resolveBaseConnectorDefinition(serverType, row);
+  if (!base) return undefined;
+  if (row && row.enabled) {
+    return {
+      ...base,
+      forwardFiles: row.forwardFiles === true,
+      forwardFileInputs: row.forwardFileInputs === true,
+    };
+  }
+  return base;
 }
 
 export async function hasConnectorDefinition(serverType: string): Promise<boolean> {

--- a/apps/xyne-claw-auth/backend/src/mcp/runner.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/runner.ts
@@ -336,7 +336,8 @@ export async function listToolsForUser(
 
   const definition = await resolveConnectorDefinition(serverType);
   const writeTools = definition?.writeTools ?? [];
-  return { serverType, serverName, tools, writeTools };
+  const forwardFileInputs = definition?.forwardFileInputs === true;
+  return { serverType, serverName, tools, writeTools, forwardFileInputs };
 }
 
 // Servers whose tools' binary output should be forwarded to the user as a file

--- a/apps/xyne-claw-auth/backend/src/mcp/types.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/types.ts
@@ -11,6 +11,10 @@ export interface McpServerTools {
   readonly serverType: string;
   readonly serverName: string;
   readonly displayName?: string;
+  /** When true, this server accepts inbound workspace files: the pod expands a
+   *  `{{file:<path>}}` marker in outbound tool args into base64 before the call
+   *  leaves the pod. Sourced from McpServer.forwardFileInputs. */
+  readonly forwardFileInputs?: boolean;
   readonly tools: McpToolInfo[];
   readonly writeTools: readonly string[];
 }
@@ -115,6 +119,10 @@ export interface ResolvedConnectorDefinition {
   /** When true, binary content (EmbeddedResource blob / image / audio) returned
    *  by this server's tools is forwarded to the user as a file attachment. */
   readonly forwardFiles: boolean;
+  /** When true, the xyne-claw runtime may expand a `{{file:<path>}}` marker in
+   *  this server's outbound tool args into the base64 of a workspace file before
+   *  the MCP call leaves the pod (inbound file → MCP). DB-driven admin toggle. */
+  readonly forwardFileInputs: boolean;
   buildStdioCommand(credentials: Record<string, unknown>): StdioLaunchConfig;
   buildHttpConfig(credentials: Record<string, unknown>): HttpLaunchConfig;
 }

--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -58,6 +58,11 @@ interface McpServerTools {
   readonly serverType: string;
   readonly serverName: string;
   readonly displayName?: string;
+  // DB-driven (McpServer.forwardFileInputs), surfaced via /mcp/tools. When true
+  // this server may receive inbound workspace files as base64. Primary source of
+  // truth; the CLAW_FILE_INPUT_FORWARDING_SERVERS env allowlist is a deprecated
+  // rollout fallback only.
+  readonly forwardFileInputs?: boolean;
   readonly tools: McpToolInfo[];
   readonly writeTools: readonly string[];
 }
@@ -114,8 +119,11 @@ export interface McpToolGroup {
 // symlink escape) so the agent cannot exfiltrate host files (claw-auth secrets,
 // /etc/*, or another session's data).
 //
-// Allowlist source: the CLAW_FILE_INPUT_FORWARDING_SERVERS env var (comma-
-// separated serverTypes). Mirrors claw-auth's FILE_FORWARDING_SERVERS pattern.
+// Allowlist source (DEPRECATED fallback): the CLAW_FILE_INPUT_FORWARDING_SERVERS
+// env var (comma-separated serverTypes). The primary source of truth is now the
+// per-server DB flag McpServer.forwardFileInputs, surfaced on each McpServerTools
+// entry via /mcp/tools. This env set is OR'd in only so existing deployments keep
+// working during rollout; remove it once every enabled server sets the DB flag.
 const FILE_INPUT_FORWARDING_SERVERS = new Set<string>(
   (process.env["CLAW_FILE_INPUT_FORWARDING_SERVERS"] ?? "")
     .split(",")
@@ -249,7 +257,10 @@ export async function loadMcpToolsForUser(
       // the last dot, breaking tool dispatch. Replace everything except
       // alphanumerics, underscores, and hyphens.
       const safeName = `${server.serverName}__${mcpTool.name}`.replace(/[^a-zA-Z0-9_\-]/g, "_");
-      const acceptsFiles = isFileInputForwardingServer(server.serverType);
+      // DB flag (McpServer.forwardFileInputs) is authoritative; the env allowlist
+      // is a deprecated rollout fallback (see FILE_INPUT_FORWARDING_SERVERS).
+      const acceptsFiles =
+        server.forwardFileInputs === true || isFileInputForwardingServer(server.serverType);
       const baseDescription = mcpTool.description || `Tool ${mcpTool.name} from ${displayName}`;
       const definition: ToolDefinition & { serviceName?: string; backendId?: string; selectionKey?: string } = {
         name: safeName,


### PR DESCRIPTION
## 1. Problem Description
Inbound file forwarding (expanding a `{{file:<path>}}` marker in an MCP tool's outbound arguments into the base64 of a workspace file before the call leaves the xyne-claw pod) was gated ONLY by the `CLAW_FILE_INPUT_FORWARDING_SERVERS` env var. That var is not set on the `xyne-claw` deployment, so the allowlist is empty and no server can receive attachments. This blocked `@ExpenseFinops` (serverType `jusbiz-mcp`) from submitting receipts to the expense API, which requires base64 of the attachment. There was no per-server DB toggle for the input path, unlike the output path which already has `McpServer.forwardFiles`.

## 2. How the issue was identified
The expense agent failed to send a receipt attachment. Tracing `apps/xyne-claw/src/mcp.ts` showed `acceptsFiles` was derived solely from the env-based `FILE_INPUT_FORWARDING_SERVERS` set (empty in prod), so no `{{file:…}}` usage hint was appended and no base64 substitution occurred.

## 3. Solution implemented
Move the input-forwarding allowlist from env to a per-server DB flag, mirroring the existing output-path `forwardFiles` flag:
- Add `McpServer.forwardFileInputs Boolean @default(false)` + migration.
- `resolveConnectorDefinition` now overlays `forwardFiles`/`forwardFileInputs` from the DB row onto EVERY resolved connector definition — including static HTTP adapters like `jusbiz-mcp` whose row has no `httpConfigTemplate` and never reaches `buildDynamicDefinition`. These two booleans do not influence the launch/spawn command, so DB-driving them does not weaken the "never spawn from a DB row" security guarantee.
- Surface `forwardFileInputs` on `ResolvedConnectorDefinition` and on the `/mcp/tools` `McpServerTools` payload (via `listToolsForUser`).
- xyne-claw pod: `acceptsFiles` now reads `server.forwardFileInputs` (DB) as the source of truth; the `CLAW_FILE_INPUT_FORWARDING_SERVERS` env allowlist is kept only as a deprecated rollout fallback (OR'd in) so existing deployments keep working.

## 4. Documentation
N/A

## 5. DB Alter Details
New migration `20260807180000_add_forward_file_inputs`: `ALTER TABLE "mcp_servers" ADD COLUMN "forwardFileInputs" BOOLEAN NOT NULL DEFAULT false;`

## 6. Data fix Details
To enable for the expense server after deploy (data change, applied by an admin):
`UPDATE "mcp_servers" SET "forwardFileInputs" = true WHERE "type" = 'jusbiz-mcp';`
(add `ardra-finops` too if that adapter is also used).

## 7. Environment variable Changes
`CLAW_FILE_INPUT_FORWARDING_SERVERS` is now optional/deprecated. It is no longer required — the DB flag supersedes it. It is still OR'd in as a fallback for backward compatibility during rollout; remove it once every enabled server has the DB flag set.

## 8. Testing
Type-checked. `apps/xyne-claw` (pod) tsc: 0 errors including `mcp.ts`. `apps/xyne-claw-auth` tsc: only pre-existing `@prisma/client` "no exported member" errors (the generated client is not built in the offline sandbox — CI generates it); no new type errors in the touched files. End-to-end validation to run after deploy: enable the DB flag for `jusbiz-mcp`, confirm the JusBiz tool description shows the `{{file:…}}` hint, submit a real receipt, and grep the `xyne-claw` pod log for `[mcp] forwarded N workspace file(s) to jusbiz-mcp`.

## 9. Services to which this change is to be deployed
`xyne-claw-auth` (backend + Prisma migration) and `xyne-claw` (pod runtime).

## 10. Main PR link
N/A (raised against main)