### PR TITLE
feat: XYNE-55156 : dashboard changes for visualize tool

### DIFF
--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -768,13 +768,12 @@ const XyneAISidebar = ({
 
   // Scroll to bottom function
   const scrollToBottom = useCallback((): void => {
-    // Forced/embedded instances sit inside a scrollable settings panel; 'nearest' keeps the
-    // scroll contained to this chat box instead of dragging the ancestor panel into view.
+    // `block: 'nearest'` ALWAYS — not just for forced/embedded instances.
     messagesEndRef.current?.scrollIntoView({
       behavior: 'smooth',
-      ...(isAgentForced && { block: 'nearest' }),
+      block: 'nearest',
     });
-  }, [isAgentForced]);
+  }, []);
 
   // AI Onboarding: derive answered count and visible suggestions from messages
   // No context dispatches — avoids re-renders that interfere with streaming

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPicker.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPicker.tsx
@@ -3,7 +3,7 @@ import { Command } from 'cmdk';
 import { FileText, Hashtag, MicOn, PhoneDefault, TicketToken } from '@xyne/icons';
 import { Hash, Loader2, Lock, Users } from 'lucide-react';
 import type { Channel } from '@xyne/shared';
-import { ChannelVisibility } from '@xyne/shared';
+import { ChannelVisibility, isDeskChannelType } from '@xyne/shared';
 import Avatar from '../../../ui/Avatar/Avatar';
 import { useSearchMetrics } from '../../../../hooks/useSearchMetrics';
 import { TabType } from '../../ChatDirectory/ChannelCommandMenu.types';
@@ -163,6 +163,7 @@ export const ContextPicker = ({
       channel => visibleAllChannels.find(vc => vc.id === channel.id) ?? { ...channel },
     ) as VisibleChannel[];
     const grouped = groupChannelsByScope(visibleChannels, allChannelsUserStatus);
+    const deskChannels = visibleChannels.filter(c => isDeskChannelType(c.type));
 
     const sortByActivity = (list: VisibleChannel[]): VisibleChannel[] =>
       [...list].sort(
@@ -183,7 +184,7 @@ export const ContextPicker = ({
         searchableNames: getDMSearchableNames(channel, currentUserID, usersById),
       });
     });
-    sortByActivity(grouped.channels).forEach(channel => {
+    sortByActivity([...grouped.channels, ...deskChannels]).forEach(channel => {
       result.push({
         channel,
         category: ChannelCategory.CHANNELS,

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAIUtils.ts
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAIUtils.ts
@@ -214,8 +214,15 @@ export function transformToolOutput(
 export function parseStreamingContent(content: string): StreamingParsedContent {
   let cleaned = content.replace(/<think>[\s\S]*?<\/think>/gi, '');
   cleaned = cleaned.replace(/<think>[\s\S]*/gi, '');
-  cleaned = cleaned.replace(/```json\s*/gi, '');
-  cleaned = cleaned.replace(/```\s*/gi, '');
+
+  const isJsonEnvelope =
+    /^\s*(?:```json)?\s*\{/.test(cleaned) ||
+    cleaned.includes('"summary"') ||
+    cleaned.includes('"keypoints"');
+  if (isJsonEnvelope) {
+    cleaned = cleaned.replace(/```json\s*/gi, '');
+    cleaned = cleaned.replace(/```\s*/gi, '');
+  }
   cleaned = cleaned.trim();
 
   let summary = '';

--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.tsx
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.tsx
@@ -1,0 +1,53 @@
+import { memo, type ReactElement } from 'react';
+import { QueryVisualizationType } from '@xyne/shared';
+import { getRendererForType } from '../../DynamicDashboard/ComponentGrid/renderers';
+import { parseChartJSON, chartMinContentWidth } from './ChartBlock.utils';
+import type { ChartBlockProps } from './ChartBlock.types';
+
+const HEIGHT_BY_TYPE: Partial<Record<QueryVisualizationType, string>> = {
+  [QueryVisualizationType.KPI]: 'h-28',
+  [QueryVisualizationType.KPI_COMPARE]: 'h-28',
+  [QueryVisualizationType.DATA_TABLE]: 'h-80',
+};
+const DEFAULT_HEIGHT = 'h-56';
+
+const ChartBlockComponent = ({ jsonSource }: ChartBlockProps): ReactElement => {
+  const payload = parseChartJSON(jsonSource);
+
+  if (!payload) {
+    return (
+      <div className='my-4 p-4 bg-muted/50 border border-border rounded-lg'>
+        <div className='flex items-center justify-center gap-2'>
+          <div className='animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full' />
+          <p className='text-sm text-muted-foreground'>Rendering chart...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { title, visualType, data } = payload;
+  // Non-null: parseChartJSON only returns types the registry can render.
+  const Renderer = getRendererForType(visualType)!;
+
+  const minWidth = chartMinContentWidth(visualType, data);
+
+  return (
+    <div className='my-4 rounded-lg border border-border bg-card p-3'>
+      <div className='mb-2 text-sm font-medium text-foreground'>{title}</div>
+      <div
+        className={`${HEIGHT_BY_TYPE[visualType] ?? DEFAULT_HEIGHT} ${
+          minWidth > 0 ? 'overflow-x-auto overflow-y-hidden' : ''
+        }`}
+      >
+        <div className='h-full' {...(minWidth > 0 ? { style: { minWidth } } : {})}>
+          <Renderer data={data} title={title} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ChartBlock = memo(
+  ChartBlockComponent,
+  (prev, next) => prev.jsonSource === next.jsonSource,
+);

--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.types.ts
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.types.ts
@@ -1,0 +1,13 @@
+import type { QueryVisualizationType } from '@xyne/shared';
+
+export interface ChartBlockProps {
+  jsonSource: string;
+  messageId?: string;
+}
+
+export interface ChartBlockPayload {
+  title: string;
+  /** Narrowed at the parse boundary — guaranteed to have a renderer. */
+  visualType: QueryVisualizationType;
+  data: unknown;
+}

--- a/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.utils.ts
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/ChartBlock.utils.ts
@@ -1,0 +1,88 @@
+import { QueryVisualizationType } from '@xyne/shared';
+import { getRendererForType } from '../../DynamicDashboard/ComponentGrid/renderers';
+import {
+  CHART_XAXIS_MIN_TICK_GAP,
+  CHART_YAXIS_WIDTH,
+} from '../../DynamicDashboard/ComponentGrid/renderers/constants';
+import { formatTimeTick } from '../../DynamicDashboard/ComponentGrid/renderers/utils';
+import type { ChartBlockPayload } from './ChartBlock.types';
+
+// Approximate rendered width of one character at CHART_TICK_STYLE
+const CHART_TICK_CHAR_PX = 6.6;
+
+/**
+ * Parse a ```chart fence into a payload with a NARROWED visualType.
+ */
+export function parseChartJSON(source: string): ChartBlockPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+  const { title, visualType, data } = parsed as Record<string, unknown>;
+  if (typeof title !== 'string' || typeof visualType !== 'string') return null;
+  if (data === undefined) return null;
+
+  const narrowed = asRenderableVisualType(visualType);
+  if (!narrowed) return null;
+
+  return { title, visualType: narrowed, data };
+}
+
+/** A visualType string is renderable only if the registry has a renderer for it. */
+function asRenderableVisualType(value: string): QueryVisualizationType | null {
+  const candidate = value as QueryVisualizationType;
+  return getRendererForType(candidate) ? candidate : null;
+}
+
+export function isValidChartJSON(source: string): boolean {
+  return parseChartJSON(source) !== null;
+}
+
+/**
+ * Minimum content width a chart needs for every x-axis label to stay visible,
+ * or 0 when the type has no text x-axis (pie/donut/kpi/table).
+ */
+export function chartMinContentWidth(visualType: QueryVisualizationType, data: unknown): number {
+  const key = X_LABEL_KEY[visualType];
+  if (!key || !Array.isArray(data) || data.length === 0) return 0;
+
+  const usesTimeFormat = TIME_FORMATTED_TYPES.has(visualType);
+  const labels = new Set<string>();
+  for (const row of data) {
+    if (!row || typeof row !== 'object') continue;
+    const raw = (row as Record<string, unknown>)[key];
+    // Only the shapes the contract allows (string | number | Date); anything
+    // else would stringify to '[object Object]' and collapse distinct rows.
+    let text: string;
+    if (raw instanceof Date) text = raw.toISOString();
+    else if (typeof raw === 'string') text = raw;
+    else if (typeof raw === 'number' && Number.isFinite(raw)) text = String(raw);
+    else continue;
+    labels.add(usesTimeFormat ? formatTimeTick(text) : text);
+  }
+  if (labels.size === 0) return 0;
+
+  let widest = 0;
+  for (const l of labels) widest = Math.max(widest, l.length * CHART_TICK_CHAR_PX);
+  const slot = widest + CHART_XAXIS_MIN_TICK_GAP;
+  return labels.size * slot + CHART_YAXIS_WIDTH;
+}
+
+/** Which field supplies the x-axis label, per chart type. */
+const X_LABEL_KEY: Partial<Record<QueryVisualizationType, string>> = {
+  [QueryVisualizationType.BAR_CHART]: 'label',
+  [QueryVisualizationType.LINE_CHART]: 'x',
+  [QueryVisualizationType.AREA_CHART]: 'x',
+  [QueryVisualizationType.SCATTER_CHART]: 'x',
+};
+
+/** Types whose XAxis passes ticks through formatTimeTick before rendering. */
+const TIME_FORMATTED_TYPES: ReadonlySet<QueryVisualizationType> = new Set([
+  QueryVisualizationType.LINE_CHART,
+  QueryVisualizationType.AREA_CHART,
+]);

--- a/apps/dashboard/src/components/Markdown/ChartBlock/index.ts
+++ b/apps/dashboard/src/components/Markdown/ChartBlock/index.ts
@@ -1,0 +1,2 @@
+export { ChartBlock } from './ChartBlock';
+export type { ChartBlockProps, ChartBlockPayload } from './ChartBlock.types';

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -199,6 +199,8 @@ import { useSelector } from '@xstate/react';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 import { useAskAiTicketContext } from '../../hooks/useAskAiTicketContext';
 import { clearDeskContactsCache } from '../../hooks/useDeskContacts';
+import { XyneAIStar } from '../../components/icons/xyne-ai';
+import { trackAskAIOpened } from '../../services/otel/xyneAIMetrics';
 import {
   channelService,
   CreateChannelFormData,
@@ -2378,6 +2380,25 @@ const SupportScreen = (): ReactElement => {
                             </button>
                           </Tooltip>
                         ))}
+                      {isSelectedChannelJoined && selectedChannelId !== ALL_CHANNELS_ID && (
+                        <Tooltip content='Ask AI' side='bottom'>
+                          <button
+                            onClick={() => {
+                              if (!selectedChannelId) return;
+                              trackAskAIOpened(
+                                emailChannels?.find(c => c.id === selectedChannelId)?.scopeType,
+                              );
+                              xyneAIActor.send({ type: 'OPEN', channelId: selectedChannelId });
+                            }}
+                            className='p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-accent'
+                            data-track-category='Support'
+                            data-track-name='OPEN_XYNE_AI'
+                            data-track-metadata={JSON.stringify({ channelId: selectedChannelId })}
+                          >
+                            <XyneAIStar />
+                          </button>
+                        </Tooltip>
+                      )}
                       {isSelectedChannelJoined &&
                         selectedChannelId !== ALL_CHANNELS_ID &&
                         channelPreference?.metricsEnabled && (

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -7,6 +7,7 @@ import type { Components } from 'react-markdown';
 import { MermaidBlock } from '../components/Markdown/MermaidBlock';
 import { FilesystemBlock } from '../components/Markdown/FilesystemBlock';
 import { D2Block } from '../components/Markdown/D2Block';
+import { ChartBlock } from '../components/Markdown/ChartBlock';
 import { ClawCitationGroup } from '../components/Chat/XyneAISidebar/components/ClawCitationGroup';
 import { ThreadCitationChip } from '../components/ui/MessageBubble/ThreadCitationChip';
 import { parseCiteGroupHref } from '../components/ui/TipTapExtensions/CitationMark';
@@ -80,6 +81,13 @@ const CodeBlock = ({
       />
     ) : (
       <D2Block source={codeString} messageId={(props as { messageId: string }).messageId} />
+    );
+  }
+
+  // ── Chart (visualize tool output) ──
+  if (language === 'chart') {
+    return (
+      <ChartBlock jsonSource={codeString} messageId={(props as { messageId: string }).messageId} />
     );
   }
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
