### PR TITLE
fix: XYNE-55554 fix FlowJSON activity UI

### DIFF
--- a/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
+++ b/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
@@ -3,6 +3,7 @@ import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -48,7 +49,9 @@ export const DirectMessageActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          {getFlowJsonPreviewText(message.content) ?? (
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          )}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
+++ b/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
@@ -3,6 +3,7 @@ import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { Hashtag } from '@xyne/icons';
@@ -51,7 +52,9 @@ export const KeywordMatchActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          {getFlowJsonPreviewText(message.content) ?? (
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          )}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
@@ -4,6 +4,7 @@ import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { AtMark } from '@xyne/icons';
 import { ActivityItemCard } from './ActivityItemCard';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -52,7 +53,9 @@ export const MessageMentionActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          {getFlowJsonPreviewText(message.content) ?? (
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          )}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
@@ -3,6 +3,7 @@ import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -46,7 +47,9 @@ export const MessageRepliedActivity = ({
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          {getFlowJsonPreviewText(message.content) ?? (
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+          )}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
@@ -3,6 +3,7 @@ import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -103,10 +104,12 @@ export const MessageRepliedActivityV2 = ({
         />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          <RenderMessageWithHTML
-            message={latestReplyMessage.content}
-            showEdited={latestReplyMessage.edited}
-          />
+          {getFlowJsonPreviewText(latestReplyMessage.content) ?? (
+            <RenderMessageWithHTML
+              message={latestReplyMessage.content}
+              showEdited={latestReplyMessage.edited}
+            />
+          )}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
@@ -3,6 +3,7 @@ import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -23,6 +24,7 @@ export const ReactionAddedActivity = ({
 
   if (!reaction || !message || !reaction.userId || !message.conversation) return null;
 
+  const reactionPreview = getReactionMessagePreview(message.content);
   const actionText = activity.actorAction === 'added' ? 'reacted' : 'removed reaction';
   const isThreadReply = message.conversation?.initialMessageId !== message.messageId;
   const targetPath = `${baseRoute}/${message.conversation?.channelId}${isThreadReply ? `/${message.conversation?.conversationId}` : ''}#origin=${message.conversation?.conversationId}${isThreadReply ? `&messageId=${message.messageId}` : ''}`;
@@ -50,10 +52,9 @@ export const ReactionAddedActivity = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
       ) : (
-        <RenderMessageWithHTML
-          message={getReactionMessagePreview(message.content)}
-          showEdited={message.edited}
-        />
+        (getFlowJsonPreviewText(reactionPreview) ?? (
+          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} />
+        ))
       )}
     </ActivityItemCard>
   );

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
@@ -3,6 +3,7 @@ import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -50,6 +51,8 @@ export const ReactionAddedActivityV2 = ({
     return null;
   }
 
+  const reactionPreview = getReactionMessagePreview(message.content);
+
   // Format description text
   let descriptionText: string;
   if (uniqueReactorCount <= 1) {
@@ -81,10 +84,9 @@ export const ReactionAddedActivityV2 = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
       ) : (
-        <RenderMessageWithHTML
-          message={getReactionMessagePreview(message.content)}
-          showEdited={message.edited}
-        />
+        (getFlowJsonPreviewText(reactionPreview) ?? (
+          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} />
+        ))
       )}
     </ActivityItemCard>
   );

--- a/apps/dashboard/src/utils/flowPreview.ts
+++ b/apps/dashboard/src/utils/flowPreview.ts
@@ -29,7 +29,7 @@ function stripFlowMarkup(raw: string): string {
 /**
  * Returns a clean single-line preview string for a FlowJSON message, or null if
  * the content is not a FlowJSON message. Joins the flow title with every text
- * `content` prop in the component tree.
+ * `content` prop in the component tree, plus plan `desc` / `todos[].text`.
  */
 export function getFlowJsonPreviewText(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
@@ -54,8 +54,25 @@ export function getFlowJsonPreviewText(content: string): string | null {
         if (!comp || typeof comp !== 'object') continue;
         const c = comp as Record<string, unknown>;
         const p = c['props'] as Record<string, unknown> | undefined;
-        if (p && typeof p['content'] === 'string' && p['content'].trim()) {
-          texts.push(p['content'].trim());
+        if (p) {
+          if (typeof p['content'] === 'string' && p['content'].trim()) {
+            texts.push(p['content'].trim());
+          }
+          // Plan cards (planComponentSchema) hold their prose in `desc` and each
+          // step in `todos[].text` — neither is a `content` prop, so without this
+          // a whole plan collapses to just its title.
+          if (typeof p['desc'] === 'string' && p['desc'].trim()) {
+            texts.push(p['desc'].trim());
+          }
+          if (Array.isArray(p['todos'])) {
+            for (const todo of p['todos']) {
+              if (!todo || typeof todo !== 'object') continue;
+              const t = todo as Record<string, unknown>;
+              if (typeof t['text'] === 'string' && t['text'].trim()) {
+                texts.push(t['text'].trim());
+              }
+            }
+          }
         }
         if (Array.isArray(c['children'])) walk(c['children'] as unknown[]);
       }


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Fix ticket activity UI for FlowJSON 

Root cause

Condensed mode never actually built a text preview. It passed the raw message content to RenderMessageWithHTML, which sees data-flow-json and mounts the real FlowScreenManager card unconditionally, then wrapped it in a line-clamp-1 div and hoped CSS would hide the rest. But -webkit-line-clamp only clamps inline content — on the legacy -webkit-box implementation it does nothing to block-level children. 
Electron 33 ships Chromium 130, which still uses that legacy path, so the card rendered at full height; newer browser Chromium has the LayoutNG rewrite that clamps blocks, which is why the web app happened to look fine. 

Solution
Stop rendering the card in condensed rows and render text instead. getFlowJsonPreviewText extracts the data-flow-json attribute, unescapes it, JSON.parses it, and walks the component tree collecting the flow title plus every content, plan desc, and todos[].text string, joined with —. Each of the seven condensed Activity components now does getFlowJsonPreviewText(content) ?? <RenderMessageWithHTML …/> — a preview string for flow messages, unchanged behaviour for everything else. The result is a real one-line string that clamps identically on every engine, and it avoids mounting an
interactive card with focusable buttons in every virtualized list row.
  
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/c3ef8d7f-4aca-4507-b707-ce53575eeac7" />

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
