### PR TITLE
feat: XYNE-55472 support multiple desk channels per Xyne App

### DIFF
--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -3,7 +3,7 @@ import { WORKSPACE_LEVEL } from '@/integrations/core/sourceScope';
 import {
   buildAppDeskSourceName,
   buildSlackDeskSourceName,
-  extractInstalledAppId,
+  resolveAppDeskInstalledAppId,
   extractSlackChannelId,
 } from '../integrations/core/deskSources';
 import { ChannelRepository, CreateChannelInput } from '../database/repositories/channelRepository';
@@ -934,15 +934,6 @@ export class ChannelController {
           res.status(403).json({ error: 'App must have the desk:write permission to back a desk' });
           return;
         }
-        const sourceName = buildAppDeskSourceName(installedAppId);
-        const existingSource = await db.externalSource.findUnique({
-          where: { name: sourceName },
-          select: { id: true, isActive: true },
-        });
-        if (existingSource?.isActive) {
-          res.status(409).json({ error: 'A desk already exists for this app' });
-          return;
-        }
       }
 
       // For DM channels, ensure scopeId is provided (other user's ID)
@@ -1257,30 +1248,18 @@ export class ChannelController {
             ...(assigneeUserGroupId && { assigneeUserGroupId }),
           });
 
-          const sourceName = buildAppDeskSourceName(installedAppId);
-          const appCredentials = encrypt(JSON.stringify({ installedAppId }));
-          const existingAppSource = await db.externalSource.findUnique({
-            where: { name: sourceName },
-            select: { id: true },
+          await db.externalSource.create({
+            data: {
+              name: buildAppDeskSourceName(channel.id),
+              sourceType: 'app-desk',
+              displayName: name!,
+              channelId: channel.id,
+              externalIdentifier: installedAppId,
+              credentials: encrypt(JSON.stringify({ installedAppId })),
+              isActive: true,
+              workspaceId: req.user!.workspaceId!,
+            },
           });
-          if (existingAppSource) {
-            await db.externalSource.update({
-              where: { id: existingAppSource.id },
-              data: { isActive: true, credentials: appCredentials, channelId: channel.id, displayName: name! },
-            });
-          } else {
-            await db.externalSource.create({
-              data: {
-                name: sourceName,
-                sourceType: 'app-desk',
-                displayName: name!,
-                channelId: channel.id,
-                credentials: appCredentials,
-                isActive: true,
-                workspaceId: req.user!.workspaceId!,
-              },
-            });
-          }
 
           await this.channelParticipantRepository.addParticipant(
             channel.id,
@@ -1294,7 +1273,7 @@ export class ChannelController {
           });
           const code = (error as { code?: string })?.code;
           if (code === 'P2002') {
-            res.status(409).json({ error: 'A desk already exists for this app' });
+            res.status(409).json({ error: 'A desk already exists for this channel' });
           } else {
             res.status(500).json({ error: 'Failed to create app desk' });
           }
@@ -1480,7 +1459,7 @@ export class ChannelController {
 
       const source = await db.externalSource.findFirst({
         where: { channelId },
-        select: { name: true, displayName: true, sourceType: true, isActive: true },
+        select: { name: true, displayName: true, sourceType: true, isActive: true, externalIdentifier: true },
         orderBy: { createdAt: 'desc' },
       });
       const hasSource = !!source;
@@ -1490,7 +1469,7 @@ export class ChannelController {
       let connectedLabel: string | null = null;
       let outboundConfigured = true;
       if (source?.sourceType === 'app-desk') {
-        const installedAppId = extractInstalledAppId(source.name) ?? '';
+        const installedAppId = resolveAppDeskInstalledAppId(source) ?? '';
         const installedApp = await db.installedApps.findUnique({
           where: { id: installedAppId },
           select: { webhookUrl: true, app: { select: { name: true, signingSecret: true } } },

--- a/apps/backend/src/integrations/core/deskSources.ts
+++ b/apps/backend/src/integrations/core/deskSources.ts
@@ -3,16 +3,19 @@ export const DESK_SOURCE_PREFIXES = {
   SLACK: 'slack-desk-',
 } as const;
 
-export const buildAppDeskSourceName = (installedAppId: string): string =>
-  `${DESK_SOURCE_PREFIXES.APP}${installedAppId}`;
+export const buildAppDeskSourceName = (channelId: string): string =>
+  `${DESK_SOURCE_PREFIXES.APP}${channelId}`;
 
 export const buildSlackDeskSourceName = (slackChannelId: string): string =>
   `${DESK_SOURCE_PREFIXES.SLACK}${slackChannelId}`;
 
-export const extractInstalledAppId = (sourceName: string): string | null =>
-  sourceName.startsWith(DESK_SOURCE_PREFIXES.APP)
-    ? sourceName.slice(DESK_SOURCE_PREFIXES.APP.length) || null
-    : null;
+export const resolveAppDeskInstalledAppId = (
+  source: { externalIdentifier: string | null; name: string },
+): string | null =>
+  source.externalIdentifier ||
+  (source.name.startsWith(DESK_SOURCE_PREFIXES.APP)
+    ? source.name.slice(DESK_SOURCE_PREFIXES.APP.length) || null
+    : null);
 
 export const extractSlackChannelId = (sourceName: string): string | null =>
   sourceName.startsWith(DESK_SOURCE_PREFIXES.SLACK)

--- a/apps/backend/src/integrations/routes/app-desk.ts
+++ b/apps/backend/src/integrations/routes/app-desk.ts
@@ -4,7 +4,7 @@ import { authV2Middleware } from '@/middleware/authV2Middleware';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
 import { appDeskService } from '@/services/appDeskService';
-import { DESK_SOURCE_PREFIXES, extractInstalledAppId } from '@/integrations/core/deskSources';
+import { resolveAppDeskInstalledAppId } from '@/integrations/core/deskSources';
 
 const TAG = '[AppDesk]';
 const APPROVED_STATUSES = [AppPermissionStatus.APPROVED, AppPermissionStatus.PENDINGDELETE];
@@ -49,18 +49,9 @@ router.get('/apps', authV2Middleware.authenticate, async (req: Request, res: Res
   try {
     const workspaceId = req.user!.workspaceId!;
 
-    const claimedSources = await db.externalSource.findMany({
-      where: { name: { startsWith: DESK_SOURCE_PREFIXES.APP }, isActive: true },
-      select: { name: true },
-    });
-    const claimedAppIds = claimedSources
-      .map(s => extractInstalledAppId(s.name))
-      .filter((id): id is string => id !== null);
-
     const installedApps = await db.installedApps.findMany({
       where: {
         user: { workspaceId },
-        ...(claimedAppIds.length > 0 && { id: { notIn: claimedAppIds } }),
         installedAppPermissions: {
           some: {
             status: { in: APPROVED_STATUSES },
@@ -75,11 +66,23 @@ router.get('/apps', authV2Middleware.authenticate, async (req: Request, res: Res
       },
     });
 
+    const appDeskSources = await db.externalSource.findMany({
+      where: { sourceType: 'app-desk', isActive: true, workspaceId },
+      select: { name: true, externalIdentifier: true },
+    });
+    const deskCountByInstall = new Map<string, number>();
+    for (const source of appDeskSources) {
+      const installedAppId = resolveAppDeskInstalledAppId(source);
+      if (!installedAppId) continue;
+      deskCountByInstall.set(installedAppId, (deskCountByInstall.get(installedAppId) ?? 0) + 1);
+    }
+
     const eligible = installedApps.map(a => ({
       installedAppId: a.id,
       appId: a.appId,
       name: a.app.name,
       description: a.app.description,
+      deskCount: deskCountByInstall.get(a.id) ?? 0,
     }));
 
     res.json({ apps: eligible });
@@ -161,16 +164,16 @@ router.post(
       const source = await db.externalSource.findFirst({
         where: { channelId, sourceType: 'app-desk', isActive: false },
         orderBy: { createdAt: 'desc' },
-        select: { id: true, name: true },
+        select: { id: true, name: true, externalIdentifier: true },
       });
       if (!source) {
         res.status(404).json({ error: 'No disconnected integration found for this channel' });
         return;
       }
 
-      const installedAppId = extractInstalledAppId(source.name);
+      const installedAppId = resolveAppDeskInstalledAppId(source);
       if (!installedAppId) {
-        res.status(400).json({ error: 'Invalid app-desk source name' });
+        res.status(400).json({ error: 'App-desk source is missing its backing install' });
         return;
       }
       const installedApp = await db.installedApps.findFirst({

--- a/apps/backend/src/services/appDeskService.ts
+++ b/apps/backend/src/services/appDeskService.ts
@@ -13,7 +13,7 @@ import { EmailRepository } from '@/database/repositories/emailRepository';
 import { ExternalSourceRepository } from '@/database/repositories/externalSourceRepository';
 import { decrypt } from '@/services/encryptionService';
 import { syncTicketEmailCount } from '@/database/syncTicketEmailCount';
-import { extractInstalledAppId } from '@/integrations/core/deskSources';
+import { resolveAppDeskInstalledAppId } from '@/integrations/core/deskSources';
 import { dispatchEmailEventForEmailId } from '@/apps/core/emailUtils';
 import { sendWebhookNotification } from '@/apps/core/eventSubscriptionUtils';
 import { AppEventType, BaseAppEvent, DeskReplyEventPayload, DeskReplyAttachment } from '@/apps/types';
@@ -52,9 +52,9 @@ class AppDeskService {
     const threadId = initialEmail.externalThreadId; // the app's thread key
     if (!threadId) throw new Error(`No externalThreadId found for conversation ${conversationId}`);
 
-    const installedAppId = extractInstalledAppId(externalSource.name);
+    const installedAppId = resolveAppDeskInstalledAppId(externalSource);
     if (!installedAppId) {
-      throw new Error(`Invalid app-desk source name: ${externalSource.name}`);
+      throw new Error(`App-desk source ${externalSource.name} is missing its backing install`);
     }
     const installedApp = await this.prisma.installedApps.findUnique({
       where: { id: installedAppId },

--- a/apps/dashboard/src/components/Chat/AddChannelForm/AddChannelForm.tsx
+++ b/apps/dashboard/src/components/Chat/AddChannelForm/AddChannelForm.tsx
@@ -94,6 +94,7 @@ interface EligibleApp {
   appId: string;
   name: string;
   description: string | null;
+  deskCount: number;
 }
 
 interface AddChannelFormProps {
@@ -655,8 +656,7 @@ export const AddChannelForm: React.FC<AddChannelFormProps> = ({
                 <div className='font-medium'>No eligible apps found</div>
                 <div className='text-xs text-muted-foreground mt-1'>
                   An app must be installed with the <span className='font-mono'>desk:write</span>{' '}
-                  permission and not already back another desk. Set this up in{' '}
-                  <span className='font-medium'>Xyne Apps</span> first.
+                  permission. Set this up in <span className='font-medium'>Xyne Apps</span> first.
                 </div>
               </div>
             </div>
@@ -675,12 +675,18 @@ export const AddChannelForm: React.FC<AddChannelFormProps> = ({
                           {app.description}
                         </span>
                       )}
+                      {!!app.deskCount && (
+                        <span className='ml-2 text-xs text-muted-foreground'>
+                          backs {app.deskCount} desk{app.deskCount === 1 ? '' : 's'}
+                        </span>
+                      )}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
               <p className='text-xs text-muted-foreground'>
-                Apps already backing a desk are hidden. One app backs one desk.
+                One app can back multiple desks. Your app receives the{' '}
+                <span className='font-mono'>channelId</span> on every event to tell them apart.
               </p>
             </>
           )}

--- a/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/AppDeskIntegrationCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/AppDeskIntegrationCard.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 import { disconnectAppDesk, reconnectAppDesk } from '../../../services/clients/appDeskApi';
 import {
   useChannelIntegrationInfo,
@@ -16,17 +17,25 @@ export const AppDeskIntegrationCard = ({
   channelId,
   canManage,
 }: AppDeskIntegrationCardProps): ReactElement | null => {
+  const queryClient = useQueryClient();
   const { isConnected, hasSource, sourceType, connectedLabel } =
     useChannelIntegrationInfo(channelId);
 
   if (sourceType !== 'app-desk' || !hasSource) return null;
   if (!canManage) return null;
 
+  // Connecting/disconnecting changes the desk count the create-desk picker shows, and that
+  // list sits behind the global 5-minute staleTime.
+  const invalidateEligibleApps = (): void => {
+    void queryClient.invalidateQueries({ queryKey: ['app-desk-eligible-apps'] });
+  };
+
   const handleDisconnect = async (): Promise<void> => {
     try {
       await disconnectAppDesk(channelId);
       toast.success('Xyne App disconnected. Conversation history is preserved.');
       clearChannelConnectedEmailCache(channelId);
+      invalidateEligibleApps();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to disconnect — please try again.');
       throw err;
@@ -38,6 +47,7 @@ export const AppDeskIntegrationCard = ({
       await reconnectAppDesk(channelId);
       toast.success('Xyne App reconnected.');
       clearChannelConnectedEmailCache(channelId);
+      invalidateEligibleApps();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to reconnect — please try again.');
       throw err;

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1658,6 +1658,8 @@ const SupportScreen = (): ReactElement => {
     onSuccess: () => {
       setShowCreateChannelModal(false);
       toast.success('Channel created successfully');
+      void queryClient.invalidateQueries({ queryKey: ['app-desk-eligible-apps'] });
+      void queryClient.invalidateQueries({ queryKey: ['slack-desk-channels'] });
     },
     onError: (error: Error) => {
       toast.error('Failed to create channel', {


### PR DESCRIPTION
An app-based desk was limited to one desk channel per installed app, because the ExternalSource.name unique key was derived from the install (app-desk-<installedAppId>). Integrators wanting several support channels had to register a separate Xyne App per channel, each with its own JWT, signing secret and webhook config.

Desk sources are now keyed by the channel they back (app-desk-<channelId>), matching the existing Slack desk pattern, with the backing install stored on externalIdentifier. One app registration now serves any number of desks, disambiguated by the channelId already present in both the inbound payload and the outbound DESK_REPLY event, so there is no contract change for integrators. 1:1 still works; it is simply the single-desk case.

Desks created before this change keep their app-desk-<installedAppId> name and resolve through a fallback in resolveAppDeskInstalledAppId, so no schema or data migration is required.

Also fix the create-desk connector pickers showing stale data: app-desk-eligible-apps and slack-desk-channels sit behind a global 5-minute staleTime and were never invalidated, so a just-connected app or Slack channel kept appearing until a hard refresh.

Services-Requiring-Redeployment:
  - backend
  - dashboard
  
## POT 

https://github.com/user-attachments/assets/2ba9fbec-3b2a-4532-a691-e84a16bc5ac8



## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
