### PR TITLE
fix: XYNE-55544 show duplicate panel only when analysis confirms a du…

### DIFF
--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
@@ -588,6 +588,15 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     debounceMs: 2000,
   });
 
+  // Retrieval always returns its top-ranked tickets, so a non-empty candidate list means
+  // "closest matches", not "duplicate". Only surface the panel once the analysis has actually
+  // confirmed a duplicate and named a ticket — otherwise unrelated tickets get shown as similar.
+  const showDuplicatePanel = Boolean(
+    duplicateCheck?.analysis?.isDuplicate &&
+    duplicateCheck?.analysis?.duplicateTicketId &&
+    duplicateCheck?.candidates?.length,
+  );
+
   // Once the user acts on the board (manual select, accept, or reject), suppress all further AI suggestions
   const [boardAISuggestionSuppressed, setBoardAISuggestionSuppressed] = useState(false);
   const [boardSelectorOpen, setBoardSelectorOpen] = useState(false);
@@ -2360,16 +2369,14 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
               <span>Checking for duplicates...</span>
             </div>
           )}
-          {(duplicateCheck?.candidates?.length ?? 0) > 0 && (
+          {showDuplicatePanel && (
             <div className='rounded-lg border border-border bg-muted p-4 mb-2 transition-all duration-200 ease-out'>
               <div className='space-y-2'>
                 <div className='flex items-center justify-between pb-0.5'>
                   <span className='flex items-center gap-2'>
                     <Copy className='size-3' strokeWidth={2.5} />
                     <p className='text-sm font-medium text-foreground leading-5'>
-                      {duplicateCheck?.analysis?.isDuplicate
-                        ? 'Duplicate ticket found'
-                        : 'Similar tickets found'}
+                      Duplicate ticket found
                     </p>
                   </span>
                   <Button
@@ -2381,10 +2388,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
                     <X strokeWidth={2.33} className='size-3.5' />
                   </Button>
                 </div>
-                {(duplicateCheck?.analysis?.isDuplicate
-                  ? duplicateCheck?.candidates?.slice(0, 1)
-                  : duplicateCheck?.candidates?.slice(0, 5)
-                )?.map(candidate => {
+                {duplicateCheck?.candidates?.slice(0, 1)?.map(candidate => {
                   const candidateLink = candidateLinks.get(candidate.id);
 
                   return (


### PR DESCRIPTION
The create-ticket duplicate panel rendered whenever the check returned any candidate, so a project with no related tickets still showed its top-ranked results under "Similar tickets found". Retrieval always returns its closest matches and has no notion of "nothing found", so that list was often unrelated - a PostHog analytics ticket surfaced payment-gateway tickets that only shared the words "implement" and "integration".

The duplicate analysis had already rejected those candidates; the UI just never read its verdict.

- gate the panel on analysis.isDuplicate plus a resolved duplicateTicketId, which also covers the case where the candidate-set guard nulls an unknown id but leaves isDuplicate true
- drop the now-unreachable "Similar tickets found" header and the five-candidate slice

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-55544

`CreateTicketModal` gated the duplicate panel on `candidates.length > 0` alone. That
list is Vespa's top-N ranking, which always returns its closest matches regardless of
how weak they are — there is no "nothing found" result and no relevance floor. So in a
project with nothing related, the panel still opened with five unrelated tickets.

The LLM duplicate analysis was already returning `isDuplicate: false` for these; the UI
simply never read `analysis`. Gating on the verdict makes the panel reflect the decision
that was already being computed.

The extra `duplicateTicketId` condition also closes a smaller bug: when the backend's
candidate-set guard nulls an id the model returned but that isn't in the candidate list
(`ticketDuplicateService.ts`), `isDuplicate` stays `true`. Previously that rendered
"Duplicate ticket found" over the top-ranked candidate the model never endorsed.

Condition is extracted to a `showDuplicatePanel` const rather than inlined — inlining
forced a multi-line `&&` chain in JSX, which re-indented the whole panel and turned a
3-line change into a ~150-line diff.

Scope note: this fixes what users see. It does not change retrieval. Follow-ups worth
tracking separately: no relevance floor on candidates (`relevanceScore` is computed and
carried but never read), and the fuzzy fallback firing on every dedupe check and mixing
`default_fuzzy`-ranked hits into a `duplicate_detection`-ranked list.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Static verification only so far:

- `npx prettier --check` passes on the changed file
- `npx tsc --noEmit -p tsconfig.app.json` introduces no new errors. One pre-existing
  error in this file (`BoardType.FLOW`, line 472) also fails on clean `main`.
- Diff reviewed; single file, 12 insertions / 8 deletions

Not yet done — needs a run before merge:
- No manual UI verification of the three states (no duplicate → panel hidden;
  confirmed duplicate → panel shows one ticket; check in flight → spinner only)
- Pre-commit hooks did not run locally (`core.hooksPath` is overridden to
  `/etc/git-guardian/hooks`, so `.husky/pre-commit` was bypassed). gitleaks, dashboard
  lint, dashboard build and `change-analysis.sh` all skipped — which is also why the
  `Services-Requiring-Redeployment:` footer is absent from the commit.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- render-gating on an existing analysis field; no test harness for CreateTicketModal today -->

### Manual

<!-- Nothing below was run in the session that produced this change — tick as you verify. -->

**Users**
- [ ] Single user

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)

**Surface & data**
- [ ] Web browser
- [ ] Empty state
- [ ] Narrow viewport, dark + light theme

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass <!-- no backend files touched -->
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- typecheck run, lint + build not -->
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- no new deps -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed <!-- no docs cover this panel -->
- [x] No debug logging or commented-out code left behind