### PR TITLE
Revert "fix: XYNE-55599 pre prod recording (#417)"

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -423,16 +423,6 @@ export class CallController {
           title: 'Untitled Notes',
         });
 
-        stage = 'bot_user_lookup';
-        const xyneAutomaticBot = await this.getOrCreateBotUser(req.user!.workspaceId!);
-        stage = 'dm_channel_resolution';
-        const headlessChannelId = await repositories.channels.findOrCreateDMChannel(
-          userId,
-          [xyneAutomaticBot.id],
-          repositories.channelParticipants,
-          req.user!.workspaceId!
-        );
-
         const roomLink = `${livekitService.getClientUrl()}/call/${callExternalId}?type=${callType}`;
         const roomMetadata = JSON.stringify({
           callType: 'HEADLESS',
@@ -440,7 +430,6 @@ export class CallController {
           createdBy: userId,
           workspaceId: req.user!.workspaceId,
           notesCanvasId,
-          channelId: headlessChannelId,
         });
 
         stage = 'livekit_room_creation';
@@ -474,7 +463,7 @@ export class CallController {
           externalId: callExternalId,
           callId: callExternalId,
           roomLink,
-          channelId: headlessChannelId,
+          channelId: null,
           notesCanvasId,
         });
         return;


### PR DESCRIPTION
This reverts PR #417 (commit 41b1c57f307b0b7850b04408b8f48c2e4efd800f).

Reverts the changes to `apps/backend/src/controllers/callController.ts` that added bot user lookup + DM channel resolution and set `channelId: headlessChannelId` on the headless call. Restores `channelId: null` behavior.

Services-Requiring-Redeployment:
  - backend

Requested by @Shubham Dhamija.