### PR TITLE
fix: repair Alertmanager graph links with unescaped > in URL

### DIFF
--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackBlockKitParser.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackBlockKitParser.ts
@@ -4,7 +4,7 @@
  */
 
 import { escapeForSlackWithMarkdown, escapeForSlack } from '@clearfeed-ai/slack-to-html';
-import { parseMrkdwnBlocks } from './slackUtils';
+import { parseMrkdwnBlocks, encodeAnglesInsideLinkUrls } from './slackUtils';
 import { logger } from '../../../../utils/logger';
 
 /**
@@ -12,14 +12,17 @@ import { logger } from '../../../../utils/logger';
  * errors from @clearfeed-ai/slack-to-html and falls back to plain-text escaping.
  */
 function safeEscapeForSlackWithMarkdown(text: string): string {
+  // Repair link URLs whose unescaped `<`/`>` would otherwise truncate the link
+  // token in the escaper (breaks Grafana graph links in Alertmanager alerts).
+  const sanitized = encodeAnglesInsideLinkUrls(text);
   try {
-    return escapeForSlackWithMarkdown(text);
+    return escapeForSlackWithMarkdown(sanitized);
   } catch (error) {
     if (error instanceof RangeError && error.message?.includes('Maximum call stack')) {
       logger.warn('[SlackBlockKitParser] escapeForSlackWithMarkdown stack overflow, falling back to plain text', {
-        textPreview: text.slice(0, 200),
+        textPreview: sanitized.slice(0, 200),
       });
-      return escapeForSlack(text);
+      return escapeForSlack(sanitized);
     }
     throw error;
   }

--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackUtils.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackUtils.ts
@@ -175,3 +175,42 @@ export function parseMrkdwnBlocks<T>(content: string, handlers: MrkdwnBlockHandl
 
   return results;
 }
+
+// ============================================================================
+// Link-URL angle-bracket sanitizer
+// ============================================================================
+
+/**
+ * Percent-encode `<` and `>` that appear *inside a link URL*.
+ *
+ * Alertmanager / Grafana templates emit graph links whose URL carries an
+ * unescaped `>` (e.g. a PromQL threshold `...sum(rate(istio[5m]))>100`). The
+ * downstream Slack→HTML escaper (`@clearfeed-ai/slack-to-html`) terminates a
+ * link token at the FIRST `>`, so the URL is truncated and its tail leaks out
+ * as literal text — producing the broken `">📈` / `100|📈>` remnants seen in
+ * #production-swat alert threads.
+ *
+ * Slack's own spec requires senders to entity-escape `<`/`>` inside link URLs;
+ * these alert senders don't. We repair it here BEFORE escaping, for both link
+ * forms, without touching plain-text `>` (so "more than 100 > 5" is preserved):
+ *   1. HTML anchors:      <a ... href="URL" ...>
+ *   2. Slack link syntax: <scheme://URL>  and  <scheme://URL|label>
+ */
+export function encodeAnglesInsideLinkUrls(text: string): string {
+  const enc = (url: string): string => url.replace(/</g, '%3C').replace(/>/g, '%3E');
+
+  // 1) HTML anchor href attribute (double- or single-quoted).
+  let out = text.replace(/href\s*=\s*"([^"]*)"/gi, (_m, url: string) => `href="${enc(url)}"`);
+  out = out.replace(/href\s*=\s*'([^']*)'/gi, (_m, url: string) => `href='${enc(url)}'`);
+
+  // 2) Slack link syntax <url> / <url|label>. Anchor on a real scheme so we
+  //    never touch mentions (<@U…>), channels (<#C…>) or plain-text angles.
+  //    Capture the whole token up to the LAST `>` and split the optional
+  //    `|label` (labels never contain `<`, `>` or `|`).
+  out = out.replace(
+    /<((?:https?|mailto):[^\s<]*?)(\|[^<>|]*)?>(?=\s|$|[^A-Za-z0-9])/g,
+    (_m, url: string, label: string | undefined) => `<${enc(url)}${label || ''}>`,
+  );
+
+  return out;
+}


### PR DESCRIPTION
## Problem
Alertmanager/Grafana graph links in #production-swat render broken — the message body shows leaked remnants like `">📈` or `100|📈>` on the **Graph:** line instead of a clickable chart link.

Root cause: the graph URL carries an unescaped `>` (a PromQL threshold, e.g. `...rate(5xx)>100`). The Slack→HTML escaper (`@clearfeed-ai/slack-to-html`) terminates a link token at the **first** `>`, so the URL is truncated and its tail leaks out as literal text. This affects **both** link forms present in these alerts: HTML anchors `<a href="URL">` (leaks `">📈`) and Slack link syntax `<URL|label>` (leaks `100|📈>`).

## Fix
Add `encodeAnglesInsideLinkUrls()` in `slackUtils.ts` — percent-encodes `<`/`>` (`%3C`/`%3E`) inside link URLs for both forms, and wire it into `safeEscapeForSlackWithMarkdown` in `slackBlockKitParser.ts` so it runs before escaping on every mrkdwn path.

Scoped precisely so there is no collateral change:
- Only `href="..."`/`href='...'` values and `<http(s)://…>` / `<mailto:…>` link tokens are rewritten.
- Plain-text `>` (e.g. "more than 100 > 5") is untouched.
- Slack mentions `<@U…>` and channel refs `<#C…>` are untouched.

## Validation
- Live repro through the actual `escapeForSlackWithMarkdown` before/after: both broken forms now render a clean `<a …>📈</a>`; clean links and plain-text `>` unchanged.
- `tsc --noEmit` on `apps/backend`: 0 type errors.

Files changed:
- apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackUtils.ts
- apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackBlockKitParser.ts