### PR TITLE
feat: add tray icon and recording pill in toggle settings

### DIFF
--- a/apps/dashboard/src/components/Settings/MenuBarIconToggle.tsx
+++ b/apps/dashboard/src/components/Settings/MenuBarIconToggle.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from 'react';
+import { Switch } from '../ui/Switch';
+import { useTraySettings } from '../../hooks/useTraySettings';
+
+export function MenuBarIconToggle(): ReactElement | null {
+  const { trayVisible, isSupported, setTrayVisible } = useTraySettings();
+
+  if (!isSupported) return null;
+
+  const isMac = window.electronAPI?.platform === 'darwin';
+  const surface = isMac ? 'menu bar' : 'system tray';
+
+  return (
+    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+      <div>
+        <p className='text-sm font-medium text-foreground'>
+          {isMac ? 'Menu bar icon' : 'System tray icon'}
+        </p>
+        <p className='text-xs text-muted-foreground mt-0.5'>
+          Show the Xyne icon in your {surface} for quick recording controls. Hiding it does not
+          affect the recording keyboard shortcut.
+        </p>
+      </div>
+      <Switch
+        id='menu-bar-icon'
+        aria-label={`Show ${surface} icon`}
+        checked={trayVisible}
+        onCheckedChange={setTrayVisible}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -44,6 +44,8 @@ import { linkOpenPrefIsRelevant } from '../../../utils/openLink';
 import { logger } from '../../../utils/logger';
 
 import { MeetingDetectionToggle } from '../MeetingDetectionToggle';
+import { MenuBarIconToggle } from '../MenuBarIconToggle';
+import { RecordingPillToggle } from '../RecordingPillToggle';
 import { ClawOverlayToggle } from '../ClawOverlayToggle';
 import { UpdateAssignmentStatusModal } from '../../AppSidebar/UpdateAssignmentStatusModal';
 import { VoiceSignatureModal } from '../VoiceSignatureModal/VoiceSignatureModal';
@@ -619,6 +621,10 @@ const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => (
         onCheckedChange={checked => state.setRecordingVersion(checked ? 'v2' : 'v1')}
       />
     </div>
+
+    <MenuBarIconToggle />
+
+    <RecordingPillToggle />
 
     {/* Recording section divider */}
     <div className='pt-2'>

--- a/apps/dashboard/src/components/Settings/RecordingPillToggle.tsx
+++ b/apps/dashboard/src/components/Settings/RecordingPillToggle.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from 'react';
+import { Switch } from '../ui/Switch';
+import { useRecordingPillSettings } from '../../hooks/useRecordingPillSettings';
+
+export function RecordingPillToggle(): ReactElement | null {
+  const { pillEnabled, isSupported, setPillEnabled } = useRecordingPillSettings();
+
+  if (!isSupported) return null;
+
+  return (
+    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+      <div>
+        <p className='text-sm font-medium text-foreground'>Floating recording pill</p>
+        <p className='text-xs text-muted-foreground mt-0.5'>
+          Show a draggable pill with the timer and recording controls when Xyne is in the background
+        </p>
+      </div>
+      <Switch
+        id='recording-pill'
+        aria-label='Show floating recording pill'
+        checked={pillEnabled}
+        onCheckedChange={setPillEnabled}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/hooks/useRecordingPillSettings.ts
+++ b/apps/dashboard/src/hooks/useRecordingPillSettings.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export const useRecordingPillSettings = (): {
+  pillEnabled: boolean;
+  isSupported: boolean;
+  setPillEnabled: (enabled: boolean) => void;
+} => {
+  const api = window.electronAPI?.recordingPillSettings;
+  const isSupported = !!api;
+  const [pillEnabled, setPillEnabled] = useState(true);
+
+  useEffect(() => {
+    if (!api) return;
+
+    let cancelled = false;
+    void api
+      .getEnabled()
+      .then(enabled => {
+        if (!cancelled) setPillEnabled(enabled);
+      })
+      .catch(() => undefined);
+
+    const unsubscribe = api.onEnabledChanged(setPillEnabled);
+    return (): void => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [api]);
+
+  const updatePillEnabled = useCallback(
+    (enabled: boolean): void => {
+      if (!api) return;
+      setPillEnabled(enabled);
+      api.setEnabled(enabled);
+    },
+    [api],
+  );
+
+  return { pillEnabled, isSupported, setPillEnabled: updatePillEnabled };
+};

--- a/apps/dashboard/src/hooks/useRecordingVersion.ts
+++ b/apps/dashboard/src/hooks/useRecordingVersion.ts
@@ -4,7 +4,7 @@ export const RECORDING_VERSION_STORAGE_KEY = 'xyne:recording-version';
 
 export type RecordingVersion = 'v1' | 'v2';
 
-const DEFAULT_RECORDING_VERSION: RecordingVersion = 'v1';
+const DEFAULT_RECORDING_VERSION: RecordingVersion = 'v2';
 
 const listeners = new Set<() => void>();
 
@@ -17,7 +17,7 @@ const getSnapshot = (): string => localStorage.getItem(RECORDING_VERSION_STORAGE
 const getServerSnapshot = (): string => DEFAULT_RECORDING_VERSION;
 
 const parseVersion = (raw: string): RecordingVersion =>
-  raw === 'v2' ? 'v2' : DEFAULT_RECORDING_VERSION;
+  raw === 'v2' || raw === 'v1' ? raw : DEFAULT_RECORDING_VERSION;
 
 const saveVersion = (version: RecordingVersion): void => {
   localStorage.setItem(RECORDING_VERSION_STORAGE_KEY, version);

--- a/apps/dashboard/src/hooks/useTraySettings.ts
+++ b/apps/dashboard/src/hooks/useTraySettings.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export const useTraySettings = (): {
+  trayVisible: boolean;
+  isSupported: boolean;
+  setTrayVisible: (visible: boolean) => void;
+} => {
+  const api = window.electronAPI?.tray;
+  const isSupported = !!api;
+  const [trayVisible, setTrayVisible] = useState(true);
+
+  useEffect(() => {
+    if (!api) return;
+
+    let cancelled = false;
+    void api
+      .getVisible()
+      .then(visible => {
+        if (!cancelled) setTrayVisible(visible);
+      })
+      .catch(() => undefined);
+
+    const unsubscribe = api.onVisibleChanged(setTrayVisible);
+    return (): void => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [api]);
+
+  const updateTrayVisible = useCallback(
+    (visible: boolean): void => {
+      if (!api) return;
+      setTrayVisible(visible);
+      api.setVisible(visible);
+    },
+    [api],
+  );
+
+  return { trayVisible, isSupported, setTrayVisible: updateTrayVisible };
+};

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -157,6 +157,17 @@ export interface ElectronAPI {
     dragStart: () => void;
     dragEnd: () => void;
   };
+  platform?: string;
+  tray?: {
+    getVisible: () => Promise<boolean>;
+    setVisible: (visible: boolean) => void;
+    onVisibleChanged: (callback: (visible: boolean) => void) => () => void;
+  };
+  recordingPillSettings?: {
+    getEnabled: () => Promise<boolean>;
+    setEnabled: (enabled: boolean) => void;
+    onEnabledChanged: (callback: (enabled: boolean) => void) => () => void;
+  };
   clawOverlay?: {
     setIgnoreMouse: (ignore: boolean) => void;
     setExpanded: (expanded: boolean) => void;

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -16,12 +16,18 @@ import {
 } from '../services/media-permission';
 import { setCustomScreenPickerEnabled, setCachedUser } from '../services/request-interceptor';
 import { hideMeetingPopup, hideMeetingPopupAfter } from '../services/meeting-popup-window';
-import { isPillSender, setRecordingPillTheme } from '../services/recording-pill-window';
+import {
+  isPillSender,
+  isRecordingPillEnabled,
+  setRecordingPillTheme,
+} from '../services/recording-pill-window';
+import { isTrayVisible, setTrayVisible } from '../services/tray';
 import {
   focusMainWindow,
   markRendererReady,
   resumeRecordingFromOutside,
   setOverlayMinimized,
+  setRecordingPillEnabled,
   stopRecording,
   syncRecordingState,
 } from '../services/recording-controller';
@@ -134,6 +140,23 @@ function isMainWindowSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
     errorLogger.warn('[ipc] Blocked privileged IPC from untrusted sender');
   }
   return trusted;
+}
+
+function isAppWindowSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
+  const frame = event.senderFrame;
+  const trusted =
+    !!frame && frame.parent === null && !!BrowserWindow.fromWebContents(event.sender);
+  if (!trusted) {
+    errorLogger.warn('[ipc] Blocked UI-preference IPC from untrusted sender');
+  }
+  return trusted;
+}
+
+function broadcastToAppWindows(channel: string, value: unknown): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send(channel, value);
+  }
 }
 
 // XYNE-16859 Issue 24: the error-report screen/mic capture handlers can enumerate
@@ -566,6 +589,22 @@ export function setupIpcHandlers(): void {
   ipcMain.on('recording-pill:resume-recording', (event) => {
     if (!isPillSender(event)) return;
     resumeRecordingFromOutside('pill');
+  });
+
+  ipcMain.handle('tray:get-visible', () => isTrayVisible());
+
+  ipcMain.on('tray:set-visible', (event, visible: unknown) => {
+    if (!isAppWindowSender(event)) return;
+    setTrayVisible(!!visible);
+    broadcastToAppWindows('tray:visible-changed', isTrayVisible());
+  });
+
+  ipcMain.handle('recording-pill:get-enabled', () => isRecordingPillEnabled());
+
+  ipcMain.on('recording-pill:set-enabled', (event, enabled: unknown) => {
+    if (!isAppWindowSender(event)) return;
+    setRecordingPillEnabled(!!enabled);
+    broadcastToAppWindows('recording-pill:enabled-changed', isRecordingPillEnabled());
   });
 
   ipcMain.on('recording:set-minimized', (event, isMinimized: unknown) => {

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -376,6 +376,28 @@ const electronAPI = {
     dragEnd: () => ipcRenderer.send('recording-pill:drag-end'),
   },
 
+  platform: process.platform,
+
+  tray: {
+    getVisible: () => ipcRenderer.invoke('tray:get-visible'),
+    setVisible: (visible: boolean) => ipcRenderer.send('tray:set-visible', visible),
+    onVisibleChanged: (callback: (visible: boolean) => void) => {
+      const listener = (_event: unknown, visible: boolean) => callback(visible);
+      ipcRenderer.on('tray:visible-changed', listener);
+      return () => ipcRenderer.removeListener('tray:visible-changed', listener);
+    },
+  },
+
+  recordingPillSettings: {
+    getEnabled: () => ipcRenderer.invoke('recording-pill:get-enabled'),
+    setEnabled: (enabled: boolean) => ipcRenderer.send('recording-pill:set-enabled', enabled),
+    onEnabledChanged: (callback: (enabled: boolean) => void) => {
+      const listener = (_event: unknown, enabled: boolean) => callback(enabled);
+      ipcRenderer.on('recording-pill:enabled-changed', listener);
+      return () => ipcRenderer.removeListener('recording-pill:enabled-changed', listener);
+    },
+  },
+
   clawOverlay: {
     setIgnoreMouse: (ignore: boolean) => ipcRenderer.send('claw:set-ignore-mouse', ignore),
     setExpanded: (expanded: boolean) => ipcRenderer.send('claw:set-expanded', expanded),

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -1,7 +1,13 @@
 import { app, BrowserWindow, powerMonitor, powerSaveBlocker } from 'electron';
 import log from 'electron-log/main';
 import { getMainWindow, createMainWindow, setWindowReferences } from '../window/manager';
-import { showRecordingPill, hideRecordingPill, isPillWindow } from './recording-pill-window';
+import {
+  showRecordingPill,
+  hideRecordingPill,
+  isPillWindow,
+  isRecordingPillEnabled,
+  persistRecordingPillEnabled,
+} from './recording-pill-window';
 
 export type RecordingTrigger = 'tray' | 'shortcut' | 'pill';
 
@@ -157,7 +163,7 @@ function cancelPendingPillSync(): void {
 
 function syncPillVisibility(): void {
   cancelPendingPillSync();
-  if (active && (minimized || !isMainWindowFocused())) {
+  if (active && isRecordingPillEnabled() && (minimized || !isMainWindowFocused())) {
     showRecordingPill({
       startTime: startTime ?? Date.now(),
       paused,
@@ -175,6 +181,12 @@ function scheduleSyncPillVisibility(): void {
     pillSyncTimer = null;
     syncPillVisibility();
   }, PILL_SYNC_DEBOUNCE_MS);
+}
+
+export function setRecordingPillEnabled(enabled: boolean): void {
+  persistRecordingPillEnabled(enabled);
+  syncPillVisibility();
+  log.info(`[RecordingController] Recording pill ${enabled ? 'enabled' : 'disabled'}`);
 }
 
 export function setOverlayMinimized(next: boolean): void {

--- a/apps/electron/src/services/recording-pill-window.ts
+++ b/apps/electron/src/services/recording-pill-window.ts
@@ -5,6 +5,7 @@ import log from 'electron-log/main';
 
 const pillStore = new Store({ name: 'recording-pill' });
 const POSITION_KEY = 'pillPosition';
+const ENABLED_KEY = 'pillEnabled';
 
 let pillWindow: BrowserWindow | null = null;
 let hideTimer: ReturnType<typeof setTimeout> | null = null;
@@ -49,6 +50,14 @@ export function isPillSender(event: Electron.IpcMainEvent): boolean {
     event.sender === pillWindow.webContents &&
     event.senderFrame === pillWindow.webContents.mainFrame
   );
+}
+
+export function isRecordingPillEnabled(): boolean {
+  return pillStore.get(ENABLED_KEY, true) as boolean;
+}
+
+export function persistRecordingPillEnabled(enabled: boolean): void {
+  pillStore.set(ENABLED_KEY, enabled);
 }
 
 export function setRecordingPillTheme(theme: RecordingPillTheme): void {

--- a/apps/electron/src/services/tray.ts
+++ b/apps/electron/src/services/tray.ts
@@ -1,5 +1,6 @@
 import { Menu, Tray, nativeImage } from 'electron';
 import path from 'path';
+import Store from 'electron-store';
 import log from 'electron-log/main';
 import { getMainWindow, createMainWindow, setWindowReferences } from '../window/manager';
 import {
@@ -16,8 +17,12 @@ import { RECORDING_SHORTCUT } from './global-shortcuts';
 
 const PAUSED_TITLE = ' Paused';
 
+const trayStore = new Store({ name: 'tray' });
+const VISIBLE_KEY = 'trayVisible';
+
 let tray: Tray | null = null;
 let timerInterval: ReturnType<typeof setInterval> | null = null;
+let unsubscribeRecordingState: (() => void) | null = null;
 
 function formatElapsed(snapshot: RecordingSnapshot): string {
   const startTime = snapshot.startTime ?? Date.now();
@@ -103,7 +108,7 @@ function syncTrayToState(snapshot: RecordingSnapshot): void {
   }
 }
 
-export function initTray(): void {
+function createTray(): void {
   if (tray) return;
 
   const iconPath = path.join(__dirname, '..', '..', 'assets', 'images', 'xyneMenubarTemplate.png');
@@ -120,7 +125,43 @@ export function initTray(): void {
     tray.on('click', () => void openXyne());
   }
   syncTrayToState(getRecordingSnapshot());
-  onRecordingStateChange(syncTrayToState);
+  unsubscribeRecordingState = onRecordingStateChange(syncTrayToState);
 
   log.info('[Tray] Menu bar icon initialized');
+}
+
+function destroyTray(): void {
+  if (unsubscribeRecordingState) {
+    unsubscribeRecordingState();
+    unsubscribeRecordingState = null;
+  }
+  if (timerInterval) {
+    clearInterval(timerInterval);
+    timerInterval = null;
+  }
+  if (!tray) return;
+  tray.destroy();
+  tray = null;
+  log.info('[Tray] Menu bar icon removed');
+}
+
+export function isTrayVisible(): boolean {
+  return trayStore.get(VISIBLE_KEY, true) as boolean;
+}
+
+export function setTrayVisible(visible: boolean): void {
+  trayStore.set(VISIBLE_KEY, visible);
+  if (visible) {
+    createTray();
+  } else {
+    destroyTray();
+  }
+}
+
+export function initTray(): void {
+  if (!isTrayVisible()) {
+    log.info('[Tray] Menu bar icon hidden by preference');
+    return;
+  }
+  createTray();
 }


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1fdcb0n0VXS18G1nl4xEZ3hzqSVLIZGgn/view?usp=sharing
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
