### PR TITLE
Feature/user question widget

### DIFF
--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -141,8 +141,8 @@ function getFlowJsonRawTextForMentions(content: string): string | null {
  * Friendly notification label for a flow CARD (plan, etc.) whose todos/title
  * don't live in text `content` props — so extractTextFromFlowJson returns ''
  * and the preview would otherwise fall back to the meaningless "Flow JSON" text
- * node. Currently handles the `plan` component; returns null for other flows so
- * the caller keeps its existing extraction.
+ * node. Handles plan and user-question artifacts; returns null for other flows
+ * so the caller keeps its existing extraction.
  */
 function getFlowCardNotificationLabel(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
@@ -159,11 +159,22 @@ function getFlowCardNotificationLabel(content: string): string | null {
     const plan = Array.isArray(flow.components)
       ? flow.components.find((c) => c?.type === 'plan')
       : undefined;
-    if (!plan) return null;
-    const rawTitle = plan.props?.['title'];
-    const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
-    const verb = plan.props?.['phase'] === 'proposed' ? 'Proposed a plan' : 'Shared a plan';
-    return title ? `📋 ${verb}: ${title}` : `📋 ${verb}`;
+    if (plan) {
+      const rawTitle = plan.props?.['title'];
+      const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
+      const verb = plan.props?.['phase'] === 'proposed' ? 'Proposed a plan' : 'Shared a plan';
+      return title ? `📋 ${verb}: ${title}` : `📋 ${verb}`;
+    }
+    const questionSet = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'user_question')
+      : undefined;
+    if (!questionSet) return null;
+    const questions = questionSet.props?.['questions'];
+    const count = Array.isArray(questions) ? questions.length : 0;
+    const phase = questionSet.props?.['phase'];
+    if (phase === 'answered') return `✅ Answered ${count || 'agent'} question${count === 1 ? '' : 's'}`;
+    if (phase === 'declined') return 'Question request declined';
+    return count > 1 ? `💬 Agent wants to ask you ${count} questions` : '💬 Agent wants to ask you a question';
   } catch {
     return null;
   }

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -141,8 +141,8 @@ function getFlowJsonRawTextForMentions(content: string): string | null {
  * Friendly notification label for a flow CARD (plan, etc.) whose todos/title
  * don't live in text `content` props — so extractTextFromFlowJson returns ''
  * and the preview would otherwise fall back to the meaningless "Flow JSON" text
- * node. Handles plan and user-question artifacts; returns null for other flows
- * so the caller keeps its existing extraction.
+ * node. Handles plan, diff, code, ticket, chart and user-question artifacts;
+ * returns null for other flows so the caller keeps its existing extraction.
  */
 function getFlowCardNotificationLabel(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
@@ -164,6 +164,41 @@ function getFlowCardNotificationLabel(content: string): string | null {
       const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
       const verb = plan.props?.['phase'] === 'proposed' ? 'Proposed a plan' : 'Shared a plan';
       return title ? `📋 ${verb}: ${title}` : `📋 ${verb}`;
+    }
+    const diff = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'diff')
+      : undefined;
+    if (diff) {
+      const rawPath = diff.props?.['path'];
+      const path = typeof rawPath === 'string' ? rawPath.trim() : '';
+      return path ? `📝 Shared a diff: ${path}` : '📝 Shared a diff';
+    }
+    const code = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'code')
+      : undefined;
+    if (code) {
+      const rawLanguage = code.props?.['language'];
+      const language = typeof rawLanguage === 'string' ? rawLanguage.trim() : '';
+      return language ? `💻 Shared ${language} code` : '💻 Shared a code snippet';
+    }
+    const ticket = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'ticket')
+      : undefined;
+    if (ticket) {
+      const rawXyneId = ticket.props?.['xyneId'];
+      const rawTitle = ticket.props?.['title'];
+      const xyneId = typeof rawXyneId === 'string' ? rawXyneId.trim() : '';
+      const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
+      if (xyneId && title) return `🎫 Filed ${xyneId}: ${title}`;
+      return xyneId ? `🎫 Filed ${xyneId}` : '🎫 Filed a ticket';
+    }
+    const chart = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'chart')
+      : undefined;
+    if (chart) {
+      const rawCaption = chart.props?.['caption'];
+      const caption = typeof rawCaption === 'string' ? rawCaption.trim() : '';
+      return caption ? `📊 ${caption}` : '📊 Shared a chart';
     }
     const questionSet = Array.isArray(flow.components)
       ? flow.components.find((c) => c?.type === 'user_question')

--- a/apps/dashboard/src/components/flowUI/nodes/ArtifactRenderBoundary.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ArtifactRenderBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ArtifactRenderBoundaryProps {
+  children: ReactNode;
+  fallbackText: string;
+}
+
+interface ArtifactRenderBoundaryState {
+  failed: boolean;
+}
+
+export class ArtifactRenderBoundary extends Component<
+  ArtifactRenderBoundaryProps,
+  ArtifactRenderBoundaryState
+> {
+  public override state: ArtifactRenderBoundaryState = { failed: false };
+
+  public static getDerivedStateFromError(): ArtifactRenderBoundaryState {
+    return { failed: true };
+  }
+
+  public override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[flowUI] artifact failed to render', error, info.componentStack);
+  }
+
+  public override render(): ReactNode {
+    if (this.state.failed) {
+      return (
+        <pre className='overflow-x-auto whitespace-pre-wrap p-4 font-mono text-xs text-muted-foreground'>
+          {this.props.fallbackText}
+        </pre>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/dashboard/src/components/flowUI/nodes/ChartBody.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ChartBody.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ChartProps } from '@xyne/shared';
+import { ChartTooltip } from '../../DynamicDashboard/ComponentGrid/renderers/ChartTooltip';
+import {
+  CHART_GRID_DASH,
+  CHART_MARGIN,
+} from '../../DynamicDashboard/ComponentGrid/renderers/constants';
+
+const AXIS_TEXT_COLOR = 'hsl(var(--muted-foreground))';
+const GRID_STROKE_COLOR = 'hsl(var(--border))';
+const CURSOR_FILL_COLOR = 'hsl(var(--accent))';
+const TICK_STYLE = {
+  fill: AXIS_TEXT_COLOR,
+  fontSize: 11,
+  fontFamily: '"Geist Mono", monospace',
+} as const;
+
+const SERIES_COLORS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+];
+const seriesColor = (index: number): string =>
+  SERIES_COLORS[index % SERIES_COLORS.length] ?? SERIES_COLORS[0]!;
+
+const VALUE_LABEL_STYLE = { fill: AXIS_TEXT_COLOR, fontSize: 11 } as const;
+const LEGEND_STYLE = { fontSize: 11, color: AXIS_TEXT_COLOR } as const;
+
+function compactValue(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}m`;
+  if (abs >= 1_000) return `${(value / 1_000).toFixed(1).replace(/\.0$/, '')}k`;
+  return String(value);
+}
+
+function pivotSeries(rows: ReadonlyArray<{ x: string; y: number; series?: string | undefined }>): {
+  data: Array<Record<string, string | number>>;
+  names: string[];
+} {
+  const names: string[] = [];
+  const byX = new Map<string, Record<string, string | number>>();
+  for (const row of rows) {
+    const name = row.series ?? 'value';
+    if (!names.includes(name)) names.push(name);
+    const existing = byX.get(row.x) ?? { x: row.x };
+    existing[name] = row.y;
+    byX.set(row.x, existing);
+  }
+  return { data: [...byX.values()], names };
+}
+
+const axisProps = { tick: TICK_STYLE, tickLine: false, axisLine: false } as const;
+const gridProps = {
+  strokeDasharray: CHART_GRID_DASH,
+  stroke: GRID_STROKE_COLOR,
+  vertical: false,
+} as const;
+
+const ChartBody: React.FC<{ props: ChartProps; height: number }> = ({ props, height }) => {
+  if (props.type === 'line' || props.type === 'area') {
+    const { data, names } = pivotSeries(props.series);
+    const multi = names.length > 1;
+    return (
+      <ResponsiveContainer width='100%' height={height}>
+        {props.type === 'line' ? (
+          <LineChart data={data} margin={CHART_MARGIN}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey='x' {...axisProps} />
+            <YAxis {...axisProps} width={40} tickFormatter={compactValue} />
+            <Tooltip content={<ChartTooltip />} />
+            {multi && <Legend wrapperStyle={LEGEND_STYLE} />}
+            {names.map((name, index) => (
+              <Line
+                key={name}
+                type='monotone'
+                dataKey={name}
+                stroke={seriesColor(index)}
+                strokeWidth={2}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        ) : (
+          <AreaChart data={data} margin={CHART_MARGIN}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey='x' {...axisProps} />
+            <YAxis {...axisProps} width={40} tickFormatter={compactValue} />
+            <Tooltip content={<ChartTooltip />} />
+            {multi && <Legend wrapperStyle={LEGEND_STYLE} />}
+            {names.map((name, index) => (
+              <Area
+                key={name}
+                type='monotone'
+                dataKey={name}
+                stroke={seriesColor(index)}
+                fill={seriesColor(index)}
+                fillOpacity={0.2}
+                strokeWidth={2}
+                isAnimationActive={false}
+              />
+            ))}
+          </AreaChart>
+        )}
+      </ResponsiveContainer>
+    );
+  }
+
+  if (props.type === 'pie' || props.type === 'donut') {
+    return (
+      <ResponsiveContainer width='100%' height={height}>
+        <PieChart>
+          <Tooltip content={<ChartTooltip />} />
+          <Legend wrapperStyle={LEGEND_STYLE} />
+          <Pie
+            data={props.points}
+            dataKey='value'
+            nameKey='label'
+            innerRadius={props.type === 'donut' ? '55%' : 0}
+            outerRadius='80%'
+            isAnimationActive={false}
+          >
+            {props.points.map((point, index) => (
+              <Cell
+                key={point.label}
+                fill={seriesColor(index)}
+                stroke='hsl(var(--card))'
+                strokeWidth={2}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width='100%' height={height}>
+      <BarChart data={props.points} margin={CHART_MARGIN}>
+        <CartesianGrid {...gridProps} />
+        <XAxis dataKey='label' {...axisProps} />
+        <YAxis hide />
+        <Tooltip content={<ChartTooltip />} cursor={{ fill: CURSOR_FILL_COLOR, opacity: 0.4 }} />
+        <Bar
+          dataKey='value'
+          fill={seriesColor(0)}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={48}
+          isAnimationActive={false}
+        >
+          <LabelList
+            dataKey='value'
+            position='top'
+            formatter={compactValue}
+            style={VALUE_LABEL_STYLE}
+          />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default ChartBody;

--- a/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
@@ -1,0 +1,51 @@
+import React, { Suspense } from 'react';
+import type { ChartProps, FlowComponent } from '@xyne/shared';
+import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+
+const ChartBody = React.lazy(() => import('./ChartBody'));
+
+const CHART_HEIGHT_PX = 220;
+
+export const ChartNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as ChartProps | undefined;
+  if (!props?.type) return null;
+  const hasData =
+    props.type === 'line' || props.type === 'area'
+      ? props.series.length > 0
+      : props.points.length > 0;
+  if (!hasData) return null;
+
+  const fallbackText =
+    props.type === 'line' || props.type === 'area'
+      ? props.series.map(point => `${point.x}: ${point.y}`).join('\n')
+      : props.points.map(point => `${point.label}: ${point.value}`).join('\n');
+
+  return (
+    <section
+      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className='px-4 pb-2 pt-4'>
+        <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+          Chart
+        </span>
+      </div>
+
+      <div className='border-t border-border px-2 pt-3'>
+        <ArtifactRenderBoundary fallbackText={fallbackText}>
+          <Suspense fallback={<div style={{ height: CHART_HEIGHT_PX }} />}>
+            <ChartBody props={props} height={CHART_HEIGHT_PX} />
+          </Suspense>
+        </ArtifactRenderBoundary>
+      </div>
+
+      {props.caption && (
+        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
+          <p className='text-xs leading-[1.2] text-muted-foreground'>{props.caption}</p>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { File } from '@pierre/diffs/react';
+import { CopyCopied, CopyDefault } from '@xyne/icons';
+import type { CodeProps, FlowComponent } from '@xyne/shared';
+import { useCopyButton } from '../../../hooks/useCopyButton';
+import { useDiffsTheme } from './useDiffsTheme';
+import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+
+export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as CodeProps | undefined;
+  const { copied, copy } = useCopyButton();
+  const themeOptions = useDiffsTheme();
+
+  if (!props?.code) return null;
+  const { code, language } = props;
+
+  return (
+    <section
+      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className='flex items-center justify-between gap-2 px-4 pb-2 pt-4'>
+        <div className='flex items-center gap-2'>
+          <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+            Code
+          </span>
+          {language && (
+            <span className='flex h-[18px] items-center'>
+              <span className='rounded bg-muted px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] text-muted-foreground'>
+                {language}
+              </span>
+            </span>
+          )}
+        </div>
+        <button
+          type='button'
+          onClick={() => copy(code)}
+          aria-label={copied ? 'Copied' : 'Copy code'}
+          className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+          data-track-category='CODE_ARTIFACT'
+          data-track-name='COPY_CODE'
+        >
+          {copied ? (
+            <CopyCopied size={16} className='shrink-0' />
+          ) : (
+            <CopyDefault size={16} className='shrink-0' />
+          )}
+        </button>
+      </div>
+
+      <div className='max-h-[420px] overflow-auto border-t border-border text-xs'>
+        <ArtifactRenderBoundary fallbackText={code}>
+          <File
+            file={{ name: 'snippet', contents: code, ...(language ? { lang: language } : {}) }}
+            options={{
+              ...themeOptions,
+              disableFileHeader: true,
+              disableLineNumbers: true,
+              overflow: 'scroll',
+            }}
+            disableWorkerPool
+          />
+        </ArtifactRenderBoundary>
+      </div>
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
@@ -1,0 +1,122 @@
+import React, { useMemo, useState } from 'react';
+import { PatchDiff } from '@pierre/diffs/react';
+import { MaximizeFourArrow, MultipleCrossCancelDefault } from '@xyne/icons';
+import type { DiffProps, FlowComponent } from '@xyne/shared';
+import Dialog from '../../ui/Dialog';
+import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+import { useDiffsTheme } from './useDiffsTheme';
+
+function diffStat(patch: string): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  let inHunk = false;
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('@@')) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith('+')) added++;
+    else if (line.startsWith('-')) removed++;
+  }
+  return { added, removed };
+}
+
+const DiffStat: React.FC<{ added: number; removed: number }> = ({ added, removed }) => (
+  <span className='shrink-0 font-mono text-xs tabular-nums'>
+    <span className='text-[var(--diff-stat-add-fg)]'>+{added}</span>{' '}
+    <span className='text-[var(--diff-stat-del-fg)]'>−{removed}</span>
+  </span>
+);
+
+export const DiffNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as DiffProps | undefined;
+  const [expanded, setExpanded] = useState(false);
+  const themeOptions = useDiffsTheme();
+  const stat = useMemo(() => diffStat(props?.patch ?? ''), [props?.patch]);
+
+  if (!props?.patch || !props.path) return null;
+  const { path, patch } = props;
+
+  const diffOptions = {
+    ...themeOptions,
+    disableFileHeader: true,
+    diffStyle: 'unified' as const,
+    overflow: 'scroll' as const,
+  };
+
+  return (
+    <>
+      <section
+        className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+        style={node.style}
+      >
+        <div className='flex items-center justify-between gap-2 px-4 pb-2 pt-4'>
+          <div className='flex min-w-0 items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+              Diff
+            </span>
+            <span className='truncate font-mono text-xs text-foreground' title={path}>
+              {path}
+            </span>
+          </div>
+          <div className='flex shrink-0 items-center gap-2'>
+            <DiffStat added={stat.added} removed={stat.removed} />
+            <button
+              type='button'
+              onClick={() => setExpanded(true)}
+              aria-label='Expand diff'
+              className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='DIFF_ARTIFACT'
+              data-track-name='EXPAND_DIFF'
+            >
+              <MaximizeFourArrow size={16} className='shrink-0' />
+            </button>
+          </div>
+        </div>
+
+        <div className='max-h-[420px] overflow-auto border-t border-border text-xs'>
+          <ArtifactRenderBoundary fallbackText={patch}>
+            <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
+          </ArtifactRenderBoundary>
+        </div>
+      </section>
+
+      <Dialog
+        open={expanded}
+        onOpenChange={setExpanded}
+        title={path}
+        description='Proposed change'
+        className='max-w-4xl overflow-hidden'
+      >
+        <div className='flex flex-col'>
+          <div className='flex items-center justify-between gap-3 px-5 py-4 pb-0'>
+            <div className='flex min-w-0 items-center gap-2'>
+              <span className='truncate font-mono text-sm text-foreground' title={path}>
+                {path}
+              </span>
+              <DiffStat added={stat.added} removed={stat.removed} />
+            </div>
+            <button
+              type='button'
+              onClick={() => setExpanded(false)}
+              aria-label='Close'
+              className='rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='DIFF_ARTIFACT'
+              data-track-name='CLOSE_DIFF_DIALOG'
+            >
+              <MultipleCrossCancelDefault size={18} />
+            </button>
+          </div>
+          <div className='max-h-[70vh] overflow-auto px-5 py-4 text-xs'>
+            <ArtifactRenderBoundary fallbackText={patch}>
+              <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
+            </ArtifactRenderBoundary>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -17,6 +17,10 @@ import { PlanNode } from './PlanNode';
 import { PrNode } from './PrNode';
 import { CallScheduleNode } from './CallScheduleNode';
 import { UserQuestionNode } from './UserQuestionNode';
+import { CodeNode } from './CodeNode';
+import { DiffNode } from './DiffNode';
+import { TicketNode } from './TicketNode';
+import { ChartNode } from './ChartNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
 // is kept in ./PrApprovalNode.tsx but unlinked so 'pr_approval' isn't a live artifact.
 
@@ -66,6 +70,10 @@ NodeRegistry.register('pr', PrNode);
 // NodeRegistry.register('pr_approval', PrApprovalNode); // unlinked for now
 NodeRegistry.register('call_schedule', CallScheduleNode);
 NodeRegistry.register('user_question', UserQuestionNode);
+NodeRegistry.register('code', CodeNode);
+NodeRegistry.register('diff', DiffNode);
+NodeRegistry.register('ticket', TicketNode);
+NodeRegistry.register('chart', ChartNode);
 
 /**
  * Kept for backward compatibility with existing callers/imports.

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -16,6 +16,7 @@ import { LinkNode } from './LinkNode';
 import { PlanNode } from './PlanNode';
 import { PrNode } from './PrNode';
 import { CallScheduleNode } from './CallScheduleNode';
+import { UserQuestionNode } from './UserQuestionNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
 // is kept in ./PrApprovalNode.tsx but unlinked so 'pr_approval' isn't a live artifact.
 
@@ -64,6 +65,7 @@ NodeRegistry.register('plan', PlanNode);
 NodeRegistry.register('pr', PrNode);
 // NodeRegistry.register('pr_approval', PrApprovalNode); // unlinked for now
 NodeRegistry.register('call_schedule', CallScheduleNode);
+NodeRegistry.register('user_question', UserQuestionNode);
 
 /**
  * Kept for backward compatibility with existing callers/imports.

--- a/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import type { FlowComponent, TicketProps } from '@xyne/shared';
+import { cn } from '../../../utils/classNames';
+
+const STATUS_META: Record<TicketProps['status'], { label: string; className: string }> = {
+  TODO: { label: 'Todo', className: 'bg-orange-500/15 text-orange-600' },
+  STARTED: { label: 'Started', className: 'bg-blue-500/15 text-blue-600' },
+  PAUSED: { label: 'Paused', className: 'bg-teal-500/15 text-teal-600' },
+  CANCELLED: { label: 'Cancelled', className: 'bg-red-500/15 text-red-600' },
+  COMPLETED: { label: 'Completed', className: 'bg-green-500/15 text-green-600' },
+};
+
+const PRIORITY_META: Record<TicketProps['priority'], { label: string; className: string }> = {
+  LOW: { label: 'Low', className: 'text-muted-foreground' },
+  MEDIUM: { label: 'Medium', className: 'text-[var(--status-pending)]' },
+  HIGH: { label: 'High', className: 'text-[var(--diff-stat-del-fg)]' },
+  CRITICAL: { label: 'Critical', className: 'text-destructive' },
+};
+
+function formatEta(eta: string): string | null {
+  const parsed = new Date(eta);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+}
+
+export const TicketNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as TicketProps | undefined;
+  if (!props?.xyneId || !props.title) return null;
+
+  const status = STATUS_META[props.status];
+  const priority = PRIORITY_META[props.priority];
+  const eta = props.eta ? formatEta(props.eta) : null;
+
+  return (
+    <section
+      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className='flex flex-col gap-2 px-4 pb-3 pt-4'>
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-foreground'>
+            {props.xyneId}
+          </span>
+          <span
+            className={cn(
+              'rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px]',
+              status.className,
+            )}
+          >
+            {status.label}
+          </span>
+          <span className={cn('text-xs font-semibold leading-[18px]', priority.className)}>
+            {priority.label}
+          </span>
+          {eta && (
+            <span className='ml-auto shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
+              {eta}
+            </span>
+          )}
+        </div>
+        <p className='text-sm leading-[1.35] text-foreground'>{props.title}</p>
+      </div>
+
+      <div className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
+        <a
+          href={props.url}
+          className='rounded-lg border border-border bg-background px-2 py-1.5 text-sm font-medium leading-[1.2] !text-foreground !no-underline hover:bg-muted'
+          data-track-category='TICKET_ARTIFACT'
+          data-track-name='OPEN_TICKET'
+        >
+          Open in tracker
+        </a>
+      </div>
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
@@ -1,0 +1,228 @@
+import React, { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useFlow } from '../FlowContext';
+import type { FlowAction, FlowComponent, UserQuestionItem } from '@xyne/shared';
+
+interface UserQuestionNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+type Answers = Record<string, string | string[]>;
+const SKIP_QUESTION_OPTION = 'Skip this question';
+
+/**
+ * The thread counterpart to PlanNode: one self-contained FlowJSON artifact
+ * instead of a trail of button messages. A tab selects the prompt to answer;
+ * answers remain in FlowRenderer state, so switching tabs never loses input.
+ */
+export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
+  const props = node.props as
+    | {
+        title: string;
+        questions: UserQuestionItem[];
+        phase?: 'pending' | 'answered' | 'declined';
+        answers?: Answers;
+        notes?: Record<string, string>;
+        submitAction?: FlowAction;
+        dismissAction?: FlowAction;
+      }
+    | undefined;
+  const { state, updateFieldValue, executeAction } = useFlow();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // Question-set cards posted before terminal phases were introduced do not
+  // have `phase`. Treat them as pending so opening an older thread never tries
+  // to read a non-existent persisted `answers` object.
+  const phase = props?.phase ?? 'pending';
+  const terminal = phase !== 'pending';
+  const answers = (terminal ? props?.answers ?? {} : state.values.answers ?? {}) as Answers;
+  const notes = (terminal ? props?.notes ?? {} : state.values.notes ?? {}) as Record<string, string>;
+  const activeQuestion = props?.questions[activeIndex];
+  const requiredQuestions = useMemo(
+    () => props?.questions.filter(question => question.required !== false) ?? [],
+    [props?.questions],
+  );
+
+  if (!props || !activeQuestion) return null;
+
+  const updateAnswer = (questionId: string, value: string | string[]) => {
+    updateFieldValue('answers', { ...answers, [questionId]: value });
+  };
+
+  const toggleMultipleChoice = (option: string, checked: boolean) => {
+    const selected = Array.isArray(answers[activeQuestion.id])
+      ? (answers[activeQuestion.id] as string[])
+      : [];
+    if (option === SKIP_QUESTION_OPTION && checked) {
+      updateAnswer(activeQuestion.id, [SKIP_QUESTION_OPTION]);
+      return;
+    }
+    updateAnswer(
+      activeQuestion.id,
+      checked
+        ? [...selected.filter(value => value !== SKIP_QUESTION_OPTION), option]
+        : selected.filter(value => value !== option),
+    );
+  };
+
+  const hasAnswer = (question: UserQuestionItem) => {
+    const answer = answers[question.id];
+    return Array.isArray(answer)
+      ? answer.length > 0
+      : typeof answer === 'string' && answer.trim().length > 0;
+  };
+
+  const isQuestionComplete = (question: UserQuestionItem) =>
+    hasAnswer(question) || Boolean(notes[question.id]?.trim());
+
+  const submit = () => {
+    const unanswered = requiredQuestions.find(question => !isQuestionComplete(question));
+    if (unanswered) {
+      const index = props.questions.findIndex(question => question.id === unanswered.id);
+      setActiveIndex(Math.max(0, index));
+      toast.error('Please answer each required question before submitting.');
+      return;
+    }
+    if (props.submitAction) void executeAction(props.submitAction);
+  };
+
+  const selectedAnswer = answers[activeQuestion.id];
+  return (
+    <section
+      className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className={`flex flex-col gap-3 p-4 ${terminal ? 'opacity-60' : ''}`}>
+      <div className='flex items-center justify-between gap-2'>
+        <div className='flex items-center gap-2'>
+        <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>Question</span>
+        {terminal && <span className={`rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] ${phase === 'answered' ? 'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]' : 'bg-destructive/10 text-destructive'}`}>{phase === 'answered' ? 'Answered' : 'Declined'}</span>}
+        </div>
+        {props.questions.length > 1 && <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>{activeIndex + 1}/{props.questions.length}</span>}
+      </div>
+      <div className='flex gap-2 overflow-x-auto border-b border-border'>
+        {props.questions.map((question, index) => (
+          <button
+            key={question.id}
+            type='button'
+            onClick={() => setActiveIndex(index)}
+            disabled={state.submitting}
+            className={`shrink-0 rounded-t-xl px-3 py-2 text-sm font-medium transition-colors ${
+              activeIndex === index
+                ? 'bg-muted text-foreground'
+                : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+            }`}
+          >
+            {isQuestionComplete(question) && <span className='mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle' aria-label='Answered or noted' />}
+            {props.questions.length === 1
+              ? props.title
+              : (question.label ?? question.id)}
+          </button>
+        ))}
+      </div>
+
+      <div className='space-y-5'>
+        <h3 className='text-lg font-semibold leading-[1.2] text-foreground'>
+          {activeQuestion.question}
+        </h3>
+
+        {activeQuestion.type === 'open_ended' && (
+          <div className='space-y-2'>
+            <textarea
+              value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
+              onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
+              placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
+              disabled={state.submitting || terminal}
+              rows={4}
+              className='w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+            />
+            {!terminal && <button type='button' onClick={() => updateAnswer(activeQuestion.id, 'Skip this question')} className='text-xs font-medium text-muted-foreground hover:text-foreground'>Skip this question</button>}
+          </div>
+        )}
+
+        {activeQuestion.type === 'single_choice' && (
+          <div className='space-y-3'>
+            {activeQuestion.options.map(option => (
+              <label
+                key={option}
+                className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+              >
+                <input
+                  type='radio'
+                  name={activeQuestion.id}
+                  checked={selectedAnswer === option}
+                  disabled={state.submitting || terminal}
+                  onChange={() => updateAnswer(activeQuestion.id, option)}
+                  className='h-4 w-4 border-border text-primary focus:ring-ring'
+                />
+                {option}
+              </label>
+            ))}
+          </div>
+        )}
+
+        {activeQuestion.type === 'multiple_choice' && (
+          <div className='space-y-3'>
+            {activeQuestion.options.map(option => {
+              const selected = Array.isArray(selectedAnswer) && selectedAnswer.includes(option);
+              return (
+                <label
+                  key={option}
+                  className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+                >
+                  <input
+                    type='checkbox'
+                    checked={selected}
+                    disabled={state.submitting || terminal}
+                    onChange={event => toggleMultipleChoice(option, event.target.checked)}
+                    className='h-4 w-4 rounded border-border text-primary focus:ring-ring'
+                  />
+                  {option}
+                </label>
+              );
+            })}
+          </div>
+        )}
+
+        <div className='border-t border-dashed border-border pt-4'>
+          <textarea
+            value={notes[activeQuestion.id] ?? ''}
+            onChange={event => updateFieldValue('notes', { ...notes, [activeQuestion.id]: event.target.value })}
+            placeholder='+ Add notes (optional)'
+            disabled={state.submitting || terminal}
+            rows={2}
+            className='w-full resize-y rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+          />
+        </div>
+      </div>
+      </div>
+      {phase === 'answered' && (
+        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
+          <p className='text-xs leading-[1.2] text-muted-foreground'>Answers submitted</p>
+        </div>
+      )}
+      {phase === 'declined' && <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'><p className='text-xs leading-[1.2] text-muted-foreground'>Question declined.</p></div>}
+      {!terminal && <footer className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
+        <button
+          type='button'
+          onClick={submit}
+          disabled={state.submitting}
+          className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60'
+        >
+          Submit answers
+        </button>
+        {props.dismissAction && (
+          <button
+            type='button'
+            onClick={() => void executeAction(props.dismissAction!)}
+            disabled={state.submitting}
+            className='rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+          >
+            Dismiss
+          </button>
+        )}
+      </footer>}
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
@@ -36,8 +36,11 @@ export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
   // to read a non-existent persisted `answers` object.
   const phase = props?.phase ?? 'pending';
   const terminal = phase !== 'pending';
-  const answers = (terminal ? props?.answers ?? {} : state.values.answers ?? {}) as Answers;
-  const notes = (terminal ? props?.notes ?? {} : state.values.notes ?? {}) as Record<string, string>;
+  const answers = (terminal ? (props?.answers ?? {}) : (state.values['answers'] ?? {})) as Answers;
+  const notes = (terminal ? (props?.notes ?? {}) : (state.values['notes'] ?? {})) as Record<
+    string,
+    string
+  >;
   const activeQuestion = props?.questions[activeIndex];
   const requiredQuestions = useMemo(
     () => props?.questions.filter(question => question.required !== false) ?? [],
@@ -94,135 +97,182 @@ export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
       style={node.style}
     >
       <div className={`flex flex-col gap-3 p-4 ${terminal ? 'opacity-60' : ''}`}>
-      <div className='flex items-center justify-between gap-2'>
-        <div className='flex items-center gap-2'>
-        <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>Question</span>
-        {terminal && <span className={`rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] ${phase === 'answered' ? 'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]' : 'bg-destructive/10 text-destructive'}`}>{phase === 'answered' ? 'Answered' : 'Declined'}</span>}
-        </div>
-        {props.questions.length > 1 && <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>{activeIndex + 1}/{props.questions.length}</span>}
-      </div>
-      <div className='flex gap-2 overflow-x-auto border-b border-border'>
-        {props.questions.map((question, index) => (
-          <button
-            key={question.id}
-            type='button'
-            onClick={() => setActiveIndex(index)}
-            disabled={state.submitting}
-            className={`shrink-0 rounded-t-xl px-3 py-2 text-sm font-medium transition-colors ${
-              activeIndex === index
-                ? 'bg-muted text-foreground'
-                : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-            }`}
-          >
-            {isQuestionComplete(question) && <span className='mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle' aria-label='Answered or noted' />}
-            {props.questions.length === 1
-              ? props.title
-              : (question.label ?? question.id)}
-          </button>
-        ))}
-      </div>
-
-      <div className='space-y-5'>
-        <h3 className='text-lg font-semibold leading-[1.2] text-foreground'>
-          {activeQuestion.question}
-        </h3>
-
-        {activeQuestion.type === 'open_ended' && (
-          <div className='space-y-2'>
-            <textarea
-              value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
-              onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
-              placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
-              disabled={state.submitting || terminal}
-              rows={4}
-              className='w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
-            />
-            {!terminal && <button type='button' onClick={() => updateAnswer(activeQuestion.id, 'Skip this question')} className='text-xs font-medium text-muted-foreground hover:text-foreground'>Skip this question</button>}
-          </div>
-        )}
-
-        {activeQuestion.type === 'single_choice' && (
-          <div className='space-y-3'>
-            {activeQuestion.options.map(option => (
-              <label
-                key={option}
-                className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+        <div className='flex items-center justify-between gap-2'>
+          <div className='flex items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+              Question
+            </span>
+            {terminal && (
+              <span
+                className={`rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] ${phase === 'answered' ? 'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]' : 'bg-destructive/10 text-destructive'}`}
               >
-                <input
-                  type='radio'
-                  name={activeQuestion.id}
-                  checked={selectedAnswer === option}
-                  disabled={state.submitting || terminal}
-                  onChange={() => updateAnswer(activeQuestion.id, option)}
-                  className='h-4 w-4 border-border text-primary focus:ring-ring'
-                />
-                {option}
-              </label>
-            ))}
+                {phase === 'answered' ? 'Answered' : 'Declined'}
+              </span>
+            )}
           </div>
-        )}
+          {props.questions.length > 1 && (
+            <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
+              {activeIndex + 1}/{props.questions.length}
+            </span>
+          )}
+        </div>
+        <div className='flex gap-2 overflow-x-auto border-b border-border'>
+          {props.questions.map((question, index) => (
+            <button
+              key={question.id}
+              type='button'
+              data-track-category='USER_QUESTION_ARTIFACT'
+              data-track-name='SELECT_QUESTION_TAB'
+              onClick={() => setActiveIndex(index)}
+              disabled={state.submitting}
+              className={`shrink-0 rounded-t-xl px-3 py-2 text-sm font-medium transition-colors ${
+                activeIndex === index
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+              }`}
+            >
+              {isQuestionComplete(question) && (
+                <span
+                  className='mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle'
+                  aria-label='Answered or noted'
+                />
+              )}
+              {props.questions.length === 1 ? props.title : (question.label ?? question.id)}
+            </button>
+          ))}
+        </div>
 
-        {activeQuestion.type === 'multiple_choice' && (
-          <div className='space-y-3'>
-            {activeQuestion.options.map(option => {
-              const selected = Array.isArray(selectedAnswer) && selectedAnswer.includes(option);
-              return (
+        <div className='space-y-5'>
+          <h3 className='text-lg font-semibold leading-[1.2] text-foreground'>
+            {activeQuestion.question}
+          </h3>
+
+          {activeQuestion.type === 'open_ended' && (
+            <div className='space-y-2'>
+              <textarea
+                value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
+                data-track-category='USER_QUESTION_ARTIFACT'
+                data-track-name='EDIT_OPEN_ENDED_ANSWER'
+                onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
+                placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
+                disabled={state.submitting || terminal}
+                rows={4}
+                className='w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+              />
+              {!terminal && (
+                <button
+                  type='button'
+                  data-track-category='USER_QUESTION_ARTIFACT'
+                  data-track-name='SKIP_QUESTION'
+                  onClick={() => updateAnswer(activeQuestion.id, 'Skip this question')}
+                  className='text-xs font-medium text-muted-foreground hover:text-foreground'
+                >
+                  Skip this question
+                </button>
+              )}
+            </div>
+          )}
+
+          {activeQuestion.type === 'single_choice' && (
+            <div className='space-y-3'>
+              {activeQuestion.options.map(option => (
                 <label
                   key={option}
                   className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
                 >
                   <input
-                    type='checkbox'
-                    checked={selected}
+                    type='radio'
+                    data-track-category='USER_QUESTION_ARTIFACT'
+                    data-track-name='SELECT_SINGLE_CHOICE'
+                    name={activeQuestion.id}
+                    checked={selectedAnswer === option}
                     disabled={state.submitting || terminal}
-                    onChange={event => toggleMultipleChoice(option, event.target.checked)}
-                    className='h-4 w-4 rounded border-border text-primary focus:ring-ring'
+                    onChange={() => updateAnswer(activeQuestion.id, option)}
+                    className='h-4 w-4 border-border text-primary focus:ring-ring'
                   />
                   {option}
                 </label>
-              );
-            })}
-          </div>
-        )}
+              ))}
+            </div>
+          )}
 
-        <div className='border-t border-dashed border-border pt-4'>
-          <textarea
-            value={notes[activeQuestion.id] ?? ''}
-            onChange={event => updateFieldValue('notes', { ...notes, [activeQuestion.id]: event.target.value })}
-            placeholder='+ Add notes (optional)'
-            disabled={state.submitting || terminal}
-            rows={2}
-            className='w-full resize-y rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
-          />
+          {activeQuestion.type === 'multiple_choice' && (
+            <div className='space-y-3'>
+              {activeQuestion.options.map(option => {
+                const selected = Array.isArray(selectedAnswer) && selectedAnswer.includes(option);
+                return (
+                  <label
+                    key={option}
+                    className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+                  >
+                    <input
+                      type='checkbox'
+                      data-track-category='USER_QUESTION_ARTIFACT'
+                      data-track-name='TOGGLE_MULTIPLE_CHOICE'
+                      checked={selected}
+                      disabled={state.submitting || terminal}
+                      onChange={event => toggleMultipleChoice(option, event.target.checked)}
+                      className='h-4 w-4 rounded border-border text-primary focus:ring-ring'
+                    />
+                    {option}
+                  </label>
+                );
+              })}
+            </div>
+          )}
+
+          <div className='border-t border-dashed border-border pt-4'>
+            <textarea
+              value={notes[activeQuestion.id] ?? ''}
+              data-track-category='USER_QUESTION_ARTIFACT'
+              data-track-name='EDIT_QUESTION_NOTES'
+              onChange={event =>
+                updateFieldValue('notes', { ...notes, [activeQuestion.id]: event.target.value })
+              }
+              placeholder='+ Add notes (optional)'
+              disabled={state.submitting || terminal}
+              rows={2}
+              className='w-full resize-y rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+            />
+          </div>
         </div>
-      </div>
       </div>
       {phase === 'answered' && (
         <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
           <p className='text-xs leading-[1.2] text-muted-foreground'>Answers submitted</p>
         </div>
       )}
-      {phase === 'declined' && <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'><p className='text-xs leading-[1.2] text-muted-foreground'>Question declined.</p></div>}
-      {!terminal && <footer className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
-        <button
-          type='button'
-          onClick={submit}
-          disabled={state.submitting}
-          className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60'
-        >
-          Submit answers
-        </button>
-        {props.dismissAction && (
+      {phase === 'declined' && (
+        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
+          <p className='text-xs leading-[1.2] text-muted-foreground'>Question declined.</p>
+        </div>
+      )}
+      {!terminal && (
+        <footer className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
           <button
             type='button'
-            onClick={() => void executeAction(props.dismissAction!)}
+            data-track-category='USER_QUESTION_ARTIFACT'
+            data-track-name='SUBMIT_ANSWERS'
+            onClick={submit}
             disabled={state.submitting}
-            className='rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+            className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60'
           >
-            Dismiss
+            Submit answers
           </button>
-        )}
-      </footer>}
+          {props.dismissAction && (
+            <button
+              type='button'
+              data-track-category='USER_QUESTION_ARTIFACT'
+              data-track-name='DISMISS_QUESTION'
+              onClick={() => void executeAction(props.dismissAction!)}
+              disabled={state.submitting}
+              className='rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+            >
+              Dismiss
+            </button>
+          )}
+        </footer>
+      )}
     </section>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/useDiffsTheme.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/useDiffsTheme.ts
@@ -1,0 +1,30 @@
+import { useMemo, useSyncExternalStore } from 'react';
+
+function subscribeToThemeAttribute(onStoreChange: () => void): () => void {
+  if (typeof document === 'undefined') return () => {};
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+  return () => observer.disconnect();
+}
+
+function getThemeAttribute(): string {
+  if (typeof document === 'undefined') return 'classic';
+  return document.documentElement.getAttribute('data-theme') ?? 'classic';
+}
+
+export function useDiffsTheme(): {
+  theme: { light: string; dark: string };
+  themeType: 'light' | 'dark';
+} {
+  const theme = useSyncExternalStore(subscribeToThemeAttribute, getThemeAttribute, () => 'classic');
+  return useMemo(
+    () => ({
+      theme: { light: 'github-light', dark: 'github-dark' },
+      themeType: theme === 'midnight' ? ('dark' as const) : ('light' as const),
+    }),
+    [theme],
+  );
+}

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -110,6 +110,9 @@
     --pr-badge-danger-bg: #faebeb;
     --pr-badge-danger-fg: #ff0f0f;
 
+    --diff-stat-add-fg: #16a34a;
+    --diff-stat-del-fg: #dc2626;
+
     /* Workflow status colors - accessible on light bg */
     --status-new: #6b7280;
     --status-pending: #d97706;
@@ -241,6 +244,8 @@
     --pr-badge-merged-fg: #3716a3;
     --pr-badge-danger-bg: #faebeb;
     --pr-badge-danger-fg: #ff0f0f;
+    --diff-stat-add-fg: #16a34a;
+    --diff-stat-del-fg: #dc2626;
     --status-failure: #dc2626;
     --status-paused: #7c3aed;
     --ticket-accent: #445bb2;
@@ -373,6 +378,9 @@
     --pr-badge-merged-fg: #a78bfa;
     --pr-badge-danger-bg: #2a1414;
     --pr-badge-danger-fg: #f87171;
+
+    --diff-stat-add-fg: #4ade80;
+    --diff-stat-del-fg: #f87171;
 
     /* Workflow status colors - accessible on dark bg */
     --status-new: #b0b4ba;
@@ -1659,6 +1667,15 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: normal;
+}
+
+.jp-message-html:has(.flow-artifact-wide) {
+  display: block;
+  width: 100%;
+}
+
+.flow-ui-container:has(.flow-artifact-wide) {
+  max-width: none;
 }
 
 /* Make inline emojis larger than surrounding text */

--- a/apps/xyne-claw-auth/backend/src/lib/ticket-card.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/ticket-card.ts
@@ -1,0 +1,51 @@
+import type { TicketArtifact } from "xyne-claw-shared";
+import { spacesAppFetchGet } from "./spaces-api.js";
+
+const TICKET_STATUSES = ["TODO", "STARTED", "PAUSED", "CANCELLED", "COMPLETED"] as const;
+const TICKET_PRIORITIES = ["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const;
+
+export function parseXyneIdFromToolResult(resultText: string): string | null {
+  const match = /^\s*xyneId:\s*(\S+)\s*$/im.exec(resultText);
+  return match?.[1] ?? null;
+}
+
+export async function fetchTicketForCard(
+  xyneId: string,
+  appToken: string,
+): Promise<TicketArtifact | null> {
+  try {
+    const data = (await spacesAppFetchGet(
+      `/ticket/${encodeURIComponent(xyneId)}`,
+      appToken,
+    )) as {
+      id?: string;
+      xyneId?: string;
+      title?: string;
+      statusV2?: string;
+      priority?: string;
+      eta?: string | null;
+      workspaceId?: string;
+      channelId?: string;
+      conversationId?: string;
+    };
+    if (!data?.id || !data.xyneId || !data.title) return null;
+    if (!data.workspaceId || !data.channelId || !data.conversationId) return null;
+
+    const status = TICKET_STATUSES.find((candidate) => candidate === data.statusV2);
+    const priority = TICKET_PRIORITIES.find((candidate) => candidate === data.priority);
+    if (!status || !priority) return null;
+
+    return {
+      xyneId: data.xyneId,
+      title: data.title,
+      status,
+      priority,
+      ...(data.eta ? { eta: data.eta } : {}),
+      url: `/${encodeURIComponent(data.workspaceId)}/chat/dir/${encodeURIComponent(data.channelId)}?${new URLSearchParams(
+        { tab: "tickets", ticketId: data.id, conversationId: data.conversationId },
+      ).toString()}`,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/routes/app-callback.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/app-callback.ts
@@ -373,8 +373,8 @@ router.post("/callback", async (req: Request, res: Response) => {
     const { getQuestion, deleteQuestion } = await import("./pending-questions.js");
     const { setSession } = await import("./webhook.js");
     const question = await getQuestion(questionId);
-    const questionText = question?.question ?? "a question";
-    const optionsList = question?.options?.join(", ") ?? "";
+    const questionText = question?.questions?.[0]?.question ?? "a question";
+    const optionsList = question?.questions?.[0]?.options?.join(", ") ?? "";
 
     try {
       const agent = await findAgent(answerAgentSlug, answerSpacesAppId);

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -17,11 +17,12 @@ import { CONFIG } from "../config.js";
 import { prisma } from "../db.js";
 import { decrypt } from "../crypto.js";
 import { executeTwinApprovalDelivery } from "../lib/twin-delivery.js";
+import { fetchTicketForCard, parseXyneIdFromToolResult } from "../lib/ticket-card.js";
 import { verifySpacesSignature } from "../middleware/verify-spaces-signature.js";
 import { agentRunRepository } from "../repositories/index.js";
 import { recordTwinApprovalOutcome } from "../services/twinResponseFeedback.js";
 import type { FlowDefinition } from "xyne-claw-shared";
-import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, buildUserQuestionFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
+import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, buildUserQuestionFlow, buildTicketFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
 import { clearActivePlanCard, setPlanExecMeta, clearPlanExecMeta, normalizePlanTitle } from "../lib/session-context.js";
 import { executeTool as executeGatewayTool } from "../mcpgateway/services/execution.js";
 import { GATEWAY_KEY_PREFIX, parseGatewayCatalogSource } from "../mcpgateway/key-format.js";
@@ -447,8 +448,19 @@ async function finishWriteSuccess(opts: {
   channelId?: string | undefined;
   resultText: string;
 }): Promise<void> {
-  const { heading, details } = summarizeToolResult(opts.tool, opts.resultText);
-  const flow = buildWriteResultFlow({ tool: opts.tool, ok: true, heading, details });
+  let flow: FlowDefinition | null = null;
+  if (opts.tool === "spaces-create-ticket") {
+    const xyneId = parseXyneIdFromToolResult(opts.resultText);
+    const agent = xyneId ? await getAgentTokenAndUserId(opts.agentSlug, opts.spacesAppId) : null;
+    if (xyneId && agent) {
+      const ticket = await fetchTicketForCard(xyneId, agent.token);
+      if (ticket) flow = buildTicketFlow(ticket);
+    }
+  }
+  if (!flow) {
+    const { heading, details } = summarizeToolResult(opts.tool, opts.resultText);
+    flow = buildWriteResultFlow({ tool: opts.tool, ok: true, heading, details });
+  }
   await replaceFlowCardWithFlow(opts.messageId, opts.agentSlug, flow, opts.conversationId, opts.channelId, opts.spacesAppId);
   if (opts.actionId === "approve-continue" || opts.actionId === "retry-continue") {
     await dispatchContinuationRun({

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -21,7 +21,7 @@ import { verifySpacesSignature } from "../middleware/verify-spaces-signature.js"
 import { agentRunRepository } from "../repositories/index.js";
 import { recordTwinApprovalOutcome } from "../services/twinResponseFeedback.js";
 import type { FlowDefinition } from "xyne-claw-shared";
-import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
+import { mdToMrkdwn, buildWriteResultFlow, buildPlanFlow, buildUserQuestionFlow, PLAN_COMPONENT_ID } from "xyne-claw-shared";
 import { clearActivePlanCard, setPlanExecMeta, clearPlanExecMeta, normalizePlanTitle } from "../lib/session-context.js";
 import { executeTool as executeGatewayTool } from "../mcpgateway/services/execution.js";
 import { GATEWAY_KEY_PREFIX, parseGatewayCatalogSource } from "../mcpgateway/key-format.js";
@@ -966,15 +966,17 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
 
     // ── 3. User question answer ───────────────────────────────────────────────
     if (actionType === "user-answer") {
+      const isQuestionDismissal = actionId === "dismiss-user-question";
       const questionId = data["questionId"] as string;
       const answerAgentSlug = data["agentSlug"] as string;
       const answerSpacesAppId = data["spacesAppId"] as string | undefined;
       const answerChannelId = data["channelId"] as string;
       const answerConversationId = data["conversationId"] as string;
       const answerUserId = data["userId"] as string;
-      const answer = values["answer"] as string | undefined;
+      const rawAnswers = values["answers"];
+      const rawNotes = values["notes"];
 
-      if (!questionId || !answer || !answerUserId) {
+      if (!questionId || !answerUserId) {
         res.status(400).json({ type: "error", message: "Missing user-answer fields" } satisfies AppActionResponse);
         return;
       }
@@ -986,19 +988,87 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         return;
       }
 
-      // Acknowledge immediately so the widget closes
-      resp = { type: "close_screen", finalMessage: `✅ You answered: "${answer}"` };
-      res.json(resp);
-      void replaceFlowCardWithText(messageId, answerAgentSlug, `✅ You answered: **"${answer}"**`, answerConversationId);
-
-      // Fire-and-forget: start new /run with the answer as context
       try {
         const { getQuestion, deleteQuestion } = await import("./pending-questions.js");
         const { setSession } = await import("./webhook.js");
 
-        const question = await getQuestion(questionId);
-        const questionText = question?.question ?? "a question";
-        const optionsList = question?.options?.join(", ") ?? "";
+        const questionSet = await getQuestion(questionId);
+        if (!questionSet) {
+          res.status(404).json({ type: "error", message: "This question set has expired." } satisfies AppActionResponse);
+          return;
+        }
+        if (isQuestionDismissal) {
+          resp = { type: "close_screen", finalMessage: "Question dismissed." };
+          res.json(resp);
+          void replaceFlowCardWithFlow(messageId, answerAgentSlug, buildUserQuestionFlow(questionSet.questions, {
+            questionId,
+            agentSlug: answerAgentSlug,
+            channelId: answerChannelId,
+            conversationId: answerConversationId,
+            userId: answerUserId,
+          }, { phase: "declined", decidedAt: new Date().toISOString() }), answerConversationId, undefined, answerSpacesAppId);
+          await deleteQuestion(questionId).catch(() => {});
+          return;
+        }
+        const answers = rawAnswers && typeof rawAnswers === "object" && !Array.isArray(rawAnswers)
+          ? rawAnswers as Record<string, unknown>
+          : {};
+        const persistedAnswers: Record<string, string | string[]> = {};
+        const persistedNotes: Record<string, string> = {};
+        const renderedAnswers: string[] = [];
+        for (const prompt of questionSet.questions) {
+          const answer = answers[prompt.id];
+          const required = prompt.required !== false;
+          const note = rawNotes && typeof rawNotes === "object" && !Array.isArray(rawNotes)
+            ? (rawNotes as Record<string, unknown>)[prompt.id]
+            : undefined;
+          const noteText = typeof note === "string" ? note.trim() : "";
+          const hasNote = noteText.length > 0;
+          if (prompt.type === "open_ended") {
+            if ((typeof answer !== "string" || !answer.trim()) && required && !hasNote) {
+              res.status(400).json({ type: "error", message: `Please answer: ${prompt.question}` } satisfies AppActionResponse);
+              return;
+            }
+            if (typeof answer === "string" && answer.trim()) {
+              persistedAnswers[prompt.id] = answer.trim();
+              renderedAnswers.push(`${prompt.question}: ${answer.trim()}`);
+            }
+          if (hasNote) {
+              persistedNotes[prompt.id] = noteText;
+              renderedAnswers.push(`${prompt.question} — Notes: ${noteText}`);
+            }
+            continue;
+          }
+          const selected = prompt.type === "multiple_choice" ? (Array.isArray(answer) ? answer : []) : (typeof answer === "string" ? [answer] : []);
+          if ((required && selected.length === 0 && !hasNote) || selected.some(value => typeof value !== "string" || !prompt.options?.includes(value))) {
+            res.status(400).json({ type: "error", message: `Please choose a valid answer for: ${prompt.question}` } satisfies AppActionResponse);
+            return;
+          }
+          if (selected.length) {
+            const validSelected = selected as string[];
+            persistedAnswers[prompt.id] = prompt.type === "multiple_choice" ? validSelected : validSelected[0]!;
+            renderedAnswers.push(`${prompt.question}: ${validSelected.join(", ")}`);
+          }
+          if (hasNote) {
+            persistedNotes[prompt.id] = noteText;
+            renderedAnswers.push(`${prompt.question} — Notes: ${noteText}`);
+          }
+        }
+        const answerSummary = renderedAnswers.join("\n");
+        resp = { type: "close_screen", finalMessage: "✅ Answers submitted" };
+        res.json(resp);
+        void replaceFlowCardWithFlow(messageId, answerAgentSlug, buildUserQuestionFlow(questionSet.questions, {
+          questionId,
+          agentSlug: answerAgentSlug,
+          channelId: answerChannelId,
+          conversationId: answerConversationId,
+          userId: answerUserId,
+        }, {
+          phase: "answered",
+          answers: persistedAnswers,
+          ...(Object.keys(persistedNotes).length ? { notes: persistedNotes } : {}),
+          decidedAt: new Date().toISOString(),
+        }), answerConversationId, undefined, answerSpacesAppId);
 
         const agent = await findAgentForFlow(answerAgentSlug, answerSpacesAppId);
         const appToken = agent?.spacesAppToken
@@ -1019,8 +1089,8 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
           },
           body: JSON.stringify({
             userId: answerUserId,
-            task: `The user answered "${answer}" to your question: "${questionText}". Continue the task based on this answer.`,
-            context: `Previous question: ${questionText}\nOptions: ${optionsList}\nUser's answer: ${answer}`,
+            task: `The user answered your questions. Continue the task based on these answers:\n${answerSummary}`,
+            context: `User answers:\n${answerSummary}`,
             conversationId: answerConversationId,
             channelId: answerChannelId,
             agentSlug: answerAgentSlug,
@@ -1031,6 +1101,16 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
 
         const runBody = (await runRes.json()) as { success: boolean; sessionId?: string };
         if (runBody.success && runBody.sessionId && agent) {
+          // Like plan approval, this direct /internal/run dispatch skips the
+          // mention path that ordinarily lights the thread's working pill.
+          void emitAgentWorkingSignal({
+            conversationId: answerConversationId,
+            channelId: answerChannelId,
+            agentSlug: answerAgentSlug,
+            spacesAppUserId: agent.spacesAppUserId ?? undefined,
+            appToken,
+            toolLabel: "Working on your answers…",
+          });
           await setSession(runBody.sessionId, {
             mentionedUserId: agent.spacesAppUserId ?? "",
             senderId: answerUserId,
@@ -1038,7 +1118,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
             channelId: answerChannelId,
             channelName: answerChannelId,
             conversationId: answerConversationId,
-            task: `User answered: ${answer}`,
+            task: `User answers:\n${answerSummary}`,
             agentId: agent.id,
             agentOrgId: agent.orgId,
             agentSlug: answerAgentSlug,
@@ -1049,7 +1129,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
           });
         }
 
-        log.info(`[flow-action] User answered "${answer}" → new /run (session=${runBody.sessionId})`);
+        log.info(`[flow-action] User answered question set ${questionId} → new /run (session=${runBody.sessionId})`);
         await deleteQuestion(questionId).catch(() => {});
       } catch (err) {
         log.error("[flow-action] Failed to start new run with answer:", err);

--- a/apps/xyne-claw-auth/backend/src/routes/pending-questions.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/pending-questions.ts
@@ -13,6 +13,7 @@
 import { Router, type Request, type Response } from "express";
 import { redisService } from "../redis.js";
 import { requireStrictS2S } from "../middleware/require-auth.js";
+import type { UserQuestion } from "xyne-claw-shared";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("pending-questions");
@@ -27,8 +28,7 @@ export interface StoredQuestion {
   agentSlug: string;
   channelId: string;
   conversationId: string;
-  question: string;
-  options: string[];
+  questions: UserQuestion[];
 }
 
 export async function getQuestion(questionId: string): Promise<StoredQuestion | null> {
@@ -46,18 +46,17 @@ export async function deleteQuestion(questionId: string): Promise<void> {
 // POST / — store a pending question
 router.post("/", requireStrictS2S, async (req: Request, res: Response) => {
   try {
-    const { questionId, userId, agentSlug, channelId, conversationId, question, options } = req.body as {
+    const { questionId, userId, agentSlug, channelId, conversationId, questions } = req.body as {
       questionId?: string;
       userId?: string;
       agentSlug?: string;
       channelId?: string;
       conversationId?: string;
-      question?: string;
-      options?: string[];
+      questions?: UserQuestion[];
     };
 
-    if (!questionId || !question || !options?.length) {
-      res.status(400).json({ success: false, error: "questionId, question, and options are required" });
+    if (!questionId || !Array.isArray(questions) || questions.length === 0) {
+      res.status(400).json({ success: false, error: "questionId and questions are required" });
       return;
     }
 
@@ -67,14 +66,13 @@ router.post("/", requireStrictS2S, async (req: Request, res: Response) => {
       agentSlug: agentSlug ?? "",
       channelId: channelId ?? "",
       conversationId: conversationId ?? "",
-      question,
-      options,
+      questions,
     };
 
     const redis = redisService.getConnection();
     await redis.set(`${PREFIX}${questionId}`, JSON.stringify(data), "EX", TTL);
 
-    log.info(`[pending-questions] Stored question ${questionId}: "${question}" (${options.length} options)`);
+    log.info(`[pending-questions] Stored question set ${questionId} (${questions.length} questions)`);
     res.json({ success: true });
   } catch (err) {
     log.error("[pending-questions] Store error:", err);

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -4905,10 +4905,13 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     }
 
     // ── Post question buttons in thread ──
-    const pendingQuestions = (payload as { pendingQuestions?: Array<{ questionId: string; question: string; options: string[] }> }).pendingQuestions;
+    const pendingQuestions = (payload as { pendingQuestions?: Array<{ questionId: string; questions?: import("xyne-claw-shared").UserQuestion[]; question?: string; options?: string[] }> }).pendingQuestions;
     if (pendingQuestions?.length) {
+      let postedQuestionSets = 0;
       for (const q of pendingQuestions) {
-        const questionFlow = withSpacesAppId(buildUserQuestionFlow(q.question, q.options, {
+        const questions = q.questions?.length ? q.questions : q.question && q.options?.length ? [{ id: "q1", question: q.question, type: "single_choice" as const, options: q.options }] : undefined;
+        if (!questions) continue;
+        const questionFlow = withSpacesAppId(buildUserQuestionFlow(questions, {
           questionId: q.questionId,
           agentSlug: ctx.agentSlug ?? "",
           channelId: ctx.channelId,
@@ -4921,8 +4924,9 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
           flow: questionFlow,
           userId: ctx.spacesAppUserId,
         }, token);
+        postedQuestionSets += 1;
       }
-      log.info(`Posted ${pendingQuestions.length} question(s) in thread ${ctx.conversationId}`);
+      log.info(`Posted ${postedQuestionSets} question set(s) in thread ${ctx.conversationId}`);
     }
 
     // ── Post /goal suggestion FlowUI card in thread ──

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -88,7 +88,7 @@ import {
 } from "../lib/session-context.js";
 import { emitAgentWorkingSignal } from "../surfaces/spaces/client.js";
 import JSZip from "jszip";
-import { buildWriteApprovalFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, isTwinDelivery } from "xyne-claw-shared";
+import { buildWriteApprovalFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildPlanFlow, buildCodeFlow, buildDiffFlow, buildChartFlow, isTwinDelivery } from "xyne-claw-shared";
 import type { TwinDelivery } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 
@@ -5370,6 +5370,74 @@ router.post("/progress", requireStrictS2S, async (req: Request, res: Response) =
     renderPlanCard(sessionId, todos, conversationId, agentSlug).catch((e) =>
       clog.warn(`[webhook/progress] renderPlanCard failed for ${sessionId}:`, e instanceof Error ? e.message : e),
     );
+    return;
+  }
+
+  const artifactKind = (req.body as { kind?: string }).kind;
+  if (artifactKind === "code" || artifactKind === "diff" || artifactKind === "chart") {
+    void touchRunRecovery(sessionId).catch(() => {});
+    void (async () => {
+      const ctx = await resolveSessionContext(sessionId, conversationId, agentSlug).catch(() => null);
+      if (!ctx || ctx.responseMode !== "conversation") return;
+      const log = createLogger("webhook/progress", ctx.traceId ?? sessionId.slice(0, 8));
+      const body = req.body as {
+        code?: string;
+        language?: string;
+        path?: string;
+        patch?: string;
+        type?: string;
+        points?: Array<{ label?: unknown; value?: unknown }>;
+        series?: Array<{ x?: unknown; y?: unknown; series?: unknown }>;
+        caption?: string;
+      };
+      let flow;
+      if (artifactKind === "code") {
+        if (!body.code?.trim()) return;
+        flow = buildCodeFlow(body.code, body.language);
+      } else if (artifactKind === "diff") {
+        if (!body.path?.trim() || !body.patch?.trim()) return;
+        flow = buildDiffFlow(body.path.trim(), body.patch);
+      } else {
+        const caption = body.caption?.trim() || undefined;
+        if (body.type === "line" || body.type === "area") {
+          const series = Array.isArray(body.series)
+            ? body.series
+                .map((point) => ({
+                  x: String(point?.x ?? "").trim(),
+                  y: Number(point?.y),
+                  ...(typeof point?.series === "string" && point.series.trim()
+                    ? { series: point.series.trim() }
+                    : {}),
+                }))
+                .filter((point) => point.x !== "" && Number.isFinite(point.y))
+            : [];
+          if (series.length === 0) return;
+          flow = buildChartFlow({ type: body.type, series, ...(caption ? { caption } : {}) });
+        } else if (body.type === "bar" || body.type === "pie" || body.type === "donut") {
+          const points = Array.isArray(body.points)
+            ? body.points
+                .map((point) => ({ label: String(point?.label ?? "").trim(), value: Number(point?.value) }))
+                .filter((point) => point.label !== "" && Number.isFinite(point.value))
+            : [];
+          if (points.length === 0) return;
+          flow = buildChartFlow({ type: body.type, points, ...(caption ? { caption } : {}) });
+        } else {
+          log.warn(`Skipped chart card: unknown type ${String(body.type)}`);
+          return;
+        }
+      }
+      try {
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow: withSpacesAppId(flow, ctx.spacesAppId),
+          userId: ctx.spacesAppUserId,
+        }, ctx.appToken);
+        log.info(`Posted ${artifactKind} card in thread ${ctx.conversationId}`);
+      } catch (err) {
+        log.warn(`Failed to post ${artifactKind} card`, { error: err instanceof Error ? err.message : String(err) });
+      }
+    })();
     return;
   }
 

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -3766,7 +3766,7 @@ async function processTask(
     }
 
     clog.info(
-      `[follow-ups] callback sessionId=${sessionId} pendingQuestions=${pendingQuestions.length} followUpCount=${pendingQuestions.find((question) => question.purpose === "follow_up_suggestions")?.options.length ?? 0}`,
+      `[follow-ups] callback sessionId=${sessionId} pendingQuestions=${pendingQuestions.length} followUpCount=${pendingQuestions.find((question) => question.purpose === "follow_up_suggestions")?.options?.length ?? 0}`,
     );
     await sendCallback(callbackUrl, sessionToken, {
       sessionId,

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -27,7 +27,11 @@ export type FlowComponentType =
   | 'pr'
   | 'pr_approval'
   | 'call_schedule'
-  | 'user_question';
+  | 'user_question'
+  | 'code'
+  | 'diff'
+  | 'ticket'
+  | 'chart';
 
 export interface FlowComponent {
   id: string;

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -26,7 +26,8 @@ export type FlowComponentType =
   | 'plan'
   | 'pr'
   | 'pr_approval'
-  | 'call_schedule';
+  | 'call_schedule'
+  | 'user_question';
 
 export interface FlowComponent {
   id: string;
@@ -188,4 +189,3 @@ export function isFlowDefinition(obj: unknown): obj is FlowDefinition {
     Array.isArray((obj as Record<string, unknown>).components)
   );
 }
-

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -524,6 +524,104 @@ export const userQuestionComponentSchema = baseComponentSchema.extend({ type: z.
 export type UserQuestionItem = z.infer<typeof userQuestionItemSchema>;
 export type UserQuestionProps = z.infer<typeof userQuestionPropsSchema>;
 
+export const codePropsSchema = z
+  .object({
+    code: z.string().min(1),
+    language: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const codeComponentSchema = baseComponentSchema.extend({
+  type: z.literal('code'),
+  props: codePropsSchema,
+});
+
+export const diffPropsSchema = z
+  .object({
+    path: z.string().min(1),
+    patch: z.string().min(1),
+  })
+  .strict();
+
+export const diffComponentSchema = baseComponentSchema.extend({
+  type: z.literal('diff'),
+  props: diffPropsSchema,
+});
+
+export const ticketStatusSchema = z.enum(['TODO', 'STARTED', 'PAUSED', 'CANCELLED', 'COMPLETED']);
+export const ticketPrioritySchema = z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
+
+export const ticketPropsSchema = z
+  .object({
+    xyneId: z.string().min(1),
+    title: z.string().min(1),
+    status: ticketStatusSchema,
+    priority: ticketPrioritySchema,
+    eta: z.string().optional(),
+    url: z.string().min(1),
+  })
+  .strict();
+
+export const ticketComponentSchema = baseComponentSchema.extend({
+  type: z.literal('ticket'),
+  props: ticketPropsSchema,
+});
+
+export const chartPointSchema = z
+  .object({ label: z.string().min(1), value: z.number().finite() })
+  .strict();
+
+export const chartSeriesPointSchema = z
+  .object({
+    x: z.string().min(1),
+    y: z.number().finite(),
+    series: z.string().min(1).optional(),
+  })
+  .strict();
+
+const CHART_MAX_POINTS = 200;
+
+const categoryChartSchema = <T extends 'bar' | 'pie' | 'donut'>(type: T) =>
+  z
+    .object({
+      type: z.literal(type),
+      points: z.array(chartPointSchema).min(1).max(24),
+      caption: z.string().min(1).optional(),
+    })
+    .strict();
+
+const seriesChartSchema = <T extends 'line' | 'area'>(type: T) =>
+  z
+    .object({
+      type: z.literal(type),
+      series: z.array(chartSeriesPointSchema).min(1).max(CHART_MAX_POINTS),
+      caption: z.string().min(1).optional(),
+    })
+    .strict();
+
+export const chartPropsSchema = z.discriminatedUnion('type', [
+  categoryChartSchema('bar'),
+  categoryChartSchema('pie'),
+  categoryChartSchema('donut'),
+  seriesChartSchema('line'),
+  seriesChartSchema('area'),
+]);
+
+export const chartComponentSchema = baseComponentSchema.extend({
+  type: z.literal('chart'),
+  props: chartPropsSchema,
+});
+
+export type CodeProps = z.infer<typeof codePropsSchema>;
+export type DiffProps = z.infer<typeof diffPropsSchema>;
+export type TicketProps = z.infer<typeof ticketPropsSchema>;
+export type TicketArtifactStatus = z.infer<typeof ticketStatusSchema>;
+export type TicketArtifactPriority = z.infer<typeof ticketPrioritySchema>;
+export type ChartProps = z.infer<typeof chartPropsSchema>;
+export type ChartType = ChartProps['type'];
+export type ChartPoint = z.infer<typeof chartPointSchema>;
+export type ChartSeriesPoint = z.infer<typeof chartSeriesPointSchema>;
+
 // Recursive container schemas need z.lazy
 export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
   z.discriminatedUnion('type', [
@@ -545,6 +643,10 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     prApprovalComponentSchema,
     callScheduleComponentSchema,
     userQuestionComponentSchema,
+    codeComponentSchema,
+    diffComponentSchema,
+    ticketComponentSchema,
+    chartComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema
     baseComponentSchema.extend({
       type: z.literal('row'),

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -500,6 +500,30 @@ export type DurationMinutes = z.infer<typeof durationMinutesSchema>;
 export type CallScheduleProps = z.infer<typeof callSchedulePropsSchema>;
 export type CallSchedulePhase = CallScheduleProps['phase'];
 
+export const userQuestionItemSchema = z.discriminatedUnion('type', [
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('single_choice'), options: z.array(z.string().min(1)).min(2).max(9), required: z.boolean().optional() }).strict(),
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('multiple_choice'), options: z.array(z.string().min(1)).min(2).max(9), required: z.boolean().optional() }).strict(),
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('open_ended'), placeholder: z.string().optional(), required: z.boolean().optional() }).strict(),
+]);
+
+export const userQuestionPropsSchema = z.object({
+  title: z.string().min(1),
+  questions: z.array(userQuestionItemSchema).min(1).max(8),
+  // Absent on cards posted before terminal question states were introduced;
+  // the renderer interprets absence as `pending`.
+  phase: z.enum(['pending', 'answered', 'declined']).optional(),
+  answers: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  /** Optional notes are scoped to the individual prompt id. */
+  notes: z.record(z.string()).optional(),
+  decidedAt: z.string().optional(),
+  submitAction: flowActionSchema.optional(),
+  dismissAction: flowActionSchema.optional(),
+}).strict();
+
+export const userQuestionComponentSchema = baseComponentSchema.extend({ type: z.literal('user_question'), props: userQuestionPropsSchema });
+export type UserQuestionItem = z.infer<typeof userQuestionItemSchema>;
+export type UserQuestionProps = z.infer<typeof userQuestionPropsSchema>;
+
 // Recursive container schemas need z.lazy
 export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
   z.discriminatedUnion('type', [
@@ -520,6 +544,7 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     prComponentSchema,
     prApprovalComponentSchema,
     callScheduleComponentSchema,
+    userQuestionComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema
     baseComponentSchema.extend({
       type: z.literal('row'),

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -29,7 +29,11 @@ type FlowComponentType =
   | 'image'
   | 'link'
   | 'plan'
-  | 'user_question';
+  | 'user_question'
+  | 'code'
+  | 'diff'
+  | 'ticket'
+  | 'chart';
 
 interface FlowComponentStyle {
   padding?: string;
@@ -795,9 +799,10 @@ export function buildCloneApprovalFlow(
  * is included solely for the fail-closed caller check; flow-action re-reads the
  * real approver from the DB.
  */
-/** Rendering caps for the git-style diff card. FlowJSON has no native diff
- *  component, so each line is its own styled text node — cap the totals so a
- *  full-file rewrite can't emit thousands of components. */
+/** Rendering caps for the skill-update diff card, which predates the native
+ *  `diff` component and still renders each line as its own styled text node —
+ *  cap the totals so a full-file rewrite can't emit thousands of components.
+ *  New callers should emit a `diff` component (buildDiffFlow) instead. */
 const DIFF_CARD_MAX_HUNKS = 6;
 const DIFF_CARD_MAX_LINES = 60;
 const DIFF_LINE_MAX_CHARS = 160;
@@ -928,4 +933,105 @@ export function buildSkillUpdateApprovalFlow(
       ...(context.spacesAppId ? { spacesAppId: context.spacesAppId } : {}),
     });
   return b.build();
+}
+
+const CODE_ARTIFACT_MAX_CHARS = 20_000;
+
+function clipArtifact(body: string, marker: string): string {
+  return body.length > CODE_ARTIFACT_MAX_CHARS
+    ? `${body.slice(0, CODE_ARTIFACT_MAX_CHARS)}\n${marker}`
+    : body;
+}
+
+export function buildCodeFlow(code: string, language?: string): FlowDefinition {
+  return new FlowBuilder(`code-${crypto.randomUUID()}`)
+    .addComponent({
+      id: 'code',
+      type: 'code',
+      props: {
+        code: clipArtifact(code, '… truncated'),
+        ...(language ? { language } : {}),
+      },
+    })
+    .build();
+}
+
+export function buildDiffFlow(path: string, patch: string): FlowDefinition {
+  const firstMeaningfulLine = patch.split('\n').find((line) => line.trim() !== '') ?? '';
+  const headed =
+    firstMeaningfulLine.startsWith('diff --git ') || firstMeaningfulLine.startsWith('--- ');
+  const headedPatch = headed ? patch : `--- a/${path}\n+++ b/${path}\n${patch}`;
+  return new FlowBuilder(`diff-${crypto.randomUUID()}`)
+    .addComponent({
+      id: 'diff',
+      type: 'diff',
+      props: {
+        path,
+        patch: clipArtifact(headedPatch, ' … diff truncated'),
+      },
+    })
+    .build();
+}
+
+export interface TicketArtifact {
+  xyneId: string;
+  title: string;
+  status: 'TODO' | 'STARTED' | 'PAUSED' | 'CANCELLED' | 'COMPLETED';
+  priority: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+  eta?: string;
+  url: string;
+}
+
+export function buildTicketFlow(ticket: TicketArtifact): FlowDefinition {
+  return new FlowBuilder(`ticket-${ticket.xyneId}`)
+    .addComponent({
+      id: 'ticket',
+      type: 'ticket',
+      props: {
+        xyneId: ticket.xyneId,
+        title: ticket.title,
+        status: ticket.status,
+        priority: ticket.priority,
+        ...(ticket.eta ? { eta: ticket.eta } : {}),
+        url: ticket.url,
+      },
+    })
+    .build();
+}
+
+export interface ChartPoint {
+  label: string;
+  value: number;
+}
+
+export interface ChartSeriesPoint {
+  x: string;
+  y: number;
+  series?: string;
+}
+
+export type ChartArtifact =
+  | { type: 'bar'; points: ChartPoint[]; caption?: string }
+  | { type: 'pie'; points: ChartPoint[]; caption?: string }
+  | { type: 'donut'; points: ChartPoint[]; caption?: string }
+  | { type: 'line'; series: ChartSeriesPoint[]; caption?: string }
+  | { type: 'area'; series: ChartSeriesPoint[]; caption?: string };
+
+const CHART_MAX_CATEGORY_POINTS = 24;
+const CHART_MAX_SERIES_POINTS = 200;
+
+export function buildChartFlow(chart: ChartArtifact): FlowDefinition {
+  let props: Record<string, unknown>;
+  if (chart.type === 'line' || chart.type === 'area') {
+    props = { type: chart.type, series: chart.series.slice(0, CHART_MAX_SERIES_POINTS) };
+  } else {
+    props = { type: chart.type, points: chart.points.slice(0, CHART_MAX_CATEGORY_POINTS) };
+  }
+  return new FlowBuilder(`chart-${crypto.randomUUID()}`)
+    .addComponent({
+      id: 'chart',
+      type: 'chart',
+      props: { ...props, ...(chart.caption ? { caption: chart.caption } : {}) },
+    })
+    .build();
 }

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -8,6 +8,7 @@
  */
 
 import type { TwinDelivery, TwinReplyDestination } from "../types/twin-delivery.js";
+import type { UserQuestion } from "../tools/types.js";
 
 // ── Inlined FlowUI types (mirrors @xyne/shared) ──────────────────────────────
 
@@ -27,7 +28,8 @@ type FlowComponentType =
   | 'divider'
   | 'image'
   | 'link'
-  | 'plan';
+  | 'plan'
+  | 'user_question';
 
 interface FlowComponentStyle {
   padding?: string;
@@ -552,8 +554,7 @@ export function buildTwinApprovalFlow(params: TwinApprovalFlowParams): FlowDefin
  * User question — radio group with the agent's options + submit button.
  */
 export function buildUserQuestionFlow(
-  question: string,
-  options: string[],
+  questions: UserQuestion[],
   context: {
     questionId: string;
     agentSlug: string;
@@ -561,15 +562,31 @@ export function buildUserQuestionFlow(
     conversationId: string;
     userId: string;
   },
+  opts?: {
+    phase?: 'pending' | 'answered' | 'declined';
+    answers?: Record<string, string | string[]>;
+    notes?: Record<string, string>;
+    decidedAt?: string;
+  },
 ): FlowDefinition {
-  return new FlowBuilder(`user-question-${crypto.randomUUID()}`)
-    .addText('q', question)
-    .addSelect('answer', 'answer', {
-      label: 'Choose an option',
-      required: true,
-      options: options.map((opt) => ({ label: opt, value: opt })),
+  const phase = opts?.phase ?? 'pending';
+  return new FlowBuilder(`user-question-${context.questionId}`)
+    .addComponent({
+      id: 'questions',
+      type: 'user_question',
+      props: {
+        title: questions.length === 1 ? 'Question' : 'Questions',
+        questions,
+        phase,
+        ...(opts?.answers ? { answers: opts.answers } : {}),
+        ...(opts?.notes ? { notes: opts.notes } : {}),
+        ...(opts?.decidedAt ? { decidedAt: opts.decidedAt } : {}),
+        ...(phase === 'pending' ? {
+          submitAction: { type: 'submit', actionId: 'user-answer' },
+          dismissAction: { type: 'submit', actionId: 'dismiss-user-question' },
+        } : {}),
+      },
     })
-    .addButton('submit', 'Submit', { type: 'submit', actionId: 'user-answer' }, { variant: 'primary' })
     .setData({
       actionType: 'user-answer',
       questionId: context.questionId,

--- a/packages/xyne-claw-shared/src/flow/code-artifact-flow.test.ts
+++ b/packages/xyne-claw-shared/src/flow/code-artifact-flow.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { buildChartFlow, buildCodeFlow, buildDiffFlow, buildTicketFlow } from "./builder.js";
+
+describe("buildCodeFlow", () => {
+  it("emits one static code component with no action surface", () => {
+    const flow = buildCodeFlow("const a = 1;\n", "typescript");
+
+    expect(flow.components).toHaveLength(1);
+    expect(flow.components[0]).toMatchObject({
+      id: "code",
+      type: "code",
+      props: { code: "const a = 1;\n", language: "typescript" },
+    });
+    expect(flow.data).toBeUndefined();
+    expect(flow.components[0]?.props).not.toHaveProperty("submitAction");
+  });
+
+  it("omits language when absent rather than emitting an empty one", () => {
+    const flow = buildCodeFlow("plain text");
+    expect(flow.components[0]?.props).not.toHaveProperty("language");
+  });
+});
+
+describe("buildDiffFlow", () => {
+  const hunk = "@@ -41,2 +41,3 @@\n-messaging.onTokenRefresh(noop);\n+messaging.onTokenRefresh((t) => registerDevice(t));\n";
+
+  it("adds file headers to a bare hunk list so the patch parses", () => {
+    const flow = buildDiffFlow("src/push/token.ts", hunk);
+
+    expect(flow.components).toHaveLength(1);
+    expect(flow.components[0]).toMatchObject({ id: "diff", type: "diff" });
+    const props = flow.components[0]?.props as { path: string; patch: string };
+    expect(props.path).toBe("src/push/token.ts");
+    expect(props.patch).toBe(`--- a/src/push/token.ts\n+++ b/src/push/token.ts\n${hunk}`);
+    expect(flow.data).toBeUndefined();
+  });
+
+  it("still adds headers when a hunk body line looks like a file header", () => {
+    const sqlHunk = "@@ -1,2 +1,1 @@\n SELECT 1;\n--- TODO: remove this\n";
+    const flow = buildDiffFlow("db/migrations/002.sql", sqlHunk);
+    const { patch } = flow.components[0]?.props as { patch: string };
+    expect(patch.startsWith("--- a/db/migrations/002.sql\n+++ b/db/migrations/002.sql\n")).toBe(true);
+  });
+
+  it("leaves an already-headed patch untouched", () => {
+    const full = `diff --git a/x.ts b/x.ts\n--- a/x.ts\n+++ b/x.ts\n${hunk}`;
+    const flow = buildDiffFlow("x.ts", full);
+    expect((flow.components[0]?.props as { patch: string }).patch).toBe(full);
+  });
+
+  it("truncates a runaway patch with a visible marker", () => {
+    const huge = `@@ -1,1 +1,1 @@\n${"+x\n".repeat(20_000)}`;
+    const flow = buildDiffFlow("big.ts", huge);
+    const { patch } = flow.components[0]?.props as { patch: string };
+    expect(patch.length).toBeLessThan(huge.length);
+    expect(patch.endsWith("… diff truncated")).toBe(true);
+  });
+});
+
+describe("buildTicketFlow", () => {
+  it("emits a static ticket component carrying only server-derived fields", () => {
+    const flow = buildTicketFlow({
+      xyneId: "XYS-0441",
+      title: "Fix Android push: stale FCM token after SDK bump",
+      status: "TODO",
+      priority: "HIGH",
+      eta: "2026-02-02T00:00:00.000Z",
+      url: "/chat/dir/c1/conv1/tkt1",
+    });
+    expect(flow.components).toHaveLength(1);
+    expect(flow.components[0]).toMatchObject({
+      id: "ticket",
+      type: "ticket",
+      props: { xyneId: "XYS-0441", status: "TODO", priority: "HIGH" },
+    });
+    expect(flow.data).toBeUndefined();
+  });
+
+  it("omits eta when the ticket has no due date", () => {
+    const flow = buildTicketFlow({
+      xyneId: "XYS-0442",
+      title: "No due date",
+      status: "STARTED",
+      priority: "LOW",
+      url: "/chat/dir/c1/conv1/tkt2",
+    });
+    expect(flow.components[0]?.props).not.toHaveProperty("eta");
+  });
+});
+
+describe("buildChartFlow", () => {
+  it("preserves the caller's point order rather than sorting", () => {
+    const points = [
+      { label: "Mon", value: 31 },
+      { label: "Tue", value: 2100 },
+      { label: "Wed", value: 4800 },
+    ];
+    const flow = buildChartFlow({ type: "bar", points, caption: "Push failures per day" });
+    expect(flow.components[0]?.props).toMatchObject({
+      type: "bar",
+      points,
+      caption: "Push failures per day",
+    });
+  });
+
+  it("caps category charts so one call can't emit an unbounded chart", () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({ label: `d${i}`, value: i }));
+    const flow = buildChartFlow({ type: "bar", points: many });
+    const { points } = flow.components[0]?.props as { points: unknown[] };
+    expect(points).toHaveLength(24);
+  });
+
+  it("carries multi-series line data under `series`, not `points`", () => {
+    const series = [
+      { x: "Mon", y: 1, series: "android" },
+      { x: "Mon", y: 2, series: "ios" },
+    ];
+    const flow = buildChartFlow({ type: "line", series });
+    expect(flow.components[0]?.props).toMatchObject({ type: "line", series });
+    expect(flow.components[0]?.props).not.toHaveProperty("points");
+  });
+
+  it("omits caption when absent", () => {
+    const flow = buildChartFlow({ type: "donut", points: [{ label: "a", value: 1 }] });
+    expect(flow.components[0]?.props).not.toHaveProperty("caption");
+  });
+});

--- a/packages/xyne-claw-shared/src/flow/user-question-flow.test.ts
+++ b/packages/xyne-claw-shared/src/flow/user-question-flow.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { buildUserQuestionFlow } from "./builder.js";
+
+describe("buildUserQuestionFlow", () => {
+  it("emits one typed question-set card with all response modes", () => {
+    const flow = buildUserQuestionFlow(
+      [
+        {
+          id: "scope",
+          label: "Version scope",
+          question: "Which versions?",
+          type: "single_choice",
+          options: ["4.2.1", "All"],
+        },
+        {
+          id: "targets",
+          question: "Which targets?",
+          type: "multiple_choice",
+          options: ["Android", "iOS"],
+        },
+        {
+          id: "detail",
+          question: "Anything else?",
+          type: "open_ended",
+          placeholder: "Optional context",
+        },
+      ],
+      {
+        questionId: "set-1",
+        agentSlug: "agent",
+        channelId: "channel",
+        conversationId: "conversation",
+        userId: "user",
+      },
+    );
+
+    expect(flow.components).toHaveLength(1);
+    expect(flow.components[0]).toMatchObject({
+      id: "questions",
+      type: "user_question",
+      props: {
+        title: "Questions",
+        submitAction: { type: "submit", actionId: "user-answer" },
+        dismissAction: { type: "submit", actionId: "dismiss-user-question" },
+      },
+    });
+    expect(flow.data).toMatchObject({
+      actionType: "user-answer",
+      questionId: "set-1",
+    });
+  });
+
+  it("keeps a stable card id and emits a read-only answered phase", () => {
+    const flow = buildUserQuestionFlow(
+      [
+        {
+          id: "scope",
+          question: "Which versions?",
+          type: "single_choice",
+          options: ["One", "All"],
+        },
+      ],
+      {
+        questionId: "set-2",
+        agentSlug: "agent",
+        channelId: "channel",
+        conversationId: "conversation",
+        userId: "user",
+      },
+      { phase: "answered", answers: { scope: "All" }, notes: "Please include patch notes" },
+    );
+    expect(flow.screenId).toBe("user-question-set-2");
+    expect(flow.components[0]?.props).toMatchObject({ phase: "answered", answers: { scope: "All" } });
+    expect(flow.components[0]?.props).not.toHaveProperty("submitAction");
+  });
+});

--- a/packages/xyne-claw-shared/src/flow/user-question-flow.test.ts
+++ b/packages/xyne-claw-shared/src/flow/user-question-flow.test.ts
@@ -67,7 +67,7 @@ describe("buildUserQuestionFlow", () => {
         conversationId: "conversation",
         userId: "user",
       },
-      { phase: "answered", answers: { scope: "All" }, notes: "Please include patch notes" },
+      { phase: "answered", answers: { scope: "All" }, notes: { scope: "Please include patch notes" } },
     );
     expect(flow.screenId).toBe("user-question-set-2");
     expect(flow.components[0]?.props).toMatchObject({ phase: "answered", answers: { scope: "All" } });

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -20,8 +20,8 @@ export {
 } from "./skill-diff/index.js";
 export type { SkillDiff, SkillForAuthz, ApproverResolution, SkillApprovalAuthz } from "./skill-diff/index.js";
 export { createSkillTool, updateSkillTool } from "./tools/skill-management/index.js";
-export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow } from "./flow/builder.js";
-export type { FlowDefinition, FlowComponent, FlowAction, SelectOption } from "./flow/builder.js";
+export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildCodeFlow, buildDiffFlow, buildTicketFlow, buildChartFlow } from "./flow/builder.js";
+export type { FlowDefinition, FlowComponent, FlowAction, SelectOption, TicketArtifact, ChartArtifact } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
 export type { Todo, TodoStatus, PlanPhase, PlanTodoInput } from "./flow/plan-flow.js";
 export { todoTools, todoWriteTool, todoReadTool, getPlan, clearPlan, PLAN_TOOL_SLUGS, isPlanToolSlug } from "./tools/todo/todo-tools.js";

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -1,4 +1,4 @@
-export type { ToolDefinition, ToolInputSchema, ConfigField, ToolExecutionContext, PendingQuestion, PendingResponse } from "./tools/types.js";
+export type { ToolDefinition, ToolInputSchema, ConfigField, ToolExecutionContext, PendingQuestion, PendingResponse, UserQuestion, UserQuestionType } from "./tools/types.js";
 export { getAllCustomTools, getCustomTool, getToolsBySource } from "./tools/registry.js";
 export { takeLlmCitations, peekLlmCitations, recordLlmCitations } from "./tools/add-citations/tools.js";
 export { respondToUser, COPILOT_SYSTEM_INSTRUCTION } from "./tools/respond-to-user/index.js";

--- a/packages/xyne-claw-shared/src/tools/ask-question/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/ask-question/tools.ts
@@ -1,5 +1,7 @@
 import crypto from "node:crypto";
-import type { ToolDefinition } from "../types.js";
+import type { ToolDefinition, UserQuestion, UserQuestionType } from "../types.js";
+
+const SKIP_QUESTION_OPTION = "Skip this question";
 
 export const ASK_QUESTION_CONFIG_SCHEMA = {
   CLAW_AUTH_URL: {
@@ -14,8 +16,15 @@ export const askUserQuestion: ToolDefinition = {
   slug: "ask-user-question",
   name: "Ask User Question",
   description:
-    "Ask the user a question with 2-4 options. The user will see clickable buttons in the chat " +
-    "and can pick one. A new agent run will automatically start with their answer as context. " +
+    "Use this only when you need the user's decision or missing information before you can safely continue. " +
+    "Do not use it for facts you can determine with available context or tools. Batch related, independent questions " +
+    "into one card (1-8 questions) instead of asking them one at a time. Each question needs `question` and `type`: " +
+    "`single_choice` for exactly one option, `multiple_choice` for one or more options, or `open_ended` for free text. " +
+    "Choice questions require 2-8 concise `options`; open-ended questions must not include options. Use a short, " +
+    "The UI adds a default 'Skip this question' response, so do not add your own skip option. " +
+    "human-readable `label` for the question tab (for example, 'Version scope') and an optional stable `id`; when " +
+    "id is omitted, q1, q2, etc. are generated. Set `required: false` only when the question is genuinely optional. " +
+    "A new agent run automatically starts with the structured answers and any per-question notes as context. " +
     "IMPORTANT: After calling this tool, you MUST stop immediately. Do NOT continue working, " +
     "do NOT call any other tools, do NOT make assumptions about the answer. Just report that " +
     "you've asked the question and end your response. The user's answer will arrive in a new run.",
@@ -24,24 +33,33 @@ export const askUserQuestion: ToolDefinition = {
   inputSchema: {
     type: "object",
     properties: {
-      question: { type: "string", description: "The question to ask the user" },
-      options: {
+      questions: {
         type: "array",
-        items: { type: "string" },
-        description: "2-4 answer options the user can choose from",
+        description: "One or more questions to ask together (at most 8).",
+        items: { type: "object", properties: {
+          id: { type: "string" }, label: { type: "string" }, question: { type: "string" }, type: { type: "string", description: "single_choice, multiple_choice, or open_ended" }, options: { type: "array", items: { type: "string" } }, required: { type: "boolean" }, placeholder: { type: "string" },
+        }, required: ["question", "type"] },
       },
     },
-    required: ["question", "options"],
+    required: ["questions"],
   },
   async execute(params, context) {
     if (!context) return "Error: No execution context available.";
-    const question = params["question"] as string;
-    const options = params["options"] as string[];
-
-    if (!question) return "Error: question is required.";
-    if (!options || options.length < 2 || options.length > 4) {
-      return "Error: provide 2-4 options.";
+    const rawQuestions = params["questions"];
+    if (!Array.isArray(rawQuestions) || rawQuestions.length < 1 || rawQuestions.length > 8) return "Error: provide 1-8 questions.";
+    const validTypes: UserQuestionType[] = ["single_choice", "multiple_choice", "open_ended"];
+    const questions: UserQuestion[] = [];
+    for (let index = 0; index < rawQuestions.length; index += 1) {
+      const raw = rawQuestions[index] as Record<string, unknown>;
+      const question = typeof raw?.["question"] === "string" ? raw["question"].trim() : "";
+      const type = raw?.["type"] as UserQuestionType;
+      const options = Array.isArray(raw?.["options"]) ? raw["options"].filter((option): option is string => typeof option === "string" && option.trim().length > 0).map(option => option.trim()) : undefined;
+      if (!question || !validTypes.includes(type)) return `Error: question ${index + 1} needs a prompt and a valid type.`;
+      if (type !== "open_ended" && (!options || options.length < 2 || options.length > 8)) return `Error: ${type} question ${index + 1} needs 2-8 options.`;
+      if (type === "open_ended" && options?.length) return `Error: open_ended question ${index + 1} must not include options.`;
+      questions.push({ id: typeof raw["id"] === "string" && raw["id"].trim() ? raw["id"].trim() : `q${index + 1}`, ...(typeof raw["label"] === "string" && raw["label"].trim() ? { label: raw["label"].trim() } : {}), question, type, ...(options ? { options: options.includes(SKIP_QUESTION_OPTION) ? options : [...options, SKIP_QUESTION_OPTION] } : {}), ...(typeof raw["required"] === "boolean" ? { required: raw["required"] } : {}), ...(type === "open_ended" && typeof raw["placeholder"] === "string" ? { placeholder: raw["placeholder"] } : {}) });
     }
+    if (new Set(questions.map(question => question.id)).size !== questions.length) return "Error: each question id must be unique.";
 
     const meta = context.meta ?? {};
     const authUrl = context.config["CLAW_AUTH_URL"] ?? "http://localhost:3003";
@@ -61,8 +79,7 @@ export const askUserQuestion: ToolDefinition = {
           agentSlug: meta["agentSlug"],
           channelId: meta["channelId"],
           conversationId: meta["conversationId"],
-          question,
-          options,
+          questions,
         }),
         signal: AbortSignal.timeout(10_000),
       });
@@ -80,8 +97,8 @@ export const askUserQuestion: ToolDefinition = {
     }
 
     // Push to pendingQuestions collector so it's included in callback
-    context.pendingQuestions?.push({ questionId, question, options });
+    context.pendingQuestions?.push({ questionId, questions });
 
-    return `STOP — Question posted to user: "${question}" with options: ${options.join(", ")}. Do NOT continue working. Do NOT call any more tools. Do NOT assume an answer. Simply tell the user you've asked the question and wait. A new agent run will start automatically when they answer.`;
+    return `STOP — Posted ${questions.length} question(s) to the user. Do NOT continue working. Do NOT call any more tools. Do NOT assume an answer. Simply tell the user you've asked the questions and wait. A new agent run will start automatically when they answer.`;
   },
 };

--- a/packages/xyne-claw-shared/src/tools/code-artifacts/index.ts
+++ b/packages/xyne-claw-shared/src/tools/code-artifacts/index.ts
@@ -1,0 +1,1 @@
+export { postCodeBlock, postDiff, postChart } from "./tools.js";

--- a/packages/xyne-claw-shared/src/tools/code-artifacts/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/code-artifacts/tools.ts
@@ -1,0 +1,171 @@
+import type { ToolDefinition, ToolExecutionContext } from "../types.js";
+
+function pushArtifactCard(
+  ctx: ToolExecutionContext | undefined,
+  body: Record<string, unknown>,
+): void {
+  const url = ctx?.progressUrl;
+  if (!url || !ctx?.sessionId) return;
+  void fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(ctx.s2sKey ? { "x-s2s-key": ctx.s2sKey } : {}),
+    },
+    body: JSON.stringify({ sessionId: ctx.sessionId, ...body }),
+  }).catch(() => {});
+}
+
+export const postCodeBlock: ToolDefinition = {
+  slug: "post-code-block",
+  name: "Post Code Block",
+  description:
+    "Post a code snippet into the thread as its own card — monospaced, syntax-highlighted, " +
+    "with a copy button. Use this when the code IS the answer (a patch you would apply, a " +
+    "config the user must paste, a query you ran) and the reader will want to copy it. Do " +
+    "NOT use it for short inline expressions — put those in backticks in your reply instead, " +
+    "and do not repeat the snippet in your text after posting it. " +
+    "`language` is a syntax-highlighting hint (typescript, python, sql, bash, json, …); omit " +
+    "it only when the content genuinely has no language. To show a CHANGE to an existing " +
+    "file, use post-diff instead — it renders the change inline as unified +/− lines.",
+  source: "custom:code-artifacts",
+  inputSchema: {
+    type: "object",
+    properties: {
+      code: { type: "string", description: "The snippet body, verbatim. No surrounding ``` fences." },
+      language: { type: "string", description: "Syntax highlighting hint, e.g. typescript" },
+    },
+    required: ["code"],
+  },
+  async execute(params, context) {
+    const code = typeof params["code"] === "string" ? params["code"] : "";
+    if (!code.trim()) return "Error: code is required.";
+    const rawLanguage = params["language"];
+    const language = typeof rawLanguage === "string" && rawLanguage.trim() ? rawLanguage.trim() : undefined;
+
+    pushArtifactCard(context, { kind: "code", code, ...(language ? { language } : {}) });
+    return `Posted a ${language ?? "code"} snippet (${code.split("\n").length} lines) to the thread. Do not repeat it in your reply — the user can already see and copy it.`;
+  },
+};
+
+export const postDiff: ToolDefinition = {
+  slug: "post-diff",
+  name: "Post Diff",
+  description:
+    "Post a proposed edit into the thread as a diff card — file path, +N/−M stat, and the " +
+    "changed lines rendered in place with an expand-to-full-patch control. Use this whenever " +
+    "you are showing a change to an existing file, instead of pasting before/after blocks. " +
+    "`patch` is unified-diff text: `@@` hunk headers with ` `/`+`/`-` line prefixes. Bare " +
+    "hunks are fine — the file headers are added for you from `path`. " +
+    "This card only DISPLAYS the change: it applies nothing and asks the user for nothing, so " +
+    "if you need the edit made, still say what you intend to do next.",
+  source: "custom:code-artifacts",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string", description: "Repo-relative file path, e.g. src/push/token.ts" },
+      patch: { type: "string", description: "Unified diff text with @@ hunk headers" },
+    },
+    required: ["path", "patch"],
+  },
+  async execute(params, context) {
+    const path = typeof params["path"] === "string" ? params["path"].trim() : "";
+    const patch = typeof params["patch"] === "string" ? params["patch"] : "";
+    if (!path) return "Error: path is required.";
+    if (!patch.trim()) return "Error: patch is required.";
+    if (!/^@@|^diff --git |^--- /m.test(patch)) {
+      return "Error: patch must be unified-diff text (at least one @@ hunk header).";
+    }
+
+    pushArtifactCard(context, { kind: "diff", path, patch });
+    return `Posted a diff card for ${path} to the thread. Do not repeat the patch in your reply — the user can already see it.`;
+  },
+};
+
+export const postChart: ToolDefinition = {
+  slug: "post-chart",
+  name: "Post Chart",
+  description:
+    "Post a chart into the thread. Use it when the SHAPE of the data is the point (a spike, a " +
+    "cliff, a trend, a split) and a sentence would undersell it. Do NOT use it to dump numbers: " +
+    "if the reader needs exact values, write them out or use a table instead. " +
+    "Pick `type`: `bar` to compare categories, `line` for a trend over time, `area` for a trend " +
+    "where the volume matters, `pie` or `donut` for parts of a whole (only when the parts sum to " +
+    "something meaningful and there are at most ~6 of them). " +
+    "`bar`/`pie`/`donut` take `points` ({label, value}, at most 24, in the order you want them " +
+    "read). `line`/`area` take `series` ({x, y}, plus an optional `series` name per row to draw " +
+    "several lines on one chart). " +
+    "`caption` is where the conclusion goes, e.g. 'Push failures per day · 4.2.1 shipped Tue'.",
+  source: "custom:code-artifacts",
+  inputSchema: {
+    type: "object",
+    properties: {
+      type: { type: "string", description: "bar, line, area, pie, or donut" },
+      points: {
+        type: "array",
+        description: "bar/pie/donut only. 1-24 points, in display order.",
+        items: {
+          type: "object",
+          properties: { label: { type: "string" }, value: { type: "number" } },
+          required: ["label", "value"],
+        },
+      },
+      series: {
+        type: "array",
+        description: "line/area only. Points along an x axis; repeat `series` to draw multiple lines.",
+        items: {
+          type: "object",
+          properties: { x: { type: "string" }, y: { type: "number" }, series: { type: "string" } },
+          required: ["x", "y"],
+        },
+      },
+      caption: { type: "string", description: "One line under the chart stating the takeaway." },
+    },
+    required: ["type"],
+  },
+  async execute(params, context) {
+    const type = typeof params["type"] === "string" ? params["type"].trim().toLowerCase() : "";
+    const rawCaption = params["caption"];
+    const caption = typeof rawCaption === "string" && rawCaption.trim() ? rawCaption.trim() : undefined;
+
+    if (type === "line" || type === "area") {
+      const raw = params["series"];
+      if (!Array.isArray(raw) || raw.length < 1) return `Error: ${type} charts need a 'series' array.`;
+      if (raw.length > 200) return "Error: at most 200 series points — aggregate the data first.";
+      const series: Array<{ x: string; y: number; series?: string }> = [];
+      for (let i = 0; i < raw.length; i += 1) {
+        const row = raw[i] as Record<string, unknown>;
+        const x = typeof row?.["x"] === "string" ? row["x"].trim() : "";
+        const y = row?.["y"];
+        const name = typeof row?.["series"] === "string" && row["series"].trim() ? row["series"].trim() : undefined;
+        if (!x) return `Error: series point ${i + 1} needs an x value.`;
+        if (typeof y !== "number" || !Number.isFinite(y)) return `Error: series point ${i + 1} needs a finite y.`;
+        series.push({ x, y, ...(name ? { series: name } : {}) });
+      }
+      pushArtifactCard(context, { kind: "chart", type, series, ...(caption ? { caption } : {}) });
+      const lines = new Set(series.map((point) => point.series ?? "")).size;
+      return `Posted a ${type} chart (${series.length} points, ${lines} series) to the thread. Do not list the values again — state what the shape means.`;
+    }
+
+    if (type === "bar" || type === "pie" || type === "donut") {
+      const raw = params["points"];
+      if (!Array.isArray(raw) || raw.length < 1) return `Error: ${type} charts need a 'points' array.`;
+      if (raw.length > 24) return "Error: at most 24 points — aggregate or trim the series first.";
+      const points: Array<{ label: string; value: number }> = [];
+      for (let i = 0; i < raw.length; i += 1) {
+        const point = raw[i] as Record<string, unknown>;
+        const label = typeof point?.["label"] === "string" ? point["label"].trim() : "";
+        const value = point?.["value"];
+        if (!label) return `Error: point ${i + 1} needs a label.`;
+        if (typeof value !== "number" || !Number.isFinite(value)) {
+          return `Error: point ${i + 1} needs a finite numeric value.`;
+        }
+        points.push({ label, value });
+      }
+      pushArtifactCard(context, { kind: "chart", type, points, ...(caption ? { caption } : {}) });
+      return `Posted a ${points.length}-point ${type} chart to the thread. Do not list the values again — state what the shape means.`;
+    }
+
+    return "Error: type must be one of bar, line, area, pie, donut.";
+  },
+};

--- a/packages/xyne-claw-shared/src/tools/registry.ts
+++ b/packages/xyne-claw-shared/src/tools/registry.ts
@@ -8,6 +8,7 @@ import * as google from "./google/index.js";
 import * as microsoft from "./microsoft/index.js";
 import * as schedule from "./schedule/index.js";
 import * as askQuestion from "./ask-question/index.js";
+import * as codeArtifacts from "./code-artifacts/index.js";
 import * as addCitations from "./add-citations/index.js";
 import * as attachment from "./attachment/index.js";
 import * as researchAgent from "./research-agent/index.js";
@@ -41,6 +42,9 @@ function register(tool: ToolDefinition): void {
 register(schedule.scheduleTask);
 register(schedule.scheduledJobControl);
 register(askQuestion.askUserQuestion);
+register(codeArtifacts.postCodeBlock);
+register(codeArtifacts.postDiff);
+register(codeArtifacts.postChart);
 register(addCitations.addCitationsTool);
 
 // Register google tools

--- a/packages/xyne-claw-shared/src/tools/types.ts
+++ b/packages/xyne-claw-shared/src/tools/types.ts
@@ -21,9 +21,23 @@ export interface ConfigField {
 
 export interface PendingQuestion {
   questionId: string;
-  question: string;
-  options: string[];
+  questions?: UserQuestion[];
+  /** Legacy follow-up suggestion chips still use this compact shape. */
+  question?: string;
+  options?: string[];
   purpose?: "clarification" | "follow_up_suggestions";
+}
+
+export type UserQuestionType = "single_choice" | "multiple_choice" | "open_ended";
+
+export interface UserQuestion {
+  id: string;
+  label?: string;
+  question: string;
+  type: UserQuestionType;
+  options?: string[];
+  required?: boolean;
+  placeholder?: string;
 }
 
 export interface PendingResponse {


### PR DESCRIPTION
POT - 
<img width="923" height="1035" alt="Screenshot 2026-08-10 at 15 34 58" src="https://github.com/user-attachments/assets/006b0f69-5b9b-408e-85f1-451f349fe1d5" />
<img width="1021" height="702" alt="Screenshot 2026-08-10 at 19 06 39" src="https://github.com/user-attachments/assets/58ace28d-c659-4646-a41d-6aca9d6e4979" />
<img width="1026" height="1355" alt="Screenshot 2026-08-10 at 19 06 45" src="https://github.com/user-attachments/assets/6900eddc-4180-4bae-b518-98b8e3ab01e1" />

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
