### PR TITLE
fix: replace flipped channel exists in getConversationAttachements wi…

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -3546,6 +3546,11 @@ export const queries: AnyQueryRegistry = defineQueries({
     }
   ),
 
+  /**
+   * @deprecated Use getConversationAttachementsV2. The flipped, visibility-only channel exists
+   * here materializes every public channel on hydration and can wedge a syncer worker (Aug 2026
+   * WAL-starvation incidents). Kept only for already-deployed clients; do not add call sites.
+   */
   getConversationAttachements: defineQuery(
     z.object({
       channelId: z.string(),
@@ -3575,6 +3580,37 @@ export const queries: AnyQueryRegistry = defineQueries({
             )
           )
         )
+      );
+
+      if (start) {
+        query = query.start(
+          { id: start.attachementId, createdAt: start.createdAt },
+          { inclusive: true }
+        );
+      }
+
+      query = query.orderBy('createdAt', direction === 'forward' ? 'desc' : 'asc');
+
+      if (limit) {
+        query = query.limit(limit);
+      }
+
+      return query;
+    }
+  ),
+
+  // V2: channel access (public-or-participant) is left to MessageAttachmentsACL. V1's inline
+  // flipped channel exists materialized every public channel on hydration (Aug 2026 WAL incidents).
+  getConversationAttachementsV2: defineQuery(
+    z.object({
+      channelId: z.string(),
+      limit: z.number(),
+      start: z.object({ attachementId: z.string(), createdAt: z.number() }).nullable(),
+      direction: z.literal('forward').or(z.literal('backward')),
+    }),
+    ({ args: { channelId, limit, start, direction } }) => {
+      let query = zql.message_attachments.whereExists('conversation', (conv) =>
+        conv.where('channelId', channelId)
       );
 
       if (start) {

--- a/apps/dashboard/src/components/Chat/FileListV2.tsx
+++ b/apps/dashboard/src/components/Chat/FileListV2.tsx
@@ -26,7 +26,7 @@ const PAGE_SIZE = 20;
 const FileListV2: React.FC<FileListProps> = ({ channelId }) => {
   const [anchor, setAnchor] = useState<Anchor>(LATEST_ANCHOR);
   const [attachementsResponse, attachementsDetails] = useCachedQuery(
-    queries.getConversationAttachements({
+    queries.getConversationAttachementsV2({
       channelId: channelId,
       limit: PAGE_SIZE,
       start: anchor.row,

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3075,35 +3075,18 @@ export const queries = defineQueries({
         .one();
     },
   ),
-  getConversationAttachements: defineQuery(
+  // V2: channel access (public-or-participant) is left to MessageAttachmentsACL. V1's inline
+  // flipped channel exists materialized every public channel on hydration (Aug 2026 WAL incidents).
+  getConversationAttachementsV2: defineQuery(
     z.object({
       channelId: z.string(),
       limit: z.number(),
       start: z.object({ attachementId: z.string(), createdAt: z.number() }).nullable(),
       direction: z.literal('forward').or(z.literal('backward')),
     }),
-    ({ ctx, args: { channelId, limit, start, direction } }) => {
-      let query = zql.message_attachments;
-      query = query.where(({ exists }) =>
-        exists('conversation', conv =>
-          conv.where('channelId', channelId).where(({ or, exists }) =>
-            or(
-              exists('channel', c => c.where('visibility', '=', ChannelVisibility.PUBLIC), {
-                flip: true,
-              }),
-              exists(
-                'channel',
-                c =>
-                  c.whereExists(
-                    'participants',
-                    v => v.where('userId', ctx.userID).where('channelId', channelId),
-                    { flip: true },
-                  ),
-                { flip: true },
-              ),
-            ),
-          ),
-        ),
+    ({ args: { channelId, limit, start, direction } }) => {
+      let query = zql.message_attachments.whereExists('conversation', conv =>
+        conv.where('channelId', channelId),
       );
 
       if (start) {


### PR DESCRIPTION
…th ACL-backed V2

The flipped, visibility-only exists('channel', ...) in getConversationAttachements compiled to a full cross-workspace channels scan on every hydration pass, which could run unboundedly on the production replica — wedging a syncer worker at 100% CPU, pinning the SQLite WAL read-mark, and freezing checkpointing pod-wide (the Aug 10-11 zero-02 WAL-growth incidents, 27GB WAL day one).

getConversationAttachementsV2 keeps only the channelId scoping and pagination; channel access (workspace + public-or-participant) is already enforced by MessageAttachmentsACL at hydration with unflipped point lookups. V1 is removed from shared, kept deprecated in the backend for already-deployed clients, and the sole dashboard call site now uses V2.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
