### PR TITLE
feat: improve notification delivery reliability

### DIFF
--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -170,6 +170,27 @@ interface UserPreferences {
   };
 }
 
+interface BrowserPushFallbackResult {
+  attempted: number;
+  delivered: number;
+  failed: number;
+}
+
+function isBrowserPushPermanentFailure(error: unknown): boolean {
+  const statusCode = (error as { statusCode?: number; status?: number })?.statusCode
+    ?? (error as { statusCode?: number; status?: number })?.status;
+
+  return statusCode === 404 || statusCode === 410;
+}
+
+function getBrowserPushErrorDetails(error: unknown): { statusCode?: number; message: string } {
+  const maybeError = error as { statusCode?: number; status?: number; message?: string };
+  return {
+    statusCode: maybeError?.statusCode ?? maybeError?.status,
+    message: maybeError?.message ?? 'Browser push delivery failed',
+  };
+}
+
 class NotificationService {
   constructor() {
     this.initializeWebPush();
@@ -532,7 +553,7 @@ class NotificationService {
         );
 
         const existingMetadata = (existingWorkflowMessage.metadata as any) || {};
-        let updatedMetadata = {
+        const updatedMetadata = {
           ...existingMetadata,
           workflowStatus:
             status === 'SUCCESS' ? 'SUCCESS' : status === 'FAILURE' ? 'FAILED' : status,
@@ -834,6 +855,120 @@ class NotificationService {
     return fcmPushService.isSendEnabled();
   }
 
+  private isBrowserPushFallbackEnabled(): boolean {
+    if (process.env.ENABLE_BROWSER_PUSH_FALLBACK !== 'true') {
+      return false;
+    }
+
+    return Boolean(process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY);
+  }
+
+  private async sendBrowserPushFallback(
+    userId: string,
+    data: NotificationData,
+  ): Promise<BrowserPushFallbackResult> {
+    const emptyResult: BrowserPushFallbackResult = { attempted: 0, delivered: 0, failed: 0 };
+
+    try {
+      if (!this.isBrowserPushFallbackEnabled()) {
+        logger.info('[NOTIFICATION-SERVICE] BROWSER PUSH FALLBACK SKIPPED (disabled or VAPID missing)', {
+          userId,
+          notificationType: data.type,
+        });
+        return emptyResult;
+      }
+
+      const subscriptions = await repositories.browserNotificationSubscriptions.findByUserId(userId, true);
+      if (subscriptions.length === 0) {
+        logger.info('[NOTIFICATION-SERVICE] BROWSER PUSH FALLBACK SKIPPED (no subscriptions)', {
+          userId,
+          notificationType: data.type,
+        });
+        return emptyResult;
+      }
+
+      const notification = await this.createSessionNotification(
+        userId,
+        data,
+        NotificationDeliveryMethod.BROWSER,
+      );
+
+      const payload = JSON.stringify({
+        title: data.title,
+        message: data.message,
+        body: data.message,
+        notificationId: notification.id,
+        actionUrl: data.actionUrl,
+        relatedEntityType: data.relatedEntityType,
+        relatedEntityId: data.relatedEntityId,
+        metadata: data.metadata,
+        tag: `${data.type}:${data.relatedEntityId ?? notification.id}`,
+        icon: data.imageUrl || '/images/notification.png',
+        badge: '/images/notification.png',
+      });
+
+      const result: BrowserPushFallbackResult = { attempted: subscriptions.length, delivered: 0, failed: 0 };
+
+      await Promise.allSettled(
+        subscriptions.map(async subscription => {
+          const pushSubscription = {
+            endpoint: subscription.endpoint,
+            keys: {
+              p256dh: subscription.p256dh,
+              auth: subscription.auth,
+            },
+          };
+
+          try {
+            await webpush.sendNotification(pushSubscription, payload);
+            result.delivered += 1;
+            await repositories.browserNotificationSubscriptions.updateLastUsed(subscription.id);
+          } catch (error) {
+            result.failed += 1;
+            const details = getBrowserPushErrorDetails(error);
+
+            if (isBrowserPushPermanentFailure(error)) {
+              await repositories.browserNotificationSubscriptions.deactivateByEndpoint(subscription.endpoint);
+              logger.warn('[NOTIFICATION-SERVICE] BROWSER PUSH FALLBACK DEACTIVATED invalid subscription', {
+                userId,
+                subscriptionId: subscription.id,
+                endpoint: subscription.endpoint,
+                statusCode: details.statusCode,
+                error: details.message,
+              });
+              return;
+            }
+
+            logger.warn('[NOTIFICATION-SERVICE] BROWSER PUSH FALLBACK FAILED for subscription', {
+              userId,
+              subscriptionId: subscription.id,
+              statusCode: details.statusCode,
+              error: details.message,
+            });
+          }
+        }),
+      );
+
+      logger.info('[NOTIFICATION-SERVICE] BROWSER PUSH FALLBACK completed', {
+        userId,
+        notificationId: notification.id,
+        notificationType: data.type,
+        attempted: result.attempted,
+        delivered: result.delivered,
+        failed: result.failed,
+      });
+
+      return result;
+    } catch (error) {
+      logger.warn('[NOTIFICATION-SERVICE] BROWSER PUSH FALLBACK FAILED before delivery attempts', {
+        userId,
+        notificationType: data.type,
+        error,
+      });
+      return emptyResult;
+    }
+  }
+
   /**
    * Unified notification delivery method for both desktop (WebSocket) and mobile (FCM) channels.
    *
@@ -962,6 +1097,11 @@ class NotificationService {
         if (hasActiveConnections) {
           deliveredViaApp = true;
           logger.info(`[NOTIFICATION-SERVICE] Spaces delivery detected for user ${userId}, type: ${data.type}`);
+        } else {
+          const browserFallbackResult = await this.sendBrowserPushFallback(userId, data);
+          if (browserFallbackResult.delivered > 0) {
+            deliveredViaApp = true;
+          }
         }
       } else {
         logger.info(`[NOTIFICATION-SERVICE] DESKTOP SKIPPED (sendDesktop=false): User ${userId} | Type: ${data.type}`);

--- a/apps/dashboard/public/sw.js
+++ b/apps/dashboard/public/sw.js
@@ -80,7 +80,10 @@ self.addEventListener('push', (event) => {
         actionUrl: data.actionUrl,
         relatedEntityType: data.relatedEntityType,
         relatedEntityId: data.relatedEntityId,
-        ...data.metadata
+        // Keep metadata nested for click fallback code while also preserving
+        // the legacy top-level spread used by older notification payloads.
+        metadata: data.metadata || {},
+        ...(data.metadata || {})
       },
       actions: data.actions || [
         {


### PR DESCRIPTION
## Summary
- Adds a no-DB-change browser Web Push fallback for eligible desktop notifications when no active websocket connection is detected.
- Uses existing browser_notification_subscriptions rows and existing /sw.js push/click handlers.
- Deactivates invalid browser push subscriptions on permanent provider errors (404/410) using existing repository methods.
- Keeps existing websocket, Electron toast, mobile FCM/APNS queue, preferences, unread counts, Prisma schema, and Zero schema unchanged.

## Proof of Testing
| TC | Result | Evidence |
|---|---|---|
| TC1 Service Worker fallback readiness | PASS | Authenticated app route showed overlay; /sw.js registered; push handler, click handler, and nested metadata support verified. Code: apps/dashboard/src/main.tsx:97, apps/dashboard/public/sw.js:61, apps/dashboard/public/sw.js:83 |
| TC2 Backend fallback is gated and no-DB | PASS | git diff only includes apps/backend/src/services/notificationService.ts and apps/dashboard/public/sw.js; fallback requires ENABLE_BROWSER_PUSH_FALLBACK=true and VAPID keys. Code: apps/backend/src/services/notificationService.ts:858, apps/backend/src/services/notificationService.ts:873, apps/backend/src/services/notificationService.ts:881 |
| TC3 Invalid subscription cleanup and non-throwing reliability | PASS | 404/410 classified as permanent, existing subscription deactivated, outer fallback catches/logs and returns empty result instead of throwing. Code: apps/backend/src/services/notificationService.ts:179, apps/backend/src/services/notificationService.ts:930, apps/backend/src/services/notificationService.ts:962 |
| TC4 Existing desktop/mobile behavior preserved | PASS | websocket delivery remains first desktop path; fallback runs only when user has no active websocket; mobile queue branch unchanged. Code: apps/backend/src/services/notificationService.ts:1096, apps/backend/src/services/notificationService.ts:1101, apps/backend/src/services/notificationService.ts:922 |

Validation commands:
- NODE_OPTIONS=--max-old-space-size=4096 npx eslint src/services/notificationService.ts — PASS
- node --check apps/dashboard/public/sw.js — PASS
- git diff --check — PASS
- pre-commit hook completed during git commit — PASS
- Full backend/dashboard tsc were attempted; they currently fail on pre-existing shared/Flow type drift unrelated to this PR before/without these changes.