### PR TITLE
fix: persist full tool invocations, remove cumulative byte cap

### DIFF
--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -1986,8 +1986,6 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   let streamRateTimer: ReturnType<typeof setInterval> | null = null;
   let turnStreamRateSamples: StreamRateSample[] = [];
   const MAX_RESULT_LEN = 50_000;
-  const MAX_INVOCATIONS_BYTES = 1_000_000;
-  let invocationsSizeEstimate = 0;
 
   const coerceResult = (result: unknown): string => {
     if (typeof result === "string") return result;
@@ -2275,10 +2273,8 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
       const started = inflightCalls.get(event.toolCallId);
       if (!started) {
         log.warn(`[agent] tool_execution_end without matching start: ${event.toolCallId} (${event.toolName}) isError=${event.isError} — push skipped`);
-      } else if (invocationsSizeEstimate >= MAX_INVOCATIONS_BYTES) {
-        log.warn(`[agent] tool_execution_end size-cap reached: ${event.toolCallId} (${event.toolName}) — push skipped (size=${invocationsSizeEstimate})`);
       }
-      if (started && invocationsSizeEstimate < MAX_INVOCATIONS_BYTES) {
+      if (started) {
         // Persist EXACTLY what the model saw — no second, persist-only cut.
         // The model-visible result is already bounded in-execute: custom / MCP /
         // subagent tools go through promoteIfOversized (tool-output.ts — 32KB
@@ -2290,6 +2286,15 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
         // and (b) cut the MCP `{"content":[…]}` JSON envelope mid-string, so the
         // frontend's JSON.parse failed and citation-chunk parsing broke. Storing
         // the coerced result verbatim keeps DB == model and the JSON valid.
+        //
+        // There is deliberately NO cumulative byte cap on this persist path: a
+        // run-wide cap silently dropped the DB + debug copies of every tool
+        // AFTER the threshold while the model still had them, breaking the
+        // DB == debug == model parity above and surfacing as the finalize sweep
+        // label "(no result — tool end event was not received)". Each result is
+        // already bounded by the in-execute spill (32KB bulk / 128KB retrieval),
+        // and MAX_TOOL_INVOCATIONS in agentRunRepository bounds the row count, so
+        // the full invocation set is persisted verbatim.
         const fullResult = coerceResult(event.result);
         const citations = takeCitations(event.toolCallId);
         const debug = takeDebug(event.toolCallId);
@@ -2312,7 +2317,6 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
           ...(bgTask ? { background: true, backgroundState: "running" as const, backgroundTaskId: bgTask.taskId } : {}),
         };
         toolInvocations.push(inv);
-        invocationsSizeEstimate += fullResult.length + 200; // rough overhead per invocation
         // Stream the invocation to xyne-claw-auth so Control Center watchers see tools populate live
         pushInvocation(progressUrl, sessionId ?? conversationId ?? "unknown", inv);
         pushDebugEvent("tool_execution_end", {


### PR DESCRIPTION
## Summary
Removes the run-wide `MAX_INVOCATIONS_BYTES` (1MB cumulative) cap in `apps/xyne-claw/src/agent.ts` so that the full set of tool invocations is persisted, relying on the existing in-execute spill behaviour to bound each result.

1. **Problem Description:**
Tool invocations sometimes persist as `"result": "(no result — tool end event was not received)"` with `durationMs: 0` and `status: "completed"`, even though the agent clearly received the tool result (it produced a final answer from it). Happens often on long-running tasks. This is a parity break: the model got the result but the DB and debug-event copies did not.

2. **How the issue was identified:**
Traced the tool-invocation lifecycle on `feature/deploy-xyneclaw`. On `tool_execution_start` the agent pushes a `status:"running"` placeholder row (no size guard). On `tool_execution_end` the completed row was gated behind a cumulative byte cap: `if (started && invocationsSizeEstimate < MAX_INVOCATIONS_BYTES)`. Once a run's accumulated tool output crossed 1MB, every subsequent `tool_execution_end` skipped persistence to the local finalize array, the DB (`pushInvocation`/`appendToolInvocation`), AND the debug-events stream (`pushDebugEvent`) — while the model still had the result in-context. At finalize, the orphaned `running` row is swept to `completed` and relabelled `(no result — tool end event was not received)` (agentRunRepository.ts). Since each result is already bounded by the in-execute spill (tool-output.ts: 32KB bulk / 128KB retrieval, tail spilled to a file behind a preview + path), and `MAX_TOOL_INVOCATIONS` (default 1000) bounds the row count, the cumulative byte cap was redundant and actively broke DB == debug == model parity.

3. **Solution implemented:**
Removed `MAX_INVOCATIONS_BYTES` and the `invocationsSizeEstimate` accumulator, and dropped the size gate so every completed tool row is persisted verbatim (DB + debug + finalize array). Each result stays bounded by the existing spill logic; the row-count cap remains the backstop. Worst-case column size is bounded by spill (~128KB/result) × row cap. Added a comment documenting the no-cumulative-cap invariant.

4. Documentation: N/A
5. DB Alter Details: N/A
6. Data fix Details: N/A
7. Environment variable Changes: N/A — removes reliance on the hardcoded 1MB constant; `MAX_TOOL_INVOCATIONS` env override still applies as the row-count backstop.
8. Testing: Typechecked `apps/xyne-claw` (`tsc --noEmit`) — only pre-existing `@google-cloud/storage` module-not-installed errors in the sandbox, none in `agent.ts`. Root cause reproduced via a faithful standalone logic repro of the size-cap + finalize sweep that regenerated the exact placeholder payload including `durationMs: 0`.
9. Services to which this change is to be deployed: xyne-claw (agent runtime).
10. Main PR link (if against a release branch): N/A — targets `feature/deploy-xyneclaw`.