### PR TITLE
fix: auto-recover Electron main window on renderer crash

### DIFF
--- a/apps/electron/src/services/crash-recovery-policy.test.ts
+++ b/apps/electron/src/services/crash-recovery-policy.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Dependency-free assertions for crash-recovery-policy.
+ * Run with: npx tsx src/services/crash-recovery-policy.test.ts
+ * (no test framework is configured in this package).
+ */
+import assert from 'assert';
+import {
+  shouldRecoverFromReason,
+  CrashRetryBudget,
+} from './crash-recovery-policy';
+
+let passed = 0;
+function check(name: string, fn: () => void) {
+  fn();
+  passed++;
+  console.log(`  ok - ${name}`);
+}
+
+// --- shouldRecoverFromReason ------------------------------------------------
+check('recovers on a hard crash', () => {
+  assert.strictEqual(shouldRecoverFromReason('crashed'), true);
+});
+check('recovers on oom / killed / launch-failed', () => {
+  assert.strictEqual(shouldRecoverFromReason('oom'), true);
+  assert.strictEqual(shouldRecoverFromReason('killed'), true);
+  assert.strictEqual(shouldRecoverFromReason('launch-failed'), true);
+});
+check('does NOT recover on a clean exit (normal teardown)', () => {
+  assert.strictEqual(shouldRecoverFromReason('clean-exit'), false);
+});
+
+// --- CrashRetryBudget -------------------------------------------------------
+check('allows up to maxRetries inside the window, then stops', () => {
+  const b = new CrashRetryBudget({ maxRetries: 3, windowMs: 60_000 });
+  const t = 1_000_000;
+  assert.strictEqual(b.tryConsume(t), true);       // 1
+  assert.strictEqual(b.tryConsume(t + 1), true);   // 2
+  assert.strictEqual(b.tryConsume(t + 2), true);   // 3
+  assert.strictEqual(b.tryConsume(t + 3), false);  // budget exhausted
+});
+check('recovers budget once attempts age out of the window', () => {
+  const b = new CrashRetryBudget({ maxRetries: 2, windowMs: 10_000 });
+  const t = 5_000_000;
+  assert.strictEqual(b.tryConsume(t), true);
+  assert.strictEqual(b.tryConsume(t + 1), true);
+  assert.strictEqual(b.tryConsume(t + 2), false);          // within window
+  assert.strictEqual(b.tryConsume(t + 10_001), true);      // old attempts expired
+});
+check('attemptsInWindow reflects only in-window attempts', () => {
+  const b = new CrashRetryBudget({ maxRetries: 5, windowMs: 10_000 });
+  const t = 2_000_000;
+  b.tryConsume(t);
+  b.tryConsume(t + 5_000);
+  assert.strictEqual(b.attemptsInWindow(t + 6_000), 2);
+  assert.strictEqual(b.attemptsInWindow(t + 14_000), 1); // only the t+5000 attempt is still in-window
+});
+check('reset clears the budget', () => {
+  const b = new CrashRetryBudget({ maxRetries: 1, windowMs: 60_000 });
+  assert.strictEqual(b.tryConsume(1), true);
+  assert.strictEqual(b.tryConsume(2), false);
+  b.reset();
+  assert.strictEqual(b.tryConsume(3), true);
+});
+
+console.log(`\nAll ${passed} assertions passed.`);

--- a/apps/electron/src/services/crash-recovery-policy.ts
+++ b/apps/electron/src/services/crash-recovery-policy.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure, dependency-free policy for recovering the main window after a
+ * renderer crash. Kept free of any `electron` imports so it can be unit-tested
+ * in plain Node.
+ *
+ * Context: when the main renderer dies Electron leaves a blank window that only
+ * a manual reload fixes. We auto-recover, but we must NOT reload forever if the
+ * renderer is hard-failing on load — otherwise the app thrashes. This module
+ * decides (a) whether a given crash reason is worth recovering and (b) whether
+ * we are still within the retry budget.
+ */
+
+/**
+ * Electron's `render-process-gone` reasons. A clean exit is a normal teardown
+ * (e.g. window closing) and must never trigger a recovery reload.
+ */
+export type RenderProcessGoneReason =
+  | 'clean-exit'
+  | 'abnormal-exit'
+  | 'killed'
+  | 'crashed'
+  | 'oom'
+  | 'launch-failed'
+  | 'integrity-failure';
+
+/** A reason is recoverable if it is anything other than a clean teardown. */
+export function shouldRecoverFromReason(reason: string): boolean {
+  return reason !== 'clean-exit';
+}
+
+export interface RetryBudgetOptions {
+  /** Max recovery attempts allowed inside the rolling window. */
+  maxRetries: number;
+  /** Rolling window length in milliseconds. */
+  windowMs: number;
+}
+
+export const DEFAULT_RETRY_BUDGET: RetryBudgetOptions = {
+  maxRetries: 3,
+  windowMs: 60_000,
+};
+
+/**
+ * Sliding-window retry budget. Records recovery attempts and reports whether a
+ * new attempt is still permitted, so a renderer that keeps crashing on load
+ * falls back to an error page instead of an infinite reload loop.
+ */
+export class CrashRetryBudget {
+  private attempts: number[] = [];
+
+  constructor(private readonly options: RetryBudgetOptions = DEFAULT_RETRY_BUDGET) {}
+
+  /**
+   * @returns true if a recovery attempt is allowed at time `now`. When allowed,
+   * the attempt is recorded. When the budget is exhausted, nothing is recorded
+   * and the caller should show a terminal error page.
+   */
+  tryConsume(now: number = Date.now()): boolean {
+    const cutoff = now - this.options.windowMs;
+    this.attempts = this.attempts.filter((t) => t > cutoff);
+    if (this.attempts.length >= this.options.maxRetries) {
+      return false;
+    }
+    this.attempts.push(now);
+    return true;
+  }
+
+  /** Number of attempts still counted inside the current window. */
+  attemptsInWindow(now: number = Date.now()): number {
+    const cutoff = now - this.options.windowMs;
+    return this.attempts.filter((t) => t > cutoff).length;
+  }
+
+  reset(): void {
+    this.attempts = [];
+  }
+}

--- a/apps/electron/src/services/error-handler.ts
+++ b/apps/electron/src/services/error-handler.ts
@@ -5,10 +5,19 @@
  * process crashes, and other critical errors that could crash the application.
  */
 
+import path from 'path';
 import { app, BrowserWindow } from 'electron';
 import log from 'electron-log/main';
 import { Logger, errorLogger } from './logger/Logger';
 import ElectronEvent from './logger/electron-events';
+import { getMainWindow, loadApp } from '../window/manager';
+import { shouldRecoverFromReason, CrashRetryBudget } from './crash-recovery-policy';
+
+/**
+ * Sliding-window retry budget for main-window renderer recovery. Prevents an
+ * infinite reload loop when the renderer hard-fails on load.
+ */
+const mainWindowRetryBudget = new CrashRetryBudget();
 
 /**
  * Setup all global error handlers
@@ -68,6 +77,43 @@ export function setupGlobalErrorHandlers(): void {
 }
 
 /**
+ * Recover the main window after its renderer dies.
+ *
+ * Historically this handler only logged, so a crashed main renderer left a
+ * permanent blank window that only a manual Cmd+Shift+R could fix. We now
+ * re-run loadApp() (which paints the branded loading splash first, then the
+ * dashboard) so the app self-heals in ~1-2s, guarded by a retry budget so a
+ * renderer that keeps failing on load falls back to an error page instead of
+ * looping forever.
+ */
+function recoverMainWindow(window: BrowserWindow, reason: string): void {
+  if (window !== getMainWindow() || window.isDestroyed()) {
+    // Auxiliary windows (claw overlay, recording pill, etc.) register their own
+    // per-window render-process-gone handlers and recover themselves.
+    return;
+  }
+
+  if (!shouldRecoverFromReason(reason)) {
+    return; // clean-exit / normal teardown — nothing to recover.
+  }
+
+  if (mainWindowRetryBudget.tryConsume()) {
+    log.warn(`[ErrorHandler] Main renderer gone (${reason}); auto-recovering via loadApp()`);
+    void loadApp(window).catch((error) => {
+      log.error('[ErrorHandler] Auto-recovery loadApp failed:', error);
+    });
+    return;
+  }
+
+  // Budget exhausted — stop thrashing and show a terminal error page.
+  log.error(`[ErrorHandler] Main renderer recovery budget exhausted (${reason}); showing error page`);
+  const errorPage = path.join(__dirname, '..', '..', 'assets', 'load-error.html');
+  void window.loadFile(errorPage).catch((error) => {
+    log.error('[ErrorHandler] Failed to show load-error page:', error);
+  });
+}
+
+/**
  * Setup error handlers for renderer processes
  */
 function setupRendererErrorHandlers(): void {
@@ -86,6 +132,12 @@ function setupRendererErrorHandlers(): void {
     }, 'ErrorHandler');
 
     Logger.flushLogs();
+
+    // Auto-recover the main window so users no longer face a permanent white
+    // screen requiring a manual reload.
+    if (window) {
+      recoverMainWindow(window, details.reason);
+    }
   });
 
   // Monitor new windows as they're created

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -101,6 +101,9 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
     ...createOpts,
     show: false,
     title: config.window.title,
+    // Match the loading splash background so a renderer-crash gap shows the app
+    // background instead of a raw-white flash before auto-recovery repaints.
+    backgroundColor: '#f5f5f5',
     titleBarStyle: 'hiddenInset',
     // Align the macOS traffic lights with the AppNavigator icons on the 52px
     // top bar (nudged down 2px past the centered 18px for a visual match).


### PR DESCRIPTION
## 1. Problem Description
When the Electron main renderer crashes, the main window goes blank/white and stays there — the only recovery is a manual Cmd+Shift+R. Every auxiliary window (claw overlay, recording pill) already auto-reloads on crash, but the main window's global `render-process-gone` handler in `apps/electron/src/services/error-handler.ts` only logged.

## 2. How the issue was identified
Reported on device Venkatesan-S-LK72P4494D. Backend logs (VictoriaLogs `xyne-logging-bridge` stream) show `render_process_gone reason=crashed exit_code=5` — 3 events in 24h for the reporter and 40 crashes fleet-wide over 7 days across multiple users. No OOM.

## 3. Solution implemented
- New dependency-free `crash-recovery-policy.ts`: a reason gate (`shouldRecoverFromReason`, skips `clean-exit`) plus a sliding-window `CrashRetryBudget` (3 attempts / 60s) to prevent reload loops.
- `error-handler.ts` now recovers the MAIN window on a non-clean `render-process-gone` by re-running `loadApp()` (branded loading splash → dashboard); when the retry budget is exhausted it shows `load-error.html` instead of looping. Auxiliary windows keep their own handlers.
- `manager.ts`: set window `backgroundColor: '#f5f5f5'` (matches the loading splash) to avoid a raw-white flash.
- Result: a ~1–2s branded auto-reload instead of a stuck white screen.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A

## 8. Testing
- `npx tsc --noEmit` on `apps/electron` → PASS (exit 0).
- Executable assertions for the recovery policy (7/7 passed): recovers on crashed/oom/killed/launch-failed, does NOT recover on clean-exit, allows up to 3 retries then stops, budget recovers as attempts age out, reset works. Committed as `crash-recovery-policy.test.ts`.

## 9. Services to which this change is to be deployed
Desktop (Electron) client.

## 10. Main PR link
N/A