### PR TITLE
fix: order thread gallery attachments to match rendered thumbnails [release-20260805]

### DIFF
--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -89,7 +89,11 @@ const ThreadList = ({
     const result = threadMessages.flatMap(msg => {
       if (!msg.hasAttachment || !msg.attachments?.length) return [];
 
-      return msg.attachments.map(att => ({
+      const ordered = [...msg.attachments].sort(
+        (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+      );
+
+      return ordered.map(att => ({
         attachmentId: att.id,
         fileName: att.originalFilename,
         fileUrl: `/attachments/${att.id}/download`,

--- a/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
+++ b/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
@@ -983,7 +983,11 @@ const AttachmentGalleryModalInner: React.FC = () => {
     const allAttachments: AttachmentRef[] = threadMessages.flatMap(msg => {
       if (!msg.hasAttachment || !msg.attachments?.length) return [];
 
-      return msg.attachments.map(att => {
+      const ordered = [...msg.attachments].sort(
+        (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+      );
+
+      return ordered.map(att => {
         const ref: AttachmentRef = {
           attachmentId: att.id,
           fileName: att.originalFilename,


### PR DESCRIPTION
> Cherry-pick of #414 onto `release-20260805`. The surrounding files differ between `main` and this branch, but the two hunks touched here are identical on both, so the fix applies unchanged.

## Problem

Opening an image from a message that has thread replies puts the viewer on the wrong slide. With five images uploaded in order, the thumbnails render 1–5 correctly, but clicking the **first** one opens the viewer showing something like **"4 of 5"** — the wrong image, with a wrong counter.

Messages without replies are unaffected.

## Root cause

The gallery array and the rendered thumbnails were built in **two different orders**.

Thumbnails render from a sorted copy — `MessageBubble.tsx:200`:

```tsx
const orderedAttachments = [...attachments].sort(
  (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
);
```

But the thread gallery builders used `msg.attachments` raw, and the Zero query has no ordering on that relation — `packages/shared/src/zero/queries.ts:804` is a bare `.related('attachments')`, so rows come back in arbitrary (effectively PK) order.

`startIndex` is a `findIndex` into that shuffled array, so the visually-first image resolves to index 3 → **"4 of 5"**.

Two builders had this, and both only engage when the message has replies — which is exactly why the bug is thread-only:

- **`ThreadList.tsx:94`** precomputes `allThreadAttachments`, which `MessageAttachment.tsx:1173` short-circuits to (`allThreadAttachments || allAttachments…`), bypassing the already-sorted list entirely.
- **`FileViewerModal.tsx:985`** re-queries the thread and `UPDATE`s the machine with its own flatMap, overwriting whatever index was passed in.

Without a thread, `allAttachments` (already sorted) is used and the count is correct.

## Fix

Sort each message's attachments by the same key as the render path, in both builders:

```tsx
const ordered = [...msg.attachments].sort(
  (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
);
```

Cross-message order was already correct — the messages relation has `.orderBy('createdAt', 'asc')`. Only within-message ordering was the gap.

## Testing

- Dashboard lint + build pass (full pre-commit gate).
- Verified against a threaded message with multiple images: clicking the Nth thumbnail now opens slide N and the counter reads `N of M`.

Best verified on a thread where images were uploaded out of id order — that's the case that reproduced.

## Known related issue (not addressed here)

Both gallery builders — and `MessageBubble.tsx:235`'s `handleFileClick` — include soft-deleted attachments (`isDeleted`), while rendering filters them out at `MessageBubble.tsx:205`. That inflates the "of M" total and shifts indices past a deleted file. Same class of bug, but distinct from the ordering issue fixed here; deliberately left out to keep this change scoped.
