### PR TITLE
fix: XYNE-55527 fixing acls for resource-access and resources

### DIFF
--- a/apps/backend/scripts/create-member-login.ts
+++ b/apps/backend/scripts/create-member-login.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env npx tsx
+
+import { PrismaClient } from '@prisma/client';
+import { AuthProvider, OrgRole, UserStatus, WorkspaceRole } from '@xyne/shared';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { hashPassword } from '../src/utils/passwordUtils';
+
+dotenv.config({
+  path: fileURLToPath(new URL('../.env.local', import.meta.url)),
+  quiet: true,
+});
+
+const prisma = new PrismaClient();
+const DEFAULT_WORKSPACE_NAME = 'Default Workspace';
+const MEMBER_PERMISSIONS = [
+  'TICKETS',
+  'WORKFLOWS',
+  'AGENTS',
+  'MODELS',
+  'TOOLS',
+  'AGENT-TOOLS-MAPPINGS',
+  'ANALYTICS',
+  'PROJECTS',
+  'XYNE-APPS',
+  'CHANNELS',
+  'CANVASES',
+].map((resourceName) => ({ resourceName, accessType: 'WRITE' }));
+
+function deriveName(email: string): string {
+  return email
+    .split('@')[0]
+    .split(/[._-]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function promptForPassword(prompt: string): Promise<string> {
+  if (!process.stdin.isTTY || !process.stdin.setRawMode) {
+    throw new Error(
+      'A password argument or MEMBER_LOGIN_PASSWORD is required in non-interactive mode.'
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    let password = '';
+
+    const finish = (): void => {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      process.stdin.removeListener('data', onData);
+      process.stdout.write('\n');
+    };
+    const onData = (data: Buffer): void => {
+      for (const input of data.toString('utf8')) {
+        if (input === '\u0003') {
+          finish();
+          reject(new Error('Cancelled.'));
+          return;
+        }
+        if (input === '\r' || input === '\n') {
+          finish();
+          resolve(password);
+          return;
+        }
+        if (input === '\u007f' || input === '\b') {
+          if (password.length > 0) {
+            password = password.slice(0, -1);
+            process.stdout.write('\b \b');
+          }
+          continue;
+        }
+
+        password += input;
+        process.stdout.write('*');
+      }
+    };
+
+    process.stdout.write(prompt);
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.on('data', onData);
+  });
+}
+
+async function main(): Promise<void> {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('This local-development script cannot run with NODE_ENV=production.');
+  }
+
+  const email = (process.argv[2] ?? '').trim().toLowerCase();
+  let password = process.argv[3] ?? process.env.MEMBER_LOGIN_PASSWORD ?? '';
+  const name = (process.argv[4] ?? '').trim() || deriveName(email) || 'Member';
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new Error('Usage: npx tsx scripts/create-member-login.ts <email> [password] [name]');
+  }
+  if (!password) {
+    password = await promptForPassword('Password: ');
+    const confirmation = await promptForPassword('Confirm password: ');
+    if (password !== confirmation) {
+      throw new Error('Passwords do not match.');
+    }
+  }
+  if (password.length < 8 || password.length > 128) {
+    throw new Error('Password must be between 8 and 128 characters.');
+  }
+
+  const workspace = await prisma.workspace.findFirst({
+    where: { name: DEFAULT_WORKSPACE_NAME },
+    select: { id: true, orgId: true },
+  });
+  if (!workspace) {
+    throw new Error(`"${DEFAULT_WORKSPACE_NAME}" was not found. Run pnpm run services first.`);
+  }
+
+  // Mirrors the MEMBER entries in src/services/permissionMatrix.ts without
+  // importing that service and starting unrelated backend infrastructure.
+  const expectedPermissions = MEMBER_PERMISSIONS;
+  const resources = await prisma.resource.findMany({
+    where: {
+      name: { in: expectedPermissions.map(({ resourceName }) => resourceName) },
+    },
+    select: { id: true, name: true },
+  });
+  const resourcesByName = new Map(resources.map((resource) => [resource.name, resource.id]));
+  const missingResources = expectedPermissions.filter(
+    ({ resourceName }) => !resourcesByName.has(resourceName)
+  );
+  if (missingResources.length > 0) {
+    console.warn(
+      `Skipping MEMBER resources not present in this database: ${missingResources
+        .map(({ resourceName }) => resourceName)
+        .join(', ')}.`
+    );
+  }
+  const grantablePermissions = expectedPermissions.filter(({ resourceName }) =>
+    resourcesByName.has(resourceName)
+  );
+
+  const [existingOrgMember, existingUser] = await Promise.all([
+    prisma.orgMember.findUnique({ where: { email } }),
+    prisma.user.findUnique({
+      where: {
+        email_workspaceId: {
+          email,
+          workspaceId: workspace.id,
+        },
+      },
+    }),
+  ]);
+
+  if ((existingOrgMember && !existingUser) || (!existingOrgMember && existingUser)) {
+    throw new Error(
+      `${email} has a partial existing identity. Refusing to modify it automatically.`
+    );
+  }
+
+  let userId: string;
+  const passwordHash = await hashPassword(password);
+
+  if (existingOrgMember && existingUser) {
+    const isMatchingMember =
+      existingOrgMember.memberId === existingUser.orgMemberId &&
+      existingOrgMember.orgId === workspace.orgId &&
+      existingOrgMember.role === OrgRole.MEMBER &&
+      existingOrgMember.leftAt === null &&
+      existingUser.role === WorkspaceRole.MEMBER &&
+      existingUser.authProvider === AuthProvider.EMAIL &&
+      existingUser.status === UserStatus.ACTIVE &&
+      existingUser.leftAt === null;
+
+    if (!isMatchingMember) {
+      throw new Error(
+        `${email} already exists but is not an active EMAIL/MEMBER account in ${DEFAULT_WORKSPACE_NAME}.`
+      );
+    }
+
+    const [adminAccessCount, adminGroupCount] = await Promise.all([
+      prisma.resourceAccess.count({
+        where: { userId: existingUser.id, accessType: 'ADMIN' },
+      }),
+      prisma.userGroupMapping.count({
+        where: {
+          userId: existingUser.id,
+          userGroup: { name: 'ADMIN' },
+        },
+      }),
+    ]);
+    if (adminAccessCount > 0 || adminGroupCount > 0) {
+      throw new Error(
+        `${email} already has admin access. Refusing to reset or relabel the account.`
+      );
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await tx.orgMember.update({
+        where: { memberId: existingOrgMember.memberId },
+        data: { passwordHash },
+      });
+      for (const permission of grantablePermissions) {
+        await tx.resourceAccess.upsert({
+          where: {
+            userId_resourceId_accessType: {
+              userId: existingUser.id,
+              resourceId: resourcesByName.get(permission.resourceName)!,
+              accessType: permission.accessType,
+            },
+          },
+          update: {},
+          create: {
+            userId: existingUser.id,
+            resourceId: resourcesByName.get(permission.resourceName)!,
+            accessType: permission.accessType,
+            workspaceId: workspace.id,
+          },
+        });
+      }
+    });
+    userId = existingUser.id;
+    console.log(`Updated the password for existing MEMBER account ${email}.`);
+  } else {
+    const createdUser = await prisma.$transaction(async (tx) => {
+      const orgMember = await tx.orgMember.create({
+        data: {
+          email,
+          orgId: workspace.orgId,
+          role: OrgRole.MEMBER,
+          passwordHash,
+        },
+      });
+
+      const user = await tx.user.create({
+        data: {
+          email,
+          name,
+          authProvider: AuthProvider.EMAIL,
+          providerUserId: `email-${email}`,
+          status: UserStatus.ACTIVE,
+          workspaceId: workspace.id,
+          role: WorkspaceRole.MEMBER,
+          orgMemberId: orgMember.memberId,
+        },
+      });
+
+      for (const permission of grantablePermissions) {
+        await tx.resourceAccess.create({
+          data: {
+            userId: user.id,
+            resourceId: resourcesByName.get(permission.resourceName)!,
+            accessType: permission.accessType,
+            workspaceId: workspace.id,
+          },
+        });
+      }
+
+      return user;
+    });
+    userId = createdUser.id;
+    console.log(`Created MEMBER account ${email}.`);
+  }
+
+  const accessRows = await prisma.resourceAccess.findMany({
+    where: { userId },
+    select: {
+      accessType: true,
+      resource: { select: { name: true } },
+    },
+  });
+  const actualPermissions = new Set(
+    accessRows.map((row) => `${row.resource.name}:${row.accessType}`)
+  );
+  const missingPermissions = grantablePermissions.filter(
+    ({ resourceName, accessType }) => !actualPermissions.has(`${resourceName}:${accessType}`)
+  );
+  const hasAdminAccess = accessRows.some((row) => row.accessType === 'ADMIN');
+
+  if (missingPermissions.length > 0) {
+    throw new Error(
+      `MEMBER permissions are incomplete: ${missingPermissions
+        .map(({ resourceName, accessType }) => `${resourceName}:${accessType}`)
+        .join(', ')}. Run scripts/seed-acl.ts and retry.`
+    );
+  }
+  if (hasAdminAccess) {
+    throw new Error('Safety check failed: the account has direct ADMIN access.');
+  }
+
+  console.log(`Member login is ready for ${DEFAULT_WORKSPACE_NAME}.`);
+  console.log(`Email: ${email}`);
+  console.log('Role: MEMBER (non-admin)');
+}
+
+main()
+  .catch((error) => {
+    console.error('Failed to create member login:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/dashboard/src/components/ResourceAccess/ResourceAccessModal/ResourceAccessModal.tsx
+++ b/apps/dashboard/src/components/ResourceAccess/ResourceAccessModal/ResourceAccessModal.tsx
@@ -15,7 +15,9 @@ import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useUser } from '../../../hooks/useUsers';
-import { AccessType, UserStatus } from '@xyne/shared';
+import { usePermissions } from '../../../hooks/usePermissions';
+import { useAuth } from '../../../hooks/useAuth';
+import { AccessType, UserStatus, WorkspaceRole } from '@xyne/shared';
 import Avatar from '../../ui/Avatar/Avatar';
 import { userActivationApi } from '../../../api/userActivationApi';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -59,6 +61,30 @@ export const ResourceAccessModal = ({
 
   // Fetch user's current access for all resources
   const [userAccess] = useCachedQuery(queries.getResourceAccessForUser({ userId: userId ?? '' }));
+
+  // Workspace admins/owners can edit every resource; everyone else can only edit resources
+  // they hold WRITE or ADMIN on (see editableResourceNames below).
+  const { user } = useAuth();
+  const isWorkspaceAdminOrOwner =
+    (user?.role as WorkspaceRole) === WorkspaceRole.ADMIN ||
+    (user?.role as WorkspaceRole) === WorkspaceRole.OWNER;
+
+  // The current (viewing) user's own permissions. A resource row is only editable when the
+  // viewer holds WRITE or ADMIN on that resource; otherwise the dropdown is disabled and
+  // shows a "no access" label, since the viewer can't meaningfully see/manage it.
+  const viewerPermissions = usePermissions();
+  const editableResourceNames = useMemo(() => {
+    const names = new Set<string>();
+    for (const permission of viewerPermissions) {
+      if (
+        permission.accessType === AccessType.WRITE ||
+        permission.accessType === AccessType.ADMIN
+      ) {
+        names.add(permission.resourceName);
+      }
+    }
+    return names;
+  }, [viewerPermissions]);
 
   // Local state for access changes
   const [accessState, setAccessState] = useState<Record<string, AccessType | 'NONE'>>({});
@@ -374,39 +400,48 @@ export const ResourceAccessModal = ({
                     )}
                   </div>
                   <div className='w-[140px] shrink-0'>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant='outline'
-                          size='sm'
-                          className='h-7 w-full justify-between text-xs'
-                          disabled={loading}
-                        >
-                          <span className='truncate'>
-                            {accessTypeOptions.find(
-                              opt =>
-                                String(opt.value) === String(accessState[resource.id] || 'NONE'),
-                            )?.label || 'Access'}
-                          </span>
-                          <ChevronDown className='ml-1 h-3 w-3 shrink-0 opacity-50' />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align='start' className='w-[140px]'>
-                        {accessTypeOptions.map(option => (
-                          <DropdownMenuItem
-                            key={option.value}
-                            onClick={() =>
-                              handleAccessChange(resource.id, option.value as AccessType | 'NONE')
-                            }
-                            className='text-xs'
+                    {isWorkspaceAdminOrOwner || editableResourceNames.has(resource.name) ? (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant='outline'
+                            size='sm'
+                            className='h-7 w-full justify-between text-xs'
+                            disabled={loading}
                           >
-                            <span className='flex-1'>{option.label}</span>
-                            {String(accessState[resource.id] || 'NONE') ===
-                              String(option.value) && <Check className='h-3 w-3' />}
-                          </DropdownMenuItem>
-                        ))}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                            <span className='truncate'>
+                              {accessTypeOptions.find(
+                                opt =>
+                                  String(opt.value) === String(accessState[resource.id] || 'NONE'),
+                              )?.label || 'Access'}
+                            </span>
+                            <ChevronDown className='ml-1 h-3 w-3 shrink-0 opacity-50' />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align='start' className='w-[140px]'>
+                          {accessTypeOptions.map(option => (
+                            <DropdownMenuItem
+                              key={option.value}
+                              onClick={() =>
+                                handleAccessChange(resource.id, option.value as AccessType | 'NONE')
+                              }
+                              className='text-xs'
+                            >
+                              <span className='flex-1'>{option.label}</span>
+                              {String(accessState[resource.id] || 'NONE') ===
+                                String(option.value) && <Check className='h-3 w-3' />}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    ) : (
+                      <div
+                        className='flex h-7 w-full items-center justify-center rounded-md border border-dashed border-border text-[10px] font-medium text-muted-foreground'
+                        title="You don't have access to manage this resource"
+                      >
+                        Permission Denied
+                      </div>
+                    )}
                   </div>
                 </div>
               ))}

--- a/packages/shared/src/zero/acl/tables/resource-access-acl.ts
+++ b/packages/shared/src/zero/acl/tables/resource-access-acl.ts
@@ -1,8 +1,7 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { AccessType } from '../../schema';
+import { WorkspaceRole } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
-import { isGuestContext } from '../core/guest-acl-utils';
 
 export class ResourceAccessACL extends BaseQueryACL<'resource_access'> {
   constructor(ctx: Context) {
@@ -10,30 +9,14 @@ export class ResourceAccessACL extends BaseQueryACL<'resource_access'> {
   }
 
   canSelect<TReturn>(query: Query<'resource_access', Schema, TReturn>): Query<'resource_access', Schema, TReturn> {
-    // Guests can only see their own records, never admin-level records
-    if (isGuestContext(this.ctx)) {
-      return query.where('userId', this.ctx.userID);
+    if (this.ctx.role === WorkspaceRole.ADMIN || this.ctx.role === WorkspaceRole.OWNER) {
+      return query;
     }
 
-    // User Management admins (ADMIN on USERS resource) can see all records
-    // Non-admins can only see their own records
-    return query.where(({ or, cmp, exists }) =>
-      or(
-        // Can see own records
-        cmp('userId', this.ctx.userID),
-        // Or if admin on USERS resource
-        exists('resource', (resourceQuery) =>
-          resourceQuery
-            .where('name', 'USERS')
-            .where(({ exists }) =>
-              exists('resourceAccess', (accessQuery) =>
-                accessQuery
-                  .where('userId', this.ctx.userID)
-                  .where('accessType', AccessType.ADMIN)
-              )
-            )
-        )
-      )
+    return query.whereExists('resource', (resourceQuery) =>
+      resourceQuery.whereExists('resourceAccess', (accessQuery) =>
+        accessQuery.where('userId', this.ctx.userID),
+      ),
     );
   }
 }

--- a/packages/shared/src/zero/acl/tables/resources-acl.ts
+++ b/packages/shared/src/zero/acl/tables/resources-acl.ts
@@ -1,8 +1,6 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { AccessType } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
-import { isGuestContext } from '../core/guest-acl-utils';
 
 export class ResourcesACL extends BaseQueryACL<'resources'> {
   constructor(ctx: Context) {
@@ -10,31 +8,6 @@ export class ResourcesACL extends BaseQueryACL<'resources'> {
   }
 
   canSelect<TReturn>(query: Query<'resources', Schema, TReturn>): Query<'resources', Schema, TReturn> {
-    // Guests can only see resources they have explicit access to, never admin-level resources
-    if (isGuestContext(this.ctx)) {
-      return query.whereExists('resourceAccess', (accessQuery) =>
-        accessQuery.where('userId', this.ctx.userID)
-      );
-    }
-
-    // User Management admins (ADMIN on USERS resource) can see all resources
-    // Non-admins can only see resources they have some access to
-    return query.where(({ or, exists }) =>
-      or(
-        // Can see resources they have access to
-        exists('resourceAccess', (accessQuery) =>
-          accessQuery.where('userId', this.ctx.userID)
-        ),
-        // Or if admin on USERS resource (User Management admin)
-        exists('resourceAccess', (accessQuery) =>
-          accessQuery
-            .where('userId', this.ctx.userID)
-            .where('accessType', AccessType.ADMIN)
-            .where(({ exists }) =>
-              exists('resource', (r) => r.where('name', 'USERS'))
-            )
-        )
-      )
-    );
+    return query;
   }
 }

--- a/project.nix
+++ b/project.nix
@@ -12,6 +12,7 @@
 
     packages = with pkgs; [
       nodejs
+      pnpm
       just
     ];
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard
  - backend

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
