### PR TITLE
Fix/release 20260805 pr413 changes

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -204,6 +204,18 @@ export const ticketTagMappingTable = table("ticket_tag_mappings")
   })
   .primaryKey("id");
 
+export const ticketExportTable = table("ticket_exports")
+  .columns({
+    id: string(),
+    workspaceId: string(),
+    requestedBy: string(),
+    status: string(),
+    filters: string(),
+    createdAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey("id");
+
 export const ticketReferenceMappingTable = table("ticket_reference_mappings")
   .columns({
     workspaceId: string(),
@@ -3044,6 +3056,19 @@ export const ticketTagTableRelationships = relationships(ticketTagTable, ({ one 
   })
 }));
 
+export const ticketExportTableRelationships = relationships(ticketExportTable, ({ one }) => ({
+  workspace: one({
+    sourceField: ["workspaceId"],
+    destField: ["id"],
+    destSchema: workspaceTable,
+  }),
+  requester: one({
+    sourceField: ["requestedBy"],
+    destField: ["id"],
+    destSchema: userTable,
+  })
+}));
+
 export const ticketReferenceMappingTableRelationships = relationships(ticketReferenceMappingTable, ({ one }) => ({
   sourceTicket: one({
     sourceField: ["sourceTicketId"],
@@ -3453,6 +3478,11 @@ export const userTableRelationships = relationships(userTable, ({ one, many }) =
     sourceField: ["id"],
     destField: ["userId"],
     destSchema: collectionPermissionTable,
+  }),
+  requestedTicketExports: many({
+    sourceField: ["id"],
+    destField: ["requestedBy"],
+    destSchema: ticketExportTable,
   })
 }));
 
@@ -3727,6 +3757,11 @@ export const workspaceTableRelationships = relationships(workspaceTable, ({ one,
     sourceField: ["id"],
     destField: ["workspaceId"],
     destSchema: roleTable,
+  }),
+  ticketExports: many({
+    sourceField: ["id"],
+    destField: ["workspaceId"],
+    destSchema: ticketExportTable,
   })
 }));
 
@@ -4732,6 +4767,7 @@ export const schema = createSchema(
       ticketTagTable,
       projectTagTable,
       ticketTagMappingTable,
+      ticketExportTable,
       ticketReferenceMappingTable,
       ticketStageEtaTable,
       workflowTable,
@@ -4905,6 +4941,7 @@ export const schema = createSchema(
       ticketActivityTableRelationships,
       ticketEntityMappingTableRelationships,
       ticketTagTableRelationships,
+      ticketExportTableRelationships,
       ticketReferenceMappingTableRelationships,
       ticketStageEtaTableRelationships,
       workflowTableRelationships,
@@ -5019,6 +5056,7 @@ export type TicketEntityMapping = Row<typeof schema.tables.ticket_entity_mapping
 export type TicketTag = Row<typeof schema.tables.ticket_tags>;
 export type ProjectTag = Row<typeof schema.tables.project_tags>;
 export type TicketTagMapping = Row<typeof schema.tables.ticket_tag_mappings>;
+export type TicketExport = Row<typeof schema.tables.ticket_exports>;
 export type TicketReferenceMapping = Row<typeof schema.tables.ticket_reference_mappings>;
 export type TicketStageEta = Row<typeof schema.tables.ticket_stage_eta>;
 export type Workflow = Row<typeof schema.tables.workflows>;

--- a/apps/backend/prisma/migrations/20260729174804_ticket_export/migration.sql
+++ b/apps/backend/prisma/migrations/20260729174804_ticket_export/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "public"."ticket_exports" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "requestedBy" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "filters" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ticket_exports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ticket_exports_workspaceId_requestedBy_createdAt_idx"
+  ON "public"."ticket_exports"("workspaceId", "requestedBy", "createdAt" DESC);

--- a/apps/backend/prisma/migrations/20260810120000_add_ticket_reports_resource/migration.sql
+++ b/apps/backend/prisma/migrations/20260810120000_add_ticket_reports_resource/migration.sql
@@ -1,0 +1,12 @@
+INSERT INTO "public"."resources" ("id", "name", "description", "createdAt", "updatedAt")
+SELECT
+  'ticket-reports-resource',
+  'TICKET-REPORTS',
+  'Ticket report export endpoints (/api/ticket-reports/*)',
+  NOW(),
+  NOW()
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "public"."resources"
+  WHERE "name" = 'TICKET-REPORTS'
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -351,6 +351,23 @@ model TicketTagMapping {
   @@schema("public")
 }
 
+
+model TicketExport {
+  id              String    @id @default(cuid())
+  workspaceId     String
+  requestedBy     String
+  status          String
+  filters         String
+  createdAt       DateTime
+  updatedAt       DateTime
+  workspace       Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  requester       User      @relation(fields: [requestedBy], references: [id], onDelete: Cascade, name: "RequestedTicketExports")
+
+  @@index([workspaceId, requestedBy, createdAt(sort: Desc)])
+  @@map("ticket_exports")
+  @@schema("public")
+}
+
 model TicketReferenceMapping {
   workspaceId String // denormalized tenant key (stamped on insert)
   id             String                   @id @default(cuid())
@@ -844,6 +861,7 @@ model User {
   recordings                CallRecording[]         // call recordings this user started
 
   permissions CollectionPermission[]
+  requestedTicketExports TicketExport[] @relation("RequestedTicketExports")
   @@unique([providerUserId, workspaceId])
   @@unique([email, workspaceId])
   @@index([email])
@@ -1473,6 +1491,7 @@ model Workspace {
   tools             Tool[]
   userGroups        UserGroup[]
   roles             Role[]
+  ticketExports     TicketExport[]
 
   @@unique([orgId, name])
   @@index([orgId])

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -87,6 +87,7 @@ import { bookmarkReminderService } from '@/services/bookmarkReminderService';
 import linkPreviewRoutes from '@/routes/linkPreview';
 import bundleRoutes from '@/routes/bundles';
 import projectRoutes from '@/routes/projects';
+import ticketReportRoutes from '@/routes/ticketReports';
 import boardRoutes from '@/routes/boards';
 import searchMetricsRoutes from '@/routes/searchMetrics';
 import knowledgeRoutes from '@/routes/knowledge';
@@ -513,6 +514,12 @@ export class App {
       authMiddleware.authenticate,
       aclMiddleware.checkAccess,
       ticketRoutes
+    );
+    this.app.use(
+      '/api/ticket-reports',
+      authMiddleware.authenticate,
+      aclMiddleware.checkAccess,
+      ticketReportRoutes
     );
     this.app.use(
       '/api/workflows',

--- a/apps/backend/src/controllers/ticketReportController.ts
+++ b/apps/backend/src/controllers/ticketReportController.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import { WorkspaceRole } from '@xyne/shared';
+import { z } from 'zod';
+import {
+  downloadTicketExportRequestSchema,
+  ticketReportService,
+} from '@/services/ticketReportService';
+import { AppError } from '@/middleware/errorHandler';
+import { logger } from '@/utils/logger';
+
+function toExportUser(req: Request) {
+  const user = req.user!;
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    workspaceId: user.workspaceId,
+    role: user.role as WorkspaceRole,
+  };
+}
+
+export class TicketReportController {
+  async downloadExport(req: Request, res: Response): Promise<void> {
+    try {
+      const body = downloadTicketExportRequestSchema.parse(req.body);
+      const { buffer, fileName } = await ticketReportService.downloadExport(
+        body,
+        toExportUser(req),
+      );
+
+      res.setHeader(
+        'Content-Type',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+      res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+      res.setHeader('Content-Length', buffer.length.toString());
+      res.send(buffer);
+    } catch (error) {
+      logger.error('[TicketReportController] downloadExport failed', error);
+      const statusCode =
+        error instanceof z.ZodError ? 400 : error instanceof AppError ? error.statusCode : 500;
+      res.status(statusCode).json({
+        success: false,
+        error:
+          error instanceof z.ZodError
+            ? error.errors
+            : error instanceof AppError
+              ? error.message
+              : 'Failed to download export',
+      });
+    }
+  }
+}

--- a/apps/backend/src/database/acl/acl-factory.ts
+++ b/apps/backend/src/database/acl/acl-factory.ts
@@ -496,6 +496,8 @@ export class ACLFactory {
       return new BaseQueryACL(ctx, prisma)
     case 'entity':
       return new BaseQueryACL(ctx, prisma)
+    case 'ticketExport':
+      return new BaseQueryACL(ctx, prisma)
     case 'entityAlias':
       return new BaseQueryACL(ctx, prisma)
     }

--- a/apps/backend/src/routes/ticketReports.ts
+++ b/apps/backend/src/routes/ticketReports.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { TicketReportController } from '../controllers/ticketReportController';
+
+const router = Router();
+const ticketReportController = new TicketReportController();
+
+router.post('/exports/download', ticketReportController.downloadExport);
+
+export default router;

--- a/apps/backend/src/services/permissionMatrix.ts
+++ b/apps/backend/src/services/permissionMatrix.ts
@@ -12,6 +12,7 @@ import { aclAuditService } from './aclAuditService';
  */
 export type ResourceName =
   | 'TICKETS'
+  | 'TICKET-REPORTS'
   | 'WORKFLOWS'
   | 'AGENTS'
   | 'MODELS'
@@ -80,6 +81,7 @@ export const PERMISSION_MATRIX: Record<WorkspaceRole, readonly PermissionEntry[]
   ],
   ADMIN: [
     { resourceName: 'TICKETS', accessType: AccessType.ADMIN },
+    { resourceName: 'TICKET-REPORTS', accessType: AccessType.ADMIN },
     { resourceName: 'WORKFLOWS', accessType: AccessType.ADMIN },
     { resourceName: 'AGENTS', accessType: AccessType.ADMIN },
     { resourceName: 'MODELS', accessType: AccessType.ADMIN },
@@ -103,6 +105,7 @@ export const PERMISSION_MATRIX: Record<WorkspaceRole, readonly PermissionEntry[]
   ],
   OWNER: [
     { resourceName: 'TICKETS', accessType: AccessType.ADMIN },
+    { resourceName: 'TICKET-REPORTS', accessType: AccessType.ADMIN },
     { resourceName: 'WORKFLOWS', accessType: AccessType.ADMIN },
     { resourceName: 'AGENTS', accessType: AccessType.ADMIN },
     { resourceName: 'MODELS', accessType: AccessType.ADMIN },

--- a/apps/backend/src/services/ticketReportService.ts
+++ b/apps/backend/src/services/ticketReportService.ts
@@ -1,0 +1,1258 @@
+import { z } from 'zod';
+import * as XLSX from 'xlsx';
+import { AccessType, ProjectType, TicketPriority, TicketStatusV2, UserStatus, WorkspaceRole } from '@xyne/shared';
+import { Prisma } from '@prisma/client';
+import { DatabaseClient } from '@/database/client';
+import { repositories } from '@/database/repositories';
+import { AppError } from '@/middleware/errorHandler';
+import {
+  STANDARD_TICKET_REPORT_COLUMNS,
+  redactOpaqueExportIdentifier,
+  ticketReportXlsxBuilder,
+  TicketExportTicket,
+  TicketExportLink,
+  TicketExportActivity,
+} from '@/services/ticketReportXlsxBuilder';
+import { logger } from '@/utils/logger';
+
+const prisma = DatabaseClient.getInstance();
+
+const ticketExportInclude = {
+  board: { include: { project: true } },
+  project: true,
+  channel: true,
+  createdByUser: true,
+  updatedByUser: true,
+  assignedToUser: true,
+  tags: true,
+} satisfies Prisma.TicketInclude;
+
+type RawExportTicket = Prisma.TicketGetPayload<{ include: typeof ticketExportInclude }>;
+
+function formatFileStamp(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`;
+}
+
+const MAX_EXPORT_ROWS = 1000;
+const MAX_ACTIVITY_ROWS = 5000;
+const TICKET_REPORT_RESOURCE_NAME = 'TICKET-REPORTS';
+const ESTIMATED_CORE_COLUMNS = 19;
+const ESTIMATED_BYTES_PER_CELL = 32;
+const STALE_EXPORT_TIMEOUT_MS = 15 * 60 * 1000;
+
+const badRequest = (message: string): AppError => new AppError(message, 400);
+const forbidden = (message: string): AppError => new AppError(message, 403);
+const notFound = (message: string): AppError => new AppError(message, 404);
+const conflict = (message: string): AppError => new AppError(message, 409);
+
+export type TicketExportStatus = 'PENDING' | 'IN_PROGRESS' | 'READY' | 'EXPIRED' | 'FAILED' | 'CANCELED';
+
+const dateRangeSchema = z
+  .object({
+    from: z.coerce.date().optional(),
+    to: z.coerce.date().optional(),
+  })
+  .refine(range => !range.from || !range.to || range.from <= range.to, {
+    message: 'Date range start must be before or equal to end',
+  });
+
+export const ticketExportFiltersSchema = z.object({
+  projectId: z.string().min(1).optional(),
+  sourceChannelId: z.string().min(1).optional(),
+  boardIds: z.array(z.string().min(1)).optional(),
+  dateRange: dateRangeSchema.optional(),
+  statuses: z.array(z.nativeEnum(TicketStatusV2)).optional(),
+  priorities: z.array(z.nativeEnum(TicketPriority)).optional(),
+  assignees: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+  includeArchived: z.boolean().default(false),
+  includeLinkedTickets: z.boolean().default(true),
+  includeLinkedTicketDetails: z.boolean().default(false),
+  includeActivity: z.boolean().default(false),
+  timezone: z.string().default('UTC'),
+  columnsByBoard: z.record(z.array(z.string().min(1)).min(1)).optional(),
+});
+
+export const createTicketExportRequestSchema = z.object({
+  workspaceId: z.string().min(1),
+  filters: ticketExportFiltersSchema.default({}),
+});
+
+export const downloadTicketExportRequestSchema = z.union([
+  z.object({ exportId: z.string().min(1) }),
+  createTicketExportRequestSchema,
+]);
+
+export type CreateTicketExportRequestInput = z.infer<typeof createTicketExportRequestSchema>;
+export type DownloadTicketExportRequestInput = z.infer<typeof downloadTicketExportRequestSchema>;
+export type TicketExportFilters = z.infer<typeof ticketExportFiltersSchema>;
+export type TicketExportPermissionLevel = 'ADMIN' | 'WRITE' | 'READ';
+
+export interface TicketExportEstimate {
+  rowCount: number;
+  linkedTicketCount: number;
+  activityRowCount: number;
+  sheetCount: number;
+  estimatedCells: number;
+  estimatedBytes: number;
+}
+
+interface AuthenticatedUser {
+  id: string;
+  email: string;
+  name?: string;
+  workspaceId: string;
+  role?: WorkspaceRole;
+}
+
+interface ExportContext {
+  exportRecord: {
+    id: string;
+    workspaceId: string;
+    requestedBy: string;
+    filters: string;
+    status: TicketExportStatus;
+  };
+  user: AuthenticatedUser;
+  permissionLevel: TicketExportPermissionLevel;
+}
+
+export class TicketReportService {
+  async requestExport(input: CreateTicketExportRequestInput, user: AuthenticatedUser) {
+    const { workspaceId, filters } = input;
+
+    await this.validateExportRequest(input, user);
+
+    const now = new Date();
+    const exportRecord = await prisma.ticketExport.create({
+      data: {
+        workspaceId,
+        requestedBy: user.id,
+        status: 'PENDING',
+        filters: JSON.stringify(filters),
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+
+    return this.sanitizeExportRecord(exportRecord);
+  }
+
+  async validateExportRequest(
+    input: CreateTicketExportRequestInput,
+    user: AuthenticatedUser,
+  ): Promise<void> {
+    const estimate = await this.estimateExport(input, user);
+    if (estimate.rowCount > MAX_EXPORT_ROWS) {
+      throw badRequest(
+        `Export exceeds maximum limit of ${MAX_EXPORT_ROWS.toLocaleString()} tickets. Please narrow your filters.`,
+      );
+    }
+    if (estimate.rowCount === 0) {
+      throw badRequest('No tickets found for the selected filters');
+    }
+    if (estimate.activityRowCount > MAX_ACTIVITY_ROWS) {
+      throw badRequest(
+        `Export exceeds maximum limit of ${MAX_ACTIVITY_ROWS.toLocaleString()} activity rows. Please narrow your filters or exclude activity.`,
+      );
+    }
+  }
+
+  async estimateExport(
+    input: CreateTicketExportRequestInput,
+    user: AuthenticatedUser,
+  ): Promise<TicketExportEstimate> {
+    const { workspaceId, filters } = input;
+    if (workspaceId !== user.workspaceId) {
+      throw forbidden('Workspace mismatch');
+    }
+
+    const permissionLevel = await this.assertCanCreateExport(user, workspaceId);
+    await this.assertWorkspaceExportEnabled(workspaceId);
+    await this.assertScopeAllowed(user, permissionLevel, filters.projectId);
+    await this.validateFilterScope(workspaceId, filters);
+    await this.assertSourceContextAllowed(user, filters);
+
+    const visibleTicketWhere = this.buildVisibleTicketWhere(workspaceId, filters, user.id);
+    const [rowCount, ticketGroups] = await Promise.all([
+      prisma.ticket.count({ where: visibleTicketWhere }),
+      prisma.ticket.groupBy({
+        by: ['boardId'],
+        where: visibleTicketWhere,
+        _count: { _all: true },
+      }),
+    ]);
+    const boardCount = ticketGroups.length;
+
+    let linkedTicketCount = 0;
+    let linkedBoardCount = 0;
+    let activityRowCount = 0;
+    if (rowCount > 0 && rowCount <= MAX_EXPORT_ROWS && filters.includeLinkedTickets) {
+      const [outboundLinks, inboundLinks] = await Promise.all([
+        prisma.ticketReferenceMapping.findMany({
+          where: { sourceTicket: visibleTicketWhere },
+          select: { targetTicketId: true },
+        }),
+        prisma.ticketReferenceMapping.findMany({
+          where: { targetTicket: visibleTicketWhere },
+          select: { sourceTicketId: true },
+        }),
+      ]);
+      const targetIds = [
+        ...new Set([
+          ...outboundLinks.map(row => row.targetTicketId),
+          ...inboundLinks.map(row => row.sourceTicketId),
+        ]),
+      ];
+      const targetTickets = await prisma.ticket.findMany({
+        where: { id: { in: targetIds }, workspaceId },
+        select: {
+          id: true,
+          boardId: true,
+          channelId: true,
+          channel: { select: { visibility: true } },
+        },
+      });
+      const visibleTargets = await this.applyPrivateChannelVisibility(user.id, targetTickets);
+      linkedTicketCount = visibleTargets.length;
+      linkedBoardCount = new Set(visibleTargets.map(ticket => ticket.boardId)).size;
+    }
+    if (rowCount > 0 && rowCount <= MAX_EXPORT_ROWS && filters.includeActivity) {
+      activityRowCount = await prisma.ticketActivity.count({
+        where: { ticket: visibleTicketWhere },
+      });
+    }
+
+    const sheetCount =
+      1 +
+      boardCount +
+      (filters.includeLinkedTickets ? 1 : 0) +
+      (filters.includeLinkedTicketDetails ? linkedBoardCount : 0) +
+      (filters.includeActivity ? 1 : 0);
+    const estimatedCells =
+      ticketGroups.reduce(
+        (total, group) =>
+          total +
+          group._count._all *
+            (filters.columnsByBoard?.[group.boardId]?.length ?? ESTIMATED_CORE_COLUMNS),
+        0,
+      ) +
+      linkedTicketCount * 10 +
+      activityRowCount * 11;
+
+    return {
+      rowCount,
+      linkedTicketCount,
+      activityRowCount,
+      sheetCount,
+      estimatedCells,
+      estimatedBytes: estimatedCells * ESTIMATED_BYTES_PER_CELL,
+    };
+  }
+
+  private async generateExport(
+    exportId: string,
+    workspaceId: string,
+  ): Promise<{ buffer: Buffer; fileName: string }> {
+    const exportRecord = await prisma.ticketExport.findFirst({
+      where: { id: exportId, workspaceId },
+    });
+    if (!exportRecord) {
+      throw notFound('Export not found');
+    }
+
+    const staleBefore = new Date(Date.now() - STALE_EXPORT_TIMEOUT_MS);
+    const isStaleInProgress =
+      exportRecord.status === 'IN_PROGRESS' && exportRecord.updatedAt < staleBefore;
+    if (!['PENDING', 'READY', 'FAILED'].includes(exportRecord.status) && !isStaleInProgress) {
+      throw conflict('Export is not available for download');
+    }
+
+    const user = await repositories.users.findById(exportRecord.requestedBy);
+    if (!user || user.status !== UserStatus.ACTIVE || user.leftAt) {
+      throw forbidden('Export requester is no longer an active workspace member');
+    }
+    if (user.workspaceId !== workspaceId) {
+      throw forbidden('Workspace mismatch');
+    }
+
+    const claimedExport = await prisma.ticketExport.updateMany({
+      where: {
+        id: exportId,
+        workspaceId,
+        OR: [
+          { status: { in: ['PENDING', 'READY', 'FAILED'] } },
+          { status: 'IN_PROGRESS', updatedAt: { lt: staleBefore } },
+        ],
+      },
+      data: { status: 'IN_PROGRESS', updatedAt: new Date() },
+    });
+    if (claimedExport.count !== 1) {
+      throw conflict('Export is already being generated');
+    }
+
+    try {
+      const filters = this.normalizeFilters(exportRecord.filters);
+      const exportUser: AuthenticatedUser = {
+        id: user.id,
+        email: user.email,
+        workspaceId: user.workspaceId,
+        name: user.name ?? undefined,
+        role: user.role ? (user.role as WorkspaceRole) : undefined,
+      };
+      const permissionLevel = await this.assertCanCreateExport(exportUser, exportRecord.workspaceId);
+      await this.assertWorkspaceExportEnabled(exportRecord.workspaceId);
+      await this.assertScopeAllowed(exportUser, permissionLevel, filters.projectId);
+      await this.validateFilterScope(exportRecord.workspaceId, filters);
+      await this.assertSourceContextAllowed(exportUser, filters);
+
+      const ctx: ExportContext = {
+        exportRecord: exportRecord as ExportContext['exportRecord'],
+        user: exportUser,
+        permissionLevel,
+      };
+
+      const workspace = await prisma.workspace.findUnique({ where: { id: exportRecord.workspaceId } });
+      if (!workspace) {
+        throw notFound('Workspace not found');
+      }
+
+      const tickets = await this.fetchVisibleTickets(ctx, filters);
+      if (tickets.length === 0) {
+        throw badRequest('No tickets found for the selected filters');
+      }
+      const ticketsByBoard = this.groupTicketsByBoard(tickets);
+
+      const links: TicketExportLink[] = [];
+      let linkedTicketsByBoard: Map<string, { board: TicketExportTicket['board']; tickets: TicketExportTicket[] }> | undefined;
+
+      if (filters.includeLinkedTickets) {
+        const { links: foundLinks, linkedTickets } = await this.buildLinkedTicketData(
+          ctx,
+          tickets,
+          filters.includeLinkedTicketDetails,
+        );
+        links.push(...foundLinks);
+        if (filters.includeLinkedTicketDetails && linkedTickets.length > 0) {
+          linkedTicketsByBoard = this.groupTicketsByBoard(linkedTickets);
+        }
+      }
+
+      let activities: TicketExportActivity[] = [];
+      if (filters.includeActivity) {
+        activities = await this.buildActivityData(ctx, tickets);
+      }
+
+      const generatedAt = new Date();
+      const workbook = ticketReportXlsxBuilder.buildWorkbook({
+        exportId,
+        workspaceName: workspace.name,
+        projectScope: filters.projectId
+          ? tickets.find(ticket => ticket.projectId === filters.projectId)?.project?.name ?? filters.projectId
+          : 'Entire workspace',
+        generatedAt,
+        generatedBy: ctx.user.name || ctx.user.email,
+        filters: filters as Record<string, unknown>,
+        includeLinks: filters.includeLinkedTickets,
+        includeActivity: filters.includeActivity,
+        ticketsByBoard,
+        links,
+        linkedTicketsByBoard,
+        activities,
+        columnsByBoard: filters.columnsByBoard,
+      });
+
+      const buffer = XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' });
+      if (buffer.length === 0) {
+        throw new Error('Generated workbook is empty');
+      }
+
+      const fileName = `ticket-report-${workspace.name}-${formatFileStamp(new Date())}.xlsx`.replace(/[^a-zA-Z0-9._-]/g, '_');
+      await prisma.ticketExport.updateMany({
+        where: { id: exportId, workspaceId },
+        data: { status: 'READY', updatedAt: new Date() },
+      });
+      logger.info(`[TicketReportService] Export ${exportId} generated for direct download: ${buffer.length} bytes`);
+      return { buffer, fileName };
+    } catch (error) {
+      await prisma.ticketExport.updateMany({
+        where: { id: exportId, workspaceId },
+        data: { status: 'FAILED', updatedAt: new Date() },
+      });
+      throw error;
+    }
+  }
+
+  async listExports(user: AuthenticatedUser, page = 1, pageSize = 20) {
+    await this.assertHasExportResourceAccess(user, 'READ');
+    const skip = (Math.max(page, 1) - 1) * Math.min(Math.max(pageSize, 1), 100);
+    const take = Math.min(Math.max(pageSize, 1), 100);
+
+    const [items, total] = await Promise.all([
+      prisma.ticketExport.findMany({
+        where: { workspaceId: user.workspaceId, requestedBy: user.id },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take,
+      }),
+      prisma.ticketExport.count({ where: { workspaceId: user.workspaceId, requestedBy: user.id } }),
+    ]);
+
+    return {
+      items: items.map(r => this.sanitizeExportRecord(r)),
+      total,
+      page,
+      pageSize: take,
+    };
+  }
+
+  async downloadExport(input: DownloadTicketExportRequestInput, user: AuthenticatedUser) {
+    const record =
+      'exportId' in input
+        ? await prisma.ticketExport.findFirst({
+            where: {
+              id: input.exportId,
+              workspaceId: user.workspaceId,
+              requestedBy: user.id,
+            },
+          })
+        : await this.requestExport(input, user);
+
+    if (!record) {
+      throw notFound('Export not found');
+    }
+
+    const filters = this.normalizeFilters(record.filters);
+    await this.assertCanAccessExport(user, record.workspaceId, filters.projectId ?? null);
+    return this.generateExport(record.id, record.workspaceId);
+  }
+
+  private async assertCanCreateExport(
+    user: AuthenticatedUser,
+    _workspaceId: string,
+  ): Promise<TicketExportPermissionLevel> {
+    return this.assertHasExportResourceAccess(user, 'WRITE');
+  }
+
+  private async assertCanAccessExport(
+    user: AuthenticatedUser,
+    _workspaceId: string,
+    projectId: string | null,
+  ): Promise<void> {
+    const permissionLevel = await this.assertHasExportResourceAccess(user, 'READ');
+    await this.assertScopeAllowed(user, permissionLevel, projectId ?? undefined);
+  }
+
+  private async assertHasExportResourceAccess(
+    user: AuthenticatedUser,
+    requiredAccess: 'READ' | 'WRITE',
+  ): Promise<TicketExportPermissionLevel> {
+    const activeMember = await prisma.user.findFirst({
+      where: {
+        id: user.id,
+        workspaceId: user.workspaceId,
+        status: UserStatus.ACTIVE,
+        leftAt: null,
+      },
+      select: { id: true },
+    });
+    if (!activeMember) {
+      throw forbidden('Only active workspace members can access ticket exports');
+    }
+
+    const resource = await prisma.resource.findUnique({
+      where: { name: TICKET_REPORT_RESOURCE_NAME },
+      select: { id: true },
+    });
+    if (!resource) {
+      throw new AppError('Export permission resource not configured', 500);
+    }
+
+    const [hasAdmin, hasWrite, hasRead] = await Promise.all([
+      repositories.resourceAccess.hasAccess(user.id, resource.id, AccessType.ADMIN),
+      repositories.resourceAccess.hasAccess(user.id, resource.id, AccessType.WRITE),
+      repositories.resourceAccess.hasAccess(user.id, resource.id, AccessType.READ),
+    ]);
+
+    if (requiredAccess === 'WRITE' && !hasWrite) {
+      throw forbidden('You do not have permission to export tickets');
+    }
+    if (requiredAccess === 'READ' && !(hasRead || hasWrite)) {
+      throw forbidden('You do not have permission to access ticket exports');
+    }
+    return hasAdmin ? 'ADMIN' : hasWrite ? 'WRITE' : 'READ';
+  }
+
+  private async assertWorkspaceExportEnabled(workspaceId: string): Promise<void> {
+    const workspace = await prisma.workspace.findUnique({
+      where: { id: workspaceId },
+      select: { status: true, metadata: true },
+    });
+    if (!workspace || workspace.status !== 'ACTIVE') {
+      throw forbidden('Workspace is not active');
+    }
+    const metadata = this.asRecord(workspace.metadata);
+    if (metadata.ticketExportEnabled === false) {
+      throw forbidden('Ticket export is disabled for this workspace');
+    }
+  }
+
+  private async assertScopeAllowed(
+    user: AuthenticatedUser,
+    permissionLevel: TicketExportPermissionLevel,
+    projectId?: string,
+  ): Promise<void> {
+    if (permissionLevel === 'ADMIN') return;
+    if (!projectId) {
+      throw badRequest('Project scope is required for project-level ticket export permission');
+    }
+    if (!(await this.isProjectMemberOrCreator(user, projectId))) {
+      throw forbidden('You do not have ticket export permission for the selected project');
+    }
+  }
+
+  private async isProjectMemberOrCreator(
+    user: AuthenticatedUser,
+    projectId: string,
+  ): Promise<boolean> {
+    const project = await prisma.project.findFirst({
+      where: {
+        id: projectId,
+        workspaceId: user.workspaceId,
+        OR: [
+          { createdBy: user.id },
+          { channels: { some: { participants: { some: { userId: user.id } } } } },
+        ],
+      },
+      select: { id: true },
+    });
+    return Boolean(project);
+  }
+
+  private async validateFilterScope(
+    workspaceId: string,
+    filters: TicketExportFilters,
+  ): Promise<void> {
+    if (filters.projectId) {
+      const project = await prisma.project.findFirst({
+        where: { id: filters.projectId, workspaceId, type: { not: ProjectType.DM } },
+        select: { id: true },
+      });
+      if (!project) throw notFound('Project not found in workspace');
+    }
+    if (filters.boardIds?.length) {
+      const uniqueBoardIds = [...new Set(filters.boardIds)];
+      const validBoards = await prisma.board.count({
+        where: {
+          id: { in: uniqueBoardIds },
+          workspaceId,
+          ...(filters.projectId ? { projectId: filters.projectId } : {}),
+        },
+      });
+      if (validBoards !== uniqueBoardIds.length) {
+        throw badRequest('One or more boards are invalid for the selected scope');
+      }
+    }
+  }
+
+  private async assertSourceContextAllowed(
+    user: AuthenticatedUser,
+    filters: TicketExportFilters,
+  ): Promise<void> {
+    if (!filters.sourceChannelId) return;
+    if (!filters.projectId) {
+      throw badRequest('Channel-origin exports must be restricted to the linked project');
+    }
+
+    const channel = await prisma.channel.findFirst({
+      where: {
+        id: filters.sourceChannelId,
+        workspaceId: user.workspaceId,
+        projectId: filters.projectId,
+        participants: { some: { userId: user.id } },
+      },
+      select: { id: true },
+    });
+    if (!channel) {
+      throw forbidden(
+        'You are no longer a member of this channel or it is not linked to the selected project',
+      );
+    }
+  }
+
+  private normalizeFilters(raw: unknown): TicketExportFilters {
+    let value = raw;
+    if (typeof raw === 'string') {
+      try {
+        value = JSON.parse(raw) as unknown;
+      } catch {
+        value = {};
+      }
+    }
+    const parsed = ticketExportFiltersSchema.safeParse(value);
+    return parsed.success ? parsed.data : ticketExportFiltersSchema.parse({});
+  }
+
+  private buildTicketWhere(
+    workspaceId: string,
+    filters: TicketExportFilters,
+  ): Prisma.TicketWhereInput {
+    const where: Prisma.TicketWhereInput = { workspaceId };
+
+    if (filters.projectId) {
+      where.projectId = filters.projectId;
+    }
+    if (filters.boardIds && filters.boardIds.length > 0) {
+      where.boardId = { in: filters.boardIds };
+    }
+    if (filters.dateRange?.from || filters.dateRange?.to) {
+      where.createdAt = {};
+      if (filters.dateRange.from) where.createdAt.gte = filters.dateRange.from;
+      if (filters.dateRange.to) where.createdAt.lte = filters.dateRange.to;
+    }
+    if (filters.statuses && filters.statuses.length > 0) {
+      where.statusV2 = { in: filters.statuses as TicketStatusV2[] };
+    }
+    if (filters.priorities && filters.priorities.length > 0) {
+      where.priority = { in: filters.priorities as TicketPriority[] };
+    }
+    if (filters.assignees && filters.assignees.length > 0) {
+      where.assignedTo = { in: filters.assignees };
+    }
+    if (filters.tags && filters.tags.length > 0) {
+      where.tags = {
+        some: {
+          OR: [{ id: { in: filters.tags } }, { name: { in: filters.tags } }],
+        },
+      };
+    }
+    if (!filters.includeArchived) {
+      where.isArchived = false;
+    }
+
+    return where;
+  }
+
+  private async fetchVisibleTickets(ctx: ExportContext, filters: TicketExportFilters): Promise<TicketExportTicket[]> {
+    const where = this.buildVisibleTicketWhere(ctx.exportRecord.workspaceId, filters, ctx.user.id);
+
+    const tickets = await prisma.ticket.findMany({
+      where,
+      take: MAX_EXPORT_ROWS + 1,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      include: ticketExportInclude,
+    });
+
+    if (tickets.length > MAX_EXPORT_ROWS) {
+      throw badRequest(`Export exceeds maximum limit of ${MAX_EXPORT_ROWS.toLocaleString()} tickets`);
+    }
+
+    const enriched = await this.enrichCustomFields(tickets, ctx.exportRecord.workspaceId);
+    return enriched;
+  }
+
+  private buildVisibleTicketWhere(
+    workspaceId: string,
+    filters: TicketExportFilters,
+    userId: string,
+  ): Prisma.TicketWhereInput {
+    return {
+      AND: [
+        this.buildTicketWhere(workspaceId, filters),
+        {
+          OR: [
+            { channel: { visibility: { not: 'PRIVATE' } } },
+            {
+              channel: {
+                visibility: 'PRIVATE',
+                participants: { some: { userId } },
+              },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  private async applyPrivateChannelVisibility<
+    T extends { channelId: string; channel: { visibility: string } | null },
+  >(
+    userId: string,
+    tickets: T[],
+  ): Promise<T[]> {
+    const privateChannelIds = new Set<string>();
+    for (const t of tickets) {
+      if (t.channel?.visibility === 'PRIVATE') {
+        privateChannelIds.add(t.channelId);
+      }
+    }
+
+    if (privateChannelIds.size === 0) {
+      return tickets;
+    }
+
+    const memberships = await prisma.channelParticipant.findMany({
+      where: { channelId: { in: Array.from(privateChannelIds) }, userId },
+      select: { channelId: true },
+    });
+    const allowedChannelIds = new Set(memberships.map(m => m.channelId));
+
+    return tickets.filter(t => t.channel?.visibility !== 'PRIVATE' || allowedChannelIds.has(t.channelId));
+  }
+
+  private async enrichCustomFields(
+    tickets: RawExportTicket[],
+    workspaceId: string,
+  ): Promise<TicketExportTicket[]> {
+    const ticketIds = tickets.map(t => t.id);
+    const fieldValues = ticketIds.length
+      ? await prisma.formEntityValues.findMany({
+          where: { entityId: { in: ticketIds }, entityType: 'TICKET' },
+        })
+      : [];
+
+    const fieldIds = [...new Set(fieldValues.map(fv => fv.fieldId))];
+    const fieldDefs = fieldIds.length
+      ? await prisma.formFields.findMany({
+          where: {
+            OR: [
+              { id: { in: fieldIds } },
+              { globalFieldId: { in: fieldIds } },
+            ],
+          },
+          include: { globalField: true },
+        })
+      : [];
+    const fieldById = new Map<
+      string,
+      { name: string; type: string | null; options: Map<string, string> }
+    >();
+    for (const fd of fieldDefs) {
+      const field = {
+        name: fd.globalField?.fieldName ?? fd.fieldName ?? fd.id,
+        type: fd.globalField?.fieldType ?? fd.fieldType ?? null,
+        options: this.parseFieldOptionMap(
+          fd.globalField?.fieldOptions ??
+            fd.fieldOptions ??
+            fd.globalField?.fieldEnum ??
+            fd.fieldEnum,
+        ),
+      };
+      // Legacy values reference form_fields.id, while current values reference
+      // global_fields.id through form_fields.globalFieldId. Index both forms so
+      // exports remain compatible with tickets created before and after the
+      // global-field migration.
+      fieldById.set(fd.id, field);
+      if (fd.globalFieldId) {
+        fieldById.set(fd.globalFieldId, field);
+      }
+    }
+
+    const userIds = new Set<string>();
+    for (const fv of fieldValues) {
+      const field = fieldById.get(fv.fieldId);
+      if (field?.type !== 'USER') continue;
+      this.flattenDisplayValues(fv.actualFieldValue ?? fv.fieldValue).forEach(value =>
+        userIds.add(value),
+      );
+    }
+    const [customFieldUsers, groups] = await Promise.all([
+      userIds.size
+        ? prisma.user.findMany({
+            where: { id: { in: [...userIds] }, workspaceId },
+            select: { id: true, name: true, displayName: true, email: true },
+          })
+        : [],
+      prisma.userGroup.findMany({
+        where: {
+          id: {
+            in: [...new Set(tickets.map(ticket => ticket.userGroupId).filter(Boolean) as string[])],
+          },
+          workspaceId,
+        },
+        select: { id: true, name: true },
+      }),
+    ]);
+    const userNameById = new Map(
+      customFieldUsers.map(user => [
+        user.id,
+        user.displayName || user.name || user.email,
+      ]),
+    );
+    const groupById = new Map(groups.map(group => [group.id, group]));
+    const valuesByTicket = new Map<string, Record<string, string | number | Date | null>>();
+    for (const fv of fieldValues) {
+      const field = fieldById.get(fv.fieldId);
+      const name = field?.name ?? 'Unknown custom field';
+      if (!name) continue;
+      const existing = valuesByTicket.get(fv.entityId) ?? {};
+      const raw: unknown = fv.actualFieldValue ?? fv.fieldValue;
+      const values = this.flattenDisplayValues(raw).map(value =>
+        redactOpaqueExportIdentifier(
+          userNameById.get(value) ?? field?.options.get(value) ?? value,
+        ),
+      );
+      existing[name] = values.length === 0 ? null : values.join(', ');
+      valuesByTicket.set(fv.entityId, existing);
+    }
+
+    return tickets.map(t => ({
+      ...t,
+      assignee: t.assignedToUser,
+      tags: t.tags.map(tt => ({ id: tt.id, name: tt.name })),
+      group: t.userGroupId ? groupById.get(t.userGroupId) ?? null : null,
+      customFields: valuesByTicket.get(t.id) ?? {},
+    })) as TicketExportTicket[];
+  }
+
+  private groupTicketsByBoard(tickets: TicketExportTicket[]) {
+    const map = new Map<string, { board: TicketExportTicket['board']; tickets: TicketExportTicket[] }>();
+    for (const t of tickets) {
+      const entry = map.get(t.board.id);
+      if (entry) {
+        entry.tickets.push(t);
+      } else {
+        map.set(t.board.id, { board: t.board, tickets: [t] });
+      }
+    }
+    return map;
+  }
+
+  private async buildLinkedTicketData(ctx: ExportContext, primaryTickets: TicketExportTicket[], includeDetails: boolean) {
+    const sourceTicketIds = primaryTickets.map(t => t.id);
+    if (sourceTicketIds.length === 0) {
+      return { links: [], linkedTickets: [] };
+    }
+
+    const [mappings, subTicketMappings] = await Promise.all([
+      prisma.ticketReferenceMapping.findMany({
+        where: {
+          OR: [
+            { sourceTicketId: { in: sourceTicketIds } },
+            { targetTicketId: { in: sourceTicketIds } },
+          ],
+        },
+      }),
+      prisma.ticketSubTicketMapping.findMany({
+        where: { ticketId: { in: sourceTicketIds } },
+        include: {
+          subTicket: {
+            include: {
+              mappedTicket: { include: ticketExportInclude },
+            },
+          },
+        },
+      }),
+    ]);
+
+    const targetTicketIds = [
+      ...new Set(
+        mappings.flatMap(mapping =>
+          sourceTicketIds.includes(mapping.sourceTicketId)
+            ? [mapping.targetTicketId]
+            : [mapping.sourceTicketId],
+        ),
+      ),
+    ];
+    if (targetTicketIds.length === 0) {
+      const mappedSubTickets = subTicketMappings
+        .map(mapping => mapping.subTicket.mappedTicket)
+        .filter((ticket): ticket is RawExportTicket => Boolean(ticket));
+      if (mappedSubTickets.length === 0) {
+        return { links: [], linkedTickets: [] };
+      }
+    }
+
+    let targets = await prisma.ticket.findMany({
+      where: { id: { in: targetTicketIds }, workspaceId: ctx.exportRecord.workspaceId },
+      include: ticketExportInclude,
+    });
+    targets.push(
+      ...subTicketMappings
+        .map(mapping => mapping.subTicket.mappedTicket)
+        .filter(
+          (ticket): ticket is RawExportTicket =>
+            Boolean(ticket) && !targets.some(existing => existing.id === ticket?.id),
+        ),
+    );
+
+    targets = await this.applyPrivateChannelVisibility(ctx.user.id, targets);
+
+    const visibleTargetMap = new Map(targets.map(t => [t.id, t]));
+    const primaryMap = new Map(primaryTickets.map(t => [t.id, t]));
+
+    const links: TicketExportLink[] = [];
+    for (const m of mappings) {
+      const primaryIsSource = primaryMap.has(m.sourceTicketId);
+      const source = primaryMap.get(primaryIsSource ? m.sourceTicketId : m.targetTicketId);
+      const target = visibleTargetMap.get(primaryIsSource ? m.targetTicketId : m.sourceTicketId);
+      if (!target || !source) continue;
+      links.push({
+        sourceTicketKey: source.xyneId,
+        sourceTitle: source.title,
+        sourceBoardName: source.board.name,
+        relationshipType: m.relationType,
+        targetTicketKey: target.xyneId,
+        targetTitle: target.title,
+        targetBoardName: target.board.name,
+        targetProjectName: target.project?.name ?? '',
+        targetStatus: target.statusV2 ?? target.status,
+        targetAssigneeName: target.assignedToUser?.name ?? target.assignedToUser?.email ?? '',
+      });
+    }
+    for (const mapping of subTicketMappings) {
+      const source = primaryMap.get(mapping.ticketId);
+      const target = mapping.subTicket.mappedTicket
+        ? visibleTargetMap.get(mapping.subTicket.mappedTicket.id)
+        : undefined;
+      if (!source || !target) continue;
+      links.push({
+        sourceTicketKey: source.xyneId,
+        sourceTitle: source.title,
+        sourceBoardName: source.board.name,
+        relationshipType: 'SUB_TICKET',
+        targetTicketKey: target.xyneId,
+        targetTitle: target.title,
+        targetBoardName: target.board.name,
+        targetProjectName: target.project?.name ?? '',
+        targetStatus: target.statusV2 ?? target.status,
+        targetAssigneeName: target.assignedToUser?.name ?? target.assignedToUser?.email ?? '',
+      });
+    }
+
+    let linkedTickets: TicketExportTicket[] = [];
+    if (includeDetails) {
+      const uniqueTargets = [...visibleTargetMap.values()];
+      linkedTickets = await this.enrichCustomFields(
+        uniqueTargets,
+        ctx.exportRecord.workspaceId,
+      );
+    }
+
+    return { links, linkedTickets };
+  }
+
+  private async buildActivityData(ctx: ExportContext, tickets: TicketExportTicket[]): Promise<TicketExportActivity[]> {
+    const ticketIds = tickets.map(t => t.id);
+    if (ticketIds.length === 0) return [];
+
+    const activities = await prisma.ticketActivity.findMany({
+      where: { ticketId: { in: ticketIds } },
+      orderBy: { timestamp: 'desc' },
+      take: MAX_ACTIVITY_ROWS + 1,
+      include: { updatedByUser: true, ticket: { include: { board: true, project: true } } },
+    });
+
+    if (activities.length > MAX_ACTIVITY_ROWS) {
+      throw badRequest(`Export exceeds maximum activity limit of ${MAX_ACTIVITY_ROWS.toLocaleString()} rows`);
+    }
+
+    const excludedActivityPattern = /(comment|message|attachment|email|workflow)/i;
+    const allowedActivities = activities.filter(activity => {
+      const value = this.asRecord(activity.value);
+      return !excludedActivityPattern.test(String(value.type ?? value.activityType ?? ''));
+    });
+    const referencedIds = new Set<string>();
+    for (const activity of allowedActivities) {
+      const value = this.asRecord(activity.value);
+      for (const candidate of [
+        ...this.flattenDisplayValues(value.oldValue),
+        ...this.flattenDisplayValues(value.newValue),
+      ]) {
+        referencedIds.add(candidate);
+      }
+    }
+    const ids = [...referencedIds];
+    const [users, boards, projects, channels, groups, ticketTags, projectTags, stages, referencedTickets, fields] =
+      ids.length
+        ? await Promise.all([
+            prisma.user.findMany({
+              where: { id: { in: ids }, workspaceId: ctx.exportRecord.workspaceId },
+              select: { id: true, name: true, displayName: true, email: true },
+            }),
+            prisma.board.findMany({
+              where: { id: { in: ids }, workspaceId: ctx.exportRecord.workspaceId },
+              select: { id: true, name: true },
+            }),
+            prisma.project.findMany({
+              where: { id: { in: ids }, workspaceId: ctx.exportRecord.workspaceId },
+              select: { id: true, name: true },
+            }),
+            prisma.channel.findMany({
+              where: { id: { in: ids }, workspaceId: ctx.exportRecord.workspaceId },
+              select: { id: true, name: true },
+            }),
+            prisma.userGroup.findMany({
+              where: { id: { in: ids }, workspaceId: ctx.exportRecord.workspaceId },
+              select: { id: true, name: true },
+            }),
+            prisma.ticketTag.findMany({
+              where: { id: { in: ids }, ticket: { workspaceId: ctx.exportRecord.workspaceId } },
+              select: { id: true, name: true },
+            }),
+            prisma.projectTag.findMany({
+              where: {
+                id: { in: ids },
+                projectId: { in: [...new Set(tickets.map(ticket => ticket.projectId))] },
+              },
+              select: { id: true, name: true },
+            }),
+            prisma.stage.findMany({
+              where: {
+                id: { in: ids },
+                board: { workspaceId: ctx.exportRecord.workspaceId },
+              },
+              select: { id: true, name: true },
+            }),
+            prisma.ticket.findMany({
+              where: { id: { in: ids }, workspaceId: ctx.exportRecord.workspaceId },
+              select: { id: true, xyneId: true, title: true },
+            }),
+            prisma.formFields.findMany({
+              where: {
+                id: { in: ids },
+                form: { workspaceId: ctx.exportRecord.workspaceId },
+              },
+              include: { globalField: true },
+            }),
+          ])
+        : [[], [], [], [], [], [], [], [], [], []];
+    const humanNameById = new Map<string, string>();
+    users.forEach(user =>
+      humanNameById.set(user.id, user.displayName || user.name || user.email),
+    );
+    for (const entities of [boards, projects, channels, groups, ticketTags, projectTags, stages]) {
+      entities.forEach(entity => humanNameById.set(entity.id, entity.name));
+    }
+    referencedTickets.forEach(ticket =>
+      humanNameById.set(ticket.id, `${ticket.xyneId} — ${ticket.title}`),
+    );
+    fields.forEach(field => {
+      const label = field.globalField?.fieldName ?? field.fieldName;
+      if (label) humanNameById.set(field.id, label);
+      const optionMap = this.parseFieldOptionMap(
+        field.globalField?.fieldOptions ??
+          field.fieldOptions ??
+          field.globalField?.fieldEnum ??
+          field.fieldEnum,
+      );
+      optionMap.forEach((value, id) => humanNameById.set(id, value));
+    });
+
+    return allowedActivities.map(a => {
+      const value = this.asRecord(a.value);
+      const resolveValue = (raw: unknown): string =>
+        this.flattenDisplayValues(raw)
+          .map(item => humanNameById.get(item) ?? redactOpaqueExportIdentifier(item))
+          .join(', ');
+      return {
+        ticketKey: a.ticket.xyneId,
+        ticketTitle: a.ticket.title,
+        projectName: a.ticket.project.name,
+        boardName: a.ticket.board.name,
+        timestamp: a.timestamp,
+        actorName: a.updatedByUser?.name ?? a.updatedByUser?.email ?? 'System',
+        activityType: String(value.type || a.activityType || ''),
+        fieldChanged: value.field
+          ? humanNameById.get(String(value.field)) ??
+            redactOpaqueExportIdentifier(String(value.field))
+          : '',
+        oldValue: resolveValue(value.oldValue),
+        newValue: resolveValue(value.newValue),
+        visibilityResult: 'Included',
+      };
+    });
+  }
+
+  async getScopeOptions(user: AuthenticatedUser) {
+    const permissionLevel = await this.assertHasExportResourceAccess(user, 'WRITE');
+    await this.assertWorkspaceExportEnabled(user.workspaceId);
+    const projectWhere: Prisma.ProjectWhereInput = {
+      workspaceId: user.workspaceId,
+      type: { not: ProjectType.DM },
+      ...(permissionLevel === 'ADMIN'
+        ? {}
+        : {
+            OR: [
+              { createdBy: user.id },
+              { channels: { some: { participants: { some: { userId: user.id } } } } },
+            ],
+          }),
+    };
+    const [projects, users] = await Promise.all([
+      prisma.project.findMany({
+        where: projectWhere,
+        orderBy: { name: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          code: true,
+          boards: {
+            orderBy: { name: 'asc' },
+            select: { id: true, name: true, projectId: true },
+          },
+        },
+      }),
+      prisma.user.findMany({
+        where: { workspaceId: user.workspaceId, status: UserStatus.ACTIVE, leftAt: null },
+        orderBy: { name: 'asc' },
+        select: { id: true, name: true, displayName: true, email: true },
+      }),
+    ]);
+    const tags = await prisma.projectTag.findMany({
+      where: { projectId: { in: projects.map(project => project.id) } },
+      orderBy: { name: 'asc' },
+      select: { id: true, name: true, projectId: true },
+    });
+    const boardIds = projects.flatMap(project => project.boards.map(board => board.id));
+    const stages = boardIds.length
+      ? await prisma.stage.findMany({
+          where: { boardId: { in: boardIds } },
+          select: { id: true, boardId: true },
+        })
+      : [];
+    const stageBoardById = new Map(stages.map(stage => [stage.id, stage.boardId]));
+    const contextIds = [...boardIds, ...stages.map(stage => stage.id)];
+    const mappings = contextIds.length
+      ? await prisma.formContextMapping.findMany({
+          where: {
+            contextId: { in: contextIds },
+            contextType: { in: ['BOARD', 'STAGE'] },
+            entityType: 'TICKET',
+          },
+          select: { contextId: true, contextType: true, formId: true },
+        })
+      : [];
+    const formFields = mappings.length
+      ? await prisma.formFields.findMany({
+          where: { formId: { in: [...new Set(mappings.map(mapping => mapping.formId))] } },
+          orderBy: [{ sequenceNumber: 'asc' }, { createdAt: 'asc' }],
+          include: { globalField: true },
+        })
+      : [];
+    const fieldsByFormId = new Map<string, typeof formFields>();
+    for (const field of formFields) {
+      const existing = fieldsByFormId.get(field.formId) ?? [];
+      existing.push(field);
+      fieldsByFormId.set(field.formId, existing);
+    }
+    const customFieldsByBoardId = new Map<
+      string,
+      Array<{ key: string; label: string; kind: 'CUSTOM'; fieldType: string }>
+    >();
+    for (const mapping of mappings) {
+      const boardId =
+        mapping.contextType === 'BOARD'
+          ? mapping.contextId
+          : stageBoardById.get(mapping.contextId);
+      if (!boardId) continue;
+      const existing = customFieldsByBoardId.get(boardId) ?? [];
+      const existingKeys = new Set(existing.map(field => field.key));
+      for (const field of fieldsByFormId.get(mapping.formId) ?? []) {
+        const label = field.globalField?.fieldName ?? field.fieldName;
+        const fieldType = field.globalField?.fieldType ?? field.fieldType;
+        if (!label || !fieldType) continue;
+        const key = `custom:${label}`;
+        if (existingKeys.has(key)) continue;
+        existing.push({ key, label, kind: 'CUSTOM', fieldType });
+        existingKeys.add(key);
+      }
+      customFieldsByBoardId.set(boardId, existing);
+    }
+    const standardColumns = STANDARD_TICKET_REPORT_COLUMNS.map(column => ({
+      ...column,
+      kind: 'STANDARD' as const,
+    }));
+    return {
+      permissionLevel,
+      projects: projects.map(project => ({
+        ...project,
+        boards: project.boards.map(board => ({
+          ...board,
+          columns: [...standardColumns, ...(customFieldsByBoardId.get(board.id) ?? [])],
+        })),
+      })),
+      users: users.map(option => ({
+        id: option.id,
+        name: option.displayName || option.name || option.email,
+      })),
+      tags,
+      statuses: Object.values(TicketStatusV2),
+      priorities: Object.values(TicketPriority),
+    };
+  }
+
+  private sanitizeExportRecord(record: Awaited<ReturnType<typeof prisma.ticketExport.create>>) {
+    return {
+      id: record.id,
+      workspaceId: record.workspaceId,
+      requestedBy: record.requestedBy,
+      status: record.status,
+      filters: this.normalizeFilters(record.filters),
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    };
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private flattenDisplayValues(value: unknown): string[] {
+    if (value === null || value === undefined || value === '') return [];
+    if (Array.isArray(value)) return value.flatMap(item => this.flattenDisplayValues(item));
+    if (typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      const preferred = record.label ?? record.name ?? record.value ?? record.id;
+      return preferred === undefined
+        ? [JSON.stringify(record)]
+        : this.flattenDisplayValues(preferred);
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (
+        (trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+        (trimmed.startsWith('{') && trimmed.endsWith('}'))
+      ) {
+        try {
+          return this.flattenDisplayValues(JSON.parse(trimmed));
+        } catch {
+          return [value];
+        }
+      }
+    }
+    return [String(value)];
+  }
+
+  private parseFieldOptionMap(value: unknown): Map<string, string> {
+    const options = this.flattenDisplayOptionRecords(value);
+    return new Map(options.map(option => [option.id, option.value]));
+  }
+
+  private flattenDisplayOptionRecords(value: unknown): Array<{ id: string; value: string }> {
+    if (typeof value === 'string') {
+      try {
+        return this.flattenDisplayOptionRecords(JSON.parse(value));
+      } catch {
+        return [];
+      }
+    }
+    if (!Array.isArray(value)) return [];
+    return value.flatMap(option => {
+      if (typeof option === 'string') return [{ id: option, value: option }];
+      if (!option || typeof option !== 'object') return [];
+      const record = option as Record<string, unknown>;
+      const id = record.id ?? record.value;
+      const label = record.value ?? record.label ?? record.name ?? record.id;
+      return id === undefined || label === undefined
+        ? []
+        : [{ id: String(id), value: String(label) }];
+    });
+  }
+
+}
+
+export const ticketReportService = new TicketReportService();

--- a/apps/backend/src/services/ticketReportXlsxBuilder.ts
+++ b/apps/backend/src/services/ticketReportXlsxBuilder.ts
@@ -1,0 +1,324 @@
+import * as XLSX from 'xlsx';
+import type { Ticket, Board, Project, Channel, User } from '@prisma/client';
+
+export interface TicketExportTicket extends Ticket {
+  board: Board & { project: Project | null };
+  project: Project | null;
+  channel: Channel | null;
+  assignee: User | null;
+  createdByUser: User | null;
+  updatedByUser: User | null;
+  tags: { id: string; name: string }[];
+  group?: { id: string; name: string } | null;
+  customFields: Record<string, string | number | Date | null | undefined>;
+}
+
+export interface TicketExportLink {
+  sourceTicketKey: string;
+  sourceTitle: string;
+  sourceBoardName: string;
+  relationshipType: string;
+  targetTicketKey: string;
+  targetTitle: string;
+  targetBoardName: string;
+  targetProjectName: string;
+  targetStatus: string;
+  targetAssigneeName: string;
+}
+
+export interface TicketExportActivity {
+  ticketKey: string;
+  ticketTitle: string;
+  projectName: string;
+  boardName: string;
+  timestamp: Date;
+  actorName: string;
+  activityType: string;
+  fieldChanged: string;
+  oldValue: string;
+  newValue: string;
+  visibilityResult: string;
+}
+
+export interface ExportWorkbookInput {
+  exportId: string;
+  workspaceName: string;
+  projectScope: string;
+  generatedAt: Date;
+  generatedBy: string;
+  filters: Record<string, unknown>;
+  includeLinks: boolean;
+  includeActivity: boolean;
+  ticketsByBoard: Map<string, { board: TicketExportTicket['board']; tickets: TicketExportTicket[] }>;
+  links: TicketExportLink[];
+  linkedTicketsByBoard?: Map<string, { board: TicketExportTicket['board']; tickets: TicketExportTicket[] }>;
+  activities: TicketExportActivity[];
+  columnsByBoard?: Record<string, string[]>;
+}
+
+export const STANDARD_TICKET_REPORT_COLUMNS = [
+  { key: 'ticketKey', label: 'Ticket Key' },
+  { key: 'title', label: 'Title' },
+  { key: 'workspace', label: 'Workspace' },
+  { key: 'project', label: 'Project' },
+  { key: 'board', label: 'Board' },
+  { key: 'channel', label: 'Channel' },
+  { key: 'status', label: 'Status' },
+  { key: 'stage', label: 'Stage' },
+  { key: 'priority', label: 'Priority' },
+  { key: 'archived', label: 'Archived' },
+  { key: 'createdBy', label: 'Created By' },
+  { key: 'assignedTo', label: 'Assigned To' },
+  { key: 'updatedBy', label: 'Updated By' },
+  { key: 'group', label: 'Group' },
+  { key: 'createdAt', label: 'Created At' },
+  { key: 'updatedAt', label: 'Updated At' },
+  { key: 'eta', label: 'ETA' },
+  { key: 'closedAt', label: 'Closed At' },
+  { key: 'tags', label: 'Tags' },
+] as const;
+
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r', '\n'];
+const OPAQUE_DATABASE_ID_PATTERNS = [
+  /^c[a-z0-9]{20,}$/i,
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  /^[0-9a-f]{24}$/i,
+];
+
+export function redactOpaqueExportIdentifier(value: string): string {
+  return OPAQUE_DATABASE_ID_PATTERNS.some(pattern => pattern.test(value))
+    ? 'Unavailable'
+    : value;
+}
+
+function sanitizeCell(value: unknown): string | number | Date | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+  const str = redactOpaqueExportIdentifier(String(value));
+  const needsEscape = FORMULA_TRIGGERS.some(trigger => str.startsWith(trigger));
+  if (needsEscape) {
+    return "'" + str.replace(/'/g, "''");
+  }
+  return str;
+}
+
+function buildRow(values: unknown[]): (string | number | Date | null)[] {
+  return values.map(sanitizeCell);
+}
+
+export class TicketReportXlsxBuilder {
+  buildWorkbook(input: ExportWorkbookInput): XLSX.WorkBook {
+    const wb = XLSX.utils.book_new();
+    const usedSheetNames = new Set<string>();
+
+    const summaryWs = this.buildSummarySheet(input);
+    this.appendSheet(wb, summaryWs, 'Summary', usedSheetNames);
+
+    for (const [, { board, tickets }] of input.ticketsByBoard) {
+      const ws = this.buildBoardSheet(
+        input.workspaceName,
+        board,
+        tickets,
+        input.columnsByBoard?.[board.id],
+      );
+      this.appendSheet(
+        wb,
+        ws,
+        board.name || 'Untitled Board',
+        usedSheetNames,
+      );
+    }
+
+    if (input.includeLinks) {
+      const linksWs = this.buildLinksSheet(input.links);
+      this.appendSheet(wb, linksWs, 'Ticket Links', usedSheetNames);
+    }
+
+    if (input.linkedTicketsByBoard) {
+      for (const [, { board, tickets }] of input.linkedTicketsByBoard) {
+        const ws = this.buildBoardSheet(
+          input.workspaceName,
+          board,
+          tickets,
+          input.columnsByBoard?.[board.id],
+        );
+        this.appendSheet(
+          wb,
+          ws,
+          `Linked - ${board.name || 'Untitled Board'}`,
+          usedSheetNames,
+        );
+      }
+    }
+
+    if (input.includeActivity) {
+      const activityWs = this.buildActivitySheet(input.activities);
+      this.appendSheet(wb, activityWs, 'Activity', usedSheetNames);
+    }
+
+    return wb;
+  }
+
+  private buildSummarySheet(input: ExportWorkbookInput): XLSX.WorkSheet {
+    const rows: (string | number | Date | null)[][] = [
+      ['Workspace', input.workspaceName],
+      ['Project', input.projectScope],
+      ['Generated at', input.generatedAt],
+      ['Generated by', input.generatedBy],
+      [
+        'Board names',
+        [
+          ...new Set(
+            Array.from(input.ticketsByBoard.values()).map(entry => entry.board.name),
+          ),
+        ].join(', '),
+      ],
+      ['Total tickets', Array.from(input.ticketsByBoard.values()).reduce((sum, b) => sum + b.tickets.length, 0)],
+    ];
+    return XLSX.utils.aoa_to_sheet(rows.map(buildRow));
+  }
+
+  private buildBoardSheet(
+    workspaceName: string,
+    board: TicketExportTicket['board'],
+    tickets: TicketExportTicket[],
+    selectedColumnKeys?: string[],
+  ): XLSX.WorkSheet {
+    const customFieldKeys = new Set<string>();
+    for (const t of tickets) {
+      Object.keys(t.customFields).forEach(k => customFieldKeys.add(k));
+    }
+    selectedColumnKeys
+      ?.filter(key => key.startsWith('custom:'))
+      .forEach(key => customFieldKeys.add(key.substring('custom:'.length)));
+    const standardColumns = [
+      { key: 'ticketKey', label: 'Ticket Key', value: (t: TicketExportTicket): unknown => t.xyneId },
+      { key: 'title', label: 'Title', value: (t: TicketExportTicket): unknown => t.title },
+      { key: 'workspace', label: 'Workspace', value: (): unknown => workspaceName },
+      { key: 'project', label: 'Project', value: (t: TicketExportTicket): unknown => t.project?.name ?? board.project?.name ?? null },
+      { key: 'board', label: 'Board', value: (): unknown => board.name },
+      { key: 'channel', label: 'Channel', value: (t: TicketExportTicket): unknown => t.channel?.name ?? null },
+      { key: 'status', label: 'Status', value: (t: TicketExportTicket): unknown => t.statusV2 ?? t.status },
+      { key: 'stage', label: 'Stage', value: (t: TicketExportTicket): unknown => t.stageName },
+      { key: 'priority', label: 'Priority', value: (t: TicketExportTicket): unknown => t.priority },
+      { key: 'archived', label: 'Archived', value: (t: TicketExportTicket): unknown => t.isArchived ? 'Yes' : 'No' },
+      { key: 'createdBy', label: 'Created By', value: (t: TicketExportTicket): unknown => t.createdByUser?.name ?? t.createdByUser?.email ?? null },
+      { key: 'assignedTo', label: 'Assigned To', value: (t: TicketExportTicket): unknown => t.assignee?.name ?? t.assignee?.email ?? null },
+      { key: 'updatedBy', label: 'Updated By', value: (t: TicketExportTicket): unknown => t.updatedByUser?.name ?? t.updatedByUser?.email ?? null },
+      { key: 'group', label: 'Group', value: (t: TicketExportTicket): unknown => t.group?.name ?? null },
+      { key: 'createdAt', label: 'Created At', value: (t: TicketExportTicket): unknown => t.createdAt },
+      { key: 'updatedAt', label: 'Updated At', value: (t: TicketExportTicket): unknown => t.updatedAt },
+      { key: 'eta', label: 'ETA', value: (t: TicketExportTicket): unknown => t.eta },
+      { key: 'closedAt', label: 'Closed At', value: (t: TicketExportTicket): unknown => t.closedAt },
+      { key: 'tags', label: 'Tags', value: (t: TicketExportTicket): unknown => t.tags.map(tag => tag.name).join(', ') },
+    ];
+    const customColumns = Array.from(customFieldKeys).map(fieldName => ({
+      key: `custom:${fieldName}`,
+      label: fieldName,
+      value: (ticket: TicketExportTicket): unknown => ticket.customFields[fieldName] ?? null,
+    }));
+    const selected = selectedColumnKeys ? new Set(selectedColumnKeys) : null;
+    let columns = [...standardColumns, ...customColumns].filter(
+      column => !selected || selected.has(column.key),
+    );
+    if (columns.length === 0) {
+      columns = standardColumns.filter(column => column.key === 'ticketKey');
+    }
+    const headers = columns.map(column => column.label);
+
+    const rows = tickets.map(t =>
+      buildRow(columns.map(column => column.value(t))),
+    );
+
+    return XLSX.utils.aoa_to_sheet([buildRow(headers), ...rows]);
+  }
+
+  private buildLinksSheet(links: TicketExportLink[]): XLSX.WorkSheet {
+    const headers = [
+      'Source Ticket Key',
+      'Source Ticket Title',
+      'Source Board',
+      'Relationship Type',
+      'Target Ticket Key',
+      'Target Ticket Title',
+      'Target Board',
+      'Target Project',
+      'Target Status',
+      'Target Assignee',
+    ];
+    const rows = links.map(l =>
+      buildRow([
+        l.sourceTicketKey,
+        l.sourceTitle,
+        l.sourceBoardName,
+        l.relationshipType,
+        l.targetTicketKey,
+        l.targetTitle,
+        l.targetBoardName,
+        l.targetProjectName,
+        l.targetStatus,
+        l.targetAssigneeName,
+      ]),
+    );
+    return XLSX.utils.aoa_to_sheet([buildRow(headers), ...rows]);
+  }
+
+  private buildActivitySheet(activities: TicketExportActivity[]): XLSX.WorkSheet {
+    const headers = [
+      'Ticket Key',
+      'Ticket Title',
+      'Project',
+      'Board',
+      'Activity Timestamp',
+      'Actor',
+      'Activity Type',
+      'Field Changed',
+      'Old Value',
+      'New Value',
+      'Visibility Result',
+    ];
+    const rows = activities.map(a =>
+      buildRow([
+        a.ticketKey,
+        a.ticketTitle,
+        a.projectName,
+        a.boardName,
+        a.timestamp,
+        a.actorName,
+        a.activityType,
+        a.fieldChanged,
+        a.oldValue,
+        a.newValue,
+        a.visibilityResult,
+      ]),
+    );
+    return XLSX.utils.aoa_to_sheet([buildRow(headers), ...rows]);
+  }
+
+  private appendSheet(
+    workbook: XLSX.WorkBook,
+    worksheet: XLSX.WorkSheet,
+    requestedName: string,
+    usedNames: Set<string>,
+  ): void {
+    const base = this.safeSheetName(requestedName);
+    let name = base;
+    let suffix = 2;
+    while (usedNames.has(name.toLowerCase())) {
+      const marker = ` (${suffix})`;
+      name = `${base.substring(0, 31 - marker.length)}${marker}`;
+      suffix += 1;
+    }
+    usedNames.add(name.toLowerCase());
+    XLSX.utils.book_append_sheet(workbook, worksheet, name);
+  }
+
+  private safeSheetName(name: string): string {
+    const sanitized = name.replace(/[*\\/[\]:?]/g, '-').substring(0, 31);
+    return sanitized || 'Sheet';
+  }
+}
+
+export const ticketReportXlsxBuilder = new TicketReportXlsxBuilder();

--- a/apps/backend/src/zero/acl/core/acl-factory.ts
+++ b/apps/backend/src/zero/acl/core/acl-factory.ts
@@ -424,6 +424,8 @@ export class ACLFactory {
         return new WorkspaceOrganizationsACL(ctx);
       case 'workspaces':
         return new WorkspacesACL(ctx);
+      case 'ticket_exports':
+        return new BaseACL<any>(ctx);
       case 'guest_access':
         return new GuestAccessACL(ctx, table);
     }

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -3006,6 +3006,9 @@ export const queries = defineQueries({
     }
   ),
 
+  ticketExportsForCurrentUser: defineQuery(() => {
+    return zql.ticket_exports.orderBy('createdAt', 'desc').limit(100);
+  }),
   getAllProjects: defineQuery(() => {
     return zql.projects
       .where('type', '!=', ProjectType.DM)

--- a/apps/dashboard/src/api/ticketReportsApi.ts
+++ b/apps/dashboard/src/api/ticketReportsApi.ts
@@ -1,0 +1,81 @@
+import { apiInstance } from '../services/clients/apiClient';
+
+export type TicketExportStatus =
+  | 'PENDING'
+  | 'IN_PROGRESS'
+  | 'READY'
+  | 'EXPIRED'
+  | 'FAILED'
+  | 'CANCELED';
+
+export interface TicketExportFilters {
+  projectId?: string;
+  sourceChannelId?: string;
+  boardIds?: string[];
+  dateRange?: { from?: string; to?: string };
+  statuses?: string[];
+  priorities?: string[];
+  assignees?: string[];
+  tags?: string[];
+  includeArchived?: boolean;
+  includeLinkedTickets?: boolean;
+  includeLinkedTicketDetails?: boolean;
+  includeActivity?: boolean;
+  timezone?: string;
+  columnsByBoard?: Record<string, string[]>;
+}
+
+type TicketExportDownloadRequest =
+  | { exportId: string }
+  | { workspaceId: string; filters: TicketExportFilters };
+
+function getErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const { error, message } = payload as { error?: unknown; message?: unknown };
+  if (typeof error === 'string') return error;
+  if (typeof message === 'string') return message;
+  if (Array.isArray(error)) {
+    const messages = error
+      .map(item =>
+        item &&
+        typeof item === 'object' &&
+        typeof (item as { message?: unknown }).message === 'string'
+          ? (item as { message: string }).message
+          : null,
+      )
+      .filter((item): item is string => Boolean(item));
+    return messages.length > 0 ? messages.join(', ') : null;
+  }
+  return null;
+}
+
+export const ticketReportsApi = {
+  downloadExport: async (
+    request: TicketExportDownloadRequest,
+  ): Promise<{ blob: Blob; fileName: string }> => {
+    try {
+      const res = await apiInstance.post('/ticket-reports/exports/download', request, {
+        responseType: 'blob',
+      });
+      const disposition = String(res.headers['content-disposition'] || '');
+      const match = disposition.match(/filename="?([^"]+)"?/);
+      const fileName =
+        match?.[1] ?? `ticket-export-${'exportId' in request ? request.exportId : Date.now()}.xlsx`;
+      return { blob: res.data as Blob, fileName };
+    } catch (error) {
+      const data = (error as { response?: { data?: unknown } })?.response?.data;
+      if (data instanceof Blob) {
+        try {
+          const parsed: unknown = JSON.parse(await data.text());
+          const message = getErrorMessage(parsed);
+          if (message) throw new Error(message);
+        } catch (parseError) {
+          if (parseError instanceof Error && parseError.name !== 'SyntaxError') {
+            throw parseError;
+          }
+        }
+      }
+      throw error;
+    }
+  },
+};

--- a/apps/dashboard/src/components/ResourceAccess/ResourceAccessModal/ResourceAccessModal.tsx
+++ b/apps/dashboard/src/components/ResourceAccess/ResourceAccessModal/ResourceAccessModal.tsx
@@ -76,7 +76,14 @@ export const ResourceAccessModal = ({
   const editableResourceNames = useMemo(() => {
     const names = new Set<string>();
     for (const permission of viewerPermissions) {
-      if (permission.accessType === 'WRITE' || permission.accessType === 'ADMIN') {
+
+
+
+
+
+
+
+
         names.add(permission.resourceName);
       }
     }

--- a/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
@@ -132,10 +132,12 @@ export const TicketFiltersDropdown = ({
   hasActiveView,
   workspaceView = false,
   leadingControl,
+  trailingControl,
 }: TicketFiltersProps & {
   searchValue?: string;
   onSearchChange?: (searchTerm: string) => void;
   leadingControl?: ReactElement;
+  trailingControl?: ReactElement | undefined;
 }): ReactElement => {
   const [boardOpen, setBoardOpen] = useState(false);
   const [hasBoardDropdownOpened, setHasBoardDropdownOpened] = useState(false);
@@ -1022,6 +1024,8 @@ export const TicketFiltersDropdown = ({
             />
           </div>
         </div>
+
+        {trailingControl}
       </div>
     </div>
   );

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -159,6 +159,7 @@ import ProfileSidebar from '../components/ProfileSidebar/ProfileSidebar';
 import UserGroupSidePanel from '../components/UserGroup/UserGroupSidePanel/UserGroupSidePanel';
 import GlobalCommandMenu from '../components/GlobalCommandMenu/GlobalCommandMenu';
 import ProductInsightsScreen from './ProductInsightsScreen/ProductInsightsScreen';
+import TicketReportsScreen from './TicketReportsScreen/TicketReportsScreen';
 import LaunchScreen from './LaunchScreen/LaunchScreen';
 import { AssignmentConfigWrapper } from '../components/UserGroup/AssignmentConfigScreen';
 import { ShortcutsHelpModal } from '../components/ShortcutsHelpModal/ShortcutsHelpModal';
@@ -1142,6 +1143,14 @@ export const router = createBrowserRouter([
                 element: (
                   <ResourceProtectedRoute resourceName='PRODUCT-INSIGHTS'>
                     <ProductInsightsScreen />
+                  </ResourceProtectedRoute>
+                ),
+              },
+              {
+                path: 'ticket-reports',
+                element: (
+                  <ResourceProtectedRoute resourceName='TICKET-REPORTS' minAccess='WRITE'>
+                    <TicketReportsScreen />
                   </ResourceProtectedRoute>
                 ),
               },

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { logger, Event } from '../../utils/logger';
 import { useAuth } from '../../hooks/useAuth';
-import { useCanCreateTicket } from '../../hooks/usePermissions';
+import { useCanCreateTicket, usePermissions } from '../../hooks/usePermissions';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import {
@@ -28,6 +28,7 @@ import {
   Share2,
 } from 'lucide-react';
 import { CalendarView } from '../../components/Tickets/CalendarView';
+import TicketReportsScreen from '../../routes/TicketReportsScreen/TicketReportsScreen';
 import {
   DndContext,
   DragOverlay,
@@ -69,6 +70,7 @@ import type {
 import {
   TicketStatusV2,
   FormContextType,
+  AccessType,
   FormEntityType,
   FormFieldType,
   ChannelType,
@@ -265,6 +267,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const { isMobile } = usePlatform();
   const { baseRoute, buildChannelRoute } = useRouteContext();
   const canCreateTicket = useCanCreateTicket(); // Check ticket permissions
+  const permissions = usePermissions();
+  const canExportTickets = permissions.some(
+    permission =>
+      permission.resourceName === 'TICKET-REPORTS' &&
+      (permission.accessType === AccessType.WRITE || permission.accessType === AccessType.ADMIN),
+  );
   const zero = useZero();
   const isDraggingRef = useRef(false);
 
@@ -477,6 +485,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const [state, send] = useMachine(ticketFiltersMachine);
   const layoutView = searchParams.get('layout') ?? 'kanban';
   const isKanbanLayout = layoutView === 'kanban';
+  const showTicketReport = searchParams.get('ticketReport') === '1';
   const groupBy: GroupByType = useMemo(
     () => parseGroupBy(state.context.groupBy),
     [state.context.groupBy],
@@ -2196,6 +2205,26 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     return availableColumns.filter(col => col.key !== 'status');
   }, [layoutView, availableColumns]);
 
+  if (showTicketReport && channelId && effectiveProjectId) {
+    return (
+      <TicketReportsScreen
+        embedded
+        lockedProjectId={effectiveProjectId}
+        sourceChannelId={channelId}
+        onClose={() => {
+          setSearchParams(
+            previous => {
+              const next = new URLSearchParams(previous);
+              next.delete('ticketReport');
+              return next;
+            },
+            { replace: true },
+          );
+        }}
+      />
+    );
+  }
+
   return (
     <div
       data-testid='projects-board-page'
@@ -2241,6 +2270,41 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
               groupBy={typeof groupBy === 'object' ? JSON.stringify(groupBy) : groupBy}
               hasActiveView={!!selectedViewId}
               workspaceView={isWorkspaceView}
+              trailingControl={
+                canExportTickets ? (
+                  <Button
+                    type='button'
+                    variant='outline'
+                    size='sm'
+                    className='rounded-[10px] border-border'
+                    onClick={() => {
+                      if (channelId && effectiveProjectId) {
+                        setSearchParams(previous => {
+                          const next = new URLSearchParams(previous);
+                          next.set('ticketReport', '1');
+                          return next;
+                        });
+                        return;
+                      }
+                      const params = new URLSearchParams();
+                      if (effectiveProjectId) {
+                        params.set('projectId', effectiveProjectId);
+                        params.set('lockProject', '1');
+                      }
+                      if (boardId) params.set('boardId', boardId);
+                      const prefix = user?.workspaceId ? `/${user.workspaceId}` : '';
+                      void navigate(
+                        `${prefix}/ticket-reports${params.size ? `?${params.toString()}` : ''}`,
+                      );
+                    }}
+                    data-track-category='TicketReports'
+                    data-track-name='OpenTicketReports'
+                  >
+                    <Download className='size-4' />
+                    <span>Export report</span>
+                  </Button>
+                ) : undefined
+              }
               {...(isWorkspaceView
                 ? {
                     leadingControl: (

--- a/apps/dashboard/src/routes/ProjectsScreen/ProjectsListView.tsx
+++ b/apps/dashboard/src/routes/ProjectsScreen/ProjectsListView.tsx
@@ -1,14 +1,18 @@
 import { ReactElement, useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useZero } from '../../hooks/useZero';
 import { toast } from 'sonner';
 import { Button, ButtonType, Modal } from '@juspay/blend-design-system';
 import { ProjectForm, ProjectCard } from '../../components/Project';
 import { apiInstance } from '../../services/clients/apiClient';
 import { queries } from '../../zero/queries';
-import type { Project as ZeroProject } from '@xyne/shared';
+import { AccessType, type Project as ZeroProject } from '@xyne/shared';
 import { mutators } from '../../zero/mutators';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { usePlatform } from '../../hooks/usePlatform';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useAuth } from '../../hooks/useAuth';
+import { Download } from 'lucide-react';
 
 const ProjectsListView = (): ReactElement => {
   const zero = useZero();
@@ -16,6 +20,14 @@ const ProjectsListView = (): ReactElement => {
   const [editingProject, setEditingProject] = useState<ZeroProject | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const { isMobile } = usePlatform();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const permissions = usePermissions();
+  const canExportTickets = permissions.some(
+    permission =>
+      permission.resourceName === 'TICKET-REPORTS' &&
+      (permission.accessType === AccessType.WRITE || permission.accessType === AccessType.ADMIN),
+  );
   const searchInputRef = useRef<HTMLInputElement>(null);
   // Fetch all projects using zero
   const [projects] = useCachedQuery(queries.getAllProjects());
@@ -86,13 +98,31 @@ const ProjectsListView = (): ReactElement => {
         <div className='mb-6'>
           <div className='flex items-center justify-between mb-2'>
             <h2 className='text-lg font-bold text-foreground'>Projects</h2>
-            <Button
-              buttonType={ButtonType.PRIMARY}
-              text='New'
-              onClick={() => setShowCreateModal(true)}
-              data-track-category='Projects'
-              data-track-name='CreateProject'
-            />
+            <div className='flex items-center gap-2'>
+              {canExportTickets && (
+                <button
+                  type='button'
+                  onClick={() => {
+                    void navigate(
+                      `${user?.workspaceId ? `/${user.workspaceId}` : ''}/ticket-reports?from=listProjects`,
+                    );
+                  }}
+                  className='inline-flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent'
+                  data-track-category='TicketReports'
+                  data-track-name='OpenReportsFromProjectList'
+                >
+                  <Download className='size-4' />
+                  Export report
+                </button>
+              )}
+              <Button
+                buttonType={ButtonType.PRIMARY}
+                text='New'
+                onClick={() => setShowCreateModal(true)}
+                data-track-category='Projects'
+                data-track-name='CreateProject'
+              />
+            </div>
           </div>
           <p className='text-xs text-muted-foreground'>Manage your projects</p>
           <div className='mt-3'>

--- a/apps/dashboard/src/routes/TicketReportsScreen/TicketReportsScreen.tsx
+++ b/apps/dashboard/src/routes/TicketReportsScreen/TicketReportsScreen.tsx
@@ -1,0 +1,824 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  AlertCircle,
+  ArrowLeft,
+  Download,
+  FileSpreadsheet,
+  Loader2,
+  RotateCcw,
+  SlidersHorizontal,
+} from 'lucide-react';
+import {
+  ticketReportsApi,
+  type TicketExportFilters,
+  type TicketExportStatus,
+} from '../../api/ticketReportsApi';
+import { AccessType, FormEntityType, UserStatus } from '@xyne/shared';
+import { useAuthContextValues } from '../../hooks/useAuth';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
+import { Button } from '../../components/ui/Button';
+import { MultiSelect } from '../../components/ui/MultiSelect';
+import { Switch } from '../../components/ui/Switch';
+
+interface TicketReportsScreenProps {
+  embedded?: boolean;
+  lockedProjectId?: string;
+  sourceChannelId?: string;
+  onClose?: () => void;
+}
+
+const STATUS_STYLES: Record<TicketExportStatus, string> = {
+  PENDING: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  IN_PROGRESS: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  READY: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  EXPIRED: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  FAILED: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  CANCELED: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+};
+const STALE_EXPORT_TIMEOUT_MS = 15 * 60 * 1000;
+
+function isRetryableExport(status: string, updatedAt: number | null | undefined): boolean {
+  if (status === 'FAILED') return true;
+  if ((status !== 'PENDING' && status !== 'IN_PROGRESS') || !updatedAt) return false;
+  return updatedAt < Date.now() - STALE_EXPORT_TIMEOUT_MS;
+}
+
+function formatDate(timestamp: number | null | undefined): string {
+  if (!timestamp) return '-';
+  return new Date(timestamp).toLocaleString();
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  const apiError = (error as { response?: { data?: { error?: unknown } } })?.response?.data?.error;
+  if (typeof apiError === 'string') {
+    // eslint-disable-next-line no-control-regex
+    const cleanMessage = apiError.replace(/\u001b\[[0-9;]*m/g, '');
+    if (cleanMessage.includes('ticket_exports') && cleanMessage.includes('does not exist')) {
+      return 'Ticket export storage is not initialized. Apply the ticket export database migration and try again.';
+    }
+    return cleanMessage;
+  }
+  if (Array.isArray(apiError)) {
+    return apiError
+      .map(item => {
+        if (!item || typeof item !== 'object') return '';
+        const record = item as Record<string, unknown>;
+        return typeof record['message'] === 'string' ? record['message'] : '';
+      })
+      .filter(Boolean)
+      .join(', ');
+  }
+  return error instanceof Error ? error.message : fallback;
+}
+
+const TicketReportsScreen = ({
+  embedded = false,
+  lockedProjectId,
+  sourceChannelId,
+  onClose,
+}: TicketReportsScreenProps): React.ReactElement => {
+  const { workspaceId } = useAuthContextValues();
+  const permissions = usePermissions();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const fromListProjects = searchParams.get('from') === 'listProjects';
+  const routeLockedProjectId =
+    searchParams.get('lockProject') === '1'
+      ? (searchParams.get('projectId') ?? undefined)
+      : undefined;
+  const effectiveLockedProjectId = lockedProjectId ?? routeLockedProjectId;
+
+  const [projectId, setProjectId] = useState(
+    effectiveLockedProjectId ?? searchParams.get('projectId') ?? '',
+  );
+  const [boardIds, setBoardIds] = useState<string[]>(
+    searchParams.get('boardId') ? [searchParams.get('boardId')!] : [],
+  );
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [statuses, setStatuses] = useState<string[]>([]);
+  const [priorities, setPriorities] = useState<string[]>([]);
+  const [assignees, setAssignees] = useState<string[]>([]);
+  const [tags, setTags] = useState<string[]>([]);
+  const [columnsByBoard, setColumnsByBoard] = useState<Record<string, string[]>>({});
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const [includeLinkedTickets, setIncludeLinkedTickets] = useState(true);
+  const [includeLinkedTicketDetails, setIncludeLinkedTicketDetails] = useState(false);
+  const [includeActivity, setIncludeActivity] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const [requestPending, setRequestPending] = useState(false);
+
+  const [projectRows, projectQueryDetails] = useCachedQuery(queries.getAllProjects());
+  const [userRows, userQueryDetails] = useCachedQuery(queries.getUsersV2());
+  const allBoardIds = useMemo(
+    () => (projectRows ?? []).flatMap(project => (project.boards ?? []).map(board => board.id)),
+    [projectRows],
+  );
+  const [stageRows, stageQueryDetails] = useCachedQuery(
+    queries.getStagesByBoardIds({ boardIds: allBoardIds }),
+  );
+  const [formRows, formQueryDetails] = useCachedQuery(queries.getAllForms());
+  const [projectTagRows] = useCachedQuery(queries.projectTagsByProjectId({ projectId }), {
+    enabled: Boolean(projectId),
+  });
+  const [exportRows, exportQueryDetails] = useCachedQuery(queries.ticketExportsForCurrentUser());
+  const scopeLoading =
+    projectQueryDetails.type !== 'complete' ||
+    userQueryDetails.type !== 'complete' ||
+    stageQueryDetails.type !== 'complete' ||
+    formQueryDetails.type !== 'complete';
+  const exportsLoading = exportQueryDetails.type !== 'complete';
+  const exportPermission = permissions.find(
+    permission => permission.resourceName === 'TICKET-REPORTS',
+  );
+  const requiresProject = exportPermission?.accessType === AccessType.WRITE;
+  const standardColumns = useMemo(
+    () =>
+      [
+        ['ticketKey', 'Ticket Key'],
+        ['title', 'Title'],
+        ['workspace', 'Workspace'],
+        ['project', 'Project'],
+        ['board', 'Board'],
+        ['channel', 'Channel'],
+        ['status', 'Status'],
+        ['stage', 'Stage'],
+        ['priority', 'Priority'],
+        ['archived', 'Archived'],
+        ['createdBy', 'Created By'],
+        ['assignedTo', 'Assigned To'],
+        ['updatedBy', 'Updated By'],
+        ['group', 'Group'],
+        ['createdAt', 'Created At'],
+        ['updatedAt', 'Updated At'],
+        ['eta', 'ETA'],
+        ['closedAt', 'Closed At'],
+        ['tags', 'Tags'],
+      ].map(([key, label]) => ({ key: key!, label: label!, kind: 'STANDARD' as const })),
+    [],
+  );
+  const customColumnsByContext = useMemo(() => {
+    const columnsByContext = new Map<
+      string,
+      Map<string, { key: string; label: string; kind: 'CUSTOM'; fieldType?: string }>
+    >();
+    for (const form of formRows ?? []) {
+      for (const mapping of form.formContextMappings ?? []) {
+        if (mapping.entityType !== FormEntityType.TICKET) continue;
+        const columns =
+          columnsByContext.get(mapping.contextId) ??
+          new Map<string, { key: string; label: string; kind: 'CUSTOM'; fieldType?: string }>();
+        for (const field of form.formFields ?? []) {
+          const label = field.globalField?.fieldName ?? field.fieldName;
+          const fieldType = field.globalField?.fieldType ?? field.fieldType;
+          if (!label || !fieldType) continue;
+          columns.set(`custom:${label}`, {
+            key: `custom:${label}`,
+            label,
+            kind: 'CUSTOM',
+            fieldType,
+          });
+        }
+        columnsByContext.set(mapping.contextId, columns);
+      }
+    }
+    return columnsByContext;
+  }, [formRows]);
+  const stageIdsByBoard = useMemo(() => {
+    const idsByBoard = new Map<string, string[]>();
+    for (const stage of stageRows ?? []) {
+      const stageIds = idsByBoard.get(stage.boardId) ?? [];
+      stageIds.push(stage.id);
+      idsByBoard.set(stage.boardId, stageIds);
+    }
+    return idsByBoard;
+  }, [stageRows]);
+  const projects = useMemo(
+    () =>
+      (projectRows ?? [])
+        .map(project => ({
+          id: project.id,
+          name: project.name,
+          code: project.code,
+          boards: (project.boards ?? [])
+            .map(board => {
+              const contextIds = [board.id, ...(stageIdsByBoard.get(board.id) ?? [])];
+              const customColumns = new Map<
+                string,
+                { key: string; label: string; kind: 'CUSTOM'; fieldType?: string }
+              >();
+              for (const contextId of contextIds) {
+                for (const [key, column] of customColumnsByContext.get(contextId) ?? []) {
+                  customColumns.set(key, column);
+                }
+              }
+              return {
+                id: board.id,
+                name: board.name,
+                projectId: board.projectId,
+                columns: [...standardColumns, ...customColumns.values()],
+              };
+            })
+            .sort((left, right) => left.name.localeCompare(right.name)),
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name)),
+    [customColumnsByContext, projectRows, stageIdsByBoard, standardColumns],
+  );
+  const users = (userRows ?? [])
+    .filter(user => user.status === UserStatus.ACTIVE && !user.leftAt)
+    .map(user => ({
+      id: user.id,
+      name: user.displayName || user.name || user.email,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const selectedProject = projects.find(project => project.id === projectId);
+  const availableBoards = projectId
+    ? (selectedProject?.boards ?? [])
+    : projects.flatMap(project => project.boards);
+  const availableTags = projectId ? (projectTagRows ?? []) : [];
+  const boardOptions = availableBoards.map(board => ({ value: board.id, label: board.name }));
+  const statusOptions = ['TODO', 'STARTED', 'PAUSED', 'CANCELLED', 'COMPLETED'].map(status => ({
+    value: status,
+    label: status
+      .replaceAll('_', ' ')
+      .toLowerCase()
+      .replace(/\b\w/g, letter => letter.toUpperCase()),
+  }));
+  const priorityOptions = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'].map(priority => ({
+    value: priority,
+    label: priority.toLowerCase().replace(/\b\w/g, letter => letter.toUpperCase()),
+  }));
+  const assigneeOptions = users.map(user => ({ value: user.id, label: user.name }));
+  const tagOptions = availableTags.map(tag => ({ value: tag.id, label: tag.name }));
+  const configurableBoards =
+    boardIds.length > 0
+      ? availableBoards.filter(board => boardIds.includes(board.id))
+      : availableBoards;
+
+  const payload = useMemo((): { filters: TicketExportFilters } => {
+    const filters: TicketExportFilters = {
+      includeArchived,
+      includeLinkedTickets,
+      includeLinkedTicketDetails: includeLinkedTickets && includeLinkedTicketDetails,
+      includeActivity,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+      ...(Object.keys(columnsByBoard).length > 0 ? { columnsByBoard } : {}),
+      ...(projectId ? { projectId } : {}),
+      ...(sourceChannelId ? { sourceChannelId } : {}),
+      ...(boardIds.length ? { boardIds } : {}),
+      ...(statuses.length ? { statuses } : {}),
+      ...(priorities.length ? { priorities } : {}),
+      ...(assignees.length ? { assignees } : {}),
+      ...(tags.length ? { tags } : {}),
+    };
+    if (fromDate || toDate) {
+      filters.dateRange = {};
+      if (fromDate) filters.dateRange.from = new Date(`${fromDate}T00:00:00`).toISOString();
+      if (toDate) filters.dateRange.to = new Date(`${toDate}T23:59:59.999`).toISOString();
+    }
+    return { filters };
+  }, [
+    assignees,
+    boardIds,
+    columnsByBoard,
+    fromDate,
+    includeActivity,
+    includeArchived,
+    includeLinkedTicketDetails,
+    includeLinkedTickets,
+    priorities,
+    projectId,
+    statuses,
+    sourceChannelId,
+    tags,
+    toDate,
+  ]);
+
+  useEffect(() => {
+    setBoardIds(current => current.filter(id => availableBoards.some(board => board.id === id)));
+    setTags(current => current.filter(id => availableTags.some(tag => tag.id === id)));
+    setColumnsByBoard(current =>
+      Object.fromEntries(
+        Object.entries(current).filter(([boardId]) =>
+          availableBoards.some(board => board.id === boardId),
+        ),
+      ),
+    );
+  }, [projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleRequest = async (): Promise<void> => {
+    setRequestPending(true);
+    setFormError(null);
+    try {
+      const { blob, fileName } = await ticketReportsApi.downloadExport({
+        workspaceId,
+        filters: payload.filters,
+      });
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      setFormError(errorMessage(error, 'Failed to request export'));
+    } finally {
+      setRequestPending(false);
+    }
+  };
+
+  const handleDownload = async (record: { id: string }): Promise<void> => {
+    setDownloadingId(record.id);
+    try {
+      const { blob, fileName } = await ticketReportsApi.downloadExport({
+        exportId: record.id,
+      });
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      setFormError(errorMessage(error, 'Failed to download export'));
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  const items = exportRows ?? [];
+  const inputClass =
+    'h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground outline-none transition-colors focus:border-ring focus:ring-2 focus:ring-ring/20';
+  const resetFilters = (): void => {
+    if (!requiresProject && !effectiveLockedProjectId) setProjectId('');
+    setBoardIds([]);
+    setStatuses([]);
+    setPriorities([]);
+    setAssignees([]);
+    setTags([]);
+    setColumnsByBoard({});
+    setFromDate('');
+    setToDate('');
+    setIncludeArchived(false);
+    setIncludeLinkedTickets(true);
+    setIncludeLinkedTicketDetails(false);
+    setIncludeActivity(false);
+    setFormError(null);
+  };
+  const toggleBoardColumn = (boardId: string, allKeys: string[], key: string): void => {
+    setColumnsByBoard(current => {
+      const selected = current[boardId] ?? allKeys;
+      const next = selected.includes(key)
+        ? selected.filter(columnKey => columnKey !== key)
+        : [...selected, key];
+      if (next.length === 0) return current;
+      if (next.length === allKeys.length) {
+        const { [boardId]: _removed, ...rest } = current;
+        return rest;
+      }
+      return { ...current, [boardId]: next };
+    });
+  };
+  const selectAllBoardColumns = (boardId: string): void => {
+    setColumnsByBoard(current => {
+      const { [boardId]: _removed, ...rest } = current;
+      return rest;
+    });
+  };
+  const selectCoreBoardColumns = (boardId: string): void => {
+    setColumnsByBoard(current => ({
+      ...current,
+      [boardId]: ['ticketKey', 'title', 'status', 'priority', 'assignedTo', 'updatedAt'],
+    }));
+  };
+
+  return (
+    <div
+      className={`flex h-full flex-col overflow-y-auto ${embedded ? 'bg-muted' : 'bg-muted/40'}`}
+    >
+      <div className={`mx-auto w-full max-w-7xl ${embedded ? 'p-4' : 'p-4 md:p-6'}`}>
+        {(!embedded || onClose) && (
+          <button
+            type='button'
+            onClick={() => {
+              if (embedded && onClose) {
+                onClose();
+                return;
+              }
+              if (fromListProjects) {
+                void navigate(`${workspaceId ? `/${workspaceId}` : ''}/listProjects`);
+                return;
+              }
+              void navigate(-1);
+            }}
+            className='mb-6 flex items-center gap-2 text-muted-foreground transition-colors hover:text-foreground'
+            data-track-category='TicketReports'
+            data-track-name='Back'
+          >
+            <ArrowLeft size={20} />
+            <span>{fromListProjects ? 'Back to Projects' : 'Back'}</span>
+          </button>
+        )}
+
+        <div className='mb-6 flex items-start gap-3'>
+          <div className='flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary'>
+            <FileSpreadsheet className='size-5' />
+          </div>
+          <div>
+            <h1 className='text-2xl font-semibold tracking-tight text-foreground'>
+              Ticket reports
+            </h1>
+            <p className='mt-1 text-sm text-muted-foreground'>
+              Build and download an XLSX report from the tickets you are allowed to access.
+            </p>
+          </div>
+        </div>
+
+        <section className='mb-6 overflow-visible rounded-xl border border-border bg-background shadow-sm'>
+          <div className='flex flex-wrap items-center justify-between gap-3 border-b border-border px-5 py-4'>
+            <div className='flex items-center gap-2'>
+              <SlidersHorizontal className='size-4 text-muted-foreground' />
+              <div>
+                <h2 className='text-sm font-semibold text-foreground'>Configure report</h2>
+                <p className='text-xs text-muted-foreground'>
+                  Empty optional filters include every available value.
+                </p>
+              </div>
+            </div>
+            <Button type='button' variant='ghost' size='sm' onClick={resetFilters}>
+              <RotateCcw className='size-4' />
+              Reset filters
+            </Button>
+          </div>
+
+          <div className='p-5'>
+            {scopeLoading ? (
+              <div className='flex min-h-40 items-center justify-center'>
+                <Loader2 className='size-5 animate-spin text-muted-foreground' />
+              </div>
+            ) : (
+              <>
+                <div className='grid grid-cols-1 gap-x-5 gap-y-4 md:grid-cols-2 xl:grid-cols-3'>
+                  <div className='flex flex-col gap-1'>
+                    <span className='text-sm font-medium leading-none text-foreground'>
+                      Project {requiresProject && <span className='text-destructive'>*</span>}
+                    </span>
+                    {effectiveLockedProjectId ? (
+                      <div className={`${inputClass} flex items-center bg-muted/40`}>
+                        {selectedProject
+                          ? `${selectedProject.name} (${selectedProject.code})`
+                          : 'Channel project'}
+                      </div>
+                    ) : (
+                      <select
+                        value={projectId}
+                        onChange={event => setProjectId(event.target.value)}
+                        className={inputClass}
+                        data-track-category='TicketReports'
+                        data-track-name='SelectProject'
+                      >
+                        {!requiresProject && <option value=''>All projects</option>}
+                        {requiresProject && <option value=''>Select a project</option>}
+                        {projects.map(project => (
+                          <option key={project.id} value={project.id}>
+                            {project.name} ({project.code})
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                    <span className='text-xs font-normal text-muted-foreground'>
+                      {effectiveLockedProjectId
+                        ? 'Reports opened from a channel are restricted to its linked project.'
+                        : requiresProject
+                          ? 'A project is required for your access level.'
+                          : 'All projects is the default.'}
+                    </span>
+                  </div>
+
+                  <MultiSelect
+                    label='Boards'
+                    options={boardOptions}
+                    selectedValues={boardIds}
+                    onChange={setBoardIds}
+                    placeholder='All boards'
+                    helperText='No selection includes all boards.'
+                    disabled={requiresProject && !projectId}
+                  />
+                  <MultiSelect
+                    label='Statuses'
+                    options={statusOptions}
+                    selectedValues={statuses}
+                    onChange={setStatuses}
+                    placeholder='All statuses'
+                    helperText='No selection includes all statuses.'
+                  />
+                  <MultiSelect
+                    label='Priorities'
+                    options={priorityOptions}
+                    selectedValues={priorities}
+                    onChange={setPriorities}
+                    placeholder='All priorities'
+                    helperText='No selection includes all priorities.'
+                  />
+                  <MultiSelect
+                    label='Assignees'
+                    options={assigneeOptions}
+                    selectedValues={assignees}
+                    onChange={setAssignees}
+                    placeholder='All assignees'
+                    helperText='No selection includes assigned and unassigned tickets.'
+                  />
+                  <MultiSelect
+                    label='Tags'
+                    options={tagOptions}
+                    selectedValues={tags}
+                    onChange={setTags}
+                    placeholder='All tags'
+                    helperText='No selection includes tickets with any or no tag.'
+                    disabled={requiresProject && !projectId}
+                  />
+
+                  <label className='flex flex-col gap-1.5 text-sm font-medium text-foreground'>
+                    Created from
+                    <input
+                      type='date'
+                      value={fromDate}
+                      onChange={event => setFromDate(event.target.value)}
+                      className={inputClass}
+                      data-track-category='TicketReports'
+                      data-track-name='CreatedFrom'
+                    />
+                    <span className='text-xs font-normal text-muted-foreground'>
+                      Optional start date.
+                    </span>
+                  </label>
+                  <label className='flex flex-col gap-1.5 text-sm font-medium text-foreground'>
+                    Created to
+                    <input
+                      type='date'
+                      value={toDate}
+                      min={fromDate || undefined}
+                      onChange={event => setToDate(event.target.value)}
+                      className={inputClass}
+                      data-track-category='TicketReports'
+                      data-track-name='CreatedTo'
+                    />
+                    <span className='text-xs font-normal text-muted-foreground'>
+                      Includes the full selected day.
+                    </span>
+                  </label>
+                </div>
+
+                <div className='mt-6 rounded-lg border border-border bg-muted/30 p-4'>
+                  <div className='mb-3'>
+                    <h3 className='text-sm font-semibold text-foreground'>Columns by board</h3>
+                    <p className='mt-1 text-xs text-muted-foreground'>
+                      Each board worksheet can have a different set of columns. Boards left
+                      unchanged include every standard and custom field.
+                    </p>
+                  </div>
+                  {configurableBoards.length === 0 ? (
+                    <p className='text-sm text-muted-foreground'>
+                      Select a project to configure its board columns.
+                    </p>
+                  ) : (
+                    <div className='space-y-2'>
+                      {configurableBoards.map(board => {
+                        const allKeys = board.columns.map(column => column.key);
+                        const selectedKeys = columnsByBoard[board.id] ?? allKeys;
+                        const customFieldCount = board.columns.filter(
+                          column => column.kind === 'CUSTOM',
+                        ).length;
+                        return (
+                          <details
+                            key={board.id}
+                            className='group rounded-lg border border-border bg-background'
+                          >
+                            <summary className='flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3'>
+                              <div className='min-w-0'>
+                                <div className='truncate text-sm font-medium text-foreground'>
+                                  {board.name}
+                                </div>
+                                <div className='text-xs text-muted-foreground'>
+                                  {selectedKeys.length} of {allKeys.length} columns
+                                  {customFieldCount > 0
+                                    ? ` · ${customFieldCount} custom fields`
+                                    : ' · no custom fields'}
+                                </div>
+                              </div>
+                              <span className='text-xs font-medium text-primary group-open:hidden'>
+                                Configure
+                              </span>
+                              <span className='hidden text-xs font-medium text-muted-foreground group-open:inline'>
+                                Close
+                              </span>
+                            </summary>
+                            <div className='border-t border-border px-4 py-3'>
+                              <div className='mb-3 flex flex-wrap gap-2'>
+                                <Button
+                                  type='button'
+                                  variant='outline'
+                                  size='sm'
+                                  onClick={() => selectAllBoardColumns(board.id)}
+                                  data-track-category='TicketReports'
+                                  data-track-name='SelectAllBoardColumns'
+                                >
+                                  Select all
+                                </Button>
+                                <Button
+                                  type='button'
+                                  variant='ghost'
+                                  size='sm'
+                                  onClick={() => selectCoreBoardColumns(board.id)}
+                                  data-track-category='TicketReports'
+                                  data-track-name='SelectCoreBoardColumns'
+                                >
+                                  Core columns
+                                </Button>
+                              </div>
+                              <div className='grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3'>
+                                {board.columns.map(column => (
+                                  <label
+                                    key={column.key}
+                                    className='flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-muted'
+                                  >
+                                    <input
+                                      type='checkbox'
+                                      checked={selectedKeys.includes(column.key)}
+                                      onChange={() =>
+                                        toggleBoardColumn(board.id, allKeys, column.key)
+                                      }
+                                      className='size-4 accent-primary'
+                                      data-track-category='TicketReports'
+                                      data-track-name='ToggleBoardColumn'
+                                    />
+                                    <span className='min-w-0 truncate'>{column.label}</span>
+                                    {column.kind === 'CUSTOM' && (
+                                      <span className='ml-auto rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary'>
+                                        Custom
+                                      </span>
+                                    )}
+                                  </label>
+                                ))}
+                              </div>
+                              <p className='mt-3 text-xs text-muted-foreground'>
+                                At least one column must remain selected for each board.
+                              </p>
+                            </div>
+                          </details>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+
+                <div className='mt-6 rounded-lg border border-border bg-muted/30 p-4'>
+                  <h3 className='mb-3 text-sm font-semibold text-foreground'>Report contents</h3>
+                  <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+                    <Switch
+                      checked={includeArchived}
+                      onCheckedChange={setIncludeArchived}
+                      label='Include archived tickets'
+                    />
+                    <Switch
+                      checked={includeLinkedTickets}
+                      onCheckedChange={setIncludeLinkedTickets}
+                      label='Include linked-ticket references'
+                    />
+                    <Switch
+                      checked={includeLinkedTicketDetails}
+                      onCheckedChange={setIncludeLinkedTicketDetails}
+                      label='Include linked-ticket detail sheets'
+                      disabled={!includeLinkedTickets}
+                    />
+                    <Switch
+                      checked={includeActivity}
+                      onCheckedChange={setIncludeActivity}
+                      label='Include activity history'
+                    />
+                  </div>
+                </div>
+              </>
+            )}
+
+            {formError && (
+              <div className='mt-4 flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2.5 text-sm text-destructive'>
+                <AlertCircle className='mt-0.5 size-4 shrink-0' />
+                <span className='break-words'>{formError}</span>
+              </div>
+            )}
+
+            <div className='mt-5 flex flex-wrap items-center gap-3 border-t border-border pt-5'>
+              <Button
+                type='button'
+                onClick={() => {
+                  void handleRequest();
+                }}
+                disabled={requestPending || (requiresProject && !projectId)}
+                loading={requestPending}
+                data-track-category='TicketReports'
+                data-track-name='GenerateExport'
+              >
+                <FileSpreadsheet className='size-4' />
+                Download report
+              </Button>
+              <span className='text-xs text-muted-foreground'>
+                The report is generated directly and its configuration is saved in history.
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section className='overflow-hidden rounded-xl border border-border bg-background shadow-sm'>
+          <div className='flex items-center justify-between border-b border-border px-5 py-4'>
+            <div>
+              <h2 className='text-sm font-semibold text-foreground'>Generated reports</h2>
+              <p className='text-xs text-muted-foreground'>
+                Files are generated when you click download and are not stored.
+              </p>
+            </div>
+            <span className='text-xs text-muted-foreground'>Live updates</span>
+          </div>
+
+          <div className='overflow-x-auto'>
+            <table className='w-full text-left text-sm'>
+              <thead className='bg-muted/50 text-xs uppercase text-muted-foreground'>
+                <tr>
+                  <th className='px-4 py-3'>Status</th>
+                  <th className='px-4 py-3'>Requested by</th>
+                  <th className='px-4 py-3'>Created</th>
+                  <th className='px-4 py-3 text-right'>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {exportsLoading && (
+                  <tr>
+                    <td colSpan={4} className='px-4 py-8 text-center'>
+                      <Loader2 className='mx-auto h-5 w-5 animate-spin' />
+                    </td>
+                  </tr>
+                )}
+                {!exportsLoading && items.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className='px-4 py-10 text-center text-muted-foreground'>
+                      No reports generated yet.
+                    </td>
+                  </tr>
+                )}
+                {items.map(record => (
+                  <tr key={record.id} className='border-t border-border'>
+                    <td className='px-4 py-3'>
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[record.status as TicketExportStatus]}`}
+                      >
+                        {record.status}
+                      </span>
+                    </td>
+                    <td className='px-4 py-3'>You</td>
+                    <td className='px-4 py-3'>{formatDate(record.createdAt)}</td>
+                    <td className='px-4 py-3 text-right'>
+                      {(record.status === 'READY' ||
+                        isRetryableExport(record.status, record.updatedAt)) && (
+                        <button
+                          type='button'
+                          onClick={() => {
+                            void handleDownload(record);
+                          }}
+                          disabled={downloadingId === record.id}
+                          className='inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs font-medium text-foreground hover:bg-accent'
+                          data-track-category='TicketReports'
+                          data-track-name='DownloadExport'
+                        >
+                          {downloadingId === record.id ? (
+                            <Loader2 className='h-3.5 w-3.5 animate-spin' />
+                          ) : record.status !== 'READY' ? (
+                            <RotateCcw className='h-3.5 w-3.5' />
+                          ) : (
+                            <Download className='h-3.5 w-3.5' />
+                          )}
+                          {record.status !== 'READY' ? 'Retry' : 'Download'}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+TicketReportsScreen.displayName = 'TicketReportsScreen';
+
+export default TicketReportsScreen;

--- a/packages/shared/src/zero/acl/core/query-acl-factory.ts
+++ b/packages/shared/src/zero/acl/core/query-acl-factory.ts
@@ -48,6 +48,7 @@ import {
   TicketReferenceMappingsACL,
   TicketSubTicketMappingsACL,
   TicketTagsACL,
+  TicketExportsACL,
   ProjectTagsACL,
   TicketTagMappingsACL,
   TicketsACL,
@@ -228,6 +229,8 @@ export class QueryACLFactory {
         return new TicketSubTicketMappingsACL(ctx) as BaseQueryACL<TTable>;
       case 'ticket_tags':
         return new TicketTagsACL(ctx) as BaseQueryACL<TTable>;
+      case 'ticket_exports':
+        return new TicketExportsACL(ctx) as BaseQueryACL<TTable>;
       case 'project_tags':
         return new ProjectTagsACL(ctx) as BaseQueryACL<TTable>;
       case 'ticket_tag_mappings':

--- a/packages/shared/src/zero/acl/tables/index.ts
+++ b/packages/shared/src/zero/acl/tables/index.ts
@@ -55,6 +55,7 @@ export { TicketEntityMappingsACL } from './ticket-entity-mappings-acl';
 export { TicketReferenceMappingsACL } from './ticket-reference-mappings-acl';
 export { TicketSubTicketMappingsACL } from './ticket-sub-ticket-mappings-acl';
 export { TicketTagsACL } from './ticket-tags-acl';
+export { TicketExportsACL } from './ticket-exports-acl';
 export { ProjectTagsACL } from './project-tags-acl';
 export { TicketTagMappingsACL } from './ticket-tag-mappings-acl';
 export { TicketsACL } from './tickets-acl';

--- a/packages/shared/src/zero/acl/tables/ticket-exports-acl.ts
+++ b/packages/shared/src/zero/acl/tables/ticket-exports-acl.ts
@@ -1,0 +1,17 @@
+import type { Query } from '@rocicorp/zero';
+import type { Context, Schema } from '../../schema';
+import { BaseQueryACL } from '../core/base-acl';
+
+export class TicketExportsACL extends BaseQueryACL<'ticket_exports'> {
+  constructor(ctx: Context) {
+    super(ctx, 'ticket_exports');
+  }
+
+  canSelect<TReturn>(
+    query: Query<'ticket_exports', Schema, TReturn>,
+  ): Query<'ticket_exports', Schema, TReturn> {
+    return query
+      .where('workspaceId', this.ctx.workspaceId)
+      .where('requestedBy', this.ctx.userID);
+  }
+}

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2451,6 +2451,9 @@ export const queries = defineQueries({
         );
     },
   ),
+  ticketExportsForCurrentUser: defineQuery(() => {
+    return zql.ticket_exports.orderBy('createdAt', 'desc').limit(100);
+  }),
   getAllProjects: defineQuery(() => {
     return zql.projects.orderBy('createdAt', 'desc').related('boards');
   }),

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -276,6 +276,18 @@ export const projectTagTable = table('project_tags')
   })
   .primaryKey('id');
 
+export const ticketExportTable = table('ticket_exports') // TicketExport
+  .columns({
+    id: string(),
+    workspaceId: string(),
+    requestedBy: string(),
+    status: string(),
+    filters: string(),
+    createdAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey('id');
+
 export const ticketTagMappingTable = table('ticket_tag_mappings')
   .columns({
     workspaceId: string(), // denormalized tenant key (stamped on insert)
@@ -2872,6 +2884,11 @@ export const userGroupTableRelationships = relationships(userGroupTable, ({ one,
     destField: ['userGroupId'],
     destSchema: collectionPermissionTable,
   }),
+  ticketExports: many({
+    sourceField: ['id'],
+    destField: ['requestedBy'],
+    destSchema: ticketExportTable,
+  }),
 }));
 
 export const userTableRelationships = relationships(userTable, ({ one, many }) => ({
@@ -3949,6 +3966,24 @@ export const workspaceTableRelationships = relationships(workspaceTable, ({ one,
     destField: ['workspaceId'],
     destSchema: userGroupTable,
   }),
+  ticketExports: many({
+    sourceField: ['id'],
+    destField: ['workspaceId'],
+    destSchema: ticketExportTable,
+  }),
+}));
+
+export const ticketExportTableRelationships = relationships(ticketExportTable, ({ one }) => ({
+  workspace: one({
+    sourceField: ['workspaceId'],
+    destField: ['id'],
+    destSchema: workspaceTable,
+  }),
+  requestedByUser: one({
+    sourceField: ['requestedBy'],
+    destField: ['id'],
+    destSchema: userTable,
+  }),
 }));
 
 export const workspaceOrganizationTableRelationships = relationships(workspaceOrganizationTable, ({ one }) => ({
@@ -4511,6 +4546,7 @@ export const schema = createSchema({
     ticketEntityMappingTable,
     ticketTagTable,
     projectTagTable,
+    ticketExportTable,
     ticketTagMappingTable,
     ticketReferenceMappingTable,
     ticketStageEtaTable,
@@ -4643,6 +4679,7 @@ export const schema = createSchema({
     ticketEntityMappingTableRelationships,
     ticketTagTableRelationships,
     projectTagTableRelationships,
+    ticketExportTableRelationships,
     ticketTagMappingTableRelationships,
     ticketReferenceMappingTableRelationships,
     ticketStageEtaTableRelationships,
@@ -4774,6 +4811,7 @@ export type TicketActivity = Row<typeof schema.tables.ticket_activities>;
 export type TicketEntityMapping = Row<typeof schema.tables.ticket_entity_mappings>;
 export type TicketTag = Row<typeof schema.tables.ticket_tags>;
 export type ProjectTag = Row<typeof schema.tables.project_tags>;
+export type TicketExport = Row<typeof schema.tables.ticket_exports>;
 export type TicketTagMapping = Row<typeof schema.tables.ticket_tag_mappings>;
 export type TicketAssignment = Row<typeof schema.tables.ticket_assignments>;
 export type TicketReferenceMapping = Row<typeof schema.tables.ticket_reference_mappings>;


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
