### PR TITLE
fix: surface failed call recordings instead of silently omitting them

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -38,7 +38,8 @@ import {
   InvitationResponse,
   MeetingStatus,
   NotificationType,
-  RecordingType, AttachmentEntityType } from '@xyne/shared';
+  RecordingType, AttachmentEntityType,
+  isRecordingFailure } from '@xyne/shared';
 import { storageService } from '@/services/storage';
 import { CallVespaFeedSource, queueCallVespaFeed } from '@/services/callVespaQueue';
 import { callShareService } from '@/services/callShareService';
@@ -1090,6 +1091,11 @@ export class CallController {
       const callsWithRecording = await repositories.callRecordings.callIdsWithRecording(
         calls.map((call) => call.id),
       );
+      // A call is "failed" only when it has a terminal-failed recording AND no
+      // UPLOADED one — a later successful attempt supersedes an earlier failure.
+      const callsWithFailedRecording = await repositories.callRecordings.callIdsWithFailedRecording(
+        calls.map((call) => call.id),
+      );
 
       const recordings = calls.map((call) => {
         const metadata = call.metadata as { systemMessageId?: string } | null;
@@ -1108,6 +1114,8 @@ export class CallController {
           hasTranscript: !!call.transcript,
           hasSummary: !!call.aiSummary,
           hasRecording: callsWithRecording.has(call.id),
+          recordingFailed:
+            !callsWithRecording.has(call.id) && callsWithFailedRecording.has(call.id),
           labels: call.labels,
           markedItems: call.markedItems,
           summaryTemplateId: call.summaryTemplateId,
@@ -1247,6 +1255,11 @@ export class CallController {
       // recordings-list endpoint. Not message-attachment-based: NOTE_TAKER
       // (headless) calls never create a message/attachment for their recording.
       const uploadedRecording = await repositories.callRecordings.findLatestUploadedByCallId(call.id).catch(() => null);
+      // The most recent recording attempt (any status) drives the failed-state
+      // surfacing: without an UPLOADED recording, a terminal-failed latest attempt
+      // is shown to the user instead of an indefinite "preparing"/"unavailable".
+      const latestRecording = await repositories.callRecordings.findLatestByCallId(call.id).catch(() => null);
+      const recordingFailed = !uploadedRecording && isRecordingFailure(latestRecording?.status);
       // Backward-compat: historical call rows stored the notes canvas link as
       // `notesCanvasViewAccessId`. Fall back to that key if the new one isn't
       // present so the notes tab keeps rendering for pre-migration calls.
@@ -1296,6 +1309,8 @@ export class CallController {
               : null,
           citationSegments,
           hasRecording: !!uploadedRecording,
+          recordingStatus: latestRecording?.status ?? null,
+          recordingFailed,
         },
       });
     } catch (error) {

--- a/apps/backend/src/database/repositories/callRecordingRepository.ts
+++ b/apps/backend/src/database/repositories/callRecordingRepository.ts
@@ -107,6 +107,34 @@ export class CallRecordingRepository {
     return new Set(rows.map((r) => r.callId));
   }
 
+  /**
+   * Of the given calls, which have at least one recording in a terminal failure
+   * state (egress/upload failed). Bulk lookup mirroring callIdsWithRecording so
+   * the list/detail endpoints can surface failures instead of silently omitting
+   * them. Callers should treat a call as "failed" only when it also has no
+   * UPLOADED recording (a later successful attempt supersedes an earlier failure).
+   */
+  async callIdsWithFailedRecording(callIds: string[]): Promise<Set<string>> {
+    if (callIds.length === 0) return new Set();
+    const rows = await this.db.callRecording.findMany({
+      where: {
+        callId: { in: callIds },
+        status: { in: [RecordingStatus.RECORDING_FAILED, RecordingStatus.RECORDING_UPLOAD_FAILED] },
+      },
+      select: { callId: true },
+      distinct: ['callId'],
+    });
+    return new Set(rows.map((r) => r.callId));
+  }
+
+  /** Most recent non-deleted recording for a call (any status), newest first. */
+  async findLatestByCallId(callId: string): Promise<CallRecording | null> {
+    return this.db.callRecording.findFirst({
+      where: { callId, status: { not: RecordingStatus.RECORDING_DELETED } },
+      orderBy: { startedAt: 'desc' },
+    });
+  }
+
   /** Patch the egressId in after startEgress() returns. */
   async setEgressId(id: string, egressId: string): Promise<void> {
     await this.db.callRecording.update({ where: { id }, data: { egressId } });

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -397,6 +397,14 @@ export default function RecordingDetailV2Screen(): ReactElement {
   useEffect(() => {
     if (!recordingId || isLive || !recording || recording.hasRecording) return;
 
+    // A terminal egress/upload failure will never produce audio — stop immediately
+    // and surface the failure instead of polling for minutes then showing a vague
+    // "unavailable" indistinguishable from an old audio-less recording.
+    if (recording.recordingFailed) {
+      setAudioPollExhausted(true);
+      return;
+    }
+
     // A recording that ended long ago and still has no audio is never going to get
     // one — mark playback unavailable immediately instead of polling for minutes.
     const endedAtMs = recording.endedAt ? new Date(recording.endedAt).getTime() : null;
@@ -424,6 +432,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
               ? {
                   ...current,
                   hasRecording: !!fresh.hasRecording,
+                  recordingFailed: !!fresh.recordingFailed,
                   durationMs: fresh.durationMs ?? current.durationMs,
                 }
               : current,
@@ -433,7 +442,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
     }, AUDIO_POLL_INTERVAL_MS);
 
     return (): void => window.clearInterval(timer);
-  }, [recordingId, isLive, recording?.hasRecording, recording?.endedAt]);
+  }, [recordingId, isLive, recording?.hasRecording, recording?.recordingFailed, recording?.endedAt]);
 
   const loadRecording = async (id: string): Promise<void> => {
     try {
@@ -685,6 +694,8 @@ export default function RecordingDetailV2Screen(): ReactElement {
   // Polling has given up (or was skipped for an old recording) and there is still no
   // stitched audio, so the control bar shows an unavailable indicator, not a spinner.
   const audioUnavailable = !isLive && !recording.hasRecording && audioPollExhausted;
+  // A specific kind of unavailability: the recording is known to have failed egress/upload.
+  const audioFailed = audioUnavailable && !!recording.recordingFailed;
   const hasDetailedSummary = !!recording.detailedSummaryCanvasId;
   const isOwner = recording.createdByUserId === currentUser?.id;
   const selectedSummaryTemplate =
@@ -757,6 +768,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                 onStopped={() => void loadRecording(recording.externalId)}
                 isAudioPreparing={!showAudioPlayer && !audioPollExhausted}
                 isAudioUnavailable={audioUnavailable}
+                isAudioFailed={audioFailed}
                 {...(showAudioPlayer
                   ? {
                       onLoadAudio: (signal: AbortSignal) =>

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
@@ -41,6 +41,8 @@ interface LiveRecordingControlBarProps {
   isAudioPreparing?: boolean;
   /** True once playback is known to be unavailable for this recording. */
   isAudioUnavailable?: boolean;
+  /** True when the recording is unavailable specifically because egress/upload failed. */
+  isAudioFailed?: boolean;
 }
 
 /** Stands in when there is no audio to load, so the playback hook can stay unconditional. */
@@ -54,6 +56,7 @@ export const LiveRecordingControlBar = ({
   onMarkerSelect,
   isAudioPreparing = false,
   isAudioUnavailable = false,
+  isAudioFailed = false,
 }: LiveRecordingControlBarProps): ReactElement | null => {
   // Recording session state — only meaningful when this tab owns the live session.
   const activeExternalId = useRecordingStore(context => context.externalId);
@@ -119,6 +122,7 @@ export const LiveRecordingControlBar = ({
         recording={recording}
         isAudioPreparing={isAudioPreparing}
         isAudioUnavailable={isAudioUnavailable}
+        isAudioFailed={isAudioFailed}
         {...(onLoadAudio ? { onLoadAudio } : {})}
         {...(onMarkerSelect ? { onMarkerSelect } : {})}
       />
@@ -353,6 +357,8 @@ interface RecordedTimelineBarProps {
   isAudioPreparing?: boolean;
   /** True once playback is known to be unavailable (e.g. older recordings). */
   isAudioUnavailable?: boolean;
+  /** True when unavailability is due to a terminal egress/upload failure. */
+  isAudioFailed?: boolean;
 }
 
 const RecordedTimelineBar = ({
@@ -361,6 +367,7 @@ const RecordedTimelineBar = ({
   onMarkerSelect,
   isAudioPreparing = false,
   isAudioUnavailable = false,
+  isAudioFailed = false,
 }: RecordedTimelineBarProps): ReactElement => {
   const fallbackDurationMs =
     recording.durationMs ??
@@ -394,7 +401,9 @@ const RecordedTimelineBar = ({
   const audioControlLabel = isStitching
     ? 'Preparing audio'
     : showAudioUnavailable
-      ? 'Recording is not available for playback.'
+      ? isAudioFailed
+        ? 'Recording failed — no audio was captured.'
+        : 'Recording is not available for playback.'
       : !onLoadAudio
         ? 'Audio is unavailable for this recording'
         : playback.state === 'loading'
@@ -468,7 +477,15 @@ const RecordedTimelineBar = ({
     <div className='mb-6 rounded-2xl border border-border bg-card px-5 py-4'>
       <div className='flex min-h-11 items-center gap-4'>
         {showAudioUnavailable ? (
-          <Tooltip content='Recording is not available for playback.'>{playButton}</Tooltip>
+          <Tooltip
+            content={
+              isAudioFailed
+                ? 'Recording failed — no audio was captured.'
+                : 'Recording is not available for playback.'
+            }
+          >
+            {playButton}
+          </Tooltip>
         ) : (
           playButton
         )}

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -32,6 +32,8 @@ export interface Recording {
   hasTranscript: boolean;
   hasSummary: boolean;
   hasRecording?: boolean;
+  /** Terminal egress/upload failure with no playable audio (RECORDING_FAILED / RECORDING_UPLOAD_FAILED). */
+  recordingFailed?: boolean;
   labels?: string[];
   markedItems?: unknown[];
   summaryTemplateId?: string | null;
@@ -131,6 +133,8 @@ export interface RecordingDetail extends Recording {
   detailedSummaryCanvasId: string | null;
   citationSegments: CitationSegment[];
   hasRecording?: boolean;
+  /** Latest recording attempt's status (any state), or null when none exists. */
+  recordingStatus?: string | null;
   linkedTicketId?: string | null;
   linkedTicketMessageId?: string | null;
 }

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -1035,6 +1035,20 @@ export enum RecordingStatus {
   RECORDING_DELETED = 'RECORDING_DELETED',
 }
 
+/**
+ * Terminal recording states where egress/upload failed and the recording will
+ * never produce playable audio on its own. PROCESSING_FAILED is intentionally
+ * excluded: the stitch queue retries it, so it may still recover.
+ */
+export function isRecordingFailure(
+  status: RecordingStatus | string | null | undefined,
+): boolean {
+  return (
+    status === RecordingStatus.RECORDING_FAILED ||
+    status === RecordingStatus.RECORDING_UPLOAD_FAILED
+  );
+}
+
 // @ts-ignore TS1294
 export enum SessionRecordingProcessStatus {
   PENDING = 'PENDING',


### PR DESCRIPTION
## Problem
When a call recording's egress/upload permanently fails (observed in **preprod**: the LiveKit egress service account `livekit-egress-sa@xyne-spaces.iam.gserviceaccount.com` lacks `storage.objects.create` on the GCS recordings bucket → HLS segments never land), the recording row ends up in `RECORDING_UPLOAD_FAILED` (or `RECORDING_FAILED`). This state was **never surfaced**:

- The recordings list/detail derive presence only from `RECORDING_UPLOADED`, so a failed recording looks identical to "no recording".
- The detail screen polls `hasRecording` for ~5 minutes and then shows a generic **"Recording is not available for playback"**, indistinguishable from an old audio‑less recording. The user gets no signal that the recording *failed*.

Note: the underlying preprod outage is an **infra/IAM** issue (grant GCS write to the egress SA). This PR fixes the **product gap** — a permanent failure should be shown, not silently swallowed.

## Change (backend-first, additive, no migration — enum states already exist)
- **shared**: add `isRecordingFailure()` as the single source of truth for terminal egress/upload failure states. `PROCESSING_FAILED` is intentionally excluded because the stitch queue retries it and it may still recover.
- **backend repo** (`callRecordingRepository`): add `callIdsWithFailedRecording()` (bulk) and `findLatestByCallId()` (latest non-deleted recording, any status).
- **backend controller** (`callController`): expose `recordingFailed` on `GET /api/calls/recordings` (list) and `recordingStatus` + `recordingFailed` on `GET /api/calls/recordings/:callId` (detail). A call is treated as failed only when it has a terminal-failed recording **and no** `RECORDING_UPLOADED` one (a later success supersedes an earlier failure). `hasRecording` semantics are unchanged (backward compatible).
- **dashboard**: `Recording`/`RecordingDetail` types carry the new fields; the detail screen (`RecordingDetailV2Screen`) stops polling immediately on a terminal failure (instead of waiting ~5 min) and renders an explicit **"Recording failed — no audio was captured."** state via `LiveRecordingControlBar`.

## Scope / follow-ups
- The RecordingsV2 **list** rows are driven by a Zero query over the `calls` table and do not consume these REST fields. Surfacing a failed badge directly in that list requires syncing `call_recordings` status into Zero (with proper ACL) and is intentionally left as a follow-up. This PR fixes the detail surface where the user lands after clicking a recording, plus the REST list field for API consistency.

## Validation
- `packages/shared` builds clean (`tsc`).
- `apps/backend` `tsc --noEmit` passes.
- `apps/dashboard` `tsc --noEmit`: no errors in touched files (only a pre-existing, unrelated `posthog-js` module-resolution error in `mixpanelService.ts`).