### PR TITLE
fix: order thread gallery attachments to match rendered thumbnails [release-20260810]

### DIFF
--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -91,7 +91,11 @@ const ThreadList = ({
     const result = threadMessages.flatMap(msg => {
       if (!msg.hasAttachment || !msg.attachments?.length) return [];
 
-      return msg.attachments.map(att => ({
+      const ordered = [...msg.attachments].sort(
+        (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+      );
+
+      return ordered.map(att => ({
         attachmentId: att.id,
         fileName: att.originalFilename,
         fileUrl: `/attachments/${att.id}/download`,

--- a/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
+++ b/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
@@ -982,7 +982,11 @@ const AttachmentGalleryModalInner: React.FC = () => {
     const allAttachments: AttachmentRef[] = threadMessages.flatMap(msg => {
       if (!msg.hasAttachment || !msg.attachments?.length) return [];
 
-      return msg.attachments.map(att => {
+      const ordered = [...msg.attachments].sort(
+        (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
+      );
+
+      return ordered.map(att => {
         const ref: AttachmentRef = {
           attachmentId: att.id,
           fileName: att.originalFilename,


### PR DESCRIPTION
Cherry-pick of `1f79f22` onto `release-20260810` (originally merged into `release-20260805` via #415).

The Zero `attachments` relation on `threadConversationV2` has no `orderBy`, so related rows come back in arbitrary order. `AttachmentsBlock` renders its thumbnails from a copy sorted by `(createdAt, id)`, but both thread gallery builders mapped `msg.attachments` raw.

Because `startIndex` is a `findIndex` into that unsorted array, clicking the first thumbnail of a five-image message opened the viewer on the wrong slide and showed a counter like "4 of 5". This only surfaced on messages with replies: `ThreadList`'s precomputed `allThreadAttachments` short-circuits the already-sorted `allAttachments` in `MessageAttachment`, and `FileViewerModal` then overwrites the machine with its own unsorted rebuild.

Sort each message's attachments by the same `(createdAt, id)` key as the render path in both builders. Cross-message order was already correct via the messages-level `orderBy`.

Services-Requiring-Redeployment:
  - dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)