### PR TITLE
fix: XYNE-55452 open Knowledge Base sidebar tab to all users

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
+++ b/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
@@ -4,10 +4,6 @@
  */
 export const PATH_TO_RESOURCE: Record<string, string> = {
   '/support': 'SUPPORT',
-  // NOTE (XYNE-55452): '/knowledge-base' is intentionally NOT mapped to a resource.
-  // The Knowledge Base entry must be visible/accessible to every workspace user
-  // regardless of resource access, so it is deliberately left ungated here.
-  // Do not re-add a KNOWLEDGE-BASE mapping without revisiting that requirement.
   '/analytics': 'ANALYTICS',
   '/dashboards': 'ANALYTICS',
   '/user-groups': 'USER-GROUPS',

--- a/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
+++ b/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
@@ -4,7 +4,10 @@
  */
 export const PATH_TO_RESOURCE: Record<string, string> = {
   '/support': 'SUPPORT',
-  '/knowledge-base': 'KNOWLEDGE-BASE',
+  // NOTE (XYNE-55452): '/knowledge-base' is intentionally NOT mapped to a resource.
+  // The Knowledge Base entry must be visible/accessible to every workspace user
+  // regardless of resource access, so it is deliberately left ungated here.
+  // Do not re-add a KNOWLEDGE-BASE mapping without revisiting that requirement.
   '/analytics': 'ANALYTICS',
   '/dashboards': 'ANALYTICS',
   '/user-groups': 'USER-GROUPS',


### PR DESCRIPTION
## What
Open the **Knowledge Base** sidebar entry to all workspace users, regardless of resource access.

Jira: XYNE-55452

## Why
Previously the Knowledge Base nav item was gated behind the `KNOWLEDGE-BASE` resource with `AccessType.ADMIN`. Users without that resource grant (e.g. regular members) could not see or reach Knowledge Base at all. The requirement is for Knowledge Base to be visible/accessible to everyone.

## Change
Single-file, scoped change in `apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts`: removed the `'/knowledge-base': 'KNOWLEDGE-BASE'` entry from `PATH_TO_RESOURCE`.

`filterNavItemsByPermission` (in `navigationConfig.ts`) treats any path absent from `PATH_TO_RESOURCE` as `requiresAccess = false`, so the Knowledge Base item now renders for every user. Because `permittedGlobalPaths` is derived from the same visible-nav set, the Support rail "Help Center" entry (which shares `/knowledge-base`) is consistently ungated too. All other resource gates are unchanged.

## Testing (POT)
Verified with two users in the same workspace:
- **User A** — has `KNOWLEDGE-BASE: ADMIN` (12 grants): sees Knowledge Base (baseline, unchanged).
- **User B** — 0 resource grants, not admin: **now sees Knowledge Base** and can open the page. Other admin-gated items (User Management, Workspace Management, Analytics, etc.) remain correctly hidden for User B, confirming the change is scoped to the Knowledge Base entry only.

A screen recording demonstrating both users was shared with the team.