### PR TITLE
fix: restrict Threads inbox API to channel membership

### DIFF
--- a/apps/backend/src/database/repositories/conversationParticipantRepository.ts
+++ b/apps/backend/src/database/repositories/conversationParticipantRepository.ts
@@ -301,8 +301,21 @@ export class ConversationParticipantRepository extends BaseRepository<
       userId,
       isSubscribed: true,
       lastReplyAt: { not: null },
-      // Skip orphan participants so a missing required conversation does not fail the entire query.
-      conversation: { is: {} },
+      // Restrict the Threads inbox to channels the user actually belongs to.
+      // A participant row alone (e.g. created by an @mention) is not enough: the
+      // shared ConversationParticipantsACL allows any PUBLIC channel, so without
+      // this predicate a user sees threads in public channels they never joined.
+      // Requiring channel membership here (ANDed with the ACL) also skips orphan
+      // participants whose required conversation is missing.
+      conversation: {
+        is: {
+          channel: {
+            is: {
+              participants: { some: { userId } },
+            },
+          },
+        },
+      },
       ...sectionWhere,
     });
 


### PR DESCRIPTION
## Problem
The Threads inbox endpoint `GET /api/conversations/threads` (`getUserThreads` → `ConversationParticipantRepository.findUserThreadsPage` → `findUserThreadSection`) listed every thread the user had a `conversationParticipant` row for. The shared `ConversationParticipantsACL` non-guest branch allows **any `PUBLIC` channel OR channels the user is a member of**. Because an `@mention` inserts a `conversationParticipant` row for the mentioned user, a user could see threads in public channels they never joined.

Reported: "Why am I getting thread messages for a public channel I am not part of?"

## Fix
Add a channel-membership predicate to `findUserThreadSection` in `apps/backend/src/database/repositories/conversationParticipantRepository.ts`. The thread's channel must include the user as a participant (`conversation.channel.participants.some.userId`). Because `applyToWhere` ANDs this with the existing ACL, the `PUBLIC`-channel branch is tightened to require membership. This also subsumes the previous `conversation: { is: {} }` orphan-skip.

## Behavior change / trade-off
A user who is `@mentioned` in a public channel they have NOT joined will no longer see that thread in their Threads inbox. This is the intended restriction. Notifications for the mention are unaffected (separate path). If we later want "mentioned-but-not-a-member" threads to still appear, that becomes an explicit opt-in rather than the default.

## Scope
- Only the Threads inbox list query changed. The shared ACL is intentionally left unchanged to avoid altering Zero sync / notification read paths.
- Sibling endpoint `getConversationMessage` still only membership-checks PRIVATE channels; not touched here (out of scope for this request).

## Validation
- `tsc --noEmit` passes for `apps/backend`.
- Manual: as a user who is NOT a member of a public channel but IS a conversationParticipant (via mention), the thread should no longer appear in `GET /api/conversations/threads`; as a channel member it still appears.