### PR TITLE
fix: force Zero reconnect on wake/network change (Electron stuck-on-loading)

### DIFF
--- a/apps/dashboard/src/components/ZeroConnectionStatus/ZeroConnectionFailureModal.tsx
+++ b/apps/dashboard/src/components/ZeroConnectionStatus/ZeroConnectionFailureModal.tsx
@@ -2,7 +2,6 @@ import { ReactElement } from 'react';
 import { RefreshCw, X } from 'lucide-react';
 import { isElectronApp } from '../../utils/electronApp';
 import { logger, Event as LoggerEvent } from '../../utils/logger';
-import { useAuth } from '@/hooks/useAuth';
 
 interface ZeroConnectionFailureModalProps {
   onClose?: () => void;
@@ -12,14 +11,17 @@ export const ZeroConnectionFailureModal = ({
   onClose,
 }: ZeroConnectionFailureModalProps = {}): ReactElement => {
   const isElectron = isElectronApp();
-  const { logout } = useAuth();
 
   const handleRefresh = (): void => {
     logger.info(LoggerEvent.APP_REFRESH, {
       trigger: 'USER_CLICK_CONNECTION_FAILURE_MODAL',
     });
 
-    logout();
+    // Reload the app to re-establish the Zero connection. Previously this called
+    // logout(), which signed the user out entirely (especially disruptive on
+    // Electron) instead of simply reconnecting — contradicting the modal copy
+    // ("Click below to reload the app" / "refresh").
+    window.location.reload();
   };
 
   return (

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -101,6 +101,8 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
   const retryCountRef = useRef(0);
   const resetTimerRef = useRef<NodeJS.Timeout | null>(null);
   const previousStateRef = useRef<string>('');
+  const latestStateNameRef = useRef<string>('');
+  const disconnectedNudgeTimerRef = useRef<NodeJS.Timeout | null>(null);
   const MAX_RETRIES = 4;
 
   const getRetryDelay = (retryCount: number): number => {
@@ -254,9 +256,48 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
     }
   }, [context.userID, schemaVersion, isHydrated]);
 
+  // Force a Zero reconnect when the OS/network wakes the app back up.
+  // After the laptop sleeps or the WiFi changes, the underlying socket is dead
+  // but Zero's internal ping/reconnect timers were frozen while suspended, so
+  // nothing tells it to reconnect and the app can sit on the loader for ~60s
+  // (or until a manual restart). The browser fires `online` / `visibilitychange`
+  // / `focus` on wake — use those to nudge Zero to reconnect immediately.
+  useEffect(() => {
+    const forceReconnect = (trigger: string): void => {
+      // Only nudge when we're not already connected — avoid churning a healthy socket.
+      if (latestStateNameRef.current === 'connected') {
+        return;
+      }
+      logger.info(LoggerEvent.ZERO_ERROR_RECONNECT_INITIATED, {
+        trigger,
+        reason: `network/visibility wake (state=${latestStateNameRef.current || 'unknown'})`,
+      });
+      void zero.connection.connect();
+    };
+
+    const handleOnline = (): void => forceReconnect('NETWORK_ONLINE');
+    const handleVisibility = (): void => {
+      if (document.visibilityState === 'visible') {
+        forceReconnect('VISIBILITY_VISIBLE');
+      }
+    };
+    const handleFocus = (): void => forceReconnect('WINDOW_FOCUS');
+
+    window.addEventListener('online', handleOnline);
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleFocus);
+
+    return (): void => {
+      window.removeEventListener('online', handleOnline);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [zero]);
+
   useEffect(() => {
     const currentState = state.name;
     const previousState = previousStateRef.current;
+    latestStateNameRef.current = currentState;
 
     switch (currentState) {
       case 'needs-auth':
@@ -321,13 +362,35 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
           clearTimeout(modalTimerRef.current);
           modalTimerRef.current = null;
         }
+        if (disconnectedNudgeTimerRef.current) {
+          clearTimeout(disconnectedNudgeTimerRef.current);
+          disconnectedNudgeTimerRef.current = null;
+        }
         setShowModal(false);
         handlePostErrorReset(previousState);
         break;
-      case 'disconnected':
-        // Don't show modal for disconnected state, only for error state
+      case 'disconnected': {
+        // Don't show modal for disconnected state, only for error state.
         handlePostErrorReset(previousState);
+        // The `disconnected` state (e.g. "unable to connect for 60s", ping
+        // failure after sleep/WiFi change) is otherwise a dead-end: the error
+        // retry ladder never runs for it, so the app can sit on the loader
+        // until a manual restart. Schedule a single bounded reconnect nudge.
+        if (disconnectedNudgeTimerRef.current) {
+          clearTimeout(disconnectedNudgeTimerRef.current);
+        }
+        disconnectedNudgeTimerRef.current = setTimeout(() => {
+          disconnectedNudgeTimerRef.current = null;
+          if (latestStateNameRef.current !== 'connected') {
+            logger.info(LoggerEvent.ZERO_ERROR_RECONNECT_INITIATED, {
+              trigger: 'ZERO_SOCKET_DISCONNECTED',
+              reason: 'bounded reconnect nudge from disconnected state',
+            });
+            void zero.connection.connect();
+          }
+        }, 3000);
         break;
+      }
       default:
         handlePostErrorReset(previousState);
         break;
@@ -344,6 +407,10 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
       if (modalTimerRef.current) {
         clearTimeout(modalTimerRef.current);
         modalTimerRef.current = null;
+      }
+      if (disconnectedNudgeTimerRef.current) {
+        clearTimeout(disconnectedNudgeTimerRef.current);
+        disconnectedNudgeTimerRef.current = null;
       }
     };
   }, [state.name]);


### PR DESCRIPTION
## Problem
The Xyne Spaces Electron app frequently gets stuck on the loading / "Connection Lost" screen after the MacBook lid is closed, on wake from sleep, or after a WiFi change — recovering only after a full restart. Reported repeatedly (notably on Sridhar Ratnakumar's sessions).

## Root cause
The disconnect itself is normal (the network dropped). The stuck-ness comes from the dashboard never proactively reconnecting Zero:

1. **No wake trigger.** `apps/dashboard/src/providers/InitialStateLoader.tsx` (and `ZeroProvider.tsx`) register no `online` / `visibilitychange` / `focus` listeners. While the OS is suspended, Zero's internal ping/reconnect timers are frozen, so on wake the dead socket is never nudged to reconnect — the app relies solely on Zero's own ~60s internal give-up window.
2. **`disconnected` was a no-op.** In `InitialStateLoader`'s connection-state effect, only the `error` state runs the retry ladder (`zero.connection.connect()` with backoff). The `disconnected` branch (e.g. "Zero was unable to connect for 60 seconds", "Server ping request failed") only called `handlePostErrorReset` and otherwise did nothing, so the post-sleep connecting/disconnected flap never re-entered a retry path.
3. **Modal signed the user out.** `components/ZeroConnectionStatus/ZeroConnectionFailureModal.tsx`'s "Reload app" button called `logout()` instead of reloading — on Electron this ejected the user entirely, contradicting the modal's own copy.

Grafana (Electron 1.184/1.185, 14d) corroborates: 78× `zero_socket_disconnected` matching 78× "unable to connect for 60 seconds" one-for-one, and `zero_error_reload_initiated = 0` (the reload recovery path never fired).

## Changes
- **`InitialStateLoader.tsx`**: add `online` / `visibilitychange` (visible) / `focus` listeners that call `zero.connection.connect()` on wake, guarded to only fire when not already connected (a `latestStateNameRef` tracks the live state); log `ZERO_ERROR_RECONNECT_INITIATED` with the trigger.
- **`InitialStateLoader.tsx`**: give the `disconnected` state a single bounded (3s) reconnect nudge instead of a no-op; clear it on `connected` and on unmount.
- **`ZeroConnectionFailureModal.tsx`**: `handleRefresh()` now `window.location.reload()` instead of `logout()` (removes the `useAuth` dependency), so the user reconnects and stays signed in.

## Testing
- `tsc --noEmit` (dashboard): 0 new type errors — identical error count (406, all pre-existing `@xyne/shared` build-state debt) with and without this change; neither changed file appears in the errors.
- `eslint` on both changed files: 0 errors (remaining warnings are pre-existing in the file).
- Behavioral demo recorded: a wake fires real `online` + `visibilitychange` DOM events; old code stays "stuck on loading", new code logs `ZERO_ERROR_RECONNECT_INITIATED {trigger:NETWORK_ONLINE}` and reconnects; modal reloads instead of logging out.
- Note: a faithful end-to-end repro (real macOS suspend + authenticated live Zero session) still needs on-device verification.

## Risk / rollout
Low blast radius — three files, additive listeners and a bounded timer, all guarded to avoid churning a healthy socket. No schema or backend changes. Frontend-only; ships with the normal dashboard/Electron build.