### PR TITLE
fix: XYNE-55575 disabling an automation doesn't stop its in-flight runs

### DIFF
--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -19,6 +19,7 @@ import { automationContextStorage } from './automation-context-storage';
 import { PauseStep } from './pause-step';
 import {
   AUTOMATION_WORKFLOW_TYPE,
+  mayDrainInFlight,
   parseAutomationConfig,
   parseAutomationMetadata,
   readAutomationMeta,
@@ -94,10 +95,15 @@ export class AutomationExecutor {
       );
       return undefined;
     }
-    if (workflow.status !== AutomationStatus.ACTIVE) {
+    if (workflow.status !== AutomationStatus.ACTIVE && !mayDrainInFlight(workflow)) {
+      await this.prisma.workflowExecution.update({
+        where: { id: executionId },
+        data: { status: AutomationRunStatus.CANCELLED },
+      });
       logger.info(
-        `[automations] runExecution: workflow ${workflow.id} is ${workflow.status} (no longer live) — running captured config for ${executionId}`,
+        `[automations] runExecution: workflow ${workflow.id} is ${workflow.status} (no longer live) — run ${executionId} CANCELLED`,
       );
+      return undefined;
     }
 
     const config = parseAutomationConfig(workflow.context);

--- a/apps/backend/src/automations/queue/automation.worker.ts
+++ b/apps/backend/src/automations/queue/automation.worker.ts
@@ -10,6 +10,7 @@ import { AutomationExecutor } from '../engine/automation-executor';
 import { AutomationStatus, AutomationRunStatus } from '../types/status';
 import {
   AUTOMATION_WORKFLOW_TYPE,
+  mayDrainInFlight,
   parseAutomationConfig,
   readAutomationMeta,
 } from '../types/workflow-adapter';
@@ -106,10 +107,15 @@ class AutomationWorker {
       logger.warn(`[AUTOMATION-WORKER] workflow ${execution.workflowId} missing — dropping`);
       return;
     }
-    if (workflow.status !== AutomationStatus.ACTIVE) {
+    if (workflow.status !== AutomationStatus.ACTIVE && !mayDrainInFlight(workflow)) {
+      await db.workflowExecution.update({
+        where: { id: executionId },
+        data: { status: AutomationRunStatus.CANCELLED },
+      });
       logger.info(
-        `[AUTOMATION-WORKER] workflow ${workflow.id} is ${workflow.status} (no longer live) — running captured config anyway for execution=${executionId}`,
+        `[AUTOMATION-WORKER] workflow ${workflow.id} is ${workflow.status} (no longer live) — execution=${executionId} CANCELLED`,
       );
+      return;
     }
 
     const stateForChain = await getAutomationPauseState(executionId);

--- a/apps/backend/src/automations/services/approval.service.ts
+++ b/apps/backend/src/automations/services/approval.service.ts
@@ -231,7 +231,7 @@ class ApprovalService {
     liveId: string,
     actorUserId: string,
     nextStatus: AutomationStatus.ACTIVE | AutomationStatus.DISABLED,
-    opts: { isEnvAdmin?: boolean } = {},
+    opts: { isEnvAdmin?: boolean; cancelQueued?: boolean } = {},
   ): Promise<AutomationView> {
     if (nextStatus !== AutomationStatus.ACTIVE && nextStatus !== AutomationStatus.DISABLED) {
       throw new ApprovalError(
@@ -262,9 +262,9 @@ class ApprovalService {
       );
       return automation;
     }
-    const automation = await automationService.disable(liveId);
+    const automation = await automationService.disable(liveId, opts.cancelQueued ?? true);
     logger.info(
-      `[approval] toggleLive DISABLED id=${liveId} actorUserId=${actorUserId}`,
+      `[approval] toggleLive DISABLED id=${liveId} actorUserId=${actorUserId} cancelQueued=${opts.cancelQueued ?? true}`,
     );
     return automation;
   }

--- a/apps/backend/src/automations/services/automation.service.ts
+++ b/apps/backend/src/automations/services/automation.service.ts
@@ -9,7 +9,9 @@ import { stepRegistry } from '../steps/step-registry';
 import { encryptWebhookStepHeaders } from '../engine/webhook-step-encryption';
 import {
   AUTOMATION_WORKFLOW_TYPE,
+  buildAutomationMetadata,
   parseAutomationConfig,
+  parseAutomationMetadata,
   triggerTypeToEventType,
   workflowToAutomation,
   type AutomationView,
@@ -79,10 +81,12 @@ class AutomationService {
     );
 
     const headersEncrypted = encryptWebhookStepHeaders(config.steps);
+    const { drainInFlight: _drained, ...metadata } = parseAutomationMetadata(existing.metadata);
     const updated = await repositories.workflows.update(id, {
       status: AutomationStatus.ACTIVE,
       eventType: triggerTypeToEventType(config.trigger.type),
       ...(headersEncrypted ? { context: JSON.stringify(config) } : {}),
+      metadata: buildAutomationMetadata(metadata),
       updatedAt: new Date(),
     });
 
@@ -92,9 +96,9 @@ class AutomationService {
     return { automation: workflowToAutomation(updated), validation };
   }
 
-  async disable(id: string): Promise<AutomationView> {
+  async disable(id: string, cancelQueued = true): Promise<AutomationView> {
     const t0 = Date.now();
-    logger.info(`[AUTOMATION-SERVICE] disable START id=${id}`);
+    logger.info(`[AUTOMATION-SERVICE] disable START id=${id} cancelQueued=${cancelQueued}`);
     const existing = await repositories.workflows.findById(id);
     if (!existing || existing.workflowType !== AUTOMATION_WORKFLOW_TYPE) {
       logger.warn(`[AUTOMATION-SERVICE] disable REJECT id=${id} reason=not-found`);
@@ -103,6 +107,10 @@ class AutomationService {
 
     const updated = await repositories.workflows.update(id, {
       status: AutomationStatus.DISABLED,
+      metadata: buildAutomationMetadata({
+        ...parseAutomationMetadata(existing.metadata),
+        drainInFlight: !cancelQueued,
+      }),
       updatedAt: new Date(),
     });
     logger.info(

--- a/apps/backend/src/automations/types/workflow-adapter.ts
+++ b/apps/backend/src/automations/types/workflow-adapter.ts
@@ -36,6 +36,7 @@ export interface AutomationRunView extends AutomationRunSummaryView {
 interface AutomationMetadata {
   description: string | null;
   createdById: string;
+  drainInFlight?: boolean;
 }
 
 export function triggerTypeToEventType(triggerType: string): WorkflowEventType {
@@ -52,6 +53,7 @@ export function parseAutomationMetadata(raw: string | null): AutomationMetadata 
     return {
       description: parsed.description ?? null,
       createdById: parsed.createdById ?? '',
+      ...(parsed.drainInFlight ? { drainInFlight: true } : {}),
     };
   } catch {
     return { description: null, createdById: '' };
@@ -60,6 +62,13 @@ export function parseAutomationMetadata(raw: string | null): AutomationMetadata 
 
 export function buildAutomationMetadata(input: AutomationMetadata): string {
   return JSON.stringify(input);
+}
+
+export function mayDrainInFlight(workflow: Workflow): boolean {
+  return (
+    workflow.status === AutomationStatus.DISABLED &&
+    parseAutomationMetadata(workflow.metadata).drainInFlight === true
+  );
 }
 
 export function workflowToAutomation(workflow: Workflow): AutomationView {

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -15937,8 +15937,12 @@ export function createMutators(
         },
       ),
       disable: defineMutator(
-        z.object({ id: z.string(), timestamp: z.number() }),
-        async ({ tx, args: { id, timestamp } }) => {
+        z.object({
+          id: z.string(),
+          timestamp: z.number(),
+          cancelQueued: z.boolean().optional(),
+        }),
+        async ({ tx, args: { id, timestamp, cancelQueued } }) => {
           logger.info(`[Mutator] automations.disable START id=${id}`);
           const existing = await tx.run(zql.workflows.where('id', id).one());
           if (!existing || existing.workflowType !== 'Automations') {
@@ -15963,7 +15967,9 @@ export function createMutators(
               const { approvalService } = await import(
                 '../automations/services/approval.service'
               );
-              await approvalService.toggleLive(id, authData.sub, AutomationStatus.DISABLED);
+              await approvalService.toggleLive(id, authData.sub, AutomationStatus.DISABLED, {
+                cancelQueued: cancelQueued ?? true,
+              });
               logger.info(
                 `[Mutator] automations.disable asyncTask OK id=${id} elapsedMs=${Date.now() - t0}`,
               );

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
@@ -415,17 +415,21 @@ export function AutomationBuilder({
   });
 
   const disableMutation = useMutation({
-    mutationFn: (id: string): Promise<void> => {
+    mutationFn: ({ id, cancelQueued }: { id: string; cancelQueued: boolean }): Promise<void> => {
       setSavedStatus(AutomationStatusValues.DISABLED);
       setErrorMessage(null);
-      zero.mutate(mutators.automations.disable({ id, timestamp: Date.now() }));
-      toast.success('Automation disabled');
+      zero.mutate(mutators.automations.disable({ id, timestamp: Date.now(), cancelQueued }));
+      toast.success(
+        cancelQueued ? 'Automation disabled, queued runs will not fire' : 'Automation disabled',
+      );
       return Promise.resolve();
     },
     onError: err => {
       setErrorMessage(err instanceof Error ? err.message : 'Disable failed');
     },
   });
+
+  const [disableDialogOpen, setDisableDialogOpen] = useState(false);
 
   const archiveMutation = useMutation({
     mutationFn: (id: string): Promise<void> => {
@@ -685,8 +689,8 @@ export function AutomationBuilder({
 
   const handleDisable = useCallback((): void => {
     if (!savedId) return;
-    disableMutation.mutate(savedId);
-  }, [disableMutation, savedId]);
+    setDisableDialogOpen(true);
+  }, [savedId]);
 
   const handleArchive = useCallback((): void => {
     if (!savedId) return;
@@ -840,8 +844,9 @@ export function AutomationBuilder({
                   </Button>
                 )
               ) : null}
-              {/* Admin-only: permanently retire a live automation. */}
-              {isLiveRow && savedId && isAutomationsAdmin ? (
+              {/* Admin-only: permanently retire an automation. Only offered once it is
+                  DISABLED, so it has to be switched off first. */}
+              {savedId && isAutomationsAdmin && savedStatus === AutomationStatusValues.DISABLED ? (
                 <Button
                   variant='outline'
                   size='sm'
@@ -1277,6 +1282,58 @@ export function AutomationBuilder({
               data-track-name='reject-confirm'
             >
               Reject
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+
+      <Dialog
+        open={disableDialogOpen}
+        onOpenChange={setDisableDialogOpen}
+        title='Disable automation?'
+        className='sm:max-w-md'
+      >
+        <div className='flex flex-col gap-2 px-5 py-4 text-sm'>
+          <p className='text-base font-semibold text-foreground'>
+            Disable {name || 'this automation'}?
+          </p>
+          <p className='text-muted-foreground'>What should happen to the runs already queued?</p>
+          <div className='flex flex-wrap items-center justify-end gap-2 pt-4'>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => setDisableDialogOpen(false)}
+              data-track-category='automation-builder'
+              data-track-name='disable-cancel'
+            >
+              Cancel
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              disabled={disableMutation.isPending}
+              onClick={() => {
+                if (savedId) disableMutation.mutate({ id: savedId, cancelQueued: false });
+                setDisableDialogOpen(false);
+              }}
+              data-track-category='automation-builder'
+              data-track-name='disable-keep-queued'
+            >
+              Let them finish
+            </Button>
+            <Button
+              variant='destructive'
+              size='sm'
+              disabled={disableMutation.isPending}
+              loading={disableMutation.isPending}
+              onClick={() => {
+                if (savedId) disableMutation.mutate({ id: savedId, cancelQueued: true });
+                setDisableDialogOpen(false);
+              }}
+              data-track-category='automation-builder'
+              data-track-name='disable-cancel-queued'
+            >
+              Stop them
             </Button>
           </div>
         </div>

--- a/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
@@ -67,6 +67,7 @@ export function AutomationsList({
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<ListCategory>('all');
   const [pendingDelete, setPendingDelete] = useState<Automation | null>(null);
+  const [pendingDisable, setPendingDisable] = useState<Automation | null>(null);
   const me = useSelf();
   const zero = useZero();
   const navigate = useNavigate();
@@ -132,15 +133,18 @@ export function AutomationsList({
     },
   });
   const disableMutation = useMutation({
-    mutationFn: (id: string): Promise<void> => {
-      zero.mutate(mutators.automations.disable({ id, timestamp: Date.now() }));
-      toast.success('Automation disabled');
+    mutationFn: ({ id, cancelQueued }: { id: string; cancelQueued: boolean }): Promise<void> => {
+      zero.mutate(mutators.automations.disable({ id, timestamp: Date.now(), cancelQueued }));
+      toast.success(
+        cancelQueued ? 'Automation disabled, queued runs will not fire' : 'Automation disabled',
+      );
       return Promise.resolve();
     },
     onError: err => {
       toast.error(err instanceof Error ? err.message : 'Disable failed');
     },
   });
+
   const archiveMutation = useMutation({
     mutationFn: (id: string): Promise<void> => {
       zero.mutate(mutators.automations.archive({ id, timestamp: Date.now() }));
@@ -255,7 +259,7 @@ export function AutomationsList({
                   onClone={() => handleClone(item)}
                   onDelete={() => setPendingDelete(item)}
                   onArchive={
-                    isAutomationsAdmin && isLiveStatus(item.status)
+                    isAutomationsAdmin && item.status === AutomationStatusValues.DISABLED
                       ? () => archiveMutation.mutate(item.id)
                       : undefined
                   }
@@ -263,13 +267,12 @@ export function AutomationsList({
                     isLiveStatus(item.status) &&
                     (item.status === AutomationStatusValues.DISABLED ||
                       (item.status === AutomationStatusValues.ACTIVE && isAutomationsAdmin))
-                      ? next =>
-                          next ? activateMutation.mutate(item.id) : disableMutation.mutate(item.id)
+                      ? next => (next ? activateMutation.mutate(item.id) : setPendingDisable(item))
                       : undefined
                   }
                   toggleLoading={
                     (activateMutation.isPending && activateMutation.variables === item.id) ||
-                    (disableMutation.isPending && disableMutation.variables === item.id)
+                    (disableMutation.isPending && disableMutation.variables?.id === item.id)
                   }
                 />
               ))}
@@ -277,6 +280,64 @@ export function AutomationsList({
           )}
         </div>
       </div>
+
+      <Dialog
+        open={pendingDisable !== null}
+        onOpenChange={open => {
+          if (!open) setPendingDisable(null);
+        }}
+        title='Disable automation?'
+        className='sm:max-w-md'
+      >
+        <div className='flex flex-col gap-2 px-5 py-4 text-sm'>
+          <p className='text-base font-semibold text-foreground'>
+            Disable {pendingDisable?.name || 'this automation'}?
+          </p>
+          <p className='text-muted-foreground'>What should happen to the runs already queued?</p>
+          <div className='flex flex-wrap items-center justify-end gap-2 pt-4'>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => setPendingDisable(null)}
+              data-track-category='automations-list'
+              data-track-name='disable-cancel'
+            >
+              Cancel
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              disabled={disableMutation.isPending}
+              onClick={() => {
+                if (pendingDisable) {
+                  disableMutation.mutate({ id: pendingDisable.id, cancelQueued: false });
+                  setPendingDisable(null);
+                }
+              }}
+              data-track-category='automations-list'
+              data-track-name='disable-keep-queued'
+            >
+              Let them finish
+            </Button>
+            <Button
+              variant='destructive'
+              size='sm'
+              disabled={disableMutation.isPending}
+              loading={disableMutation.isPending}
+              onClick={() => {
+                if (pendingDisable) {
+                  disableMutation.mutate({ id: pendingDisable.id, cancelQueued: true });
+                  setPendingDisable(null);
+                }
+              }}
+              data-track-category='automations-list'
+              data-track-name='disable-cancel-queued'
+            >
+              Stop them
+            </Button>
+          </div>
+        </div>
+      </Dialog>
 
       <Dialog
         open={pendingDelete !== null}

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -11342,7 +11342,11 @@ export const mutators = defineMutators({
       },
     ),
     disable: defineMutator(
-      z.object({ id: z.string(), timestamp: z.number() }),
+      z.object({
+        id: z.string(),
+        timestamp: z.number(),
+        cancelQueued: z.boolean().optional(),
+      }),
       async ({ tx, args: { id, timestamp } }) => {
         const existing = await tx.run(zql.workflows.where('id', id).one());
         if (!existing || existing.workflowType !== 'Automations') {


### PR DESCRIPTION
disable() only flipped the workflow row to DISABLED. Both dispatch layers detected the non-ACTIVE parent and deliberately continued ("running captured config anyway"), so every already-created run still executed. Because the delay step parks runs in EXTERNAL_WAIT for up to 30 days, a disabled reminder chain kept posting for weeks. New triggers already stopped correctly — the event router filters on status: ACTIVE — only in-flight runs were affected.

The same applied to versions retired by supersede: non-terminal runs under ARCHIVED parents kept executing the old config alongside the new version.

- cancel-and-return on a non-ACTIVE parent in the queue worker and the executor (the schedule worker calls the executor directly, so both need it)
- cascade cancellation of non-terminal executions from disable() and the archive path; RUNNING is left to the executor guard to avoid racing its terminal write

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
