### PR TITLE
fix: repair Direct Messages walkthrough tour selectors

### DIFF
--- a/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
@@ -510,6 +510,7 @@ const DmsPage = (): ReactElement => {
               id='dm-search-input'
               ref={dmSearchInputRef}
               type='text'
+              data-testid='search-messages-input'
               className='w-full h-11 pl-12 pr-10 py-3 bg-background rounded-full border border-border text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0'
               placeholder='Search DMs (Cmd+K)'
               autoFocus={!isMobile}

--- a/apps/dashboard/src/config/walkthroughConfig.ts
+++ b/apps/dashboard/src/config/walkthroughConfig.ts
@@ -11,25 +11,21 @@ export const walkthroughConfig: Record<WalkthroughFeature, DriveStep[]> = {
       },
     },
     {
-      element: '[data-testid="open-dms-button"]',
+      element: '[data-testid="search-messages-input"]',
       popover: {
-        title: 'Dedicated DMs View',
-        description: 'Click this button to open the full-screen Direct Messages workspace.',
-        side: 'right',
+        title: 'Find a Conversation',
+        description: 'Search across all your direct messages to quickly jump to any chat.',
+        side: 'bottom',
+        align: 'start',
       },
     },
     {
-      element: '#sidebar-add-dm-btn',
+      element: '[data-testid="create-new-message-btn"]',
       popover: {
-        title: 'Quick Add DM',
-        description: 'You can also instantly start a new conversation right here from the sidebar!',
-        side: 'right',
-      },
-      onHighlightStarted: (element?: Element) => {
-        if (element) (element as HTMLElement).style.opacity = '1';
-      },
-      onDeselected: (element?: Element) => {
-        if (element) (element as HTMLElement).style.opacity = '';
+        title: 'Start a New Message',
+        description: 'Click here to start a new direct message with anyone on your team.',
+        side: 'bottom',
+        align: 'end',
       },
     },
   ],


### PR DESCRIPTION
## Summary
The Direct Messages product tour (driver.js walkthrough, feature key `direct_messages`) had two of its three steps pointing at selectors that do not resolve to visible controls on the DMs page, so the tour highlighted nothing (step 2) or highlighted an empty region (step 3).

## PR Checklist

1. **Problem Description:**
Steps 2 and 3 of the `direct_messages` walkthrough were broken:
- Step 2 targeted `[data-testid="open-dms-button"]`, which does not exist anywhere in the codebase. driver.js fell back to a 0×0 centered dummy element, so the popover said "Click this button to open the full-screen Direct Messages workspace" while highlighting nothing.
- Step 3 targeted `#sidebar-add-dm-btn`, which resolves to a 22×22 element in the far-left rail that is not a visible control in the DMs-page context, so the highlight cutout landed on an empty region near the empty-state illustration.

2. **How the issue was identified:**
Reproduced the tour on `/chat/dm` (route rendered by `DmsPage.tsx`) in a dev sandbox at desktop viewport (1440×900). Instrumented driver.js to report `.driver-active-element`: step 2 resolved to `#driver-dummy-element` (0×0, not visible); step 3 resolved to `#sidebar-add-dm-btn` at x=94, w=22 with no visible button rendered there. Confirmed `[data-testid="open-dms-button"]` has zero occurrences in the repo.

3. **Solution implemented:**
Repointed both steps to real, always-visible controls that exist in BOTH the mobile and desktop branches of `DmsPage.tsx`:
- Step 2 → `[data-testid="search-messages-input"]` — "Find a Conversation"
- Step 3 → `[data-testid="create-new-message-btn"]` — "Start a New Message"
Added the shared `data-testid="search-messages-input"` to the mobile search input (it previously only had `id="dm-search-input"`; the desktop input already had the testid) so step 2 resolves on mobile too. Removed the now-unneeded `onHighlightStarted`/`onDeselected` opacity hack that existed only to reveal the hover-hidden sidebar button. Files: `apps/dashboard/src/config/walkthroughConfig.ts`, `apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx`.

4. **Documentation:** N/A

5. **DB Alter Details:** N/A

6. **Data fix Details:** N/A

7. **Environment variable Changes:** N/A

8. **Testing:**
Reproduced before/after by driving the tour end-to-end via Playwright at desktop viewport. Before: step 2 highlighted nothing (0×0 dummy), step 3 highlighted an empty 22×22 region. After: step 2 highlights the search input (319×36, visible) with the popover anchored below it, and step 3 highlights the compose/new-message button (32×32, visible) anchored to it. Verified `align`/`side` are valid `Popover` fields in the installed driver.js 1.8.0 types. Before/after screenshots attached in the originating thread.

9. **Services to deploy:** dashboard

10. **Main PR link (if against a release branch):** N/A — this PR targets `main`.