### PR TITLE
fix: XYNE-55778 Fix recording failure feedback display

### DIFF
--- a/apps/backend/src/controllers/noteTakerWebhookController.ts
+++ b/apps/backend/src/controllers/noteTakerWebhookController.ts
@@ -135,6 +135,16 @@ class NoteTakerWebhookController {
         // Give the metadata event a brief opportunity to reach the connected
         // recorder so it can show the specific save-failure message.
         await new Promise(resolve => setTimeout(resolve, 500));
+      } catch (notificationError) {
+        // Notification is best-effort. A failure must never prevent teardown of
+        // the ghost room below.
+        logger.error('[NoteTaker Webhook] recording_start_failure_notification_failed', {
+          room: roomName,
+          error: notificationError,
+        });
+      }
+
+      try {
         await livekitService.deleteRoom(roomName);
         logger.info('[NoteTaker Webhook] ghost_recording_terminated', {
           room: roomName,

--- a/apps/backend/src/controllers/noteTakerWebhookController.ts
+++ b/apps/backend/src/controllers/noteTakerWebhookController.ts
@@ -8,6 +8,7 @@ import { repositories } from '@/database/repositories';
 import { noteTakerCallRepository } from '@/database/repositories/noteTakerCallRepository';
 import { noteTakerTranscriptService } from '@/services/noteTakerTranscriptService';
 import { callRecordingService } from '@/services/callRecordingService';
+import { livekitService } from '@/services/liveKitService';
 import { emitCallStarted, emitCallEnded } from '@/automations/triggers/call.trigger';
 
 // Deferred the same way as the conversation-based flow's fallback reconcile —
@@ -107,15 +108,46 @@ class NoteTakerWebhookController {
     const callId = uuidv4();
     const roomLink = `${config.livekit.clientUrl}/call/${roomName}?type=AUDIO`;
 
-    const call = await noteTakerCallRepository.createCall({
-      callId,
-      roomName,
-      workspaceId,
-      createdBy,
-      notesCanvasId,
-      roomLink,
-      now: new Date(),
-    });
+    let call;
+    try {
+      call = await noteTakerCallRepository.createCall({
+        callId,
+        roomName,
+        workspaceId,
+        createdBy,
+        notesCanvasId,
+        roomLink,
+        now: new Date(),
+      });
+    } catch (error) {
+      // The recorder UI has already connected by the time this webhook arrives.
+      // Do not let it continue as a ghost recording: there is no Call row to
+      // associate its transcript, audio, or eventual stop event with.
+      logger.error('[NoteTaker Webhook] call_record_creation_failed', {
+        room: roomName,
+        workspaceId,
+        createdBy,
+        error,
+      });
+
+      try {
+        await livekitService.notifyRecordingStartFailure(roomName);
+        // Give the metadata event a brief opportunity to reach the connected
+        // recorder so it can show the specific save-failure message.
+        await new Promise(resolve => setTimeout(resolve, 500));
+        await livekitService.deleteRoom(roomName);
+        logger.info('[NoteTaker Webhook] ghost_recording_terminated', {
+          room: roomName,
+          reason: 'call_record_creation_failed',
+        });
+      } catch (deleteError) {
+        logger.error('[NoteTaker Webhook] ghost_recording_termination_failed', {
+          room: roomName,
+          error: deleteError,
+        });
+      }
+      return;
+    }
 
     logger.info(`[NoteTaker Webhook] Created note taker call record for ${roomName}`, {
       callId: call.id,

--- a/apps/backend/src/services/liveKitService.ts
+++ b/apps/backend/src/services/liveKitService.ts
@@ -291,6 +291,29 @@ export class LiveKitService {
     }
   }
 
+  /**
+   * Tell a connected note-taker client that its backing Call row could not be
+   * created. The client consumes this before the room is terminated.
+   */
+  async notifyRecordingStartFailure(roomName: string): Promise<void> {
+    const rooms = await this.roomService.listRooms([roomName]);
+    if (!rooms || rooms.length === 0) return;
+
+    const existingMetadata = parseRoomMetadata(
+      roomName,
+      rooms[0].metadata,
+      'recording_start_failure',
+    );
+    await this.roomService.updateRoomMetadata(
+      roomName,
+      JSON.stringify({
+        ...existingMetadata,
+        recordingStartFailure: true,
+        recordingStartFailureVersion: Date.now(),
+      }),
+    );
+  }
+
   async updateParticipantPublishSources(
     roomName: string,
     identity: string,

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -25,6 +25,9 @@ import { playAudio, AUDIO_PATHS } from '../utils/audioPlayer';
 
 let transcriptUnsubscribe: (() => void) | null = null;
 let transcriptIdCounter = 0;
+// `Room.disconnect()` emits Disconnected asynchronously. Mark a normal user
+// stop first so its callback cannot be mistaken for a server-side failure.
+const intentionallyDisconnectedRooms = new WeakSet<Room>();
 
 export interface TranscriptEntry {
   id: number;
@@ -258,6 +261,8 @@ export const recordingStore = createStore({
       };
 
       const handleRoomDisconnected = (): void => {
+        if (intentionallyDisconnectedRooms.delete(room)) return;
+
         const current = recordingStore.getSnapshot().context;
         if (current.room !== room || !ACTIVE_STATUSES.has(current.status)) return;
 
@@ -411,6 +416,7 @@ export const recordingStore = createStore({
 
       // Cleanup room
       if (context.room) {
+        intentionallyDisconnectedRooms.add(context.room);
         void context.room.disconnect();
       }
 

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -257,6 +257,40 @@ export const recordingStore = createStore({
         }
       };
 
+      const handleRoomDisconnected = (): void => {
+        const current = recordingStore.getSnapshot().context;
+        if (current.room !== room || !ACTIVE_STATUSES.has(current.status)) return;
+
+        const message =
+          'Recording stopped because its session was disconnected and could not be saved.';
+        logger.error(Event.RECORDING_ERROR, { error: message });
+        toast.error('Recording stopped', {
+          description: 'We could not save this recording. Please try again.',
+          duration: 6000,
+        });
+        recordingStore.send({ type: 'error', error: message });
+      };
+
+      const handleRoomMetadataChanged = (metadata: string): void => {
+        try {
+          const data = JSON.parse(metadata) as { recordingStartFailure?: unknown };
+          if (data.recordingStartFailure !== true) return;
+
+          const current = recordingStore.getSnapshot().context;
+          if (current.room !== room || !ACTIVE_STATUSES.has(current.status)) return;
+
+          const message = 'Recording could not be saved because its session could not be created.';
+          logger.error(Event.RECORDING_ERROR, { error: message });
+          toast.error('Recording stopped', {
+            description: 'We could not save this recording. Please try again.',
+            duration: 6000,
+          });
+          recordingStore.send({ type: 'error', error: message });
+        } catch {
+          // Ignore malformed room metadata.
+        }
+      };
+
       const handleDataReceived = (
         payload: Uint8Array,
         _participant?: unknown,
@@ -297,12 +331,16 @@ export const recordingStore = createStore({
       room.on(RoomEvent.DataReceived, handleDataReceived);
       room.on(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected);
       room.on(RoomEvent.ParticipantConnected, handleParticipantConnected);
+      room.on(RoomEvent.Disconnected, handleRoomDisconnected);
+      room.on(RoomEvent.RoomMetadataChanged, handleRoomMetadataChanged);
 
       transcriptUnsubscribe = (): void => {
         clearAgentLeftTimer();
         room.off(RoomEvent.DataReceived, handleDataReceived);
         room.off(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected);
         room.off(RoomEvent.ParticipantConnected, handleParticipantConnected);
+        room.off(RoomEvent.Disconnected, handleRoomDisconnected);
+        room.off(RoomEvent.RoomMetadataChanged, handleRoomMetadataChanged);
       };
 
       playAudio(AUDIO_PATHS.RECORDING_START);


### PR DESCRIPTION


https://github.com/user-attachments/assets/67630151-2640-49bf-9e70-7d6b249a3d69


Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
