### PR TITLE
feat: XYNE-55813 replace calendar call link

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -527,6 +527,11 @@ export const userPreferenceTable = table("user_preferences")
     userId: string(),
     askai_custom_instruction: string().optional(),
     channelSortOrder: string(),
+    channelFilterMode: string().optional(),
+    starredFilterMode: string().optional(),
+    starredSortOrder: string().optional(),
+    dmFilterMode: string().optional(),
+    dmSortOrder: string().optional(),
     enterSendsMessage: boolean(),
     allowThreadBroadcastMentions: boolean(),
     showThreadTags: boolean(),
@@ -1140,6 +1145,7 @@ export const channelSectionTable = table("channel_sections")
     isCollapsed: boolean(),
     isDeleted: boolean(),
     sortOrder: string().optional(),
+    filterMode: string().optional(),
     createdAt: number(),
     updatedAt: number().optional(),
   })
@@ -1659,6 +1665,7 @@ export const callTable = table("calls")
     summaryTemplateId: string().optional(),
     labels: json<string[]>(),
     markedItems: json<any[]>(),
+    xyneManaged: boolean(),
   })
   .primaryKey("id");
 
@@ -1689,6 +1696,7 @@ export const summaryTemplateTable = table("summary_templates")
     defaultOutlet: string(),
     createdBy: string(),
     createdAt: number(),
+    visibility: string(),
   })
   .primaryKey("id");
 
@@ -1836,6 +1844,7 @@ export const canvasCommentThreadTable = table("canvas_comment_threads")
     blockId: string(),
     anchorText: string().optional(),
     initialCommentId: string().optional(),
+    commentCount: number(),
     status: string(),
     statusUpdatedBy: string().optional(),
     statusUpdatedAt: number().optional(),
@@ -2232,6 +2241,7 @@ export const applicationReleaseTicketTable = table("application_release_tickets"
     testedBy: string().optional(),
     testedAt: number().optional(),
     failureReason: string().optional(),
+    isHotfix: boolean().optional(),
     createdAt: number(),
     updatedAt: number().optional(),
   })

--- a/apps/backend/prisma/migrations/20260812134222_calendar_managed_calls/migration.sql
+++ b/apps/backend/prisma/migrations/20260812134222_calendar_managed_calls/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."calls" ADD COLUMN     "xyneManaged" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2664,6 +2664,7 @@ model Call {
   summaryTemplateId String?
   labels            String[]    @default([]) // Tag ids (see Tag model); no FK constraint
   markedItems       Json[]      @default([]) // Marked moments/decisions/actions surfaced during the call
+  xyneManaged       Boolean     @default(false) // True when Xyne owns this Call's conference link on the source Calendar event (Xyne Call Link Auto-Injection)
 
   // Relations
   channel      Channel?          @relation(fields: [channelId], references: [id])

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -1053,7 +1053,10 @@ export class CallRepository {
             startedAt: now,
             lastActivityAt: now,
             updatedAt: now,
-            metadata: { systemMessageId: messageId, conversationId },
+            // Merge (not replace) so calendar-derived fields already on the call
+            // (organizer, attendees, provider, etc. — set by the calendar sync
+            // upsert) survive activation instead of being wiped out.
+            metadata: { ...(call.metadata as Prisma.InputJsonObject ?? {}), systemMessageId: messageId, conversationId },
           },
         });
       } else if (!callMetadata?.systemMessageId) {
@@ -1095,7 +1098,7 @@ export class CallRepository {
             startedAt: now,
             lastActivityAt: now,
             updatedAt: now,
-            metadata: { systemMessageId: messageId, conversationId },
+            metadata: { ...(call.metadata as Prisma.InputJsonObject ?? {}), systemMessageId: messageId, conversationId },
           },
         });
       } else {
@@ -1972,6 +1975,16 @@ export class CallRepository {
 
     if (!hasExternalCallChanged(existing as unknown as ExistingCallRow, data)) return;
 
+    // Merge (not replace): once a call is activated, its metadata also carries
+    // `conversationId`/`systemMessageId` (see activateScheduledCall). A plain
+    // overwrite here would wipe those out on the next calendar resync, causing
+    // the following join to think it's a fresh call and create a duplicate
+    // conversation + "started a call" system message instead of reusing them.
+    const mergedMetadata = {
+      ...(existing.metadata as Prisma.InputJsonObject ?? {}),
+      ...data.metadata,
+    };
+
     const updated = await DatabaseClient.getInstance().call.update({
       where: { externalId: data.externalId },
       data: {
@@ -1984,7 +1997,7 @@ export class CallRepository {
         timezone: data.timezone,
         xyneManaged: data.xyneManaged ?? false,
         channelId: data.channelId,
-        metadata: data.metadata,
+        metadata: mergedMetadata,
         updatedAt: data.updatedAt,
         lastActivityAt: data.lastActivityAt,
       },
@@ -2034,6 +2047,15 @@ function stableStringify(val: unknown): string {
   return `{${sorted.join(',')}}`;
 }
 
+/** Strips the activation-only keys (`conversationId`, `systemMessageId`) that
+ * activateScheduledCall stamps onto call.metadata, so calendar-resync change
+ * detection only looks at calendar-derived fields. */
+function omitActivationKeys(metadata: Prisma.JsonValue): unknown {
+  if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) return metadata;
+  const { conversationId, systemMessageId, ...rest } = metadata as Record<string, unknown>;
+  return rest;
+}
+
 function hasExternalCallChanged(
   existing: ExistingCallRow,
   data: {
@@ -2059,6 +2081,10 @@ function hasExternalCallChanged(
     existing.timezone !== data.timezone ||
     existing.xyneManaged !== (data.xyneManaged ?? false) ||
     existing.channelId !== data.channelId ||
-    stableStringify(existing.metadata) !== stableStringify(data.metadata)
+    // Compare only the calendar-derived subset of existing.metadata: once activated,
+    // existing.metadata also carries conversationId/systemMessageId (see
+    // activateScheduledCall), which never appear in the freshly computed data.metadata
+    // and would otherwise make this always report "changed".
+    stableStringify(omitActivationKeys(existing.metadata)) !== stableStringify(data.metadata)
   );
 }

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -1935,6 +1935,7 @@ export class CallRepository {
     startsAt?: Date;
     endsAt?: Date;
     timezone: string;
+    xyneManaged?: boolean;
     channelId: null;
     isRecurring: boolean;
     recordingEnabled: boolean;
@@ -1953,6 +1954,7 @@ export class CallRepository {
       startsAt: true,
       endsAt: true,
       timezone: true,
+      xyneManaged: true,
       metadata: true,
     });
 
@@ -1977,6 +1979,7 @@ export class CallRepository {
         startsAt: data.startsAt,
         endsAt: data.endsAt,
         timezone: data.timezone,
+        xyneManaged: data.xyneManaged ?? false,
         metadata: data.metadata,
         updatedAt: data.updatedAt,
         lastActivityAt: data.lastActivityAt,
@@ -2011,6 +2014,7 @@ interface ExistingCallRow {
   startsAt: Date | null;
   endsAt: Date | null;
   timezone: string;
+  xyneManaged: boolean;
   metadata: Prisma.JsonValue;
 }
 
@@ -2035,6 +2039,7 @@ function hasExternalCallChanged(
     startsAt?: Date;
     endsAt?: Date;
     timezone: string;
+    xyneManaged?: boolean;
     metadata: Prisma.InputJsonObject;
   },
 ): boolean {
@@ -2046,6 +2051,7 @@ function hasExternalCallChanged(
     existing.startsAt?.getTime() !== data.startsAt?.getTime() ||
     existing.endsAt?.getTime() !== data.endsAt?.getTime() ||
     existing.timezone !== data.timezone ||
+    existing.xyneManaged !== (data.xyneManaged ?? false) ||
     stableStringify(existing.metadata) !== stableStringify(data.metadata)
   );
 }

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -1936,7 +1936,8 @@ export class CallRepository {
     endsAt?: Date;
     timezone: string;
     xyneManaged?: boolean;
-    channelId: null;
+    /** Self-DM channel backing a Xyne-managed calendar call; null for a plain mirrored (unmanaged) event. */
+    channelId: string | null;
     isRecurring: boolean;
     recordingEnabled: boolean;
     startedAt: Date;
@@ -1955,12 +1956,14 @@ export class CallRepository {
       endsAt: true,
       timezone: true,
       xyneManaged: true,
+      channelId: true,
       metadata: true,
     });
 
     if (!existing) {
-      // No channel to denormalize from (external calendar calls have channelId=null),
-      // so inherit the workspace of the organizer who owns the calendar sync.
+      // Xyne-managed calendar calls carry a resolved self-DM channelId; plain
+      // mirrored (unmanaged) events have none, so inherit the workspace of the
+      // organizer who owns the calendar sync instead of denormalizing from a channel.
       const workspaceId = await resolveWorkspaceIdFromModel(DatabaseClient.getInstance(), 'user', { id: data.createdByUserId });
       await DatabaseClient.getInstance().call.create({ data: { ...data, workspaceId } });
       queueCallVespaFeed(data.id, { source: CallVespaFeedSource.CallRepositoryUpsertExternalCalendarCallCreate });
@@ -1980,6 +1983,7 @@ export class CallRepository {
         endsAt: data.endsAt,
         timezone: data.timezone,
         xyneManaged: data.xyneManaged ?? false,
+        channelId: data.channelId,
         metadata: data.metadata,
         updatedAt: data.updatedAt,
         lastActivityAt: data.lastActivityAt,
@@ -2015,6 +2019,7 @@ interface ExistingCallRow {
   endsAt: Date | null;
   timezone: string;
   xyneManaged: boolean;
+  channelId: string | null;
   metadata: Prisma.JsonValue;
 }
 
@@ -2040,6 +2045,7 @@ function hasExternalCallChanged(
     endsAt?: Date;
     timezone: string;
     xyneManaged?: boolean;
+    channelId: string | null;
     metadata: Prisma.InputJsonObject;
   },
 ): boolean {
@@ -2052,6 +2058,7 @@ function hasExternalCallChanged(
     existing.endsAt?.getTime() !== data.endsAt?.getTime() ||
     existing.timezone !== data.timezone ||
     existing.xyneManaged !== (data.xyneManaged ?? false) ||
+    existing.channelId !== data.channelId ||
     stableStringify(existing.metadata) !== stableStringify(data.metadata)
   );
 }

--- a/apps/backend/src/database/repositories/externalSourceRepository.ts
+++ b/apps/backend/src/database/repositories/externalSourceRepository.ts
@@ -258,6 +258,22 @@ export class ExternalSourceRepository {
     return `calendar-${suffix}-${ownerUserId}`;
   }
 
+  /**
+   * Fully disconnect a calendar source: clears the stored refresh/access
+   * tokens (not just the watch channel) and marks it inactive. Used by the
+   * "Disconnect" action in Calendar preferences so a subsequent reconnect
+   * goes through Google's/Microsoft's OAuth consent screen again from
+   * scratch — required to pick up newly-added scopes (e.g. calendar.events)
+   * that an existing token grant wouldn't otherwise include.
+   */
+  async disconnectCalendarSource(id: string): Promise<void> {
+    await this.update(id, {
+      externalIdentifier: null,
+      isActive: false,
+      credentials: serializeCalendarCredentials({ refreshToken: '' }),
+    });
+  }
+
   async findCalendarSourceByOwner(
     ownerUserId: string,
     provider: CalendarProvider,

--- a/apps/backend/src/queues/googleCalendarSyncQueue.ts
+++ b/apps/backend/src/queues/googleCalendarSyncQueue.ts
@@ -112,7 +112,9 @@ async function performManualSync(sourceId: string): Promise<void> {
       MAX_CALENDAR_EVENTS_PER_SYNC
     );
 
-    const reconciledEvents = await reconcileXyneCallLinks(events, credentials, user.email);
+    const reconciledEvents = await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
+      reconcileXyneCallLinks(events, credentials, user.email, user.workspaceId),
+    );
 
     await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
       storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, {
@@ -172,7 +174,9 @@ async function performIncrementalSync(
       MAX_CALENDAR_EVENTS_PER_SYNC
     );
 
-    const reconciledEvents = await reconcileXyneCallLinks(events, credentials, user.email);
+    const reconciledEvents = await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
+      reconcileXyneCallLinks(events, credentials, user.email, user.workspaceId),
+    );
 
     await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
       storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, {
@@ -215,7 +219,9 @@ async function performIncrementalSync(
         MAX_CALENDAR_EVENTS_PER_SYNC
       );
 
-      const reconciledEvents = await reconcileXyneCallLinks(events, credentials, user.email);
+      const reconciledEvents = await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
+        reconcileXyneCallLinks(events, credentials, user.email, user.workspaceId),
+      );
 
       await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
         storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, {
@@ -239,7 +245,7 @@ async function performIncrementalSync(
     }
 
     await runWithContext({ userId, workspaceId: user.workspaceId }, async () => {
-      const reconciledEvents = await reconcileXyneCallLinks(result.events, credentials, user.email);
+      const reconciledEvents = await reconcileXyneCallLinks(result.events, credentials, user.email, user.workspaceId);
       await storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, { isFullSync: false });
     });
 

--- a/apps/backend/src/queues/googleCalendarSyncQueue.ts
+++ b/apps/backend/src/queues/googleCalendarSyncQueue.ts
@@ -23,6 +23,7 @@ import {
   fetchAllGoogleEventsForBaseline,
 } from '@/services/googleCalendarApi';
 import { storeGCalEventsAsCallsForUser } from '@/services/googleCalendarCallStore';
+import { reconcileXyneCallLinks } from '@/services/xyneCallLinkInjector';
 import { GoogleCalendarWatchService } from '@/services/googleCalendarWatchService';
 import {
   CALENDAR_SYNC_LOOKAHEAD_DAYS,
@@ -52,6 +53,30 @@ type EnqueueIncrementalSyncOptions = {
 function continuationJobId(sourceId: string, pageToken: string): string {
   const tokenHash = createHash('sha1').update(pageToken).digest('hex');
   return `google-calendar-incremental-${sourceId}-${tokenHash}`;
+}
+
+/**
+ * Bull refuses to create a new job when a job with the same jobId already
+ * exists in a terminal state (failed/completed) that hasn't been removed.
+ * Since our jobIds are deterministic per sourceId (by design, to serialize
+ * access to the Google syncToken cursor), a single exhausted-retries failure
+ * would otherwise permanently block every future sync for that source.
+ * Clear out any dead job for this id before adding a fresh one.
+ */
+async function clearDeadJobForReenqueue(queue: Bull.Queue, jobId: string): Promise<void> {
+  try {
+    const existing = await queue.getJob(jobId);
+    if (!existing) return;
+    if ((await existing.isFailed()) || (await existing.isCompleted())) {
+      await existing.remove();
+      logger.warn(`${TAG} Cleared stale job before re-enqueue`, { jobId });
+    }
+  } catch (err) {
+    logger.warn(`${TAG} Failed to check/clear stale job before re-enqueue`, {
+      jobId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 async function resolveSourceId(jobData: CalendarSyncJobData): Promise<string> {
@@ -87,8 +112,10 @@ async function performManualSync(sourceId: string): Promise<void> {
       MAX_CALENDAR_EVENTS_PER_SYNC
     );
 
+    const reconciledEvents = await reconcileXyneCallLinks(events, credentials, user.email);
+
     await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
-      storeGCalEventsAsCallsForUser(events, userId, user.email, {
+      storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, {
         isFullSync: true,
         timeRange: { startsAfter: now, startsBefore: future },
         skipCancelRemoved: truncated,
@@ -145,8 +172,10 @@ async function performIncrementalSync(
       MAX_CALENDAR_EVENTS_PER_SYNC
     );
 
+    const reconciledEvents = await reconcileXyneCallLinks(events, credentials, user.email);
+
     await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
-      storeGCalEventsAsCallsForUser(events, userId, user.email, {
+      storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, {
         isFullSync: true,
         skipCancelRemoved: truncated,
       }),
@@ -186,8 +215,10 @@ async function performIncrementalSync(
         MAX_CALENDAR_EVENTS_PER_SYNC
       );
 
+      const reconciledEvents = await reconcileXyneCallLinks(events, credentials, user.email);
+
       await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
-        storeGCalEventsAsCallsForUser(events, userId, user.email, {
+        storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, {
           isFullSync: true,
           skipCancelRemoved: truncated,
         }),
@@ -207,9 +238,10 @@ async function performIncrementalSync(
       return null;
     }
 
-    await runWithContext({ userId, workspaceId: user.workspaceId }, () =>
-      storeGCalEventsAsCallsForUser(result.events, userId, user.email, { isFullSync: false }),
-    );
+    await runWithContext({ userId, workspaceId: user.workspaceId }, async () => {
+      const reconciledEvents = await reconcileXyneCallLinks(result.events, credentials, user.email);
+      await storeGCalEventsAsCallsForUser(reconciledEvents, userId, user.email, { isFullSync: false });
+    });
 
     if (result.nextPageToken) {
       logger.warn(`${TAG} Incremental sync hit event cap, scheduling continuation`, {
@@ -311,8 +343,10 @@ class GoogleCalendarSyncQueue {
         throw err;
       }
       if (continuation) {
+        const continuationId = continuationJobId(continuation.sourceId, continuation.pageToken);
+        await clearDeadJobForReenqueue(queue, continuationId);
         await queue.add('incremental-sync', continuation, {
-          jobId: continuationJobId(continuation.sourceId, continuation.pageToken),
+          jobId: continuationId,
           delay: 0,
         });
       }
@@ -333,12 +367,12 @@ class GoogleCalendarSyncQueue {
 
   async enqueueManualSync(sourceId: string): Promise<void> {
     const queue = await this.ensureQueue();
+    const jobId = `google-calendar-manual-${sourceId}`;
+    await clearDeadJobForReenqueue(queue, jobId);
     await queue.add(
       'manual-sync',
       { sourceId },
-      {
-        jobId: `google-calendar-manual-${sourceId}`,
-      }
+      { jobId }
     );
   }
 
@@ -348,11 +382,13 @@ class GoogleCalendarSyncQueue {
   ): Promise<void> {
     const queue = await this.ensureQueue();
     const jobIdSuffix = options?.jobIdSuffix ? `-${options.jobIdSuffix}` : '';
+    const jobId = `google-calendar-incremental-${sourceId}${jobIdSuffix}`;
+    await clearDeadJobForReenqueue(queue, jobId);
     await queue.add(
       'incremental-sync',
       { sourceId },
       {
-        jobId: `google-calendar-incremental-${sourceId}${jobIdSuffix}`,
+        jobId,
         delay: options?.delayMs ?? 0,
       }
     );

--- a/apps/backend/src/queues/microsoftCalendarSyncQueue.ts
+++ b/apps/backend/src/queues/microsoftCalendarSyncQueue.ts
@@ -47,6 +47,30 @@ function continuationJobId(sourceId: string, deltaLink: string): string {
   return `microsoft-calendar-incremental-${sourceId}-${cursorHash}`;
 }
 
+/**
+ * Bull refuses to create a new job when a job with the same jobId already
+ * exists in a terminal state (failed/completed) that hasn't been removed.
+ * Since our jobIds are deterministic per sourceId (by design, to serialize
+ * access to the Microsoft delta cursor), a single exhausted-retries failure
+ * would otherwise permanently block every future sync for that source.
+ * Clear out any dead job for this id before adding a fresh one.
+ */
+async function clearDeadJobForReenqueue(queue: Bull.Queue, jobId: string): Promise<void> {
+  try {
+    const existing = await queue.getJob(jobId);
+    if (!existing) return;
+    if ((await existing.isFailed()) || (await existing.isCompleted())) {
+      await existing.remove();
+      logger.warn(`${TAG} Cleared stale job before re-enqueue`, { jobId });
+    }
+  } catch (err) {
+    logger.warn(`${TAG} Failed to check/clear stale job before re-enqueue`, {
+      jobId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 async function resolveSourceId(jobData: CalendarSyncJobData): Promise<string> {
   if (jobData.sourceId) return jobData.sourceId;
   throw new Error(
@@ -319,8 +343,10 @@ class MicrosoftCalendarSyncQueue {
         throw err;
       }
       if (continuation) {
+        const continuationId = continuationJobId(continuation.sourceId, continuation.deltaLink);
+        await clearDeadJobForReenqueue(queue, continuationId);
         await queue.add('incremental-sync', continuation, {
-          jobId: continuationJobId(continuation.sourceId, continuation.deltaLink),
+          jobId: continuationId,
           delay: 0,
         });
       }
@@ -341,23 +367,23 @@ class MicrosoftCalendarSyncQueue {
 
   async enqueueManualSync(sourceId: string): Promise<void> {
     const queue = await this.ensureQueue();
+    const jobId = `microsoft-calendar-manual-${sourceId}`;
+    await clearDeadJobForReenqueue(queue, jobId);
     await queue.add(
       'manual-sync',
       { sourceId },
-      {
-        jobId: `microsoft-calendar-manual-${sourceId}`,
-      }
+      { jobId }
     );
   }
 
   async enqueueIncrementalSync(sourceId: string): Promise<void> {
     const queue = await this.ensureQueue();
+    const jobId = `microsoft-calendar-incremental-${sourceId}`;
+    await clearDeadJobForReenqueue(queue, jobId);
     await queue.add(
       'incremental-sync',
       { sourceId },
-      {
-        jobId: `microsoft-calendar-incremental-${sourceId}`,
-      }
+      { jobId }
     );
   }
 

--- a/apps/backend/src/routes/calendarOAuth.ts
+++ b/apps/backend/src/routes/calendarOAuth.ts
@@ -27,6 +27,7 @@ const GOOGLE_CALENDAR_SCOPES = [
   'email',
   'profile',
   'https://www.googleapis.com/auth/calendar.readonly',
+  'https://www.googleapis.com/auth/calendar.events',
 ];
 const MICROSOFT_CALENDAR_SCOPES = [
   'openid',

--- a/apps/backend/src/routes/calendarWatch.ts
+++ b/apps/backend/src/routes/calendarWatch.ts
@@ -4,7 +4,9 @@
  * POST /api/calendar/watch/google      — Setup Google Calendar push watch
  * POST /api/calendar/watch/microsoft   — Setup Microsoft Calendar push subscription
  * GET  /api/calendar/watch/status      — Check if calendar watch is active
- * DELETE /api/calendar/watch/:provider — Stop calendar watch
+ * DELETE /api/calendar/watch/:provider — Disconnect calendar (stop watch + clear stored
+ *                                         OAuth credentials so reconnecting re-prompts
+ *                                         for consent, picking up any newly-added scopes)
  */
 
 import express from 'express';
@@ -197,8 +199,9 @@ router.delete('/:provider', async (req, res) => {
           id: subscription.id,
           email: subscription.displayName,
         });
+        await repositories.externalSources.disconnectCalendarSource(subscription.id);
       }
-      logger.info(`[CALENDAR_SYNC][GOOGLE][WATCH] Watch stopped for ${user.email}`);
+      logger.info(`[CALENDAR_SYNC][GOOGLE][WATCH] Disconnected calendar for ${user.email}`);
     } else if (provider === 'microsoft') {
       const subscription = await repositories.externalSources.findCalendarSourceByOwner(
         userId,
@@ -209,13 +212,14 @@ router.delete('/:provider', async (req, res) => {
           id: subscription.id,
           email: subscription.displayName,
         });
+        await repositories.externalSources.disconnectCalendarSource(subscription.id);
       }
-      logger.info(`[CALENDAR_SYNC][MICROSOFT][WATCH] Subscription deleted for ${user.email}`);
+      logger.info(`[CALENDAR_SYNC][MICROSOFT][WATCH] Disconnected calendar for ${user.email}`);
     } else {
       return res.status(400).json({ success: false, error: 'Invalid provider' });
     }
 
-    return res.json({ success: true, message: `Calendar ${provider} watch stopped` });
+    return res.json({ success: true, message: `Calendar ${provider} disconnected` });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error(

--- a/apps/backend/src/services/calendarCallStore.utils.ts
+++ b/apps/backend/src/services/calendarCallStore.utils.ts
@@ -44,6 +44,8 @@ export interface ExternalCalendarCallData {
   endsAt?: Date;
   timezone: string;
   xyneManaged?: boolean;
+  /** Self-DM channel backing a Xyne-managed call so LiveKit room creation on join succeeds. */
+  channelId?: string | null;
   metadata: Prisma.InputJsonObject;
 }
 
@@ -88,7 +90,7 @@ export async function upsertExternalCalendarCall(
     endsAt: data.endsAt,
     timezone: data.timezone,
     xyneManaged: data.xyneManaged ?? false,
-    channelId: null,
+    channelId: data.channelId ?? null,
     isRecurring: false,
     recordingEnabled: false,
     startedAt: now,

--- a/apps/backend/src/services/calendarCallStore.utils.ts
+++ b/apps/backend/src/services/calendarCallStore.utils.ts
@@ -8,6 +8,7 @@ import { logger } from '@/utils/logger';
 import { type Prisma } from '@prisma/client';
 import { CallOrigin, CallStatus, CallType } from '@xyne/shared';
 import { repositories } from '@/database/repositories';
+import { livekitService } from '@/services/liveKitService';
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
@@ -76,6 +77,37 @@ export async function upsertExternalCalendarCall(
   data: ExternalCalendarCallData,
   now: Date
 ): Promise<void> {
+  let status = data.status;
+
+  // Calendar providers only know that a non-cancelled event is scheduled; they
+  // do not know whether its Xyne room is currently live. A self-triggered
+  // Calendar webhook (for example, after injecting the Xyne link) can arrive
+  // after LiveKit has activated the Call. Do not let that stale Calendar state
+  // downgrade a genuinely active room back to SCHEDULED.
+  if (status === CallStatus.SCHEDULED) {
+    const existing = await repositories.calls.findByExternalId(data.externalId);
+    if (existing?.status === CallStatus.ACTIVE) {
+      try {
+        const rooms = await livekitService.listRooms([data.externalId]);
+        const room = rooms.find((candidate) => candidate.name === data.externalId);
+        if (room && room.numParticipants > 0) {
+          status = CallStatus.ACTIVE;
+          logger.info(`${data.externalId} Calendar sync preserved ACTIVE call status`, {
+            numParticipants: room.numParticipants,
+          });
+        }
+      } catch (err) {
+        // A transient LiveKit lookup failure is not evidence that the call has
+        // ended. Preserve ACTIVE and let room_finished/call validation perform
+        // the authoritative transition later.
+        status = CallStatus.ACTIVE;
+        logger.warn(`${data.externalId} LiveKit status check failed; preserving ACTIVE`, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
   await repositories.calls.upsertExternalCalendarCall({
     externalId: data.externalId,
     id: uuidv4(),
@@ -84,7 +116,7 @@ export async function upsertExternalCalendarCall(
     createdByUserId: data.createdByUserId,
     callType: data.callType,
     callOrigin: data.callOrigin,
-    status: data.status,
+    status,
     roomLink: data.roomLink,
     startsAt: data.startsAt,
     endsAt: data.endsAt,

--- a/apps/backend/src/services/calendarCallStore.utils.ts
+++ b/apps/backend/src/services/calendarCallStore.utils.ts
@@ -43,6 +43,7 @@ export interface ExternalCalendarCallData {
   startsAt?: Date;
   endsAt?: Date;
   timezone: string;
+  xyneManaged?: boolean;
   metadata: Prisma.InputJsonObject;
 }
 
@@ -86,6 +87,7 @@ export async function upsertExternalCalendarCall(
     startsAt: data.startsAt,
     endsAt: data.endsAt,
     timezone: data.timezone,
+    xyneManaged: data.xyneManaged ?? false,
     channelId: null,
     isRecurring: false,
     recordingEnabled: false,

--- a/apps/backend/src/services/calendarConferencePatcher.ts
+++ b/apps/backend/src/services/calendarConferencePatcher.ts
@@ -1,0 +1,145 @@
+/**
+ * Calendar Conference Patcher (Xyne Call Link Auto-Injection)
+ *
+ * Builds the managed description block for a Google Calendar event and
+ * PATCHes it via the organizer's delegated OAuth token.
+ * - Internal-only events: clears the existing (non-Xyne) conference entry
+ *   AND upserts the description link. Google Calendar's API only accepts a
+ *   custom (addOn-type) conference entry from applications registered as an
+ *   actual Google Workspace Marketplace conferencing partner — confirmed via
+ *   a live 400 "Invalid conference data" response, so we cannot render
+ *   "Join Xyne Call" in the native join UI without that registration. Instead
+ *   we remove the stale/incorrect conference so it doesn't linger, and rely
+ *   on the description link as the join path (FR-9, reduced scope).
+ * - External-participant events: description link only, conference entry
+ *   left untouched (FR-4/FR-9).
+ * On a 412 (stale etag) the caller gets one fresh re-fetch + retry; beyond
+ * that it surfaces the error so the reconciler leaves the event untouched.
+ */
+
+import { type GCalEvent } from '@/services/googleCalendarCallStore';
+import {
+  getGoogleEventById,
+  patchGoogleEvent,
+  GoogleCalendarPatchConflictError,
+} from '@/services/googleCalendarApi';
+import { logger } from '@/utils/logger';
+
+const TAG = '[CALENDAR_SYNC][GOOGLE][CONFERENCE_PATCHER]';
+
+const MANAGED_DESCRIPTION_START = '<!-- xyne-call:start -->';
+const MANAGED_DESCRIPTION_END = '<!-- xyne-call:end -->';
+
+/** Escapes a URL for safe use inside an HTML attribute in the event description. */
+export function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function buildManagedBlock(roomLink: string): string {
+  // Google Calendar's description field renders a small safe subset of HTML
+  // (bold, links, line breaks) in both Web and mobile clients, so this shows
+  // as a clean clickable "Join Xyne Call" link instead of a raw pasted URL.
+  const href = escapeHtmlAttribute(roomLink);
+  return `${MANAGED_DESCRIPTION_START}\n<b>𝓧  <a href="${href}">Join Xyne Call</a></b>\n${MANAGED_DESCRIPTION_END}`;
+}
+
+/**
+ * Idempotently upsert the managed block inside an event description,
+ * preserving all other content. Replaces an existing block in place, or
+ * appends a new one if none exists yet.
+ */
+export function upsertManagedDescription(
+  existingDescription: string | undefined,
+  roomLink: string
+): string {
+  const block = buildManagedBlock(roomLink);
+  const description = existingDescription ?? '';
+  const startIdx = description.indexOf(MANAGED_DESCRIPTION_START);
+  const endIdx = description.indexOf(MANAGED_DESCRIPTION_END);
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = description.slice(0, startIdx);
+    const after = description.slice(endIdx + MANAGED_DESCRIPTION_END.length);
+    return `${before}${block}${after}`;
+  }
+
+  if (description.trim().length === 0) return block;
+  return `${description}\n\n${block}`;
+}
+
+/**
+ * Google Calendar conferenceData payload used to clear an existing (non-Xyne)
+ * conference entry. Google rejects custom addOn-type conference entries from
+ * apps that aren't a registered conferencing partner, so the best we can do
+ * without that registration is remove the stale entry rather than replace it.
+ */
+export const CLEARED_CONFERENCE_DATA = null;
+
+export interface ReconcileConferenceOptions {
+  roomLink: string;
+  xyneCallId: string;
+  /** True for internal-only events — also clears the existing conference entry. */
+  replaceConference: boolean;
+}
+
+function buildPatchBody(event: GCalEvent, options: ReconcileConferenceOptions) {
+  const description = upsertManagedDescription(event.description, options.roomLink);
+  const existingPrivate = event.extendedProperties?.private ?? {};
+
+  const body: Record<string, unknown> = {
+    description,
+    extendedProperties: {
+      private: {
+        ...existingPrivate,
+        xyneManaged: 'true',
+        xyneCallId: options.xyneCallId,
+        xyneRoomLink: options.roomLink,
+      },
+    },
+  };
+
+  if (options.replaceConference) {
+    body.conferenceData = CLEARED_CONFERENCE_DATA;
+  }
+
+  return body;
+}
+
+/**
+ * PATCH the organizer's Calendar event with the managed description (and,
+ * for internal-only events, the replaced conference entry). Retries exactly
+ * once on a 412 conflict by re-fetching the event and rebuilding the patch
+ * against its fresh etag; any further failure is thrown for the caller to
+ * log and skip (event is left untouched until the next sync).
+ */
+export async function reconcileEventConference(
+  accessToken: string,
+  event: GCalEvent,
+  options: ReconcileConferenceOptions
+): Promise<GCalEvent> {
+  if (!event.id) {
+    throw new Error('Cannot patch a Google Calendar event without an id');
+  }
+
+  const attemptPatch = async (target: GCalEvent): Promise<GCalEvent> => {
+    const body = buildPatchBody(target, options);
+    return patchGoogleEvent(accessToken, target.id!, body, {
+      conferenceDataVersion: options.replaceConference,
+      etag: target.etag,
+    });
+  };
+
+  try {
+    return await attemptPatch(event);
+  } catch (err) {
+    if (!(err instanceof GoogleCalendarPatchConflictError)) throw err;
+
+    logger.warn(`${TAG} Patch conflict, re-evaluating once`, { eventId: event.id });
+    const fresh = await getGoogleEventById(accessToken, event.id);
+    return attemptPatch(fresh);
+  }
+}

--- a/apps/backend/src/services/calendarConferencePatcher.ts
+++ b/apps/backend/src/services/calendarConferencePatcher.ts
@@ -112,6 +112,31 @@ function buildPatchBody(event: GCalEvent, options: ReconcileConferenceOptions) {
   return body;
 }
 
+/** Whether Google already contains the exact managed state this PATCH would establish. */
+export function isEventReconciledWithOptions(
+  event: GCalEvent,
+  options: ReconcileConferenceOptions
+): boolean {
+  const privateProperties = event.extendedProperties?.private;
+  if (
+    privateProperties?.xyneManaged !== 'true' ||
+    privateProperties.xyneCallId !== options.xyneCallId ||
+    privateProperties.xyneRoomLink !== options.roomLink ||
+    privateProperties.xyneChannelId !== options.channelId
+  ) {
+    return false;
+  }
+
+  const description = event.description ?? '';
+  const hasRoomLink =
+    description.includes(options.roomLink) ||
+    description.includes(escapeHtmlAttribute(options.roomLink));
+  if (!hasRoomLink) return false;
+
+  if (!options.replaceConference) return true;
+  return (event.conferenceData?.entryPoints ?? []).length === 0;
+}
+
 /**
  * PATCH the organizer's Calendar event with the managed description (and,
  * for internal-only events, the replaced conference entry). Retries exactly
@@ -143,6 +168,10 @@ export async function reconcileEventConference(
 
     logger.warn(`${TAG} Patch conflict, re-evaluating once`, { eventId: event.id });
     const fresh = await getGoogleEventById(accessToken, event.id);
+    if (isEventReconciledWithOptions(fresh, options)) {
+      logger.info(`${TAG} Fresh event already reconciled after conflict`, { eventId: event.id });
+      return fresh;
+    }
     return attemptPatch(fresh);
   }
 }

--- a/apps/backend/src/services/calendarConferencePatcher.ts
+++ b/apps/backend/src/services/calendarConferencePatcher.ts
@@ -82,6 +82,8 @@ export const CLEARED_CONFERENCE_DATA = null;
 export interface ReconcileConferenceOptions {
   roomLink: string;
   xyneCallId: string;
+  /** Organizer's self-DM channel backing the Call row, so joinCall can resolve a real Channel. */
+  channelId: string;
   /** True for internal-only events — also clears the existing conference entry. */
   replaceConference: boolean;
 }
@@ -98,6 +100,7 @@ function buildPatchBody(event: GCalEvent, options: ReconcileConferenceOptions) {
         xyneManaged: 'true',
         xyneCallId: options.xyneCallId,
         xyneRoomLink: options.roomLink,
+        xyneChannelId: options.channelId,
       },
     },
   };

--- a/apps/backend/src/services/calendarSyncConfig.ts
+++ b/apps/backend/src/services/calendarSyncConfig.ts
@@ -1,2 +1,69 @@
+import { superpositionClient } from '@/services/superpositionClient';
+
 export const CALENDAR_SYNC_LOOKAHEAD_DAYS = 30;
 export const MAX_CALENDAR_EVENTS_PER_SYNC = 100;
+
+const XYNE_TEAM_ELIGIBILITY_FLAG_KEY = 'xyne-team-domains';
+
+export interface TeamEligibilityConfig {
+  /** Email domains eligible for Xyne Call auto-injection, e.g. "juspay.in". */
+  domains: string[];
+  /** UserProfile.team values eligible for Xyne Call auto-injection. */
+  teams: string[];
+}
+
+const EMPTY_ELIGIBILITY_CONFIG: TeamEligibilityConfig = { domains: [], teams: [] };
+
+/**
+ * Single Superposition (CAC) key gating Xyne Call auto-injection eligibility
+ * (see Xyne Call Link Auto-Injection PRD, FR-2). Value shape:
+ *   { "domains": ["juspay.in"], "teams": ["Xyne"] }
+ * Sourced from Superposition instead of a plain env var so it can be
+ * toggled/rolled out without a redeploy. Missing, empty, malformed, or
+ * unreachable config is treated as "feature disabled" — never throws.
+ */
+export async function getTeamEligibilityConfig(): Promise<TeamEligibilityConfig> {
+  if (!superpositionClient.isReady()) return EMPTY_ELIGIBILITY_CONFIG;
+  try {
+    const raw = await superpositionClient.getObjectValue(XYNE_TEAM_ELIGIBILITY_FLAG_KEY, {
+      domains: [],
+      teams: [],
+    });
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return EMPTY_ELIGIBILITY_CONFIG;
+
+    const obj = raw as Record<string, unknown>;
+    const normalizeList = (value: unknown): string[] =>
+      Array.isArray(value)
+        ? value
+            .filter((v): v is string => typeof v === 'string')
+            .map((v) => v.trim().toLowerCase())
+            .filter((v) => v.length > 0)
+        : [];
+
+    return { domains: normalizeList(obj.domains), teams: normalizeList(obj.teams) };
+  } catch {
+    return EMPTY_ELIGIBILITY_CONFIG;
+  }
+}
+
+/**
+ * Whether the given organizer is eligible for Xyne Call auto-injection:
+ * eligible when either their email domain OR their UserProfile team
+ * (case-insensitive) is present in the CAC-configured allowlist.
+ */
+export async function isTeamEligible(params: {
+  email?: string | null;
+  team?: string | null;
+}): Promise<boolean> {
+  const { domains, teams } = await getTeamEligibilityConfig();
+  if (domains.length === 0 && teams.length === 0) return false;
+
+  const emailDomain = params.email?.trim().toLowerCase().split('@')[1];
+  if (emailDomain && domains.includes(emailDomain)) return true;
+
+  const team = params.team?.trim().toLowerCase();
+  if (team && teams.includes(team)) return true;
+
+  return false;
+}
+

--- a/apps/backend/src/services/googleCalendarApi.ts
+++ b/apps/backend/src/services/googleCalendarApi.ts
@@ -10,6 +10,83 @@ import { logger } from '@/utils/logger';
 
 const TAG = '[CALENDAR_SYNC][GOOGLE][API]';
 
+/** Thrown when a PATCH is rejected due to a stale etag (If-Match precondition failed). */
+export class GoogleCalendarPatchConflictError extends Error {
+  constructor(eventId: string) {
+    super(`Google Calendar PATCH conflict (412) for event ${eventId}`);
+    this.name = 'GoogleCalendarPatchConflictError';
+  }
+}
+
+export async function getGoogleEventById(
+  accessToken: string,
+  eventId: string
+): Promise<GCalEvent> {
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(eventId)}`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(30_000),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Google Calendar API ${res.status}: ${text}`);
+  }
+
+  return (await res.json()) as GCalEvent;
+}
+
+/**
+ * PATCH a single Google Calendar event owned by the connected (organizer)
+ * user. Used by the Xyne Call Link Auto-Injection reconciler to replace/inject
+ * the conference entry and description block. Callers own retry-on-conflict
+ * decisions; this function only performs the network call and surfaces a
+ * typed error for 412 so callers can distinguish "stale etag, re-evaluate
+ * once" from other failures.
+ */
+export async function patchGoogleEvent(
+  accessToken: string,
+  eventId: string,
+  body: Record<string, unknown>,
+  options?: { conferenceDataVersion?: boolean; etag?: string }
+): Promise<GCalEvent> {
+  const params = new URLSearchParams({ sendUpdates: 'all' });
+  if (options?.conferenceDataVersion) {
+    params.set('conferenceDataVersion', '1');
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+  };
+  if (options?.etag) {
+    headers['If-Match'] = options.etag;
+  }
+
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(eventId)}?${params.toString()}`,
+    {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    }
+  );
+
+  if (res.status === 412) {
+    throw new GoogleCalendarPatchConflictError(eventId);
+  }
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Google Calendar API ${res.status}: ${text}`);
+  }
+
+  return (await res.json()) as GCalEvent;
+}
+
 interface CalendarFetchResult<TEvent> {
   events: TEvent[];
   truncated: boolean;

--- a/apps/backend/src/services/googleCalendarApi.ts
+++ b/apps/backend/src/services/googleCalendarApi.ts
@@ -18,10 +18,7 @@ export class GoogleCalendarPatchConflictError extends Error {
   }
 }
 
-export async function getGoogleEventById(
-  accessToken: string,
-  eventId: string
-): Promise<GCalEvent> {
+export async function getGoogleEventById(accessToken: string, eventId: string): Promise<GCalEvent> {
   const res = await fetch(
     `https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(eventId)}`,
     {
@@ -52,7 +49,9 @@ export async function patchGoogleEvent(
   body: Record<string, unknown>,
   options?: { conferenceDataVersion?: boolean; etag?: string }
 ): Promise<GCalEvent> {
-  const params = new URLSearchParams({ sendUpdates: 'all' });
+  // This is a background reconciliation, not an organizer-authored update.
+  // Suppress attendee emails; webhook delivery is unaffected by sendUpdates.
+  const params = new URLSearchParams({ sendUpdates: 'none' });
   if (options?.conferenceDataVersion) {
     params.set('conferenceDataVersion', '1');
   }

--- a/apps/backend/src/services/googleCalendarCallStore.ts
+++ b/apps/backend/src/services/googleCalendarCallStore.ts
@@ -142,6 +142,7 @@ export async function storeGCalEventAsCall(
       endsAt,
       timezone: event.start?.timeZone ?? 'UTC',
       xyneManaged,
+      channelId: xyneManaged ? (event.extendedProperties?.private?.xyneChannelId ?? null) : null,
       metadata: {
         provider: 'google',
         calendarOwnerEmail,

--- a/apps/backend/src/services/googleCalendarCallStore.ts
+++ b/apps/backend/src/services/googleCalendarCallStore.ts
@@ -40,17 +40,25 @@ export interface GCalAttendee {
 
 export interface GCalEvent {
   id?: string;
+  etag?: string;
   summary?: string;
   description?: string;
   start?: GCalDateTime;
   end?: GCalDateTime;
   location?: string;
   status?: string;
+  eventType?: string;
+  recurringEventId?: string;
   htmlLink?: string;
   organizer?: { email?: string; displayName?: string; self?: boolean };
   attendees?: GCalAttendee[];
   hangoutLink?: string;
-  conferenceData?: { entryPoints?: { uri?: string; entryPointType?: string }[] };
+  conferenceData?: {
+    conferenceId?: string;
+    conferenceSolution?: { name?: string; key?: { type?: string } };
+    entryPoints?: { uri?: string; entryPointType?: string; label?: string }[];
+  };
+  extendedProperties?: { private?: Record<string, string> };
 }
 
 export interface GCalListResponse {
@@ -69,6 +77,15 @@ function parseGCalDateTime(dt?: GCalDateTime): Date | undefined {
 }
 
 function resolveRoomLink(event: GCalEvent): string | undefined {
+  // Xyne Call Link Auto-Injection: once an event has been patched, the private
+  // xyneRoomLink property is the canonical URL for the parallel Call record,
+  // used for summary posting/post-call workflows regardless of whether the
+  // Calendar conference entry itself was replaced (internal-only) or left
+  // untouched (external-participant, Xyne link lives in the description only).
+  const xyneRoomLink = event.extendedProperties?.private?.xyneRoomLink;
+  if (event.extendedProperties?.private?.xyneManaged === 'true' && xyneRoomLink) {
+    return xyneRoomLink;
+  }
   if (event.hangoutLink) return event.hangoutLink;
   const videoEntry = event.conferenceData?.entryPoints?.find((e) => e.entryPointType === 'video');
   if (videoEntry?.uri) return videoEntry.uri;
@@ -107,6 +124,8 @@ export async function storeGCalEventAsCall(
     (a) => !organizerEmail || a.email !== organizerEmail
   );
 
+  const xyneManaged = event.extendedProperties?.private?.xyneManaged === 'true';
+
   await upsertExternalCalendarCall(
     {
       externalId,
@@ -122,6 +141,7 @@ export async function storeGCalEventAsCall(
       startsAt,
       endsAt,
       timezone: event.start?.timeZone ?? 'UTC',
+      xyneManaged,
       metadata: {
         provider: 'google',
         calendarOwnerEmail,

--- a/apps/backend/src/services/googleCalendarCallStore.ts
+++ b/apps/backend/src/services/googleCalendarCallStore.ts
@@ -48,6 +48,11 @@ export interface GCalEvent {
   location?: string;
   status?: string;
   eventType?: string;
+  /**
+   * Present on expanded recurring instances. Because all fetches use
+   * singleEvents=true, each occurrence intentionally keeps its own event.id,
+   * Call row, and Xyne room rather than mutating the series master.
+   */
   recurringEventId?: string;
   htmlLink?: string;
   organizer?: { email?: string; displayName?: string; self?: boolean };

--- a/apps/backend/src/services/xyneCallLinkInjector.ts
+++ b/apps/backend/src/services/xyneCallLinkInjector.ts
@@ -29,7 +29,7 @@
 import { type GCalEvent } from '@/services/googleCalendarCallStore';
 import { type CalendarCredentials } from '@/services/calendarTokenRefresh';
 import { isTeamEligible } from '@/services/calendarSyncConfig';
-import { resolveXyneCallForEvent } from '@/services/xyneCallService';
+import { resolveXyneCallForEvent, resolveXyneChannelForUser } from '@/services/xyneCallService';
 import { reconcileEventConference, escapeHtmlAttribute } from '@/services/calendarConferencePatcher';
 import { buildCalendarExternalId } from '@/services/calendarCallStore.utils';
 import { DatabaseClient } from '@/database/client';
@@ -100,7 +100,8 @@ function isAlreadyReconciled(event: GCalEvent, internalOnly: boolean): boolean {
 async function reconcileOne(
   event: GCalEvent,
   credentials: CalendarCredentials,
-  userEmail: string
+  userEmail: string,
+  workspaceId: string
 ): Promise<GCalEvent> {
 
 
@@ -131,6 +132,7 @@ async function reconcileOne(
 
   try {
     const { roomLink, isNew } = await resolveXyneCallForEvent(credentials.userId, event.id!);
+    const channelId = await resolveXyneChannelForUser(credentials.userId, workspaceId);
     logger.info(`${TAG} ${isNew ? 'call_created' : 'call_recovered'}`, {
       eventId: event.id,
       internalOnly,
@@ -140,6 +142,7 @@ async function reconcileOne(
     const patched = await reconcileEventConference(credentials.accessToken, event, {
       roomLink,
       xyneCallId,
+      channelId,
       replaceConference: internalOnly,
     });
 
@@ -165,12 +168,13 @@ async function reconcileOne(
 export async function reconcileXyneCallLinks(
   events: GCalEvent[],
   credentials: CalendarCredentials,
-  userEmail: string
+  userEmail: string,
+  workspaceId: string
 ): Promise<GCalEvent[]> {
   const results: GCalEvent[] = [];
   for (const event of events) {
     try {
-      results.push(await reconcileOne(event, credentials, userEmail));
+      results.push(await reconcileOne(event, credentials, userEmail, workspaceId));
     } catch (err) {
       logger.error(`${TAG} Unexpected reconciliation error, storing original event`, {
         eventId: event.id,

--- a/apps/backend/src/services/xyneCallLinkInjector.ts
+++ b/apps/backend/src/services/xyneCallLinkInjector.ts
@@ -1,0 +1,183 @@
+/**
+ * Xyne Call Link Injector (Xyne Call Link Auto-Injection reconciler)
+ *
+ * For every eligible event organized by a connected, allowlisted user:
+ * creates/recovers a hosted Xyne Call, clears the existing (non-Xyne)
+ * conference entry when every participant is internal (@juspay.in), and
+ * always upserts the managed description link. Ineligible/ambiguous events
+ * pass through untouched. One event failing must never abort the batch
+ * (PRD §9).
+ *
+ * Note: Google Calendar's API rejects a custom addOn-type conference entry
+ * from apps that aren't a registered conferencing partner (confirmed via a
+ * live 400 "Invalid conference data" response) — so "replace" here means
+ * clearing the stale entry, not rendering "Join Xyne Call" in the native
+ * join UI. The Xyne link is always reachable via the description instead.
+ *
+ * Eligibility gates (in order):
+ *  1. Has an id and organizer email; not cancelled; not an out-of-office /
+ *     focus-time / working-location / Gmail-derived event (FR-5).
+ *  2. The event's organizer email must equal the connected user's email —
+ *     never patch an event where the user is only an attendee (FR-3).
+ *  3. The organizer must be eligible per the Superposition-backed CAC config —
+ *     either their email domain OR their UserProfile team is allowlisted (FR-2).
+ * Internal-only vs external-participant classification (FR-4) is a
+ * separate, hardcoded check against @juspay.in — distinct from the
+ * allowlist above, which only gates whether Xyne acts on the event at all.
+ */
+
+import { type GCalEvent } from '@/services/googleCalendarCallStore';
+import { type CalendarCredentials } from '@/services/calendarTokenRefresh';
+import { isTeamEligible } from '@/services/calendarSyncConfig';
+import { resolveXyneCallForEvent } from '@/services/xyneCallService';
+import { reconcileEventConference, escapeHtmlAttribute } from '@/services/calendarConferencePatcher';
+import { buildCalendarExternalId } from '@/services/calendarCallStore.utils';
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+
+const TAG = '[CALENDAR_SYNC][GOOGLE][XYNE_CALL_INJECTOR]';
+
+const INTERNAL_PARTICIPANT_DOMAIN = 'juspay.in';
+const SKIPPED_EVENT_TYPES = new Set(['outOfOffice', 'focusTime', 'workingLocation', 'fromGmail']);
+
+type SkipReason =
+  | 'missing_id_or_organizer'
+  | 'cancelled'
+  | 'unsupported_event_type'
+  | 'not_organizer'
+  | 'not_eligible';
+
+function normalizeEmail(email: string | undefined): string {
+  return (email ?? '').trim().toLowerCase();
+}
+
+function emailDomain(email: string | undefined): string | null {
+  const normalized = normalizeEmail(email);
+  const domain = normalized.split('@')[1];
+  return domain && domain.length > 0 ? domain : null;
+}
+
+/** Fetches the organizer's team from UserProfile, if any. */
+async function getUserTeam(userId: string): Promise<string | null> {
+  const profile = await DatabaseClient.getInstance().userProfile.findUnique({
+    where: { userId },
+    select: { team: true },
+  });
+  return profile?.team ?? null;
+}
+
+function isEligibleShape(event: GCalEvent): SkipReason | null {
+  if (!event.id || !event.organizer?.email) return 'missing_id_or_organizer';
+  if (event.status === 'cancelled') return 'cancelled';
+  if (event.eventType && SKIPPED_EVENT_TYPES.has(event.eventType)) return 'unsupported_event_type';
+  return null;
+}
+
+/** Every organizer + attendee email must resolve to the internal domain. */
+function isInternalOnly(event: GCalEvent): boolean {
+  const emails = [event.organizer?.email, ...(event.attendees ?? []).map((a) => a.email)];
+  return emails.every((email) => emailDomain(email) === INTERNAL_PARTICIPANT_DOMAIN);
+}
+
+/** FR-7: is this event already correctly reconciled, so no patch is needed? */
+function isAlreadyReconciled(event: GCalEvent, internalOnly: boolean): boolean {
+  const priv = event.extendedProperties?.private;
+  const roomLink = priv?.xyneRoomLink;
+  if (priv?.xyneManaged !== 'true' || !roomLink) return false;
+
+  const descriptionHasLink = (event.description ?? '').includes(escapeHtmlAttribute(roomLink));
+  if (!descriptionHasLink) return false;
+
+  if (!internalOnly) return true; // conference entry is intentionally left untouched
+
+  // Internal-only: reconciled means the stale (non-Xyne) conference entry has
+  // been cleared — we can't set our own entry point (see module doc), so
+  // there's nothing to match against, only an absence to confirm.
+  const hasConferenceEntry = (event.conferenceData?.entryPoints ?? []).length > 0;
+  return !hasConferenceEntry;
+}
+
+async function reconcileOne(
+  event: GCalEvent,
+  credentials: CalendarCredentials,
+  userEmail: string
+): Promise<GCalEvent> {
+
+
+  const shapeSkipReason = isEligibleShape(event);
+  if (shapeSkipReason) {
+    logger.info(`${TAG} Skipped`, { eventId: event.id, reason: shapeSkipReason });
+    return event;
+  }
+
+  if (normalizeEmail(event.organizer?.email) !== normalizeEmail(userEmail)) {
+    logger.info(`${TAG} Skipped`, { eventId: event.id, reason: 'not_organizer' satisfies SkipReason });
+    return event;
+  }
+
+  const team = await getUserTeam(credentials.userId);
+  const eligible = await isTeamEligible({ email: userEmail, team });
+  if (!eligible) {
+    logger.info(`${TAG} Skipped`, { eventId: event.id, reason: 'not_eligible' satisfies SkipReason });
+    return event;
+  }
+
+  const internalOnly = isInternalOnly(event);
+
+  if (isAlreadyReconciled(event, internalOnly)) {
+    logger.info(`${TAG} Already reconciled, no patch needed`, { eventId: event.id, internalOnly });
+    return event;
+  }
+
+  try {
+    const { roomLink, isNew } = await resolveXyneCallForEvent(credentials.userId, event.id!);
+    logger.info(`${TAG} ${isNew ? 'call_created' : 'call_recovered'}`, {
+      eventId: event.id,
+      internalOnly,
+    });
+
+    const xyneCallId = buildCalendarExternalId('google', credentials.userId, event.id!);
+    const patched = await reconcileEventConference(credentials.accessToken, event, {
+      roomLink,
+      xyneCallId,
+      replaceConference: internalOnly,
+    });
+
+    logger.info(`${TAG} patched`, { eventId: event.id, internalOnly });
+    return patched;
+  } catch (err) {
+    logger.error(`${TAG} patch_failed`, {
+      eventId: event.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    // Per PRD: a failed patch must not mark the event as managed and must
+    // not abort the batch — fall back to the unpatched event so the normal
+    // (passive) storage pipeline still runs on it.
+    return event;
+  }
+}
+
+/**
+ * Reconcile Xyne Call links for a batch of already-fetched Google Calendar
+ * events. Returns events in the same order, patched where eligible and
+ * unchanged otherwise. A single event's failure never aborts the batch.
+ */
+export async function reconcileXyneCallLinks(
+  events: GCalEvent[],
+  credentials: CalendarCredentials,
+  userEmail: string
+): Promise<GCalEvent[]> {
+  const results: GCalEvent[] = [];
+  for (const event of events) {
+    try {
+      results.push(await reconcileOne(event, credentials, userEmail));
+    } catch (err) {
+      logger.error(`${TAG} Unexpected reconciliation error, storing original event`, {
+        eventId: event.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      results.push(event);
+    }
+  }
+  return results;
+}

--- a/apps/backend/src/services/xyneCallLinkInjector.ts
+++ b/apps/backend/src/services/xyneCallLinkInjector.ts
@@ -30,7 +30,10 @@ import { type GCalEvent } from '@/services/googleCalendarCallStore';
 import { type CalendarCredentials } from '@/services/calendarTokenRefresh';
 import { isTeamEligible } from '@/services/calendarSyncConfig';
 import { resolveXyneCallForEvent, resolveXyneChannelForUser } from '@/services/xyneCallService';
-import { reconcileEventConference, escapeHtmlAttribute } from '@/services/calendarConferencePatcher';
+import {
+  reconcileEventConference,
+  escapeHtmlAttribute,
+} from '@/services/calendarConferencePatcher';
 import { buildCalendarExternalId } from '@/services/calendarCallStore.utils';
 import { DatabaseClient } from '@/database/client';
 import { logger } from '@/utils/logger';
@@ -74,18 +77,24 @@ function isEligibleShape(event: GCalEvent): SkipReason | null {
 }
 
 /** Every organizer + attendee email must resolve to the internal domain. */
-function isInternalOnly(event: GCalEvent): boolean {
+export function isInternalOnly(event: GCalEvent): boolean {
   const emails = [event.organizer?.email, ...(event.attendees ?? []).map((a) => a.email)];
   return emails.every((email) => emailDomain(email) === INTERNAL_PARTICIPANT_DOMAIN);
 }
 
 /** FR-7: is this event already correctly reconciled, so no patch is needed? */
-function isAlreadyReconciled(event: GCalEvent, internalOnly: boolean): boolean {
+function isAlreadyReconciled(
+  event: GCalEvent,
+  internalOnly: boolean,
+  expectedCallId: string
+): boolean {
   const priv = event.extendedProperties?.private;
   const roomLink = priv?.xyneRoomLink;
-  if (priv?.xyneManaged !== 'true' || !roomLink) return false;
+  if (priv?.xyneManaged !== 'true' || priv.xyneCallId !== expectedCallId || !roomLink) return false;
 
-  const descriptionHasLink = (event.description ?? '').includes(escapeHtmlAttribute(roomLink));
+  const description = event.description ?? '';
+  const descriptionHasLink =
+    description.includes(roomLink) || description.includes(escapeHtmlAttribute(roomLink));
   if (!descriptionHasLink) return false;
 
   if (!internalOnly) return true; // conference entry is intentionally left untouched
@@ -101,10 +110,8 @@ async function reconcileOne(
   event: GCalEvent,
   credentials: CalendarCredentials,
   userEmail: string,
-  workspaceId: string
+  resolveChannelId: () => Promise<string>
 ): Promise<GCalEvent> {
-
-
   const shapeSkipReason = isEligibleShape(event);
   if (shapeSkipReason) {
     logger.info(`${TAG} Skipped`, { eventId: event.id, reason: shapeSkipReason });
@@ -112,33 +119,29 @@ async function reconcileOne(
   }
 
   if (normalizeEmail(event.organizer?.email) !== normalizeEmail(userEmail)) {
-    logger.info(`${TAG} Skipped`, { eventId: event.id, reason: 'not_organizer' satisfies SkipReason });
-    return event;
-  }
-
-  const team = await getUserTeam(credentials.userId);
-  const eligible = await isTeamEligible({ email: userEmail, team });
-  if (!eligible) {
-    logger.info(`${TAG} Skipped`, { eventId: event.id, reason: 'not_eligible' satisfies SkipReason });
+    logger.info(`${TAG} Skipped`, {
+      eventId: event.id,
+      reason: 'not_organizer' satisfies SkipReason,
+    });
     return event;
   }
 
   const internalOnly = isInternalOnly(event);
+  const xyneCallId = buildCalendarExternalId('google', credentials.userId, event.id!);
 
-  if (isAlreadyReconciled(event, internalOnly)) {
+  if (isAlreadyReconciled(event, internalOnly, xyneCallId)) {
     logger.info(`${TAG} Already reconciled, no patch needed`, { eventId: event.id, internalOnly });
     return event;
   }
 
   try {
     const { roomLink, isNew } = await resolveXyneCallForEvent(credentials.userId, event.id!);
-    const channelId = await resolveXyneChannelForUser(credentials.userId, workspaceId);
+    const channelId = await resolveChannelId();
     logger.info(`${TAG} ${isNew ? 'call_created' : 'call_recovered'}`, {
       eventId: event.id,
       internalOnly,
     });
 
-    const xyneCallId = buildCalendarExternalId('google', credentials.userId, event.id!);
     const patched = await reconcileEventConference(credentials.accessToken, event, {
       roomLink,
       xyneCallId,
@@ -171,10 +174,41 @@ export async function reconcileXyneCallLinks(
   userEmail: string,
   workspaceId: string
 ): Promise<GCalEvent[]> {
+  if (events.length === 0) return events;
+
+  // Team/config eligibility and the backing self-DM channel are constant for
+  // the entire batch. Resolve eligibility once, and lazily memoize the channel
+  // so an already-reconciled batch does not perform any channel work.
+  let eligible: boolean;
+  try {
+    const team = await getUserTeam(credentials.userId);
+    eligible = await isTeamEligible({ email: userEmail, team });
+  } catch (err) {
+    logger.error(`${TAG} Failed to resolve batch eligibility, storing original events`, {
+      eventCount: events.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return events;
+  }
+
+  if (!eligible) {
+    logger.info(`${TAG} Batch skipped`, {
+      eventCount: events.length,
+      reason: 'not_eligible' satisfies SkipReason,
+    });
+    return events;
+  }
+
+  let channelIdPromise: Promise<string> | undefined;
+  const resolveChannelId = (): Promise<string> => {
+    channelIdPromise ??= resolveXyneChannelForUser(credentials.userId, workspaceId);
+    return channelIdPromise;
+  };
+
   const results: GCalEvent[] = [];
   for (const event of events) {
     try {
-      results.push(await reconcileOne(event, credentials, userEmail, workspaceId));
+      results.push(await reconcileOne(event, credentials, userEmail, resolveChannelId));
     } catch (err) {
       logger.error(`${TAG} Unexpected reconciliation error, storing original event`, {
         eventId: event.id,

--- a/apps/backend/src/services/xyneCallService.ts
+++ b/apps/backend/src/services/xyneCallService.ts
@@ -10,8 +10,8 @@
  * route, since Calendar invitees — internal or external — shouldn't need a
  * Xyne account just to open the link (PRD: OPEN access, anyone with the link
  * can request or join). Actual persistence of the Call row (xyneManaged,
- * roomLink) happens through the existing storeGCalEventAsCall upsert pipeline
- * once the Calendar PATCH succeeds.
+ * roomLink, channelId) happens through the existing storeGCalEventAsCall
+ * upsert pipeline once the Calendar PATCH succeeds.
  */
 
 import { repositories } from '@/database/repositories';
@@ -44,4 +44,23 @@ export async function resolveXyneCallForEvent(
 
   const roomLink = buildCallInviteUrl(externalId);
   return { roomLink, isNew: !existing };
+}
+
+/**
+ * Resolves (or creates) the organizer's self-DM channel to back a Xyne-managed
+ * calendar call. The join API (`joinCall`) requires `call.channelId` to resolve
+ * a real Channel before it will create the LiveKit room on first join — without
+ * one it fails with "Channel not found", since calendar-mirrored calls are
+ * otherwise created with channelId=null (see calendarCallStore.utils.ts).
+ */
+export async function resolveXyneChannelForUser(
+  userId: string,
+  workspaceId: string
+): Promise<string> {
+  return repositories.channels.findOrCreateDMChannel(
+    userId,
+    [userId],
+    repositories.channelParticipants,
+    workspaceId
+  );
 }

--- a/apps/backend/src/services/xyneCallService.ts
+++ b/apps/backend/src/services/xyneCallService.ts
@@ -1,0 +1,47 @@
+/**
+ * Xyne Call Service (Xyne Call Link Auto-Injection)
+ *
+ * Resolves the hosted Xyne Call for a given Google Calendar event: recovers
+ * a previously-created call's room link so it never changes across syncs,
+ * or derives a fresh one for a not-yet-managed event. No explicit "create
+ * room" API call is needed — the room is created implicitly on first join.
+ * The link always points at the external/guest invite flow (dashboard-external,
+ * no Xyne login required) rather than the internal authenticated dashboard
+ * route, since Calendar invitees — internal or external — shouldn't need a
+ * Xyne account just to open the link (PRD: OPEN access, anyone with the link
+ * can request or join). Actual persistence of the Call row (xyneManaged,
+ * roomLink) happens through the existing storeGCalEventAsCall upsert pipeline
+ * once the Calendar PATCH succeeds.
+ */
+
+import { repositories } from '@/database/repositories';
+import { buildCallInviteUrl } from '@/utils/urlUtils';
+import { buildCalendarExternalId } from '@/services/calendarCallStore.utils';
+
+export interface ResolvedXyneCall {
+  /** Canonical Xyne Call join URL. Stable across recoveries. */
+  roomLink: string;
+  /** True when no prior Xyne-managed call existed for this event. */
+  isNew: boolean;
+}
+
+/**
+ * Create-or-recover the hosted Xyne Call for a Google Calendar event owned
+ * by userId. Recovery is keyed off the same deterministic external ID the
+ * passive mirror pipeline already uses, so a previously-managed event always
+ * gets back the exact same join link.
+ */
+export async function resolveXyneCallForEvent(
+  userId: string,
+  googleEventId: string
+): Promise<ResolvedXyneCall> {
+  const externalId = buildCalendarExternalId('google', userId, googleEventId);
+  const existing = await repositories.calls.findByExternalId(externalId);
+
+  if (existing?.xyneManaged && existing.roomLink) {
+    return { roomLink: existing.roomLink, isNew: false };
+  }
+
+  const roomLink = buildCallInviteUrl(externalId);
+  return { roomLink, isNew: !existing };
+}

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -4318,6 +4318,7 @@ export function createMutators(
             updatedAt: now,
             labels: [],
             markedItems: [],
+            xyneManaged: false,
             metadata: {
               systemMessageId,
               conversationId,

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -710,7 +710,7 @@ const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => {
           variant='outline'
           size='sm'
           disabled={isDisconnecting}
-          onClick={handleDisconnectCalendar}
+          onClick={() => void handleDisconnectCalendar()}
           data-track-category='PREFERENCES'
           data-track-name='DisconnectCalendar'
         >

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -571,153 +571,153 @@ const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => {
   };
 
   return (
-  <div className='space-y-6'>
-    <SectionHeader title='Calls' subtitle='Configure your default call join settings' />
+    <div className='space-y-6'>
+      <SectionHeader title='Calls' subtitle='Configure your default call join settings' />
 
-    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Join with microphone turned off</p>
-        <p className='text-xs text-muted-foreground mt-0.5'>Mute your mic when joining a call</p>
+      <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Join with microphone turned off</p>
+          <p className='text-xs text-muted-foreground mt-0.5'>Mute your mic when joining a call</p>
+        </div>
+        <Switch
+          id='call-join-muted'
+          checked={state.callJoinMuted}
+          onCheckedChange={state.setCallJoinMuted}
+        />
       </div>
-      <Switch
-        id='call-join-muted'
-        checked={state.callJoinMuted}
-        onCheckedChange={state.setCallJoinMuted}
-      />
-    </div>
 
-    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Join with camera turned off</p>
+      <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Join with camera turned off</p>
+          <p className='text-xs text-muted-foreground mt-0.5'>
+            Disable your camera when joining a call
+          </p>
+        </div>
+        <Switch
+          id='call-join-without-video'
+          checked={state.callJoinWithoutVideo}
+          onCheckedChange={state.setCallJoinWithoutVideo}
+        />
+      </div>
+
+      <div className='p-3 rounded-lg border border-border bg-muted/30 space-y-3'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Call media quality</p>
+          <p className='text-xs text-muted-foreground mt-0.5'>
+            Target capture quality for new camera and screen-share tracks.
+          </p>
+        </div>
+        <QualitySelect
+          id='call-video-quality'
+          label='Video'
+          value={state.callVideoQuality}
+          onChange={state.setCallVideoQuality}
+        />
+        <QualitySelect
+          id='call-screen-share-quality'
+          label='Screen share'
+          value={state.callScreenShareQuality}
+          onChange={state.setCallScreenShareQuality}
+        />
+      </div>
+
+      <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Use new recording experience</p>
+          <p className='text-xs text-muted-foreground mt-0.5'>
+            {state.canSwitchRecordingVersion
+              ? 'Switch between the classic and redesigned recording interface on this device.'
+              : 'Stop the active recording before switching experiences.'}
+          </p>
+        </div>
+        <Switch
+          id='recording-version-v2'
+          aria-label='Use new recording experience'
+          checked={state.recordingVersion === 'v2'}
+          disabled={!state.canSwitchRecordingVersion}
+          onCheckedChange={checked => state.setRecordingVersion(checked ? 'v2' : 'v1')}
+        />
+      </div>
+
+      <MenuBarIconToggle />
+
+      <RecordingPillToggle />
+
+      {/* Recording section divider */}
+      <div className='pt-2'>
+        <p id='recording-tab-view-label' className='text-sm font-semibold text-foreground'>
+          Recording tab view
+        </p>
         <p className='text-xs text-muted-foreground mt-0.5'>
-          Disable your camera when joining a call
+          Which view opens by default when notes are created during a recording
         </p>
       </div>
-      <Switch
-        id='call-join-without-video'
-        checked={state.callJoinWithoutVideo}
-        onCheckedChange={state.setCallJoinWithoutVideo}
-      />
-    </div>
 
-    <div className='p-3 rounded-lg border border-border bg-muted/30 space-y-3'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Call media quality</p>
-        <p className='text-xs text-muted-foreground mt-0.5'>
-          Target capture quality for new camera and screen-share tracks.
-        </p>
-      </div>
-      <QualitySelect
-        id='call-video-quality'
-        label='Video'
-        value={state.callVideoQuality}
-        onChange={state.setCallVideoQuality}
-      />
-      <QualitySelect
-        id='call-screen-share-quality'
-        label='Screen share'
-        value={state.callScreenShareQuality}
-        onChange={state.setCallScreenShareQuality}
-      />
-    </div>
-
-    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Use new recording experience</p>
-        <p className='text-xs text-muted-foreground mt-0.5'>
-          {state.canSwitchRecordingVersion
-            ? 'Switch between the classic and redesigned recording interface on this device.'
-            : 'Stop the active recording before switching experiences.'}
-        </p>
-      </div>
-      <Switch
-        id='recording-version-v2'
-        aria-label='Use new recording experience'
-        checked={state.recordingVersion === 'v2'}
-        disabled={!state.canSwitchRecordingVersion}
-        onCheckedChange={checked => state.setRecordingVersion(checked ? 'v2' : 'v1')}
-      />
-    </div>
-
-    <MenuBarIconToggle />
-
-    <RecordingPillToggle />
-
-    {/* Recording section divider */}
-    <div className='pt-2'>
-      <p id='recording-tab-view-label' className='text-sm font-semibold text-foreground'>
-        Recording tab view
-      </p>
-      <p className='text-xs text-muted-foreground mt-0.5'>
-        Which view opens by default when notes are created during a recording
-      </p>
-    </div>
-
-    {/* Layout options */}
-    <div className='space-y-3' role='radiogroup' aria-labelledby='recording-tab-view-label'>
-      {LAYOUT_OPTIONS.map(option => {
-        const isSelected = state.recordingDefaultLayout === option.value;
-        return (
-          <button
-            key={option.value}
-            type='button'
-            role='radio'
-            aria-checked={isSelected}
-            onClick={() => state.setRecordingDefaultLayout(option.value)}
-            className={cn(
-              'w-full flex items-center gap-4 p-3 rounded-xl border transition-all duration-150',
-              isSelected
-                ? 'border-action-primary bg-action-primary/5'
-                : 'border-border bg-muted/30 hover:bg-muted/50',
-            )}
-            data-track-category='PREFERENCES'
-            data-track-name={`SelectRecordingLayout_${option.value}`}
-          >
-            <option.Preview />
-            <div className='flex-1 text-left min-w-0'>
-              <p className='text-sm font-medium text-foreground'>{option.title}</p>
-              <p className='text-xs text-muted-foreground mt-0.5'>{option.description}</p>
-            </div>
-            {/* Radio indicator */}
-            <div
+      {/* Layout options */}
+      <div className='space-y-3' role='radiogroup' aria-labelledby='recording-tab-view-label'>
+        {LAYOUT_OPTIONS.map(option => {
+          const isSelected = state.recordingDefaultLayout === option.value;
+          return (
+            <button
+              key={option.value}
+              type='button'
+              role='radio'
+              aria-checked={isSelected}
+              onClick={() => state.setRecordingDefaultLayout(option.value)}
               className={cn(
-                'w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-colors duration-150',
-                isSelected ? 'border-action-primary' : 'border-border',
+                'w-full flex items-center gap-4 p-3 rounded-xl border transition-all duration-150',
+                isSelected
+                  ? 'border-action-primary bg-action-primary/5'
+                  : 'border-border bg-muted/30 hover:bg-muted/50',
               )}
+              data-track-category='PREFERENCES'
+              data-track-name={`SelectRecordingLayout_${option.value}`}
             >
-              {isSelected && <div className='w-2.5 h-2.5 rounded-full bg-action-primary' />}
-            </div>
-          </button>
-        );
-      })}
-    </div>
+              <option.Preview />
+              <div className='flex-1 text-left min-w-0'>
+                <p className='text-sm font-medium text-foreground'>{option.title}</p>
+                <p className='text-xs text-muted-foreground mt-0.5'>{option.description}</p>
+              </div>
+              {/* Radio indicator */}
+              <div
+                className={cn(
+                  'w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-colors duration-150',
+                  isSelected ? 'border-action-primary' : 'border-border',
+                )}
+              >
+                {isSelected && <div className='w-2.5 h-2.5 rounded-full bg-action-primary' />}
+              </div>
+            </button>
+          );
+        })}
+      </div>
 
-    {/* Calendar connection */}
-    <div className='pt-2'>
-      <p className='text-sm font-semibold text-foreground'>Calendar</p>
-      <p className='text-xs text-muted-foreground mt-0.5'>
-        Disconnect to revoke access and reconnect with updated permissions.
-      </p>
-    </div>
-    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Disconnect Calendar</p>
+      {/* Calendar connection */}
+      <div className='pt-2'>
+        <p className='text-sm font-semibold text-foreground'>Calendar</p>
         <p className='text-xs text-muted-foreground mt-0.5'>
-          Stops calendar sync and clears the stored connection.
+          Disconnect to revoke access and reconnect with updated permissions.
         </p>
       </div>
-      <Button
-        variant='outline'
-        size='sm'
-        disabled={isDisconnecting}
-        onClick={handleDisconnectCalendar}
-        data-track-category='PREFERENCES'
-        data-track-name='DisconnectCalendar'
-      >
-        {isDisconnecting ? 'Disconnecting…' : 'Disconnect'}
-      </Button>
+      <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Disconnect Calendar</p>
+          <p className='text-xs text-muted-foreground mt-0.5'>
+            Stops calendar sync and clears the stored connection.
+          </p>
+        </div>
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={isDisconnecting}
+          onClick={handleDisconnectCalendar}
+          data-track-category='PREFERENCES'
+          data-track-name='DisconnectCalendar'
+        >
+          {isDisconnecting ? 'Disconnecting…' : 'Disconnect'}
+        </Button>
+      </div>
     </div>
-  </div>
   );
 };
 

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -64,6 +64,8 @@ import { useToolbarItems } from '../../../hooks/useToolbarItems';
 import { isRequiredToolbarPath } from '../../AppSidebar/navigationConfig';
 import type { PreferenceSection, PreferencesProps, NavItem } from '.';
 import { RecordingLayout } from '../../../stores/recordingStore';
+import { disconnectCalendar } from '../../../services/clients/calendarApi';
+import { toast } from 'sonner';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 const NAV_ITEMS: NavItem[] = [
@@ -553,7 +555,22 @@ const LAYOUT_OPTIONS: LayoutOption[] = [
   },
 ];
 
-const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => (
+const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => {
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const handleDisconnectCalendar = async () => {
+    setIsDisconnecting(true);
+    try {
+      await disconnectCalendar('GOOGLE');
+      toast.success('Calendar disconnected. Reconnect to grant updated permissions.');
+    } catch {
+      toast.error('Failed to disconnect calendar. Please try again.');
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  return (
   <div className='space-y-6'>
     <SectionHeader title='Calls' subtitle='Configure your default call join settings' />
 
@@ -674,8 +691,35 @@ const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => (
         );
       })}
     </div>
+
+    {/* Calendar connection */}
+    <div className='pt-2'>
+      <p className='text-sm font-semibold text-foreground'>Calendar</p>
+      <p className='text-xs text-muted-foreground mt-0.5'>
+        Disconnect to revoke access and reconnect with updated permissions.
+      </p>
+    </div>
+    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
+      <div>
+        <p className='text-sm font-medium text-foreground'>Disconnect Calendar</p>
+        <p className='text-xs text-muted-foreground mt-0.5'>
+          Stops calendar sync and clears the stored connection.
+        </p>
+      </div>
+      <Button
+        variant='outline'
+        size='sm'
+        disabled={isDisconnecting}
+        onClick={handleDisconnectCalendar}
+        data-track-category='PREFERENCES'
+        data-track-name='DisconnectCalendar'
+      >
+        {isDisconnecting ? 'Disconnecting…' : 'Disconnect'}
+      </Button>
+    </div>
   </div>
-);
+  );
+};
 
 // ─── Messaging ──────────────────────────────────────────────────────────────
 // Section is desktop-only (see NAV_ITEMS), so no isMobile branching needed.

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
@@ -184,6 +184,7 @@ function mapVespaCallResultToCall(result: DisplaySearchResult, workspaceId: stri
     summaryTemplateId: null,
     labels: [],
     markedItems: [],
+    xyneManaged: false,
     participants: Array.from({ length: participantCount }, (_, index) => {
       const userId = participantUserIds[index] || '';
       const displayName = stripSearchHighlight(participantNames[index]);

--- a/apps/dashboard/src/services/clients/calendarApi.ts
+++ b/apps/dashboard/src/services/clients/calendarApi.ts
@@ -24,6 +24,14 @@ export async function syncCalendar(provider: CalendarProvider): Promise<void> {
   await apiInstance.post(`/calendar/sync/${providerPath}`);
 }
 
+/** Disconnects the calendar: stops the watch and clears stored OAuth credentials
+ * so a subsequent connect goes through Google's/Microsoft's consent screen again
+ * (needed to pick up newly-added scopes like calendar.events). */
+export async function disconnectCalendar(provider: CalendarProvider): Promise<void> {
+  const providerPath = provider === 'GOOGLE' ? 'google' : 'microsoft';
+  await apiInstance.delete(`/calendar/watch/${providerPath}`);
+}
+
 export async function initCalendarOAuth(
   platform: CalendarOAuthPlatform = 'web',
 ): Promise<CalendarOAuthInitResponse> {

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1165,6 +1165,7 @@ export const callTable = table('calls')
     summaryTemplateId: string().optional(),
     labels: json<string[]>(),
     markedItems: json<any[]>(),
+    xyneManaged: boolean(),
   })
   .primaryKey('id');
 


### PR DESCRIPTION
pot - 
<img width="526" height="321" alt="Screenshot 2026-08-12 at 3 43 01 PM" src="https://github.com/user-attachments/assets/40422ea8-bfa4-41e1-bfb8-7f3434a9236a" />

<img width="1385" height="856" alt="Screenshot 2026-08-13 at 6 09 20 PM" src="https://github.com/user-attachments/assets/dc9bbe93-42d2-4f6b-b974-d7d4a52eacf2" />

<img width="1312" height="1048" alt="Screenshot 2026-08-12 at 4 05 04 PM" src="https://github.com/user-attachments/assets/1767baba-dc6b-4333-a0ec-f0d3fa61f748" />

<img width="537" height="304" alt="Screenshot 2026-08-12 at 3 42 56 PM" src="https://github.com/user-attachments/assets/e0d3906c-5eb7-4003-801d-b25fc3ccdd42" />


## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
