### PR TITLE
fix: WorkspacesACL hides the caller's own session workspace for cross-org users (ORG_REQUIRED)

### DIFF
--- a/apps/backend/src/database/acl/tables/workspaces-acl.ts
+++ b/apps/backend/src/database/acl/tables/workspaces-acl.ts
@@ -27,16 +27,26 @@ export class WorkspacesACL extends BaseQueryACL<
       return { id: this.ctx.workspaceId }
     }
     return {
-      status: 'ACTIVE',
-      organization: {
-        members: {
-          some: {
-            memberId: this.ctx.memberId,
-            // Only active memberships (leftAt null) grant access to the org's workspaces.
-            leftAt: null,
+      // The caller's session workspace is always readable. Org membership records one org
+      // per email (org_members.email is unique), while users can belong to workspaces in
+      // other orgs — for those sessions the membership clause below can never match, and
+      // hiding the caller's own workspace breaks every lookup that resolves it (e.g. app
+      // creation resolving the owning org).
+      OR: [
+        { id: this.ctx.workspaceId },
+        {
+          status: 'ACTIVE',
+          organization: {
+            members: {
+              some: {
+                memberId: this.ctx.memberId,
+                // Only active memberships (leftAt null) grant access to the org's workspaces.
+                leftAt: null,
+              },
+            },
           },
         },
-      },
+      ],
     }
   }
 


### PR DESCRIPTION
## Problem

Admins/users whose session workspace belongs to a different org than their `org_members` row get hard failures on any flow that resolves their current workspace — e.g. creating an app (Claw admin, global agents) fails with:

```
{"error":"Could not resolve organization for the current workspace","code":"ORG_REQUIRED"}
```

## Root cause

`WorkspacesACL.getWhereClause()` (introduced with the per-table ACL work in #205/#213) only grants workspace reads through an active org membership:

```ts
{ status: 'ACTIVE', organization: { members: { some: { memberId, leftAt: null } } } }
```

But `org_members.email` is globally unique — **one org per email** — while users legitimately belong to workspaces in more than one org. For those sessions the membership clause can never match the session workspace's org, so the ACL silently filters out the workspace the caller is logged into. `repositories.workspaces.findById(req.user.workspaceId)` returns `null`, and callers like `appController.createApp` misreport it as `ORG_REQUIRED` (the column is non-nullable — the row was hidden, not org-less).

**Blast radius measured in prod:** 1,852 active user–workspace rows are in this cross-org state:

```sql
SELECT count(*) FROM users u
JOIN workspaces  w  ON w.id = u."workspaceId"
JOIN org_members om ON om."memberId" = u."orgMemberId"
WHERE om."orgId" <> w."orgId" AND u.status = 'ACTIVE';
```

## Fix

The caller's session workspace **is** their tenant boundary — hiding it can only break resolution, never protect anything. `OR` it into the clause; the membership branch still governs visibility into the org's other workspaces:

```ts
OR: [
  { id: this.ctx.workspaceId },
  { status: 'ACTIVE', organization: { members: { some: { memberId, leftAt: null } } } },
]
```

`getMutateWhere()` is unchanged (still admin/owner + own workspace only).

## Follow-up (not in this PR)

The underlying conflict — cross-org workspace membership vs. one-org-per-email `org_members` — needs an owner-level decision. Other table ACLs that join through `org_members` should be audited for the same assumption.

Same fix raised against `main`, `release-20260805`, and `release-20260810`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
