### PR TITLE
fix: XYNE-55539 activity unread toggle, square canvas user list heade…

### DIFF
--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -880,7 +880,7 @@ const ActivityListView = (): ReactElement => {
             {/* Unread-only filter */}
             <label
               htmlFor='activity-unread-toggle'
-              className='flex h-7 items-center gap-2 px-2 rounded-[10px] cursor-pointer select-none transition-colors hover:bg-accent'
+              className='flex h-7 items-center gap-2 px-2 rounded-[10px] cursor-pointer select-none transition-colors hover:bg-sidebar-accent'
             >
               <span className='text-sm font-medium text-muted-foreground'>Unread</span>
               <Switch.Root
@@ -893,14 +893,14 @@ const ActivityListView = (): ReactElement => {
                 data-testid='activity-unread-toggle'
                 className={cn(
                   'relative inline-flex h-3.5 w-6 shrink-0 items-center rounded-full',
-                  'bg-muted transition-colors duration-200',
+                  'bg-sidebar-border transition-colors duration-200',
                   'data-[state=checked]:bg-primary',
                   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
                 )}
               >
                 <Switch.Thumb
                   className={cn(
-                    'block size-2.5 rounded-full bg-background shadow-sm',
+                    'block size-2.5 rounded-full bg-white shadow-sm',
                     'transition-transform duration-200',
                     'translate-x-0.5 data-[state=checked]:translate-x-3',
                   )}
@@ -960,14 +960,14 @@ const ActivityListView = (): ReactElement => {
                       data-testid='activity-actionable-toggle'
                       className={cn(
                         'relative inline-flex h-5 w-9 items-center rounded-full',
-                        'bg-muted transition-colors duration-200',
+                        'bg-sidebar-border transition-colors duration-200',
                         'data-[state=checked]:bg-primary',
                         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
                       )}
                     >
                       <Switch.Thumb
                         className={cn(
-                          'block h-4 w-4 rounded-full bg-background shadow-sm',
+                          'block h-4 w-4 rounded-full bg-white shadow-sm',
                           'transition-transform duration-200',
                           'translate-x-0.5 data-[state=checked]:translate-x-4',
                         )}

--- a/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
@@ -1,12 +1,4 @@
-import {
-  ReactElement,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Tooltip } from '../ui/Tooltip/Tooltip';
 import { useAuth } from '../../hooks/useAuth';
@@ -247,10 +239,6 @@ const AppSidebar = (): ReactElement => {
     setIsStatusModalOpen(false);
   };
 
-  const navListRef = useRef<HTMLUListElement | null>(null);
-  const navItemRefs = useRef<Record<string, HTMLLIElement | null>>({});
-  const [activeMarkerY, setActiveMarkerY] = useState<number | null>(null);
-
   // Hide footer only on pages that have their own complete navigation (channels, bookmarks, threads, etc.)
   const hasChannelOrThreadId =
     (location.pathname.includes('/chat/dir/') && location.pathname.split('/').length > 3) ||
@@ -307,39 +295,15 @@ const AppSidebar = (): ReactElement => {
     e.preventDefault();
   };
 
-  const updateActiveMarker = useCallback((): void => {
-    if (window.innerWidth < 500) return;
-    const listEl = navListRef.current;
-    if (!listEl) return;
-
-    const activeItemEl = navItemRefs.current[activeRoute];
-    // Active route isn't a rail item (e.g. it lives in the "More" menu) — hide
-    // the sliding marker so only the "More" button reads as active.
-    if (!activeItemEl) {
-      setActiveMarkerY(null);
-      return;
-    }
-
-    const containerRect = listEl.getBoundingClientRect();
-    const itemRect = activeItemEl.getBoundingClientRect();
-
-    setActiveMarkerY(itemRect.top - containerRect.top);
-  }, [activeRoute]);
-
   useEffect(() => {
     const handleResize = (): void => {
       setWindowWidth(window.innerWidth);
-      updateActiveMarker();
     };
     window.addEventListener('resize', handleResize);
     return (): void => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [updateActiveMarker]);
-
-  useLayoutEffect(() => {
-    updateActiveMarker();
-  }, [updateActiveMarker, toolbarItems, aiLandingDefault, windowWidth]);
+  }, []);
 
   if (isMobile || windowWidth < 500) {
     return (
@@ -372,23 +336,10 @@ const AppSidebar = (): ReactElement => {
             />
           ) : (
             <nav>
-              <ul ref={navListRef} className='relative flex flex-col gap-4'>
-                {activeMarkerY !== null && (
-                  <div
-                    aria-hidden='true'
-                    className='absolute left-0 z-0 h-8 w-8 rounded-lg border border-sidebar-border bg-sidebar-accent transition-transform duration-200 ease-out pointer-events-none'
-                    style={{ transform: `translate3d(0px, ${activeMarkerY}px, 0)` }}
-                  />
-                )}
+              <ul className='relative flex flex-col gap-4'>
                 {/* Xyne AI nav item — only visible when "Open AI on launch" is enabled */}
                 {aiLandingDefault && (
-                  <li
-                    key='/ai'
-                    ref={el => {
-                      navItemRefs.current['/ai'] = el;
-                    }}
-                    className='relative z-10'
-                  >
+                  <li key='/ai' className='relative'>
                     <Tooltip content='Xyne AI' side='right' delayDuration={0}>
                       <Link
                         to={prefixWs('/ai')}
@@ -398,9 +349,9 @@ const AppSidebar = (): ReactElement => {
                         data-track-name='Sidebar_Nav_Item'
                         data-track-metadata={JSON.stringify({ path: '/ai', label: 'Xyne AI' })}
                         className={cn(
-                          'size-8 flex items-center justify-center rounded-lg cursor-pointer transition-colors',
+                          'size-8 flex items-center justify-center rounded-lg cursor-pointer border border-transparent transition-colors',
                           activeRoute === '/ai'
-                            ? 'text-sidebar-accent-foreground'
+                            ? 'bg-sidebar-accent border-sidebar-border text-sidebar-accent-foreground'
                             : 'bg-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
                         )}
                       >
@@ -421,13 +372,7 @@ const AppSidebar = (): ReactElement => {
                   const testId = `nav-${item.label.toLowerCase().replace(/\s+/g, '-')}`;
 
                   return (
-                    <li
-                      key={item.path}
-                      ref={el => {
-                        navItemRefs.current[item.path] = el;
-                      }}
-                      className='relative z-10'
-                    >
+                    <li key={item.path} className='relative'>
                       <Tooltip content={item.label} side='right' delayDuration={0}>
                         <Link
                           to={prefixWs(item.path)}
@@ -441,9 +386,9 @@ const AppSidebar = (): ReactElement => {
                             label: item.label,
                           })}
                           className={cn(
-                            'relative size-8 flex items-center justify-center rounded-lg cursor-pointer transition-colors',
+                            'relative size-8 flex items-center justify-center rounded-lg cursor-pointer border border-transparent transition-colors',
                             isActive
-                              ? 'text-sidebar-accent-foreground'
+                              ? 'bg-sidebar-accent border-sidebar-border text-sidebar-accent-foreground'
                               : 'bg-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
                           )}
                         >
@@ -474,7 +419,7 @@ const AppSidebar = (): ReactElement => {
                 })}
 
                 {/* More menu — overflow items + customize toolbar (Slack-style) */}
-                <li className='relative z-10'>
+                <li className='relative'>
                   <Popover
                     open={isMoreOpen}
                     onOpenChange={setIsMoreOpen}

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -1144,7 +1144,6 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                                 }
                                 size='sm'
                                 count={3}
-                                shape='square'
                               />
                             </button>
                           }


### PR DESCRIPTION
…r ui , app sidebar active icon transition (#390)

Services-Requiring-Redeployment:
  - dashboard


(cherry picked from commit a747137d3b5dd772f3451786652669b8850b1d1c)

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
- app sidebar icons: remove translate y transition on active and keep consistent hover & active states.
- canvas header avatar icons fix
- activity unread toggle ui fix (background, thumb & hover state)

Fixing ui fixes/improvements from feedbacks given.
user list header in canvas screen:
previously:
<img width="228" height="112" alt="image" src="https://github.com/user-attachments/assets/02fab4fe-1753-4d78-872f-3db81b93f2f4" />
fixed: 
<img width="334" height="152" alt="image" src="https://github.com/user-attachments/assets/491e99e5-349e-46df-b1d8-ebee82de5f7e" />
activity unread toggle (hover state + toggle thumb and background change):
<img width="232" height="100" alt="image" src="https://github.com/user-attachments/assets/9bc5e63a-766f-4a4c-ba36-1cae5cc27fa8" />
<img width="326" height="130" alt="image" src="https://github.com/user-attachments/assets/d814ebc1-8dc4-4284-8310-c527a4c63e83" />


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
