### PR TITLE
fix: hide Created By line in Info panel for one-to-one DMs

### DIFF
--- a/apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx
+++ b/apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx
@@ -392,10 +392,13 @@ const AboutChannel = ({
           </div>
         )}
 
-        <div className='text-[14px] text-muted-foreground py-4 text-center'>
-          Created By <span className='text-primary'>{getUserDisplayName(createdByUser)}</span> on{' '}
-          <span className='visual-regression-hide'>{formatDate(channel.createdAt)}</span>
-        </div>
+        {/* Created-by line — hidden for 1:1 DMs; shown for group DMs and channels */}
+        {!isDM && (
+          <div className='text-[14px] text-muted-foreground py-4 text-center'>
+            Created By <span className='text-primary'>{getUserDisplayName(createdByUser)}</span> on{' '}
+            <span className='visual-regression-hide'>{formatDate(channel.createdAt)}</span>
+          </div>
+        )}
       </div>
       <div className='mt-auto p-[12px] text-[12px] flex items-center justify-center text-muted-foreground font-light border-t border-border visual-regression-hide'>
         Channel ID: {channel.id}


### PR DESCRIPTION
## What
In the channel Info panel (About tab), the "Created By <user> on <date>" line was shown for every conversation type, including one-to-one DMs. For a 1:1 DM, showing who "created the channel" is meaningless.

This change hides that line only for one-to-one DMs. It remains unchanged for group DMs and all channel types.

## How
`AboutChannel.tsx` already receives an `isDM` prop that is `isOneToOneDMChannel(channel.scopeType)` (true only for 1:1 DMs; group DMs pass `isDM={false}`). The "Created By" block is now wrapped in `{!isDM && (...)}`.

## Files
- apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx

## Testing
- Typecheck (tsc --noEmit) passes.
- Manual: open Info panel on a 1:1 DM → no "Created By" line; on a group DM / channel → line still shows.