### PR TITLE
feat: SDLCT-0001 Bitbucket pull request integration for Xyne tickets

### DIFF
--- a/apps/backend/src/controllers/ticketPullRequestController.ts
+++ b/apps/backend/src/controllers/ticketPullRequestController.ts
@@ -1,0 +1,134 @@
+// Thin HTTP boundary for the ticket-initiated Bitbucket PR flow.
+//
+// Responsibilities: authenticate the actor, parse params/body, delegate to
+// TicketPullRequestService, and map typed service errors to HTTP responses.
+// No provider calls or DB access happen here.
+
+import { Request, Response } from 'express';
+import { ticketPullRequestService } from '@/services/ticketPullRequestService';
+import { resolveTicketPrFlags } from '@/services/ticketPrFeatureFlags';
+import { TicketPullRequestError } from '@/types/ticketPullRequest';
+import { logger } from '@/utils/logger';
+
+export class TicketPullRequestController {
+  /** Resolve { userId, workspaceId } or send 401 and return null. */
+  private actor(req: Request, res: Response): { userId: string; workspaceId: string } | null {
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    if (!userId || !workspaceId) {
+      res.status(401).json({ error: 'User not authenticated' });
+      return null;
+    }
+    return { userId, workspaceId };
+  }
+
+  private fail(res: Response, error: unknown, context: string): void {
+    if (error instanceof TicketPullRequestError) {
+      res.status(error.httpStatus).json({ error: error.message, code: error.code });
+      return;
+    }
+    logger.error(`[TicketPR] ${context} failed:`, error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+
+  getFlags = async (req: Request, res: Response): Promise<void> => {
+    const actor = this.actor(req, res);
+    if (!actor) return;
+    try {
+      const flags = await resolveTicketPrFlags({
+        workspaceId: actor.workspaceId,
+        userId: actor.userId,
+      });
+      res.json({ flags });
+    } catch (error) {
+      this.fail(res, error, 'getFlags');
+    }
+  };
+
+  list = async (req: Request, res: Response): Promise<void> => {
+    const actor = this.actor(req, res);
+    if (!actor) return;
+    try {
+      const pullRequests = await ticketPullRequestService.listPullRequestsForTicket(
+        req.params.ticketId,
+        actor,
+      );
+      res.json({ pullRequests });
+    } catch (error) {
+      this.fail(res, error, 'list');
+    }
+  };
+
+  create = async (req: Request, res: Response): Promise<void> => {
+    const actor = this.actor(req, res);
+    if (!actor) return;
+    try {
+      const { repositoryUrl, sourceBranchName, destinationBranchName, title, description } =
+        req.body ?? {};
+      if (!repositoryUrl || !sourceBranchName || !destinationBranchName) {
+        res.status(400).json({
+          error: 'repositoryUrl, sourceBranchName and destinationBranchName are required',
+        });
+        return;
+      }
+      const pullRequest = await ticketPullRequestService.createPullRequestFromTicket(
+        req.params.ticketId,
+        { repositoryUrl, sourceBranchName, destinationBranchName, title, description },
+        actor,
+      );
+      res.status(201).json({ pullRequest });
+    } catch (error) {
+      this.fail(res, error, 'create');
+    }
+  };
+
+  link = async (req: Request, res: Response): Promise<void> => {
+    const actor = this.actor(req, res);
+    if (!actor) return;
+    try {
+      const { pullRequestUrl } = req.body ?? {};
+      if (!pullRequestUrl) {
+        res.status(400).json({ error: 'pullRequestUrl is required' });
+        return;
+      }
+      const pullRequest = await ticketPullRequestService.linkExistingPullRequest(
+        req.params.ticketId,
+        { pullRequestUrl },
+        actor,
+      );
+      res.status(201).json({ pullRequest });
+    } catch (error) {
+      this.fail(res, error, 'link');
+    }
+  };
+
+  refresh = async (req: Request, res: Response): Promise<void> => {
+    const actor = this.actor(req, res);
+    if (!actor) return;
+    try {
+      const pullRequest = await ticketPullRequestService.refreshPullRequest(
+        req.params.ticketId,
+        req.params.pullRequestId,
+        actor,
+      );
+      res.json({ pullRequest });
+    } catch (error) {
+      this.fail(res, error, 'refresh');
+    }
+  };
+
+  unlink = async (req: Request, res: Response): Promise<void> => {
+    const actor = this.actor(req, res);
+    if (!actor) return;
+    try {
+      await ticketPullRequestService.unlinkPullRequest(
+        req.params.ticketId,
+        req.params.pullRequestId,
+        actor,
+      );
+      res.status(204).send();
+    } catch (error) {
+      this.fail(res, error, 'unlink');
+    }
+  };
+}

--- a/apps/backend/src/git-providers/bitbucket/apis.ts
+++ b/apps/backend/src/git-providers/bitbucket/apis.ts
@@ -4,6 +4,19 @@ import { transformBitbucketDiff } from '@/utils/diffUtils';
 import { PullRequestData, BitbucketDuplicatePRError } from '@/types/bitbucket';
 import { config } from '@/config/env';
 
+/** Normalized, credential-free view of a Bitbucket pull request. */
+export interface BitbucketPullRequestDetails {
+  prId: number;
+  title: string;
+  description: string;
+  state: string; // OPEN | MERGED | DECLINED (Bitbucket raw states)
+  sourceBranchName: string;
+  destinationBranchName: string;
+  prUrl: string;
+  commentCount: number;
+  reviewers: Array<{ name: string; email?: string; approved?: boolean }>;
+}
+
 const BASE_URL = config.bitbucket.baseUrl;
 
 export class BitbucketManager {
@@ -114,6 +127,52 @@ export class BitbucketManager {
         return null;
       }
     }
+
+  /**
+   * Fetch a single pull request's details from Bitbucket.
+   * Used by the ticket-initiated link/refresh flows. Returns a normalized,
+   * credential-free view of the PR. Returns null when the PR cannot be read
+   * (not found / inaccessible) so callers can surface a redacted error.
+   */
+  async getPullRequestById(
+    projectKey: string,
+    repoSlug: string,
+    prId: number,
+  ): Promise<BitbucketPullRequestDetails | null> {
+    try {
+      const url = this.buildPullRequestUrl(projectKey, repoSlug, prId);
+      const { data, status } = await this.makeRequest<any>(url, 'GET');
+      if (status < 200 || status >= 300) {
+        logger.warn(`[Bitbucket-API] getPullRequestById ${prId} returned status ${status}`);
+        return null;
+      }
+      const reviewers = Array.isArray(data?.reviewers)
+        ? data.reviewers.map((r: any) => ({
+            name: r?.user?.displayName ?? r?.user?.name ?? 'Unknown',
+            email: r?.user?.emailAddress ?? undefined,
+            approved: Boolean(r?.approved),
+          }))
+        : [];
+      return {
+        prId: data?.id ?? prId,
+        title: data?.title ?? '',
+        description: data?.description ?? '',
+        state: data?.state ?? 'OPEN',
+        sourceBranchName: data?.fromRef?.displayId ?? '',
+        destinationBranchName: data?.toRef?.displayId ?? '',
+        prUrl: data?.links?.self?.[0]?.href ?? '',
+        commentCount:
+          typeof data?.properties?.commentCount === 'number'
+            ? data.properties.commentCount
+            : 0,
+        reviewers,
+      };
+    } catch (error) {
+      // Do NOT surface raw provider errors (may contain credentials/host detail).
+      logger.error(`[Bitbucket-API] Error fetching PR ${prId}:`, error);
+      return null;
+    }
+  }
 
   async raisePr(
     repoUrl: string,

--- a/apps/backend/src/routes/tickets.ts
+++ b/apps/backend/src/routes/tickets.ts
@@ -12,6 +12,7 @@ import { ReleaseReportController } from '@/controllers/releaseReportController';
 import { authorize } from '@/middleware/authorize';
 import { analyticsAuthMiddleware } from '@/middleware/analyticsAuth';
 import { FlowRunExportController } from '@/controllers/flowRunExportController';
+import { TicketPullRequestController } from '@/controllers/ticketPullRequestController';
 
 const router = Router();
 const ticketController = new TicketController();
@@ -20,6 +21,7 @@ const analyticsController = new AnalyticsController();
 const kanbanTicketController = new KanbanTicketController();
 const releaseReportController = new ReleaseReportController();
 const flowRunExportController = new FlowRunExportController();
+const ticketPullRequestController = new TicketPullRequestController();
 
 // Note: Authentication and ACL middleware are applied at the app level
 
@@ -49,6 +51,41 @@ router.get('/:ticketId/pending-human-intervention', ticketController.getPendingH
 router.get('/:ticketId/latest-email-tags', ticketController.getLatestEmailTags);
 
 router.post('/:ticketId/attachments/from-conversation', ticketController.addAttachmentsFromConversation);
+
+// ── Ticket ⇄ Bitbucket Pull Request integration (SDLCT-0001) ────────────────
+// Reads require TICKETS.READ; mutations require TICKETS.WRITE. Feature-flag
+// gating (panel/create/link/strict) is enforced inside the service so the
+// endpoints ship dark until rolled out.
+router.get(
+  '/pull-requests/flags',
+  authorize('TICKETS', AccessType.READ),
+  ticketPullRequestController.getFlags,
+);
+router.get(
+  '/:ticketId/pull-requests',
+  authorize('TICKETS', AccessType.READ),
+  ticketPullRequestController.list,
+);
+router.post(
+  '/:ticketId/pull-requests',
+  authorize('TICKETS', AccessType.WRITE),
+  ticketPullRequestController.create,
+);
+router.post(
+  '/:ticketId/pull-requests/link',
+  authorize('TICKETS', AccessType.WRITE),
+  ticketPullRequestController.link,
+);
+router.post(
+  '/:ticketId/pull-requests/:pullRequestId/refresh',
+  authorize('TICKETS', AccessType.WRITE),
+  ticketPullRequestController.refresh,
+);
+router.delete(
+  '/:ticketId/pull-requests/:pullRequestId',
+  authorize('TICKETS', AccessType.WRITE),
+  ticketPullRequestController.unlink,
+);
 
 router.post('/:ticketId/release-notes/generate', releaseNotesController.generateReleaseNotes);
 router.post(

--- a/apps/backend/src/services/ticketPrFeatureFlags.ts
+++ b/apps/backend/src/services/ticketPrFeatureFlags.ts
@@ -1,0 +1,63 @@
+// Feature-flag gates for the ticket-initiated Bitbucket PR integration.
+//
+// All flags DEFAULT TO FALSE so the feature ships dark and is rolled out per
+// the Tech Doc's staged plan (read-only panel first, then link, then create,
+// then webhook sync, then strict validation). Flags resolve through the
+// existing Superposition client and fall back to the default on any error.
+
+import { superpositionClient } from '@/services/superpositionClient';
+import { logger } from '@/utils/logger';
+
+export const TICKET_PR_FLAGS = {
+  PANEL: 'ticket_pr_panel_enabled',
+  CREATE: 'ticket_pr_create_enabled',
+  LINK: 'ticket_pr_link_enabled',
+  WEBHOOK_SYNC: 'ticket_pr_webhook_sync_enabled',
+  STRICT_VALIDATION: 'ticket_pr_strict_validation_enabled',
+} as const;
+
+export type TicketPrFlagKey = (typeof TICKET_PR_FLAGS)[keyof typeof TICKET_PR_FLAGS];
+
+export interface TicketPrFlagContext {
+  workspaceId?: string;
+  userId?: string;
+  boardId?: string;
+}
+
+/**
+ * Resolve a single ticket-PR feature flag. Never throws — returns `false` if
+ * Superposition is unavailable, so a misconfigured flag store cannot
+ * accidentally enable a write path.
+ */
+export async function isTicketPrFlagEnabled(
+  flag: TicketPrFlagKey,
+  context: TicketPrFlagContext = {},
+): Promise<boolean> {
+  try {
+    if (!superpositionClient.isReady()) {
+      return false;
+    }
+    // Build a plain string record so it satisfies OpenFeature's EvaluationContext
+    // index-signature (a named-optional interface does not).
+    const evalContext: Record<string, string> = {};
+    if (context.workspaceId) evalContext.workspaceId = context.workspaceId;
+    if (context.userId) evalContext.userId = context.userId;
+    if (context.boardId) evalContext.boardId = context.boardId;
+    return await superpositionClient.getBooleanValue(flag, false, evalContext);
+  } catch (error) {
+    logger.error(`[TicketPR] Failed to resolve flag '${flag}':`, error);
+    return false;
+  }
+}
+
+/** Resolve all ticket-PR flags at once (used by the panel bootstrap endpoint). */
+export async function resolveTicketPrFlags(
+  context: TicketPrFlagContext = {},
+): Promise<Record<TicketPrFlagKey, boolean>> {
+  const entries = await Promise.all(
+    Object.values(TICKET_PR_FLAGS).map(
+      async (flag) => [flag, await isTicketPrFlagEnabled(flag, context)] as const,
+    ),
+  );
+  return Object.fromEntries(entries) as Record<TicketPrFlagKey, boolean>;
+}

--- a/apps/backend/src/services/ticketPrValidation.test.ts
+++ b/apps/backend/src/services/ticketPrValidation.test.ts
@@ -1,0 +1,106 @@
+// Unit tests for the pure ticket-PR helpers. No DB/provider — safe to run in CI.
+
+import {
+  parseBitbucketRepoUrl,
+  parseBitbucketPrUrl,
+  extractTicketKeyFromTitle,
+  computeValidation,
+} from './ticketPrValidation';
+
+describe('parseBitbucketRepoUrl', () => {
+  it('parses a standard repo URL', () => {
+    expect(
+      parseBitbucketRepoUrl('https://bitbucket.juspay.net/projects/XYNE/repos/xyne-spaces'),
+    ).toEqual({ projectKey: 'XYNE', repoSlug: 'xyne-spaces' });
+  });
+
+  it('strips a trailing path and .git suffix', () => {
+    expect(
+      parseBitbucketRepoUrl('https://bitbucket.juspay.net/projects/XYNE/repos/xyne-spaces.git/browse'),
+    ).toEqual({ projectKey: 'XYNE', repoSlug: 'xyne-spaces' });
+  });
+
+  it('returns null for a non-Bitbucket URL', () => {
+    expect(parseBitbucketRepoUrl('https://github.com/foo/bar')).toBeNull();
+    expect(parseBitbucketRepoUrl('')).toBeNull();
+  });
+});
+
+describe('parseBitbucketPrUrl', () => {
+  const PR = 'https://bitbucket.juspay.net/projects/XYNE/repos/xyne-spaces/pull-requests/8594';
+
+  it('parses a canonical PR URL', () => {
+    expect(parseBitbucketPrUrl(PR)).toEqual({
+      projectKey: 'XYNE',
+      repoSlug: 'xyne-spaces',
+      prId: 8594,
+      prUrl: PR,
+    });
+  });
+
+  it('strips trailing segments and query/fragment', () => {
+    expect(parseBitbucketPrUrl(`${PR}/overview?commentId=12#foo`)?.prUrl).toBe(PR);
+  });
+
+  it('returns null for a repo URL without a PR id', () => {
+    expect(
+      parseBitbucketPrUrl('https://bitbucket.juspay.net/projects/XYNE/repos/xyne-spaces'),
+    ).toBeNull();
+  });
+});
+
+describe('extractTicketKeyFromTitle', () => {
+  it.each([
+    ['XYNE-123: fix the thing', 'XYNE-123'],
+    ['feat: XYNE-123 add the thing', 'XYNE-123'],
+    ['fix: XYNE-123: subject', 'XYNE-123'],
+    ['xyne-99 lowercase key', 'XYNE-99'],
+  ])('extracts %s -> %s', (title, expected) => {
+    expect(extractTicketKeyFromTitle(title)).toBe(expected);
+  });
+
+  it('returns null when no key is present', () => {
+    expect(extractTicketKeyFromTitle('just a random title')).toBeNull();
+    expect(extractTicketKeyFromTitle('')).toBeNull();
+  });
+});
+
+describe('computeValidation', () => {
+  it('is valid when the title key matches the ticket', () => {
+    expect(
+      computeValidation({ ticketXyneId: 'XYNE-123', prTitle: 'XYNE-123: do it' }).state,
+    ).toBe('valid');
+  });
+
+  it('warns (non-strict) when the title lacks the ticket key', () => {
+    const r = computeValidation({ ticketXyneId: 'XYNE-123', prTitle: 'no key here' });
+    expect(r.state).toBe('warning');
+    expect(r.reason).toBe('missing-ticket-key');
+  });
+
+  it('is invalid (strict) when the title lacks the ticket key', () => {
+    expect(
+      computeValidation({ ticketXyneId: 'XYNE-123', prTitle: 'no key here', strict: true }).state,
+    ).toBe('invalid');
+  });
+
+  it('is invalid when the ticket is resolved regardless of title', () => {
+    const r = computeValidation({
+      ticketXyneId: 'XYNE-123',
+      prTitle: 'XYNE-123: do it',
+      ticketResolved: true,
+    });
+    expect(r.state).toBe('invalid');
+    expect(r.reason).toBe('ticket-resolved');
+  });
+
+  it('is invalid on duplicate PRs', () => {
+    const r = computeValidation({ ticketXyneId: 'XYNE-123', prTitle: 'XYNE-123', duplicate: true });
+    expect(r.state).toBe('invalid');
+    expect(r.reason).toBe('duplicate-pr');
+  });
+
+  it('is unknown when no title is available', () => {
+    expect(computeValidation({ ticketXyneId: 'XYNE-123' }).state).toBe('unknown');
+  });
+});

--- a/apps/backend/src/services/ticketPrValidation.ts
+++ b/apps/backend/src/services/ticketPrValidation.ts
@@ -1,0 +1,117 @@
+// Pure, dependency-free helpers for the ticket-initiated Bitbucket PR flow.
+//
+// Kept free of DB / provider imports so they can be unit-tested in isolation
+// and reused by both the API path and the webhook path without side effects.
+
+import type {
+  TicketPullRequestValidation,
+  TicketPullRequestValidationState,
+} from '@/types/ticketPullRequest';
+
+export interface ParsedBitbucketRepo {
+  projectKey: string;
+  repoSlug: string;
+}
+
+export interface ParsedBitbucketPr extends ParsedBitbucketRepo {
+  prId: number;
+  prUrl: string; // canonical, query/fragment stripped
+}
+
+/**
+ * Parse a Bitbucket repository URL into { projectKey, repoSlug }.
+ * Accepts e.g. https://bitbucket.host/projects/XYNE/repos/xyne-spaces (with or
+ * without a trailing path / .git suffix). Returns null when it is not a
+ * recognizable Bitbucket Server repo URL.
+ */
+export function parseBitbucketRepoUrl(repoUrl: string): ParsedBitbucketRepo | null {
+  if (!repoUrl) return null;
+  const match = repoUrl.match(/\/projects\/([^/]+)\/repos\/([^/?#]+)/i);
+  if (!match) return null;
+  const projectKey = match[1];
+  const repoSlug = match[2].replace(/\.git$/i, '');
+  if (!projectKey || !repoSlug) return null;
+  return { projectKey, repoSlug };
+}
+
+/**
+ * Parse a Bitbucket pull-request URL into repo + prId + canonical URL.
+ * Accepts .../projects/KEY/repos/SLUG/pull-requests/123[/overview?...#...].
+ * Returns null when it is not a recognizable Bitbucket PR URL.
+ */
+export function parseBitbucketPrUrl(prUrl: string): ParsedBitbucketPr | null {
+  if (!prUrl) return null;
+  const match = prUrl.match(
+    /^(https?:\/\/[^/]+\/projects\/([^/]+)\/repos\/([^/]+)\/pull-requests\/(\d+))/i,
+  );
+  if (!match) return null;
+  const canonical = match[1];
+  const projectKey = match[2];
+  const repoSlug = match[3];
+  const prId = parseInt(match[4], 10);
+  if (!Number.isFinite(prId)) return null;
+  return { projectKey, repoSlug, prId, prUrl: canonical };
+}
+
+// Same family of ticket-key patterns the validation service accepts:
+//   "feat: XYNE-123 title", "fix: XYNE-123: title", "XYNE-123: title"
+const TICKET_KEY_IN_TITLE = /^(?:(?:feat|fix):\s+)?([A-Za-z][A-Za-z0-9]*)-\s*(\d+)\s*[:\s]/;
+
+/** Extract a normalized ticket key (e.g. "XYNE-123") from a PR title, or null. */
+export function extractTicketKeyFromTitle(title: string): string | null {
+  if (!title) return null;
+  const m = title.trim().match(TICKET_KEY_IN_TITLE);
+  if (!m) return null;
+  return `${m[1].toUpperCase()}-${m[2]}`;
+}
+
+export interface ComputeValidationInput {
+  ticketXyneId: string;
+  prTitle?: string;
+  prStatus?: string; // PRStatus
+  ticketResolved?: boolean;
+  duplicate?: boolean;
+  /** Strict mode makes a missing/mismatched ticket key `invalid` instead of `warning`. */
+  strict?: boolean;
+}
+
+/**
+ * Normalize a PR's association with its ticket into a UI-ready validation
+ * object. Pure — no I/O. `unknown` is returned when there is not enough
+ * information (e.g. no title available) to make a judgement.
+ */
+export function computeValidation(input: ComputeValidationInput): TicketPullRequestValidation {
+  const { ticketXyneId, prTitle, ticketResolved, duplicate, strict } = input;
+
+  if (ticketResolved) {
+    return {
+      state: 'invalid',
+      reason: 'ticket-resolved',
+      message: `Ticket ${ticketXyneId} is already resolved.`,
+    };
+  }
+
+  if (duplicate) {
+    return {
+      state: 'invalid',
+      reason: 'duplicate-pr',
+      message: `Another PR with the same branches is already linked to ${ticketXyneId}.`,
+    };
+  }
+
+  if (prTitle === undefined || prTitle === null || prTitle === '') {
+    return { state: 'unknown' };
+  }
+
+  const keyInTitle = extractTicketKeyFromTitle(prTitle);
+  if (keyInTitle && keyInTitle.toUpperCase() === ticketXyneId.toUpperCase()) {
+    return { state: 'valid' };
+  }
+
+  const state: TicketPullRequestValidationState = strict ? 'invalid' : 'warning';
+  return {
+    state,
+    reason: 'missing-ticket-key',
+    message: `PR title does not contain this ticket key (${ticketXyneId}).`,
+  };
+}

--- a/apps/backend/src/services/ticketPullRequestService.ts
+++ b/apps/backend/src/services/ticketPullRequestService.ts
@@ -1,0 +1,445 @@
+// TicketPullRequestService
+//
+// Owns the ticket-INITIATED Bitbucket PR flow: create a PR from a ticket, link
+// an existing PR by URL, list linked PRs, refresh metadata, and unlink. The
+// webhook-INITIATED flow (Bitbucket -> ticket status/assignment) already lives
+// in bitbucketWebhookService + prTicketStatusSyncService and is unchanged here;
+// both paths converge on the same `pull_requests` persistence.
+//
+// Security: every method takes an authenticated actor and enforces that the
+// ticket belongs to the actor's workspace before mutating linkage. Repository
+// credentials and raw provider errors are never returned to callers.
+
+import type { PullRequests, Ticket } from '@prisma/client';
+import { PRStatus, ActivityType } from '@xyne/shared';
+import { DatabaseClient } from '@/database/client';
+import { TicketRepository } from '@/database/repositories/ticketRepository';
+import { PRMetricsRepository } from '@/database/repositories/pullRequestsRepository';
+import { getBitbucketManager } from '@/git-providers/factory';
+import type { BitbucketPullRequestDetails } from '@/git-providers/bitbucket/apis';
+import { recordTicketTimelineEvent } from '@/services/ticketTimelineEventService';
+import { isTicketPrFlagEnabled, TICKET_PR_FLAGS } from '@/services/ticketPrFeatureFlags';
+import {
+  parseBitbucketPrUrl,
+  parseBitbucketRepoUrl,
+  computeValidation,
+} from '@/services/ticketPrValidation';
+import {
+  TicketPullRequestError,
+  type CreateTicketPRInput,
+  type LinkTicketPRInput,
+  type TicketPullRequestDto,
+  type TicketPullRequestValidation,
+} from '@/types/ticketPullRequest';
+import { logger } from '@/utils/logger';
+
+interface Actor {
+  userId: string;
+  workspaceId: string;
+}
+
+/** Map a raw Bitbucket PR state to our PRStatus enum. */
+function mapBitbucketStateToPRStatus(state: string): PRStatus {
+  switch ((state || '').toUpperCase()) {
+    case 'MERGED':
+      return PRStatus.MERGED;
+    case 'DECLINED':
+    case 'REJECTED':
+      return PRStatus.DECLINED;
+    case 'DELETED':
+      return PRStatus.DELETED;
+    default:
+      return PRStatus.OPEN;
+  }
+}
+
+export class TicketPullRequestService {
+  private readonly prisma = DatabaseClient.getInstance();
+  private readonly ticketRepository: TicketRepository;
+  private readonly prMetricsRepository: PRMetricsRepository;
+
+  constructor(
+    ticketRepository: TicketRepository = new TicketRepository(),
+    prMetricsRepository: PRMetricsRepository = new PRMetricsRepository(),
+  ) {
+    this.ticketRepository = ticketRepository;
+    this.prMetricsRepository = prMetricsRepository;
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  async listPullRequestsForTicket(
+    ticketId: string,
+    actor: Actor,
+  ): Promise<TicketPullRequestDto[]> {
+    await this.requirePanelEnabled(actor);
+    const ticket = await this.requireTicketAccess(ticketId, actor);
+
+    const rows = await this.prisma.pullRequests.findMany({
+      where: { ticketId, workspaceId: actor.workspaceId },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    return rows.map((row) => this.toDto(row, ticket, /* validation */ undefined));
+  }
+
+  async createPullRequestFromTicket(
+    ticketId: string,
+    input: CreateTicketPRInput,
+    actor: Actor,
+  ): Promise<TicketPullRequestDto> {
+    await this.requireFlag(TICKET_PR_FLAGS.CREATE, actor);
+    const ticket = await this.requireTicketAccess(ticketId, actor);
+
+    const parsedRepo = parseBitbucketRepoUrl(input.repositoryUrl);
+    if (!parsedRepo) {
+      throw new TicketPullRequestError(
+        'INVALID_INPUT',
+        'repositoryUrl is not a recognizable Bitbucket repository URL.',
+        400,
+      );
+    }
+    if (!input.sourceBranchName || !input.destinationBranchName) {
+      throw new TicketPullRequestError(
+        'INVALID_INPUT',
+        'sourceBranchName and destinationBranchName are required.',
+        400,
+      );
+    }
+
+    const manager = getBitbucketManager();
+    // raisePr persists the PR row (with ticketId) via PRMetricsRepository and
+    // returns the PR URL. It also handles the duplicate-PR (409) case.
+    const prUrl = await manager.raisePr(
+      input.repositoryUrl,
+      /* childExecutionId */ `ticket-${ticket.id}`,
+      input.destinationBranchName,
+      input.sourceBranchName,
+      parsedRepo.projectKey,
+      parsedRepo.repoSlug,
+      input.title ?? ticket.title,
+      input.description ?? this.buildDescription(ticket),
+      ticket.xyneId,
+      ticket.id,
+    );
+
+    if (!prUrl) {
+      throw new TicketPullRequestError(
+        'PROVIDER_ERROR',
+        'Failed to create the pull request in Bitbucket. Check repository access and branch names.',
+        502,
+      );
+    }
+
+    const parsedPr = parseBitbucketPrUrl(prUrl);
+    const row = parsedPr
+      ? await this.prMetricsRepository.findPrByIdAndUrl(parsedPr.prId, parsedPr.prUrl)
+      : null;
+
+    await this.recordActivity(ticket, `raised pull request ${prUrl}`, actor.userId);
+    logger.info(
+      `[TicketPR] Created PR for ticket ${ticket.xyneId} (${ticket.id}) by ${actor.userId}: ${prUrl}`,
+    );
+
+    if (!row) {
+      // PR created in Bitbucket but the row wasn't found (e.g. race). Return a
+      // minimal DTO so the UI can still render the created PR.
+      return this.syntheticDto(ticket, prUrl, parsedPr?.prId ?? 0, input);
+    }
+    return this.toDto(row, ticket, undefined);
+  }
+
+  async linkExistingPullRequest(
+    ticketId: string,
+    input: LinkTicketPRInput,
+    actor: Actor,
+  ): Promise<TicketPullRequestDto> {
+    await this.requireFlag(TICKET_PR_FLAGS.LINK, actor);
+    const ticket = await this.requireTicketAccess(ticketId, actor);
+
+    const parsed = parseBitbucketPrUrl(input.pullRequestUrl);
+    if (!parsed) {
+      throw new TicketPullRequestError(
+        'INVALID_PR_URL',
+        'pullRequestUrl is not a recognizable Bitbucket pull-request URL.',
+        400,
+      );
+    }
+
+    const details = await this.fetchPrDetails(parsed.projectKey, parsed.repoSlug, parsed.prId);
+
+    await this.prMetricsRepository.createOrUpdatePR({
+      prId: details.prId,
+      prUrl: parsed.prUrl,
+      repoName: parsed.repoSlug,
+      repoUrl: this.repoUrlFromPrUrl(parsed.prUrl),
+      sourceBranchName: details.sourceBranchName,
+      destinationBranchName: details.destinationBranchName,
+      numberOfComments: details.commentCount,
+      ticketId: ticket.id,
+    });
+
+    const row = await this.prMetricsRepository.findPrByIdAndUrl(details.prId, parsed.prUrl);
+    const validation = await this.validateForTicket(ticket, details);
+
+    await this.recordActivity(ticket, `linked pull request ${parsed.prUrl}`, actor.userId);
+    logger.info(
+      `[TicketPR] Linked PR ${parsed.prUrl} to ticket ${ticket.xyneId} (${ticket.id}) by ${actor.userId}`,
+    );
+
+    if (!row) {
+      return this.syntheticDto(ticket, parsed.prUrl, details.prId, {
+        repositoryUrl: this.repoUrlFromPrUrl(parsed.prUrl),
+        sourceBranchName: details.sourceBranchName,
+        destinationBranchName: details.destinationBranchName,
+      });
+    }
+    return this.toDto(row, ticket, validation, details);
+  }
+
+  async refreshPullRequest(
+    ticketId: string,
+    pullRequestRowId: string,
+    actor: Actor,
+  ): Promise<TicketPullRequestDto> {
+    await this.requirePanelEnabled(actor);
+    const ticket = await this.requireTicketAccess(ticketId, actor);
+    const row = await this.requireLinkedPr(ticketId, pullRequestRowId, actor);
+
+    const parsed = parseBitbucketPrUrl(row.prUrl);
+    if (!parsed) {
+      // Nothing to refresh from provider; return the stored row.
+      return this.toDto(row, ticket, undefined);
+    }
+
+    const details = await this.fetchPrDetails(parsed.projectKey, parsed.repoSlug, parsed.prId);
+
+    await this.prMetricsRepository.createOrUpdatePR({
+      prId: details.prId,
+      prUrl: parsed.prUrl,
+      repoName: parsed.repoSlug,
+      repoUrl: row.repositoryUrl,
+      sourceBranchName: details.sourceBranchName,
+      destinationBranchName: details.destinationBranchName,
+      numberOfComments: details.commentCount,
+      ticketId: ticket.id,
+    });
+
+    const updated =
+      (await this.prMetricsRepository.findPrByIdAndUrl(details.prId, parsed.prUrl)) ?? row;
+    const validation = await this.validateForTicket(ticket, details);
+    logger.info(`[TicketPR] Refreshed PR ${parsed.prUrl} on ticket ${ticket.xyneId}`);
+    return this.toDto(updated, ticket, validation, details);
+  }
+
+  async unlinkPullRequest(
+    ticketId: string,
+    pullRequestRowId: string,
+    actor: Actor,
+  ): Promise<void> {
+    await this.requirePanelEnabled(actor);
+    const ticket = await this.requireTicketAccess(ticketId, actor);
+    const row = await this.requireLinkedPr(ticketId, pullRequestRowId, actor);
+
+    // Detach from ticket (do NOT delete the PR metric row — it is still valid
+    // history). Scope by workspace + row id to prevent cross-tenant writes.
+    await this.prisma.pullRequests.updateMany({
+      where: { id: row.id, ticketId, workspaceId: actor.workspaceId },
+      data: { ticketId: null },
+    });
+
+    await this.recordActivity(ticket, `unlinked pull request ${row.prUrl}`, actor.userId);
+    logger.info(
+      `[TicketPR] Unlinked PR ${row.prUrl} from ticket ${ticket.xyneId} by ${actor.userId}`,
+    );
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────────
+
+  private async requireTicketAccess(ticketId: string, actor: Actor): Promise<Ticket> {
+    const ticket = await this.ticketRepository.getTicketById(ticketId);
+    if (!ticket) {
+      throw new TicketPullRequestError('TICKET_NOT_FOUND', 'Ticket not found', 404);
+    }
+    if (ticket.workspaceId !== actor.workspaceId) {
+      // Do not distinguish "not found" from "forbidden" beyond the code.
+      throw new TicketPullRequestError('PERMISSION_DENIED', 'Access denied', 403);
+    }
+    return ticket;
+  }
+
+  private async requireLinkedPr(
+    ticketId: string,
+    pullRequestRowId: string,
+    actor: Actor,
+  ): Promise<PullRequests> {
+    const row = await this.prisma.pullRequests.findFirst({
+      where: { id: pullRequestRowId, ticketId, workspaceId: actor.workspaceId },
+    });
+    if (!row) {
+      throw new TicketPullRequestError('PR_NOT_FOUND', 'Pull request not linked to this ticket', 404);
+    }
+    return row;
+  }
+
+  private async requirePanelEnabled(actor: Actor): Promise<void> {
+    const enabled = await isTicketPrFlagEnabled(TICKET_PR_FLAGS.PANEL, {
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+    });
+    if (!enabled) {
+      throw new TicketPullRequestError('FEATURE_DISABLED', 'Ticket PR panel is not enabled', 403);
+    }
+  }
+
+  private async requireFlag(flag: string, actor: Actor): Promise<void> {
+    await this.requirePanelEnabled(actor);
+    const enabled = await isTicketPrFlagEnabled(flag as never, {
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+    });
+    if (!enabled) {
+      throw new TicketPullRequestError('FEATURE_DISABLED', 'This action is not enabled', 403);
+    }
+  }
+
+  private async fetchPrDetails(
+    projectKey: string,
+    repoSlug: string,
+    prId: number,
+  ): Promise<BitbucketPullRequestDetails> {
+    const manager = getBitbucketManager();
+    const details = await manager.getPullRequestById(projectKey, repoSlug, prId);
+    if (!details) {
+      throw new TicketPullRequestError(
+        'REPOSITORY_INACCESSIBLE',
+        'Unable to read the pull request from Bitbucket. Check the URL and repository access.',
+        502,
+      );
+    }
+    return details;
+  }
+
+  private async validateForTicket(
+    ticket: Ticket,
+    details: BitbucketPullRequestDetails,
+  ): Promise<TicketPullRequestValidation> {
+    const strict = await isTicketPrFlagEnabled(TICKET_PR_FLAGS.STRICT_VALIDATION, {
+      workspaceId: ticket.workspaceId,
+      boardId: ticket.boardId,
+    });
+    return computeValidation({
+      ticketXyneId: ticket.xyneId,
+      prTitle: details.title,
+      prStatus: mapBitbucketStateToPRStatus(details.state),
+      ticketResolved: ticket.status === 'RESOLVED',
+      strict,
+    });
+  }
+
+  private toDto(
+    row: PullRequests,
+    ticket: Ticket,
+    validation?: TicketPullRequestValidation,
+    details?: BitbucketPullRequestDetails,
+  ): TicketPullRequestDto {
+    return {
+      id: row.id,
+      prId: row.prId,
+      repoName: row.repoName,
+      repositoryUrl: row.repositoryUrl ?? null,
+      sourceBranchName: row.sourceBranchName,
+      destinationBranchName: row.destinationBranchName,
+      status: row.status,
+      prUrl: row.prUrl ?? null,
+      ticketId: ticket.id,
+      validation: validation ?? this.cheapValidation(row, ticket),
+      reviewers: details?.reviewers,
+      commentCount: details?.commentCount ?? row.numberOfComments,
+      lastSyncedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : undefined,
+    };
+  }
+
+  /**
+   * Best-effort validation on list without a provider round-trip: we only know
+   * ticket-resolved and status. Title-based checks require refresh.
+   */
+  private cheapValidation(row: PullRequests, ticket: Ticket): TicketPullRequestValidation {
+    if (ticket.status === 'RESOLVED') {
+      return {
+        state: 'warning',
+        reason: 'ticket-resolved',
+        message: `Ticket ${ticket.xyneId} is already resolved.`,
+      };
+    }
+    if (row.status === PRStatus.DELETED) {
+      return { state: 'unknown' };
+    }
+    return { state: 'unknown' };
+  }
+
+  private syntheticDto(
+    ticket: Ticket,
+    prUrl: string,
+    prId: number,
+    input: {
+      repositoryUrl?: string;
+      sourceBranchName?: string;
+      destinationBranchName?: string;
+    },
+  ): TicketPullRequestDto {
+    return {
+      id: `pending-${prId}`,
+      prId,
+      repoName: parseBitbucketRepoUrl(input.repositoryUrl ?? prUrl)?.repoSlug ?? '',
+      repositoryUrl: input.repositoryUrl ?? this.repoUrlFromPrUrl(prUrl),
+      sourceBranchName: input.sourceBranchName ?? '',
+      destinationBranchName: input.destinationBranchName ?? '',
+      status: PRStatus.OPEN,
+      prUrl,
+      ticketId: ticket.id,
+      validation: { state: 'unknown' },
+    };
+  }
+
+  private repoUrlFromPrUrl(prUrl: string): string {
+    // Strip the /pull-requests/<id> suffix to get the repo URL.
+    return prUrl.replace(/\/pull-requests\/\d+.*$/i, '');
+  }
+
+  private buildDescription(ticket: Ticket): string {
+    return [
+      `Xyne ticket: ${ticket.xyneId}`,
+      '',
+      ticket.description ?? '',
+    ].join('\n');
+  }
+
+  private async recordActivity(ticket: Ticket, value: string, actorUserId: string): Promise<void> {
+    try {
+      await recordTicketTimelineEvent({
+        activity: {
+          ticketId: ticket.id,
+          updatedBy: actorUserId,
+          activityType: ActivityType.PR,
+          value,
+          workspaceId: ticket.workspaceId,
+          channelId: ticket.channelId,
+        },
+        message: {
+          conversationId: ticket.conversationId,
+          senderId: actorUserId,
+          content: value,
+          workspaceId: ticket.workspaceId,
+          activityType: ActivityType.PR,
+        },
+      });
+    } catch (error) {
+      // Activity is best-effort; never fail the PR operation because the
+      // timeline write failed.
+      logger.error(`[TicketPR] Failed to record activity for ticket ${ticket.id}:`, error);
+    }
+  }
+}
+
+export const ticketPullRequestService = new TicketPullRequestService();

--- a/apps/backend/src/types/ticketPullRequest.ts
+++ b/apps/backend/src/types/ticketPullRequest.ts
@@ -1,0 +1,87 @@
+// DTOs and input contracts for the ticket-initiated Bitbucket Pull Request flow.
+//
+// These types are the boundary between the ticket PR API/controller and the
+// dashboard. They MUST NOT carry any provider credentials, tokens, or raw
+// Bitbucket error payloads — only user-safe, display-ready data.
+
+export type TicketPullRequestValidationState = 'valid' | 'warning' | 'invalid' | 'unknown';
+
+export type TicketPullRequestValidationReason =
+  | 'missing-ticket-key'
+  | 'duplicate-pr'
+  | 'ticket-resolved'
+  | 'repository-inaccessible'
+  | 'permission-denied';
+
+export interface TicketPullRequestValidation {
+  state: TicketPullRequestValidationState;
+  reason?: TicketPullRequestValidationReason;
+  message?: string;
+}
+
+export interface TicketPullRequestReviewer {
+  name: string;
+  email?: string;
+  approved?: boolean;
+}
+
+/**
+ * User-facing representation of a PR linked to a ticket. Mirrors the
+ * `PullRequests` row plus opportunistically-computed validation/metadata.
+ */
+export interface TicketPullRequestDto {
+  id: string;
+  prId: number;
+  repoName: string;
+  repositoryUrl: string | null;
+  sourceBranchName: string;
+  destinationBranchName: string;
+  status: string; // OPEN | UPDATED | MERGED | DECLINED | DELETED (PRStatus)
+  prUrl: string | null;
+  ticketId: string;
+  validation: TicketPullRequestValidation;
+  reviewers?: TicketPullRequestReviewer[];
+  commentCount?: number;
+  lastSyncedAt?: string;
+}
+
+export interface CreateTicketPRInput {
+  /** Full Bitbucket repository URL, e.g. https://bitbucket.host/projects/KEY/repos/slug */
+  repositoryUrl: string;
+  sourceBranchName: string;
+  destinationBranchName: string;
+  title?: string;
+  description?: string;
+}
+
+export interface LinkTicketPRInput {
+  /** Full Bitbucket pull-request URL. */
+  pullRequestUrl: string;
+}
+
+/**
+ * Typed service errors. Mapped to HTTP status + `{ error }` at the controller
+ * boundary so route handlers stay thin and no raw errors leak to clients.
+ */
+export type TicketPullRequestErrorCode =
+  | 'TICKET_NOT_FOUND'
+  | 'PERMISSION_DENIED'
+  | 'FEATURE_DISABLED'
+  | 'INVALID_INPUT'
+  | 'INVALID_PR_URL'
+  | 'REPOSITORY_INACCESSIBLE'
+  | 'PROVIDER_ERROR'
+  | 'PR_NOT_FOUND'
+  | 'PROVIDER_UNSUPPORTED';
+
+export class TicketPullRequestError extends Error {
+  code: TicketPullRequestErrorCode;
+  httpStatus: number;
+
+  constructor(code: TicketPullRequestErrorCode, message: string, httpStatus: number) {
+    super(message);
+    this.name = 'TicketPullRequestError';
+    this.code = code;
+    this.httpStatus = httpStatus;
+  }
+}

--- a/apps/dashboard/src/api/ticketPullRequestsApi.ts
+++ b/apps/dashboard/src/api/ticketPullRequestsApi.ts
@@ -1,0 +1,94 @@
+import { apiInstance } from '../services/clients/apiClient';
+
+// Client for the ticket-initiated Bitbucket PR endpoints (SDLCT-0001).
+// Mirrors the backend DTO in apps/backend/src/types/ticketPullRequest.ts.
+
+export type TicketPrValidationState = 'valid' | 'warning' | 'invalid' | 'unknown';
+
+export interface TicketPrValidation {
+  state: TicketPrValidationState;
+  reason?: string;
+  message?: string;
+}
+
+export interface TicketPrReviewer {
+  name: string;
+  email?: string;
+  approved?: boolean;
+}
+
+export interface TicketPullRequest {
+  id: string;
+  prId: number;
+  repoName: string;
+  repositoryUrl: string | null;
+  sourceBranchName: string;
+  destinationBranchName: string;
+  status: string;
+  prUrl: string | null;
+  ticketId: string;
+  validation: TicketPrValidation;
+  reviewers?: TicketPrReviewer[];
+  commentCount?: number;
+  lastSyncedAt?: string;
+}
+
+export interface TicketPrFlags {
+  ticket_pr_panel_enabled: boolean;
+  ticket_pr_create_enabled: boolean;
+  ticket_pr_link_enabled: boolean;
+  ticket_pr_webhook_sync_enabled: boolean;
+  ticket_pr_strict_validation_enabled: boolean;
+}
+
+export interface CreateTicketPrPayload {
+  repositoryUrl: string;
+  sourceBranchName: string;
+  destinationBranchName: string;
+  title?: string;
+  description?: string;
+}
+
+export const ticketPullRequestsApi = {
+  getFlags: async (): Promise<TicketPrFlags> => {
+    const res = await apiInstance.get<{ flags: TicketPrFlags }>('/tickets/pull-requests/flags');
+    return res.data.flags;
+  },
+
+  list: async (ticketId: string): Promise<TicketPullRequest[]> => {
+    const res = await apiInstance.get<{ pullRequests: TicketPullRequest[] }>(
+      `/tickets/${ticketId}/pull-requests`,
+    );
+    return res.data.pullRequests;
+  },
+
+  create: async (
+    ticketId: string,
+    payload: CreateTicketPrPayload,
+  ): Promise<TicketPullRequest> => {
+    const res = await apiInstance.post<{ pullRequest: TicketPullRequest }>(
+      `/tickets/${ticketId}/pull-requests`,
+      payload,
+    );
+    return res.data.pullRequest;
+  },
+
+  link: async (ticketId: string, pullRequestUrl: string): Promise<TicketPullRequest> => {
+    const res = await apiInstance.post<{ pullRequest: TicketPullRequest }>(
+      `/tickets/${ticketId}/pull-requests/link`,
+      { pullRequestUrl },
+    );
+    return res.data.pullRequest;
+  },
+
+  refresh: async (ticketId: string, pullRequestId: string): Promise<TicketPullRequest> => {
+    const res = await apiInstance.post<{ pullRequest: TicketPullRequest }>(
+      `/tickets/${ticketId}/pull-requests/${pullRequestId}/refresh`,
+    );
+    return res.data.pullRequest;
+  },
+
+  unlink: async (ticketId: string, pullRequestId: string): Promise<void> => {
+    await apiInstance.delete(`/tickets/${ticketId}/pull-requests/${pullRequestId}`);
+  },
+};

--- a/apps/dashboard/src/components/Tickets/PullRequests/PullRequestsPanel.tsx
+++ b/apps/dashboard/src/components/Tickets/PullRequests/PullRequestsPanel.tsx
@@ -1,0 +1,304 @@
+import { useState } from 'react';
+import type { CSSProperties } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  ticketPullRequestsApi,
+  type TicketPullRequest,
+} from '../../../api/ticketPullRequestsApi';
+import { branchLabel, statusSwatch, validationSwatch } from './prPresentation';
+
+// PullRequestsPanel — ticket-detail surface for the Bitbucket PR integration
+// (SDLCT-0001). Lists PRs linked to a ticket, links an existing PR by URL, and
+// creates a PR from the ticket. All actions are feature-flag gated by the
+// backend; the panel hides create/link controls when the flags are off.
+//
+// Self-contained (inline styles + react-query) so it can be dropped into the
+// ticket detail view without pulling in board-specific context.
+
+interface PullRequestsPanelProps {
+  ticketId: string;
+}
+
+const styles = {
+  panel: {
+    border: '1px solid #eaecf0',
+    borderRadius: 8,
+    padding: 16,
+    fontSize: 13,
+    color: '#101828',
+    background: '#fff',
+  },
+  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 },
+  title: { fontWeight: 600, fontSize: 14 },
+  actions: { display: 'flex', gap: 8 },
+  button: {
+    border: '1px solid #d0d5dd',
+    borderRadius: 6,
+    padding: '6px 10px',
+    background: '#fff',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontWeight: 500,
+  },
+  primaryButton: {
+    border: '1px solid #155eef',
+    borderRadius: 6,
+    padding: '6px 10px',
+    background: '#155eef',
+    color: '#fff',
+    cursor: 'pointer',
+    fontSize: 12,
+    fontWeight: 500,
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '10px 0',
+    borderTop: '1px solid #f2f4f7',
+    gap: 12,
+  },
+  badge: { borderRadius: 12, padding: '2px 8px', fontSize: 11, fontWeight: 600, whiteSpace: 'nowrap' },
+  link: { color: '#155eef', textDecoration: 'none', fontWeight: 500 },
+  meta: { color: '#667085', fontSize: 12 },
+  empty: { color: '#667085', padding: '12px 0' },
+  input: {
+    border: '1px solid #d0d5dd',
+    borderRadius: 6,
+    padding: '8px 10px',
+    fontSize: 13,
+    width: '100%',
+    boxSizing: 'border-box',
+  },
+  form: { display: 'flex', flexDirection: 'column', gap: 8, marginTop: 12 },
+  formRow: { display: 'flex', gap: 8 },
+  error: { color: '#b42318', fontSize: 12, marginTop: 4 },
+} satisfies Record<string, CSSProperties>;
+
+function readError(err: unknown): string {
+  const anyErr = err as { response?: { data?: { error?: string } }; message?: string };
+  return anyErr?.response?.data?.error ?? anyErr?.message ?? 'Something went wrong';
+}
+
+export function PullRequestsPanel({ ticketId }: PullRequestsPanelProps) {
+  const queryClient = useQueryClient();
+  const [mode, setMode] = useState<'idle' | 'link' | 'create'>('idle');
+
+  const flagsQuery = useQuery({
+    queryKey: ['ticket-pr-flags'],
+    queryFn: ticketPullRequestsApi.getFlags,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const listQuery = useQuery({
+    queryKey: ['ticket-prs', ticketId],
+    queryFn: () => ticketPullRequestsApi.list(ticketId),
+    enabled: flagsQuery.data?.ticket_pr_panel_enabled ?? false,
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ['ticket-prs', ticketId] });
+
+  const refreshMutation = useMutation({
+    mutationFn: (prRowId: string) => ticketPullRequestsApi.refresh(ticketId, prRowId),
+    onSuccess: invalidate,
+  });
+
+  const unlinkMutation = useMutation({
+    mutationFn: (prRowId: string) => ticketPullRequestsApi.unlink(ticketId, prRowId),
+    onSuccess: invalidate,
+  });
+
+  // Panel is fully dark unless the flag is enabled for this workspace/user.
+  if (flagsQuery.data && !flagsQuery.data.ticket_pr_panel_enabled) {
+    return null;
+  }
+
+  const flags = flagsQuery.data;
+  const prs = listQuery.data ?? [];
+
+  return (
+    <div style={styles.panel}>
+      <div style={styles.header}>
+        <div style={styles.title}>Pull Requests</div>
+        <div style={styles.actions}>
+          {flags?.ticket_pr_link_enabled && (
+            <button style={styles.button} onClick={() => setMode(mode === 'link' ? 'idle' : 'link')}>
+              Link PR
+            </button>
+          )}
+          {flags?.ticket_pr_create_enabled && (
+            <button
+              style={styles.primaryButton}
+              onClick={() => setMode(mode === 'create' ? 'idle' : 'create')}
+            >
+              Create PR
+            </button>
+          )}
+        </div>
+      </div>
+
+      {listQuery.isLoading && <div style={styles.meta}>Loading pull requests…</div>}
+      {listQuery.isError && <div style={styles.error}>{readError(listQuery.error)}</div>}
+
+      {!listQuery.isLoading && prs.length === 0 && (
+        <div style={styles.empty}>No pull requests linked to this ticket yet.</div>
+      )}
+
+      {prs.map((pr) => (
+        <PullRequestRow
+          key={pr.id}
+          pr={pr}
+          onRefresh={() => refreshMutation.mutate(pr.id)}
+          onUnlink={() => unlinkMutation.mutate(pr.id)}
+          busy={refreshMutation.isPending || unlinkMutation.isPending}
+        />
+      ))}
+
+      {mode === 'link' && (
+        <LinkPrForm ticketId={ticketId} onDone={() => { setMode('idle'); invalidate(); }} />
+      )}
+      {mode === 'create' && (
+        <CreatePrForm ticketId={ticketId} onDone={() => { setMode('idle'); invalidate(); }} />
+      )}
+    </div>
+  );
+}
+
+function PullRequestRow({
+  pr,
+  onRefresh,
+  onUnlink,
+  busy,
+}: {
+  pr: TicketPullRequest;
+  onRefresh: () => void;
+  onUnlink: () => void;
+  busy: boolean;
+}) {
+  const status = statusSwatch(pr.status);
+  const validation = validationSwatch(pr.validation.state);
+  return (
+    <div style={styles.row}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {pr.prUrl ? (
+            <a style={styles.link} href={pr.prUrl} target="_blank" rel="noreferrer">
+              {pr.repoName} #{pr.prId}
+            </a>
+          ) : (
+            <span style={styles.link}>{pr.repoName} #{pr.prId}</span>
+          )}
+          <span style={{ ...styles.badge, color: status.color, background: status.background }}>
+            {status.label}
+          </span>
+          <span
+            style={{ ...styles.badge, color: validation.color, background: validation.background }}
+            title={pr.validation.message}
+          >
+            {validation.label}
+          </span>
+        </div>
+        <div style={styles.meta}>{branchLabel(pr)}</div>
+        {pr.validation.message && pr.validation.state !== 'valid' && (
+          <div style={{ ...styles.meta, color: validation.color }}>{pr.validation.message}</div>
+        )}
+      </div>
+      <div style={styles.actions}>
+        <button style={styles.button} disabled={busy} onClick={onRefresh}>
+          Refresh
+        </button>
+        <button style={styles.button} disabled={busy} onClick={onUnlink}>
+          Unlink
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LinkPrForm({ ticketId, onDone }: { ticketId: string; onDone: () => void }) {
+  const [url, setUrl] = useState('');
+  const mutation = useMutation({
+    mutationFn: () => ticketPullRequestsApi.link(ticketId, url.trim()),
+    onSuccess: onDone,
+  });
+  return (
+    <div style={styles.form}>
+      <input
+        style={styles.input}
+        placeholder="Paste a Bitbucket pull-request URL"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+      />
+      {mutation.isError && <div style={styles.error}>{readError(mutation.error)}</div>}
+      <div style={styles.formRow}>
+        <button
+          style={styles.primaryButton}
+          disabled={!url.trim() || mutation.isPending}
+          onClick={() => mutation.mutate()}
+        >
+          {mutation.isPending ? 'Linking…' : 'Link'}
+        </button>
+        <button style={styles.button} onClick={onDone}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CreatePrForm({ ticketId, onDone }: { ticketId: string; onDone: () => void }) {
+  const [repositoryUrl, setRepositoryUrl] = useState('');
+  const [sourceBranchName, setSourceBranchName] = useState('');
+  const [destinationBranchName, setDestinationBranchName] = useState('');
+  const mutation = useMutation({
+    mutationFn: () =>
+      ticketPullRequestsApi.create(ticketId, {
+        repositoryUrl: repositoryUrl.trim(),
+        sourceBranchName: sourceBranchName.trim(),
+        destinationBranchName: destinationBranchName.trim(),
+      }),
+    onSuccess: onDone,
+  });
+  const ready =
+    repositoryUrl.trim() && sourceBranchName.trim() && destinationBranchName.trim();
+  return (
+    <div style={styles.form}>
+      <input
+        style={styles.input}
+        placeholder="Repository URL (https://bitbucket…/projects/KEY/repos/slug)"
+        value={repositoryUrl}
+        onChange={(e) => setRepositoryUrl(e.target.value)}
+      />
+      <div style={styles.formRow}>
+        <input
+          style={styles.input}
+          placeholder="Source branch"
+          value={sourceBranchName}
+          onChange={(e) => setSourceBranchName(e.target.value)}
+        />
+        <input
+          style={styles.input}
+          placeholder="Destination branch"
+          value={destinationBranchName}
+          onChange={(e) => setDestinationBranchName(e.target.value)}
+        />
+      </div>
+      {mutation.isError && <div style={styles.error}>{readError(mutation.error)}</div>}
+      <div style={styles.formRow}>
+        <button
+          style={styles.primaryButton}
+          disabled={!ready || mutation.isPending}
+          onClick={() => mutation.mutate()}
+        >
+          {mutation.isPending ? 'Creating…' : 'Create pull request'}
+        </button>
+        <button style={styles.button} onClick={onDone}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default PullRequestsPanel;

--- a/apps/dashboard/src/components/Tickets/PullRequests/prPresentation.ts
+++ b/apps/dashboard/src/components/Tickets/PullRequests/prPresentation.ts
@@ -1,0 +1,48 @@
+// Presentation helpers for the ticket PR panel: colors + labels for PR status
+// and validation state. Pure, no React — easy to reuse and unit-test.
+
+import type {
+  TicketPrValidationState,
+  TicketPullRequest,
+} from '../../../api/ticketPullRequestsApi';
+
+export interface Swatch {
+  label: string;
+  color: string; // text color
+  background: string; // badge background
+}
+
+export function statusSwatch(status: string): Swatch {
+  switch ((status || '').toUpperCase()) {
+    case 'MERGED':
+      return { label: 'Merged', color: '#6f42c1', background: '#f3edff' };
+    case 'DECLINED':
+      return { label: 'Declined', color: '#b42318', background: '#fef3f2' };
+    case 'DELETED':
+      return { label: 'Deleted', color: '#667085', background: '#f2f4f7' };
+    case 'UPDATED':
+      return { label: 'Updated', color: '#175cd3', background: '#eff8ff' };
+    case 'OPEN':
+    default:
+      return { label: 'Open', color: '#067647', background: '#ecfdf3' };
+  }
+}
+
+export function validationSwatch(state: TicketPrValidationState): Swatch {
+  switch (state) {
+    case 'valid':
+      return { label: 'Valid', color: '#067647', background: '#ecfdf3' };
+    case 'warning':
+      return { label: 'Warning', color: '#b54708', background: '#fffaeb' };
+    case 'invalid':
+      return { label: 'Invalid', color: '#b42318', background: '#fef3f2' };
+    case 'unknown':
+    default:
+      return { label: 'Unchecked', color: '#667085', background: '#f2f4f7' };
+  }
+}
+
+export function branchLabel(pr: TicketPullRequest): string {
+  if (!pr.sourceBranchName && !pr.destinationBranchName) return '';
+  return `${pr.sourceBranchName || '?'} → ${pr.destinationBranchName || '?'}`;
+}


### PR DESCRIPTION
## SDLCT-0001 — Bitbucket Pull Request integration for Xyne Tickets

Adds the **ticket-initiated** Bitbucket PR flow: list, link-by-URL, create, refresh, and unlink pull requests directly from a ticket, with opportunistic title/state validation and a staged, feature-flag-gated dashboard panel. The existing webhook→ticket sync path is unchanged; both paths converge on the same `pull_requests` persistence.

### Backend
- `getPullRequestById` on `BitbucketManager` returns a credential-free `BitbucketPullRequestDetails` DTO — no tokens or raw provider errors leak to callers.
- `ticketPullRequestService` owns the flow; enforces workspace ownership on every mutation and maps rows to a user-safe `TicketPullRequestDto`.
- `ticketPrValidation` — pure, DB-free helpers (repo/PR URL parsing, ticket-key extraction, `computeValidation`); unit tested in isolation.
- `ticketPrFeatureFlags` — five flags default **FALSE** via Superposition and never throw (return `false` when unavailable) so misconfiguration cannot open a write path.
- `ticketPullRequestController` + ticket-scoped routes under `/api/tickets`, gated by `authorize('TICKETS', READ|WRITE)` plus the feature flags.

### Dashboard
- `ticketPullRequestsApi` client + a self-contained `PullRequestsPanel` (react-query) that stays fully dark until the panel flag is enabled.

### Tests
- `ticketPrValidation.test.ts` — 17 cases (all passing).

### Validation
- Backend `tsc --noEmit`: 0 errors.
- Backend jest (`ticketPrValidation.test.ts`): 17/17 passing.
- Dashboard `tsc --noEmit`: clean for all new files.

### Rollout
Ship dark. Enable flags in order: panel → link → create → webhook sync → strict validation.

Ticket: SDLCT-0001