### PR TITLE
fix: XYNE-55782 allow pausing steps inside control-flow branches

### DIFF
--- a/apps/backend/src/automations/engine/automation-context-storage.ts
+++ b/apps/backend/src/automations/engine/automation-context-storage.ts
@@ -4,6 +4,7 @@ export interface AutomationContextStore {
   runId: string;
   automationId: string;
   chain: readonly string[];
+  stepName?: string;
 }
 
 export const automationContextStorage = new AsyncLocalStorage<AutomationContextStore>();

--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -16,7 +16,7 @@ import type { StepRegistry } from '../steps/step-registry';
 import { BaseActionStep, BaseControlFlowStep, StepKind } from '../steps/base-step';
 import { VariableResolver, stripNullForOptionalKeys } from './variable-resolver';
 import { automationContextStorage } from './automation-context-storage';
-import { PauseStep } from './pause-step';
+import { PauseStep, type PauseBranchSegment } from './pause-step';
 import {
   isExecutableAutomationWorkflowType,
   mayDrainInFlight,
@@ -37,6 +37,23 @@ interface PreparedRun {
   startIndex: number;
   label: 'STARTED' | 'RESUMED';
   resumeAtIndex?: number;
+  resumeBranchPath?: readonly PauseBranchSegment[];
+}
+
+const PAUSE_BRANCH_PATH_KEY = '__pauseBranchPath';
+
+function readPauseBranchPath(context: AutomationContext): PauseBranchSegment[] {
+  const raw = (context as unknown as Record<string, unknown>)[PAUSE_BRANCH_PATH_KEY];
+  return Array.isArray(raw) ? (raw as PauseBranchSegment[]) : [];
+}
+
+function writePauseBranchPath(
+  context: AutomationContext,
+  path: readonly PauseBranchSegment[],
+): void {
+  const bag = context as unknown as Record<string, unknown>;
+  if (path.length === 0) delete bag[PAUSE_BRANCH_PATH_KEY];
+  else bag[PAUSE_BRANCH_PATH_KEY] = path;
 }
 
 const EXTERNAL_WAIT_STATUS = 'EXTERNAL_WAIT';
@@ -54,6 +71,26 @@ function parseStepIndexFromName(name: string): number | null {
   if (!m) return null;
   const n = Number.parseInt(m[1] as string, 10);
   return Number.isInteger(n) ? n : null;
+}
+
+function resolveBranchSteps(
+  step: AutomationStepConfig,
+  branchKey: string,
+): AutomationStepConfig[] | null {
+  const config = step.config as Record<string, unknown>;
+
+  if (branchKey === 'if_true') return (config['if_true'] as AutomationStepConfig[]) ?? null;
+  if (branchKey === 'if_false') return (config['if_false'] as AutomationStepConfig[]) ?? [];
+  if (branchKey === 'default') return (config['default'] as AutomationStepConfig[]) ?? [];
+
+  const caseMatch = /^case_(\d+)$/.exec(branchKey);
+  if (caseMatch) {
+    const cases = config['cases'] as { steps?: AutomationStepConfig[] }[] | undefined;
+    const entry = cases?.[Number.parseInt(caseMatch[1] as string, 10)];
+    return entry?.steps ?? null;
+  }
+
+  return null;
 }
 
 export class AutomationExecutor {
@@ -147,6 +184,7 @@ export class AutomationExecutor {
       config.steps,
       prep.startIndex,
       prep.resumeAtIndex,
+      prep.resumeBranchPath,
     );
   }
 
@@ -218,12 +256,15 @@ export class AutomationExecutor {
         }
       }
       const pausedIndex = pauseState.currentStepIndex;
+      const resumeBranchPath = readPauseBranchPath(initialCtx);
+      writePauseBranchPath(initialCtx, []);
       return {
         ctx: initialCtx,
         chain,
         startIndex: pausedIndex,
         label: 'RESUMED',
         resumeAtIndex: pausedIndex,
+        ...(resumeBranchPath.length > 0 ? { resumeBranchPath } : {}),
       };
     }
 
@@ -338,12 +379,13 @@ export class AutomationExecutor {
     steps: AutomationStepConfig[],
     startIndex: number,
     resumeAtIndex?: number,
+    resumeBranchPath?: readonly PauseBranchSegment[],
   ): Promise<unknown> {
     const automationId = context.automation.id;
     try {
       const walkResult = await automationContextStorage.run<Promise<WalkResult>>(
         { runId, automationId, chain },
-        () => this.walkSteps(steps, context, runId, startIndex, resumeAtIndex),
+        () => this.walkSteps(steps, context, runId, startIndex, resumeAtIndex, resumeBranchPath),
       );
 
       if (walkResult.kind === 'paused') {
@@ -387,6 +429,7 @@ export class AutomationExecutor {
     runId: string,
     startIndex: number = 0,
     resumeAtIndex?: number,
+    resumeBranchPath?: readonly PauseBranchSegment[],
   ): Promise<WalkResult> {
     for (let i = startIndex; i < steps.length; i++) {
       const step = steps[i] as AutomationStepConfig;
@@ -398,13 +441,23 @@ export class AutomationExecutor {
       }
 
       try {
-        await this.executeStep(step, context, { runId, stepName, isResuming });
+        await this.executeStep(step, context, {
+          runId,
+          stepName,
+          isResuming,
+          ...(isResuming && resumeBranchPath && resumeBranchPath.length > 0
+            ? { resumeBranchPath }
+            : {}),
+        });
 
         const stepCtxEntry = context.steps[step.id];
         await this.markStepCompleted(runId, stepName, stepCtxEntry);
       } catch (err) {
         if (PauseStep.is(err)) {
-          await this.markStepWaiting(runId, stepName, context.steps[step.id], err.statePatch);
+          if (err.branchPath.length === 0) {
+            await this.markStepWaiting(runId, stepName, context.steps[step.id], err.statePatch);
+          }
+          writePauseBranchPath(context, err.branchPath);
           await persistAutomationPauseState(runId, {
             context: JSON.stringify(context),
             currentStepIndex: i,
@@ -426,20 +479,44 @@ export class AutomationExecutor {
   private async walkNestedBranch(
     steps: AutomationStepConfig[],
     context: AutomationContext,
+    runId: string,
+    parentStepName: string,
+    branchKey: string,
+    resumePath: readonly PauseBranchSegment[] = [],
   ): Promise<void> {
-    for (const step of steps) {
+    const [resumeHere, ...deeperResume] = resumePath;
+    const startIndex =
+      resumeHere && resumeHere.branchKey === branchKey ? resumeHere.index : 0;
+
+    for (let j = startIndex; j < steps.length; j++) {
+      const step = steps[j] as AutomationStepConfig;
+      const stepName = `${parentStepName}__${branchKey}__step_${j}`;
+      const isResuming = startIndex === j && resumeHere?.branchKey === branchKey;
+
+      if (!isResuming) {
+        await this.upsertStepRow(runId, stepName, step, 'RUNNING', null);
+      }
+
       try {
         await this.executeStep(step, context, {
-          runId: '',
-          stepName: '',
-          isResuming: false,
+          runId,
+          stepName,
+          isResuming,
+          ...(isResuming && deeperResume.length > 0 ? { resumeBranchPath: deeperResume } : {}),
         });
+        await this.markStepCompleted(runId, stepName, context.steps[step.id]);
       } catch (err) {
         if (PauseStep.is(err)) {
-          throw new Error(
-            `Step "${step.id}" (${step.type}) tried to pause inside a control-flow branch. Pausing is only supported at the top level — restructure the automation so the waiting step is not nested.`,
-          );
+          await this.markStepWaiting(runId, stepName, context.steps[step.id], err.statePatch);
+          err.branchPath.unshift({ branchKey, index: j, stepName });
+          throw err;
         }
+        await this.markStepFailed(
+          runId,
+          stepName,
+          err instanceof Error ? err.message : String(err),
+          context.steps[step.id],
+        );
         throw err;
       }
     }
@@ -536,7 +613,12 @@ export class AutomationExecutor {
   private async executeStep(
     step: AutomationStepConfig,
     context: AutomationContext,
-    callCtx: { runId: string; stepName: string; isResuming: boolean },
+    callCtx: {
+      runId: string;
+      stepName: string;
+      isResuming: boolean;
+      resumeBranchPath?: readonly PauseBranchSegment[];
+    },
   ): Promise<void> {
     const stepImpl = this.stepRegistry.get(step.type);
 
@@ -552,9 +634,36 @@ export class AutomationExecutor {
         );
       }
       const t0 = Date.now();
+
+      if (callCtx.isResuming && callCtx.resumeBranchPath && callCtx.resumeBranchPath.length > 0) {
+        const [segment, ...deeper] = callCtx.resumeBranchPath;
+        const branchSteps = resolveBranchSteps(step, segment!.branchKey);
+        if (!branchSteps) {
+          throw new Error(
+            `Step "${step.id}" (${step.type}) cannot resume: branch "${segment!.branchKey}" no longer exists in the automation.`,
+          );
+        }
+        logger.info(
+          `[automations] step RESUME id=${step.id} type=${step.type} branch=${segment!.branchKey} at=${segment!.index}`,
+        );
+        await this.walkNestedBranch(
+          branchSteps,
+          context,
+          callCtx.runId,
+          callCtx.stepName,
+          segment!.branchKey,
+          [segment!, ...deeper],
+        );
+        logger.info(
+          `[automations] step OK    id=${step.id} type=${step.type} elapsedMs=${Date.now() - t0}`,
+        );
+        return;
+      }
+
       logger.info(`[automations] step START id=${step.id} type=${step.type}`);
       const output = await controlImpl.execute(safeResult.data, context, {
-        walkBranch: (steps, ctx) => this.walkNestedBranch(steps, ctx),
+        walkBranch: (steps, ctx, branchKey) =>
+          this.walkNestedBranch(steps, ctx, callCtx.runId, callCtx.stepName, branchKey),
       });
       context.steps[step.id] = { type: step.type, output };
       logger.info(
@@ -590,9 +699,14 @@ export class AutomationExecutor {
       `[automations] step ${callCtx.isResuming ? 'RESUME' : 'START'} id=${step.id} type=${step.type}`,
     );
     try {
-      const output = callCtx.isResuming
-        ? await this.invokeResume(actionImpl, callCtx.runId, callCtx.stepName, resolvedInput, context)
-        : await actionImpl.execute(resolvedInput, context);
+      const parentStore = automationContextStorage.getStore();
+      const output = await automationContextStorage.run(
+        { ...parentStore!, stepName: callCtx.stepName },
+        async () =>
+          callCtx.isResuming
+            ? this.invokeResume(actionImpl, callCtx.runId, callCtx.stepName, resolvedInput, context)
+            : actionImpl.execute(resolvedInput, context),
+      );
       context.steps[step.id] = { type: step.type, input: persistedInput, output };
       logger.info(
         `[automations] step OK    id=${step.id} type=${step.type} elapsedMs=${Date.now() - t0}`,

--- a/apps/backend/src/automations/engine/condition-evaluator.ts
+++ b/apps/backend/src/automations/engine/condition-evaluator.ts
@@ -1,6 +1,6 @@
 import type { Condition, LeafCondition } from '../types/automation-config';
 import type { AutomationContext } from '../types/context';
-import { ConditionOperator } from '../types/operators';
+import { compileConditionRegex, ConditionOperator } from '../types/operators';
 import { extractRefPath, isPureRef } from '../util/variable-ref';
 import { logger } from '@/utils/logger';
 
@@ -100,6 +100,17 @@ function applyOperator(
       }
       if (Array.isArray(resolved)) return resolved.includes(refValue);
       return false;
+
+    case ConditionOperator.MATCHES_REGEX:
+      if (typeof resolved !== 'string' || typeof refValue !== 'string') return false;
+      {
+        const regex = compileConditionRegex(refValue);
+        if (!regex) {
+          logger.info('[CONDITION] matches_regex — invalid pattern, result=false');
+          return false;
+        }
+        return regex.test(resolved);
+      }
 
     case ConditionOperator.GT:
     case ConditionOperator.GTE:

--- a/apps/backend/src/automations/engine/pause-step.ts
+++ b/apps/backend/src/automations/engine/pause-step.ts
@@ -1,6 +1,13 @@
+export interface PauseBranchSegment {
+  branchKey: string;
+  index: number;
+  stepName: string;
+}
+
 export class PauseStep extends Error {
   readonly externalRef: string | undefined;
   readonly statePatch: Record<string, unknown> | undefined;
+  readonly branchPath: PauseBranchSegment[] = [];
 
   constructor(
     reason: string,

--- a/apps/backend/src/automations/routes/automation.routes.ts
+++ b/apps/backend/src/automations/routes/automation.routes.ts
@@ -60,6 +60,7 @@ const OPERATOR_METADATA: Record<
   [ConditionOperator.EQ]: { label: 'equals', valueType: 'string' },
   [ConditionOperator.NEQ]: { label: 'does not equal', valueType: 'string' },
   [ConditionOperator.CONTAINS]: { label: 'contains', valueType: 'string' },
+  [ConditionOperator.MATCHES_REGEX]: { label: 'matches regex', valueType: 'string' },
   [ConditionOperator.GT]: { label: 'is greater than', valueType: 'number' },
   [ConditionOperator.GTE]: { label: 'is greater than or equal to', valueType: 'number' },
   [ConditionOperator.LT]: { label: 'is less than', valueType: 'number' },

--- a/apps/backend/src/automations/steps/base-step.ts
+++ b/apps/backend/src/automations/steps/base-step.ts
@@ -5,7 +5,11 @@ import type { AutomationStepConfig } from '../types/automation-config';
 import { StepCategory } from '../types/categories';
 
 export interface ControlFlowExecutionContext {
-  walkBranch(steps: AutomationStepConfig[], context: AutomationContext): Promise<void>;
+  walkBranch(
+    steps: AutomationStepConfig[],
+    context: AutomationContext,
+    branchKey: string,
+  ): Promise<void>;
 }
 
 export enum StepKind {

--- a/apps/backend/src/automations/steps/conditional.step.ts
+++ b/apps/backend/src/automations/steps/conditional.step.ts
@@ -38,7 +38,7 @@ export class ConditionalStep extends BaseControlFlowStep<typeof ConditionalConfi
   ): Promise<ConditionalOutput> {
     const result = this.evaluator.evaluate(config.condition, context);
     const branch = (result ? config.if_true : (config.if_false ?? [])) as AutomationStepConfig[];
-    await ctx.walkBranch(branch, context);
+    await ctx.walkBranch(branch, context, result ? 'if_true' : 'if_false');
     return { result };
   }
 }

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -71,7 +71,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const agentSlug = cfg.agentSlug as string;
     const prompt = cfg.prompt as string;
     const spacesAppId = await resolveSpacesAppId(cfg, agentSlug, context.automation.workspaceId);
-    const runUserId = await resolveRunUserId(spacesAppId, context.automation.createdById);
+    const runUserId = resolveAutomationRunUserId(context);
     const identityContext = await resolveHeadlessIdentityContext(runUserId, context.automation.workspaceId);
     const visibleContext = resolveVisibleConversationContext(context);
 
@@ -180,7 +180,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
       cfg.outputSchema ?? {},
     );
     const spacesAppId = await resolveSpacesAppId(cfg, agentSlug, context.automation.workspaceId);
-    const runUserId = await resolveRunUserId(spacesAppId, context.automation.createdById);
+    const runUserId = resolveAutomationRunUserId(context);
     const identityContext = await resolveHeadlessIdentityContext(runUserId, context.automation.workspaceId);
     const callbackUrl = buildCallbackUrl(store.runId, stepName);
     const visibleContext = resolveVisibleConversationContext(context);
@@ -233,6 +233,22 @@ function resolveVisibleConversationContext(
 
 function asNonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Attribute an automation agent run to the human who caused it. Pending write
+ * actions are signed for this user, and only that user can approve them.
+ * Event-less triggers fall back to the automation creator.
+ */
+function resolveAutomationRunUserId(context: AutomationContext): string {
+  const trigger = context.trigger as Record<string, unknown>;
+  const performedBy = trigger.performedBy as Record<string, unknown> | undefined;
+
+  return (
+    asNonEmptyString(trigger.authorId) ??
+    asNonEmptyString(performedBy?.id) ??
+    context.automation.createdById
+  );
 }
 
 function buildCallbackUrl(executionId: string, stepName: string): string {
@@ -306,25 +322,6 @@ async function appBelongsToWorkspace(appId: string, workspaceId: string): Promis
     select: { id: true },
   });
   return Boolean(member);
-}
-
-async function resolveRunUserId(spacesAppId: string, fallbackUserId: string): Promise<string> {
-  try {
-    const install = await db.installedApps.findFirst({
-      where: { appId: spacesAppId },
-      select: { userId: true },
-    });
-    if (install?.userId) return install.userId;
-    logger.info(
-      `[RUN_AGENT] app ${spacesAppId} has no installation — attributing to automation creator ${fallbackUserId}`,
-    );
-  } catch (err) {
-    logger.warn(
-      `[RUN_AGENT] failed to resolve app user for ${spacesAppId}; falling back to creator:`,
-      err,
-    );
-  }
-  return fallbackUserId;
 }
 
 /**

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -63,11 +63,10 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
       );
     }
 
-    const stepCount = Object.keys(context.steps).length;
-    const currentIndex = Math.max(0, stepCount - 1);
+    const stepName = store.stepName ?? `step_${Math.max(0, Object.keys(context.steps).length - 1)}`;
 
-    const sessionId = `${store.runId}:step_${currentIndex}`;
-    const callbackUrl = buildCallbackUrl(store.runId, `step_${currentIndex}`);
+    const sessionId = `${store.runId}:${stepName}`;
+    const callbackUrl = buildCallbackUrl(store.runId, stepName);
 
     const agentSlug = cfg.agentSlug as string;
     const prompt = cfg.prompt as string;
@@ -77,7 +76,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const visibleContext = resolveVisibleConversationContext(context);
 
     logger.info(
-      `[RUN_AGENT] firing — executionId=${store.runId} stepIndex=${currentIndex} agentSlug=${agentSlug} sessionId=${sessionId} userId=${runUserId}`,
+      `[RUN_AGENT] firing — executionId=${store.runId} stepName=${stepName} agentSlug=${agentSlug} sessionId=${sessionId} userId=${runUserId}`,
     );
 
     try {
@@ -93,7 +92,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
       });
     } catch (err) {
       logger.error(
-        `[RUN_AGENT] claw rejected the run — executionId=${store.runId} stepIndex=${currentIndex}:`,
+        `[RUN_AGENT] claw rejected the run — executionId=${store.runId} stepName=${stepName}:`,
         err,
       );
       throw err;
@@ -166,7 +165,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const stepName =
       typeof rowData['stepName'] === 'string'
         ? (rowData['stepName'] as string)
-        : deriveStepNameFromCtx(context);
+        : (store.stepName ?? deriveStepNameFromCtx(context));
     if (!stepName) {
       throw new Error('[RUN_AGENT] cannot derive stepName for retry');
     }

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -127,7 +127,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     );
 
     try {
-      const parsed = parseAgentJson(rawResult);
+      const parsed = coerceAgentResult(rawResult);
       assertMatchesSchema(parsed, declaredSchema);
       if (attachments.length === 0) return parsed as RunAgentOutput;
       if ('attachments' in parsed) {
@@ -222,12 +222,16 @@ function resolveVisibleConversationContext(
   context: AutomationContext,
 ): { conversationId: string; channelId: string } | null {
   const trigger = context.trigger as Record<string, unknown> | undefined;
+  const message = trigger?.message as Record<string, unknown> | undefined;
+  const ticket = trigger?.ticket as Record<string, unknown> | undefined;
   const conversationId =
     asNonEmptyString(trigger?.conversationId) ??
-    asNonEmptyString((trigger?.message as Record<string, unknown> | undefined)?.conversationId);
+    asNonEmptyString(message?.conversationId) ??
+    asNonEmptyString(ticket?.conversationId);
   const channelId =
     asNonEmptyString(trigger?.channelId) ??
-    asNonEmptyString((trigger?.message as Record<string, unknown> | undefined)?.channelId);
+    asNonEmptyString(message?.channelId) ??
+    asNonEmptyString(ticket?.channelId);
   return conversationId && channelId ? { conversationId, channelId } : null;
 }
 
@@ -383,6 +387,17 @@ function parseAgentJson(raw: unknown): Record<string, unknown> {
     throw new Error('result is not a JSON object');
   }
   return parsed as Record<string, unknown>;
+}
+
+function coerceAgentResult(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  try {
+    return parseAgentJson(raw);
+  } catch {
+    return { result: typeof raw === 'string' ? raw : String(raw ?? '') };
+  }
 }
 
 function stripJsonFence(text: string): string {

--- a/apps/backend/src/automations/steps/switch.step.ts
+++ b/apps/backend/src/automations/steps/switch.step.ts
@@ -45,12 +45,12 @@ export class SwitchStep extends BaseControlFlowStep<typeof SwitchConfigSchema, S
       const caseEntry = config.cases[i]!;
       const matched = this.evaluator.evaluate(caseEntry.condition, context);
       if (matched) {
-        await ctx.walkBranch(caseEntry.steps as AutomationStepConfig[], context);
+        await ctx.walkBranch(caseEntry.steps as AutomationStepConfig[], context, `case_${i}`);
         return { matchedIndex: i };
       }
     }
     // No case matched — run default branch
-    await ctx.walkBranch(config.default as AutomationStepConfig[], context);
+    await ctx.walkBranch(config.default as AutomationStepConfig[], context, 'default');
     return { matchedIndex: -1 };
   }
 }

--- a/apps/backend/src/automations/types/automation-config.ts
+++ b/apps/backend/src/automations/types/automation-config.ts
@@ -2,8 +2,9 @@ import { z } from 'zod';
 import type { TriggerType } from './trigger-types';
 import type { StepType } from './step-types';
 import { ControlFlowStepType } from './known-types';
-import { ConditionOperator, ConditionOperatorSchema } from './operators';
+import { compileConditionRegex, ConditionOperator, ConditionOperatorSchema } from './operators';
 import { TAG_FORMAT_REGEX } from '@xyne/shared';
+import { isPureRef } from '../util/variable-ref';
 
 function isValidHasTagValue(value: unknown): boolean {
   if (typeof value !== 'string') return false;
@@ -71,6 +72,17 @@ export const LeafConditionSchema: z.ZodType<LeafCondition> = z.object({
       code: z.ZodIssueCode.custom,
       path: ['value'],
       message: 'has_tag value must be "category:any|all:tag1,tag2,..." with valid tag names',
+    });
+  }
+  if (
+    val.operator === ConditionOperator.MATCHES_REGEX &&
+    (typeof val.value !== 'string' ||
+      (!isPureRef(val.value) && compileConditionRegex(val.value) === null))
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['value'],
+      message: 'matches_regex value must be a valid pattern such as "call\\s+now" or "/call/i"',
     });
   }
 });

--- a/apps/backend/src/automations/types/operators.ts
+++ b/apps/backend/src/automations/types/operators.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod';
 
+const MAX_CONDITION_REGEX_LENGTH = 500;
+const CONDITION_REGEX_FLAGS = /^[imsu]*$/;
+
 export enum ConditionOperator {
   EQ = 'eq',
   NEQ = 'neq',
   CONTAINS = 'contains',
+  MATCHES_REGEX = 'matches_regex',
   GT = 'gt',
   GTE = 'gte',
   LT = 'lt',
@@ -17,3 +21,30 @@ export const ConditionOperatorSchema = z.nativeEnum(ConditionOperator);
 export const VALUE_LESS_OPERATORS: ReadonlySet<ConditionOperator> = new Set([
   ConditionOperator.EXISTS,
 ]);
+
+/**
+ * Compile either a raw pattern (`call\\s+now`) or JavaScript-style pattern
+ * (`/call\\s+now/i`). Global/sticky flags are intentionally not accepted so
+ * repeated automation evaluations stay deterministic.
+ */
+export function compileConditionRegex(value: string): RegExp | null {
+  let source = value;
+  let flags = '';
+
+  if (value.startsWith('/')) {
+    const closingSlash = value.lastIndexOf('/');
+    if (closingSlash > 0) {
+      source = value.slice(1, closingSlash);
+      flags = value.slice(closingSlash + 1);
+    }
+  }
+
+  if (!source || source.length > MAX_CONDITION_REGEX_LENGTH) return null;
+  if (!CONDITION_REGEX_FLAGS.test(flags) || new Set(flags).size !== flags.length) return null;
+
+  try {
+    return new RegExp(source, flags);
+  } catch {
+    return null;
+  }
+}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.utils.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.utils.ts
@@ -49,6 +49,7 @@ const OPERATOR_VERBS: Record<string, string> = {
   eq: 'equals',
   neq: 'does not equal',
   contains: 'contains',
+  matches_regex: 'matches regex',
   gt: '>',
   gte: '≥',
   lt: '<',

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -861,6 +861,65 @@ async function pendingActionTargetValidation(
   }
 }
 
+async function postPendingWriteApprovalCards(
+  pendingActions: Array<Record<string, unknown>> | undefined,
+  ctx: SessionContext,
+  appToken: string,
+): Promise<number> {
+  if (!pendingActions?.length) return 0;
+  if (!ctx.channelId || !ctx.conversationId) {
+    clog.warn(
+      `[webhook/result] cannot post ${pendingActions.length} write approval card(s): originating thread context is missing`,
+    );
+    return 0;
+  }
+
+  let approvalCardsSent = 0;
+  for (const action of pendingActions) {
+    const targetValidation = await pendingActionTargetValidation(action, ctx, appToken);
+    if (targetValidation.error) {
+      clog.info(`[webhook/result] skipped write approval card tool=${String(action["tool"] ?? "")}: ${targetValidation.error}`);
+      continue;
+    }
+
+    const params = recordParam(action["params"]);
+    const actionDesc = formatActionDescription(String(action["tool"] ?? ""), params, targetValidation);
+    const writeFlow = withSpacesAppId(buildWriteApprovalFlow(actionDesc, {
+      serverType: String(action["serverType"] ?? ""),
+      tool: String(action["tool"] ?? ""),
+      params,
+      userId: String(action["userId"] ?? ""),
+      signature: String(action["signature"] ?? ""),
+      agentSlug: ctx.agentSlug ?? "",
+      channelId: ctx.channelId,
+      conversationId: ctx.conversationId,
+    }), ctx.spacesAppId);
+
+    if (action["tool"] === "spaces-memory-create" && params["content"]) {
+      const memContent = String(params["content"]);
+      const memDocType = typeof params["docType"] === "string" ? params["docType"] : "fact";
+      const form = new FormData();
+      const blob = new Blob([memContent], { type: "text/markdown" });
+      form.append("files", blob, `memory-${memDocType}-${Date.now()}.md`);
+      form.append("channelId", ctx.channelId);
+      form.append("conversationId", ctx.conversationId);
+      form.append("userId", ctx.spacesAppUserId);
+      form.append("flow", JSON.stringify(writeFlow));
+      await spacesAppFetchMultipart("/files/filesUpload", form, appToken);
+    } else {
+      await spacesAppFetch("/chat/postMessage", {
+        channelId: ctx.channelId,
+        conversationId: ctx.conversationId,
+        flow: writeFlow,
+        userId: ctx.spacesAppUserId,
+      }, appToken);
+    }
+    approvalCardsSent += 1;
+  }
+
+  return approvalCardsSent;
+}
+
 /**
  * Digital Twin (approval mode): open a DM with the mentioned user and send the
  * agent's result as an approve/decline flow — with attachments when present.
@@ -4722,6 +4781,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     };
     attachments?: Array<{ fileName: string; mimeType: string; data: string }>;
     pendingResponses?: Array<{ responseId: string; message: string }>;
+    pendingActions?: Array<Record<string, unknown>>;
     // Set when the worker called the suggest-goal tool. claw-auth renders a
     // one-click button below the agent's reply so the user can promote the
     // remaining work to a /goal autonomous loop. See start-goal handling in
@@ -5665,6 +5725,18 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // self-heals instead of its caller receiving a blank and nobody retrying.
     if (payload.emptyReason === "provider_capacity" && !forwardText.trim()) {
       await scheduleCapacityRetryIfNeeded(ctx, payload, false).catch(() => false);
+    }
+    if (payload.pendingActions?.length) {
+      try {
+        const approvalCardsSent = await postPendingWriteApprovalCards(payload.pendingActions, ctx, ctx.appToken);
+        log.info(`Automation: posted ${approvalCardsSent}/${payload.pendingActions.length} write action approval(s) in thread ${ctx.conversationId}`);
+      } catch (err) {
+        // Keep forwarding the automation result if Spaces temporarily rejects a
+        // card post. The pending action remains unexecuted and fail-closed.
+        log.warn("Automation: failed to post write action approval card", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
     await forwardResult(ctx.resultForwardUrl, payload, forwardText);
     return;


### PR DESCRIPTION
A RUN_AGENT nested inside a Switch case or Conditional branch failed the moment its case matched:
[POT](https://drive.google.com/file/d/1zosWfL0Sn5T3-t2XtDbJOnv53zc3D_cv/view?usp=sharing) Automation showing the agents run step inside if..else
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code lef
output of agent
<img width="1728" height="1117" alt="Screenshot 2026-09-07 at 2 32 46 PM" src="https://github.com/user-attachments/assets/a6255386-7654-409e-9450-e9a740d9f4cd" />
t behind
