### PR TITLE
fix: incomplete Slack thread migration after OOM/restart (skip parent re-insert, back-fill replies)

### DIFF
--- a/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -517,33 +517,39 @@ export async function ingestConversationSlack(
       try {
         // Skip main message ingestion if onlyReplies is true
         if (!onlyReplies) {
-          // Check for duplicate top-level message
+          // Check for duplicate top-level message.
+          //
+          // IMPORTANT: if the parent was already migrated (e.g. a previous run
+          // was OOM-killed mid-thread, leaving the parent + some replies written
+          // but the rest missing), we must NOT skip the whole thread. Doing so
+          // permanently drops the un-migrated replies. Instead we only skip
+          // re-inserting the parent and fall through to the reply loop below,
+          // which back-fills any missing replies. Each reply is de-duped
+          // independently, so re-running is fully idempotent.
           const existingTopLevel = await externalMessageRepo.findByExternalId(
             externalSourceId,
             slackMessage.externalId
           );
 
-          if (existingTopLevel) {
-            continue; // Skip duplicate
+          if (!existingTopLevel) {
+            // Ingest top-level message (throws on failure)
+            // Use userId if available, otherwise use userEmail/userName or botId
+            await ingestMessage(
+              slackMessage.externalId,
+              slackMessage.externalId, // externalThreadId same for top-level
+              slackMessage.content,
+              slackMessage.userId,
+              slackMessage.userEmail,
+              slackMessage.userName,
+              slackMessage.isDeactivated || false,
+              slackMessage.files,
+              undefined,
+              slackMessage.botId,
+              slackMessage.botName,
+              slackMessage.botUserId,
+              slackMessage.isPinned
+            );
           }
-
-          // Ingest top-level message (throws on failure)
-          // Use userId if available, otherwise use userEmail/userName or botId
-          await ingestMessage(
-            slackMessage.externalId,
-            slackMessage.externalId, // externalThreadId same for top-level
-            slackMessage.content,
-            slackMessage.userId,
-            slackMessage.userEmail,
-            slackMessage.userName,
-            slackMessage.isDeactivated || false,
-            slackMessage.files,
-            undefined,
-            slackMessage.botId,
-            slackMessage.botName,
-            slackMessage.botUserId,
-            slackMessage.isPinned
-          );
         }
 
         // Process thread replies


### PR DESCRIPTION
## Summary
Companion of #438, targeted at `feature/community_flow_release_1` instead of `main`.

When a Slack → Xyne Spaces channel migration is interrupted (e.g. the pod is OOM-killed mid-thread), the parent message and some of its replies are already written to the DB, but the remaining replies are not. On restart, `backend/src/migration/scripts/ingestConversationSlack.ts` found the existing parent via `findByExternalId` and `continue`d — skipping the **entire** reply loop and permanently dropping the un-migrated replies. The migration then resumed from the next parent, leaving that thread incompletely migrated. This matches the reported prime-sre incident.

The reply loop already de-dupes each reply independently, so it is safe to run on a partially-migrated thread — the bug was only that the parent-level `continue` prevented it from ever running.

## PR checklist
1. Problem Description: OOM/restart mid-thread caused the resumed migration to skip a thread whose parent was already migrated, permanently dropping the replies that were never ingested.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Reported incident in #xyne-spaces-feedback (prime-sre channel: a thread was not fully migrated). Traced to the parent-level duplicate `continue` in ingestConversationSlack.ts.
3. Explain the solution implemented in the PR: On an already-migrated parent, only skip re-inserting the parent and fall through to the reply loop instead of `continue`-ing. Each reply is de-duped via `findByExternalId(reply.externalThreadId)`, so re-running is idempotent and back-fills any replies missed by an interrupted run.
4. Documentation (link to docs created/updated for this change): N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): Existing incompletely-migrated threads will be back-filled automatically on the next migration/daily-sync run once this fix is deployed, because the reply loop now runs on threads whose parent already exists. No manual data fix required.
7. Environment variable Changes (if any): N/A
8. Testing (how it was tested; screenshots/links): Cherry-picked from the main-targeted branch (#438); same one-file change. Recommended follow-up test: migrate a channel with a multi-reply thread, kill the process after the parent + first reply are written, re-run, and assert all remaining replies land exactly once (no dupes, no gaps).
9. Services to which this change is to be deployed: backend (Slack migration worker / nightly sync) on the community_flow release line.
10. Main PR link (if this PR is raised against a release branch): #438 (targets main)

Requested reviewers: Mohankumar Malapureddy, Venkatesan S.