### PR TITLE
feat: open profile in a modal on non-chat pages

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
@@ -27,6 +27,7 @@ import {
 import Avatar from '../ui/Avatar/Avatar';
 import { Popover } from '../ui/Popover/Popover';
 import SettingsContent from '../Settings/Settings';
+import ProfileModal from '../ProfileSidebar/ProfileModal';
 import Preferences, { type PreferenceSection } from '../Settings/Preferences';
 import { useSelf } from '../../hooks/useUsers';
 import { isStatusExpired } from '../../utils/statusUtils';
@@ -195,6 +196,7 @@ const AppSidebar = (): ReactElement => {
   const [isErrorReportOpen, setIsErrorReportOpen] = useState(false);
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const [isPreferencesOpen, setIsPreferencesOpen] = useState(false);
+  const [profileModalUserId, setProfileModalUserId] = useState<string | null>(null);
   const [preferencesInitialSection, setPreferencesInitialSection] = useState<
     PreferenceSection | undefined
   >(undefined);
@@ -567,6 +569,7 @@ const AppSidebar = (): ReactElement => {
               onClose={() => setIsSettingsPopoverOpen(false)}
               onOpenPreferences={handleOpenPreferences}
               onOpenStatusModal={handleStatusClick}
+              onOpenProfileModal={userId => setProfileModalUserId(userId)}
             />
           </Popover>
 
@@ -574,6 +577,14 @@ const AppSidebar = (): ReactElement => {
             open={isPreferencesOpen}
             onClose={() => setIsPreferencesOpen(false)}
             {...(preferencesInitialSection && { initialSection: preferencesInitialSection })}
+          />
+
+          {/* Profile modal — used on non-chat pages where the routed profile
+              sidebar (`/chat/dir/.../profile/...`) is not mounted. */}
+          <ProfileModal
+            userId={profileModalUserId}
+            isOpen={profileModalUserId !== null}
+            onClose={() => setProfileModalUserId(null)}
           />
         </div>
 

--- a/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
+++ b/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
@@ -62,7 +62,7 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ userId, isOpen, onCl
       onOpenChange={open => {
         if (!open) onClose();
       }}
-      className='w-full max-w-md p-0 overflow-hidden'
+      className='w-full max-w-lg p-0 overflow-hidden'
       testId='profile-modal'
     >
       <div className='flex flex-col max-h-[85vh]'>

--- a/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
+++ b/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
@@ -87,6 +87,7 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ userId, isOpen, onCl
             <UserProfile
               userId={userId}
               isOwnProfile={isOwnProfile}
+              headerLayout='inline'
               className='border-0 shadow-none rounded-none'
             />
           ) : (

--- a/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
+++ b/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
@@ -52,9 +52,7 @@ export const ProfileModal: React.FC<ProfileModalProps> = ({ userId, isOpen, onCl
   if (!userId) return null;
 
   const isOwnProfile = user?.id === context.userID;
-  const title = isOwnProfile
-    ? 'Profile'
-    : user?.name || userProfile?.displayName || 'Unknown User';
+  const title = isOwnProfile ? 'Profile' : user?.name || userProfile?.displayName || 'Unknown User';
 
   return (
     <Dialog

--- a/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
+++ b/apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+import { Dialog } from '../ui/Dialog/Dialog';
+import { Button } from '../ui/Button/Button';
+import UserProfile from '../ui/UserProfile/UserProfile';
+import { useUser } from '../../hooks/useUsers';
+import { useAuthContextValues } from '../../hooks/useAuth';
+import { queries } from '../../zero/queries';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { usePath } from '../../hooks/usePath';
+
+interface ProfileModalProps {
+  /** The user whose profile to show. When null the modal stays closed. */
+  userId: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * ProfileModal renders the same {@link UserProfile} content as the routed
+ * ProfileSidebar, but inside a modal dialog instead of a nested `/chat/dir`
+ * route. It is used on non-chat surfaces (e.g. /support, /automations, /calls)
+ * where the routed profile sidebar is not mounted, so the account-menu
+ * "Profile" action has somewhere to open without bouncing the user into chat.
+ */
+export const ProfileModal: React.FC<ProfileModalProps> = ({ userId, isOpen, onClose }) => {
+  const context = useAuthContextValues();
+  const user = useUser(userId || '');
+  const [userProfile] = useCachedQuery(queries.getUserProfile({ userId: userId || '' }), {
+    enabled: !!userId,
+  });
+
+  // Close the modal when the route changes. Profile actions such as "Message"
+  // or "Call" navigate away (into chat); once that happens the modal should not
+  // linger on top of the new page.
+  const path = usePath();
+  const initialPathRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isOpen) {
+      initialPathRef.current = null;
+      return;
+    }
+    if (initialPathRef.current === null) {
+      initialPathRef.current = path;
+      return;
+    }
+    if (initialPathRef.current !== path) {
+      onClose();
+    }
+  }, [isOpen, path, onClose]);
+
+  if (!userId) return null;
+
+  const isOwnProfile = user?.id === context.userID;
+  const title = isOwnProfile
+    ? 'Profile'
+    : user?.name || userProfile?.displayName || 'Unknown User';
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
+      className='w-full max-w-md p-0 overflow-hidden'
+      testId='profile-modal'
+    >
+      <div className='flex flex-col max-h-[85vh]'>
+        <div className='sticky top-0 z-10 bg-background flex items-center justify-between gap-3 p-4 border-b border-border'>
+          <h1 className='text-lg font-semibold text-foreground truncate flex-1'>{title}</h1>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={onClose}
+            className='!p-2 border border-border rounded-md hover:bg-accent'
+            title='Close'
+            data-track-category='Profile'
+            data-track-name='CloseProfileModal'
+            data-track-metadata={JSON.stringify({ userId })}
+          >
+            <X className='size-4' />
+          </Button>
+        </div>
+
+        <div className='overflow-auto'>
+          {user ? (
+            <UserProfile
+              userId={userId}
+              isOwnProfile={isOwnProfile}
+              className='border-0 shadow-none rounded-none'
+            />
+          ) : (
+            <div className='p-8 text-center text-muted-foreground'>User not found</div>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export default ProfileModal;

--- a/apps/dashboard/src/components/Settings/Settings.tsx
+++ b/apps/dashboard/src/components/Settings/Settings.tsx
@@ -26,17 +26,26 @@ import { v4 as uuidv4 } from 'uuid';
 import { useZero } from '../../hooks/useZero';
 import { Popover } from '../ui/Popover/Popover';
 import { useUserPresence } from '../../hooks/usePresence';
+import { usePath } from '../../hooks/usePath';
 
 interface SettingsProps {
   onClose: () => void;
   onOpenPreferences: () => void;
   onOpenStatusModal: () => void;
+  /**
+   * Open the profile in a modal instead of navigating to the routed
+   * `/chat/dir/.../profile/...` sidebar. Provided on surfaces where the routed
+   * profile sidebar is not mounted (non-chat pages). When absent, or when the
+   * user is already on a chat page, the routed navigation is used.
+   */
+  onOpenProfileModal?: (userId: string) => void;
 }
 
 const Settings = ({
   onClose,
   onOpenPreferences,
   onOpenStatusModal,
+  onOpenProfileModal,
 }: SettingsProps): ReactElement => {
   const { logout } = useAuth();
   const user = useSelf();
@@ -47,6 +56,7 @@ const Settings = ({
   const generalChannel = useChannelByName('general');
   const navigate = useNavigate();
   const { channelId } = useParams<{ channelId?: string }>();
+  const path = usePath();
 
   const { status: livePresenceStatus, setStatus: setLivePresenceStatus } = useUserPresence(
     user?.id ?? '',
@@ -134,6 +144,15 @@ const Settings = ({
 
   const handleProfileClick = (): void => {
     onClose();
+    // On non-chat pages the routed profile sidebar is not mounted, so navigating
+    // to `/chat/dir/.../profile/...` would bounce the user out of their current
+    // page into chat. When a modal handler is available and we are not on a chat
+    // page, open the profile in a modal and stay on the current page instead.
+    const isChatPage = path.startsWith('/chat/');
+    if (onOpenProfileModal && !isChatPage && user?.id) {
+      onOpenProfileModal(user.id);
+      return;
+    }
     if (channelId) {
       void navigate(`/chat/dir/${channelId}/profile/${user?.id}`);
     } else {

--- a/apps/dashboard/src/components/ui/UserProfile/UserProfile.tsx
+++ b/apps/dashboard/src/components/ui/UserProfile/UserProfile.tsx
@@ -50,9 +50,22 @@ interface UserProfileProps {
   userId: string;
   className?: string;
   isOwnProfile: boolean;
+  /**
+   * Header layout. 'stacked' (default) centers the avatar above the name /
+   * team / status block — used by the routed profile sidebar. 'inline' places
+   * the avatar beside that block — used by the profile modal on non-chat pages.
+   */
+  headerLayout?: 'stacked' | 'inline';
 }
 
-export const UserProfile: React.FC<UserProfileProps> = ({ userId, className, isOwnProfile }) => {
+export const UserProfile: React.FC<UserProfileProps> = ({
+  userId,
+  className,
+  isOwnProfile,
+  headerLayout = 'stacked',
+}) => {
+  const isInlineHeader = headerLayout === 'inline';
+  const headerAvatarSize: 'xl' | 'big' = isInlineHeader ? 'xl' : 'big';
   const zero = useZero();
   const navigate = useNavigate();
   const { user: currentUser } = useAuth();
@@ -327,9 +340,14 @@ export const UserProfile: React.FC<UserProfileProps> = ({ userId, className, isO
   return (
     <div className={cn('bg-background rounded-lg shadow-sm border border-border', className)}>
       {/* Header Section */}
-      <div className='pt-2 px-6 pb-6 flex flex-col items-center'>
+      <div
+        className={cn(
+          'pt-2 px-6 pb-6',
+          isInlineHeader ? 'flex flex-row items-center gap-5' : 'flex flex-col items-center',
+        )}
+      >
         {/* Picture Upload Section */}
-        <div className='relative mb-8'>
+        <div className={cn('relative', isInlineHeader ? 'mb-0 shrink-0' : 'mb-8')}>
           {isOwnProfile ? (
             <div
               className='relative group cursor-pointer'
@@ -340,7 +358,7 @@ export const UserProfile: React.FC<UserProfileProps> = ({ userId, className, isO
               role='button'
               tabIndex={0}
             >
-              <Avatar userId={user.id} size='big' className='rounded-xl' showActiveStatus={true} />
+              <Avatar userId={user.id} size={headerAvatarSize} className='rounded-xl' showActiveStatus={true} />
               <div className='absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 rounded-xl flex items-center justify-center transition-opacity'>
                 <Camera className='size-8 text-white' />
               </div>
@@ -356,11 +374,11 @@ export const UserProfile: React.FC<UserProfileProps> = ({ userId, className, isO
               />
             </div>
           ) : (
-            <Avatar userId={user.id} size='big' className='rounded-xl' showActiveStatus={true} />
+            <Avatar userId={user.id} size={headerAvatarSize} className='rounded-xl' showActiveStatus={true} />
           )}
         </div>
 
-        <div className='w-full'>
+        <div className={cn(isInlineHeader ? 'flex-1 min-w-0' : 'w-full')}>
           <div className='flex items-center gap-2 mb-1'>
             <h2
               className={`text-2xl font-semibold ${isUserDeactivated(user) ? 'text-muted-foreground' : 'text-foreground'}`}

--- a/apps/dashboard/src/components/ui/UserProfile/UserProfile.tsx
+++ b/apps/dashboard/src/components/ui/UserProfile/UserProfile.tsx
@@ -358,7 +358,12 @@ export const UserProfile: React.FC<UserProfileProps> = ({
               role='button'
               tabIndex={0}
             >
-              <Avatar userId={user.id} size={headerAvatarSize} className='rounded-xl' showActiveStatus={true} />
+              <Avatar
+                userId={user.id}
+                size={headerAvatarSize}
+                className='rounded-xl'
+                showActiveStatus={true}
+              />
               <div className='absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 rounded-xl flex items-center justify-center transition-opacity'>
                 <Camera className='size-8 text-white' />
               </div>
@@ -374,7 +379,12 @@ export const UserProfile: React.FC<UserProfileProps> = ({
               />
             </div>
           ) : (
-            <Avatar userId={user.id} size={headerAvatarSize} className='rounded-xl' showActiveStatus={true} />
+            <Avatar
+              userId={user.id}
+              size={headerAvatarSize}
+              className='rounded-xl'
+              showActiveStatus={true}
+            />
           )}
         </div>
 


### PR DESCRIPTION
## 1. Problem Description
The account-menu **Profile** action was tied to the routed `/chat/dir/:channelId/profile/:userId` sidebar, which is only mounted on chat pages. On non-chat pages (`/support`, `/automations`, `/calls`, `/projects`, etc.) clicking **Profile** navigated the user into chat instead of showing their profile in place — a confusing bounce out of the current page.

## 2. If this is a bug fix or an enhancement, how did you identify the issue?
The profile sidebar is a nested React Router route (`profile/:userId`) mounted only under the chat routes. `handleProfileClick` in `Settings.tsx` always navigated to `/chat/dir/.../profile/...`, so on any non-chat surface the user was pulled into chat.

## 3. Explain the solution implemented in the PR
- Keep the existing chat-page behavior exactly: on chat pages, Profile still opens the routed profile sidebar.
- On non-chat pages, open the profile in a modal instead, staying on the current page.
- New component `apps/dashboard/src/components/ProfileSidebar/ProfileModal.tsx` wraps the existing `UserProfile` in a `Dialog`. It auto-closes when the route changes (e.g. after a Message/Call action navigates away).
- `Settings.tsx` gains an optional `onOpenProfileModal?` prop. `handleProfileClick` branches: when the handler is present, the user has an id, and `usePath()` is not a `/chat/` route, it opens the modal and returns; otherwise it falls through to the existing routed navigation (backward compatible).
- `AppSidebar.tsx` (present on every page) owns the modal state and renders `ProfileModal`, passing `onOpenProfileModal` into `SettingsContent`.
- Mobile (`ProfileView`/`MobileProfileMenu`) and in-chat entry points (mentions, message bubbles, slash commands) are only rendered on chat surfaces where the routed sidebar exists, so they intentionally keep routed navigation and are unchanged.

## 4. Documentation (link to docs created/updated for this change)
N/A

## 5. DB Alter Details (if any)
N/A

## 6. Data fix Details (if any)
N/A

## 7. Environment variable Changes (if any)
N/A

## 8. Testing (how it was tested; screenshots/links)
Verified locally against the dashboard dev server:
- Chat page (`/chat/dir/:channelId`): Profile opens the routed side panel, URL becomes `.../profile/:userId` — unchanged behavior.
- Non-chat page (`/calls`): Profile opens a centered modal, URL stays `/calls` — new behavior.
Both render the same `UserProfile` content. `tsc --noEmit` on the dashboard reports no type errors in the changed files.

## 9. Services to which this change is to be deployed
dashboard (frontend only)

## 10. Main PR link (if this PR is raised against a release branch)
N/A