### PR TITLE
fix: recording share 409 — preserve detailedSummaryCanvasId in Call.metadata

### DIFF
--- a/apps/backend/jest.config.cjs
+++ b/apps/backend/jest.config.cjs
@@ -16,6 +16,10 @@ module.exports = {
   coverageReporters: ['text', 'lcov', 'html'],
   setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
   moduleNameMapper: {
+    // Resolve `@/x.js` explicit-extension imports to their on-disk `.ts` source
+    // (TS ESM-style specifiers) so jest.mock() can intercept them. Must precede
+    // the generic `@/` rule below.
+    '^@/(.*)\\.js$': '<rootDir>/src/$1',
     '^@/(.*)$': '<rootDir>/src/$1',
   },
 };

--- a/apps/backend/src/controllers/recordingSharingController.ts
+++ b/apps/backend/src/controllers/recordingSharingController.ts
@@ -62,6 +62,16 @@ export class RecordingSharingController {
       res.json({ success: true, ...result });
     } catch (error) {
       if (error instanceof RecordingSharingError) {
+        // These are expected, client-facing errors (e.g. 409 "Detailed summary
+        // canvas is not ready yet"). They were previously invisible in backend
+        // logs, so a data-integrity bug behind a 409 could not be diagnosed
+        // without reconstructing it from istio + client-bridge logs.
+        logger.warn('[RecordingSharingController] recording sharing rejected', {
+          callId,
+          action: parsed.data.action,
+          status: error.status,
+          message: error.message,
+        });
         res.status(error.status).json({ success: false, message: error.message });
         return;
       }

--- a/apps/backend/src/services/noteTakerTranscriptService.finalizeMetadata.test.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.finalizeMetadata.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for the recording-share 409 bug.
+ *
+ * The detailed-summary streaming writer persists `detailedSummaryCanvasId` onto
+ * Call.metadata mid-processing (so the UI can mount the canvas). `finalizeCallUpdates`
+ * then runs at the end of processTranscript. It previously merged onto the STALE
+ * in-memory `call.metadata` snapshot captured at the start of processing and
+ * whole-column-overwrote Call.metadata — clobbering the streamed id whenever the
+ * final generation result was null (`detailedSummaryCanvasId: undefined`). The
+ * share endpoint then read an absent pointer and threw 409 "Detailed summary
+ * canvas is not ready yet" — permanently.
+ *
+ * The fix: source the merge base from a FRESH DB read, not the stale snapshot.
+ */
+
+// --- Mock the module's heavy imports so only `repositories` + `logger` matter ---
+const findByExternalId = jest.fn();
+const update = jest.fn();
+
+jest.mock('@/database/repositories', () => ({
+  repositories: { calls: { findByExternalId, update } },
+}));
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@/queues/vespaQueue', () => ({ vespaQueue: { add: jest.fn() } }));
+jest.mock('@/vespa/src/types', () => ({ fileSchema: 'file', SubApp: {} }));
+jest.mock('@/utils/distributedLock', () => ({
+  acquireLock: jest.fn(),
+  releaseLock: jest.fn(),
+}));
+jest.mock('@/services/transcriptService', () => ({ transcriptService: {} }));
+jest.mock('@/services/callDocumentService', () => ({
+  callDocumentService: {},
+  numberTranscriptSegments: jest.fn(),
+}));
+jest.mock('@/services/canvasService', () => ({ findExistingDetailedSummaryCanvas: jest.fn() }));
+jest.mock('@/bots/unified/services/unified-bot-user-service.js', () => ({
+  unifiedBotUserService: {},
+}));
+jest.mock('@/tags/service', () => ({
+  tagService: {},
+  TagServiceError: class TagServiceError extends Error {},
+}));
+jest.mock('@/database/repositories/tagRepository', () => ({ tagRepository: {} }));
+jest.mock('@xyne/shared', () => ({ TAG_FORMAT_REGEX: /.*/, TagMethod: {} }));
+
+import { noteTakerTranscriptService } from './noteTakerTranscriptService';
+
+type AnyCall = Record<string, unknown>;
+
+const invokeFinalize = (call: AnyCall, updates: unknown): Promise<void> =>
+  // finalizeCallUpdates is private; reach it directly for a focused unit test.
+  (noteTakerTranscriptService as unknown as {
+    finalizeCallUpdates: (c: AnyCall, u: unknown) => Promise<void>;
+  }).finalizeCallUpdates(call, updates);
+
+beforeEach(() => {
+  findByExternalId.mockReset();
+  update.mockReset();
+  update.mockResolvedValue({});
+});
+
+describe('finalizeCallUpdates — metadata merge does not clobber the streamed summary canvas id', () => {
+  it('preserves detailedSummaryCanvasId written mid-processing even when the final result is null', async () => {
+    // In-memory snapshot captured at processTranscript entry — predates the streaming write.
+    const staleCall: AnyCall = {
+      id: 'call-db-id',
+      externalId: 'ext-338cabed',
+      metadata: { notesCanvasId: 'notes-1' }, // NO detailedSummaryCanvasId yet
+    };
+
+    // What the DB actually holds now: the streaming writer already persisted the id.
+    findByExternalId.mockResolvedValue({
+      id: 'call-db-id',
+      externalId: 'ext-338cabed',
+      metadata: { notesCanvasId: 'notes-1', detailedSummaryCanvasId: 'summary-canvas-1' },
+    });
+
+    // generateDetailedSummaryCanvas returned null after the early persist → undefined id here.
+    await invokeFinalize(staleCall, {
+      metadata: {
+        transcriptEntryCount: 42,
+        detailedSummaryCanvasId: undefined,
+      },
+    });
+
+    expect(findByExternalId).toHaveBeenCalledWith('ext-338cabed');
+    expect(update).toHaveBeenCalledTimes(1);
+
+    const persistedMetadata = (update.mock.calls[0][1] as { metadata: Record<string, unknown> })
+      .metadata;
+
+    // The share endpoint reads exactly this key — it must survive.
+    expect(persistedMetadata.detailedSummaryCanvasId).toBe('summary-canvas-1');
+    expect(persistedMetadata.notesCanvasId).toBe('notes-1');
+    expect(persistedMetadata.transcriptEntryCount).toBe(42);
+  });
+
+  it('still writes a freshly-produced id through when generation succeeds', async () => {
+    const staleCall: AnyCall = {
+      id: 'call-db-id',
+      externalId: 'ext-1',
+      metadata: { notesCanvasId: 'notes-1' },
+    };
+    findByExternalId.mockResolvedValue({
+      id: 'call-db-id',
+      externalId: 'ext-1',
+      metadata: { notesCanvasId: 'notes-1' },
+    });
+
+    await invokeFinalize(staleCall, {
+      metadata: { transcriptEntryCount: 10, detailedSummaryCanvasId: 'summary-canvas-2' },
+    });
+
+    const persistedMetadata = (update.mock.calls[0][1] as { metadata: Record<string, unknown> })
+      .metadata;
+    expect(persistedMetadata.detailedSummaryCanvasId).toBe('summary-canvas-2');
+    expect(persistedMetadata.notesCanvasId).toBe('notes-1');
+  });
+});

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -266,9 +266,19 @@ class NoteTakerTranscriptService {
       summaryTemplateId?: string | null;
     } = {};
     if (metadataChanges.length > 0) {
+      // Re-read the LATEST metadata from the DB rather than trusting the
+      // in-memory `call` snapshot captured at the start of processTranscript.
+      // The detailed-summary streaming writer persists `detailedSummaryCanvasId`
+      // onto Call.metadata mid-processing; merging onto the stale snapshot and
+      // overwriting the whole JSON column here would clobber it, leaving the
+      // summary canvas visible in the UI but unshareable — the share endpoint
+      // then throws 409 "Detailed summary canvas is not ready yet". Sourcing the
+      // base from a fresh read preserves any key written after the snapshot.
+      const latest = await repositories.calls.findByExternalId(call.externalId);
+      const baseMetadata = latest?.metadata ?? call.metadata;
       const currentMetadata =
-        call.metadata && typeof call.metadata === 'object' && !Array.isArray(call.metadata)
-          ? (call.metadata as Record<string, unknown>)
+        baseMetadata && typeof baseMetadata === 'object' && !Array.isArray(baseMetadata)
+          ? (baseMetadata as Record<string, unknown>)
           : {};
       data.metadata = { ...currentMetadata, ...Object.fromEntries(metadataChanges) };
     }


### PR DESCRIPTION
## Problem
Sharing a recording failed with HTTP 409 "Detailed summary canvas is not ready yet", even when the detailed summary canvas had already been generated. The grant endpoint requires BOTH `notesCanvasId` AND `detailedSummaryCanvasId` in `Call.metadata`, but `detailedSummaryCanvasId` was being clobbered.

## Root cause
`finalizeCallUpdates` (noteTakerTranscriptService.ts) merged updates onto a stale in-memory snapshot of the call and then whole-column-overwrote `Call.metadata`. If the detailed-summary canvas id was written mid-processing (after the snapshot was taken), the finalize write erased it, so the share grant later saw metadata missing `detailedSummaryCanvasId` and returned 409.

## Fix
- `noteTakerTranscriptService.ts`: use a fresh DB read as the merge base in `finalizeCallUpdates` so concurrently-written canvas ids (notesCanvasId / detailedSummaryCanvasId) are preserved instead of overwritten.
- `recordingSharingController.ts`: log `RecordingSharingError` details so future 409s are diagnosable.
- Added regression test `noteTakerTranscriptService.finalizeMetadata.test.ts` (red→green) covering the mid-processing metadata-merge case; folded the `.js` mapper into `jest.config.cjs`.

## Validation
- New unit test fails on old code, passes on the fix.
- Manual end-to-end: seeded a HEADLESS call with both canvas ids, drove the real `RecordingShareModal` in the dashboard, confirmed `POST /calls/recordings/:id/sharing` returns 200 and the green "Recording shared" success toast renders.