### PR TITLE
revert: XYNE-55599 pre prod recording (cherry-pick #442)

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -423,16 +423,6 @@ export class CallController {
           title: 'Untitled Notes',
         });
 
-        stage = 'bot_user_lookup';
-        const xyneAutomaticBot = await this.getOrCreateBotUser(req.user!.workspaceId!);
-        stage = 'dm_channel_resolution';
-        const headlessChannelId = await repositories.channels.findOrCreateDMChannel(
-          userId,
-          [xyneAutomaticBot.id],
-          repositories.channelParticipants,
-          req.user!.workspaceId!
-        );
-
         const roomLink = `${livekitService.getClientUrl()}/call/${callExternalId}?type=${callType}`;
         const roomMetadata = JSON.stringify({
           callType: 'HEADLESS',
@@ -440,7 +430,6 @@ export class CallController {
           createdBy: userId,
           workspaceId: req.user!.workspaceId,
           notesCanvasId,
-          channelId: headlessChannelId,
         });
 
         stage = 'livekit_room_creation';
@@ -474,7 +463,7 @@ export class CallController {
           externalId: callExternalId,
           callId: callExternalId,
           roomLink,
-          channelId: headlessChannelId,
+          channelId: null,
           notesCanvasId,
         });
         return;


### PR DESCRIPTION
Cherry-picks the single commit from #442 (revert of "fix: XYNE-55599 pre prod recording (#417)", original commit 41b1c57f) onto fix/release-20260805-2.

Source PR: https://github.com/juspay/xyne-spaces/pull/442
Cherry-picked commit: 964ca9abd9165ced35832e38434db422a3dbdce6

1 file changed, 1 insertion(+), 12 deletions(-).