### PR TITLE
feat: add default formatting toolbar preference

### DIFF
--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -693,6 +693,19 @@ const MessagingSection: FC<{ state: PreferencesState }> = ({ state }) => (
     </div>
     <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
       <div>
+        <p className='text-sm font-medium text-foreground'>Open formatting by default</p>
+        <p className='text-xs text-muted-foreground mt-0.5'>
+          Show the formatting toolbar automatically in channel and thread message composers
+        </p>
+      </div>
+      <Switch
+        id='default-formatting-toolbar-open'
+        checked={state.defaultFormattingToolbarOpen}
+        onCheckedChange={state.setDefaultFormattingToolbarOpen}
+      />
+    </div>
+    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+      <div>
         <p className='text-sm font-medium text-foreground'>
           Allow @channel/@here in thread replies
         </p>

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -69,6 +69,7 @@ import { useTypingState } from '../../../contexts/TypingStateContext';
 import { validateFile } from '../utils/files';
 import { useScope, useShortcutById } from '../../../shortcuts';
 import { useEnterSendsMessage } from '../../../hooks/useEnterSendsMessage';
+import { useDefaultFormattingToolbarOpen } from '../../../hooks/useDefaultFormattingToolbarOpen';
 import { Preferences } from '../../Settings/Preferences';
 import { Dialog } from '../Dialog';
 import { CallTranscriptSelector } from '../../Chat/CallTranscriptSelector';
@@ -206,6 +207,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       getDroppedFilesForEntity,
     } = useDraftAttachments();
     const { enterSendsMessage } = useEnterSendsMessage();
+    const { defaultFormattingToolbarOpen } = useDefaultFormattingToolbarOpen();
     const shareableOrigin = useShareableOrigin();
     const [isPreferencesOpen, setIsPreferencesOpen] = useState(false);
     const [selectedFile, setSelectedFile] = useState<File | UploadedFile | null>(null);
@@ -302,10 +304,17 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
     const [isScheduleDialogOpen, setIsScheduleDialogOpen] = useState(false);
     const openScheduleDialog = useCallback((): void => setIsScheduleDialogOpen(true), []);
     const [isPlusMenuOpen, setIsPlusMenuOpen] = useState(false);
-    const [showFormatToolbar, setShowFormatToolbar] = useState(false);
+    const [showFormatToolbar, setShowFormatToolbar] = useState(defaultFormattingToolbarOpen);
     const [isTranscriptSelectorOpen, setIsTranscriptSelectorOpen] = useState(false);
     const [emojiSizeClass, setEmojiSizeClass] = useState('text-sm');
-    const [showMobileFormattingToolbar, setShowMobileFormattingToolbar] = useState(false);
+    const [showMobileFormattingToolbar, setShowMobileFormattingToolbar] = useState(
+      defaultFormattingToolbarOpen,
+    );
+
+    useEffect(() => {
+      setShowFormatToolbar(defaultFormattingToolbarOpen);
+      setShowMobileFormattingToolbar(defaultFormattingToolbarOpen);
+    }, [defaultFormattingToolbarOpen]);
 
     const [ticketCreated, setTicketCreated] = useState(false);
 

--- a/apps/dashboard/src/hooks/useDefaultFormattingToolbarOpen.ts
+++ b/apps/dashboard/src/hooks/useDefaultFormattingToolbarOpen.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from 'react';
+
+export const DEFAULT_FORMATTING_TOOLBAR_OPEN_KEY = 'xyne:default-formatting-toolbar-open';
+
+const listeners = new Set<() => void>();
+
+const subscribe = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getSnapshot = (): boolean => {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem(DEFAULT_FORMATTING_TOOLBAR_OPEN_KEY) === 'true';
+};
+
+const getServerSnapshot = (): boolean => false;
+
+const saveDefaultFormattingToolbarOpen = (value: boolean): void => {
+  localStorage.setItem(DEFAULT_FORMATTING_TOOLBAR_OPEN_KEY, String(value));
+  listeners.forEach(listener => listener());
+};
+
+export const useDefaultFormattingToolbarOpen = (): {
+  defaultFormattingToolbarOpen: boolean;
+  setDefaultFormattingToolbarOpen: (value: boolean) => void;
+} => {
+  const defaultFormattingToolbarOpen = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  return {
+    defaultFormattingToolbarOpen,
+    setDefaultFormattingToolbarOpen: saveDefaultFormattingToolbarOpen,
+  };
+};

--- a/apps/dashboard/src/hooks/usePreferencesState.ts
+++ b/apps/dashboard/src/hooks/usePreferencesState.ts
@@ -6,6 +6,7 @@ import { useTheme } from './useTheme';
 import { useAILandingDefault } from './useAILandingDefault';
 import { useDebugSettings } from './useDebugSettings';
 import { useEnterSendsMessage } from './useEnterSendsMessage';
+import { useDefaultFormattingToolbarOpen } from './useDefaultFormattingToolbarOpen';
 import { useShowThreadTags } from './useShowThreadTags';
 import { useSearchMode } from './useSearchMode';
 import { useThreadBroadcastMentions } from './useThreadBroadcastMentions';
@@ -43,6 +44,8 @@ export function usePreferencesState(enabled: boolean) {
   const { aiLandingDefault, setAiLandingDefault } = useAILandingDefault();
   const { settings: debugSettings, toggleSendIndicators } = useDebugSettings();
   const { enterSendsMessage, setEnterSendsMessage } = useEnterSendsMessage();
+  const { defaultFormattingToolbarOpen, setDefaultFormattingToolbarOpen } =
+    useDefaultFormattingToolbarOpen();
   const { showThreadTags, setShowThreadTags } = useShowThreadTags();
   const { searchMode, setSearchMode } = useSearchMode();
   const { showClawDashboard, setShowClawDashboard } = useClawDashboardVisibility();
@@ -136,6 +139,8 @@ export function usePreferencesState(enabled: boolean) {
     debugSettings,
     toggleSendIndicators,
     enterSendsMessage,
+    defaultFormattingToolbarOpen,
+    setDefaultFormattingToolbarOpen,
     showThreadTags,
     setShowThreadTags,
     setEnterSendsMessage,


### PR DESCRIPTION
1. Problem Description:
Users currently have to manually open the message composer formatting toolbar every time because the Show formatting button defaults to closed.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Spaces thread: add a local user preference so users can keep formatting open by default.

3. Explain the solution implemented in the PR:
Added a browser-local user preference, stored in localStorage with a false/closed fallback. Preferences > Messaging now exposes an "Open formatting by default" switch. Channel and thread InputBox instances subscribe to the same preference and initialize/sync the desktop and mobile formatting toolbar state from it.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- pnpm -C apps/dashboard exec tsc --noEmit --pretty false
- pnpm -C apps/dashboard exec eslint src/hooks/useDefaultFormattingToolbarOpen.ts src/hooks/usePreferencesState.ts src/components/ui/InputBox/InputBox.tsx src/components/Settings/Preferences/Preferences.tsx (existing warnings only)
- Captured screenshots for Preferences > Messaging and channel + thread composers with the preference enabled.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A