### PR TITLE
fix: XYNE-55606 keep the notifications row in place while it loads

### DIFF
--- a/apps/dashboard/src/components/Chat/ConversationSubscription/ConversationSubscription.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationSubscription/ConversationSubscription.tsx
@@ -6,11 +6,18 @@ import { mutators } from '../../../zero/mutators';
 import { queries } from '../../../zero/queries';
 import { v4 as uuidv4 } from 'uuid';
 import { ConversationWithTicket } from '../../ui/MessageBubble/MessageBubble.types';
+import { cn } from '../../../utils/classNames';
 
 interface ParticipantData {
   id: string;
   isSubscribed: boolean;
   participationType?: string | null;
+}
+
+interface SubscriptionLabelProps {
+  text: string;
+  sizeClassName?: string;
+  toneClassName?: string;
 }
 
 interface ConversationSubscriptionProps {
@@ -22,6 +29,9 @@ interface ConversationSubscriptionProps {
   className?: string;
   menuOpen?: boolean;
 }
+
+const WIDEST_SUBSCRIPTION_LABEL = 'Unsubscribe from notifications';
+const LOADING_SUBSCRIPTION_LABEL = 'Loading…';
 
 export const ConversationSubscription = React.forwardRef<
   HTMLButtonElement,
@@ -57,13 +67,21 @@ export const ConversationSubscription = React.forwardRef<
 
     const participant = participantProp !== undefined ? participantProp : queriedParticipant;
 
-    if (participantProp === undefined && variant !== 'lazy-icon') {
-      if (!shouldFetch) return null;
-      if (participantDetails.type !== 'complete') return null;
-    }
+    const isResolving =
+      participantProp === undefined &&
+      variant !== 'lazy-icon' &&
+      participantDetails.type !== 'complete';
+
+    if (participantProp === undefined && variant !== 'lazy-icon' && !shouldFetch) return null;
 
     const isSubscribed = participant?.isSubscribed ?? false;
     const participationType = participant?.participationType;
+    const subscriptionLabel = isResolving
+      ? LOADING_SUBSCRIPTION_LABEL
+      : isSubscribed
+        ? WIDEST_SUBSCRIPTION_LABEL
+        : 'Subscribe to notifications';
+    const showBellOn = isResolving || !isSubscribed;
 
     const handleToggleSubscription = () => {
       const timestamp = Date.now();
@@ -132,6 +150,8 @@ export const ConversationSubscription = React.forwardRef<
         <button
           ref={ref}
           onClick={handleToggleSubscription}
+          disabled={isResolving}
+          aria-busy={isResolving}
           className={`flex items-center w-full text-foreground ${className}`}
           title={isSubscribed ? 'Unsubscribe from notifications' : 'Subscribe to notifications'}
           aria-label={isSubscribed ? 'Unsubscribe from conversation' : 'Subscribe to conversation'}
@@ -139,9 +159,12 @@ export const ConversationSubscription = React.forwardRef<
           data-track-name='TOGGLE_SUBSCRIPTION_DROPDOWN'
         >
           <span className='w-4 h-4 mr-2 flex items-center justify-center text-muted-foreground'>
-            {isSubscribed ? <NotificationBellOff size={16} /> : <NotificationBellOn size={16} />}
+            {showBellOn ? <NotificationBellOn size={16} /> : <NotificationBellOff size={16} />}
           </span>
-          {isSubscribed ? 'Unsubscribe from notifications' : 'Subscribe to notifications'}
+          <SubscriptionLabel
+            text={subscriptionLabel}
+            {...(isResolving && { toneClassName: 'text-muted-foreground' })}
+          />
         </button>
       );
     }
@@ -150,26 +173,43 @@ export const ConversationSubscription = React.forwardRef<
       <button
         ref={ref}
         onClick={handleToggleSubscription}
+        disabled={isResolving}
+        aria-busy={isResolving}
         className={`flex items-center gap-2 px-3 py-2 rounded hover:bg-accent transition-colors ${className}`}
         title={isSubscribed ? 'Unsubscribe from notifications' : 'Subscribe to notifications'}
         aria-label={isSubscribed ? 'Unsubscribe from conversation' : 'Subscribe to conversation'}
         data-track-category='CONVERSATION_SUBSCRIPTION'
         data-track-name='TOGGLE_SUBSCRIPTION_BUTTON'
       >
-        {isSubscribed ? (
-          <>
-            <NotificationBellOff size={16} className='text-muted-foreground' />
-            <span className='text-sm'>Unsubscribe from notifications</span>
-          </>
+        {showBellOn ? (
+          <NotificationBellOn
+            size={16}
+            className={cn(isResolving || isSubscribed ? 'text-muted-foreground' : 'text-primary')}
+          />
         ) : (
-          <>
-            <NotificationBellOn size={16} className='text-primary' />
-            <span className='text-sm text-muted-foreground'>Subscribe to notifications</span>
-          </>
+          <NotificationBellOff size={16} className='text-muted-foreground' />
         )}
+        <SubscriptionLabel
+          text={subscriptionLabel}
+          sizeClassName='text-sm'
+          {...(!isSubscribed && { toneClassName: 'text-muted-foreground' })}
+        />
       </button>
     );
   },
 );
 
 ConversationSubscription.displayName = 'ConversationSubscription';
+
+const SubscriptionLabel = ({
+  text,
+  sizeClassName,
+  toneClassName,
+}: SubscriptionLabelProps): React.JSX.Element => (
+  <span className={cn('relative inline-flex whitespace-nowrap', sizeClassName)}>
+    <span className='invisible' aria-hidden='true'>
+      {WIDEST_SUBSCRIPTION_LABEL}
+    </span>
+    <span className={cn('absolute inset-0 flex items-center', toneClassName)}>{text}</span>
+  </span>
+);


### PR DESCRIPTION
[POT](https://drive.google.com/file/d/1t44LKlBtRUArfWxtJqGsIb3U_CEgwbYq/view?usp=sharing)

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
