### PR TITLE
Fix/xyne 54658 implement v2 knowledge base

### DIFF
--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/AgentDetailHeaderV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/AgentDetailHeaderV2.tsx
@@ -39,7 +39,7 @@ const Action = ({
     className={cn(
       'flex h-7 shrink-0 items-center gap-1.5 rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors disabled:pointer-events-none disabled:opacity-50',
       primary
-        ? 'border-border bg-primary text-primary-foreground hover:bg-primary/90'
+        ? 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90'
         : 'border-transparent text-foreground hover:bg-muted',
     )}
   >

--- a/apps/dashboard/src/routes/AIScreen/library/mcp/detail/ClawMcpDetailV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/mcp/detail/ClawMcpDetailV2.tsx
@@ -32,7 +32,7 @@ function Field({
       <div
         className={cn(
           'flex w-full gap-2 rounded-2xl border border-border bg-card',
-          single ? 'h-[54px] items-center px-4' : 'items-start p-4',
+          single ? 'h-10 items-center px-3' : 'items-start p-4',
         )}
       >
         <div className='min-w-0 flex-1'>{children}</div>

--- a/apps/dashboard/src/routes/AIScreen/library/shared/components/LibraryCard.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/components/LibraryCard.tsx
@@ -27,7 +27,7 @@ export function LibraryIconTile({
   return (
     <span
       className={cn(
-        'flex shrink-0 items-center justify-center overflow-hidden rounded-lg text-sm font-normal shadow-sm',
+        'flex shrink-0 items-center justify-center overflow-hidden rounded-lg text-sm font-medium shadow-sm',
         TILE_SIZE[size],
 
         color ? 'text-white' : 'border border-border bg-card text-muted-foreground',

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BrowseBuiltinToolsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BrowseBuiltinToolsDialog.tsx
@@ -86,7 +86,7 @@ const BuiltinCard = ({
       title={enabled ? `Remove ${entry.label}` : `Add all ${entry.label} tools`}
       data-track-category='Claw Agents'
       data-track-name='Create agent v2: quick toggle built-in group'
-      className='absolute right-9 top-2.5 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
+      className='absolute right-11 top-4 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
     >
       {enabled ? (
         <MultipleCrossCancelDefault className='size-4' aria-hidden />

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BrowseBuiltinToolsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BrowseBuiltinToolsDialog.tsx
@@ -1,4 +1,6 @@
 import { useMemo, useState, type ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
 import { Pill } from '../../primitives/Pill';
@@ -49,7 +51,7 @@ const BuiltinCard = ({
       onClick={onOpen}
       data-track-category='Claw Agents'
       data-track-name='Create agent v2: open built-in detail'
-      className='flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] p-2.5 text-left transition-colors hover:bg-muted/50'
+      className={cn(BROWSE_CARD, enabled ? BROWSE_CARD_SELECTED : BROWSE_CARD_IDLE)}
     >
       <span className='flex w-full items-center justify-between gap-2'>
         <span className='flex min-w-0 items-center gap-2'>

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BuiltinDetailPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BuiltinDetailPanel.tsx
@@ -67,7 +67,7 @@ export function BuiltinDetailPanel({
             'flex h-7 shrink-0 items-center justify-center rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors',
             enabled
               ? 'border-border bg-card text-foreground hover:bg-muted'
-              : 'border-border bg-primary text-primary-foreground hover:bg-primary/90',
+              : 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
           )}
         >
           {enabled ? 'Disable' : 'Enable'}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/BrowseKnowledgeDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/BrowseKnowledgeDialog.tsx
@@ -1,22 +1,19 @@
-import { type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
+import { ChevronRight, MultipleCrossCancelDefault, UserCheck } from '@xyne/icons';
 import { cn } from '@/utils/classNames';
-import { KnowledgeBasePicker } from '@/components/ClawAgents/KnowledgeBasePicker/KnowledgeBasePicker';
-import type { KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
+import { useClawKnowledgeBaseTree } from '@/hooks/useClawKnowledgeBaseTree';
+import type { KbCollectionNode, KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
 import { BrowseDialog } from '../../primitives/BrowseDialog';
+import { DetailEmptyState } from '../../primitives/DetailPrimitives';
+import { BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
+import { KbCollectionMeta, KbFolderTile } from './KnowledgeTiles';
+import { KnowledgeCollectionBrowser } from './KnowledgeCollectionBrowser';
+import { MatchUserAccessToggle } from './MatchUserAccessToggle';
 import type { KbScope } from './knowledgeCatalog';
+import { countGrantedFiles, grantsUnder, matchesQuery } from './knowledgeTree';
 
-const SCOPES: ReadonlyArray<{ value: KbScope; label: string; hint: string }> = [
-  {
-    value: 'COLLECTIONS',
-    label: 'Selected collections & files',
-    hint: 'Pick an explicit allowlist. Same scope for everyone.',
-  },
-  {
-    value: 'USER',
-    label: 'Match my access',
-    hint: "Inherits the running user's spaces access — per session.",
-  },
-];
+const USER_SCOPE_NOTE =
+  'This agent reads whatever the person running it can already see in Spaces, so there are no collections to pick. Turn this off to attach a fixed set instead.';
 
 interface BrowseKnowledgeDialogProps {
   open: boolean;
@@ -35,56 +32,183 @@ export function BrowseKnowledgeDialog({
   grants,
   onGrantsChange,
 }: BrowseKnowledgeDialogProps): ReactElement {
+  const kb = useClawKnowledgeBaseTree({ enabled: open });
+  const tree = useMemo(() => kb.data?.collections ?? [], [kb.data?.collections]);
+
+  const [query, setQuery] = useState('');
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const results = useMemo(() => tree.filter(root => matchesQuery(root, query)), [tree, query]);
+
+  // Chips are keyed by root collection: a grant three folders deep still has to
+  // show up (and be removable) against the card the user actually clicked.
+  const selected = useMemo(
+    () =>
+      tree
+        .map(root => ({ root, mine: grantsUnder(root, grants) }))
+        .filter(entry => entry.mine.length > 0)
+        .map(entry => ({
+          root: entry.root,
+          fileCount: countGrantedFiles(tree, entry.mine),
+          keys: new Set(entry.mine.map(grant => `${grant.collectionId}:${grant.fileId ?? '*'}`)),
+        })),
+    [tree, grants],
+  );
+
+  const removeRoot = (keys: Set<string>): void => {
+    onGrantsChange(
+      grants.filter(grant => !keys.has(`${grant.collectionId}:${grant.fileId ?? '*'}`)),
+    );
+  };
+
+  const openCollection = openId ? (tree.find(root => root.id === openId) ?? null) : null;
+  const noSpacesSession = kb.data?.noSpacesSession ?? false;
+
+  const emptyMessage =
+    scope === 'USER'
+      ? null
+      : noSpacesSession
+        ? 'Sign in to Spaces to attach Knowledge Base documents to this agent.'
+        : tree.length === 0
+          ? "You don't have access to any Knowledge Base collections yet. Create one in Spaces, or ask a teammate to share theirs."
+          : results.length === 0
+            ? 'No collections match your search.'
+            : null;
+
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={onOpenChange}
-      title='Browse knowledge'
+      onOpenChange={next => {
+        if (!next) setOpenId(null);
+        onOpenChange(next);
+      }}
+      title='Browse Knowledge Base'
       description='Choose what reference material this agent can read.'
       testId='browse-knowledge-dialog'
-      loading={false}
-      isError={false}
-      onRetry={() => undefined}
-      emptyMessage={null}
-      toolbar={
-        <div className='grid grid-cols-1 gap-2 sm:grid-cols-2'>
-          {SCOPES.map(option => {
-            const selected = scope === option.value;
-            return (
-              <button
-                key={option.value}
-                type='button'
-                onClick={() => onScopeChange(option.value)}
-                aria-pressed={selected}
-                data-track-category='Claw Agents'
-                data-track-name='Create agent v2: set KB scope'
-                className={cn(
-                  'flex flex-col items-start gap-1 rounded-[10px] border p-2.5 text-left transition-colors',
-                  selected
-                    ? 'border-primary/40 bg-primary/5'
-                    : 'border-border bg-card hover:bg-muted/50',
-                )}
-              >
-                <span className='text-sm font-semibold leading-5 text-foreground'>
-                  {option.label}
-                </span>
-                <span className='text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
-                  {option.hint}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      }
+      query={query}
+      onQueryChange={setQuery}
+      loading={kb.isLoading}
+      isError={kb.isError}
+      onRetry={() => void kb.refetch()}
+      emptyMessage={emptyMessage}
+      {...(openCollection
+        ? {
+            detail: {
+              label: openCollection.name,
+              onBack: () => setOpenId(null),
+              content: (
+                <KnowledgeCollectionBrowser
+                  root={openCollection}
+                  grants={grants}
+                  onGrantsChange={onGrantsChange}
+                  onDone={() => setOpenId(null)}
+                />
+              ),
+            },
+          }
+        : {})}
+      toolbar={<MatchUserAccessToggle scope={scope} onScopeChange={onScopeChange} />}
+      {...(scope === 'COLLECTIONS' && selected.length > 0
+        ? {
+            chips: (
+              <div className='flex flex-col gap-4 px-2'>
+                <div className='flex flex-wrap gap-2'>
+                  {selected.map(entry => (
+                    <button
+                      key={entry.root.id}
+                      type='button'
+                      onClick={() => removeRoot(entry.keys)}
+                      title={`Remove ${entry.root.name}`}
+                      aria-label={`Remove ${entry.root.name}`}
+                      data-track-category='Claw Agents'
+                      data-track-name='Create agent v2: remove KB collection'
+                      className='flex shrink-0 items-center gap-1.5 overflow-hidden rounded-[10px] border-[0.8px] border-solid border-border bg-muted py-1 pl-1 pr-2 transition-colors hover:bg-muted/70'
+                    >
+                      <KbFolderTile size='sm' />
+                      <span className='max-w-[200px] truncate text-sm font-medium leading-5 text-foreground'>
+                        {entry.root.name}
+                      </span>
+                      <span className='shrink-0 text-sm leading-5 text-muted-foreground'>
+                        {entry.fileCount} file{entry.fileCount === 1 ? '' : 's'}
+                      </span>
+                      <MultipleCrossCancelDefault
+                        className='size-3 shrink-0 text-muted-foreground'
+                        aria-hidden
+                      />
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type='button'
+                  onClick={() => onGrantsChange([])}
+                  data-track-category='Claw Agents'
+                  data-track-name='Create agent v2: remove all KB grants'
+                  className='self-end text-xs leading-4 tracking-[-0.24px] text-foreground underline underline-offset-2 transition-opacity hover:opacity-70'
+                >
+                  Remove All
+                </button>
+              </div>
+            ),
+          }
+        : {})}
     >
       {scope === 'USER' ? (
-        <p className='px-2.5 py-8 text-center text-sm leading-5 text-muted-foreground'>
-          This agent will read whatever the person running it can already see in Spaces. No
-          collections to pick.
-        </p>
+        <div className='flex min-h-0 flex-1 items-center justify-center'>
+          <div className='max-w-[380px]'>
+            <DetailEmptyState
+              icon={<UserCheck className='size-6' aria-hidden />}
+              title='Following the running user'
+              description={USER_SCOPE_NOTE}
+              className='pt-0'
+            />
+          </div>
+        </div>
       ) : (
-        <KnowledgeBasePicker value={grants} onChange={onGrantsChange} />
+        <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+          {results.map(root => (
+            <CollectionCard
+              key={root.id}
+              node={root}
+              selected={grantsUnder(root, grants).length > 0}
+              onOpen={() => setOpenId(root.id)}
+            />
+          ))}
+        </div>
       )}
     </BrowseDialog>
+  );
+}
+
+function CollectionCard({
+  node,
+  selected,
+  onOpen,
+}: {
+  node: KbCollectionNode;
+  selected: boolean;
+  onOpen: () => void;
+}): ReactElement {
+  return (
+    <button
+      type='button'
+      onClick={onOpen}
+      data-track-category='Claw Agents'
+      data-track-name='Create agent v2: open KB collection'
+      className={cn(
+        'flex w-full items-center gap-2.5 overflow-hidden rounded-2xl border-[0.8px] border-transparent p-4 text-left transition-colors',
+        selected ? BROWSE_CARD_SELECTED : BROWSE_CARD_IDLE,
+      )}
+    >
+      <KbFolderTile size='lg' />
+      <span className='flex min-w-0 flex-1 flex-col gap-1.5 overflow-hidden'>
+        <span className='flex min-w-0 items-center gap-2'>
+          <span className='min-w-0 flex-1 truncate text-sm font-medium leading-5 text-foreground'>
+            {node.name}
+          </span>
+          <ChevronRight className='size-4 shrink-0 text-muted-foreground' aria-hidden />
+        </span>
+        <KbCollectionMeta node={node} />
+      </span>
+    </button>
   );
 }

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/KnowledgeCapabilityRow.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/KnowledgeCapabilityRow.tsx
@@ -80,7 +80,7 @@ export function KnowledgeCapabilityRow({
               className='flex shrink-0 items-center gap-1.5 overflow-hidden rounded-[10px] border-[0.8px] border-solid border-border bg-muted py-1 pl-2.5 pr-2 transition-colors hover:bg-muted/70'
             >
               <span className='flex min-w-0 flex-col items-start'>
-                <span className='max-w-[220px] truncate text-sm font-semibold leading-5 text-foreground'>
+                <span className='max-w-[220px] truncate text-sm font-medium leading-5 text-foreground'>
                   {grant.label}
                 </span>
                 {grant.detail && (

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/KnowledgeCollectionBrowser.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/KnowledgeCollectionBrowser.tsx
@@ -1,0 +1,555 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  FolderDefault,
+  InformationCircle,
+  MultipleCrossCancelDefault,
+} from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import { Checkbox } from '@/components/ui/Checkbox/Checkbox';
+import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
+import type { KbCollectionNode, KbFile, KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
+import { KbCollectionMeta, KbFileTile, KbFolderTile } from './KnowledgeTiles';
+import {
+  countFiles,
+  describeFile,
+  grantCollection,
+  grantFile,
+  grantsUnder,
+  indexGrants,
+  revokeCollection,
+  revokeFile,
+} from './knowledgeTree';
+
+const SELECTED_FILES_HINT =
+  'Everything listed here is readable by the agent. Granting a folder grants everything inside it.';
+
+/** Ancestor chain from the root collection down to `id`, inclusive. */
+function pathTo(root: KbCollectionNode, id: string): KbCollectionNode[] {
+  const walk = (node: KbCollectionNode, trail: KbCollectionNode[]): KbCollectionNode[] | null => {
+    const next = [...trail, node];
+    if (node.id === id) return next;
+    for (const child of node.children ?? []) {
+      const hit = walk(child, next);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  return walk(root, []) ?? [root];
+}
+
+interface KnowledgeCollectionBrowserProps {
+  root: KbCollectionNode;
+  grants: KbSelection[];
+  onGrantsChange: (next: KbSelection[]) => void;
+  onDone: () => void;
+}
+
+export function KnowledgeCollectionBrowser({
+  root,
+  grants,
+  onGrantsChange,
+  onDone,
+}: KnowledgeCollectionBrowserProps): ReactElement {
+  const [path, setPath] = useState<KbCollectionNode[]>([root]);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set([root.id]));
+
+  const { collections: wholeGrants, files: fileGrants } = useMemo(
+    () => indexGrants(grants),
+    [grants],
+  );
+  const mine = useMemo(() => grantsUnder(root, grants), [root, grants]);
+
+  const here = path[path.length - 1] ?? root;
+  // A grant on any ancestor already covers everything below it, so those rows
+  // read as checked but can't be toggled independently.
+  const coveredHere = path.some(node => wholeGrants.has(node.id));
+
+  const openFolder = (node: KbCollectionNode): void => {
+    setPath(pathTo(root, node.id));
+    setExpanded(current => new Set(current).add(node.id));
+  };
+
+  const toggleFolder = (node: KbCollectionNode, covered: boolean): void => {
+    if (covered) return;
+    onGrantsChange(
+      wholeGrants.has(node.id) ? revokeCollection(grants, node.id) : grantCollection(grants, node),
+    );
+  };
+
+  const toggleFile = (parent: KbCollectionNode, file: KbFile, covered: boolean): void => {
+    if (covered) return;
+    onGrantsChange(
+      fileGrants.has(file.id) ? revokeFile(grants, file.id) : grantFile(grants, parent, file),
+    );
+  };
+
+  const clearMine = (): void => {
+    const removable = new Set(mine.map(grant => `${grant.collectionId}:${grant.fileId ?? '*'}`));
+    onGrantsChange(
+      grants.filter(grant => !removable.has(`${grant.collectionId}:${grant.fileId ?? '*'}`)),
+    );
+  };
+
+  const chips = mine.map(grant => {
+    const key = `${grant.collectionId}:${grant.fileId ?? '*'}`;
+    if (!grant.fileId) {
+      const node = pathTo(root, grant.collectionId).at(-1);
+      return {
+        key,
+        name: node?.name ?? 'Folder',
+        tile: <KbFolderTile size='sm' />,
+        onRemove: (): void => onGrantsChange(revokeCollection(grants, grant.collectionId)),
+      };
+    }
+    const parent = pathTo(root, grant.collectionId).at(-1);
+    const file = parent?.items?.find(item => item.id === grant.fileId);
+    return {
+      key,
+      name: file?.name ?? 'File',
+      tile: <KbFileTile name={file?.name ?? ''} size='sm' />,
+      onRemove: (): void => onGrantsChange(revokeFile(grants, grant.fileId as string)),
+    };
+  });
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col overflow-hidden px-[22px] pb-3 pt-2'>
+      <div className='flex h-11 shrink-0 items-center gap-2.5'>
+        <KbFolderTile size='lg' />
+        <div className='flex min-w-0 flex-1 flex-col gap-1'>
+          <span className='truncate text-sm font-semibold leading-[1.3] tracking-[-0.28px] text-foreground'>
+            {root.name}
+          </span>
+          <KbCollectionMeta node={root} />
+        </div>
+        <button
+          type='button'
+          onClick={onDone}
+          disabled={mine.length === 0}
+          data-track-category='Claw Agents'
+          data-track-name='Create agent v2: add KB selection'
+          className='flex h-7 shrink-0 items-center rounded-[10px] border-[0.8px] border-transparent bg-primary px-2 text-sm font-medium leading-[1.2] text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-40'
+        >
+          Add Selected
+        </button>
+      </div>
+
+      <div className='mt-8 shrink-0 border-t border-border' />
+
+      <div className='mt-4 flex shrink-0 flex-col gap-4'>
+        <div className='flex items-center gap-1.5'>
+          <span className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+            Selected Files
+          </span>
+          <Tooltip side='top' content={SELECTED_FILES_HINT}>
+            <span className='inline-flex'>
+              <InformationCircle className='size-4 shrink-0 text-muted-foreground' aria-hidden />
+            </span>
+          </Tooltip>
+        </div>
+
+        {chips.length === 0 ? (
+          <p className='text-sm leading-5 text-muted-foreground'>No files selected</p>
+        ) : (
+          <>
+            <div className='flex max-h-[88px] flex-wrap gap-2 overflow-y-auto'>
+              {chips.map(chip => (
+                <button
+                  key={chip.key}
+                  type='button'
+                  onClick={chip.onRemove}
+                  title={`Remove ${chip.name}`}
+                  aria-label={`Remove ${chip.name}`}
+                  data-track-category='Claw Agents'
+                  data-track-name='Create agent v2: remove KB grant'
+                  className='flex shrink-0 items-center gap-1.5 overflow-hidden rounded-[10px] border-[0.8px] border-solid border-border bg-muted py-1 pl-1 pr-2 transition-colors hover:bg-muted/70'
+                >
+                  {chip.tile}
+                  <span className='max-w-[200px] truncate text-sm font-medium leading-5 text-foreground'>
+                    {chip.name}
+                  </span>
+                  <MultipleCrossCancelDefault
+                    className='size-3 shrink-0 text-muted-foreground'
+                    aria-hidden
+                  />
+                </button>
+              ))}
+            </div>
+            <button
+              type='button'
+              onClick={clearMine}
+              data-track-category='Claw Agents'
+              data-track-name='Create agent v2: remove selected KB grants'
+              className='self-end text-xs leading-4 tracking-[-0.24px] text-foreground underline underline-offset-2 transition-opacity hover:opacity-70'
+            >
+              Remove Selected
+            </button>
+          </>
+        )}
+      </div>
+
+      <nav aria-label='Folder path' className='mt-8 flex shrink-0 flex-wrap items-center gap-1'>
+        {path.map((node, index) => {
+          const last = index === path.length - 1;
+          return (
+            <span key={node.id} className='flex items-center gap-1'>
+              {index > 0 && <span className='text-sm text-muted-foreground'>/</span>}
+              <button
+                type='button'
+                disabled={last}
+                onClick={() => setPath(path.slice(0, index + 1))}
+                data-track-category='Claw Agents'
+                data-track-name='Create agent v2: KB breadcrumb'
+                className={cn(
+                  'max-w-[180px] truncate rounded px-1 text-sm leading-5 transition-colors',
+                  last
+                    ? 'cursor-default font-medium text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {node.name}
+              </button>
+            </span>
+          );
+        })}
+      </nav>
+
+      <div className='mt-4 flex min-h-0 flex-1 gap-3 overflow-hidden'>
+        <div className='w-[250px] shrink-0 overflow-y-auto pr-1'>
+          <TreeNode
+            node={root}
+            covered={false}
+            activeId={here.id}
+            expanded={expanded}
+            onToggleExpanded={id =>
+              setExpanded(current => {
+                const next = new Set(current);
+                if (next.has(id)) next.delete(id);
+                else next.add(id);
+                return next;
+              })
+            }
+            grants={grants}
+            wholeGrants={wholeGrants}
+            fileGrants={fileGrants}
+            onOpenFolder={openFolder}
+            onToggleFolder={toggleFolder}
+            onToggleFile={toggleFile}
+          />
+        </div>
+
+        <div className='min-w-0 flex-1 overflow-y-auto'>
+          <FolderContents
+            node={here}
+            covered={coveredHere}
+            wholeGrants={wholeGrants}
+            fileGrants={fileGrants}
+            onOpenFolder={openFolder}
+            onToggleFolder={toggleFolder}
+            onToggleFile={toggleFile}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── left pane ─────────────────────────────────────────────────────── */
+
+interface TreeNodeProps {
+  node: KbCollectionNode;
+  covered: boolean;
+  activeId: string;
+  expanded: Set<string>;
+  onToggleExpanded: (id: string) => void;
+  grants: KbSelection[];
+  wholeGrants: Set<string>;
+  fileGrants: Set<string>;
+  onOpenFolder: (node: KbCollectionNode) => void;
+  onToggleFolder: (node: KbCollectionNode, covered: boolean) => void;
+  onToggleFile: (parent: KbCollectionNode, file: KbFile, covered: boolean) => void;
+}
+
+function TreeNode({
+  node,
+  covered,
+  activeId,
+  expanded,
+  onToggleExpanded,
+  grants,
+  wholeGrants,
+  fileGrants,
+  onOpenFolder,
+  onToggleFolder,
+  onToggleFile,
+}: TreeNodeProps): ReactElement {
+  const children = node.children ?? [];
+  const items = node.items ?? [];
+  const isOpen = expanded.has(node.id);
+  const checked = covered || wholeGrants.has(node.id);
+  const partial = !checked && grantsUnder(node, grants).length > 0;
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <TreeRow
+        active={node.id === activeId}
+        label={node.name}
+        icon={<FolderDefault className='size-4 shrink-0 text-muted-foreground' aria-hidden />}
+        checked={checked}
+        indeterminate={partial}
+        disabled={covered}
+        onCheckedChange={() => onToggleFolder(node, covered)}
+        onSelect={() => onOpenFolder(node)}
+        expandable={children.length > 0 || items.length > 0}
+        expanded={isOpen}
+        onToggleExpanded={() => onToggleExpanded(node.id)}
+        trackName='Create agent v2: open KB folder'
+      />
+
+      {isOpen && (children.length > 0 || items.length > 0) && (
+        <div className='ml-5 flex flex-col gap-2 border-l border-border pl-2'>
+          {children.map(child => (
+            <TreeNode
+              key={child.id}
+              node={child}
+              covered={checked}
+              activeId={activeId}
+              expanded={expanded}
+              onToggleExpanded={onToggleExpanded}
+              grants={grants}
+              wholeGrants={wholeGrants}
+              fileGrants={fileGrants}
+              onOpenFolder={onOpenFolder}
+              onToggleFolder={onToggleFolder}
+              onToggleFile={onToggleFile}
+            />
+          ))}
+          {items.map(file => (
+            <TreeRow
+              key={file.id}
+              active={false}
+              label={file.name}
+              checked={checked || fileGrants.has(file.id)}
+              indeterminate={false}
+              disabled={checked}
+              onCheckedChange={() => onToggleFile(node, file, checked)}
+              onSelect={() => onToggleFile(node, file, checked)}
+              expandable={false}
+              expanded={false}
+              onToggleExpanded={() => undefined}
+              trackName='Create agent v2: toggle KB file'
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TreeRow({
+  active,
+  label,
+  icon,
+  checked,
+  indeterminate,
+  disabled,
+  onCheckedChange,
+  onSelect,
+  expandable,
+  expanded,
+  onToggleExpanded,
+  trackName,
+}: {
+  active: boolean;
+  label: string;
+  icon?: ReactElement;
+  checked: boolean;
+  indeterminate: boolean;
+  disabled: boolean;
+  onCheckedChange: () => void;
+  onSelect: () => void;
+  expandable: boolean;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  trackName: string;
+}): ReactElement {
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div
+      className={cn(
+        'group flex h-8 shrink-0 items-center gap-1.5 rounded-lg px-2 transition-colors',
+        active ? 'bg-muted' : 'hover:bg-muted/50',
+      )}
+    >
+      {expandable ? (
+        <button
+          type='button'
+          onClick={onToggleExpanded}
+          aria-label={expanded ? `Collapse ${label}` : `Expand ${label}`}
+          data-track-category='Claw Agents'
+          data-track-name='Create agent v2: expand KB folder'
+          className='flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground'
+        >
+          <Chevron className='size-3.5' aria-hidden />
+        </button>
+      ) : (
+        <span className='size-4 shrink-0' aria-hidden />
+      )}
+
+      {icon}
+
+      <button
+        type='button'
+        onClick={onSelect}
+        title={label}
+        data-track-category='Claw Agents'
+        data-track-name={trackName}
+        className='min-w-0 flex-1 truncate text-left text-sm leading-5 text-foreground'
+      >
+        {label}
+      </button>
+
+      {/* Idle rows stay clean — the box only shows once it carries state or the
+          row is hovered. */}
+      <span
+        className={cn(
+          'shrink-0 transition-opacity',
+          checked || indeterminate
+            ? 'opacity-100'
+            : 'opacity-0 focus-within:opacity-100 group-hover:opacity-100',
+        )}
+      >
+        <Checkbox
+          checked={checked}
+          indeterminate={indeterminate}
+          disabled={disabled}
+          onChange={onCheckedChange}
+          label=''
+          size='sm'
+        />
+      </span>
+    </div>
+  );
+}
+
+/* ── right pane ────────────────────────────────────────────────────── */
+
+function FolderContents({
+  node,
+  covered,
+  wholeGrants,
+  fileGrants,
+  onOpenFolder,
+  onToggleFolder,
+  onToggleFile,
+}: {
+  node: KbCollectionNode;
+  covered: boolean;
+  wholeGrants: Set<string>;
+  fileGrants: Set<string>;
+  onOpenFolder: (node: KbCollectionNode) => void;
+  onToggleFolder: (node: KbCollectionNode, covered: boolean) => void;
+  onToggleFile: (parent: KbCollectionNode, file: KbFile, covered: boolean) => void;
+}): ReactElement {
+  const children = node.children ?? [];
+  const items = node.items ?? [];
+
+  if (children.length === 0 && items.length === 0) {
+    return (
+      <p className='py-10 text-center text-sm leading-5 text-muted-foreground'>
+        This folder is empty.
+      </p>
+    );
+  }
+
+  return (
+    <div className='grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2'>
+      {children.map(child => {
+        const checked = covered || wholeGrants.has(child.id);
+        const count = countFiles(child);
+        return (
+          <ContentCard
+            key={child.id}
+            tile={<KbFolderTile size='lg' />}
+            name={child.name}
+            caption={`Folder · ${count} file${count === 1 ? '' : 's'}`}
+            checked={checked}
+            disabled={covered}
+            onToggle={() => onToggleFolder(child, covered)}
+            onOpen={() => onOpenFolder(child)}
+            trackName='Create agent v2: open KB folder card'
+          />
+        );
+      })}
+      {items.map(file => (
+        <ContentCard
+          key={file.id}
+          tile={<KbFileTile name={file.name} size='lg' />}
+          name={file.name}
+          caption={describeFile(file.name).label}
+          checked={covered || fileGrants.has(file.id)}
+          disabled={covered}
+          onToggle={() => onToggleFile(node, file, covered)}
+          trackName='Create agent v2: toggle KB file card'
+        />
+      ))}
+    </div>
+  );
+}
+
+function ContentCard({
+  tile,
+  name,
+  caption,
+  checked,
+  disabled,
+  onToggle,
+  onOpen,
+  trackName,
+}: {
+  tile: ReactElement;
+  name: string;
+  caption: string;
+  checked: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+  /** Folders drill in on click; files have nothing below them, so they toggle. */
+  onOpen?: () => void;
+  trackName: string;
+}): ReactElement {
+  return (
+    <div
+      className={cn(
+        'group flex h-[60px] items-center gap-1.5 rounded-2xl border-[0.8px] p-2 transition-colors',
+        checked ? 'border-border bg-muted/50' : 'border-border bg-card hover:bg-muted/40',
+      )}
+    >
+      {tile}
+      <button
+        type='button'
+        onClick={onOpen ?? onToggle}
+        title={name}
+        data-track-category='Claw Agents'
+        data-track-name={trackName}
+        className='flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left'
+      >
+        <span className='w-full truncate text-sm font-medium leading-5 text-foreground'>
+          {name}
+        </span>
+        <span className='w-full truncate text-xs leading-4 tracking-[-0.24px] text-muted-foreground'>
+          {caption}
+        </span>
+      </button>
+      <span
+        className={cn(
+          'shrink-0 transition-opacity',
+          checked ? 'opacity-100' : 'opacity-0 focus-within:opacity-100 group-hover:opacity-100',
+        )}
+      >
+        <Checkbox checked={checked} disabled={disabled} onChange={onToggle} label='' size='sm' />
+      </span>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/KnowledgeTiles.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/KnowledgeTiles.tsx
@@ -1,0 +1,69 @@
+import { type ReactElement } from 'react';
+import { FolderDefault, Hashtag } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import type { KbCollectionNode } from '@/services/claw/clawKnowledgeBaseTypes';
+import { describeFile, type KbIconComponent } from './knowledgeTree';
+
+const TILE = {
+  sm: { box: 'size-7 rounded-lg', glyph: 'size-4' },
+  md: { box: 'size-9 rounded-[10px]', glyph: 'size-5' },
+  lg: { box: 'size-11 rounded-xl', glyph: 'size-[25px]' },
+} as const;
+
+export type KbTileSize = keyof typeof TILE;
+
+function Tile({ icon, size }: { icon: KbIconComponent; size: KbTileSize }): ReactElement {
+  const Glyph = icon;
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center border-[0.8px] border-border bg-card text-muted-foreground shadow-sm',
+        TILE[size].box,
+      )}
+      aria-hidden
+    >
+      <Glyph className={TILE[size].glyph} />
+    </span>
+  );
+}
+
+export function KbFolderTile({ size = 'md' }: { size?: KbTileSize }): ReactElement {
+  return <Tile icon={FolderDefault} size={size} />;
+}
+
+export function KbFileTile({
+  name,
+  size = 'md',
+}: {
+  name: string;
+  size?: KbTileSize;
+}): ReactElement {
+  return <Tile icon={describeFile(name).icon} size={size} />;
+}
+
+/**
+ * `# channel · Project name` — the spaces coordinates that tell two similarly
+ * named collections apart.
+ */
+export function KbCollectionMeta({ node }: { node: KbCollectionNode }): ReactElement | null {
+  const channel = node.channelName;
+  const project = node.projectName;
+  if (!channel && !project) return null;
+
+  return (
+    <span className='flex min-w-0 items-center gap-3 text-xs leading-4 tracking-[-0.24px]'>
+      {channel && (
+        <span className='flex min-w-0 items-center gap-1 text-muted-foreground'>
+          <Hashtag className='size-3 shrink-0' aria-hidden />
+          <span className='truncate'>{channel}</span>
+        </span>
+      )}
+      {project && (
+        <span className='flex min-w-0 items-center gap-1'>
+          <span className='shrink-0 text-muted-foreground/60'>Project</span>
+          <span className='truncate text-muted-foreground'>{project}</span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/MatchUserAccessToggle.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/MatchUserAccessToggle.tsx
@@ -1,0 +1,24 @@
+import { type ReactElement } from 'react';
+import { Switch } from '@/components/ui/Switch';
+import type { KbScope } from './knowledgeCatalog';
+
+export function MatchUserAccessToggle({
+  scope,
+  onScopeChange,
+}: {
+  scope: KbScope;
+  onScopeChange: (next: KbScope) => void;
+}): ReactElement {
+  return (
+    <div className='flex h-[38px] w-full shrink-0 items-center justify-between gap-4 px-2.5 py-2'>
+      <span className='min-w-0 truncate text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+        Match User Access
+      </span>
+      <Switch
+        checked={scope === 'USER'}
+        onCheckedChange={next => onScopeChange(next ? 'USER' : 'COLLECTIONS')}
+        aria-label='Match user access'
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/knowledgeTree.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/knowledgeTree.ts
@@ -1,0 +1,189 @@
+import {
+  FileBarGraph,
+  FileCode,
+  FileDefault,
+  FilePdfFormat,
+  FileText,
+  PhotoImageDefault,
+} from '@xyne/icons';
+import type { KbCollectionNode, KbFile, KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
+
+export type KbIconComponent = typeof FileDefault;
+
+const FILE_KINDS: ReadonlyArray<{
+  extensions: readonly string[];
+  label: string;
+  icon: KbIconComponent;
+}> = [
+  { extensions: ['pdf'], label: 'PDF', icon: FilePdfFormat },
+  {
+    extensions: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'heic'],
+    label: 'Image',
+    icon: PhotoImageDefault,
+  },
+  { extensions: ['xls', 'xlsx', 'csv', 'tsv'], label: 'Spreadsheet', icon: FileBarGraph },
+  { extensions: ['doc', 'docx', 'txt', 'md', 'rtf'], label: 'Document', icon: FileText },
+  {
+    extensions: ['ts', 'tsx', 'js', 'jsx', 'py', 'go', 'rs', 'java', 'json', 'yaml', 'yml', 'sh'],
+    label: 'Code',
+    icon: FileCode,
+  },
+];
+
+/** Icon + human kind for a file, derived from its extension. */
+export function describeFile(name: string): { label: string; icon: KbIconComponent } {
+  const dot = name.lastIndexOf('.');
+  const extension = dot > 0 ? name.slice(dot + 1).toLowerCase() : '';
+  const kind = FILE_KINDS.find(candidate => candidate.extensions.includes(extension));
+  if (kind) return { label: kind.label, icon: kind.icon };
+  return { label: extension ? extension.toUpperCase() : 'File', icon: FileDefault };
+}
+
+export interface KbGrantIndex {
+  /** Collections granted whole — every descendant comes along. */
+  collections: Set<string>;
+  files: Set<string>;
+}
+
+export function indexGrants(grants: readonly KbSelection[]): KbGrantIndex {
+  const collections = new Set<string>();
+  const files = new Set<string>();
+  for (const grant of grants) {
+    if (grant.fileId) files.add(grant.fileId);
+    else collections.add(grant.collectionId);
+  }
+  return { collections, files };
+}
+
+export function countFiles(node: KbCollectionNode): number {
+  let total = node.items?.length ?? 0;
+  for (const child of node.children ?? []) total += countFiles(child);
+  return total;
+}
+
+/** Every collection and file id at or below `node`. */
+export function collectSubtree(node: KbCollectionNode): KbGrantIndex {
+  const collections = new Set<string>();
+  const files = new Set<string>();
+  const walk = (current: KbCollectionNode): void => {
+    collections.add(current.id);
+    for (const item of current.items ?? []) files.add(item.id);
+    for (const child of current.children ?? []) walk(child);
+  };
+  walk(node);
+  return { collections, files };
+}
+
+export function findCollection(
+  tree: readonly KbCollectionNode[],
+  id: string,
+): KbCollectionNode | undefined {
+  for (const root of tree) {
+    const walk = (node: KbCollectionNode): KbCollectionNode | undefined => {
+      if (node.id === id) return node;
+      for (const child of node.children ?? []) {
+        const hit = walk(child);
+        if (hit) return hit;
+      }
+      return undefined;
+    };
+    const hit = walk(root);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+export function findFile(
+  tree: readonly KbCollectionNode[],
+  fileId: string,
+): { file: KbFile; parent: KbCollectionNode } | undefined {
+  const walk = (node: KbCollectionNode): { file: KbFile; parent: KbCollectionNode } | undefined => {
+    for (const item of node.items ?? [])
+      if (item.id === fileId) return { file: item, parent: node };
+    for (const child of node.children ?? []) {
+      const hit = walk(child);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  for (const root of tree) {
+    const hit = walk(root);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/**
+ * Grants live against any node in the tree, but the browse grid is keyed by
+ * root collection — so a grant three folders deep still has to light up (and be
+ * removable from) its root card.
+ */
+export function grantsUnder(root: KbCollectionNode, grants: readonly KbSelection[]): KbSelection[] {
+  const subtree = collectSubtree(root);
+  return grants.filter(grant => subtree.collections.has(grant.collectionId));
+}
+
+/** How many files a set of grants reaches — a whole-collection grant counts its subtree. */
+export function countGrantedFiles(
+  tree: readonly KbCollectionNode[],
+  grants: readonly KbSelection[],
+): number {
+  let total = 0;
+  for (const grant of grants) {
+    if (grant.fileId) {
+      total += 1;
+      continue;
+    }
+    const node = findCollection(tree, grant.collectionId);
+    total += node ? countFiles(node) : 0;
+  }
+  return total;
+}
+
+/**
+ * Adds a whole-collection grant, dropping any grant it now covers so the same
+ * file is never granted twice.
+ */
+export function grantCollection(
+  grants: readonly KbSelection[],
+  node: KbCollectionNode,
+): KbSelection[] {
+  const subtree = collectSubtree(node);
+  const kept = grants.filter(grant =>
+    grant.fileId ? !subtree.files.has(grant.fileId) : !subtree.collections.has(grant.collectionId),
+  );
+  return [...kept, { collectionId: node.id, fileId: null }];
+}
+
+export function revokeCollection(
+  grants: readonly KbSelection[],
+  collectionId: string,
+): KbSelection[] {
+  return grants.filter(grant => !(grant.collectionId === collectionId && grant.fileId === null));
+}
+
+export function grantFile(
+  grants: readonly KbSelection[],
+  parent: KbCollectionNode,
+  file: KbFile,
+): KbSelection[] {
+  return [...grants, { collectionId: parent.id, fileId: file.id }];
+}
+
+export function revokeFile(grants: readonly KbSelection[], fileId: string): KbSelection[] {
+  return grants.filter(grant => grant.fileId !== fileId);
+}
+
+export function matchesQuery(root: KbCollectionNode, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  const haystack = [
+    root.name,
+    root.channelName ?? '',
+    root.projectName ?? '',
+    root.description ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(needle);
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/BrowseMcpsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/BrowseMcpsDialog.tsx
@@ -1,4 +1,6 @@
 import { Fragment, useMemo, useState, type ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { AGENT_CATEGORIES } from '@/services/claw/agentCategory';
 import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
@@ -54,7 +56,7 @@ const McpCard = ({
       onClick={onOpen}
       data-track-category='Claw Agents'
       data-track-name='Create agent v2: open MCP detail'
-      className='flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] p-2.5 text-left transition-colors hover:bg-muted/50'
+      className={cn(BROWSE_CARD, state.enabled ? BROWSE_CARD_SELECTED : BROWSE_CARD_IDLE)}
     >
       <span className='flex w-full items-center justify-between gap-2'>
         <McpIdentity

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/BrowseMcpsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/BrowseMcpsDialog.tsx
@@ -82,7 +82,7 @@ const McpCard = ({
         title={state.enabled ? `Remove ${entry.label}` : `Add all ${entry.label} tools`}
         data-track-category='Claw Agents'
         data-track-name='Create agent v2: quick toggle MCP'
-        className='absolute right-9 top-2.5 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
+        className='absolute right-11 top-4 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
       >
         {state.enabled ? (
           <MultipleCrossCancelDefault className='size-4' aria-hidden />

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/McpDetailPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/McpDetailPanel.tsx
@@ -163,7 +163,7 @@ export function McpDetailPanel({
             'flex h-7 shrink-0 items-center justify-center rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors disabled:cursor-not-allowed disabled:opacity-50',
             enabled
               ? 'border-border bg-card text-foreground hover:bg-muted'
-              : 'border-border bg-primary text-primary-foreground hover:bg-primary/90',
+              : 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
           )}
         >
           {enabled ? 'Disable' : 'Enable'}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/BrowseSkillsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/BrowseSkillsDialog.tsx
@@ -76,7 +76,7 @@ const SkillCard = ({
       title={`${selected ? 'Remove' : 'Add'} ${entry.label}`}
       data-track-category='Claw Agents'
       data-track-name='Create agent v2: quick toggle skill'
-      className='absolute right-9 top-2.5 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
+      className='absolute right-11 top-4 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
     >
       {selected ? (
         <MultipleCrossCancelDefault className='size-4' aria-hidden />

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/BrowseSkillsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/BrowseSkillsDialog.tsx
@@ -1,4 +1,6 @@
 import { Fragment, useMemo, useState, type ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
 import { Pill } from '../../primitives/Pill';
@@ -40,7 +42,7 @@ const SkillCard = ({
       onClick={onOpen}
       data-track-category='Claw Agents'
       data-track-name='Create agent v2: open skill detail'
-      className='flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] p-2.5 text-left transition-colors hover:bg-muted/50'
+      className={cn(BROWSE_CARD, selected ? BROWSE_CARD_SELECTED : BROWSE_CARD_IDLE)}
     >
       <span className='flex w-full items-center justify-between gap-2'>
         <span className='flex min-w-0 items-center gap-2'>

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/SkillDetailPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/SkillDetailPanel.tsx
@@ -3,8 +3,8 @@ import { Staroflife } from '@xyne/icons';
 import { cn } from '@/utils/classNames';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useClawSkillFiles } from '@/hooks/useClawSkills';
-import { ProseBox } from '../../primitives/ProseBox';
-import { SectionHeading, Separator } from '../../primitives/Section';
+import { ScrollFadeBox } from '../../primitives/ProseBox';
+import { SectionHeading } from '../../primitives/Section';
 import { SkillFileTree } from './SkillFileTree';
 import {
   buildSkillFileTree,
@@ -23,29 +23,6 @@ const SKILL_MD_NODE: SkillTreeFile = {
   path: SKILL_MD,
   fileId: null,
 };
-
-const DATE_FORMAT = new Intl.DateTimeFormat('en-GB', {
-  day: 'numeric',
-  month: 'short',
-  year: 'numeric',
-});
-
-function formatDate(value: string | undefined): string {
-  if (!value) return '—';
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? '—' : DATE_FORMAT.format(parsed);
-}
-
-const MetaRow = ({ label, children }: { label: string; children: ReactNode }): ReactElement => (
-  <div className='flex h-7 w-full items-center justify-between gap-3'>
-    <span className='shrink-0 text-sm font-medium leading-[1.2] text-muted-foreground'>
-      {label}
-    </span>
-    <span className='min-w-0 truncate text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
-      {children}
-    </span>
-  </div>
-);
 
 const Body = ({ children }: { children: string }): ReactElement => (
   <p className='whitespace-pre-wrap break-words text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
@@ -111,10 +88,17 @@ export function SkillDetailPanel({
           </span>
           <div className='flex min-w-0 flex-col gap-1.5 py-px'>
             <span className='truncate text-sm font-semibold leading-[1.3] tracking-[-0.28px] text-foreground'>
-              {entry.label}
+              /{entry.label}
             </span>
             <span className='truncate text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
-              {entry.scope === 'global' ? 'Global' : 'Personal'}
+              Created by{' '}
+              {email ? (
+                <a href={`mailto:${email}`} className='underline underline-offset-2'>
+                  {entry.ownerName ?? email}
+                </a>
+              ) : (
+                <span className='underline underline-offset-2'>{entry.ownerName ?? 'Unknown'}</span>
+              )}
             </span>
           </div>
         </div>
@@ -129,7 +113,7 @@ export function SkillDetailPanel({
             'flex h-7 shrink-0 items-center justify-center rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors',
             selected
               ? 'border-border bg-card text-foreground hover:bg-muted'
-              : 'border-border bg-primary text-primary-foreground hover:bg-primary/90',
+              : 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
           )}
         >
           {selected ? 'Remove' : 'Add'}
@@ -143,37 +127,6 @@ export function SkillDetailPanel({
       )}
 
       <div className='flex w-full flex-col gap-4'>
-        <section className='flex w-full flex-col gap-3'>
-          <SectionHeading label='Details' />
-          <div className='flex w-full flex-col gap-2'>
-            <MetaRow label='Owner'>{entry.ownerName ?? '—'}</MetaRow>
-            <MetaRow label='Contact'>
-              {email ? (
-                <a href={`mailto:${email}`} className='underline underline-offset-2'>
-                  {email}
-                </a>
-              ) : (
-                '—'
-              )}
-            </MetaRow>
-            <MetaRow label='Created'>{formatDate(entry.skill.createdAt)}</MetaRow>
-            <MetaRow label='Size'>{entry.skill.content.length.toLocaleString()} characters</MetaRow>
-          </div>
-        </section>
-
-        <Separator />
-
-        <section className='flex w-full flex-col gap-4'>
-          <SectionHeading label='Instructions' />
-          {entry.skill.content ? (
-            <ProseBox height={PANE_HEIGHT}>{entry.skill.content}</ProseBox>
-          ) : (
-            <Muted>This skill has no instructions yet.</Muted>
-          )}
-        </section>
-
-        <Separator />
-
         <section className='flex w-full flex-col gap-4'>
           <SectionHeading label='Files' />
 
@@ -194,23 +147,22 @@ export function SkillDetailPanel({
                 />
               </div>
 
-              <div
-                className='min-w-0 flex-1 overflow-auto rounded-2xl border border-border bg-muted/30 p-4'
-                style={{ height: PANE_HEIGHT }}
-              >
-                {!isSkillMd && fileContent.loading ? (
-                  <div className='flex flex-col gap-2'>
-                    <Skeleton className='h-4 w-full' />
-                    <Skeleton className='h-4 w-4/5' />
-                    <Skeleton className='h-4 w-2/3' />
-                  </div>
-                ) : !isSkillMd && fileContent.isError ? (
-                  <Muted>Couldn&apos;t load {openFile.name}.</Muted>
-                ) : preview ? (
-                  <Body>{preview}</Body>
-                ) : (
-                  <Muted>{openFile.name} is empty.</Muted>
-                )}
+              <div className='min-w-0 flex-1'>
+                <ScrollFadeBox height={PANE_HEIGHT} resetKeys={[preview, openFile.path]}>
+                  {!isSkillMd && fileContent.loading ? (
+                    <div className='flex flex-col gap-2'>
+                      <Skeleton className='h-4 w-full' />
+                      <Skeleton className='h-4 w-4/5' />
+                      <Skeleton className='h-4 w-2/3' />
+                    </div>
+                  ) : !isSkillMd && fileContent.isError ? (
+                    <Muted>Couldn&apos;t load {openFile.name}.</Muted>
+                  ) : preview ? (
+                    <Body>{preview}</Body>
+                  ) : (
+                    <Muted>{openFile.name} is empty.</Muted>
+                  )}
+                </ScrollFadeBox>
               </div>
             </div>
           )}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/SkillDetailPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/SkillDetailPanel.tsx
@@ -195,7 +195,7 @@ export function SkillDetailPanel({
               </div>
 
               <div
-                className='min-w-0 flex-1 overflow-auto rounded-2xl border border-border bg-card p-4'
+                className='min-w-0 flex-1 overflow-auto rounded-2xl border border-border bg-muted/30 p-4'
                 style={{ height: PANE_HEIGHT }}
               >
                 {!isSkillMd && fileContent.loading ? (

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/BrowseSubagentsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/BrowseSubagentsDialog.tsx
@@ -1,4 +1,6 @@
 import { useMemo, useState, type ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
 import { Pill } from '../../primitives/Pill';
@@ -52,7 +54,7 @@ const SubagentCard = ({
       onClick={onOpen}
       data-track-category='Claw Agents'
       data-track-name='Create agent v2: open subagent detail'
-      className='flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] p-2.5 text-left transition-colors hover:bg-muted/50'
+      className={cn(BROWSE_CARD, selected ? BROWSE_CARD_SELECTED : BROWSE_CARD_IDLE)}
     >
       <span className='flex w-full items-center justify-between gap-2'>
         <span className='flex min-w-0 items-center gap-2'>

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/BrowseSubagentsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/BrowseSubagentsDialog.tsx
@@ -87,7 +87,7 @@ const SubagentCard = ({
       title={`${selected ? 'Remove' : 'Add'} ${entry.name}`}
       data-track-category='Claw Agents'
       data-track-name='Create agent v2: quick toggle subagent'
-      className='absolute right-9 top-2.5 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
+      className='absolute right-11 top-4 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
     >
       {selected ? (
         <MultipleCrossCancelDefault className='size-4' aria-hidden />

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/SubagentDetailPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/SubagentDetailPanel.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/utils/classNames';
 import { useClawAvailableTools } from '@/hooks/useClawAvailableTools';
 import { McpLogo } from '../mcp/McpLogo';
 import { Clamped } from '../../primitives/Clamped';
+import { ScrollFadeBox } from '../../primitives/ProseBox';
 import { SectionHeading, Separator } from '../../primitives/Section';
 import { ChipIconTile, TokenChip } from '../../primitives/TokenChip';
 import { resolveSubagentCapabilities } from './subagentDetail';
@@ -126,7 +127,7 @@ export function SubagentDetailPanel({
             'flex h-7 shrink-0 items-center justify-center rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors',
             selected
               ? 'border-border bg-card text-foreground hover:bg-muted'
-              : 'border-border bg-primary text-primary-foreground hover:bg-primary/90',
+              : 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
           )}
         >
           {selected ? 'Remove' : 'Add'}
@@ -142,15 +143,11 @@ export function SubagentDetailPanel({
       <div className='flex w-full flex-col gap-4'>
         <Section label='Instructions' info='The system prompt this subagent runs with'>
           {systemPrompt ? (
-            <Clamped
-              maxHeight={PROMPT_MAX_HEIGHT}
-              resetKey={entry.name}
-              className='rounded-2xl border border-border bg-card p-4'
-            >
-              <p className='whitespace-pre-wrap text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
+            <ScrollFadeBox height={PROMPT_MAX_HEIGHT} resetKeys={[entry.name, systemPrompt]}>
+              <p className='whitespace-pre-wrap break-words text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
                 {systemPrompt}
               </p>
-            </Clamped>
+            </ScrollFadeBox>
           ) : (
             <EmptyHint>No instructions added</EmptyHint>
           )}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/primitives/DetailPrimitives.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/primitives/DetailPrimitives.tsx
@@ -127,14 +127,21 @@ export function DetailEmptyState({
   title,
   description,
   action,
+  className,
 }: {
   icon: ReactNode;
   title: string;
   description: string;
   action?: ReactNode;
+  className?: string;
 }): ReactElement {
   return (
-    <div className='flex w-full flex-col items-center justify-center gap-4 p-8 text-center'>
+    <div
+      className={cn(
+        'flex w-full flex-col items-center justify-center gap-4 p-8 text-center',
+        className,
+      )}
+    >
       <span
         className='flex size-14 items-center justify-center rounded-2xl bg-muted text-muted-foreground'
         aria-hidden

--- a/apps/dashboard/src/routes/AIScreen/library/shared/primitives/ProseBox.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/primitives/ProseBox.tsx
@@ -1,30 +1,44 @@
-import { useLayoutEffect, useRef, useState, type ReactElement } from 'react';
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type DependencyList,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import { cn } from '@/utils/classNames';
 
 export const PROSE_BOX_HEIGHT = 298;
 
-interface ProseBoxProps {
-  children: string;
+interface ScrollFadeBoxProps {
+  children: ReactNode;
   height?: number;
   className?: string;
+  /** Re-measures when the content behind these changes. */
+  resetKeys?: DependencyList;
 }
 
-export function ProseBox({
+/**
+ * Fixed-height scroll area with a bottom fade that only appears while there is
+ * more to scroll — so a short body doesn't sit under a pointless gradient.
+ */
+export function ScrollFadeBox({
   children,
   height = PROSE_BOX_HEIGHT,
   className,
-}: ProseBoxProps): ReactElement {
+  resetKeys = [],
+}: ScrollFadeBoxProps): ReactElement {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [showFade, setShowFade] = useState(false);
 
   const sync = (): void => {
     const el = scrollRef.current;
     if (!el) return;
-    const remaining = el.scrollHeight - el.scrollTop - el.clientHeight;
-    setShowFade(remaining > 1);
+    setShowFade(el.scrollHeight - el.scrollTop - el.clientHeight > 1);
   };
 
-  useLayoutEffect(sync, [children, height]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(sync, [height, ...resetKeys]);
 
   return (
     <div className='relative w-full' style={{ height }}>
@@ -32,13 +46,11 @@ export function ProseBox({
         ref={scrollRef}
         onScroll={sync}
         className={cn(
-          'h-full w-full overflow-y-auto rounded-2xl border border-border bg-muted/30 p-4',
+          'h-full w-full overflow-y-auto rounded-2xl border-[0.8px] border-border bg-muted/30 p-4',
           className,
         )}
       >
-        <p className='whitespace-pre-wrap break-words text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
-          {children}
-        </p>
+        {children}
       </div>
       {showFade && (
         <span
@@ -47,5 +59,23 @@ export function ProseBox({
         />
       )}
     </div>
+  );
+}
+
+export function ProseBox({
+  children,
+  height = PROSE_BOX_HEIGHT,
+  className,
+}: {
+  children: string;
+  height?: number;
+  className?: string;
+}): ReactElement {
+  return (
+    <ScrollFadeBox height={height} {...(className ? { className } : {})} resetKeys={[children]}>
+      <p className='whitespace-pre-wrap break-words text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
+        {children}
+      </p>
+    </ScrollFadeBox>
   );
 }

--- a/apps/dashboard/src/routes/AIScreen/library/shared/primitives/ProseBox.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/primitives/ProseBox.tsx
@@ -32,7 +32,7 @@ export function ProseBox({
         ref={scrollRef}
         onScroll={sync}
         className={cn(
-          'h-full w-full overflow-y-auto rounded-2xl border border-border bg-card p-4',
+          'h-full w-full overflow-y-auto rounded-2xl border border-border bg-muted/30 p-4',
           className,
         )}
       >

--- a/apps/dashboard/src/routes/AIScreen/library/shared/primitives/browseCard.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/primitives/browseCard.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared look for a card inside a browse dialog.
+ *
+ * The border is always rendered — transparent when unselected — so picking a
+ * card tints it without nudging the layout by the border's width. Colours come
+ * from `--status-success` at the same 12% / 30% mix the success Pill uses.
+ */
+export const BROWSE_CARD =
+  'flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] border-[0.8px] border-transparent p-2.5 text-left transition-colors';
+
+export const BROWSE_CARD_SELECTED =
+  'border-[color-mix(in_srgb,var(--status-success)_30%,transparent)] bg-[color-mix(in_srgb,var(--status-success)_12%,transparent)]';
+
+export const BROWSE_CARD_IDLE = 'hover:bg-muted/50';

--- a/apps/dashboard/src/routes/AIScreen/library/shared/primitives/browseCard.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/primitives/browseCard.ts
@@ -6,7 +6,7 @@
  * from `--status-success` at the same 12% / 30% mix the success Pill uses.
  */
 export const BROWSE_CARD =
-  'flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] border-[0.8px] border-transparent p-2.5 text-left transition-colors';
+  'flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] border-[0.8px] border-transparent p-4 text-left transition-colors';
 
 export const BROWSE_CARD_SELECTED =
   'border-[color-mix(in_srgb,var(--status-success)_30%,transparent)] bg-[color-mix(in_srgb,var(--status-success)_12%,transparent)]';

--- a/apps/dashboard/src/routes/AIScreen/library/subagents/create/toolbox/BrowseSubagentToolsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/subagents/create/toolbox/BrowseSubagentToolsDialog.tsx
@@ -1,4 +1,10 @@
 import { useMemo, useState, type ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import {
+  BROWSE_CARD,
+  BROWSE_CARD_IDLE,
+  BROWSE_CARD_SELECTED,
+} from '../../../shared/primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { BrowseDialog, type FilterOption } from '../../../shared/primitives/BrowseDialog';
 import { Pill } from '../../../shared/primitives/Pill';
@@ -40,7 +46,7 @@ const GroupCard = ({
       onClick={onOpen}
       data-track-category='Claw Agents'
       data-track-name='Create subagent v2: open tool group detail'
-      className='flex w-full flex-col items-start justify-center gap-2 overflow-hidden rounded-[10px] p-2.5 text-left transition-colors hover:bg-muted/50'
+      className={cn(BROWSE_CARD, enabled ? BROWSE_CARD_SELECTED : BROWSE_CARD_IDLE)}
     >
       <span className='flex w-full items-center justify-between gap-2'>
         <span className='flex min-w-0 items-center gap-2'>

--- a/apps/dashboard/src/routes/AIScreen/library/subagents/create/toolbox/SubagentToolGroupPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/subagents/create/toolbox/SubagentToolGroupPanel.tsx
@@ -58,7 +58,7 @@ export function SubagentToolGroupPanel({
             'flex h-7 shrink-0 items-center justify-center rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors',
             enabled
               ? 'border-border bg-card text-foreground hover:bg-muted'
-              : 'border-border bg-primary text-primary-foreground hover:bg-primary/90',
+              : 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
           )}
         >
           {enabled ? 'Disable' : 'Enable'}

--- a/apps/dashboard/src/routes/AIScreen/library/subagents/detail/SubagentDetailHeaderV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/subagents/detail/SubagentDetailHeaderV2.tsx
@@ -34,7 +34,7 @@ const Action = ({
     className={cn(
       'flex h-7 shrink-0 items-center gap-1.5 rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors disabled:pointer-events-none disabled:opacity-50',
       primary
-        ? 'border-border bg-primary text-primary-foreground hover:bg-primary/90'
+        ? 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90'
         : 'border-transparent text-foreground hover:bg-muted',
     )}
   >


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
