### PR TITLE
Fix/acl issue in recordings sharing release 0805

### DIFF
--- a/apps/backend/src/database/acl/tables/calls-acl.ts
+++ b/apps/backend/src/database/acl/tables/calls-acl.ts
@@ -1,4 +1,5 @@
 import { Prisma, PrismaClient } from '@prisma/client'
+import { EntityUserAccess, ShareableEntityType } from '@xyne/shared'
 import { BaseQueryACL, ACLContext } from '../base-acl'
 import { getAccessibleChannelIds, isGuestContext } from './channel-access-helper'
 
@@ -8,6 +9,43 @@ export class CallsACL extends BaseQueryACL<
 > {
   constructor(ctx: ACLContext, prisma: PrismaClient) {
     super(ctx, prisma)
+  }
+
+  /**
+   * Ids of calls (headless recordings) shared with `ctx.userId` via `entity_access`
+   * (NOTE_TAKER), directly or through a userGroup/channel they belong to. `entityId`
+   * has no FK to `calls.id` (polymorphic), so this can't be expressed as a Prisma
+   * relation and is resolved as a separate lookup instead — mirrors the Zero-side
+   * `CallsACL.canSelect` `exists('shares', ...)` clause.
+   */
+  private async getSharedCallIds(): Promise<string[]> {
+    const [groupMappings, channelParticipations] = await Promise.all([
+      this.prisma.userGroupMapping.findMany({
+        where: { userId: this.ctx.userId },
+        select: { userGroupId: true },
+      }),
+      this.prisma.channelParticipant.findMany({
+        where: { userId: this.ctx.userId },
+        select: { channelId: true },
+      }),
+    ])
+    const userGroupIds = groupMappings.map((m) => m.userGroupId)
+    const channelIds = channelParticipations.map((p) => p.channelId)
+
+    const shares = await this.prisma.entityAccess.findMany({
+      where: {
+        workspaceId: this.ctx.workspaceId,
+        shareableEntityType: ShareableEntityType.NOTE_TAKER,
+        entityUserAccess: { not: EntityUserAccess.REVOKED },
+        OR: [
+          { userId: this.ctx.userId },
+          ...(userGroupIds.length ? [{ userGroupId: { in: userGroupIds } }] : []),
+          ...(channelIds.length ? [{ channelId: { in: channelIds } }] : []),
+        ],
+      },
+      select: { entityId: true },
+    })
+    return shares.map((s) => s.entityId)
   }
 
   async getWhereClause(): Promise<Prisma.CallWhereInput> {
@@ -23,6 +61,8 @@ export class CallsACL extends BaseQueryACL<
       }
     }
 
+    const sharedCallIds = await this.getSharedCallIds()
+
     return {
       AND: [
         {
@@ -30,6 +70,7 @@ export class CallsACL extends BaseQueryACL<
             { createdByUserId: this.ctx.userId },
             { participants: { some: { userId: this.ctx.userId } } },
             { channel: { participants: { some: { userId: this.ctx.userId } } } },
+            ...(sharedCallIds.length ? [{ id: { in: sharedCallIds } }] : []),
           ],
         },
         { workspaceId: this.ctx.workspaceId },

--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -9,7 +9,7 @@ import { DatabaseClient } from '@/database/client';
 import { withWorkspaceScope } from '@/database/tenant/context';
 import { repositories } from '@/database/repositories';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
-import { DEFAULT_SUMMARY_FIELDS, MessageType, CanvasRole } from '@xyne/shared';
+import { DEFAULT_SUMMARY_FIELDS, MessageType, CanvasRole, CanvasVisibility } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 import { formatToISTLocaleString } from '@/utils/dateUtils';
 import { ServerBlockNoteEditor } from '@blocknote/server-util';
@@ -1161,57 +1161,68 @@ export class CallDocumentService {
       // PRIVATE — note-taker recordings are shared per-user/group/channel via
       // entity_access, and the recording sharing API updates canvas_participants
       // in the same transaction.
-      await prisma.canvas.create({
-        data: {
-          id: canvasId,
-          title,
-          content: [],
-          channelId,
-          workspaceId,
-          createdBy: createdByUserId,
-          visibility: 'PRIVATE',
-          isTemplate: false,
-          isCollaborative: true,
-          lastEditedBy: createdByUserId,
-          lastEditedAt: now,
-          createdAt: now,
-          updatedAt: now,
-          metadata: {
-            source: 'call_detailed_summary',
-            callId,
-            conversationId,
-            isAiGenerated: true,
-            generatedAt: now.toISOString(),
-            mentionedUserIds, // Store mentioned users for side effect handler
-            version: 1, // Initial version for new canvases
+      //
+      // Bootstrapping the canvas + its two initial owners (Xyne Automatic bot,
+      // call creator) is a trusted system sequence, not the acting requester
+      // adding arbitrary participants — that requester may just be someone the
+      // recording was shared with, who isn't yet a participant on this
+      // brand-new canvas. Run it as an interactive transaction so it bypasses
+      // the per-request tenant ACL (CanvasParticipantsACL.canCreate would
+      // otherwise deny the second insert since the requester isn't a
+      // participant yet); regular canvas access after this stays ACL-gated.
+      await prisma.$transaction(async (tx) => {
+        await tx.canvas.create({
+          data: {
+            id: canvasId,
+            title,
+            content: [],
+            channelId,
+            workspaceId,
+            createdBy: createdByUserId,
+            visibility: CanvasVisibility.PRIVATE,
+            isTemplate: false,
+            isCollaborative: true,
+            lastEditedBy: createdByUserId,
+            lastEditedAt: now,
+            createdAt: now,
+            updatedAt: now,
+            metadata: {
+              source: 'call_detailed_summary',
+              callId,
+              conversationId,
+              isAiGenerated: true,
+              generatedAt: now.toISOString(),
+              mentionedUserIds, // Store mentioned users for side effect handler
+              version: 1, // Initial version for new canvases
+            },
           },
-        },
-      });
+        });
 
-      // Add Xyne Automatic bot as OWNER
-      await prisma.canvasParticipant.create({
-        data: {
-          id: participantId,
-          canvasId,
-          workspaceId,
-          userId: createdByUserId,
-          role: CanvasRole.OWNER,
-          joinedAt: now,
-          updatedAt: now,
-        },
-      });
+        // Add Xyne Automatic bot as OWNER
+        await tx.canvasParticipant.create({
+          data: {
+            id: participantId,
+            canvasId,
+            workspaceId,
+            userId: createdByUserId,
+            role: CanvasRole.OWNER,
+            joinedAt: now,
+            updatedAt: now,
+          },
+        });
 
-      // Add call creator as OWNER
-      await prisma.canvasParticipant.create({
-        data: {
-          id: uuidv4(),
-          canvasId,
-          workspaceId,
-          userId: callCreatorUserId,
-          role: CanvasRole.OWNER,
-          joinedAt: now,
-          updatedAt: now,
-        },
+        // Add call creator as OWNER
+        await tx.canvasParticipant.create({
+          data: {
+            id: uuidv4(),
+            canvasId,
+            workspaceId,
+            userId: callCreatorUserId,
+            role: CanvasRole.OWNER,
+            joinedAt: now,
+            updatedAt: now,
+          },
+        });
       });
 
       // Initialize Y-Sweet for collaborative editing

--- a/apps/backend/src/zero/acl/tables/call-participants-acl.ts
+++ b/apps/backend/src/zero/acl/tables/call-participants-acl.ts
@@ -14,14 +14,6 @@ export class CallParticipantsACL extends BaseACL<'call_participants'> {
     }
   }
 
-  private async isChannelParticipant(channelId: string, userId: string, tx: Transaction<Schema>): Promise<boolean> {
-    const row = await tx.run(zql.channel_participants
-      .where('channelId', channelId)
-      .where('userId', userId)
-      .one());
-    return !!row;
-  }
-
   // The caller may add themselves to a call they can access (self-join), but
   // inviting another user requires the caller to be the call creator or an
   // existing call participant.
@@ -58,13 +50,16 @@ export class CallParticipantsACL extends BaseACL<'call_participants'> {
       throw new MutationACLError('Call participant insert failed: guest does not have access to this channel', 'call_participants');
     }
 
-    // The invited user (args.userId), not just the caller, must be a
-    // participant of the call's channel.
-    if (!(await this.isChannelParticipant(callData.channel.id, args.userId, tx))) {
-      throw new MutationACLError('Call participant insert failed: the invited user must be a participant of the call\'s channel', 'call_participants');
-    }
+    const isParticipant = await tx.run(
+      zql.channel_participants
+        .where('channelId', callData.channel.id)
+        .where('userId', this.ctx.userID)
+        .one(),
+    );
 
-    await this.verifyCallerMayInvite(callData.id, callData.createdByUserId, args.userId, tx);
+    if (!isParticipant) {
+      throw new MutationACLError('Call participant insert failed: you must be a channel participant to join calls', 'call_participants');
+    }
   }
 
   async canUpdate(args: UpdateValue<TableSchema<'call_participants'>>, tx: Transaction<Schema>): Promise<void> {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
