### PR TITLE
feat: XYNE-55473 add unread mentions jump pill to chat sidebar

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -36,6 +36,7 @@ import { ChatDirectoryProps, ChannelCategory } from './ChatDirectory.types';
 import { keyBetween, sumSectionUnread } from './ChatDirectory.utils';
 import { renderEmoji } from '../../../utils/customEmojiUtils';
 import { useAllUnreadCount } from '../../../hooks/useUnreadCount';
+import UnreadMentionsPill, { useOffscreenUnreadSections } from './UnreadMentionsPill';
 import { useMutation } from '@tanstack/react-query';
 import { useSelector } from '@xstate/react';
 import {
@@ -82,7 +83,7 @@ import AppNavigator from '../../AppNavigator/AppNavigator';
 import { useThreadSidebarState } from '../../../hooks/useUnreadThreadsCount';
 import { useOverdueRemindersCount } from '../../../hooks/useOverdueRemindersCount';
 import { useRecapUnreadCount, usePrefetchRecap } from '../../../hooks/useRecapData';
-import { stateMachineActor } from '../../../machines/stateMachine';
+import { stateMachineActor, type VisibleChannel } from '../../../machines/stateMachine';
 import { usePendingDelayedMessagesCount } from '../../../hooks/useUserDelayedMessages';
 
 const ContainerDropZone = ({
@@ -227,6 +228,30 @@ const ChatDirectory = ({
 
   // Get unread counts for all channels (for DMs)
   const unreadCounts = useAllUnreadCount();
+  const unreadSectionIds = useMemo(() => {
+    const hasBadge = (list: VisibleChannel[]): boolean =>
+      list.some(c => (unreadCounts[c.id] ?? 0) > 0 && c.id !== activeChannelId);
+
+    const ids: string[] = [];
+    if (hasBadge(starredDisplayChannels)) ids.push(ChannelCategory.STARRED);
+    for (const { section, channels: sectionChannels } of displaySectioned) {
+      if (hasBadge(sectionChannels)) ids.push(section.id);
+    }
+    if (hasBadge(defaultDisplayChannels)) ids.push(ChannelCategory.CHANNELS);
+    if (hasBadge(dmDisplayChannels)) ids.push(ChannelCategory.DIRECT_MESSAGES);
+    return ids;
+  }, [
+    starredDisplayChannels,
+    displaySectioned,
+    defaultDisplayChannels,
+    dmDisplayChannels,
+    unreadCounts,
+    activeChannelId,
+  ]);
+  const { above: unreadSectionAbove, below: unreadSectionBelow } = useOffscreenUnreadSections(
+    listContainerRef,
+    unreadSectionIds,
+  );
 
   const unreadActivityStats = useMemo(() => {
     const allOrdered = [...starred, ...channels, ...directMessages];
@@ -481,7 +506,7 @@ const ChatDirectory = ({
       <div className='w-full h-[52px] shrink-0'>
         <AppNavigator />
       </div>
-      <div className='flex-1 min-h-0 px-3 pt-3 pb-12 sm:pb-0 flex flex-col border-t border-sidebar-border-muted'>
+      <div className='relative flex-1 min-h-0 px-3 pt-3 pb-12 sm:pb-0 flex flex-col border-t border-sidebar-border-muted'>
         <div className='block sm:hidden -mx-2 px-2 bg-background/70 backdrop-blur-md rounded-b-3xl border-b border-black/10'>
           <div className='px-2 pt-2 pb-3 flex items-center justify-between'>
             <div className='flex items-center gap-2'>
@@ -501,10 +526,13 @@ const ChatDirectory = ({
             </div>
           </div>
         </div>
-        <div className='hidden sm:flex pt-2 pb-3 px-2 h-10 items-center justify-between mb-2 shrink-0'>
+        <div className='relative hidden sm:flex pt-2 pb-3 px-2 h-10 items-center justify-between mb-2 shrink-0'>
           <h2 className='text-base font-semibold leading-normal text-sidebar-accent-foreground'>
             Inbox
           </h2>
+          <div className='pointer-events-none absolute inset-0 flex items-center justify-center'>
+            <UnreadMentionsPill target={unreadSectionAbove} direction='up' />
+          </div>
         </div>
 
         <div
@@ -690,7 +718,10 @@ const ChatDirectory = ({
             <DndContext {...dndContextProps}>
               <ContainerDropZone id={`section-drop-${STARRED_CONTAINER}`}>
                 {(starred.length > 0 || activeOverlayChannel !== null) && (
-                  <Accordion.Item value={ChannelCategory.STARRED}>
+                  <Accordion.Item
+                    value={ChannelCategory.STARRED}
+                    data-sidebar-section={ChannelCategory.STARRED}
+                  >
                     <Accordion.Trigger asChild>
                       <button className='group flex items-center justify-start gap-2 w-full h-7 text-sidebar-foreground text-xs font-medium px-3'>
                         <span className='size-4 flex items-center justify-center shrink-0'>
@@ -785,7 +816,10 @@ const ChatDirectory = ({
               )}
 
               {/* Channels  */}
-              <Accordion.Item value={ChannelCategory.CHANNELS}>
+              <Accordion.Item
+                value={ChannelCategory.CHANNELS}
+                data-sidebar-section={ChannelCategory.CHANNELS}
+              >
                 <Accordion.Header asChild>
                   <div className='group px-3 flex items-center justify-between gap-2 '>
                     <Accordion.Trigger asChild>
@@ -969,7 +1003,10 @@ const ChatDirectory = ({
                 </Accordion.Content>
               </Accordion.Item>
               {/* DMS  */}
-              <Accordion.Item value={ChannelCategory.DIRECT_MESSAGES}>
+              <Accordion.Item
+                value={ChannelCategory.DIRECT_MESSAGES}
+                data-sidebar-section={ChannelCategory.DIRECT_MESSAGES}
+              >
                 <Accordion.Header asChild>
                   <div className='group px-3 flex items-center justify-between gap-2 '>
                     <Accordion.Trigger asChild>
@@ -1036,6 +1073,10 @@ const ChatDirectory = ({
               </Accordion.Item>
             </DndContext>
           </Accordion.Root>
+        </div>
+
+        <div className='pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center'>
+          <UnreadMentionsPill target={unreadSectionBelow} direction='down' />
         </div>
 
         <Dialog

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SortableSection.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SortableSection.tsx
@@ -94,6 +94,7 @@ const SortableSection = ({
       }}
       style={style}
       value={section.id}
+      data-sidebar-section={section.id}
       className='group/item'
     >
       {/* The header itself is the drag handle: a click toggles the section, a

--- a/apps/dashboard/src/components/Chat/ChatDirectory/UnreadMentionsPill.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/UnreadMentionsPill.tsx
@@ -1,0 +1,101 @@
+import { ReactElement, RefObject, useEffect, useState } from 'react';
+import { ArrowDown, ArrowUp } from '@xyne/icons';
+
+export interface OffscreenUnreadSections {
+  above: HTMLElement | null;
+  below: HTMLElement | null;
+}
+
+type Position = 'above' | 'below' | 'visible';
+
+export const useOffscreenUnreadSections = (
+  containerRef: RefObject<HTMLDivElement | null>,
+  sectionIds: readonly string[],
+): OffscreenUnreadSections => {
+  const [state, setState] = useState<OffscreenUnreadSections>({ above: null, below: null });
+  const sectionKey = sectionIds.join('\n');
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const ids = sectionKey ? sectionKey.split('\n') : [];
+    const clear = (): void =>
+      setState(prev => (prev.above || prev.below ? { above: null, below: null } : prev));
+
+    if (!container || ids.length === 0) {
+      clear();
+      return;
+    }
+
+    const elements = new Map<string, HTMLElement>();
+    for (const id of ids) {
+      const el = container.querySelector<HTMLElement>(`[data-sidebar-section="${CSS.escape(id)}"]`);
+      if (el) elements.set(id, el);
+    }
+    if (elements.size === 0) {
+      clear();
+      return;
+    }
+
+    const positions = new Map<string, Position>();
+    const sync = (): void => {
+      let above: HTMLElement | null = null;
+      let below: HTMLElement | null = null;
+      for (const id of ids) {
+        const el = elements.get(id);
+        if (!el) continue;
+        const position = positions.get(id);
+        if (position === 'above') above = el;
+        else if (position === 'below' && !below) below = el;
+      }
+      setState(prev => (prev.above === above && prev.below === below ? prev : { above, below }));
+    };
+
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).dataset['sidebarSection'];
+          if (!id) continue;
+          const root = entry.rootBounds;
+          if (entry.isIntersecting || !root) positions.set(id, 'visible');
+          else positions.set(id, entry.boundingClientRect.top >= root.bottom ? 'below' : 'above');
+        }
+        sync();
+      },
+      { root: container },
+    );
+
+    for (const el of elements.values()) observer.observe(el);
+
+    return (): void => observer.disconnect();
+  }, [containerRef, sectionKey]);
+
+  return state;
+};
+
+interface UnreadMentionsPillProps {
+  target: HTMLElement | null;
+  direction: 'up' | 'down';
+}
+
+const UnreadMentionsPill = ({
+  target,
+  direction,
+}: UnreadMentionsPillProps): ReactElement | null => {
+  if (!target) return null;
+
+  return (
+    <button
+      type='button'
+      className='pointer-events-auto flex shrink-0 items-center gap-1.5 rounded-full bg-sidebar-primary px-3 py-1 text-xs font-medium text-sidebar-primary-foreground shadow-md transition-colors hover:opacity-90'
+      onClick={() => target.scrollIntoView({ block: 'start', behavior: 'smooth' })}
+      data-track-category='CHAT_SIDEBAR'
+      data-track-name='JUMP_TO_UNREAD_MENTION'
+      data-track-metadata={JSON.stringify({ direction })}
+    >
+      {direction === 'up' ? <ArrowUp size={12} /> : <ArrowDown size={12} />}
+      Unread mentions
+    </button>
+  );
+};
+
+export default UnreadMentionsPill;


### PR DESCRIPTION
## POT

https://github.com/user-attachments/assets/f1d462de-8f90-44c6-8f0c-3d76fa4cce95



## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
