### PR TITLE
feat: GENIUS-5430 Error log using Lua filter

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -19,7 +19,11 @@ RATE_LIMIT_MAX_REQUESTS=100
 
 # Logging
 LOG_LEVEL=debug
-LOG_FILE_PATH=logs/app.log
+# Streams error-level logs to Fluent Bit (docker-compose.dev.yml) for the
+# VictoriaLogs/Grafana error dashboard. Off by default.
+LOG_FLUENT_ENABLED=false
+LOG_FLUENT_HOST=localhost
+LOG_FLUENT_PORT=24224
 
 # Database Configuration
 DATABASE_URL=postgresql://xyne:xyne123@localhost:5433/xyne_dev_db?schema=public

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -107,6 +107,7 @@
     "express-rate-limit": "^8.5.2",
     "fast-xml-parser": "^5.10.1",
     "file-type": "^21.3.3",
+    "fluent-logger": "^3.4.1",
     "form-data": "4.0.6",
     "fractional-indexing": "^3.2.0",
     "google-auth-library": "^10.4.0",

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -24,7 +24,12 @@ const envSchema = Joi.object({
   RATE_LIMIT_WINDOW_MS: Joi.number().default(900000),
   RATE_LIMIT_MAX_REQUESTS: Joi.number().default(100),
   LOG_LEVEL: Joi.string().valid('error', 'warn', 'info', 'debug').default('info'),
-  LOG_FILE_PATH: Joi.string().default('logs/app.log'),
+  // Streams error-level logs to Fluent Bit's forward input (see docker/fluent-bit/).
+  // Off by default so envs without a Fluent Bit endpoint (e.g. prod, until one
+  // is provisioned there) don't try to connect anywhere.
+  LOG_FLUENT_ENABLED: Joi.boolean().default(false),
+  LOG_FLUENT_HOST: Joi.string().default('localhost'),
+  LOG_FLUENT_PORT: Joi.number().default(24224),
   LOG_USER_SESSION_CHANGES: Joi.boolean().default(true),
   DATABASE_URL: Joi.string().required(),
   DATABASE_READ_REPLICA_POOL_URL: Joi.string().optional().default(''),
@@ -503,7 +508,11 @@ export const config = {
   },
   logging: {
     level: envVars.LOG_LEVEL,
-    filePath: envVars.LOG_FILE_PATH,
+    fluent: {
+      enabled: envVars.LOG_FLUENT_ENABLED,
+      host: envVars.LOG_FLUENT_HOST,
+      port: envVars.LOG_FLUENT_PORT,
+    },
     logUserSessionChanges: envVars.LOG_USER_SESSION_CHANGES,
   },
   database: {

--- a/apps/backend/src/types/fluent-logger.d.ts
+++ b/apps/backend/src/types/fluent-logger.d.ts
@@ -4,6 +4,8 @@ declare module "fluent-logger" {
 		port?: number;
 		timeout?: number;
 		reconnectInterval?: number;
+		messageQueueSizeLimit?: number;
+		highWaterMark?: number;
 		level?: string;
 		format?: unknown;
 	}

--- a/apps/backend/src/types/fluent-logger.d.ts
+++ b/apps/backend/src/types/fluent-logger.d.ts
@@ -1,0 +1,25 @@
+declare module "fluent-logger" {
+	interface FluentTransportOptions {
+		host?: string;
+		port?: number;
+		timeout?: number;
+		reconnectInterval?: number;
+		level?: string;
+		format?: unknown;
+	}
+
+	interface FluentTransportConstructor {
+		// Returned instance is a winston-compatible Transport (winston.transport);
+		// kept as `object` here since winston-transport isn't a direct dependency
+		// of this package and so isn't resolvable as a type import.
+		new (tag: string, options?: FluentTransportOptions): object;
+	}
+
+	const fluentLogger: {
+		support: {
+			winstonTransport(): FluentTransportConstructor;
+		};
+	};
+
+	export default fluentLogger;
+}

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -55,18 +55,27 @@ const normalizeErrors = winston.format((info) => {
   return info;
 });
 
-// fluent-logger's msgpack encoder has no cycle detection and throws on BigInt;
-// break cycles and stringify BigInt before anything reaches it.
-//
-// Tracks the current ancestor chain (not every object ever seen) so two
-// separate references to the same shared, non-cyclic object
+// msgpack has no cycle detection and throws on BigInt; break cycles and stringify BigInt first.
 function decycle(value: unknown, ancestors: unknown[]): unknown {
   if (typeof value === 'bigint') return value.toString();
   if (value instanceof Error) return serializeError(value);
   if (typeof value !== 'object' || value === null) return value;
   if (ancestors.includes(value)) return '[Circular]';
+  // msgpack encodes these natively; skip them or they'd flatten into {} / one key per byte.
+  if (value instanceof Date) return value.toISOString();
+  if (Buffer.isBuffer(value)) return value.toString('base64');
+  if (ArrayBuffer.isView(value)) {
+    const view = value as NodeJS.TypedArray;
+    return Buffer.from(view.buffer, view.byteOffset, view.byteLength).toString('base64');
+  }
 
   const nextAncestors = [...ancestors, value];
+  if (value instanceof Map) {
+    return decycle(Object.fromEntries(value), nextAncestors);
+  }
+  if (value instanceof Set) {
+    return decycle([...value], nextAncestors);
+  }
   if (Array.isArray(value)) {
     return value.map((item) => decycle(item, nextAncestors));
   }
@@ -79,9 +88,7 @@ function decycle(value: unknown, ancestors: unknown[]): unknown {
 
 const sanitizeForFluent = winston.format((info) => decycle(info, []) as winston.Logform.TransformableInfo);
 
-// Runs once at call time, before winston-transport clones `info` per
-// transport -- that clone drops non-enumerable Error fields and can happen
-// asynchronously under a different request's AsyncLocalStorage context.
+// Runs once at call time, before winston-transport's per-transport clone drops Error fields.
 const sharedFormat = winston.format.combine(
   winston.format.timestamp(),
   winston.format.errors({ stack: true }),
@@ -89,9 +96,16 @@ const sharedFormat = winston.format.combine(
   injectContext()
 );
 
+// sharedFormat's timestamp is UTC ISO for Fluent Bit; re-render local for console output.
+function formatLocalTimestamp(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
 const productionFormat = winston.format.printf(({ timestamp, level, message, ...meta }) => {
   return JSON.stringify({
-    timestamp,
+    timestamp: typeof timestamp === 'string' ? formatLocalTimestamp(timestamp) : timestamp,
     level,
     message,
     ...meta,
@@ -104,7 +118,7 @@ const devFormat = winston.format.combine(
     const context = module || service;
     const contextPrefix = context ? `[${context}] ` : '';
     const metaString = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
-    const time = typeof timestamp === 'string' ? timestamp.slice(11) : timestamp;
+    const time = typeof timestamp === 'string' ? formatLocalTimestamp(timestamp).slice(11) : timestamp;
     return `${time} ${level}: ${contextPrefix}${message}${metaString}`;
   })
 );
@@ -118,9 +132,8 @@ const transports: winston.transport[] = [
   }),
 ];
 
-// fluent-logger's Sender calls `socket.setTimeout(timeout)` but never
-// attaches a 'timeout' listener -- per Node's net.Socket docs that event
-// fires on idle 
+// fluent-logger sets a socket timeout but never handles it. Guard the connect phase only
+// (removed on 'connect', per-socket) so idle established connections and replaced sockets are safe.
 function guardSenderSocketTimeout(sender: { _socket: Socket | null }): void {
   let socket: Socket | null = null;
   Object.defineProperty(sender, '_socket', {
@@ -128,8 +141,14 @@ function guardSenderSocketTimeout(sender: { _socket: Socket | null }): void {
     get: () => socket,
     set: (next: Socket | null) => {
       socket = next;
-      socket?.once('timeout', () => {
-        socket?.destroy(new Error('fluent socket idle timeout'));
+      if (!next) return;
+      const s = next;
+      const onTimeout = () => {
+        s.destroy(new Error('fluent socket connect timeout'));
+      };
+      s.once('timeout', onTimeout);
+      s.once('connect', () => {
+        s.removeListener('timeout', onTimeout);
       });
     },
   });
@@ -140,14 +159,26 @@ if (config.logging.fluent.enabled) {
   const fluentTransport = new FluentTransport('error.backend', {
     host: config.logging.fluent.host,
     port: config.logging.fluent.port,
-    timeout: 3000, // ms, not seconds
+    timeout: 10_000, // ms, not seconds; connect timeout only, see guardSenderSocketTimeout
     reconnectInterval: 30000,
     messageQueueSizeLimit: 1000, // bound memory when Fluent Bit is unreachable
-    highWaterMark: 1000, // avoid backpressure freezing the Console transport too
+    highWaterMark: 1000,
     level: 'error',
     format: fluentFormat,
-  }) as winston.transport & { sender: { _socket: Socket | null } };
+  }) as winston.transport & {
+    sender: { _socket: Socket | null };
+    log: (info: winston.Logform.TransformableInfo, callback: (err?: unknown, ok?: boolean) => void) => void;
+  };
   guardSenderSocketTimeout(fluentTransport.sender);
+
+  // fluent-logger only calls back on delivery, so an outage stalls winston's Writable and
+  // freezes Console too. Make it fire-and-forget; the sender has its own queue/reconnect.
+  const deliverToSender = fluentTransport.log.bind(fluentTransport);
+  fluentTransport.log = (info, callback) => {
+    deliverToSender(info, () => {});
+    callback();
+  };
+
   transports.push(fluentTransport);
 }
 

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -1,5 +1,6 @@
 import winston from 'winston';
 import { AsyncLocalStorage } from 'async_hooks';
+import fluentLogger from 'fluent-logger';
 import { config } from '@/config/env';
 
 export interface LogContext {
@@ -84,10 +85,44 @@ const devFormat = winston.format.combine(
   })
 );
 
+// Streamed straight to Fluent Bit's forward input (docker/fluent-bit/) over
+// TCP -- no intermediate log file. The forward protocol carries its own
+// event time, so unlike a file-tailed format there's no timestamp string to
+// keep in sync with a Fluent Bit parser.
+const fluentFormat = winston.format.combine(
+  winston.format.timestamp(),
+  winston.format.errors({ stack: true }),
+  normalizeErrors(),
+  injectContext(),
+  winston.format.json()
+);
+
+const transports: winston.transport[] = [
+  new winston.transports.Console({
+    format: config.env === 'development' || config.env === 'test' ? devFormat : productionFormat,
+  }),
+];
+
+if (config.logging.fluent.enabled) {
+  const FluentTransport = fluentLogger.support.winstonTransport();
+  transports.push(
+    new FluentTransport('error.backend', {
+      host: config.logging.fluent.host,
+      port: config.logging.fluent.port,
+      timeout: 3.0,
+      reconnectInterval: 30000,
+      level: 'error',
+      format: fluentFormat,
+    }) as winston.transport
+  );
+}
+
 export const logger = winston.createLogger({
   level: config.logging.level,
-  format: config.env === 'development' || config.env === 'test' ? devFormat : productionFormat,
-  transports: [new winston.transports.Console()],
+  // No logger-level `format`: it would run before each transport's own
+  // format (e.g. devFormat's colorize() would corrupt `level` for the
+  // Fluent transport too), so format is set per-transport instead.
+  transports,
   exitOnError: false,
   defaultMeta: {
     version: '1.0',

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -54,48 +54,55 @@ const normalizeErrors = winston.format((info) => {
   return info;
 });
 
-const productionFormat = winston.format.combine(
+// fluent-logger's msgpack encoder has no cycle detection and throws on BigInt;
+// break cycles and stringify BigInt before anything reaches it.
+const sanitizeForFluent = winston.format((info) => {
+  const seen = new WeakSet<object>();
+  return JSON.parse(
+    JSON.stringify(info, (_key, value) => {
+      if (typeof value === 'bigint') return value.toString();
+      if (value instanceof Error) return serializeError(value);
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return '[Circular]';
+        seen.add(value);
+      }
+      return value;
+    })
+  );
+});
+
+// Runs once at call time, before winston-transport clones `info` per
+// transport -- that clone drops non-enumerable Error fields and can happen
+// asynchronously under a different request's AsyncLocalStorage context.
+const sharedFormat = winston.format.combine(
   winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
   winston.format.errors({ stack: true }),
   normalizeErrors(),
-  injectContext(),
-  winston.format.json(),
-  winston.format.printf(({ timestamp, level, message, ...meta }) => {
-    return JSON.stringify({
-      timestamp,
-      level,
-      message,
-      ...meta,
-    });
-  })
+  injectContext()
 );
 
+const productionFormat = winston.format.printf(({ timestamp, level, message, ...meta }) => {
+  return JSON.stringify({
+    timestamp,
+    level,
+    message,
+    ...meta,
+  });
+});
 
 const devFormat = winston.format.combine(
   winston.format.colorize(),
-  winston.format.timestamp({ format: 'HH:mm:ss' }),
-  winston.format.errors({ stack: true }),
-  normalizeErrors(),
-  injectContext(),
   winston.format.printf(({ timestamp, level, message, module, service, ...meta }) => {
     const context = module || service;
     const contextPrefix = context ? `[${context}] ` : '';
     const metaString = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
-    return `${timestamp} ${level}: ${contextPrefix}${message}${metaString}`;
+    const time = typeof timestamp === 'string' ? timestamp.slice(11) : timestamp;
+    return `${time} ${level}: ${contextPrefix}${message}${metaString}`;
   })
 );
 
-// Streamed straight to Fluent Bit's forward input (docker/fluent-bit/) over
-// TCP -- no intermediate log file. The forward protocol carries its own
-// event time, so unlike a file-tailed format there's no timestamp string to
-// keep in sync with a Fluent Bit parser.
-const fluentFormat = winston.format.combine(
-  winston.format.timestamp(),
-  winston.format.errors({ stack: true }),
-  normalizeErrors(),
-  injectContext(),
-  winston.format.json()
-);
+// Streamed straight to Fluent Bit's forward input (docker/fluent-bit/) -- no file, no parser to sync.
+const fluentFormat = winston.format.combine(sanitizeForFluent(), winston.format.json());
 
 const transports: winston.transport[] = [
   new winston.transports.Console({
@@ -109,8 +116,10 @@ if (config.logging.fluent.enabled) {
     new FluentTransport('error.backend', {
       host: config.logging.fluent.host,
       port: config.logging.fluent.port,
-      timeout: 3.0,
+      timeout: 3000, // ms, not seconds
       reconnectInterval: 30000,
+      messageQueueSizeLimit: 1000, // bound memory when Fluent Bit is unreachable
+      highWaterMark: 1000, // avoid backpressure freezing the Console transport too
       level: 'error',
       format: fluentFormat,
     }) as winston.transport
@@ -119,9 +128,7 @@ if (config.logging.fluent.enabled) {
 
 export const logger = winston.createLogger({
   level: config.logging.level,
-  // No logger-level `format`: it would run before each transport's own
-  // format (e.g. devFormat's colorize() would corrupt `level` for the
-  // Fluent transport too), so format is set per-transport instead.
+  format: sharedFormat,
   transports,
   exitOnError: false,
   defaultMeta: {

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import winston from 'winston';
 import { AsyncLocalStorage } from 'async_hooks';
 import fluentLogger from 'fluent-logger';
+import type { Socket } from 'net';
 import { config } from '@/config/env';
 
 export interface LogContext {
@@ -56,26 +57,33 @@ const normalizeErrors = winston.format((info) => {
 
 // fluent-logger's msgpack encoder has no cycle detection and throws on BigInt;
 // break cycles and stringify BigInt before anything reaches it.
-const sanitizeForFluent = winston.format((info) => {
-  const seen = new WeakSet<object>();
-  return JSON.parse(
-    JSON.stringify(info, (_key, value) => {
-      if (typeof value === 'bigint') return value.toString();
-      if (value instanceof Error) return serializeError(value);
-      if (typeof value === 'object' && value !== null) {
-        if (seen.has(value)) return '[Circular]';
-        seen.add(value);
-      }
-      return value;
-    })
-  );
-});
+//
+// Tracks the current ancestor chain (not every object ever seen) so two
+// separate references to the same shared, non-cyclic object
+function decycle(value: unknown, ancestors: unknown[]): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Error) return serializeError(value);
+  if (typeof value !== 'object' || value === null) return value;
+  if (ancestors.includes(value)) return '[Circular]';
+
+  const nextAncestors = [...ancestors, value];
+  if (Array.isArray(value)) {
+    return value.map((item) => decycle(item, nextAncestors));
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    out[key] = decycle((value as Record<string, unknown>)[key], nextAncestors);
+  }
+  return out;
+}
+
+const sanitizeForFluent = winston.format((info) => decycle(info, []) as winston.Logform.TransformableInfo);
 
 // Runs once at call time, before winston-transport clones `info` per
 // transport -- that clone drops non-enumerable Error fields and can happen
 // asynchronously under a different request's AsyncLocalStorage context.
 const sharedFormat = winston.format.combine(
-  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+  winston.format.timestamp(),
   winston.format.errors({ stack: true }),
   normalizeErrors(),
   injectContext()
@@ -110,20 +118,37 @@ const transports: winston.transport[] = [
   }),
 ];
 
+// fluent-logger's Sender calls `socket.setTimeout(timeout)` but never
+// attaches a 'timeout' listener -- per Node's net.Socket docs that event
+// fires on idle 
+function guardSenderSocketTimeout(sender: { _socket: Socket | null }): void {
+  let socket: Socket | null = null;
+  Object.defineProperty(sender, '_socket', {
+    configurable: true,
+    get: () => socket,
+    set: (next: Socket | null) => {
+      socket = next;
+      socket?.once('timeout', () => {
+        socket?.destroy(new Error('fluent socket idle timeout'));
+      });
+    },
+  });
+}
+
 if (config.logging.fluent.enabled) {
   const FluentTransport = fluentLogger.support.winstonTransport();
-  transports.push(
-    new FluentTransport('error.backend', {
-      host: config.logging.fluent.host,
-      port: config.logging.fluent.port,
-      timeout: 3000, // ms, not seconds
-      reconnectInterval: 30000,
-      messageQueueSizeLimit: 1000, // bound memory when Fluent Bit is unreachable
-      highWaterMark: 1000, // avoid backpressure freezing the Console transport too
-      level: 'error',
-      format: fluentFormat,
-    }) as winston.transport
-  );
+  const fluentTransport = new FluentTransport('error.backend', {
+    host: config.logging.fluent.host,
+    port: config.logging.fluent.port,
+    timeout: 3000, // ms, not seconds
+    reconnectInterval: 30000,
+    messageQueueSizeLimit: 1000, // bound memory when Fluent Bit is unreachable
+    highWaterMark: 1000, // avoid backpressure freezing the Console transport too
+    level: 'error',
+    format: fluentFormat,
+  }) as winston.transport & { sender: { _socket: Socket | null } };
+  guardSenderSocketTimeout(fluentTransport.sender);
+  transports.push(fluentTransport);
 }
 
 export const logger = winston.createLogger({

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -271,11 +271,52 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_SERVER_ROOT_URL=http://localhost:3333
+      # VictoriaLogs datasource isn't bundled with core Grafana.
+      - GF_INSTALL_PLUGINS=victoriametrics-logs-datasource
+      - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victoriametrics-logs-datasource
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - victoriametrics
+      - victorialogs-errors
+    # Lets webhook contact points (e.g. the Desk alert integration) reach the
+    # backend running on the host, same as zero-cache's ZERO_MUTATE_URL below.
+    extra_hosts:
+      - "host.containers.internal:host-gateway"
+    restart: unless-stopped
+
+  # VictoriaLogs - error-only log instance (fed by Fluent Bit below)
+  victorialogs-errors:
+    image: victoriametrics/victoria-logs:latest
+    container_name: ${COMPOSE_PROJECT_NAME:-xyne}-victorialogs-errors
+    command:
+      - '--storageDataPath=/storage'
+      - '--httpListenAddr=:9428'
+      - '--retentionPeriod=1' # Month; this instance only holds deduped errors
+    ports:
+      - "${VICTORIALOGS_ERRORS_BIND_PORT:-9428}:9428"
+    volumes:
+      - victorialogs_errors_data:/storage
+    restart: unless-stopped
+
+  # Fluent Bit - receives backend error logs over the Fluentd forward
+  # protocol (streamed directly from Winston, see apps/backend/src/utils/logger.ts),
+  # normalizes + hashes them via the Lua filter, and forwards them to the
+  # victorialogs-errors instance above.
+  fluent-bit:
+    image: fluent/fluent-bit:3.1
+    container_name: ${COMPOSE_PROJECT_NAME:-xyne}-fluent-bit
+    volumes:
+      - ./docker/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
+      - ./docker/fluent-bit/normalize_hash.lua:/fluent-bit/etc/normalize_hash.lua
+    ports:
+      - "${FLUENT_BIT_HTTP_BIND_PORT:-2020}:2020" # Fluent Bit metrics/health
+      # Backend runs on the host in local dev, so it connects to this forward
+      # input over localhost (LOG_FLUENT_HOST/LOG_FLUENT_PORT in .env.local).
+      - "${FLUENT_BIT_FORWARD_BIND_PORT:-24224}:24224"
+    depends_on:
+      - victorialogs-errors
     restart: unless-stopped
 
   # Superposition - Feature Flag & Configuration Management
@@ -330,6 +371,8 @@ volumes:
   fake_gcs_data:
     driver: local
   victoriametrics_data:
+    driver: local
+  victorialogs_errors_data:
     driver: local
   grafana_data:
     driver: local

--- a/docker/fluent-bit/fluent-bit.conf
+++ b/docker/fluent-bit/fluent-bit.conf
@@ -1,0 +1,45 @@
+[SERVICE]
+    Flush           1
+    Daemon          Off
+    Log_Level       info
+    HTTP_Server     On
+    HTTP_Listen     0.0.0.0
+    HTTP_Port       2020
+
+# Backend streams error-level logs directly over the Fluentd forward
+# protocol (see apps/backend/src/utils/logger.ts, fluent-logger) -- no file
+# tailing, no parser needed. The protocol carries its own event time and the
+# tag ("error.backend"), matching the Match patterns below.
+[INPUT]
+    Name    forward
+    Listen  0.0.0.0
+    Port    24224
+
+# Defensive filter: the Winston transport already only forwards records at
+# `error` level, but this keeps the pipeline correct if that ever changes
+# upstream.
+[FILTER]
+    Name    grep
+    Match   error.*
+    Regex   level ^(error|fatal)$
+
+# Normalizes the message (strips ids/timestamps/numbers) and stamps a
+# `fingerprint` hash so VictoriaLogs can group recurring errors together
+# and compute count / first_occurrence / last_occurrence via LogsQL.
+[FILTER]
+    Name    lua
+    Match   error.*
+    script  normalize_hash.lua
+    call    normalize_and_hash
+
+[OUTPUT]
+    Name            http
+    Match           error.*
+    Host            victorialogs-errors
+    Port            9428
+    URI             /insert/jsonline?_stream_fields=fingerprint,module&_msg_field=message&_time_field=timestamp
+    Format          json_lines
+    Json_date_key   timestamp
+    Json_date_format iso8601
+    Header          Content-Type application/stream+json
+    Retry_Limit     5

--- a/docker/fluent-bit/fluent-bit.conf
+++ b/docker/fluent-bit/fluent-bit.conf
@@ -37,7 +37,7 @@
     Match           error.*
     Host            victorialogs-errors
     Port            9428
-    URI             /insert/jsonline?_stream_fields=fingerprint,module&_msg_field=message&_time_field=timestamp
+    URI             /insert/jsonline?_stream_fields=normalized_module&_msg_field=message&_time_field=timestamp
     Format          json_lines
     Json_date_key   timestamp
     Json_date_format iso8601

--- a/docker/fluent-bit/normalize_hash.lua
+++ b/docker/fluent-bit/normalize_hash.lua
@@ -10,11 +10,12 @@ local function normalize(message)
 
   -- UUIDs
   m = string.gsub(m, '%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x', '<uuid>')
-  -- ISO-ish timestamps
-  m = string.gsub(m, '%d%d%d%d%-%d%d%-%d%d[T ]%d%d:%d%d:%d%d[%.%d]*Z?', '<ts>')
+  -- ISO-ish timestamps (m is already lower-cased, so match lower t/z)
+  m = string.gsub(m, '%d%d%d%d%-%d%d%-%d%d[t ]%d%d:%d%d:%d%d[%.%d]*z?', '<ts>')
   -- hex addresses / long hex ids (e.g. 0x7ffee, object hashes)
   m = string.gsub(m, '0x%x+', '<hex>')
-  m = string.gsub(m, '%x%x%x%x%x%x%x%x%x%x%x%x+', '<hex>')
+  -- decimal digits are valid %x, so use the same token as plain numbers below
+  m = string.gsub(m, '%x%x%x%x%x%x%x%x%x%x%x%x+', '<num>')
   -- plain numbers (ids, ports, line numbers, durations)
   m = string.gsub(m, '%d+', '<num>')
   -- quoted string literals (paths, values interpolated into the message)
@@ -42,8 +43,12 @@ end
 
 function normalize_and_hash(tag, timestamp, record)
   local template = normalize(record['message'])
+  -- module can carry dynamic data (e.g. `vespa-search, <searchId>`); normalize
+  -- it too so it doesn't blow up VictoriaLogs stream cardinality as a label.
+  local normalized_module = normalize(record['module'])
   record['normalized_message'] = template
-  record['fingerprint'] = djb2((record['module'] or '') .. '|' .. template)
+  record['normalized_module'] = normalized_module
+  record['fingerprint'] = djb2(normalized_module .. '|' .. template)
 
   -- code = 1: keep record, replaced with modified fields
   return 1, timestamp, record

--- a/docker/fluent-bit/normalize_hash.lua
+++ b/docker/fluent-bit/normalize_hash.lua
@@ -1,0 +1,50 @@
+-- Normalizes an error log message into a stable template and hashes it,
+-- so VictoriaLogs can group recurring occurrences of "the same" error
+-- (e.g. `stats by (fingerprint) count(), min(_time), max(_time)`).
+
+local function normalize(message)
+  if message == nil then
+    return ''
+  end
+  local m = string.lower(tostring(message))
+
+  -- UUIDs
+  m = string.gsub(m, '%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x', '<uuid>')
+  -- ISO-ish timestamps
+  m = string.gsub(m, '%d%d%d%d%-%d%d%-%d%d[T ]%d%d:%d%d:%d%d[%.%d]*Z?', '<ts>')
+  -- hex addresses / long hex ids (e.g. 0x7ffee, object hashes)
+  m = string.gsub(m, '0x%x+', '<hex>')
+  m = string.gsub(m, '%x%x%x%x%x%x%x%x%x%x%x%x+', '<hex>')
+  -- plain numbers (ids, ports, line numbers, durations)
+  m = string.gsub(m, '%d+', '<num>')
+  -- quoted string literals (paths, values interpolated into the message)
+  m = string.gsub(m, '"[^"]*"', '<str>')
+  m = string.gsub(m, "'[^']*'", '<str>')
+  -- collapse whitespace
+  m = string.gsub(m, '%s+', ' ')
+  m = string.gsub(m, '^%s+', '')
+  m = string.gsub(m, '%s+$', '')
+
+  return m
+end
+
+-- djb2: no crypto lib is bundled with Fluent Bit's Lua runtime, and plain
+-- Lua 5.1 (no LuaJIT bitops) has no bitwise operators, so this sticks to
+-- plain arithmetic. Fast, dependency-free, fine for dedup fingerprints at
+-- log-error volumes.
+local function djb2(str)
+  local hash = 5381
+  for i = 1, #str do
+    hash = ((hash * 33) + string.byte(str, i)) % 4294967296
+  end
+  return string.format('%08x', hash)
+end
+
+function normalize_and_hash(tag, timestamp, record)
+  local template = normalize(record['message'])
+  record['normalized_message'] = template
+  record['fingerprint'] = djb2((record['module'] or '') .. '|' .. template)
+
+  -- code = 1: keep record, replaced with modified fields
+  return 1, timestamp, record
+end

--- a/docker/grafana/provisioning/dashboards/victorialogs-errors.json
+++ b/docker/grafana/provisioning/dashboards/victorialogs-errors.json
@@ -13,7 +13,7 @@
           "refId": "A",
           "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs-errors" },
           "expr": "level:error",
-          "queryType": "logs"
+          "queryType": "instant"
         }
       ],
       "title": "Deduped Error Log Stream (normalized_message + fingerprint)",

--- a/docker/grafana/provisioning/dashboards/victorialogs-errors.json
+++ b/docker/grafana/provisioning/dashboards/victorialogs-errors.json
@@ -1,0 +1,53 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs-errors" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs-errors" },
+          "expr": "level:error",
+          "queryType": "logs"
+        }
+      ],
+      "title": "Deduped Error Log Stream (normalized_message + fingerprint)",
+      "type": "logs"
+    },
+    {
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs-errors" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 2,
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs-errors" },
+          "expr": "* | stats by (fingerprint) count() as occurrences",
+          "queryType": "stats"
+        }
+      ],
+      "title": "Occurrences by Fingerprint (last selected range)",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 42,
+  "tags": ["errors", "victorialogs", "xyne"],
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Error Log Fingerprints (VictoriaLogs)",
+  "uid": "xyne-error-fingerprints",
+  "version": 1
+}

--- a/docker/grafana/provisioning/datasources/victorialogs.yml
+++ b/docker/grafana/provisioning/datasources/victorialogs.yml
@@ -1,0 +1,14 @@
+# Error-only log instance fed by Fluent Bit (docker/fluent-bit/). Requires
+# the victoriametrics-logs-datasource plugin (installed via GF_INSTALL_PLUGINS
+# on the grafana service in docker-compose.dev.yml).
+
+apiVersion: 1
+
+datasources:
+  - name: VictoriaLogs-Errors
+    uid: victorialogs-errors
+    type: victoriametrics-logs-datasource
+    access: proxy
+    url: http://victorialogs-errors:9428
+    isDefault: false
+    editable: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       file-type:
         specifier: ^21.3.3
         version: 21.3.4
+      fluent-logger:
+        specifier: ^3.4.1
+        version: 3.4.1
       form-data:
         specifier: 4.0.6
         version: 4.0.6
@@ -12468,6 +12471,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-lite@0.1.3:
+    resolution: {integrity: sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw==}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -12861,6 +12867,10 @@ packages:
     resolution: {integrity: sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==}
     engines: {node: '>=18'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  fluent-logger@3.4.1:
+    resolution: {integrity: sha512-lERIhXAvhtCYeQq8K7sBDg/HY9GkiVRq5xY3oN+hcSINVKwqwBzG6LQOJK73EnV50qO59U7XEmRnn2hBzLWaHw==}
+    engines: {node: '>=6'}
 
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
@@ -13821,6 +13831,9 @@ packages:
   inquirer@8.2.7:
     resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
     engines: {node: '>=12.0.0'}
+
+  int64-buffer@0.1.10:
+    resolution: {integrity: sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -15637,6 +15650,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpack-lite@0.1.26:
+    resolution: {integrity: sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==}
+    hasBin: true
 
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
@@ -32735,6 +32752,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-lite@0.1.3: {}
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -33283,6 +33302,10 @@ snapshots:
       async: 0.2.10
       which: 1.3.1
     optional: true
+
+  fluent-logger@3.4.1:
+    dependencies:
+      msgpack-lite: 0.1.26
 
   fn.name@1.1.0: {}
 
@@ -34508,6 +34531,8 @@ snapshots:
       wrap-ansi: 6.2.0
     transitivePeerDependencies:
       - '@types/node'
+
+  int64-buffer@0.1.10: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -36925,6 +36950,13 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
+
+  msgpack-lite@0.1.26:
+    dependencies:
+      event-lite: 0.1.3
+      ieee754: 1.2.1
+      int64-buffer: 0.1.10
+      isarray: 1.0.0
 
   msgpackr-extract@3.0.4:
     dependencies:


### PR DESCRIPTION
Environment-Changes:
  - LOG_FLUENT_ENABLED: Setting fluent true or false
  - LOG_FLUENT_HOST: setting local/prod
  - LOG_FLUENT_PORT: Setting port for fluentbit

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
