### PR TITLE
fix: XYNE-55602 polish DM and ticket display behavior

### DIFF
--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -22,6 +22,7 @@ import { getInitialMessageFromConversation } from '../../../utils/conversationMe
 import { RenderMessageWithHTML } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import { sanitizeHtmlString } from '../../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../../utils/flowPreview';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 interface DmListItemProps {
   channel: Channel;
@@ -106,7 +107,7 @@ export const DmListItem = ({
     const senderFirstName = getSenderLabel(
       lastMessage.senderId === context.userID,
       isDM,
-      lastMessageSender?.name,
+      lastMessageSender ? getUserDisplayName(lastMessageSender) : undefined,
     );
 
     const prefix = senderFirstName ? `${senderFirstName}: ` : '';

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
@@ -38,6 +38,7 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { Channel, ChannelScopeType } from '@xyne/shared';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import { FilterPills, type FilterPillOption } from '../../ui/FilterPills';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 // Simple component for DM search results (no message preview)
 const DmSearchResultItem = ({
@@ -78,7 +79,9 @@ const DmSearchResultItem = ({
 interface DmUserSearchResultItemProps {
   user: {
     id: string;
-    name: string;
+    name?: string | null;
+    email?: string | null;
+    displayName?: string | null;
   };
   isSelected: boolean;
   isCurrentUser?: boolean;
@@ -93,7 +96,7 @@ const DmUserSearchResultItem = ({
     <div className={`flex items-center gap-3 px-2 py-2 ${isSelected ? 'bg-accent' : ''}`}>
       <Avatar userId={user.id} size='md' showActiveStatus className='rounded-lg' />
       <span className='text-sm font-medium text-foreground truncate'>
-        {user.name}
+        {getUserDisplayName(user)}
         {isCurrentUser ? ' (you)' : ''}
       </span>
     </div>
@@ -179,7 +182,6 @@ const DmsPage = (): ReactElement => {
     userChannelStatuses,
     loadMore,
     firstItemIndex,
-    selectedChannelMovedVersion,
     jumpToChannel,
   } = useDmsPaginatedMessages({ selectedChannelId: channelId });
 
@@ -324,19 +326,6 @@ const DmsPage = (): ReactElement => {
     });
     return (): void => cancelAnimationFrame(raf);
   }, [directMessages]);
-
-  // Scroll to top when the selected channel receives a new message and moves to top.
-  // Only fires in live mode (the hook guards this internally).
-  useEffect(() => {
-    if (
-      activeTab === 'all' &&
-      !isMobile &&
-      selectedChannelMovedVersion > 0 &&
-      virtuosoRef.current
-    ) {
-      virtuosoRef.current.scrollToIndex({ index: 0, align: 'start', behavior: 'auto' });
-    }
-  }, [activeTab, selectedChannelMovedVersion, isMobile]);
 
   const handleAddDirectMessage = (): void => {
     setShowAddDmForm(true);

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
@@ -345,23 +345,25 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
 
   const getGroupDMParticipants = (channel: { name: string; scopeType: ChannelScopeType }) => {
     const otherIds = parseDMParticipantIds(channel).filter(id => id !== currentUser?.id);
-    return otherIds.map(id => allUsers.find(u => u.id === id)).filter(Boolean) as {
-      name: string;
-    }[];
+    return otherIds
+      .map(id => allUsers.find(u => u.id === id))
+      .filter((user): user is (typeof allUsers)[number] => user !== undefined);
   };
 
   const getGroupDMLabel = (channel: { name: string; scopeType: ChannelScopeType }): string => {
     const participants = getGroupDMParticipants(channel);
-    return participants.map(u => u.name).join(', ');
+    return participants.map(user => getUserDisplayName(user)).join(', ');
   };
 
   const getGroupDMBadgeLabel = (channel: { name: string; scopeType: ChannelScopeType }): string => {
     const MAX_SHOWN = 3;
     const participants = getGroupDMParticipants(channel);
-    if (participants.length <= MAX_SHOWN) return participants.map(u => u.name).join(', ');
+    if (participants.length <= MAX_SHOWN) {
+      return participants.map(user => getUserDisplayName(user)).join(', ');
+    }
     const shown = participants
       .slice(0, MAX_SHOWN)
-      .map(u => u.name)
+      .map(user => getUserDisplayName(user))
       .join(', ');
     return `${shown} +${participants.length - MAX_SHOWN} more`;
   };
@@ -391,8 +393,8 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
     return (
       <div className='max-w-[200px] flex flex-wrap gap-x-1 gap-y-0.5'>
         {participants.map((u, i) => (
-          <span key={i}>
-            {u.name}
+          <span key={u.id}>
+            {getUserDisplayName(u)}
             {i < participants.length - 1 ? ',' : ''}
           </span>
         ))}
@@ -554,8 +556,9 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
       .filter(channel => {
         const participantIds = parseDMParticipantIds(channel).filter(id => id !== currentUser?.id);
         const participants = allUsers.filter(u => participantIds.includes(u.id));
+        const query = trimmedInputValue.toLowerCase();
         return participants.some(u =>
-          u.name.toLowerCase().includes(trimmedInputValue.toLowerCase()),
+          [u.displayName, u.name, u.email].some(value => value?.toLowerCase().includes(query)),
         );
       })
       .slice(0, 5)

--- a/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
@@ -27,6 +27,7 @@ import { PriorityOptions, useAssigneeOptions } from '../TicketTable/TicketTableH
 import { v4 as uuidv4 } from 'uuid';
 import { type BoardSlaPolicy } from '../../../hooks/useChannelSlaPolicy';
 import { useAuthContextValues } from '../../../hooks/useAuth';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 const DEFAULT_VISIBLE_COLUMNS = new Set(['assignee', 'dueDate', 'priority', 'tags']);
 
@@ -429,7 +430,7 @@ export const TicketCard: React.FC<TicketCardProps> = ({
     }
 
     const assigneeDisplay = assignedUser ? (
-      <Tooltip content={assignedUser.name || assignedUser.email || 'Unknown User'}>
+      <Tooltip content={getUserDisplayName(assignedUser)}>
         <div className='relative group/assignee'>
           <Avatar
             userId={assignedUser.id}
@@ -542,7 +543,7 @@ export const TicketCard: React.FC<TicketCardProps> = ({
   // views never pass `isConversation`, so they keep the full card.
   if (isConversation) {
     const conversationAssignee = assignedUser ? (
-      <Tooltip content={assignedUser.name || assignedUser.email || 'Unknown User'}>
+      <Tooltip content={getUserDisplayName(assignedUser)}>
         <Avatar
           userId={assignedUser.id}
           showActiveStatus={false}
@@ -558,11 +559,9 @@ export const TicketCard: React.FC<TicketCardProps> = ({
         </div>
       </Tooltip>
     ) : (
-      <Tooltip content='Unassigned'>
-        <div className='w-5 h-5 rounded-lg border border-dashed border-muted-foreground bg-background flex items-center justify-center'>
-          <User className='w-3 h-3 text-muted-foreground' strokeWidth={1.5} />
-        </div>
-      </Tooltip>
+      <div className='w-5 h-5 rounded-lg border border-dashed border-muted-foreground bg-background flex items-center justify-center'>
+        <User className='w-3 h-3 text-muted-foreground' strokeWidth={1.5} />
+      </div>
     );
 
     return (
@@ -736,7 +735,7 @@ export const TicketCard: React.FC<TicketCardProps> = ({
                   {!isCompact &&
                     showAssignee &&
                     (assignedUser ? (
-                      <Tooltip content={assignedUser.name || assignedUser.email || 'Unknown User'}>
+                      <Tooltip content={getUserDisplayName(assignedUser)}>
                         <div className='relative group/assignee'>
                           <Avatar
                             userId={assignedUser.id}

--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
@@ -39,6 +39,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useRouteContext } from '../../../hooks/useRouteContext';
 import { useAllChannels } from '../../../hooks/useChannels';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -840,7 +841,7 @@ const AssigneeCellRenderer = (params: ICellRendererParams<Ticket>) => {
     <div className='flex items-center h-full'>
       {assignedUser ? (
         <div className='flex items-center gap-3'>
-          <Tooltip content={assignedUser.name || assignedUser.email || 'Unknown User'}>
+          <Tooltip content={getUserDisplayName(assignedUser)}>
             <Avatar
               userId={assignedUser.id}
               className='rounded-full size-6 flex items-center justify-center'
@@ -848,7 +849,7 @@ const AssigneeCellRenderer = (params: ICellRendererParams<Ticket>) => {
             />
           </Tooltip>
           <span className='text-muted-foreground truncate font-medium'>
-            {assignedUser.name || assignedUser.email}
+            {getUserDisplayName(assignedUser)}
           </span>
         </div>
       ) : assignedGroup ? (

--- a/apps/dashboard/src/hooks/useDmsPaginatedMessages.ts
+++ b/apps/dashboard/src/hooks/useDmsPaginatedMessages.ts
@@ -36,8 +36,6 @@ interface UseDmsPaginatedMessagesReturn {
   loadMore: () => void;
   /** Virtuoso firstItemIndex — increases by N each time N items are prepended. */
   firstItemIndex: number;
-  /** Increments each time the selected channel moves to index 0. Use to trigger scroll-to-top. */
-  selectedChannelMovedVersion: number;
   /**
    * When called with a channelId: scrolls to an existing channel or fetches and jumps to it.
    * When called without arguments: loads the previous page (newer channels) — equivalent to
@@ -98,16 +96,12 @@ export const useDmsPaginatedMessages = (
   const [firstItemIndex, setFirstItemIndex] = useState(0);
   const isFetchingRef = useRef(false);
 
-  // ── Selected channel scroll tracking ─────────────────────────────────────────
-  const [selectedChannelMovedVersion, setSelectedChannelMovedVersion] = useState(0);
-  const prevSelectedIndexRef = useRef(-1);
-  const prevSelectedActivityRef = useRef(-1);
+  // Keep the selected channel available to the live page subscription without
+  // re-creating it whenever navigation changes.
   const selectedChannelIdRef = useRef(selectedChannelId);
 
   useEffect(() => {
     selectedChannelIdRef.current = selectedChannelId;
-    prevSelectedIndexRef.current = -1;
-    prevSelectedActivityRef.current = -1;
   }, [selectedChannelId]);
 
   // ── Page 1: always-live Zero subscription ─────────────────────────────────────
@@ -138,23 +132,6 @@ export const useDmsPaginatedMessages = (
     const page1Ids = new Set(page1.map(s => s.channelId));
     const deeperRows = rowsRef.current.filter(s => !page1Ids.has(s.channelId));
     const merged = sortDesc([...page1, ...deeperRows]);
-
-    // Fire scroll-to-top when the selected channel reaches index 0 or gets a new message there.
-    const selectedId = selectedChannelIdRef.current;
-    if (selectedId) {
-      const newIdx = merged.findIndex(s => s.channelId === selectedId);
-      const newActivity = newIdx >= 0 ? merged[newIdx]!.lastActivityAt : -1;
-
-      if (
-        newIdx === 0 &&
-        (prevSelectedIndexRef.current !== 0 || prevSelectedActivityRef.current !== newActivity)
-      ) {
-        setSelectedChannelMovedVersion(v => v + 1);
-      }
-
-      prevSelectedIndexRef.current = newIdx;
-      prevSelectedActivityRef.current = newActivity;
-    }
 
     commitRows(merged);
     setHasMore(page1.length === PAGE_SIZE);
@@ -340,7 +317,6 @@ export const useDmsPaginatedMessages = (
     hasMoreBefore,
     loadMore,
     firstItemIndex,
-    selectedChannelMovedVersion,
     jumpToChannel,
   };
 };


### PR DESCRIPTION
[POT1](https://drive.google.com/file/d/1iw71tI9X5oktOeg_Af__vZFBS9YbLadi/view?usp=sharing)
[POT2](https://drive.google.com/file/d/1gEzrR2PTtAvupGq2onY4a1E9K32G1S6k/view?usp=sharing)
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
