### PR TITLE
fix: GENIUS-5442 fix automation pill issue

### DIFF
--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/EntityField.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/EntityField.tsx
@@ -12,7 +12,13 @@ import {
 } from 'lucide-react';
 import { useCachedQuery } from '../../../../hooks/useCachedQuery';
 import { queries } from '../../../../zero/queries';
-import { useActiveUserSearch, useSelf, useUser, useUsers } from '../../../../hooks/useUsers';
+import {
+  useActiveUsers,
+  useActiveUserSearch,
+  useSelf,
+  useUser,
+  useUsers,
+} from '../../../../hooks/useUsers';
 import { useUserGroups } from '../../../../hooks/useUserGroup';
 import { useAllChannels, useChannel } from '../../../../hooks/useChannels';
 import UserAvatar, { AvatarShape, AvatarSize } from '../../../UserAvatar/UserAvatar';
@@ -548,18 +554,47 @@ interface MultiFieldProps {
   placeholder: string;
 }
 
+// Search text can filter an already-selected entity out of `base` — without re-adding it,
+// would vanish the moment the search text stops matching him.
+function withSelectedOptions(
+  base: SelectorOption[],
+  value: string[],
+  resolveSelected: (id: string) => SelectorOption,
+): SelectorOption[] {
+  const present = new Set(base.map(o => o.value));
+  const selectedExtra = value.filter(v => !present.has(v)).map(resolveSelected);
+  return [...selectedExtra, ...base];
+}
+
 function MultiUsers({ value, onChange, placeholder }: MultiFieldProps): React.ReactElement {
   const [search, setSearch] = useState('');
-  const users = useActiveUserSearch(search, 30);
+  const users = useActiveUsers();
   const options: SelectorOption[] = useMemo(() => {
-    if (!users) return [];
-    return users.map(u => ({
-      value: u.id,
-      label: getUserDisplayName(u),
-      subtitle: u.email,
-      icon: <UserAvatar userId={u.id} size={AvatarSize.SM} shape={AvatarShape.CIRCULAR} />,
-    }));
-  }, [users]);
+    const byId = new Map(users.map(u => [u.id, u]));
+    const lower = search.trim().toLowerCase();
+    const base = users
+      .filter(
+        u =>
+          !lower ||
+          getUserDisplayName(u).toLowerCase().includes(lower) ||
+          u.email?.toLowerCase().includes(lower),
+      )
+      .map(u => ({
+        value: u.id,
+        label: getUserDisplayName(u),
+        subtitle: u.email,
+        icon: <UserAvatar userId={u.id} size={AvatarSize.SM} shape={AvatarShape.CIRCULAR} />,
+      }));
+    return withSelectedOptions(base, value, v => {
+      const u = byId.get(v);
+      return {
+        value: v,
+        label: u ? getUserDisplayName(u) : v,
+        subtitle: u?.email ?? null,
+        icon: <UserAvatar userId={v} size={AvatarSize.SM} shape={AvatarShape.CIRCULAR} />,
+      };
+    });
+  }, [users, search, value]);
   return (
     <EntityMultiSelector
       options={options}
@@ -577,9 +612,9 @@ function MultiUserGroups({ value, onChange, placeholder }: MultiFieldProps): Rea
   const [search, setSearch] = useState('');
   const groups = useUserGroups();
   const options: SelectorOption[] = useMemo(() => {
-    if (!groups) return [];
+    const byId = new Map((groups ?? []).map(g => [g.id, g]));
     const lower = search.trim().toLowerCase();
-    return groups
+    const base = (groups ?? [])
       .filter(g => g.isActive !== false)
       .filter(g => (lower ? g.name.toLowerCase().includes(lower) : true))
       .map(g => ({
@@ -587,7 +622,15 @@ function MultiUserGroups({ value, onChange, placeholder }: MultiFieldProps): Rea
         label: g.name,
         icon: <Users className='size-4 text-muted-foreground' />,
       }));
-  }, [groups, search]);
+    return withSelectedOptions(base, value, v => {
+      const g = byId.get(v);
+      return {
+        value: v,
+        label: g?.name || v,
+        icon: <Users className='size-4 text-muted-foreground' />,
+      };
+    });
+  }, [groups, search, value]);
   return (
     <EntityMultiSelector
       options={options}
@@ -618,18 +661,14 @@ function MultiChannels({ value, onChange, placeholder }: MultiFieldProps): React
         label: c.name || '(unnamed channel)',
         icon: channelIcon(c.type),
       }));
-    const present = new Set(base.map(o => o.value));
-    const selectedExtra: SelectorOption[] = value
-      .filter(v => !present.has(v))
-      .map(v => {
-        const c = byId.get(v);
-        return {
-          value: v,
-          label: c?.name || v,
-          icon: channelIcon(c?.type),
-        };
-      });
-    return [...selectedExtra, ...base];
+    return withSelectedOptions(base, value, v => {
+      const c = byId.get(v);
+      return {
+        value: v,
+        label: c?.name || v,
+        icon: channelIcon(c?.type),
+      };
+    });
   }, [channels, search, value]);
   return (
     <EntityMultiSelector
@@ -648,16 +687,24 @@ function MultiBoards({ value, onChange, placeholder }: MultiFieldProps): React.R
   const [search, setSearch] = useState('');
   const [boards] = useCachedQuery(queries.getAllBoardsList());
   const options: SelectorOption[] = useMemo(() => {
-    if (!boards) return [];
+    const byId = new Map((boards ?? []).map(b => [b.id, b]));
     const lower = search.trim().toLowerCase();
-    return boards
+    const base = (boards ?? [])
       .filter(b => (lower ? b.name.toLowerCase().includes(lower) : true))
       .map(b => ({
         value: b.id,
         label: b.name,
         icon: <Layers className='size-4 text-muted-foreground' />,
       }));
-  }, [boards, search]);
+    return withSelectedOptions(base, value, v => {
+      const b = byId.get(v);
+      return {
+        value: v,
+        label: b?.name || v,
+        icon: <Layers className='size-4 text-muted-foreground' />,
+      };
+    });
+  }, [boards, search, value]);
   return (
     <EntityMultiSelector
       options={options}
@@ -675,16 +722,24 @@ function MultiProjects({ value, onChange, placeholder }: MultiFieldProps): React
   const [search, setSearch] = useState('');
   const [projects] = useCachedQuery(queries.getAllProjects());
   const options: SelectorOption[] = useMemo(() => {
-    if (!projects) return [];
+    const byId = new Map((projects ?? []).map(p => [p.id, p]));
     const lower = search.trim().toLowerCase();
-    return projects
+    const base = (projects ?? [])
       .filter(p => (lower ? p.name.toLowerCase().includes(lower) : true))
       .map(p => ({
         value: p.id,
         label: p.name,
         icon: <Folder className='size-4 text-muted-foreground' />,
       }));
-  }, [projects, search]);
+    return withSelectedOptions(base, value, v => {
+      const p = byId.get(v);
+      return {
+        value: v,
+        label: p?.name || v,
+        icon: <Folder className='size-4 text-muted-foreground' />,
+      };
+    });
+  }, [projects, search, value]);
   return (
     <EntityMultiSelector
       options={options}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.utils.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.utils.ts
@@ -100,6 +100,7 @@ export function detectEntityArrayKind(fieldKey: string): EntityKind | null {
     case 'memberIds':
     case 'mentionedUserIds':
     case 'participantUserIds':
+    case 'fromUserIds':
       return EntityKind.USER;
     case 'boardIds':
       return EntityKind.BOARD;


### PR DESCRIPTION


<img width="2560" height="1347" alt="Screenshot 2026-08-10 at 4 48 00 PM" src="https://github.com/user-attachments/assets/4e81416b-f6ce-4b61-b231-29dc6a1be3d7" />

Services-Requiring-Redeployment:


  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
