### PR TITLE
fix: XYNE-55630 desk search debug logs

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -90,6 +90,8 @@ const envSchema = Joi.object({
   ENABLE_AUTOMATION_WORKER: Joi.boolean().default(false),
   ENABLE_DELAYED_MESSAGE_WORKER: Joi.boolean().default(false),
   ENABLE_EMAIL_FETCH_WORKER: Joi.boolean().default(false),
+
+  DESK_TICKET_DEBUG: Joi.boolean().default(false),
   ENABLE_EMAIL_CLASSIFICATION_WORKER: Joi.boolean().default(false),
   ENABLE_TEAM_INTELLIGENCE_WORKER: Joi.boolean().default(false),
   ENABLE_TAG_GENERATION_PIPELINE: Joi.boolean().default(false),
@@ -574,6 +576,7 @@ export const config = {
   enableAutomationWorker: envVars.ENABLE_AUTOMATION_WORKER,
   enableDelayedMessageWorker: envVars.ENABLE_DELAYED_MESSAGE_WORKER,
   enableEmailFetchWorker: envVars.ENABLE_EMAIL_FETCH_WORKER,
+  deskTicketDebug: envVars.DESK_TICKET_DEBUG as boolean,
   enableEmailClassificationWorker: envVars.ENABLE_EMAIL_CLASSIFICATION_WORKER,
   enableTeamIntelligenceWorker: envVars.ENABLE_TEAM_INTELLIGENCE_WORKER,
   enableTagGenerationPipeline: envVars.ENABLE_TAG_GENERATION_PIPELINE,

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -26,6 +26,7 @@ import {
 } from '../utils/responseProcessor';
 import { executeFuzzyFallback } from '../utils/fallback';
 import { highlightText } from '../utils/highlight';
+import { config as appConfig } from '@/config/env';
 import { superpositionClient } from '@/services/superpositionClient';
 import { sudoQueryService } from '@/services/hyperAnalytics/sudoQueryService';
 import { db } from '@/database/client';
@@ -573,7 +574,40 @@ export class SearchService {
         });
       }
 
-       if (process.env.NODE_ENV === 'development') {
+      
+      if (appConfig.deskTicketDebug) {
+        const hitIdentities = response.root?.children?.filter((child: any) =>
+          !String(child.id ?? '').startsWith('group:')
+        ).map((child: any) => {
+          const [, , hitSchema, , hitDocId] = String(child.id ?? '').split(':');
+        
+          const matchFeatures = (child.fields?.matchfeatures ?? {}) as Record<string, unknown>;
+          const scores = Object.fromEntries(
+            Object.entries(matchFeatures).filter(([, v]) => typeof v === 'number')
+          );
+          return {
+            docId: child.fields?.docId ?? hitDocId,
+            schema: hitSchema ?? child.fields?.sddocname,
+            xyneId: child.fields?.xyneId,
+            threadId: child.fields?.threadId,
+            relevance: child.relevance,
+            scores,
+          };
+        }) || [];
+
+        this.logger.info(
+          `[DESK_DEBUG_SEARCH] ${JSON.stringify({
+            searchId,
+            userId,
+            apps: app.join(','),
+            rankProfile,
+            hitCount: hitIdentities.length,
+            hits: hitIdentities,
+          })}`
+        );
+      }
+
+      if (process.env.NODE_ENV === 'development') {
         // Log only specific fields
         const simplifiedResults = response.root?.children?.map((child: any) => ({
           id: child.fields?.docId,

--- a/apps/backend/src/workers/vespaWorker.ts
+++ b/apps/backend/src/workers/vespaWorker.ts
@@ -8,6 +8,7 @@ import { NAMESPACE } from '@/vespa/vespaConfig';
 import { fetchAndMapBySchema, fetchDataBySchema, mapBySchema, VespaOperationType } from '@/zero/vespa-injection/core/mapper';
 import { vespaPostIngestHooks } from './vespaPostIngestHooks';
 import { VespaInsertionStatus } from '@xyne/shared';
+import { config } from '@/config/env';
 
 export class VespaWorker {
 	private queue: Bull.Queue<VespaJob> | null = null;
@@ -121,6 +122,27 @@ export class VespaWorker {
 	}
 
 	/**
+	 * Summarize a mapped document for logging purposes
+	 */
+	private summarizeMappedDoc(data: Record<string, unknown>): Record<string, unknown> {
+		const summary: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(data ?? {})) {
+			if (value === null || value === undefined) {
+				summary[key] = null;
+			} else if (Array.isArray(value)) {
+				summary[key] = `[${value.length} items]`;
+			} else if (typeof value === 'string') {
+				summary[key] = value.length > 120 ? `<${value.length} chars>` : value;
+			} else if (typeof value === 'object') {
+				summary[key] = `{${Object.keys(value).length} keys}`;
+			} else {
+				summary[key] = value;
+			}
+		}
+		return summary;
+	}
+
+	/**
 	 * Record a failed job in the database
 	 */
 	private async recordFailedJob(job: Bull.Job<VespaJob>, error: Error): Promise<void> {
@@ -207,6 +229,18 @@ export class VespaWorker {
 			} else {
 				logger.info(`[VESPA_WORKER] Fetching data from database for ${schema}/${docId}`);
 				mappedData = await fetchAndMapBySchema(schema, docId, jobType, app, job.data.workspaceId, job.data.orgId);
+			}
+
+			// What we are about to send to Vespa, so an indexed document can be compared
+			// against what the mapper actually produced.
+			if (config.deskTicketDebug && jobType !== 'delete') {
+				logger.info('[VESPA_WORKER] mapped document', {
+					jobId: job.id,
+					schema,
+					docId,
+					workspaceId: job.data.workspaceId ?? null,
+					mapped: this.summarizeMappedDoc(mappedData as Record<string, unknown>),
+				});
 			}
 
 			const handlers: Record<VespaJobType, () => Promise<void>> = {


### PR DESCRIPTION
Environment-Changes:
  - DESK_TICKET_DEBUG: to enable debug logs for desk

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
