### PR TITLE
feat: XYNE-55457 add nix setup CI check and fix db-setup backend path

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,0 +1,73 @@
+name: Nix CI
+
+# Guards the Nix-based local dev setup (the flake devShell + the process-compose
+# services bundle) against regressions. Two classes are covered:
+#   1. flake eval / build breakage (removed attrs, broken derivations, input drift)
+#   2. source-path drift in the process-compose bootstrap (project.nix) — the class
+#      that silently broke db-setup when the repo was restructured to apps/backend/.
+#
+# Installer + cache choice follows juspay/skills `nix-ci` (Option 1, GitHub
+# Actions): use nix-quick-install-action (NOT the DeterminateSystems installer),
+# because only its store layout is snapshotted by cache-nix-action.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+      - staging
+      - "release**"
+
+permissions:
+  contents: read
+  # Required by cache-nix-action `purge: true` — it calls the REST cache API to
+  # evict stale entries. Without it the save aborts and nothing is ever cached.
+  actions: write
+
+concurrency:
+  group: nix-ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Cancel superseded PR runs; never cancel a protected-branch push.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  nix:
+    name: Nix flake check + build + path guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: nixbuild/nix-quick-install-action@v34
+        with:
+          nix_conf: |
+            substituters = https://cache.nixos.org https://cache.nixos.asia/juspay
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= juspay:5aHaNForWL03wKOGhUn/al4BZd3HqZDWZ3hrVTcf6Fg=
+            accept-flake-config = true
+
+      # Cache /nix/store across runs — a cold closure for this stack is minutes;
+      # a warm restore is ~1 min. Keyed on the Nix inputs so it invalidates when
+      # the flake, project.nix, or nix/ tree changes.
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', '**/flake.nix', 'project.nix', 'nix/**') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-last-accessed: 604800
+          purge-primary-key: never
+
+      # 1. Eval hygiene — cheap; catches removed attrs / eval errors across outputs.
+      - name: nix flake check
+        run: nix flake check --no-build -L
+
+      # 2. Build what a developer actually consumes: the dev shell and the
+      #    process-compose services bundle. Catches broken/removed derivations.
+      - name: nix build (devShell + services bundle)
+        run: nix build -L .#devShells.x86_64-linux.default .#xyne-space-services
+
+      # 3. Source-path drift guard — the check that would have caught the
+      #    backend/ -> apps/backend/ restructure that left db-setup pointing at a
+      #    dead path and silently skipping schema push + ACL seed + admin creation.
+      - name: Bootstrap path-drift guard
+        run: bash nix/scripts/check-referenced-paths.sh

--- a/nix/scripts/check-referenced-paths.sh
+++ b/nix/scripts/check-referenced-paths.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Guard against source-path drift in the Nix bootstrap (project.nix).
+#
+# The process-compose stack shells out to fixed source paths (the backend dir,
+# the python transcription agent, the dashboard). If the repo layout moves but
+# project.nix is not updated, the affected step silently does the wrong thing.
+#
+# This exact failure shipped once already: the repo restructure (#21) moved
+# backend/ -> apps/backend/, but project.nix still set
+# BACKEND_DIR="$PROJECT_ROOT/backend". db-setup then found no backend, printed
+# "Skipping database setup", and exited 0 — so schema push, ACL seed, and admin
+# creation silently stopped running on every fresh `nix run .#xyne-space-services`.
+#
+# A `nix flake check` / `nix build` cannot catch this: the flake still evaluates
+# and builds fine. Only a check that resolves the *referenced* paths catches it.
+# This script does exactly that, with no Nix or service boot required.
+set -euo pipefail
+
+# repo root = two levels up from nix/scripts/
+cd "$(dirname "$0")/../.."
+ROOT="$PWD"
+fail=0
+
+check() {
+  local p="$1" src="$2"
+  # Skip runtime/generated locations that legitimately do not exist at checkout.
+  case "$p" in
+    data/* | .logs* | .nix-cache* | *node_modules* | dist/*) return 0 ;;
+  esac
+  if [ ! -e "$ROOT/$p" ]; then
+    echo "::error file=$src::Nix bootstrap references a missing source path: $p"
+    fail=1
+  fi
+}
+
+# 1. $PROJECT_ROOT/<path> references.
+while IFS= read -r ref; do
+  check "${ref#\$PROJECT_ROOT/}" project.nix
+done < <(grep -oE '\$PROJECT_ROOT/[A-Za-z0-9_./-]+' project.nix | sort -u)
+
+# 2. Literal `cd <relative-path>` references (skip $-prefixed and absolute paths).
+while IFS= read -r line; do
+  p="${line#cd }"
+  case "$p" in /* | \$* | "") continue ;; esac
+  check "$p" project.nix
+done < <(grep -oE 'cd [A-Za-z0-9_./-]+' project.nix | sort -u)
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "Nix bootstrap (project.nix) references a path that does not exist in the tree." >&2
+  echo "If you moved a directory, update project.nix to match the new layout." >&2
+  exit 1
+fi
+
+echo "✓ all source paths referenced by project.nix exist"

--- a/nix/scripts/check-referenced-paths.sh
+++ b/nix/scripts/check-referenced-paths.sh
@@ -35,6 +35,7 @@ check() {
 }
 
 # 1. $PROJECT_ROOT/<path> references.
+# shellcheck disable=SC2016  # we grep for the literal string $PROJECT_ROOT, no expansion intended
 while IFS= read -r ref; do
   check "${ref#\$PROJECT_ROOT/}" project.nix
 done < <(grep -oE '\$PROJECT_ROOT/[A-Za-z0-9_./-]+' project.nix | sort -u)

--- a/project.nix
+++ b/project.nix
@@ -103,7 +103,7 @@
         
         # Get project root (where we were invoked from)
         PROJECT_ROOT="$PWD"
-        BACKEND_DIR="$PROJECT_ROOT/backend"
+        BACKEND_DIR="$PROJECT_ROOT/apps/backend"
         
         echo "Project root: $PROJECT_ROOT"
         echo "Backend dir: $BACKEND_DIR"


### PR DESCRIPTION
## 1. Problem Description
The Nix-based local dev setup (`nix run .#xyne-space-services`) silently stopped bootstrapping the database. On a fresh bring-up the services come up, but `db-setup` prints "Skipping database setup" and exits 0 — so Prisma schema push, `seed-acl.ts`, and admin-user creation never run. Developers get an empty, unmigrated DB with no error. There was also no CI guarding the Nix setup at all.

## 2. If this is a bug fix or an enhancement, how did you identify the issue?
Root cause is source-path drift: `project.nix` set `BACKEND_DIR="$PROJECT_ROOT/backend"`, but the repo restructure (#21, commit 770c5466) moved `backend/` → `apps/backend/` and did not update this line. `db-setup` then looked at a directory that no longer exists, found no `node_modules`, and skipped. Confirmed live from the running stack's `.logs/db-setup.log` ("Backend dir: .../backend", "Skipping database setup"). A `nix flake check` / `nix build` cannot catch this — the flake still evaluates and builds fine; only resolving the referenced path catches it.

## 3. Explain the solution implemented in the PR
Two parts:
1. Fix the regression: `project.nix` `BACKEND_DIR` now points at `$PROJECT_ROOT/apps/backend`.
2. Prevent recurrence with a new `Nix CI` workflow (`.github/workflows/nix-ci.yml`), following juspay/skills `nix-ci` Option 1 — `nixbuild/nix-quick-install-action@v34` (not the DeterminateSystems installer) + `nix-community/cache-nix-action@v6` (with `actions: write` for cache purge). It runs `nix flake check`, builds the devShell + `xyne-space-services` bundle, and runs a new source-path drift guard (`nix/scripts/check-referenced-paths.sh`) that asserts every source path referenced by `project.nix` exists. The guard was verified to FAIL on the pre-fix tree and PASS after the fix.

Follow-ups intentionally NOT in this PR (flagged for a later change): make `db-setup` `exit 1` (fail loud) instead of `exit 0` on a missing backend dir; fix the `${pkgs.nodejs}/bin/pnpm` reference in the seed step (pnpm is not part of the nodejs derivation); and a Tier-2 "boot the stack + assert DB actually seeded" integration job.

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
N/A

## 6. Data fix Details (if any)
N/A

## 7. Environment variable Changes (if any)
N/A

## 8. Testing
- `nix flake check --no-build` — passes.
- `nix build --dry-run .#devShells.x86_64-linux.default .#xyne-space-services` — resolves cleanly (attrs `xyne-spaces-dev` / `xyne-space-services`).
- `bash nix/scripts/check-referenced-paths.sh` — exits 1 (flagging `backend`) before the project.nix fix; exits 0 after. YAML of the workflow validated.

## 9. Services to which this change is to be deployed
CI/tooling only — no runtime service deploy.

## 10. Main PR link (if this PR is raised against a release branch)
N/A (base is `main`).