### PR TITLE
fix: XYNE-55605 stop automation run history from fetching unused exec…

### DIFF
--- a/apps/backend/src/automations/routes/automation.routes.ts
+++ b/apps/backend/src/automations/routes/automation.routes.ts
@@ -19,6 +19,7 @@ import { logger } from '@/utils/logger';
 import { AutomationStatus } from '../types/status';
 import {
   workflowExecutionToRun,
+  workflowExecutionToRunSummary,
   AUTOMATION_WORKFLOW_TYPE,
   buildAutomationMetadata,
   triggerTypeToEventType,
@@ -27,7 +28,7 @@ import {
 import {
   getAutomationPauseState,
   getExecutionState,
-  stitchExecutionStateMany,
+  stitchExecutionContextMany,
 } from '@/database/repositories/workflowExecutionStateUtils';
 import { approvalService, ApprovalError } from '../services/approval.service';
 import { notifyAdminsOfArchiveRequest } from '../services/approval-notifications';
@@ -611,6 +612,13 @@ router.get(
           ? { createdAt: { ...(from ? { gte: from } : {}), ...(to ? { lte: to } : {}) } }
           : {}),
       },
+      select: {
+        id: true,
+        workflowId: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       take: limit + 1,
       ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
@@ -620,13 +628,13 @@ router.get(
     const page = hasMore ? rows.slice(0, limit) : rows;
     const nextCursor = hasMore ? (page[page.length - 1]?.id ?? null) : null;
 
-    const stitched = await stitchExecutionStateMany(page);
+    const stitched = await stitchExecutionContextMany(page);
 
     res.json({
       success: true,
       data: {
         runs: stitched.map(row =>
-          workflowExecutionToRun(row, { context: row.context }),
+          workflowExecutionToRunSummary(row, { context: row.context }),
         ),
         nextCursor,
       },

--- a/apps/backend/src/automations/types/workflow-adapter.ts
+++ b/apps/backend/src/automations/types/workflow-adapter.ts
@@ -18,15 +18,19 @@ export interface AutomationView {
   automationSeriesId: string | null;
 }
 
-export interface AutomationRunView {
+/** What the run-history list renders. No context blobs — see AutomationRunView. */
+export interface AutomationRunSummaryView {
   id: string;
   automationId: string;
   status: AutomationRunStatus;
-  triggerData: Record<string, unknown>;
-  context: Record<string, unknown>;
   error: string | null;
   startedAt: Date;
   completedAt: Date | null;
+}
+
+export interface AutomationRunView extends AutomationRunSummaryView {
+  triggerData: Record<string, unknown>;
+  context: Record<string, unknown>;
 }
 
 interface AutomationMetadata {
@@ -108,22 +112,22 @@ export function parseExecutionTriggerData(raw: string | null): Record<string, un
   }
 }
 
-export function workflowExecutionToRun(
-  execution: WorkflowExecution,
+/** The execution columns a run summary needs — lets the list query select just these. */
+type WorkflowExecutionRunFields = Pick<
+  WorkflowExecution,
+  'id' | 'workflowId' | 'status' | 'createdAt' | 'updatedAt'
+>;
+
+export function workflowExecutionToRunSummary(
+  execution: WorkflowExecutionRunFields,
   state: { context: string | null } | null,
-): AutomationRunView {
+): AutomationRunSummaryView {
   const ctx = parseExecutionTriggerData(state?.context ?? null);
   const meta = (ctx['__meta'] as { error?: string | null } | undefined) ?? {};
-  const userCtx: Record<string, unknown> = { ...ctx };
-  delete userCtx['__meta'];
-  const trigger = (ctx['trigger'] as { data?: Record<string, unknown> } | undefined) ?? {};
-  const triggerData = trigger.data ?? {};
   return {
     id: execution.id,
     automationId: execution.workflowId,
     status: (execution.status as AutomationRunStatus) || AutomationRunStatus.RUNNING,
-    triggerData,
-    context: userCtx,
     error: meta.error ?? null,
     startedAt: execution.createdAt,
     completedAt:
@@ -132,5 +136,20 @@ export function workflowExecutionToRun(
       execution.status === 'EXTERNAL_WAIT'
         ? null
         : execution.updatedAt,
+  };
+}
+
+export function workflowExecutionToRun(
+  execution: WorkflowExecution,
+  state: { context: string | null } | null,
+): AutomationRunView {
+  const ctx = parseExecutionTriggerData(state?.context ?? null);
+  const userCtx: Record<string, unknown> = { ...ctx };
+  delete userCtx['__meta'];
+  const trigger = (ctx['trigger'] as { data?: Record<string, unknown> } | undefined) ?? {};
+  return {
+    ...workflowExecutionToRunSummary(execution, state),
+    triggerData: trigger.data ?? {},
+    context: userCtx,
   };
 }

--- a/apps/backend/src/database/repositories/workflowExecutionStateUtils.ts
+++ b/apps/backend/src/database/repositories/workflowExecutionStateUtils.ts
@@ -82,6 +82,28 @@ export async function stitchExecutionStateMany<T extends WorkflowExecution>(
 }
 
 /**
+ * Like stitchExecutionStateMany, but reads only `context`. List views never use
+ * `output`, and both columns hold full JSON blobs — skipping one halves the read.
+ */
+export async function stitchExecutionContextMany<T extends { id: string }>(
+  executions: T[]
+): Promise<(T & { context: string | null })[]> {
+  if (executions.length === 0) return [];
+
+  const states = await prisma.workflowExecutionState.findMany({
+    where: { workflowExecutionId: { in: executions.map(e => e.id) } },
+    select: { workflowExecutionId: true, context: true },
+  });
+
+  const contextMap = new Map(states.map(s => [s.workflowExecutionId, s.context]));
+
+  return executions.map(execution => ({
+    ...execution,
+    context: contextMap.get(execution.id) ?? null,
+  }));
+}
+
+/**
  * Creates or updates the execution state
  */
 export async function upsertExecutionState(

--- a/apps/dashboard/src/api/automationsApi.ts
+++ b/apps/dashboard/src/api/automationsApi.ts
@@ -228,15 +228,20 @@ export interface Automation {
   automationSeriesId: string | null;
 }
 
-export interface AutomationRun {
+/** Row shape returned by the runs list — no context blobs. */
+export interface AutomationRunSummary {
   id: string;
   automationId: string;
   status: AutomationRunStatus;
-  triggerData: Record<string, unknown>;
-  context: Record<string, unknown>;
   error: string | null;
   startedAt: string;
   completedAt: string | null;
+}
+
+/** Returned by the run-detail endpoint only. */
+export interface AutomationRun extends AutomationRunSummary {
+  triggerData: Record<string, unknown>;
+  context: Record<string, unknown>;
 }
 
 export interface SaveResult {
@@ -360,7 +365,7 @@ export function releaseAutomationTemplate(attachmentId: string): Promise<{ remov
 
 // ─── Runs API (REST — replaces Zero queries for runs) ────────────────────
 export interface RunsListPage {
-  runs: AutomationRun[];
+  runs: AutomationRunSummary[];
   nextCursor: string | null;
 }
 

--- a/apps/dashboard/src/components/Automation/Automation.types.ts
+++ b/apps/dashboard/src/components/Automation/Automation.types.ts
@@ -7,6 +7,7 @@ export type {
   SwitchStepConfig,
   SwitchCaseEntry,
   AutomationRun,
+  AutomationRunSummary,
   Condition,
   LeafCondition,
   JsonSchema,

--- a/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
@@ -12,7 +12,7 @@ import {
 import { Skeleton } from '../../../ui/Skeleton';
 import { Button } from '../../../ui/Button/Button';
 import { fetchAutomationRuns } from '../../../../api/automationsApi';
-import type { AutomationRun, AutomationRunStatus } from '../../Automation.types';
+import type { AutomationRunStatus, AutomationRunSummary } from '../../Automation.types';
 import type { RunHistoryProps } from './RunHistory.types';
 
 const PAGE_SIZE = 50;
@@ -85,7 +85,7 @@ export function RunHistory({
       refetchOnWindowFocus: true,
     });
 
-  const filtered = useMemo<AutomationRun[]>(() => {
+  const filtered = useMemo<AutomationRunSummary[]>(() => {
     return data?.pages.flatMap(p => p.runs) ?? [];
   }, [data]);
 
@@ -213,7 +213,13 @@ export function RunHistory({
   );
 }
 
-function RunRow({ run, onClick }: { run: AutomationRun; onClick: () => void }): React.ReactElement {
+function RunRow({
+  run,
+  onClick,
+}: {
+  run: AutomationRunSummary;
+  onClick: () => void;
+}): React.ReactElement {
   const isComplete = run.status === 'COMPLETED' || run.status === 'FAILED';
   const duration =
     isComplete && run.completedAt

--- a/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.types.ts
+++ b/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.types.ts
@@ -1,7 +1,7 @@
-import type { AutomationRun } from '../../Automation.types';
+import type { AutomationRunSummary } from '../../Automation.types';
 
 export interface RunHistoryProps {
   automationId: string;
-  onOpenRun: (run: AutomationRun) => void;
+  onOpenRun: (run: AutomationRunSummary) => void;
   onBack: () => void;
 }

--- a/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   Copy,
   History,
+  Link2,
   Loader2,
   MoreHorizontal,
   Pencil,
@@ -26,6 +27,7 @@ import Avatar from '../../ui/Avatar/Avatar';
 import { fetchStepCatalog, fetchTriggerCatalog } from '../../../api/automationsApi';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useAuthContextValues } from '../../../hooks/useAuth';
+import { useShareableOrigin } from '../../../hooks/useShareableOrigin';
 import { useSelf, useUser } from '../../../hooks/useUsers';
 import { useZero } from '../../../hooks/useZero';
 import { useIsAutomationsAdmin } from '../useIsAutomationsAdmin';
@@ -435,6 +437,14 @@ function AutomationRow({
   const [menuOpen, setMenuOpen] = useState(false);
   const isActive = automation.status === 'ACTIVE';
   const creator = useUser(automation.createdById);
+  const shareableOrigin = useShareableOrigin();
+
+  const handleCopyLink = (): void => {
+    void navigator.clipboard
+      .writeText(`${shareableOrigin}/automations/${automation.id}`)
+      .then(() => toast.success('Link copied'))
+      .catch(() => toast.error('Could not copy link'));
+  };
 
   const handleCardClick = (e: React.MouseEvent<HTMLDivElement>): void => {
     const target = e.target as HTMLElement;
@@ -575,6 +585,14 @@ function AutomationRow({
                 onClick={() => {
                   setMenuOpen(false);
                   onClone();
+                }}
+              />
+              <RowMenuButton
+                label='Copy link'
+                icon={<Link2 className='size-4' />}
+                onClick={() => {
+                  setMenuOpen(false);
+                  handleCopyLink();
                 }}
               />
               {onShowRuns && (

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AutomationTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AutomationTab.tsx
@@ -4,7 +4,7 @@ import { AutomationBuilder } from '../../../Automation/AutomationBuilder/Automat
 import { RunHistory } from '../../../Automation/AutomationRuns/RunHistory/RunHistory';
 import { RunDetail } from '../../../Automation/AutomationRuns/RunDetail/RunDetail';
 import { AutomationApprovalsList } from '../../../Automation/AutomationApprovalsList/AutomationApprovalsList';
-import type { Automation, AutomationRun } from '../../../Automation/Automation.types';
+import type { Automation, AutomationRunSummary } from '../../../Automation/Automation.types';
 import type { useDeskSettingsForm } from '../useDeskSettingsForm';
 
 type DeskSettingsForm = ReturnType<typeof useDeskSettingsForm>;
@@ -19,7 +19,7 @@ type AutomationView =
   | { screen: 'approvals' }
   | { screen: 'builder'; automation: Automation | null; approvalReviewMode?: boolean }
   | { screen: 'runs'; automation: Automation }
-  | { screen: 'run-detail'; automation: Automation; run: AutomationRun };
+  | { screen: 'run-detail'; automation: Automation; run: AutomationRunSummary };
 
 function automationScopesToChannel(
   automation: Automation,


### PR DESCRIPTION
…ution context

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
