### PR TITLE
feat: add fork conversation endpoint

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -1939,6 +1939,87 @@ internalRouter.post("/:slug/chat/:convId/callback", async (req: Request<{ slug: 
   }
 });
 
+// POST /agents/:slug/chat/:convId/fork — copy a finished conversation into a
+// NEW conversation owned by the requesting user.
+router.post("/:slug/chat/:convId/fork", async (req: Request<{ slug: string; convId: string }>, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Authentication required" });
+      return;
+    }
+    const { slug, convId } = req.params;
+    const { targetConversationId } = (req.body ?? {}) as { targetConversationId?: string };
+    if (!targetConversationId || typeof targetConversationId !== "string") {
+      res.status(400).json({ success: false, error: "targetConversationId is required" });
+      return;
+    }
+
+    const sourceMessages = await chatMessageRepository.findByConversationAndAgent(convId, slug);
+    if (sourceMessages.length === 0) {
+      res.status(404).json({ success: false, error: "Source conversation is empty" });
+      return;
+    }
+
+    // Refuse to write into a conversation that already holds messages — a
+    // retried fork would otherwise duplicate the whole history.
+    const existingTarget = await chatMessageRepository.findByConversationAndAgent(targetConversationId, slug);
+    if (existingTarget.length > 0) {
+      res.status(409).json({ success: false, error: "Target conversation already has messages" });
+      return;
+    }
+
+    // Which PI session backs this conversation: the base id when the tree is
+    // linear, else the deepest non-first assistant's branch suffix.
+    const tree = sourceMessages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      parentId: (m as { parentId?: string | null }).parentId ?? null,
+      createdAt: m.createdAt,
+    }));
+    const leafId = tree[tree.length - 1]?.id ?? null;
+    const sourcePiConversationId = resolvePiConversationIdForPath(tree, leafId, convId);
+
+    const cloned = await cloneBranchSession({
+      sourceConversationId: piSessionStoreKey(sourcePiConversationId, slug),
+      targetConversationId: piSessionStoreKey(targetConversationId, slug),
+      branchMode: "full",
+    });
+    if (!cloned.success) {
+      log.warn(`[agent-chat/fork] session clone failed ${convId} → ${targetConversationId}: ${cloned.error ?? "unknown"}`);
+      res.status(502).json({ success: false, error: cloned.error ?? "Failed to clone session" });
+      return;
+    }
+
+    // Copy the visible history, chained linearly so the tree stays on the
+    // first-child rail — otherwise resolvePiConversationIdForPath would read
+    // the fork as a branch and the follow-up would open a fresh PI session,
+    // discarding the context we just cloned.
+    let parentId: string | null = null;
+    let copied = 0;
+    for (const msg of sourceMessages) {
+      const created = await chatMessageRepository.create({
+        conversationId: targetConversationId,
+        agentSlug: slug,
+        userId,
+        role: msg.role,
+        content: msg.content ?? "",
+        ...(msg.reasoning ? { reasoning: msg.reasoning } : {}),
+        parentId,
+        orgId: (msg as { orgId: string }).orgId,
+      });
+      parentId = created.id;
+      copied += 1;
+    }
+
+    log.info(`[agent-chat/fork] ${convId} → ${targetConversationId} slug=${slug} owner=${userId} copied=${copied}`);
+    res.json({ success: true, conversationId: targetConversationId, copied });
+  } catch (err) {
+    log.error(`[agent-chat/fork] ${req.params.convId}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+    res.status(500).json({ success: false, error: "Failed to fork conversation" });
+  }
+});
+
 // GET /agents/:slug/chat/:convId/messages — get conversation history
 router.get("/:slug/chat/:convId/messages", async (req: Request<{ slug: string; convId: string }>, res: Response) => {
   try {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
