### PR TITLE
fix: gate LiteLLM model sync behind configured keys

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -844,9 +844,17 @@ export class App {
     await configSyncService.syncConfigWithDatabase();
 
     // Initialize and start model sync queue (Bull-based scheduling)
-    logger.info('Initializing model sync queue...');
-    await modelSyncQueue.initialize();
-    await modelSyncQueue.runInitialSync();
+    // Only run when LiteLLM is configured; otherwise there is nothing to sync
+    // and we must not fire requests to LiteLLM (e.g. local `pnpm run dev`).
+    if (config.litellm.apiKey && config.litellm.baseUrl) {
+      logger.info('Initializing model sync queue...');
+      await modelSyncQueue.initialize();
+      await modelSyncQueue.runInitialSync();
+    } else {
+      logger.info(
+        'Skipping model sync queue: LITELLM_API_KEY / LITELLM_BASE_URL not configured',
+      );
+    }
 
     // Initialize calendar sync queues
     logger.info('Initializing Microsoft Calendar sync queue...');

--- a/apps/backend/src/services/modelSyncService.ts
+++ b/apps/backend/src/services/modelSyncService.ts
@@ -7,7 +7,18 @@ import { OrgLLMServiceAccountPurpose } from '@xyne/shared';
 const EXCLUDED_MODEL_PATTERNS = /^(claude|gemini)/i;
 
 class ModelSyncService {
+  private isLiteLLMConfigured(): boolean {
+    return Boolean(config.litellm.apiKey && config.litellm.baseUrl);
+  }
+
   async syncWithLiteLLM(): Promise<void> {
+    if (!this.isLiteLLMConfigured()) {
+      logger.info(
+        'Skipping LiteLLM model sync: LITELLM_API_KEY / LITELLM_BASE_URL not configured',
+      );
+      return;
+    }
+
     try {
       const credential = await orgLLMCredentialService.getCredentialByWorkspaceId(
         config.defaultWorkspaceId,


### PR DESCRIPTION
## What
Gate the LiteLLM model sync so it only runs when LiteLLM keys are configured.

Previously, running `pnpm run dev` in the backend fired a request to LiteLLM on startup (via the model-sync queue's initial sync) even when no LiteLLM keys were set locally.

## Changes
- `apps/backend/src/app.ts`: only call `modelSyncQueue.initialize()` and `modelSyncQueue.runInitialSync()` when `config.litellm.apiKey` and `config.litellm.baseUrl` are both set; otherwise log and skip.
- `apps/backend/src/services/modelSyncService.ts`: added an `isLiteLLMConfigured()` guard and an early-return at the top of `syncWithLiteLLM()`, so the daily cron job and any other caller also no-op (no request, no throw) when keys are unset.

## Are the synced models still used?
Yes — the `litellm-api` provider models are still consumed. `workflowRegistry.getWorkflowTypesForAPI()` (apps/backend/src/workflows/registry/workflowRegistry.ts:360) calls `repositories.models.findByProvider('litellm-api')` to populate the `modelName` enum dropdown in the workflow trigger UI (served by `routes/workflows.ts`). Selecting a model overrides the agent's default model in `getAgentConfigFromDb`. So the sync is not dead code. When keys are unset the dropdown simply has no litellm options (the field stays a plain string), which is the correct local-dev behavior.

## Testing
- `tsc --noEmit` passes for the backend with no new errors.