### PR TITLE
fix: guard app navigator history buttons

### DIFF
--- a/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
+++ b/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
@@ -1,5 +1,5 @@
-import { ReactElement } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { ReactElement, useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeft, ArrowRight, SearchBig } from '@xyne/icons';
 import { invokeShortcut } from '../../shortcuts';
 import { cn } from '../../utils/classNames';
@@ -10,6 +10,17 @@ const buttonClass = cn(
   'text-sidebar-secondary-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent',
 );
 
+const disabledButtonClass = cn(
+  buttonClass,
+  'cursor-not-allowed opacity-50 hover:bg-transparent hover:text-sidebar-secondary-foreground',
+);
+
+const getHistoryIndex = (): number => {
+  const historyState = window.history.state as { idx?: unknown } | null;
+  const index = historyState?.idx;
+  return typeof index === 'number' ? index : 0;
+};
+
 /**
  * Top-bar navigation cluster: history back/forward and the global (cmd+k) search.
  * Matches the Agent Hub navigator frame — back and forward sit adjacent, with the
@@ -17,6 +28,30 @@ const buttonClass = cn(
  */
 const AppNavigator = (): ReactElement => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const [historyIndex, setHistoryIndex] = useState(getHistoryIndex);
+  const maxHistoryIndexRef = useRef(historyIndex);
+
+  useEffect(() => {
+    const nextHistoryIndex = getHistoryIndex();
+    maxHistoryIndexRef.current = Math.max(maxHistoryIndexRef.current, nextHistoryIndex);
+    setHistoryIndex(nextHistoryIndex);
+  }, [location.key]);
+
+  const canGoBack = historyIndex > 0;
+  const canGoForward = historyIndex < maxHistoryIndexRef.current;
+
+  const handleGoBack = (): void => {
+    if (canGoBack) {
+      void navigate(-1);
+    }
+  };
+
+  const handleGoForward = (): void => {
+    if (canGoForward) {
+      void navigate(1);
+    }
+  };
 
   return (
     <div
@@ -27,8 +62,9 @@ const AppNavigator = (): ReactElement => {
         <button
           type='button'
           aria-label='Back'
-          onClick={() => void navigate(-1)}
-          className={buttonClass}
+          onClick={handleGoBack}
+          disabled={!canGoBack}
+          className={canGoBack ? buttonClass : disabledButtonClass}
           data-track-category='APP_NAVIGATOR'
           data-track-name='GO_BACK'
         >
@@ -37,8 +73,9 @@ const AppNavigator = (): ReactElement => {
         <button
           type='button'
           aria-label='Forward'
-          onClick={() => void navigate(1)}
-          className={buttonClass}
+          onClick={handleGoForward}
+          disabled={!canGoForward}
+          className={canGoForward ? buttonClass : disabledButtonClass}
           data-track-category='APP_NAVIGATOR'
           data-track-name='GO_FORWARD'
         >


### PR DESCRIPTION
## Summary
- Guard AppNavigator Back/Forward buttons with React Router history index (`window.history.state.idx`).
- Disable/no-op Back on a fresh direct open where `idx <= 0` so the app does not navigate out of the workspace shell into an unrecoverable route.
- Track the max in-app history index to enable Forward only after the user has moved back.

## RCA
The AppNavigator Back button called `navigate(-1)` unconditionally. On a fresh direct open there is no in-app history (`history.state.idx === 0`), so clicking Back can leave the Xyne Spaces app route/shell and make reload/force reload preserve the bad route. Existing code elsewhere already treats `history.state.idx` as the reliable guard because `history.length` is unsafe.

## Code references
- `apps/dashboard/src/components/AppNavigator/AppNavigator.tsx`: adds `getHistoryIndex`, `canGoBack`, `canGoForward`, guarded handlers, and disabled states.
- Existing pattern referenced during investigation: `apps/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx`.

## Verification
- PASS: `pnpm --filter xyne-spaces-dashboard exec prettier --write src/components/AppNavigator/AppNavigator.tsx`
- PASS: `pnpm --filter xyne-spaces-dashboard exec eslint src/components/AppNavigator/AppNavigator.tsx`
- PASS: `git diff --check`
- PASS: Browser POT from earlier run:
  - TC1 Direct Open No History: Back disabled on chat route; route unchanged after disabled click.
  - TC2 In-App History Preserved: Back enabled on DMs and returns to Chat.
  - POT verifier result: PASSED, video evidence recorded.

## Note on hooks / CI
Commit was made with `--no-verify` at Sithaarth's request because the local Husky pre-commit hook runs repo-wide dashboard lint and was blocked by unrelated existing errors in files outside this patch. CI should run the same checks and surface any remaining repo-wide failures.
