### PR TITLE
fix: enable Electron crashReporter to capture crash minidumps

### DIFF
--- a/apps/electron/src/app/main.ts
+++ b/apps/electron/src/app/main.ts
@@ -1,4 +1,4 @@
-import { app, dialog, Menu, MenuItem, MenuItemConstructorOptions } from 'electron';
+import { app, crashReporter, dialog, Menu, MenuItem, MenuItemConstructorOptions } from 'electron';
 import path from 'path';
 import log from 'electron-log/main';
 import { config } from './config';
@@ -56,6 +56,37 @@ log.initialize();
 log.transports.file.level = 'info';
 log.transports.console.level = 'info';
 log.info('[Main] Electron app starting...');
+
+/**
+ * Start Electron's crashReporter as early as possible so renderer/GPU crashes
+ * produce minidumps we can root-cause. Today the app logs `render-process-gone`
+ * with reason=crashed / exit_code=5 but captures no stack, leaving the recurring
+ * renderer crash undiagnosable. Minidumps are always written locally to
+ * app.getPath('crashDumps'); upload stays OFF unless a collector URL is
+ * configured via CRASH_REPORTER_SUBMIT_URL.
+ */
+function startCrashReporter(): void {
+  try {
+    const submitURL = process.env.CRASH_REPORTER_SUBMIT_URL;
+    const uploadToServer = Boolean(submitURL);
+    crashReporter.start({
+      productName: config.APP_NAME,
+      companyName: 'Juspay',
+      // submitURL is required by the type; when not uploading it is unused.
+      submitURL: submitURL ?? 'https://localhost/unused',
+      uploadToServer,
+      compress: true,
+    });
+    log.info(
+      `[Main] crashReporter started (uploadToServer=${uploadToServer}); dumps at`,
+      app.getPath('crashDumps'),
+    );
+  } catch (error) {
+    log.error('[Main] Failed to start crashReporter:', error);
+  }
+}
+
+startCrashReporter();
 
 // Setup global error handlers FIRST to catch any initialization errors
 setupGlobalErrorHandlers();


### PR DESCRIPTION
## 1. Problem Description
The desktop app logged `render-process-gone` (reason=crashed / exit_code=5) but never captured a stack, so the recurring renderer crash could not be root-caused. There was no `crashReporter.start()` anywhere in `apps/electron`.

## 2. How the issue was identified
Backend logs (`xyne-logging-bridge`) show 40 `render_process_gone reason=crashed` events over 7 days across multiple users — generic Chromium abnormal-termination with no minidump.

## 3. Solution implemented
- Start `crashReporter` early in `apps/electron/src/app/main.ts` (before the app is ready) so renderer/GPU crashes write minidumps to `app.getPath('crashDumps')`.
- Upload stays OFF by default; enabled only when `CRASH_REPORTER_SUBMIT_URL` is set, so dumps can later be shipped to a collector without a code change.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
Optional new var `CRASH_REPORTER_SUBMIT_URL` (unset = local dumps only, no upload).

## 8. Testing
- `npx tsc --noEmit` on `apps/electron` → PASS (exit 0).
- Companion to the auto-recovery PR (fix/electron-renderer-crash-auto-recovery); together they recover from and then diagnose the crash.

## 9. Services to which this change is to be deployed
Desktop (Electron) client.

## 10. Main PR link
N/A