### PR TITLE
fix: XYNE-17198 make the entity extraction worker real time

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -808,7 +808,7 @@ export class App {
       await emailClassificationQueue.initialize();
 
       // Producer only — messages are enqueued here at ingest; the worker (a
-      // separate process) drains them nightly.
+      // separate process) drains each thread once its debounce window elapses.
       logger.info('Initializing entity extraction queue...');
       await entityExtractionQueue.initialize();
 

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -164,8 +164,13 @@ const envSchema = Joi.object({
   // LiteLLM Configuration for AI Agents
   LITELLM_BASE_URL: Joi.string().default(''),
   LITELLM_API_KEY: Joi.string().allow('').default(''),
-  ENTITY_EXTRACTION_MODEL: Joi.string().default('glm-latest'),
+  ENABLE_ENTITY_EXTRACTION: Joi.boolean().default(true),
+  ENTITY_EXTRACTION_MODEL: Joi.string().default('glm-private'),
   ENTITY_EXTRACTION_CONCURRENCY: Joi.number().default(2),
+  // How long a thread's job sits delayed before it runs. This is the debounce
+  // window: every message on the thread inside it collapses into one job, so a
+  // busy thread costs one extraction per window, not one per message.
+  ENTITY_EXTRACTION_DEBOUNCE_MS: Joi.number().default(15 * 60 * 1000),
   // Org-level framing prepended to the mention-extraction prompt, so the model
   // knows whose data it is reading. Fixes identity-relative errors like listing
   // the org itself as an external ORGANISATION, and sharpens ORG vs MERCHANT.
@@ -670,10 +675,12 @@ export const config = {
     url: envVars.Y_SWEET_URL,
   },
   entityExtraction: {
+    enabled: envVars.ENABLE_ENTITY_EXTRACTION,
     model: envVars.ENTITY_EXTRACTION_MODEL,
     // A single extraction call takes 20-75s on this endpoint. Raising this
     // makes calls contend and time out rather than finish faster.
     concurrency: envVars.ENTITY_EXTRACTION_CONCURRENCY,
+    debounceMs: envVars.ENTITY_EXTRACTION_DEBOUNCE_MS,
     orgContext: envVars.ENTITY_EXTRACTION_ORG_CONTEXT,
   },
 

--- a/apps/backend/src/queues/entityExtractionQueue.ts
+++ b/apps/backend/src/queues/entityExtractionQueue.ts
@@ -1,30 +1,27 @@
 import Bull from 'bull';
 import { logger } from '@/utils/logger';
+import { config } from '@/config/env';
 import { redisService } from '@/services/redisService';
 
 /**
- * Producer for the nightly entity-extraction queue.
+ * Producer for the entity-extraction queue.
  *
- * Enqueued at message ingest, drained at midnight. A job is just a threadId
- * (== conversationId), keyed so a busy thread dedupes to ONE job, delayed until
- * the next IST midnight so it is processed once when the thread has settled, and
- * priority-ordered by time. Everything else — resolving the channel/workspace,
- * reading the channel's approved types (chat_container.entityTypes), gating —
- * happens in the worker, keeping the ingest path free of lookups.
+ * Enqueued at message ingest. A job is just a threadId (== conversationId),
+ * keyed so a busy thread dedupes to ONE job and held for a short debounce window
+ * so that dedupe has something to collapse: a job re-extracts the WHOLE thread,
+ * so firing one per message would cost O(n²) LLM calls over the thread's life.
+ * Everything else — resolving the channel/workspace, reading the channel's
+ * approved types (chat_container.entityTypes), gating — happens in the worker,
+ * keeping the ingest path free of lookups.
+ *
+ * A message landing while the thread's job is already active is dropped (Bull
+ * ignores the repeat add, and the job is gone once it completes). Accepted:
+ * any later message on the thread re-extracts it whole.
  *
  * Consumption lives in workers/entityExtractionWorker.ts.
  */
 export interface EntityExtractionJobData {
   threadId: string;
-}
-
-const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/** ms from now until the next 00:00 IST — the delay that batches jobs to night. */
-function msUntilNextMidnightIST(): number {
-  const istNow = Date.now() + IST_OFFSET_MS;
-  return Math.ceil(istNow / DAY_MS) * DAY_MS - istNow;
 }
 
 class EntityExtractionQueue {
@@ -65,7 +62,8 @@ class EntityExtractionQueue {
   /**
    * Feed-time entry — call when a message is ingested (threadId == conversationId).
    * Fully guarded so it can never throw into the ingest path. Bull ignores a
-   * repeat add while the job is still queued, so a busy thread stays one job.
+   * repeat add while the job is still delayed or queued, so every message inside
+   * the debounce window folds into the one job the first message created.
    */
   async enqueueForMessage(conversationId: string | undefined): Promise<void> {
     if (!this.queue || !conversationId) return;
@@ -75,7 +73,7 @@ class EntityExtractionQueue {
         {
           jobId: conversationId, // dedupe the thread
           priority: Math.max(1, Math.floor(Date.now() / 1000)), // lower = older = first
-          delay: msUntilNextMidnightIST(),
+          delay: config.entityExtraction.debounceMs,
         },
       );
     } catch (err) {
@@ -87,16 +85,23 @@ class EntityExtractionQueue {
   }
 
   /**
-   * Enqueue a thread for IMMEDIATE processing (backfill), bypassing the nightly
-   * delay. Same jobId dedup, so a thread already queued for tonight isn't
-   * duplicated. Returns true if a job was added.
+   * Enqueue a thread for IMMEDIATE processing (backfill), bypassing the debounce
+   * window. Same jobId dedup, so a thread already waiting out its window isn't
+   * duplicated — it just stays on its original schedule.
    */
   async enqueueThreadNow(threadId: string): Promise<void> {
     if (!this.queue || !threadId) return;
-    await this.queue.add(
-      { threadId },
-      { jobId: threadId, priority: Math.max(1, Math.floor(Date.now() / 1000)) },
-    );
+    try {
+      await this.queue.add(
+        { threadId },
+        { jobId: threadId, priority: Math.max(1, Math.floor(Date.now() / 1000)) },
+      );
+    } catch (err) {
+      logger.warn('[ENTITY-EXTRACTION-QUEUE] backfill enqueue failed', {
+        threadId,
+        error: String(err),
+      });
+    }
   }
 
   async close(): Promise<void> {

--- a/apps/backend/src/services/messageClassification/prompt.ts
+++ b/apps/backend/src/services/messageClassification/prompt.ts
@@ -72,11 +72,15 @@ dominant act.
 
 ## Second task — the thread as a whole
 
-Also classify the ENTIRE thread by what "done" would mean for it. Usually ONE value; return
-more only when the thread genuinely is several things at once (a bug report that also
-requests a feature). Never more than three.
+Also classify the ENTIRE thread, on TWO independent axes.
 
 ${numbered(THREAD_TYPE_CHOICES)}
+
+### Axis 1 — outcome (one, rarely two)
+
+Pick ONE of ISSUE, ALERT, QUESTION, REQUEST, FEATURE_REQUEST, DISCUSSION, ANNOUNCEMENT by
+what "done" would mean for the thread. Return a second one only when the thread genuinely
+is two things at once (a bug report that also requests a feature) — never more than two.
 
 Decide by what would have to happen for this thread to be finished:
 - fixed AND verified → ISSUE
@@ -91,10 +95,28 @@ tools that already exist? Yes → REQUEST. Needs something built → FEATURE_REQ
 
 When no other type fits, DISCUSSION.
 
+### Axis 2 — answer types (usually NONE)
+
+Then add any of HOW_TO, WHAT_HAPPENED, WHY_DECISION, WHAT_IS, KNOWN_ISSUE, REFERENCE,
+EXAMPLE, POLICY_LIMIT that apply. These are independent of the outcome — an ISSUE whose
+resolution spells out the fix is both ISSUE and HOW_TO.
+
+The bar is high and most threads clear none of it: add one ONLY if someone who was never in
+this thread could get their question answered by THIS THREAD ALONE. Tag what the thread
+ANSWERS, not what it discusses. A thread full of debugging that never lands on an answer
+gets none of these. Returning no answer types is the normal, correct outcome — do not reach
+for one to look thorough.
+
+Read each definition's "NOT" clauses before tagging: asking how to do something is not
+HOW_TO, mid-incident chatter is not WHAT_HAPPENED, a choice with no reasoning is not
+WHY_DECISION, and a value someone is unsure about is not POLICY_LIMIT.
+
+ANNOUNCEMENT is an outcome, not an answer type — a release note is ANNOUNCEMENT alone.
+
 ## Output
 
 {
-  "threadTypes": [one or more of ${THREAD_TYPE_CHOICES.map(e => e.name).join(', ')}],
+  "threadTypes": [the outcome type first, then any answer types — from ${THREAD_TYPE_CHOICES.map(e => e.name).join(', ')}],
   "classifications": [
     { "id": "<message id from thread_messages>", "messageActs": [one or more of ${ACT_NAMES.join(', ')}, or exactly ["${NO_ACT}"]] }
   ]

--- a/apps/backend/src/worker.ts
+++ b/apps/backend/src/worker.ts
@@ -276,8 +276,12 @@ class WorkerService {
       logger.info('Starting auto draft worker...');
       await autoDraftWorker.start();
 
-      logger.info('Starting entity extraction worker...');
-      await entityExtractionWorker.start();
+      if (appConfig.entityExtraction.enabled) {
+        logger.info('Starting entity extraction worker...');
+        await entityExtractionWorker.start();
+      } else {
+        logger.info('Entity extraction is disabled; skipping worker startup');
+      }
 
       if (appConfig.enableTagGenerationPipeline) {
         logger.info('Initializing tag generation pipeline...');

--- a/apps/backend/src/workers/entityExtractionWorker.ts
+++ b/apps/backend/src/workers/entityExtractionWorker.ts
@@ -10,9 +10,10 @@ import { entityExtractionService } from '@/services/entityExtraction/entityExtra
 /**
  * Consumer for the entity-extraction queue.
  *
- * Jobs are delayed until midnight IST, so this worker sits idle during the day
- * and drains the night's threads in priority (timestamp) order. Each job is one
- * settled thread: extract mentions → resolve → write entity ids back to Vespa.
+ * Each job is one thread: extract mentions → resolve → write entity ids back to
+ * Vespa. Jobs are produced by live message/ticket mutations but held for a
+ * debounce window, so this worker sees one job per busy thread per window rather
+ * than one per message — a job re-reads the whole thread either way.
  *
  * Concurrency is bounded by the shared LiteLLM key's parallel-request limit.
  */
@@ -21,6 +22,11 @@ class EntityExtractionWorker {
 
   async start(): Promise<void> {
     if (this.started) return;
+    const entityExtractionEnabled = config.entityExtraction.enabled;
+    if (!entityExtractionEnabled) {
+      logger.info('[ENTITY-EXTRACTION-WORKER] Disabled; not starting');
+      return;
+    }
 
     await entityExtractionQueue.initialize();
     const queue = entityExtractionQueue.getQueue();

--- a/packages/shared/src/tags/vocabularies.ts
+++ b/packages/shared/src/tags/vocabularies.ts
@@ -60,7 +60,19 @@ export const MESSAGE_ACTS: readonly ActEntry[] = [
 ];
 
 /**
- * What "done" would mean for a thread. A thread carries exactly one of these.
+ * How a thread is classified, on two independent axes that share this one vocabulary.
+ *
+ * The first seven are OUTCOME types — what "done" would mean for the thread. A thread
+ * carries exactly one.
+ *
+ * The rest are ANSWER types — what question the thread's content answers for someone who
+ * was never in it. A thread carries any number, and most carry none: the bar is that a
+ * reader could get their question answered by this thread alone, so tag what it answers,
+ * not what it discusses.
+ *
+ * The two are independent — a thread can be an ISSUE whose resolution is also a HOW_TO.
+ * Descriptions are prompt copy, so the "not" clauses matter as much as the definitions:
+ * near-misses are what the classifier gets wrong, and each one here is load-bearing.
  */
 export const THREAD_TYPES: readonly VocabularyEntry[] = [
   {
@@ -109,7 +121,98 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
     name: 'ANNOUNCEMENT',
     label: 'Announcement',
     color: '#14b8a6',
-    description: 'One-to-many broadcast; nothing is owed by anyone. No done state.',
+    description:
+      'One-to-many broadcast; nothing is owed by anyone. No done state. Covers dated ' +
+      'statements of change — releases, go-lives, deprecations, migrations, planned ' +
+      'maintenance. NOT internal progress chatter ("almost done with the release") or an ' +
+      'intention without commitment ("we should ship this next week").',
+  },
+
+  // ─── Answer types — what a reader could learn from this thread ──────────────
+  {
+    name: 'HOW_TO',
+    label: 'How-to',
+    color: '#0891b2',
+    description:
+      'Contains an actionable procedure — ordered steps, or a complete instruction a reader ' +
+      'could follow to accomplish the task without needing anything from elsewhere. Fires on ' +
+      'step-by-step instructions, config walkthroughs, a complete "do X then Y" resolution. ' +
+      'NOT when someone ASKS how to do something (a question is not an answer), NOT a partial ' +
+      'hint with no complete path ("check the dashboard"), NOT a description of what a feature ' +
+      'does with no steps.',
+  },
+  {
+    name: 'WHAT_HAPPENED',
+    label: 'What happened',
+    color: '#b45309',
+    description:
+      'A narrative of a specific past event — incident recap, sequence of events, impact, ' +
+      'resolution. The account of what occurred, as opposed to the causal analysis of why. ' +
+      'NOT live firefighting chatter from mid-incident (fragments, not a narrative), NOT a bot ' +
+      'alert (that is the event itself, not an account of it), NOT speculation about something ' +
+      'still ongoing.',
+  },
+  {
+    name: 'WHY_DECISION',
+    label: 'Why (decision)',
+    color: '#4f46e5',
+    description:
+      'States a decision AND the reasoning behind it. Fires on "we chose X over Y because…", ' +
+      'a tradeoff discussion that concludes in a choice, policy rationale ("we do not retry ' +
+      '3DS failures because banks flag it as fraud"). NOT a decision stated with no reasoning ' +
+      '("we are going with X"), NOT opinions that never reach a choice.',
+  },
+  {
+    name: 'WHAT_IS',
+    label: 'What is',
+    color: '#059669',
+    description:
+      'Explains a concept, term, feature or system — a definition or explainer a newcomer ' +
+      'could learn from. Answers a vocabulary question, not a task question. Fires on "X is…", ' +
+      '"X means…", capability descriptions, jargon explanations, architecture explainers. NOT ' +
+      'when the term is merely USED rather than explained, NOT a one-word or purely contextual ' +
+      'reply.',
+  },
+  {
+    name: 'KNOWN_ISSUE',
+    label: 'Known issue',
+    color: '#be123c',
+    description:
+      'An acknowledged bug or limitation, its status, and any workaround. Fires when the ' +
+      'thread establishes that something is known-broken and what to do in the meantime. NOT a ' +
+      'fresh report whose validity nobody has confirmed yet, and NOT a one-off failure that ' +
+      'was simply fixed.',
+  },
+  {
+    name: 'REFERENCE',
+    label: 'Reference',
+    color: '#334155',
+    description:
+      'Exact technical facts meant to be looked up: field lists, parameter names and types, ' +
+      'enum values, error-code meanings, formats, header lists, column schemas. Authoritative ' +
+      'values — no steps, no narrative. NOT a field mentioned in passing inside troubleshooting, ' +
+      'NOT a filled-in sample payload with no field semantics (that is EXAMPLE), NOT a UI ' +
+      'walkthrough (that is HOW_TO).',
+  },
+  {
+    name: 'EXAMPLE',
+    label: 'Example',
+    color: '#65a30d',
+    description:
+      'A concrete, complete instance whose value is that it can be copied and used: a working ' +
+      'request, a filled-in payload, a real config block, a sample report row. NOT pseudo-code ' +
+      'fragments, NOT snippets truncated or redacted to uselessness, NOT a mention of a ' +
+      'screenshot with no content.',
+  },
+  {
+    name: 'POLICY_LIMIT',
+    label: 'Policy / limit',
+    color: '#c026d3',
+    description:
+      'States an operative constraint together with its value: transaction limits, SLA ' +
+      'durations, rate limits, settlement cutoffs, retry policies, compliance thresholds. NOT a ' +
+      'limit being asked about, disputed or guessed at ("I think it is 15K?"), NOT a limit ' +
+      'being breached during an incident (that is WHAT_HAPPENED).',
   },
 ];
 
@@ -135,7 +238,11 @@ export const MESSAGE_ACT_NAMES = [
   'ANSWER',
 ] as const;
 
-/** Thread types as a const tuple — z.enum needs a literal tuple. Order is display order. */
+/**
+ * Thread types as a const tuple — z.enum needs a literal tuple. Order is display order, and
+ * it is also the chip sort order via `rank()` in both mutator copies, so outcome types stay
+ * first and answer types trail them.
+ */
 export const THREAD_TYPE_NAMES = [
   'ISSUE',
   'ALERT',
@@ -144,6 +251,14 @@ export const THREAD_TYPE_NAMES = [
   'FEATURE_REQUEST',
   'DISCUSSION',
   'ANNOUNCEMENT',
+  'HOW_TO',
+  'WHAT_HAPPENED',
+  'WHY_DECISION',
+  'WHAT_IS',
+  'KNOWN_ISSUE',
+  'REFERENCE',
+  'EXAMPLE',
+  'POLICY_LIMIT',
 ] as const;
 
 /** Built-in thread type by name; undefined for a free-form tag. */


### PR DESCRIPTION
Environment-Changes:
  - ENABLE_ENTITY_EXTRACTION: added flag to enable
  - ENTITY_EXTRACTION_DEBOUNCE_MS: how long thread will sit before going for entity extraction

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
