### PR TITLE
feature: XYNE-5272 anchor canvas comments to the text in a rail

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasCommentRail/CanvasCommentCard.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCommentRail/CanvasCommentCard.tsx
@@ -1,0 +1,232 @@
+import { useMemo, useRef, useState } from 'react';
+import { ArrowUp, Check, RotateCcw } from 'lucide-react';
+import { CanvasCommentThreadStatus } from '@xyne/shared';
+
+import { useAuth } from '../../../hooks/useAuth';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useUsers } from '../../../hooks/useUsers';
+import { queries } from '../../../zero/queries';
+import { cn } from '../../../utils/classNames';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import Avatar from '../../ui/Avatar/Avatar';
+import { formatRelativeCommentTime } from '../canvasCommentTime';
+import type { CanvasCommentHighlightThread } from '../useCanvasCommentHighlights';
+
+type UserLite = { id: string; name?: string; displayName?: string | null; email?: string };
+
+export type RailComment = {
+  id: string;
+  threadId: string;
+  body: string;
+  isInitial?: boolean;
+  createdBy: string;
+  deletedAt?: number | null;
+  editedAt?: number | null;
+  createdAt: number;
+  createdByUser?: UserLite | null;
+};
+
+interface CanvasCommentCardProps {
+  thread: CanvasCommentHighlightThread;
+  isActive: boolean;
+  editable: boolean;
+  onSelect: () => void;
+  onResolveToggle: () => void;
+  onReply: (body: string) => void;
+}
+
+const getDisplayName = (user?: UserLite | null): string =>
+  user ? getUserDisplayName(user) : 'Unknown user';
+
+/**
+ * One thread, rendered as a card that parks beside its anchored text.
+ * Collapsed by default to the initial comment plus a reply count; opening the
+ * card reveals the full transcript and the reply composer.
+ */
+export function CanvasCommentCard({
+  thread,
+  isActive,
+  editable,
+  onSelect,
+  onResolveToggle,
+  onReply,
+}: CanvasCommentCardProps): React.JSX.Element {
+  const { user } = useAuth();
+  const allUsers = useUsers();
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Only the open card pays for its transcript. Collapsed cards render from the
+  // thread row alone, so a canvas with 40 threads holds 1 comment query, not 40.
+  const [loaded = []] = useCachedQuery(queries.canvasThreadComments({ threadId: thread.id }), {
+    enabled: isActive,
+  }) as unknown as [RailComment[]];
+
+  // The thread row already carries its initial comment, so a collapsed card
+  // renders its preview with no query of its own — only the open card fetches
+  // the full transcript.
+  const fallbackInitial: RailComment | undefined = thread.initialComment
+    ? { ...thread.initialComment, threadId: thread.id, isInitial: true }
+    : undefined;
+
+  const comments = useMemo(() => {
+    const initial =
+      loaded.find(c => c.isInitial || c.id === thread.initialCommentId) ?? fallbackInitial;
+    const replies = loaded.filter(
+      c => c.id !== initial?.id && !c.isInitial && c.id !== thread.initialCommentId,
+    );
+    return [initial, ...replies].filter(Boolean) as RailComment[];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded, thread.initialCommentId, thread.initialComment?.id, thread.id]);
+
+  const replyCount = Math.max((thread.commentCount ?? 1) - 1, 0);
+  const isResolved = thread.status === CanvasCommentThreadStatus.RESOLVED;
+
+  const authorOf = (comment: RailComment): UserLite | null | undefined =>
+    allUsers.find(candidate => candidate.id === comment.createdBy) ?? comment.createdByUser;
+
+  const submit = (): void => {
+    const body = draft.trim();
+    if (!body) return;
+    onReply(body);
+    setDraft('');
+  };
+
+  const preview = comments[0];
+
+  return (
+    <div
+      role='button'
+      tabIndex={isActive ? -1 : 0}
+      aria-expanded={isActive}
+      aria-label={`Comment thread on “${thread.anchorText ?? 'selected text'}”`}
+      onClick={onSelect}
+      onKeyDown={event => {
+        if (isActive) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect();
+        }
+      }}
+      data-canvas-comment-card={thread.id}
+      data-track-category='CANVAS'
+      data-track-name='Canvas_Comment_Card_Open'
+      className={cn(
+        'canvas-comment-card pointer-events-auto cursor-default overflow-hidden rounded-xl border bg-card text-left',
+        isActive
+          ? 'border-border shadow-[0_10px_30px_hsl(var(--foreground)/0.12)]'
+          : 'border-border/70 shadow-[0_1px_2px_hsl(var(--foreground)/0.05)] hover:border-border',
+        isResolved && 'bg-muted/40',
+      )}
+    >
+      <div className='px-3 pt-3'>
+        {(isActive ? comments : [preview]).filter(Boolean).map((comment, index) => {
+          const c = comment as RailComment;
+          const isFirst = index === 0;
+          const author = authorOf(c);
+          const isDeleted = Boolean(c.deletedAt);
+          return (
+            <div key={c.id} className={cn('mb-3', !isFirst && 'mt-1')}>
+              <div className='flex min-w-0 items-center gap-2'>
+                <Avatar userId={c.createdBy} size='sm' rounded showActiveStatus={false} />
+                <span className='truncate text-[13px] font-semibold text-foreground'>
+                  {c.createdBy === user?.id ? 'You' : getDisplayName(author)}
+                </span>
+                <span className='shrink-0 text-[11.5px] text-muted-foreground'>
+                  {formatRelativeCommentTime(c.createdAt)}
+                </span>
+                <span className='flex-1' />
+                {isFirst && editable && (
+                  <button
+                    type='button'
+                    aria-label={isResolved ? 'Reopen comment' : 'Resolve comment'}
+                    title={isResolved ? 'Reopen' : 'Resolve'}
+                    onClick={event => {
+                      event.stopPropagation();
+                      onResolveToggle();
+                    }}
+                    className='canvas-comment-card__action grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground'
+                    data-track-category='CANVAS'
+                    data-track-name='Canvas_Comment_Resolve_Toggle'
+                  >
+                    {isResolved ? <RotateCcw className='size-3.5' /> : <Check className='size-4' />}
+                  </button>
+                )}
+              </div>
+
+              {isFirst && thread.anchorText && (
+                <div className='mt-1.5 flex min-w-0 pl-8'>
+                  <span className='w-[3px] shrink-0 rounded-sm bg-[#F2B43C]' />
+                  <span className='min-w-0 flex-1 whitespace-pre-wrap break-words pl-2 text-[12.5px] leading-[1.5] text-muted-foreground'>
+                    {thread.anchorText}
+                  </span>
+                </div>
+              )}
+
+              <p
+                className={cn(
+                  'mt-1 whitespace-pre-wrap break-words pl-8 text-[13.5px] leading-[1.55] text-foreground',
+                  isDeleted && 'italic text-muted-foreground',
+                  !isActive && 'line-clamp-4',
+                )}
+              >
+                {isDeleted ? 'Comment deleted' : c.body}
+              </p>
+            </div>
+          );
+        })}
+
+        {!isActive && replyCount > 0 && (
+          <button
+            type='button'
+            onClick={onSelect}
+            className='mb-3 pl-8 text-[12px] font-medium text-muted-foreground hover:text-foreground'
+            data-track-category='CANVAS'
+            data-track-name='Canvas_Comment_Expand'
+          >
+            {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+          </button>
+        )}
+      </div>
+
+      {editable && (
+        <div className='flex items-center gap-2 border-t border-border/70 px-3 py-2'>
+          <Avatar userId={user?.id ?? null} size='sm' rounded showActiveStatus={false} />
+          <input
+            ref={inputRef}
+            value={draft}
+            onChange={event => setDraft(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                submit();
+              }
+            }}
+            placeholder='Reply…'
+            aria-label='Reply to comment'
+            data-track-category='CANVAS'
+            data-track-name='Canvas_Comment_Reply_Input'
+            className='min-w-0 flex-1 border-none bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground'
+          />
+          <button
+            type='button'
+            onClick={event => {
+              event.stopPropagation();
+              submit();
+            }}
+            disabled={!draft.trim()}
+            aria-label='Send reply'
+            className={cn(
+              'grid size-7 shrink-0 place-items-center rounded-full text-background transition-colors',
+              draft.trim() ? 'bg-foreground' : 'bg-muted-foreground/40',
+            )}
+            data-track-category='CANVAS'
+            data-track-name='Canvas_Comment_Reply_Send'
+          >
+            <ArrowUp className='size-3.5' />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Canvas/CanvasCommentRail/CanvasCommentDraftCard.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCommentRail/CanvasCommentDraftCard.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react';
+import { ArrowUp } from 'lucide-react';
+import { v4 as uuidv4 } from 'uuid';
+
+import { useAuth } from '../../../hooks/useAuth';
+import { useZero } from '../../../hooks/useZero';
+import { mutators } from '../../../zero/mutators';
+import { logger, Event } from '../../../utils/logger';
+import { cn } from '../../../utils/classNames';
+import Avatar from '../../ui/Avatar/Avatar';
+import type { CanvasCommentAnchor } from '../CanvasCommentsPanel/CanvasCommentsPanel';
+
+interface CanvasCommentDraftCardProps {
+  canvasId: string;
+  anchor: CanvasCommentAnchor;
+  onBeforeCreate?: ((threadId: string, anchor: CanvasCommentAnchor) => boolean) | undefined;
+  onCreated?: (() => void) | undefined;
+  onFailed?: ((anchor: CanvasCommentAnchor) => void) | undefined;
+  onCancel: () => void;
+}
+
+/**
+ * The new-comment composer, rendered as a card in the rail rather than a
+ * popover over the document — so composing a comment happens in the same place
+ * comments live, and never covers the text being commented on.
+ *
+ * Focus lands in the field on mount; Enter commits, Escape discards.
+ */
+export function CanvasCommentDraftCard({
+  canvasId,
+  anchor,
+  onBeforeCreate,
+  onCreated,
+  onFailed,
+  onCancel,
+}: CanvasCommentDraftCardProps): React.JSX.Element {
+  const zero = useZero();
+  const { user } = useAuth();
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // rAF so the card is painted before focus — avoids the browser scrolling
+    // the document to an element that is still being positioned.
+    const frame = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  const submit = (): void => {
+    const text = body.trim();
+    if (!text || submitting) return;
+
+    const threadId = uuidv4();
+    // Paint the highlight first; if the range is gone there is nothing to anchor to.
+    if (onBeforeCreate?.(threadId, anchor) === false) {
+      onFailed?.(anchor);
+      return;
+    }
+
+    setSubmitting(true);
+    const result = zero.mutate(
+      mutators.canvasComment.createThread({
+        threadId,
+        commentId: uuidv4(),
+        canvasId,
+        blockId: anchor.blockId,
+        ...(anchor.anchorText && { anchorText: anchor.anchorText }),
+        body: text,
+        mentionedUserIds: [],
+        timestamp: Date.now(),
+      }),
+    );
+
+    void result.server
+      .then(outcome => {
+        if (outcome.type === 'error') onFailed?.(anchor);
+      })
+      .catch((error: unknown) => {
+        onFailed?.(anchor);
+        logger.error(Event.API_CALL_FAILED, {
+          reason: error,
+          context: 'canvas_comment_create',
+        });
+      });
+
+    setBody('');
+    onCreated?.();
+  };
+
+  return (
+    <div
+      className='canvas-comment-card canvas-comment-card--draft pointer-events-auto overflow-hidden rounded-xl border border-border bg-card shadow-[0_10px_30px_hsl(var(--foreground)/0.12)]'
+      data-canvas-comment-draft='true'
+    >
+      <div className='px-3 pt-3'>
+        <div className='flex min-w-0 items-center gap-2'>
+          <Avatar userId={user?.id ?? null} size='sm' rounded showActiveStatus={false} />
+          <span className='truncate text-[13px] font-semibold text-foreground'>You</span>
+        </div>
+        {anchor.anchorText && (
+          <div className='mt-1.5 flex min-w-0 pl-8'>
+            <span className='w-[3px] shrink-0 rounded-sm bg-[#F2B43C]' />
+            <span className='line-clamp-3 min-w-0 flex-1 whitespace-pre-wrap break-words pl-2 text-[12.5px] leading-[1.5] text-muted-foreground'>
+              {anchor.anchorText}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className='mt-2.5 flex items-center gap-2 border-t border-border/70 px-3 py-2'>
+        <Avatar userId={user?.id ?? null} size='sm' rounded showActiveStatus={false} />
+        <input
+          ref={inputRef}
+          value={body}
+          onChange={event => setBody(event.target.value)}
+          onKeyDown={event => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault();
+              submit();
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              onCancel();
+            }
+          }}
+          placeholder='Comment…'
+          aria-label='Write a comment'
+          data-track-category='CANVAS'
+          data-track-name='Canvas_Comment_Draft_Input'
+          className='min-w-0 flex-1 border-none bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted-foreground'
+        />
+        <button
+          type='button'
+          onClick={submit}
+          disabled={!body.trim()}
+          aria-label='Post comment'
+          className={cn(
+            'grid size-7 shrink-0 place-items-center rounded-full text-background transition-colors',
+            body.trim() ? 'bg-foreground' : 'bg-muted-foreground/40',
+          )}
+          data-track-category='CANVAS'
+          data-track-name='Canvas_Comment_Draft_Send'
+        >
+          <ArrowUp className='size-3.5' />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Canvas/CanvasCommentRail/CanvasCommentRail.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCommentRail/CanvasCommentRail.tsx
@@ -1,0 +1,278 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { MessageSquare } from 'lucide-react';
+import { CanvasCommentThreadStatus } from '@xyne/shared';
+import { v4 as uuidv4 } from 'uuid';
+
+import { useZero } from '../../../hooks/useZero';
+import { mutators } from '../../../zero/mutators';
+import { logger, Event } from '../../../utils/logger';
+import { cn } from '../../../utils/classNames';
+import type { CanvasCommentHighlightThread } from '../useCanvasCommentHighlights';
+import type { CanvasCommentAnchor } from '../CanvasCommentsPanel/CanvasCommentsPanel';
+import { CanvasCommentCard } from './CanvasCommentCard';
+import { CanvasCommentDraftCard } from './CanvasCommentDraftCard';
+import { useCanvasCommentAnchors } from './useCanvasCommentAnchors';
+
+/** Matches --canvas-comment-rail-width in global.css. */
+const RAIL_WIDTH = 344;
+/** Inset from the scroll container's right edge. */
+const RAIL_INSET = 24;
+const CARD_WIDTH = RAIL_WIDTH - RAIL_INSET * 2;
+const CARD_GAP = 12;
+const FALLBACK_CARD_HEIGHT = 104;
+const DRAFT_CARD_HEIGHT = 128;
+
+interface CanvasCommentRailProps {
+  canvasId: string;
+  containerRef: React.RefObject<HTMLElement | null>;
+  threads: CanvasCommentHighlightThread[];
+  activeThreadId: string | null;
+  editable: boolean;
+  enabled?: boolean;
+  refreshKey?: unknown;
+  onActivate: (threadId: string | null) => void;
+  /** In-flight new comment: shown as a card in the rail beside its selection. */
+  draft?: { anchor: CanvasCommentAnchor; rect: DOMRect } | null;
+  onDraftBeforeCreate?: ((threadId: string, anchor: CanvasCommentAnchor) => boolean) | undefined;
+  onDraftCreated?: (() => void) | undefined;
+  onDraftFailed?: ((anchor: CanvasCommentAnchor) => void) | undefined;
+  onDraftCancel?: (() => void) | undefined;
+}
+
+export function CanvasCommentRail({
+  canvasId,
+  containerRef,
+  threads,
+  activeThreadId,
+  editable,
+  enabled = true,
+  refreshKey,
+  onActivate,
+  draft,
+  onDraftBeforeCreate,
+  onDraftCreated,
+  onDraftFailed,
+  onDraftCancel,
+}: CanvasCommentRailProps): React.JSX.Element | null {
+  const zero = useZero();
+  const openThreads = threads.filter(thread => thread.status === CanvasCommentThreadStatus.OPEN);
+
+  const { scrollContainer, positions, isNarrow, remeasure } = useCanvasCommentAnchors({
+    containerRef,
+    threads: openThreads,
+    enabled,
+    refreshKey,
+    // A card needs its own width plus the inset — not the full rail track.
+    railWidth: CARD_WIDTH + RAIL_INSET,
+  });
+
+  const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [heights, setHeights] = useState<Record<string, number>>({});
+
+  // Measure rendered card heights so the stack can account for tall threads.
+  useLayoutEffect(() => {
+    const next: Record<string, number> = {};
+    let changed = false;
+    Object.entries(cardRefs.current).forEach(([id, element]) => {
+      if (!element) return;
+      const height = element.offsetHeight;
+      if (!height) return;
+      next[id] = height;
+      if (heights[id] !== height) changed = true;
+    });
+    if (changed || Object.keys(next).length !== Object.keys(heights).length) {
+      setHeights(next);
+    }
+  });
+
+  // Re-measure anchors when the active card expands or collapses — the stack
+  // below it has to move to make room.
+  useEffect(() => {
+    remeasure();
+  }, [activeThreadId, remeasure]);
+
+  // Reserve the reading column's right gutter while the rail has anything to
+  // show, so cards never sit on top of the text. Removing the flag lets the
+  // column glide back to full width.
+  const hasContent = Boolean(openThreads.length || draft);
+  useEffect(() => {
+    const surface =
+      containerRef.current?.querySelector<HTMLElement>('.canvas-surface') ??
+      containerRef.current?.closest<HTMLElement>('.canvas-surface') ??
+      null;
+    if (!surface) return;
+    if (hasContent) surface.dataset['canvasCommentRail'] = 'on';
+    else delete surface.dataset['canvasCommentRail'];
+    return () => {
+      delete surface.dataset['canvasCommentRail'];
+    };
+  }, [containerRef, hasContent]);
+
+  const reply = useCallback(
+    (thread: CanvasCommentHighlightThread, body: string): void => {
+      const result = zero.mutate(
+        mutators.canvasComment.reply({
+          commentId: uuidv4(),
+          threadId: thread.id,
+          canvasId,
+          body,
+          mentionedUserIds: [],
+          timestamp: Date.now(),
+        }),
+      );
+      void result.server.catch((error: unknown) => {
+        logger.error(Event.API_CALL_FAILED, { reason: error, context: 'canvas_comment_reply' });
+      });
+    },
+    [canvasId, zero],
+  );
+
+  const setStatus = useCallback(
+    (thread: CanvasCommentHighlightThread): void => {
+      zero.mutate(
+        mutators.canvasComment.setThreadStatus({
+          threadId: thread.id,
+          status:
+            thread.status === CanvasCommentThreadStatus.RESOLVED
+              ? CanvasCommentThreadStatus.OPEN
+              : CanvasCommentThreadStatus.RESOLVED,
+          timestamp: Date.now(),
+        }),
+      );
+    },
+    [zero],
+  );
+
+  if (!enabled || !scrollContainer || (!openThreads.length && !draft)) return null;
+
+  // Ideal position is the anchor's top; each card is then pushed down past the
+  // one above it. Sorting by anchor keeps document order.
+  const ordered = openThreads
+    .filter(thread => positions[thread.id])
+    .sort((a, b) => (positions[a.id]?.top ?? 0) - (positions[b.id]?.top ?? 0));
+
+  // Selection rect is in viewport space; convert to the scroll container's
+  // content space so the draft sits in the same coordinate system as the cards.
+  const scrollRect = scrollContainer.getBoundingClientRect();
+  const draftTop = draft
+    ? Math.round(draft.rect.top - scrollRect.top + scrollContainer.scrollTop)
+    : null;
+
+  const layout: Record<string, number> = {};
+  let cursor = Number.NEGATIVE_INFINITY;
+  let draftLayoutTop = draftTop;
+  let draftPlaced = draftTop === null;
+
+  const placeDraft = (): void => {
+    if (draftPlaced || draftTop === null) return;
+    draftLayoutTop = Math.max(draftTop, cursor);
+    cursor = draftLayoutTop + (heights['__draft'] ?? DRAFT_CARD_HEIGHT) + CARD_GAP;
+    draftPlaced = true;
+  };
+
+  ordered.forEach(thread => {
+    const anchor = positions[thread.id];
+    if (!anchor) return;
+    // The draft claims its slot in document order, so cards below shift down
+    // for it instead of overlapping.
+    if (draftTop !== null && !draftPlaced && draftTop <= anchor.top) placeDraft();
+    const height = heights[thread.id] ?? FALLBACK_CARD_HEIGHT;
+    const top = Math.max(anchor.top - 2, cursor);
+    layout[thread.id] = top;
+    cursor = top + height + CARD_GAP;
+  });
+  placeDraft();
+
+  const rail = (
+    <div
+      className='pointer-events-none absolute right-0 top-0 z-20'
+      style={{ width: RAIL_WIDTH, bottom: 0 }}
+      data-canvas-comment-rail='true'
+    >
+      {ordered.map(thread => {
+        const anchor = positions[thread.id];
+        if (!anchor) return null;
+        const isActive = activeThreadId === thread.id;
+
+        // Narrow: collapse to a margin badge, float the open card over the doc.
+        if (isNarrow && !isActive) {
+          return (
+            <button
+              key={thread.id}
+              type='button'
+              onClick={() => onActivate(thread.id)}
+              style={{ top: anchor.top }}
+              className='canvas-comment-badge pointer-events-auto absolute right-3 inline-flex h-[26px] items-center gap-1.5 rounded-lg border border-border bg-card px-2 text-muted-foreground shadow-[0_1px_2px_hsl(var(--foreground)/0.05)] hover:bg-accent hover:text-foreground'
+              aria-label={`${thread.commentCount ?? 1} comments on this text`}
+              data-track-category='CANVAS'
+              data-track-name='Canvas_Comment_Badge_Open'
+            >
+              <MessageSquare className='size-3.5' />
+              <span className='text-[11.5px] font-semibold'>{thread.commentCount ?? 1}</span>
+            </button>
+          );
+        }
+
+        const floating = isNarrow && isActive;
+
+        return (
+          <div
+            key={thread.id}
+            ref={element => {
+              cardRefs.current[thread.id] = element;
+            }}
+            className={cn(
+              'canvas-comment-rail__slot pointer-events-auto',
+              floating ? 'fixed' : 'absolute',
+              isActive && !floating && 'canvas-comment-rail__slot--active',
+            )}
+            style={
+              floating
+                ? {
+                    left: Math.min(
+                      Math.max(anchor.viewportLeft, 16),
+                      window.innerWidth - CARD_WIDTH - 16,
+                    ),
+                    top: anchor.viewportBottom + 10,
+                    width: CARD_WIDTH,
+                    zIndex: 130,
+                  }
+                : { top: layout[thread.id] ?? anchor.top, right: RAIL_INSET, width: CARD_WIDTH }
+            }
+          >
+            <CanvasCommentCard
+              thread={thread}
+              isActive={isActive}
+              editable={editable}
+              onSelect={() => onActivate(thread.id)}
+              onResolveToggle={() => setStatus(thread)}
+              onReply={body => reply(thread, body)}
+            />
+          </div>
+        );
+      })}
+
+      {draft && draftLayoutTop !== null && (
+        <div
+          ref={element => {
+            cardRefs.current['__draft'] = element;
+          }}
+          className='canvas-comment-rail__slot canvas-comment-rail__slot--active pointer-events-auto absolute'
+          style={{ top: draftLayoutTop, right: RAIL_INSET, width: CARD_WIDTH }}
+        >
+          <CanvasCommentDraftCard
+            canvasId={canvasId}
+            anchor={draft.anchor}
+            onBeforeCreate={onDraftBeforeCreate}
+            onCreated={onDraftCreated}
+            onFailed={onDraftFailed}
+            onCancel={onDraftCancel ?? (() => undefined)}
+          />
+        </div>
+      )}
+    </div>
+  );
+
+  return createPortal(rail, scrollContainer);
+}

--- a/apps/dashboard/src/components/Canvas/CanvasCommentRail/useCanvasCommentAnchors.ts
+++ b/apps/dashboard/src/components/Canvas/CanvasCommentRail/useCanvasCommentAnchors.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+import type { CanvasCommentHighlightThread } from '../useCanvasCommentHighlights';
+
+/**
+ * Position of one thread's anchor span, in the scroll container's *content*
+ * coordinate space (i.e. already includes scrollTop, so it stays correct while
+ * the document scrolls without needing to re-measure on every frame).
+ *
+ * `viewportTop` / `viewportBottom` / `viewportLeft` are kept alongside because
+ * the narrow-mode floating card is positioned with `position: fixed` and needs
+ * viewport coordinates instead.
+ */
+export interface CanvasCommentAnchorPosition {
+  threadId: string;
+  top: number;
+  bottom: number;
+  viewportTop: number;
+  viewportBottom: number;
+  viewportLeft: number;
+}
+
+interface UseCanvasCommentAnchorsOptions {
+  containerRef: RefObject<HTMLElement | null>;
+  threads: CanvasCommentHighlightThread[];
+  enabled?: boolean;
+  refreshKey?: unknown;
+  /** Width the rail needs before it can sit beside the document instead of over it. */
+  railWidth?: number;
+}
+
+interface UseCanvasCommentAnchorsResult {
+  scrollContainer: HTMLElement | null;
+  positions: Record<string, CanvasCommentAnchorPosition>;
+  /** True when the document column is wide enough that the rail would overlap it. */
+  isNarrow: boolean;
+  remeasure: () => void;
+}
+
+const THREAD_ATTR = 'data-canvas-comment-thread-id';
+
+const escapeSelectorValue = (value: string): string =>
+  typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+    ? CSS.escape(value)
+    : value.replace(/["\\]/g, '\\$&');
+
+export const getCanvasScrollContainer = (container: HTMLElement): HTMLElement =>
+  container.querySelector<HTMLElement>('.thin-scrollbar') ?? container;
+
+/**
+ * Measures where each open thread's highlighted text sits so comment cards can
+ * be parked next to it. Re-measures on scroll, resize, and document mutation —
+ * all coalesced into a single animation frame.
+ */
+export const useCanvasCommentAnchors = ({
+  containerRef,
+  threads,
+  enabled = true,
+  refreshKey,
+  railWidth = 360,
+}: UseCanvasCommentAnchorsOptions): UseCanvasCommentAnchorsResult => {
+  const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(null);
+  const [positions, setPositions] = useState<Record<string, CanvasCommentAnchorPosition>>({});
+  const [isNarrow, setIsNarrow] = useState(false);
+  const frameRef = useRef<number | null>(null);
+  const signatureRef = useRef('');
+
+  // Thread ids only — measuring must not re-run just because a thread's
+  // commentCount changed, or every reply would trigger a full re-measure.
+  const threadIds = threads.map(thread => thread.id).join(',');
+
+  const measure = useCallback((): void => {
+    const container = containerRef.current;
+    if (!container) return;
+    const scroller = getCanvasScrollContainer(container);
+    const scrollRect = scroller.getBoundingClientRect();
+
+    const next: Record<string, CanvasCommentAnchorPosition> = {};
+
+    threadIds
+      .split(',')
+      .filter(Boolean)
+      .forEach(threadId => {
+        const spans = scroller.querySelectorAll<HTMLElement>(
+          `[${THREAD_ATTR}="${escapeSelectorValue(threadId)}"]`,
+        );
+        if (!spans.length) return;
+
+        let viewportTop = Number.POSITIVE_INFINITY;
+        let viewportBottom = Number.NEGATIVE_INFINITY;
+        let viewportLeft = Number.POSITIVE_INFINITY;
+
+        spans.forEach(span => {
+          const rect = span.getBoundingClientRect();
+          if (!rect.width && !rect.height) return;
+          viewportTop = Math.min(viewportTop, rect.top);
+          viewportBottom = Math.max(viewportBottom, rect.bottom);
+          viewportLeft = Math.min(viewportLeft, rect.left);
+        });
+
+        if (!Number.isFinite(viewportTop)) return;
+
+        next[threadId] = {
+          threadId,
+          top: Math.round(viewportTop - scrollRect.top + scroller.scrollTop),
+          bottom: Math.round(viewportBottom - scrollRect.top + scroller.scrollTop),
+          viewportTop: Math.round(viewportTop),
+          viewportBottom: Math.round(viewportBottom),
+          viewportLeft: Math.round(viewportLeft),
+        };
+      });
+
+    // Measure the document column, not the highlighted spans — a short anchor
+    // in a wide paragraph would otherwise look like there is room to spare and
+    // the rail would be parked on top of the text.
+    const content = scroller.querySelector<HTMLElement>('.bn-editor') ?? scroller;
+    const contentRight = content.getBoundingClientRect().right;
+    const narrow = scrollRect.right - contentRight < railWidth;
+
+    const signature = JSON.stringify(next) + (narrow ? '|n' : '');
+    if (signature !== signatureRef.current) {
+      signatureRef.current = signature;
+      setPositions(next);
+      setIsNarrow(narrow);
+    }
+    setScrollContainer(current => (current === scroller ? current : scroller));
+  }, [containerRef, railWidth, threadIds]);
+
+  const schedule = useCallback((): void => {
+    if (frameRef.current !== null) return;
+    frameRef.current = window.requestAnimationFrame(() => {
+      frameRef.current = null;
+      measure();
+    });
+  }, [measure]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+    const container = containerRef.current;
+    if (!container) return;
+    const scroller = getCanvasScrollContainer(container);
+
+    schedule();
+    // BlockNote paints asynchronously; retry so anchors that mount late are caught.
+    const retries = [80, 240, 600].map(delay => window.setTimeout(schedule, delay));
+
+    scroller.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+
+    const observer =
+      typeof MutationObserver !== 'undefined' ? new MutationObserver(schedule) : null;
+    observer?.observe(scroller, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['data-id', THREAD_ATTR],
+    });
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(schedule) : null;
+    resizeObserver?.observe(scroller);
+
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+      retries.forEach(timeout => window.clearTimeout(timeout));
+      scroller.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+      observer?.disconnect();
+      resizeObserver?.disconnect();
+    };
+  }, [containerRef, enabled, refreshKey, schedule]);
+
+  return { scrollContainer, positions, isNarrow, remeasure: schedule };
+};

--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -72,7 +72,7 @@ import { useSelector } from '@xstate/react';
 import { xyneAIActor } from '../../../machines/xyneAIMachine';
 import { useCanvasEditorMentionSharing } from '@/hooks/useCanvasEditorMentionSharing';
 import { CanvasCommentsPanel } from '../CanvasCommentsPanel/CanvasCommentsPanel';
-import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
+import { CanvasCommentRail } from '../CanvasCommentRail/CanvasCommentRail';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
 
@@ -381,6 +381,8 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       isCommentsOpen,
       setIsCommentsOpen,
       inlineCommentThread,
+      commentThreads,
+      setActiveCommentThreadId,
       activeCommentBlockId,
       activeCommentThreadId,
       activeCommentAnchor,
@@ -602,26 +604,6 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
               onCreateThreadFailed={removeCommentAnchorStyle}
             />
           )}
-
-          {canvasId && inlineCommentThread && (
-            <CanvasInlineCommentThread
-              canvasId={canvasId}
-              canvasTitle={_canvasTitle}
-              channelId={channelId}
-              {...(inlineCommentThread.mode === 'thread' && {
-                thread: inlineCommentThread.thread,
-              })}
-              {...(inlineCommentThread.mode === 'create' && {
-                activeAnchor: inlineCommentThread.anchor,
-              })}
-              anchorRect={inlineCommentThread.rect}
-              editable={editable}
-              onClose={closeInlineCommentThread}
-              onBeforeCreateThread={applyCommentAnchorStyle}
-              onCreateThreadCreated={clearActiveCommentAnchor}
-              onCreateThreadFailed={removeCommentAnchorStyle}
-            />
-          )}
         </div>
 
         {/* Presentation Modal */}
@@ -647,6 +629,29 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
         )}
 
         {/* Copy button overlay for code blocks */}
+        {canvasId && (
+          <CanvasCommentRail
+            canvasId={canvasId}
+            containerRef={containerRef}
+            threads={commentThreads}
+            activeThreadId={activeCommentThreadId}
+            draft={
+              inlineCommentThread?.mode === 'create'
+                ? { anchor: inlineCommentThread.anchor, rect: inlineCommentThread.rect }
+                : null
+            }
+            onDraftBeforeCreate={applyCommentAnchorStyle}
+            onDraftCreated={() => {
+              clearActiveCommentAnchor();
+              closeInlineCommentThread();
+            }}
+            onDraftFailed={removeCommentAnchorStyle}
+            onDraftCancel={closeInlineCommentThread}
+            editable={editable}
+            onActivate={setActiveCommentThreadId}
+          />
+        )}
+
         <CanvasCodeCopyButton containerRef={containerRef} />
       </div>
     );

--- a/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
@@ -4,7 +4,6 @@ import {
   ColorStyleButton,
   CreateLinkButton,
   type FormattingToolbarProps,
-  TextAlignButton,
   useComponentsContext,
 } from '@blocknote/react';
 import { MessageSquarePlus } from 'lucide-react';
@@ -12,42 +11,50 @@ import type { FC, ReactElement } from 'react';
 import { useCallback, useEffect, useRef } from 'react';
 import { xyneAIActor, type SelectionInfo } from '../../../machines/xyneAIMachine';
 
+const SELECTION_PREVIEW_LIMIT = 50;
+const MIN_SELECTION_LENGTH = 3;
+
 type CanvasFormattingToolbarOptions = {
   canvasId?: string;
   canvasTitle?: string;
   canComment?: boolean;
 };
 
-function CanvasToolbarAttachedActions({
+/**
+ * The two primary actions on a text selection. Kept in its own component so the
+ * selection-tracking effect does not re-run when formatting state changes.
+ */
+function CanvasToolbarActions({
   onAddComment,
   canvasId,
   canvasTitle,
   canComment = true,
-}: {
-  onAddComment: () => void;
-} & CanvasFormattingToolbarOptions): ReactElement {
+}: { onAddComment: () => void } & CanvasFormattingToolbarOptions): ReactElement {
   const selectedTextRef = useRef('');
 
   useEffect(() => {
-    const updateSelectedText = (): void => {
-      const selectedText = window.getSelection()?.toString().trim() ?? '';
-      if (selectedText) {
-        selectedTextRef.current = selectedText;
-      }
+    const capture = (): void => {
+      const text = window.getSelection()?.toString().trim() ?? '';
+      // Only remember a real selection — clicking the button collapses the
+      // selection, and the last meaningful one is what we want to send.
+      if (text.length >= MIN_SELECTION_LENGTH) selectedTextRef.current = text;
     };
-
-    updateSelectedText();
-    document.addEventListener('selectionchange', updateSelectedText);
-    return (): void => document.removeEventListener('selectionchange', updateSelectedText);
+    capture();
+    document.addEventListener('selectionchange', capture);
+    return (): void => document.removeEventListener('selectionchange', capture);
   }, []);
 
-  const handleAskAI = useCallback((): void => {
+  const handleEditWithAI = useCallback((): void => {
     if (!canvasId) return;
+    const live = window.getSelection()?.toString().trim() ?? '';
+    const selectedText = live.length >= MIN_SELECTION_LENGTH ? live : selectedTextRef.current;
+    if (selectedText.length < MIN_SELECTION_LENGTH) return;
 
-    const selectedText = window.getSelection()?.toString().trim() || selectedTextRef.current;
-    if (!selectedText) return;
+    const preview =
+      selectedText.length > SELECTION_PREVIEW_LIMIT
+        ? `${selectedText.substring(0, SELECTION_PREVIEW_LIMIT)}...`
+        : selectedText;
 
-    const preview = selectedText.length > 50 ? `${selectedText.substring(0, 50)}...` : selectedText;
     const selectionInfo: SelectionInfo = {
       text: selectedText,
       preview,
@@ -57,51 +64,58 @@ function CanvasToolbarAttachedActions({
 
     xyneAIActor.send({
       type: 'OPEN',
-      canvasInfo: {
-        canvasId,
-        ...(canvasTitle && { title: canvasTitle }),
-      },
+      canvasInfo: { canvasId, ...(canvasTitle && { title: canvasTitle }) },
       selectionInfo,
     });
 
+    selectedTextRef.current = '';
     window.getSelection()?.removeAllRanges();
   }, [canvasId, canvasTitle]);
 
   return (
-    <div className='canvas-formatting-menu__attached-actions'>
-      <button
-        type='button'
-        className={`canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--left ${
-          canComment ? '' : 'canvas-formatting-menu__attached-button--single'
-        }`}
-        onMouseDown={event => event.preventDefault()}
-        onClick={handleAskAI}
-        disabled={!canvasId}
-        data-track-category='CANVAS'
-        data-track-name='Selection_Ask_AI'
-        data-track-metadata={JSON.stringify({ canvasId })}
-      >
-        <img alt='AI' width='14' height='14' src='/svgs/icons/ai-bot-gradient-star.svg' />
-        <span>Ask AI</span>
-      </button>
+    <>
       {canComment && (
         <button
           type='button'
-          className='canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--right'
+          className='canvas-selection-menu__action'
           onMouseDown={event => event.preventDefault()}
           onClick={onAddComment}
           data-track-category='CANVAS'
           data-track-name='Selection_Add_Comment'
-          data-track-metadata={JSON.stringify({ canvasId })}
+          data-track-metadata={JSON.stringify({ canvasId: canvasId ?? null })}
         >
-          <MessageSquarePlus className='size-3.5' aria-hidden='true' />
+          <MessageSquarePlus className='size-4' aria-hidden='true' />
           <span>Comment</span>
         </button>
       )}
-    </div>
+      <button
+        type='button'
+        className='canvas-selection-menu__action canvas-selection-menu__action--ai'
+        onMouseDown={event => event.preventDefault()}
+        onClick={handleEditWithAI}
+        disabled={!canvasId}
+        data-track-category='CANVAS'
+        data-track-name='Selection_Edit_With_AI'
+        data-track-metadata={JSON.stringify({ canvasId: canvasId ?? null })}
+      >
+        <img
+          alt=''
+          aria-hidden='true'
+          width='15'
+          height='15'
+          src='/svgs/icons/ai-bot-gradient-star.svg'
+        />
+        <span>Edit with AI</span>
+      </button>
+    </>
   );
 }
 
+/**
+ * Canvas selection menu: a single horizontal pill. Formatting stays as compact
+ * icons on the left so the editor keeps its controls, and the two labelled
+ * actions sit on the right where the eye lands last.
+ */
 export const createCanvasFormattingToolbar = (
   onAddComment: () => void,
   options: CanvasFormattingToolbarOptions = {},
@@ -111,35 +125,32 @@ export const createCanvasFormattingToolbar = (
   }: FormattingToolbarProps): ReactElement | null => {
     const Components = useComponentsContext();
     const canComment = options.canComment ?? true;
+    // Read-only surfaces get the AI action only — there is nothing to format.
+    const canFormat = canComment;
 
     if (!Components) return null;
 
     return (
-      <Components.FormattingToolbar.Root
-        className={`bn-toolbar bn-formatting-toolbar canvas-formatting-menu ${
-          canComment ? '' : 'canvas-formatting-menu--ask-only'
-        }`}
-      >
-        {canComment && (
+      <Components.FormattingToolbar.Root className='bn-toolbar bn-formatting-toolbar canvas-selection-menu'>
+        {canFormat && (
           <>
-            <div className='canvas-formatting-menu__type-row'>
+            <div className='canvas-selection-menu__type'>
               <BlockTypeSelect {...(blockTypeSelectItems ? { items: blockTypeSelectItems } : {})} />
             </div>
-            <div className='canvas-formatting-menu__format-grid'>
-              <ColorStyleButton />
+            <span className='canvas-selection-menu__divider' aria-hidden='true' />
+            <div className='canvas-selection-menu__format'>
               <BasicTextStyleButton basicTextStyle='bold' />
               <BasicTextStyleButton basicTextStyle='italic' />
               <BasicTextStyleButton basicTextStyle='underline' />
               <BasicTextStyleButton basicTextStyle='strike' />
-              <CreateLinkButton />
               <BasicTextStyleButton basicTextStyle='code' />
-              <TextAlignButton textAlignment='left' />
-              <TextAlignButton textAlignment='center' />
-              <TextAlignButton textAlignment='right' />
+              <CreateLinkButton />
+              <ColorStyleButton />
             </div>
+            <span className='canvas-selection-menu__divider' aria-hidden='true' />
           </>
         )}
-        <CanvasToolbarAttachedActions onAddComment={onAddComment} {...options} />
+        <CanvasToolbarActions onAddComment={onAddComment} {...options} />
       </Components.FormattingToolbar.Root>
     );
   };

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -71,7 +71,7 @@ import { xyneAIActor } from '../../../machines/xyneAIMachine';
 import { useCanvasEditorMentionSharing } from '@/hooks/useCanvasEditorMentionSharing';
 import { CanvasRole } from '@xyne/shared';
 import { CanvasCommentsPanel } from '../CanvasCommentsPanel/CanvasCommentsPanel';
-import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
+import { CanvasCommentRail } from '../CanvasCommentRail/CanvasCommentRail';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
 
@@ -483,6 +483,8 @@ export const CollaborativeCanvasEditor = forwardRef<
       isCommentsOpen,
       setIsCommentsOpen,
       inlineCommentThread,
+      commentThreads,
+      setActiveCommentThreadId,
       activeCommentBlockId,
       activeCommentThreadId,
       activeCommentAnchor,
@@ -700,26 +702,6 @@ export const CollaborativeCanvasEditor = forwardRef<
               onCreateThreadFailed={removeCommentAnchorStyle}
             />
           )}
-
-          {inlineCommentThread && (
-            <CanvasInlineCommentThread
-              canvasId={canvasId}
-              canvasTitle={title}
-              channelId={channelId}
-              {...(inlineCommentThread.mode === 'thread' && {
-                thread: inlineCommentThread.thread,
-              })}
-              {...(inlineCommentThread.mode === 'create' && {
-                activeAnchor: inlineCommentThread.anchor,
-              })}
-              anchorRect={inlineCommentThread.rect}
-              editable={editable && !isReadOnly}
-              onClose={closeInlineCommentThread}
-              onBeforeCreateThread={applyCommentAnchorStyle}
-              onCreateThreadCreated={clearActiveCommentAnchor}
-              onCreateThreadFailed={removeCommentAnchorStyle}
-            />
-          )}
         </div>
 
         {/* Presentation Modal */}
@@ -747,6 +729,29 @@ export const CollaborativeCanvasEditor = forwardRef<
         )}
 
         {/* Copy button overlay for code blocks */}
+        {canvasId && (
+          <CanvasCommentRail
+            canvasId={canvasId}
+            containerRef={containerRef}
+            threads={commentThreads}
+            activeThreadId={activeCommentThreadId}
+            draft={
+              inlineCommentThread?.mode === 'create'
+                ? { anchor: inlineCommentThread.anchor, rect: inlineCommentThread.rect }
+                : null
+            }
+            onDraftBeforeCreate={applyCommentAnchorStyle}
+            onDraftCreated={() => {
+              clearActiveCommentAnchor();
+              closeInlineCommentThread();
+            }}
+            onDraftFailed={removeCommentAnchorStyle}
+            onDraftCancel={closeInlineCommentThread}
+            editable={editable && !isReadOnly}
+            onActivate={setActiveCommentThreadId}
+          />
+        )}
+
         <CanvasCodeCopyButton containerRef={containerRef} />
       </div>
     );

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
@@ -73,30 +73,6 @@ const getSelectionRect = (container: HTMLElement | null, blockId: string): DOMRe
   );
 };
 
-const escapeSelectorValue = (value: string): string =>
-  typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
-    ? CSS.escape(value)
-    : value.replace(/["\\]/g, '\\$&');
-
-const getCommentThreadRect = (
-  container: HTMLElement | null,
-  blockId: string,
-  threadId: string,
-): DOMRect | null => {
-  if (!container) return null;
-  const escapedThreadId = escapeSelectorValue(threadId);
-  const escapedBlockId = escapeSelectorValue(blockId);
-  return (
-    container
-      .querySelector<HTMLElement>(`[data-canvas-comment-thread-id="${escapedThreadId}"]`)
-      ?.getBoundingClientRect() ??
-    container
-      .querySelector<HTMLElement>(`[data-id="${escapedBlockId}"]`)
-      ?.getBoundingClientRect() ??
-    null
-  );
-};
-
 const INLINE_COMMENT_INTERACTIVE_SELECTOR = [
   '[data-canvas-inline-comment-thread="true"]',
   '[data-overlay-portal]',
@@ -129,22 +105,14 @@ export function useCanvasCommentEditorBridge({
     setCommentHighlightVersion(version => version + 1);
   }, []);
 
-  const handleCommentAnchorClick = useCallback(
-    (thread: CanvasCommentHighlightThread, rect?: DOMRect): void => {
-      setIsCommentsOpen(false);
-      setActiveCommentBlockId(thread.blockId);
-      setActiveCommentThreadId(thread.id);
-      setActiveCommentAnchor(null);
-      if (rect) {
-        setInlineCommentThread({
-          mode: 'thread',
-          thread,
-          rect,
-        });
-      }
-    },
-    [],
-  );
+  // Clicking anchored text opens that thread's card in the rail. The floating
+  // popover is now only used for composing a brand-new comment.
+  const handleCommentAnchorClick = useCallback((thread: CanvasCommentHighlightThread): void => {
+    setActiveCommentBlockId(thread.blockId);
+    setActiveCommentThreadId(thread.id);
+    setActiveCommentAnchor(null);
+    setInlineCommentThread(null);
+  }, []);
 
   useCanvasCommentHighlights({
     canvasId,
@@ -215,26 +183,7 @@ export function useCanvasCommentEditorBridge({
     setActiveCommentThreadId(initialCommentThreadId);
     setActiveCommentAnchor(null);
 
-    const openInlineThread = (): void => {
-      const thread = commentThreads.find(candidate => candidate.id === initialCommentThreadId);
-      if (!thread) return;
-      const rect = getCommentThreadRect(
-        containerRef.current,
-        initialBlockIdToFocus,
-        initialCommentThreadId,
-      );
-      if (!rect) return;
-      openedInitialThreadKeyRef.current = initialThreadKey;
-      setInlineCommentThread({
-        mode: 'thread',
-        thread,
-        rect,
-      });
-    };
-
-    openInlineThread();
-    const timeout = window.setTimeout(openInlineThread, 300);
-    return () => window.clearTimeout(timeout);
+    // The rail renders the thread; activating it is enough to open and light it.
   }, [commentThreads, containerRef, initialBlockIdToFocus, initialCommentThreadId, ready]);
 
   const getCurrentBlockId = useCallback((): string | null => {
@@ -356,9 +305,10 @@ export function useCanvasCommentEditorBridge({
   }, [containerRef, getCurrentBlockId, getCurrentCommentAnchor]);
 
   const focusCommentBlock = useCallback(
-    (blockId: string): void => {
+    (blockId: string, threadId?: string): void => {
       setActiveCommentBlockId(blockId);
-      setActiveCommentThreadId(null);
+      // Keep the thread active so its card and highlight stay lit after the jump.
+      setActiveCommentThreadId(threadId ?? null);
       setActiveCommentAnchor(null);
       const editor = getEditor();
       if (!editor) return;
@@ -386,6 +336,8 @@ export function useCanvasCommentEditorBridge({
   return {
     isCommentsOpen,
     setIsCommentsOpen,
+    commentThreads,
+    setActiveCommentThreadId,
     inlineCommentThread,
     activeCommentBlockId,
     activeCommentThreadId,

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentHighlights.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentHighlights.ts
@@ -11,6 +11,17 @@ export type CanvasCommentHighlightThread = {
   anchorText?: string | null;
   initialCommentId?: string | null;
   commentCount?: number;
+  /**
+   * Carried by `queries.canvasCommentThreads` via `.related('initialComment')`,
+   * so a collapsed comment card can render its preview without its own query.
+   */
+  initialComment?: {
+    id: string;
+    body: string;
+    createdBy: string;
+    createdAt: number;
+    deletedAt?: number | null;
+  } | null;
 };
 
 interface UseCanvasCommentHighlightsOptions {
@@ -28,7 +39,6 @@ const COMMENT_THREAD_SELECTOR = '[data-canvas-comment-thread-id]';
 const COMMENT_THREAD_ID_ATTR = 'canvasCommentThreadId';
 const COMMENT_THREAD_OPEN_ATTR = 'canvasCommentOpen';
 const COMMENT_THREAD_ACTIVE_ATTR = 'canvasCommentActive';
-const COMMENT_THREAD_BADGE_SELECTOR = '[data-canvas-comment-thread-badge="true"]';
 
 const ensureHighlightStyles = (): void => {
   const styleId = 'canvas-comment-anchor-style';
@@ -38,85 +48,26 @@ const ensureHighlightStyles = (): void => {
   style.id = styleId;
   style.textContent = `
     [data-canvas-comment-thread-id][data-canvas-comment-open="true"] {
-      background-color: rgba(250, 204, 21, 0.42);
-      border-radius: 2px;
-      box-shadow: inset 0 -2px 0 rgba(217, 119, 6, 0.65);
+      background-color: rgba(244, 200, 90, 0.28);
+      border-bottom: 2px solid #E5A93D;
+      padding-bottom: 1px;
       cursor: pointer;
+      transition: background-color 150ms ease;
+    }
+    [data-canvas-comment-thread-id][data-canvas-comment-open="true"]:hover {
+      background-color: rgba(242, 180, 60, 0.36);
     }
     [data-canvas-comment-thread-id][data-canvas-comment-active="true"] {
-      background-color: rgba(245, 158, 11, 0.48);
-      box-shadow:
-        inset 0 -2px 0 rgba(180, 83, 9, 0.75),
-        0 0 0 2px rgba(245, 158, 11, 0.18);
-    }
-    [data-canvas-comment-thread-badge="true"] {
-      position: absolute;
-      z-index: 20;
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      height: 26px;
-      min-width: 44px;
-      padding: 0 10px;
-      border: 1px solid hsl(var(--border));
-      border-radius: 10px;
-      background: hsl(var(--background));
-      color: hsl(var(--muted-foreground));
-      box-shadow: 0 1px 4px hsl(var(--foreground) / 0.12);
-      font-size: 13px;
-      font-weight: 600;
-      line-height: 1;
-      cursor: pointer;
-      transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
-    }
-    [data-canvas-comment-thread-badge="true"]:hover {
-      background: hsl(var(--accent));
-      color: hsl(var(--foreground));
-      border-color: hsl(var(--border));
-    }
-    [data-canvas-comment-thread-badge="true"] svg {
-      width: 15px;
-      height: 15px;
-      flex-shrink: 0;
+      background-color: rgba(242, 180, 60, 0.42);
     }
   `;
   document.head.appendChild(style);
 };
 
-const getBlockSelector = (blockId: string): string => {
-  const escapedBlockId =
-    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
-      ? CSS.escape(blockId)
-      : blockId.replace(/["\\]/g, '\\$&');
-
-  return `[data-id="${escapedBlockId}"]`;
-};
-
-const getThreadSelector = (threadId: string): string => {
-  const escapedThreadId =
-    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
-      ? CSS.escape(threadId)
-      : threadId.replace(/["\\]/g, '\\$&');
-
-  return `[data-canvas-comment-thread-id="${escapedThreadId}"]`;
-};
-
-const getScrollContainer = (container: HTMLElement): HTMLElement =>
-  container.querySelector<HTMLElement>('.thin-scrollbar') ?? container;
-
 const getElementStartRect = (element: HTMLElement): DOMRect => {
   const firstRect = element.getClientRects()[0];
   if (!firstRect) return element.getBoundingClientRect();
   return new DOMRect(firstRect.left, firstRect.top, 0, firstRect.height);
-};
-
-const getNextBadgeTop = (top: number, usedTops: number[]): number => {
-  let nextTop = top;
-  while (usedTops.some(usedTop => Math.abs(usedTop - nextTop) < 30)) {
-    nextTop += 30;
-  }
-  usedTops.push(nextTop);
-  return nextTop;
 };
 
 export const useCanvasCommentHighlights = ({
@@ -140,14 +91,6 @@ export const useCanvasCommentHighlights = ({
     [threads],
   );
   const openThreadIds = useMemo(() => new Set(openThreads.map(thread => thread.id)), [openThreads]);
-  const threadBadgeData = useMemo(
-    () =>
-      openThreads.map(thread => ({
-        thread,
-        count: Math.max(thread.commentCount ?? 1, 1),
-      })),
-    [openThreads],
-  );
 
   useEffect(() => {
     if (!enabled || !canvasId) {
@@ -221,107 +164,6 @@ export const useCanvasCommentHighlights = ({
       observer?.disconnect();
     };
   }, [activeThreadId, canvasId, containerRef, enabled, openThreadIds, refreshKey]);
-
-  useEffect(() => {
-    if (!enabled || !canvasId || typeof window === 'undefined') return;
-
-    ensureHighlightStyles();
-    const container = containerRef.current;
-    if (!container) return;
-
-    const scrollContainer = getScrollContainer(container);
-
-    const removeBadges = (): void => {
-      scrollContainer
-        .querySelectorAll<HTMLElement>(COMMENT_THREAD_BADGE_SELECTOR)
-        .forEach(badge => badge.remove());
-    };
-
-    const renderBadges = (): void => {
-      removeBadges();
-      const usedTops: number[] = [];
-      threadBadgeData.forEach(({ count, thread }) => {
-        const anchorElement = scrollContainer.querySelector<HTMLElement>(
-          getThreadSelector(thread.id),
-        );
-        const blockElement = scrollContainer.querySelector<HTMLElement>(
-          getBlockSelector(thread.blockId),
-        );
-        const targetElement = anchorElement ?? blockElement;
-        if (!targetElement) return;
-
-        const scrollRect = scrollContainer.getBoundingClientRect();
-        const targetRect = targetElement.getBoundingClientRect();
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.dataset['canvasCommentThreadBadge'] = 'true';
-        button.dataset['canvasCommentBadgeThreadId'] = thread.id;
-        button.dataset['canvasCommentBlockId'] = thread.blockId;
-        button.setAttribute('aria-label', `${count} comments in this thread`);
-        button.innerHTML = `
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path>
-          </svg>
-          <span>${count > 99 ? '99+' : count}</span>
-        `;
-        const top =
-          targetRect.top -
-          scrollRect.top +
-          scrollContainer.scrollTop +
-          Math.max(0, targetRect.height / 2 - 13);
-        button.style.top = `${getNextBadgeTop(top, usedTops)}px`;
-        button.style.right = '12px';
-        button.addEventListener('click', event => {
-          event.preventDefault();
-          event.stopPropagation();
-          onAnchorClick?.(thread, targetElement.getBoundingClientRect());
-        });
-        scrollContainer.appendChild(button);
-      });
-    };
-
-    let pendingAnimationFrame: number | null = null;
-    const scheduleRenderBadges = (): void => {
-      if (pendingAnimationFrame !== null) return;
-      pendingAnimationFrame = window.requestAnimationFrame(() => {
-        pendingAnimationFrame = null;
-        renderBadges();
-      });
-    };
-
-    scheduleRenderBadges();
-    const retryTimeouts = [100, 300, 800].map(delay =>
-      window.setTimeout(scheduleRenderBadges, delay),
-    );
-    scrollContainer.addEventListener('scroll', scheduleRenderBadges, { passive: true });
-    window.addEventListener('resize', scheduleRenderBadges);
-
-    const observedEditor = scrollContainer.querySelector<HTMLElement>('.bn-editor');
-    const observer =
-      observedEditor && typeof MutationObserver !== 'undefined'
-        ? new MutationObserver(scheduleRenderBadges)
-        : null;
-    if (observer && observedEditor) {
-      observer.observe(observedEditor, {
-        childList: true,
-        subtree: true,
-        characterData: true,
-        attributes: true,
-        attributeFilter: ['data-id', 'data-canvas-comment-thread-id'],
-      });
-    }
-
-    return () => {
-      if (pendingAnimationFrame !== null) {
-        window.cancelAnimationFrame(pendingAnimationFrame);
-      }
-      retryTimeouts.forEach(timeout => window.clearTimeout(timeout));
-      scrollContainer.removeEventListener('scroll', scheduleRenderBadges);
-      window.removeEventListener('resize', scheduleRenderBadges);
-      observer?.disconnect();
-      removeBadges();
-    };
-  }, [canvasId, containerRef, enabled, onAnchorClick, refreshKey, threadBadgeData]);
 
   useEffect(() => {
     if (!enabled || !onAnchorClick) return;

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2282,146 +2282,184 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   color: hsl(var(--muted-foreground));
 }
 
-/* Canvas selected-text formatting menu. Scoped to the custom toolbar class so
-   BlockNote menus in chat, previews, and other editor surfaces keep their own
-   layout. */
-.canvas-formatting-menu.bn-formatting-toolbar {
-  width: 200px;
-  min-width: 200px;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0;
-  padding: 6px 8px;
+/* Canvas selection menu — one horizontal pill: formatting on the left, the two
+   labelled actions on the right. Scoped to the custom class so BlockNote menus
+   on other editor surfaces keep their own layout. */
+.canvas-selection-menu.bn-formatting-toolbar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2px;
+  width: auto;
+  min-width: 0;
+  height: 34px;
+  padding: 0 4px;
   border: 1px solid hsl(var(--border));
-  border-radius: 12px;
+  border-radius: 10px;
   background: hsl(var(--popover));
   color: hsl(var(--popover-foreground));
   box-shadow:
-    0 18px 44px rgb(15 23 42 / 0.13),
-    0 4px 12px rgb(15 23 42 / 0.08);
+    0 8px 26px hsl(var(--foreground) / 0.14),
+    0 2px 6px hsl(var(--foreground) / 0.06);
+  animation: canvasSelectionIn 140ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-.canvas-formatting-menu--ask-only.bn-formatting-toolbar {
-  width: auto;
-  min-width: 0;
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
+@keyframes canvasSelectionIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
-.canvas-formatting-menu--ask-only .canvas-formatting-menu__attached-actions {
-  padding-top: 0;
+.canvas-selection-menu__divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 7px 3px;
+  background: hsl(var(--border));
 }
 
-.canvas-formatting-menu__type-row {
+.canvas-selection-menu__type,
+.canvas-selection-menu__format {
   display: flex;
   align-items: center;
-  min-height: 26px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid hsl(var(--border));
+  gap: 1px;
 }
 
-.canvas-formatting-menu__type-row > button {
-  width: 100%;
+.canvas-selection-menu__type > button {
   min-height: 26px;
-  justify-content: flex-start;
-  gap: 5px;
-  padding-inline: 4px;
-  border-radius: 8px;
+  gap: 4px;
+  padding-inline: 7px;
+  border-radius: 7px;
   color: hsl(var(--foreground));
-  font-size: 12px;
+  font-size: 12.5px;
   font-weight: 500;
 }
 
-.canvas-formatting-menu__type-row > button [data-position="right"],
-.canvas-formatting-menu__type-row > button .mantine-Button-section[data-position="right"] {
-  margin-left: auto;
-}
-
-.canvas-formatting-menu__format-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 3px 5px;
-  padding-block: 6px;
-  border-bottom: 1px solid hsl(var(--border));
-}
-
-.canvas-formatting-menu__format-grid .bn-button {
-  width: 23px;
-  height: 23px;
-  min-width: 23px;
-  min-height: 23px;
-  border-radius: 6px;
+.canvas-selection-menu .bn-button {
+  width: 26px;
+  height: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  border-radius: 7px;
   color: hsl(var(--foreground));
   background: transparent;
 }
 
-.canvas-formatting-menu__format-grid .bn-button:hover,
-.canvas-formatting-menu__format-grid .bn-button[data-selected] {
+.canvas-selection-menu .bn-button:hover,
+.canvas-selection-menu .bn-button[data-selected] {
   background: hsl(var(--accent));
   color: hsl(var(--accent-foreground));
 }
 
-.canvas-formatting-menu__format-grid .bn-button svg {
+.canvas-selection-menu .bn-button svg {
   width: 15px;
   height: 15px;
 }
 
-.canvas-formatting-menu__attached-actions {
-  display: flex;
-  align-items: center;
-  padding-top: 6px;
-}
-
-.canvas-formatting-menu__attached-button {
+.canvas-selection-menu__action {
   display: inline-flex;
-  min-height: 30px;
-  flex: 1 1 0;
   align-items: center;
-  justify-content: center;
   gap: 6px;
-  border: 1px solid hsl(var(--border));
-  background: hsl(var(--card));
-  padding: 6px 10px;
+  height: 26px;
+  padding: 0 9px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
   color: hsl(var(--foreground));
+  font-family: inherit;
   font-size: 13px;
   font-weight: 500;
   line-height: 1;
   white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.canvas-selection-menu__action:hover {
+  background: hsl(var(--accent));
+}
+
+.canvas-selection-menu__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+/* Canvas comment rail — cards parked beside the text they annotate. */
+.canvas-comment-rail__slot {
   transition:
+    top 180ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.canvas-comment-rail__slot--active {
+  transform: translateX(-12px);
+}
+
+.canvas-comment-card {
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    background-color 150ms ease;
+}
+
+.canvas-comment-card__action {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.canvas-comment-card:hover .canvas-comment-card__action,
+.canvas-comment-card:focus-within .canvas-comment-card__action {
+  opacity: 1;
+}
+
+.canvas-comment-badge {
+  animation: canvasCommentBadgeIn 160ms ease both;
+  transition:
+    top 180ms cubic-bezier(0.4, 0, 0.2, 1),
     background-color 120ms ease,
     color 120ms ease;
 }
 
-.canvas-formatting-menu__attached-button:hover {
-  background: hsl(var(--accent));
-  color: hsl(var(--accent-foreground));
+@keyframes canvasCommentBadgeIn {
+  from {
+    opacity: 0;
+    transform: translateX(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
-.canvas-formatting-menu__attached-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
+@keyframes canvasCommentPanelIn {
+  from {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
-.canvas-formatting-menu__attached-button--left {
-  border-right-width: 0;
-  border-radius: 8px 0 0 8px;
+.canvas-comment-activity {
+  animation: canvasCommentPanelIn 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
-.canvas-formatting-menu__attached-button--right {
-  border-radius: 0 8px 8px 0;
-}
-
-.canvas-formatting-menu__attached-button--single {
-  border-right-width: 1px;
-  border-radius: 8px;
-}
-
-.canvas-formatting-menu__attached-button svg {
-  width: 14px;
-  height: 14px;
+@media (prefers-reduced-motion: reduce) {
+  .canvas-selection-menu.bn-formatting-toolbar,
+  .canvas-comment-badge,
+  .canvas-comment-activity {
+    animation: none;
+  }
+  .canvas-comment-rail__slot,
+  .canvas-comment-badge {
+    transition: none;
+  }
 }
 
 .canvas-inline-comment-composer button[aria-label="Mention channel"] {
@@ -2430,11 +2468,6 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
 
 .canvas-inline-comment-composer button[data-testid="mention-user-btn"] {
   color: hsl(var(--muted-foreground));
-}
-
-.canvas-inline-comment-composer button[data-testid="send-message-button"] {
-  width: 40px;
-  height: 40px;
 }
 
 /* ============================================================
@@ -2453,6 +2486,22 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   --canvas-content-width: 720px;
   /* Matches BlockNote's default .bn-editor padding-inline — the drag-handle / "+" gutter. */
   --canvas-gutter: 54px;
+}
+
+/* Comment rail gutter. The reading column is centred by `margin-inline: auto`;
+   reserving an inline-end margin slides it left so comment cards have somewhere
+   to live that is not on top of the text. Only above a width where both fit —
+   below it the rail falls back to margin badges and a floating card. */
+.canvas-surface {
+  --canvas-comment-rail-width: 344px;
+}
+
+@media (min-width: 1180px) {
+  [data-canvas-comment-rail="on"] .canvas-surface .bn-editor,
+  .canvas-surface[data-canvas-comment-rail="on"] .bn-editor {
+    margin-inline: auto var(--canvas-comment-rail-width);
+    transition: margin-inline-end 220ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
 }
 
 /* Centered reading column. .bn-editor keeps its inline padding as the


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Follow-up to #410. Canvas comments move from a fixed 390px side panel plus a popover that covered the document into cards parked beside the text they annotate.

**Positioning.** `useCanvasCommentAnchors` measures each anchored span and keeps it in sync on scroll, resize and mutation, all coalesced into one animation frame. A single downward pass stacks the cards: each keeps its ideal position next to its anchor and slides down only as far as the card above forces it.

**Creation happens in the rail.** Selecting text and pressing Comment drops a draft card into the rail *in document order* — cards below shift down to make room — with focus already in the field. Enter commits, Escape discards. The create popover is gone, so composing a comment never covers the text being commented on.

**Reading column reserves a gutter.** `.canvas-surface .bn-editor` is a centred 828px column, which left only ~184px to its right — not enough for a card, so cards were clipping body text. The column now reserves 344px while the rail has content and glides back when it is empty. Below 1180px the rail falls back to margin badges with a floating card.

**Selection menu** is one horizontal pill: formatting, then Comment and Edit with AI.

**Query cost.** Collapsed cards render from the thread row's related `initialComment`, so a canvas with N threads holds one comment query rather than N. Only the open card fetches its transcript.

Also removes ~170 lines of imperative badge DOM from `useCanvasCommentHighlights`, which the rail now renders in React.

### Not included
- **Reactions** — `canvas_comments` has no reactions column; needs a table, migration and ACL.
- **`@AI` inline document editing** — no edit pipeline exists. "Edit with AI" opens the existing Ask AI panel with the selection attached.

## Areas Touched
- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

## Zero (Sync) Changes
- [x] No Zero changes — **skip this section**

## Schema & Data Changes
- [x] No schema changes — **skip this section**

## Config, Environment & URLs
- [x] No config changes — **skip this section**

## API Contract
- [x] No API changes

## How did you test it?

Driven through Playwright against local dev on a seeded canvas, at 1600x1000:

- Rail renders one card per open thread, each anchored to its highlighted span; verified body text is no longer clipped by measuring `.bn-editor` right edge (1255) against the scroll container (1599) — a clean 344px gutter.
- Creation flow: triple-click a paragraph -> Comment -> draft card appears in the rail at x=1267 (never over the document), `document.activeElement` is the comment field, typing + Enter creates the thread and the card count increments.
- Resolve/reopen from the card header.
- Narrow fallback exercised by shrinking the available gutter — cards collapse to badges, active one floats.

### Automated
- [ ] Backend unit tests
- [ ] Claw tests
- [ ] End-to-end suite
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no existing canvas-comment test coverage to extend -->

### Manual
**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser
- [x] Empty state
- [x] Error paths (network failure, denied permission, invalid input) <!-- create failure rolls the anchor style back -->

## Checklist
- [x] Reviewed my own diff; scoped to one thing
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- npm run validate: exit 0, 0 errors -->
- [x] Formatting clean in the packages I touched
- [x] No new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `feature/*`
- [x] No debug logging or commented-out code left behind
