### PR TITLE
fix: show alert-triangle instead of spinner when recording playback is unavailable

### DIFF
--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -93,6 +93,10 @@ const RECORDING_SUMMARY_TEMPLATES: ReadonlyArray<RecordingSummaryTemplate> = [
 
 const AUDIO_POLL_INTERVAL_MS = 10_000;
 const AUDIO_POLL_MAX_ATTEMPTS = 30;
+// Audio is stitched shortly after a call ends. If a recording ended longer ago than
+// the whole poll window and still has no audio, stitching is not pending — the
+// recording simply has no playable audio, so we skip polling and mark it unavailable.
+const AUDIO_STITCH_GRACE_MS = AUDIO_POLL_INTERVAL_MS * AUDIO_POLL_MAX_ATTEMPTS;
 
 const POST_SPLIT_BUTTON_CLASS =
   'text-background hover:bg-foreground/90 hover:text-background dark:hover:bg-foreground/90 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-background';
@@ -393,6 +397,14 @@ export default function RecordingDetailV2Screen(): ReactElement {
   useEffect(() => {
     if (!recordingId || isLive || !recording || recording.hasRecording) return;
 
+    // A recording that ended long ago and still has no audio is never going to get
+    // one — mark playback unavailable immediately instead of polling for minutes.
+    const endedAtMs = recording.endedAt ? new Date(recording.endedAt).getTime() : null;
+    if (endedAtMs !== null && Date.now() - endedAtMs > AUDIO_STITCH_GRACE_MS) {
+      setAudioPollExhausted(true);
+      return;
+    }
+
     setAudioPollExhausted(false);
     let attempts = 0;
     const timer = window.setInterval(() => {
@@ -421,7 +433,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
     }, AUDIO_POLL_INTERVAL_MS);
 
     return (): void => window.clearInterval(timer);
-  }, [recordingId, isLive, recording?.hasRecording]);
+  }, [recordingId, isLive, recording?.hasRecording, recording?.endedAt]);
 
   const loadRecording = async (id: string): Promise<void> => {
     try {
@@ -670,6 +682,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
 
   // The player replaces the read-only timeline once there is audio to scrub.
   const showAudioPlayer = !isLive && !!recording.hasRecording;
+  // Polling has given up (or was skipped for an old recording) and there is still no
+  // stitched audio, so the control bar shows an unavailable indicator, not a spinner.
+  const audioUnavailable = !isLive && !recording.hasRecording && audioPollExhausted;
   const hasDetailedSummary = !!recording.detailedSummaryCanvasId;
   const isOwner = recording.createdByUserId === currentUser?.id;
   const selectedSummaryTemplate =
@@ -741,6 +756,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                 isLive={isLive}
                 onStopped={() => void loadRecording(recording.externalId)}
                 isAudioPreparing={!showAudioPlayer && !audioPollExhausted}
+                isAudioUnavailable={audioUnavailable}
                 {...(showAudioPlayer
                   ? {
                       onLoadAudio: (signal: AbortSignal) =>

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
@@ -20,7 +20,9 @@
 import { useCallback, useEffect, useState, type CSSProperties, type ReactElement } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { StopSmall, Spinner, PauseBig, PlayBig, Flag } from '@xyne/icons';
+import { AlertTriangle } from 'lucide-react';
 import { Button } from '../../../components/ui/Button/Button';
+import { Tooltip } from '../../../components/ui/Tooltip';
 import { cn } from '../../../utils/classNames';
 import { sendRecordingEvent, useRecordingStore } from '../../../hooks/useRecordingStore';
 import { calculateRecordingElapsedMs, formatElapsedTime } from '../../../utils/recordingUtils';
@@ -38,6 +40,8 @@ interface LiveRecordingControlBarProps {
   onLoadAudio?: (signal: AbortSignal) => Promise<Blob>;
   onMarkerSelect?: (item: MarkedItem) => void;
   isAudioPreparing?: boolean;
+  /** True once playback is known to be unavailable for this recording. */
+  isAudioUnavailable?: boolean;
 }
 
 /** Stands in when there is no audio to load, so the playback hook can stay unconditional. */
@@ -50,6 +54,7 @@ export const LiveRecordingControlBar = ({
   onLoadAudio,
   onMarkerSelect,
   isAudioPreparing = false,
+  isAudioUnavailable = false,
 }: LiveRecordingControlBarProps): ReactElement | null => {
   // Recording session state — only meaningful when this tab owns the live session.
   const activeExternalId = useRecordingStore(context => context.externalId);
@@ -114,6 +119,7 @@ export const LiveRecordingControlBar = ({
       <RecordedTimelineBar
         recording={recording}
         isAudioPreparing={isAudioPreparing}
+        isAudioUnavailable={isAudioUnavailable}
         {...(onLoadAudio ? { onLoadAudio } : {})}
         {...(onMarkerSelect ? { onMarkerSelect } : {})}
       />
@@ -346,6 +352,8 @@ interface RecordedTimelineBarProps {
   onMarkerSelect?: (item: MarkedItem) => void;
   /** True while the stitched audio is still on its way. */
   isAudioPreparing?: boolean;
+  /** True once playback is known to be unavailable (e.g. older recordings). */
+  isAudioUnavailable?: boolean;
 }
 
 const RecordedTimelineBar = ({
@@ -353,6 +361,7 @@ const RecordedTimelineBar = ({
   onLoadAudio,
   onMarkerSelect,
   isAudioPreparing = false,
+  isAudioUnavailable = false,
 }: RecordedTimelineBarProps): ReactElement => {
   const fallbackDurationMs =
     recording.durationMs ??
@@ -379,16 +388,28 @@ const RecordedTimelineBar = ({
   const isPlaying = playback.state === 'playing';
   const isStitching = !onLoadAudio && isAudioPreparing;
   const isAudioBusy = isStitching || playback.state === 'loading';
+  // Once stitching has given up (or never applied) and there is still no audio to
+  // load, the recording simply has no playable audio (e.g. older recordings) — show
+  // an alert-triangle instead of a spinner that would otherwise never resolve.
+  const showAudioUnavailable = !onLoadAudio && !isStitching && isAudioUnavailable;
   const audioControlLabel = isStitching
     ? 'Preparing audio'
-    : !onLoadAudio
-      ? 'Audio is unavailable for this recording'
-      : playback.state === 'loading'
-        ? 'Loading audio'
-        : isPlaying
-          ? 'Pause recording'
-          : 'Play recording';
-  const audioIconKey = isAudioBusy ? 'loading' : isPlaying ? 'pause' : 'play';
+    : showAudioUnavailable
+      ? 'Recording is not available for playback.'
+      : !onLoadAudio
+        ? 'Audio is unavailable for this recording'
+        : playback.state === 'loading'
+          ? 'Loading audio'
+          : isPlaying
+            ? 'Pause recording'
+            : 'Play recording';
+  const audioIconKey = isAudioBusy
+    ? 'loading'
+    : showAudioUnavailable
+      ? 'unavailable'
+      : isPlaying
+        ? 'pause'
+        : 'play';
 
   const selectMarker =
     playback.canSeek || onMarkerSelect
@@ -398,52 +419,60 @@ const RecordedTimelineBar = ({
         }
       : null;
 
+  const playButton = (
+    <motion.div
+      className='shrink-0'
+      initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={
+        shouldReduceMotion ? { duration: 0.15 } : { type: 'spring', stiffness: 480, damping: 30 }
+      }
+    >
+      <Button
+        type='button'
+        variant='outline'
+        size='icon'
+        onClick={() => void playback.toggle()}
+        disabled={!onLoadAudio || playback.state === 'loading'}
+        aria-busy={isAudioBusy}
+        className='size-8 rounded-full border-border bg-card text-muted-foreground hover:text-foreground'
+        aria-label={audioControlLabel}
+        title={audioControlLabel}
+        data-track-category='RecordingDetailV2'
+        data-track-name={isPlaying ? 'pause_recording' : 'play_recording'}
+      >
+        <AnimatePresence mode='wait' initial={false}>
+          <motion.span
+            key={audioIconKey}
+            className='flex items-center justify-center'
+            initial={{ opacity: 0, scale: 0.6 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.6 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.14 }}
+          >
+            {isAudioBusy ? (
+              <Spinner size={14} className='animate-spin' />
+            ) : showAudioUnavailable ? (
+              <AlertTriangle size={14} className='text-muted-foreground' />
+            ) : isPlaying ? (
+              <PauseBig size={14} strokeWidth={4} variant='Solid' />
+            ) : (
+              <PlayBig size={14} variant='Solid' />
+            )}
+          </motion.span>
+        </AnimatePresence>
+      </Button>
+    </motion.div>
+  );
+
   return (
     <div className='mb-6 rounded-2xl border border-border bg-card px-5 py-4'>
       <div className='flex min-h-11 items-center gap-4'>
-        <motion.div
-          className='shrink-0'
-          initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={
-            shouldReduceMotion
-              ? { duration: 0.15 }
-              : { type: 'spring', stiffness: 480, damping: 30 }
-          }
-        >
-          <Button
-            type='button'
-            variant='outline'
-            size='icon'
-            onClick={() => void playback.toggle()}
-            disabled={!onLoadAudio || playback.state === 'loading'}
-            aria-busy={isAudioBusy}
-            className='size-8 rounded-full border-border bg-card text-muted-foreground hover:text-foreground'
-            aria-label={audioControlLabel}
-            title={audioControlLabel}
-            data-track-category='RecordingDetailV2'
-            data-track-name={isPlaying ? 'pause_recording' : 'play_recording'}
-          >
-            <AnimatePresence mode='wait' initial={false}>
-              <motion.span
-                key={audioIconKey}
-                className='flex items-center justify-center'
-                initial={{ opacity: 0, scale: 0.6 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.6 }}
-                transition={{ duration: shouldReduceMotion ? 0 : 0.14 }}
-              >
-                {isAudioBusy ? (
-                  <Spinner size={14} className='animate-spin' />
-                ) : isPlaying ? (
-                  <PauseBig size={14} strokeWidth={4} variant='Solid' />
-                ) : (
-                  <PlayBig size={14} variant='Solid' />
-                )}
-              </motion.span>
-            </AnimatePresence>
-          </Button>
-        </motion.div>
+        {showAudioUnavailable ? (
+          <Tooltip content='Recording is not available for playback.'>{playButton}</Tooltip>
+        ) : (
+          playButton
+        )}
 
         <span className='w-12 shrink-0 text-right font-mono text-xs text-foreground'>
           {formatElapsedTime(elapsedMs)}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
@@ -19,8 +19,7 @@
 
 import { useCallback, useEffect, useState, type CSSProperties, type ReactElement } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { StopSmall, Spinner, PauseBig, PlayBig, Flag } from '@xyne/icons';
-import { AlertTriangle } from 'lucide-react';
+import { StopSmall, Spinner, PauseBig, PlayBig, Flag, AlertTriangle } from '@xyne/icons';
 import { Button } from '../../../components/ui/Button/Button';
 import { Tooltip } from '../../../components/ui/Tooltip';
 import { cn } from '../../../utils/classNames';


### PR DESCRIPTION
## What
In the V2 (xyne-oats) Recording Details flow, the play control on an ended recording showed a loading spinner while the backend stitched the audio file, polling for up to 5 minutes. Older recordings that will never have a stitched audio file therefore showed a **perpetual spinner** and the user never learned that playback was unavailable.

This PR makes the unavailable state explicit.

## Changes
- **`RecordingDetailV2Screen.tsx`**
  - Added `AUDIO_STITCH_GRACE_MS` (= poll interval × max attempts).
  - The audio-poll effect now skips polling entirely for a recording that ended longer ago than the poll window and still has no audio, marking playback unavailable immediately (`setAudioPollExhausted(true)`) instead of spinning for minutes.
  - Derived `audioUnavailable` and passed it to the control bar as `isAudioUnavailable`.
- **`LiveRecordingControlBar.tsx`**
  - Threaded a new `isAudioUnavailable` prop through `LiveRecordingControlBar` → `RecordedTimelineBar`.
  - When playback is known to be unavailable, the play control now renders an `AlertTriangle` icon (from `lucide-react`) instead of the spinner, wrapped in a `Tooltip` with the text **"Recording is not available for playback."** (also mirrored on `aria-label`/`title`).

## Behavior
- Recently ended recording, audio still stitching → spinner (unchanged).
- Audio available → normal play/pause control (unchanged).
- Older recording / stitching gave up → **alert-triangle icon + tooltip "Recording is not available for playback."** (previously: perpetual spinner).

## Validation
- `tsc --noEmit`: no new errors in the changed files.
- `eslint`: no new errors (only two pre-existing `exhaustive-deps` warnings unrelated to this change).