### PR TITLE
feat: XYNE-55325 config copy of boards- release

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -88,6 +88,7 @@ import linkPreviewRoutes from '@/routes/linkPreview';
 import bundleRoutes from '@/routes/bundles';
 import projectRoutes from '@/routes/projects';
 import boardRoutes from '@/routes/boards';
+import boardConfigCopyRoutes from '@/routes/boardConfigCopy';
 import searchMetricsRoutes from '@/routes/searchMetrics';
 import knowledgeRoutes from '@/routes/knowledge';
 import vespaSearchRoutes from '@/routes/vespaSearch';
@@ -153,6 +154,8 @@ import { warmUserRegistryQueue } from '@/queues/warmUserRegistryQueue';
 import { watchRenewalQueue } from '@/pubsub';
 import { etaDeadlineQueue } from '@/queues/etaDeadlineQueue';
 import { stageEtaDeadlineQueue } from '@/queues/stageEtaDeadlineQueue';
+import { boardConfigCopyQueue } from '@/queues/boardConfigCopyQueue';
+import { boardConfigCopyWorker } from '@/workers/boardConfigCopyWorker';
 import { assignmentReactivationQueue } from '@/queues/assignmentReactivationQueue';
 import { ticketReassignmentQueue } from '@/queues/ticketReassignmentQueue';
 import { onCallRotationQueue } from '@/queues/onCallRotationQueue';
@@ -373,6 +376,7 @@ export class App {
     // Ticket migration route (admin-only)
     this.app.use('/api/admin/migrate-tickets-xyneid', workspaceScopedRoute, ticketMigrationRoutes);
     this.app.use('/api/admin/gmail-watch-renewal', workspaceScopedRoute, gmailWatchRenewalRoutes);
+    this.app.use('/api/admin/board-config-copy', workspaceScopedRoute, boardConfigCopyRoutes);
 
     this.app.use('/migrate/api/users-data-migration', authMiddleware.authenticate, userMigrationRoutes);
 
@@ -742,6 +746,11 @@ export class App {
           await stageEtaDeadlineQueue.initialize();
         })(),
         (async () => {
+          logger.info('Initializing board config copy queue...');
+          await boardConfigCopyQueue.initialize();
+          boardConfigCopyWorker.start();
+        })(),
+        (async () => {
           logger.info('Initializing assignment reactivation queue...');
           await assignmentReactivationQueue.initialize();
         })(),
@@ -788,6 +797,10 @@ export class App {
 
       logger.info('Initializing stage ETA deadline queue...');
       await stageEtaDeadlineQueue.initialize();
+
+      logger.info('Initializing board config copy queue...');
+      await boardConfigCopyQueue.initialize();
+      boardConfigCopyWorker.start();
 
       logger.info('Initializing assignment reactivation queue...');
       await assignmentReactivationQueue.initialize();
@@ -980,6 +993,9 @@ export class App {
 
       // Close stage ETA deadline queue
       await stageEtaDeadlineQueue.close();
+
+      // Close board config copy queue
+      await boardConfigCopyQueue.close();
 
       // Close assignment reactivation queue
       await assignmentReactivationQueue.close();

--- a/apps/backend/src/controllers/boardConfigCopyController.ts
+++ b/apps/backend/src/controllers/boardConfigCopyController.ts
@@ -1,0 +1,156 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { ApiResponse } from '@/types/express';
+import { logger } from '@/utils/logger';
+import {
+  boardConfigCopyService,
+  BoardConfigCopyValidationError,
+  BoardConfigCopyConflictError,
+} from '@/services/boardConfigCopyService';
+
+const TAG = '[BoardConfigCopyController]';
+
+const categoriesSchema = z.object({
+  customFields: z.boolean(),
+  roles: z.boolean(),
+  stages: z.boolean(),
+});
+
+const prepareSchema = z
+  .object({
+    sourceBoardId: z.string().min(1),
+    targetBoardId: z.string().min(1),
+    categories: categoriesSchema,
+    stageRemapOverrides: z
+      .array(z.object({ oldStageId: z.string().min(1), newStageId: z.string().min(1) }))
+      .optional(),
+    dryRun: z.boolean().optional().default(false),
+  })
+  .strict();
+
+// The migration plan `/prepare` handed back, returned verbatim by the client. Shape-checked
+// here; every claim it makes is re-verified against the board's live state in the service,
+// and workspace/actor are overridden there from the authenticated request.
+const startMigrationSchema = z
+  .object({
+    targetBoardId: z.string().min(1),
+    workspaceId: z.string(),
+    actorUserId: z.string(),
+    ticketRemap: z.array(
+      z.object({
+        oldStageId: z.string().min(1),
+        oldStageName: z.string().min(1),
+        newStageId: z.string().min(1),
+        newStageName: z.string().min(1),
+        newStageEta: z.number().nullable(),
+        newStageStatusV2: z.string(),
+        futureStagesEtaHours: z.number(),
+      }),
+    ),
+    fieldRepoints: z.array(z.object({ oldFieldId: z.string().min(1), newFieldId: z.string().min(1) })),
+    targetOldFormId: z.string().nullable(),
+    clonedFormId: z.string().nullable(),
+    snapshotPath: z.string(),
+  })
+  .strict();
+
+export class BoardConfigCopyController {
+  /**
+   * Both halves of a copy request. Always returns the plan (what would change, and which
+   * old stages still need a target) so the remap picker can render; additionally performs
+   * the server-only work — pre-copy snapshot and custom-fields form clone — and returns
+   * `prepared` once the plan is fully resolved and `dryRun` is false.
+   *
+   * Writes no board configuration itself; the client commits that through the ordinary Zero
+   * mutators, the same way it commits an ordinary board edit.
+   */
+  static async prepare(req: Request, res: Response<ApiResponse>): Promise<void> {
+    const parsed = prepareSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: 'Invalid request body', data: parsed.error.flatten(), timestamp: new Date().toISOString() });
+      return;
+    }
+
+    const workspaceId = req.user?.workspaceId;
+    const actorUserId = req.user?.id;
+    if (!workspaceId || !actorUserId) {
+      res.status(401).json({ success: false, error: 'Authenticated workspace required', timestamp: new Date().toISOString() });
+      return;
+    }
+
+    try {
+      const result = await boardConfigCopyService.prepareCopy(parsed.data, actorUserId, workspaceId);
+      // Board-pair validation failures (wrong project, release board, missing board) come
+      // back in-band so the caller still gets the structured `errors` list, matching how
+      // the old /plan endpoint reported them.
+      if (result.errors.length > 0) {
+        res.status(400).json({ success: false, error: result.errors.join('; '), data: result, timestamp: new Date().toISOString() });
+        return;
+      }
+      res.status(200).json({
+        success: true,
+        message: result.prepared ? 'Board config copy prepared' : 'Board config copy plan',
+        data: result,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      if (error instanceof BoardConfigCopyValidationError) {
+        res.status(400).json({
+          success: false,
+          error: error.errors.join('; '),
+          data: { errors: error.errors, requiresExplicit: error.requiresExplicit },
+          timestamp: new Date().toISOString(),
+        });
+        return;
+      }
+      logger.error(`${TAG} prepare failed`, error);
+      res.status(500).json({ success: false, error: 'Failed to prepare board config copy', timestamp: new Date().toISOString() });
+    }
+  }
+
+  /**
+   * Enqueues the ticket migration a prepared copy left pending, once the client has
+   * committed the configuration. Takes the plan `/prepare` returned; the service re-checks
+   * every destination in it against the board's live stages before acting on it.
+   */
+  static async startTicketMigration(req: Request, res: Response<ApiResponse>): Promise<void> {
+    const parsed = startMigrationSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: 'Invalid request body', data: parsed.error.flatten(), timestamp: new Date().toISOString() });
+      return;
+    }
+
+    const workspaceId = req.user?.workspaceId;
+    const actorUserId = req.user?.id;
+    if (!workspaceId || !actorUserId) {
+      res.status(401).json({ success: false, error: 'Authenticated workspace required', timestamp: new Date().toISOString() });
+      return;
+    }
+
+    try {
+      const result = await boardConfigCopyService.startTicketMigration(parsed.data, actorUserId, workspaceId);
+      res.status(202).json({
+        success: true,
+        message: 'Ticket migration started',
+        data: { jobId: result.jobId },
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      if (error instanceof BoardConfigCopyValidationError) {
+        res.status(400).json({
+          success: false,
+          error: error.errors.join('; '),
+          data: { errors: error.errors },
+          timestamp: new Date().toISOString(),
+        });
+        return;
+      }
+      if (error instanceof BoardConfigCopyConflictError) {
+        res.status(409).json({ success: false, error: error.message, timestamp: new Date().toISOString() });
+        return;
+      }
+      logger.error(`${TAG} startTicketMigration failed`, error);
+      res.status(500).json({ success: false, error: 'Failed to start ticket migration', timestamp: new Date().toISOString() });
+    }
+  }
+}

--- a/apps/backend/src/queues/boardConfigCopyQueue.ts
+++ b/apps/backend/src/queues/boardConfigCopyQueue.ts
@@ -1,0 +1,164 @@
+import Bull from 'bull';
+import { logger } from '@/utils/logger';
+import { redisService } from '@/services/redisService';
+
+/**
+ * Where the tickets sitting on one retired stage should land. Fully resolved at prepare
+ * time and carried in the job payload because the old Stage row no longer exists by the
+ * time this job runs — the client's `board.update` deleted it as part of committing the
+ * new configuration, so nothing can be re-derived from the board itself.
+ */
+export interface BoardConfigCopyTicketRemap {
+  oldStageId: string;
+  oldStageName: string;
+  newStageId: string;
+  newStageName: string;
+  newStageEta: number | null;
+  newStageStatusV2: string;
+  futureStagesEtaHours: number;
+}
+
+/** A custom field present on both boards, whose existing ticket values must follow the new form. */
+export interface BoardConfigCopyFieldRepoint {
+  oldFieldId: string;
+  newFieldId: string;
+}
+
+/**
+ * Ticket-level work only. Board configuration (stages, transitions, form binding, roles,
+ * metadata) is committed by the dashboard through the ordinary Zero mutators before this
+ * job is ever enqueued — see boardConfigCopyService.prepareCopy. Everything here is work
+ * whose cost scales with the number of tickets on the board.
+ */
+export interface BoardConfigCopyJobData {
+  targetBoardId: string;
+  workspaceId: string;
+  actorUserId: string;
+  ticketRemap: BoardConfigCopyTicketRemap[];
+  fieldRepoints: BoardConfigCopyFieldRepoint[];
+  // Both null when custom fields weren't part of this copy; required together otherwise.
+  targetOldFormId: string | null;
+  clonedFormId: string | null;
+  // Object-storage path of the pre-copy snapshot, carried so the job result can surface it.
+  snapshotPath: string;
+}
+
+export interface BoardConfigCopySummary {
+  batches: number;
+  processed: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+  failedTicketIds: string[];
+  fieldValuesRepointed: number;
+  snapshotPath?: string;
+  warnings: string[];
+}
+
+class BoardConfigCopyQueue {
+  private queue: Bull.Queue<BoardConfigCopyJobData> | null = null;
+  private isInitialized = false;
+  private isInitializing = false;
+
+  async initialize(): Promise<void> {
+    if (this.isInitialized || this.isInitializing) return;
+    this.isInitializing = true;
+
+    try {
+      this.queue = new Bull<BoardConfigCopyJobData>('board-config-copy', {
+        redis: {
+          ...redisService.getRedisConfig(),
+          lazyConnect: false,
+        },
+        defaultJobOptions: {
+          attempts: 1,
+          removeOnComplete: 50,
+          removeOnFail: 100,
+        },
+        settings: {
+          lockDuration: 600000, // 10 min — auto-renewed while the processor is active
+          stalledInterval: 60000, // 1 min
+          maxStalledCount: 1,
+        },
+      });
+
+      this.setupEventListeners();
+      this.isInitialized = true;
+      logger.info('[BOARD-CONFIG-COPY-QUEUE] Initialized');
+    } catch (err) {
+      logger.error('[BOARD-CONFIG-COPY-QUEUE] Failed to initialize:', err);
+      this.isInitialized = false;
+    } finally {
+      this.isInitializing = false;
+    }
+  }
+
+  /**
+   * jobId is always the target board id, so at most one copy can run per target
+   * board at a time and the frontend can always re-derive the job id to poll status.
+   */
+  async addJob(data: BoardConfigCopyJobData): Promise<{ enqueued: boolean; reason?: string }> {
+    if (!this.queue || !this.isInitialized) {
+      throw new Error('[BOARD-CONFIG-COPY-QUEUE] Queue not initialized');
+    }
+
+    const existing = await this.queue.getJob(data.targetBoardId);
+    if (existing) {
+      const state = await existing.getState();
+      if (state === 'waiting' || state === 'active' || state === 'delayed') {
+        logger.info(
+          `[BOARD-CONFIG-COPY-QUEUE] Job already in progress for targetBoardId=${data.targetBoardId} state=${state}`,
+        );
+        return { enqueued: false, reason: `A copy is already ${state} for this board` };
+      }
+      // Stale completed/failed job for this board id — clear it before re-queuing so the
+      // deterministic jobId can be reused and the status endpoint reflects the new run.
+      await existing.remove();
+    }
+
+    await this.queue.add(data, { jobId: data.targetBoardId });
+    logger.info(`[BOARD-CONFIG-COPY-QUEUE] Enqueued job targetBoardId=${data.targetBoardId}`);
+    return { enqueued: true };
+  }
+
+  getQueue(): Bull.Queue<BoardConfigCopyJobData> {
+    if (!this.queue) {
+      throw new Error('[BOARD-CONFIG-COPY-QUEUE] Queue not initialized — call initialize() first');
+    }
+    return this.queue;
+  }
+
+  get isReady(): boolean {
+    return this.isInitialized && this.queue !== null;
+  }
+
+  private setupEventListeners(): void {
+    if (!this.queue) return;
+
+    this.queue.on('failed', (job, err) => {
+      logger.error(
+        `[BOARD-CONFIG-COPY-QUEUE] Job ${job.id} failed targetBoardId=${job.data.targetBoardId}:`,
+        err,
+      );
+    });
+
+    this.queue.on('stalled', job => {
+      logger.warn(`[BOARD-CONFIG-COPY-QUEUE] Job ${job.id} stalled targetBoardId=${job.data.targetBoardId}`);
+    });
+
+    this.queue.on('error', err => {
+      logger.error('[BOARD-CONFIG-COPY-QUEUE] Queue error:', err);
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.queue) {
+      await this.queue.close();
+      this.queue = null;
+      this.isInitialized = false;
+      logger.info('[BOARD-CONFIG-COPY-QUEUE] Closed');
+    }
+  }
+}
+
+export const boardConfigCopyQueue = new BoardConfigCopyQueue();

--- a/apps/backend/src/routes/boardConfigCopy.ts
+++ b/apps/backend/src/routes/boardConfigCopy.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import { AccessType } from '@xyne/shared';
+import { BoardConfigCopyController } from '@/controllers/boardConfigCopyController';
+import { authMiddleware } from '@/middleware/auth';
+import { authorize } from '@/middleware/authorize';
+
+const router = Router();
+const adminAuth = authorize('TICKET-MIGRATION', AccessType.ADMIN);
+
+/**
+ * @route POST /api/admin/board-config-copy/prepare
+ * @desc Validate a source/target board pair and return the stage remap plan; when that plan
+ *       is fully resolved and `dryRun` is false, also perform the server-only work (pre-copy
+ *       snapshot, custom-fields form clone) and return `prepared` — the arguments the
+ *       dashboard passes to the ordinary Zero mutators. Writes no board configuration itself,
+ *       and writes nothing at all on a call that can't yet commit.
+ * @access TICKET-MIGRATION Admin only
+ */
+router.post('/prepare', authMiddleware.authenticate, adminAuth, BoardConfigCopyController.prepare);
+
+/**
+ * @route POST /api/admin/board-config-copy/start-ticket-migration
+ * @desc Enqueue the per-ticket migration a prepared copy left pending, after the client has
+ *       committed the configuration. Returns 202 with jobId (=== targetBoardId).
+ * @access TICKET-MIGRATION Admin only
+ */
+router.post(
+  '/start-ticket-migration',
+  authMiddleware.authenticate,
+  adminAuth,
+  BoardConfigCopyController.startTicketMigration,
+);
+
+export default router;

--- a/apps/backend/src/services/boardConfigCopyService.ts
+++ b/apps/backend/src/services/boardConfigCopyService.ts
@@ -1,0 +1,1120 @@
+import { createHash } from 'crypto';
+import { BoardType, TicketStatusV2, FormContextType, FormEntityType, ApproverType } from '@xyne/shared';
+import { db } from '@/database/client';
+import { repositories } from '@/database/repositories';
+import { boardConfigCopySnapshotService } from '@/services/boardConfigCopySnapshotService';
+import { calculateETADeadline, recomputeOverallTicketEta } from '@/utils/etaCalculation';
+import { syncConversationTicketMdFromPrismaTicket } from '@/utils/ticketMd';
+import { logger } from '@/utils/logger';
+import {
+  boardConfigCopyQueue,
+  BoardConfigCopyJobData,
+  BoardConfigCopyTicketRemap,
+  BoardConfigCopyFieldRepoint,
+} from '@/queues/boardConfigCopyQueue';
+
+const TAG = '[BoardConfigCopy]';
+
+// The only categories every board is guaranteed to have at least one stage of — enforced
+// by mutators.ts's board.update validation ("Board must have at least one TODO, one
+// STARTED, and one COMPLETED stage"). PAUSED/CANCELLED have no such guarantee.
+const COMPULSORY_TICKET_STATUS_CATEGORIES = new Set<string>([
+  TicketStatusV2.TODO,
+  TicketStatusV2.STARTED,
+  TicketStatusV2.COMPLETED,
+]);
+
+export interface CopyCategorySelection {
+  customFields: boolean;
+  roles: boolean;
+  stages: boolean;
+}
+
+export interface StageRemapOverride {
+  oldStageId: string;
+  // sourceStageId of the translated new stage this old stage's tickets should land on
+  newStageId: string;
+}
+
+export interface CopyRequestInput {
+  sourceBoardId: string;
+  targetBoardId: string;
+  categories: CopyCategorySelection;
+}
+
+export interface PrepareCopyInput extends CopyRequestInput {
+  stageRemapOverrides?: StageRemapOverride[];
+  dryRun: boolean;
+}
+
+interface SourceStageRow {
+  id: string;
+  name: string;
+  eta: number | null;
+  sequenceNumber: number;
+  defaultTicketStatusV2: string;
+  requestApprovalOnEntry: boolean;
+  prStatuses: string[];
+  approvers: Array<{ approverId: string; approverType: 'USER' | 'ROLE' }>;
+  formId?: string;
+}
+
+interface SourceTransitionRow {
+  fromStageId: string | null;
+  toStageId: string;
+  formId?: string;
+  requiresApproval: boolean;
+  bypassApprovalForAutomation: boolean;
+  requestApprovalOnEntry: boolean;
+  visitSlaMode?: string;
+  fixedEtaHours?: number | null;
+  onReenter?: string;
+  approvers: Array<{ approverId: string; approverType: 'USER' | 'ROLE' }>;
+}
+
+export interface OldStageInfo {
+  id: string;
+  name: string;
+  defaultTicketStatusV2: string;
+  ticketCount: number;
+}
+
+export interface NewStagePreview {
+  sourceStageId: string;
+  name: string;
+  defaultTicketStatusV2: string;
+  sequenceNumber: number;
+}
+
+
+// ─── Prepared client-side mutation payloads ───────────────────────────────
+// Everything below is handed to the dashboard verbatim and passed straight into the SAME
+// Zero mutators the board editor uses (`board.update`, `formContextMapping.upsert`,
+// `nonLinear.syncTransitions`). Board configuration is not written server-side at all —
+// only the two things a browser genuinely cannot do (the object-storage snapshot and the
+// Prisma-only form clone) happen here.
+
+export interface PreparedStage {
+  id: string;
+  name: string;
+  eta?: number;
+  sequenceNumber: number;
+  defaultTicketStatusV2: string;
+  requestApprovalOnEntry: boolean;
+  prStatuses: string[];
+  approvers: Array<{ approverId: string; approverType: 'USER' | 'ROLE' }>;
+  formId?: string;
+}
+
+export interface PreparedBoardUpdate {
+  boardId: string;
+  boardType: string;
+  /**
+   * The COMPLETE metadata blob to persist — `board.update` replaces `metadata` wholesale
+   * rather than merging, so this is the target's existing metadata with the copied keys
+   * already layered on top (and custom-field ids remapped onto the cloned form).
+   */
+  metadata: Record<string, unknown>;
+  /**
+   * Present only when stages are being copied. `board.update` treats this as the board's
+   * complete desired stage set: stages here are upserted, and any stage on the board that
+   * is absent is deleted along with its approvers/PR-status/form mappings. That single
+   * property is what replaces the old worker's separate insert and delete phases.
+   */
+  stages?: PreparedStage[];
+  prStatusMappingIds?: Record<string, string>;
+}
+
+export interface PreparedBoardFormMapping {
+  contextId: string;
+  contextType: string;
+  entityType: string;
+  formId: string;
+  mappingId: string;
+}
+
+export interface PreparedTransition {
+  id: string;
+  fromStageId: string | null;
+  toStageId: string;
+  formId?: string;
+  requiresApproval: boolean;
+  bypassApprovalForAutomation: boolean;
+  requestApprovalOnEntry: boolean;
+  visitSlaMode?: string;
+  fixedEtaHours?: number | null;
+  onReenter?: string;
+  approvers: Array<{ id: string; approverId: string; approverType: string }>;
+}
+
+/** The committable half — present only once the copy is fully resolved and actually prepared. */
+export interface PreparedCopy {
+  snapshotPath: string;
+  customFieldsCopied: boolean;
+  rolesCopied: boolean;
+  newStageCount: number;
+  deletedOldStageCount: number;
+  /** Tickets the follow-up migration job will need to move; 0 means no job is needed. */
+  ticketsToMigrate: number;
+  boardUpdate: PreparedBoardUpdate;
+  boardFormMapping: PreparedBoardFormMapping | null;
+  transitions: PreparedTransition[] | null;
+  /**
+   * The per-ticket work left over, or null when there is none. Pass it back to
+   * `startTicketMigration` after the config mutations land — it is re-validated there, so
+   * carrying it through the client costs nothing in trust.
+   */
+  ticketMigration: BoardConfigCopyJobData | null;
+}
+
+/**
+ * One response covering both halves of a copy request.
+ *
+ * The descriptive fields (`oldStages`/`newStages`/`suggestedMapping`/`requiresExplicit`) are
+ * always returned once the board pair validates — they're what the remap picker renders from.
+ * `prepared` is added only when the copy is fully resolved AND the caller asked to commit
+ * (`dryRun: false`): that's the call that writes the snapshot, clones the custom-fields form
+ * and stashes the migration plan.
+ *
+ * So a caller that hasn't finished choosing gets plan data and no side effects — whether it
+ * said so explicitly (`dryRun: true`) or simply hasn't supplied every required override yet.
+ */
+export interface PrepareCopyResult {
+  errors: string[];
+  warnings: string[];
+  sourceBoard?: { id: string; name: string; boardType: string };
+  targetBoard?: { id: string; name: string; boardType: string };
+  newStages?: NewStagePreview[];
+  oldStages?: OldStageInfo[];
+  suggestedMapping?: Record<string, string>; // oldStageId -> sourceStageId
+  requiresExplicit?: string[]; // oldStageIds with tickets that still need an explicit mapping
+  prepared?: PreparedCopy;
+}
+
+export class BoardConfigCopyValidationError extends Error {
+  constructor(
+    public readonly errors: string[],
+    public readonly requiresExplicit?: string[],
+  ) {
+    super(errors[0] ?? 'Validation failed');
+    this.name = 'BoardConfigCopyValidationError';
+  }
+}
+
+export class BoardConfigCopyConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BoardConfigCopyConflictError';
+  }
+}
+
+export class BoardConfigCopyService {
+  // ─── Validation ─────────────────────────────────────────────────────────
+
+  private async validateBoards(sourceBoardId: string, targetBoardId: string, workspaceId: string) {
+    const errors: string[] = [];
+
+    if (sourceBoardId === targetBoardId) {
+      errors.push('Source and target boards must differ');
+    }
+
+    const [sourceBoard, targetBoard] = await Promise.all([
+      db.board.findFirst({ where: { id: sourceBoardId, workspaceId } }),
+      db.board.findFirst({ where: { id: targetBoardId, workspaceId } }),
+    ]);
+
+    if (!sourceBoard) errors.push('Source board not found');
+    if (!targetBoard) errors.push('Target board not found');
+
+    if (sourceBoard && targetBoard && sourceBoard.projectId !== targetBoard.projectId) {
+      errors.push('Source and target boards must be in the same project');
+    }
+
+    if (sourceBoard?.boardType === BoardType.RELEASE || targetBoard?.boardType === BoardType.RELEASE) {
+      errors.push('Release boards are not supported for config copy');
+    }
+
+    return { errors, sourceBoard, targetBoard };
+  }
+
+  // ─── Stage reads ────────────────────────────────────────────────────────
+
+  private async getSourceStagesOrdered(boardId: string): Promise<SourceStageRow[]> {
+    const stages = await db.stage.findMany({
+      where: { boardId },
+      orderBy: { sequenceNumber: 'asc' },
+    });
+    if (stages.length === 0) return [];
+
+    const stageIds = stages.map(s => s.id);
+    const [approvers, prMappings, formMappings] = await Promise.all([
+      db.stageApprovers.findMany({ where: { stageId: { in: stageIds } } }),
+      db.stagePRStatusMapping.findMany({ where: { stageId: { in: stageIds } } }),
+      db.formContextMapping.findMany({
+        where: { contextId: { in: stageIds }, contextType: FormContextType.STAGE, entityType: FormEntityType.TICKET },
+      }),
+    ]);
+
+    const approversByStage = new Map<string, Array<{ approverId: string; approverType: 'USER' | 'ROLE' }>>();
+    for (const a of approvers) {
+      if (!a.stageId) continue;
+      const type = (a.approverType ?? ApproverType.USER) === ApproverType.ROLE ? 'ROLE' : 'USER';
+      const approverId = type === 'ROLE' ? a.roleId : a.userId;
+      if (!approverId) continue;
+      const list = approversByStage.get(a.stageId) ?? [];
+      list.push({ approverId, approverType: type });
+      approversByStage.set(a.stageId, list);
+    }
+
+    const prByStage = new Map<string, string[]>();
+    for (const m of prMappings) {
+      const list = prByStage.get(m.stageId) ?? [];
+      list.push(m.prStatus);
+      prByStage.set(m.stageId, list);
+    }
+
+    const formByStage = new Map<string, string>();
+    for (const m of formMappings) {
+      formByStage.set(m.contextId, m.formId);
+    }
+
+    return stages.map(s => ({
+      id: s.id,
+      name: s.name,
+      eta: s.eta,
+      sequenceNumber: s.sequenceNumber,
+      defaultTicketStatusV2: s.defaultTicketStatusV2,
+      requestApprovalOnEntry: s.requestApprovalOnEntry ?? false,
+      prStatuses: prByStage.get(s.id) ?? [],
+      approvers: approversByStage.get(s.id) ?? [],
+      formId: formByStage.get(s.id),
+    }));
+  }
+
+  private async getSourceTransitions(boardId: string): Promise<SourceTransitionRow[]> {
+    const transitions = await db.stageTransition.findMany({ where: { boardId } });
+    if (transitions.length === 0) return [];
+
+    const transitionIds = transitions.map(t => t.id);
+    const approvers = await db.stageApprovers.findMany({ where: { transitionId: { in: transitionIds } } });
+
+    const approversByTransition = new Map<string, Array<{ approverId: string; approverType: 'USER' | 'ROLE' }>>();
+    for (const a of approvers) {
+      if (!a.transitionId) continue;
+      const type = (a.approverType ?? ApproverType.USER) === ApproverType.ROLE ? 'ROLE' : 'USER';
+      const approverId = type === 'ROLE' ? a.roleId : a.userId;
+      if (!approverId) continue;
+      const list = approversByTransition.get(a.transitionId) ?? [];
+      list.push({ approverId, approverType: type });
+      approversByTransition.set(a.transitionId, list);
+    }
+
+    return transitions.map(t => ({
+      fromStageId: t.fromStageId,
+      toStageId: t.toStageId,
+      formId: t.formId ?? undefined,
+      requiresApproval: t.requiresApproval ?? false,
+      bypassApprovalForAutomation: t.bypassApprovalForAutomation ?? false,
+      requestApprovalOnEntry: t.requestApprovalOnEntry ?? false,
+      visitSlaMode: t.visitSlaMode ?? undefined,
+      fixedEtaHours: t.fixedEtaHours,
+      onReenter: t.onReenter ?? undefined,
+      approvers: approversByTransition.get(t.id) ?? [],
+    }));
+  }
+
+  private async getOldStagesWithTicketCounts(targetBoardId: string): Promise<OldStageInfo[]> {
+    const [stages, counts] = await Promise.all([
+      db.stage.findMany({ where: { boardId: targetBoardId }, orderBy: { sequenceNumber: 'asc' } }),
+      db.ticket.groupBy({ by: ['stageName'], where: { boardId: targetBoardId }, _count: { _all: true } }),
+    ]);
+    const countByName = new Map(counts.map(c => [c.stageName, c._count._all]));
+    return stages.map(s => ({
+      id: s.id,
+      name: s.name,
+      defaultTicketStatusV2: s.defaultTicketStatusV2,
+      ticketCount: countByName.get(s.name) ?? 0,
+    }));
+  }
+
+  // ─── Deterministic id derivation ────────────────────────────────────────
+
+  /**
+   * Stable, content-derived id — same inputs always produce the same output. The new
+   * stage/transition ids are derived rather than random so that re-running a prepare for
+   * the same source/target pair converges on the same rows (`board.update` upserts by id)
+   * instead of minting a duplicate stage set.
+   */
+  private deriveDeterministicId(...parts: string[]): string {
+    const hash = createHash('sha256').update(parts.join(':')).digest('hex');
+    return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-${hash.slice(12, 16)}-${hash.slice(16, 20)}-${hash.slice(20, 32)}`;
+  }
+
+  // ─── Remap plan resolution ──────────────────────────────────────────────
+
+  private computeSuggestedMapping(
+    oldStages: OldStageInfo[],
+    newStages: NewStagePreview[],
+  ): Record<string, string> {
+    const suggestion: Record<string, string> = {};
+    for (const old of oldStages) {
+      if (old.ticketCount === 0) continue;
+      const match = newStages.find(n => n.defaultTicketStatusV2 === old.defaultTicketStatusV2);
+      if (match) suggestion[old.id] = match.sourceStageId;
+    }
+    return suggestion;
+  }
+
+  /**
+   * Resolves which new stage each old-stage-with-tickets should land on. Every old
+   * stage with tickets always requires an explicit admin-supplied mapping — there is
+   * no auto-resolution to an "initial stage" or similar. Returns the resolved mapping
+   * (oldStageId -> sourceStageId), the list of old stage ids still missing an override,
+   * and any supplied overrides that were rejected for a category mismatch.
+   *
+   * Invariant: a ticket may only be remapped to a new stage of the SAME defaultTicketStatusV2
+   * category it's currently in (e.g. a STARTED-status ticket can only land on a STARTED-status
+   * new stage) — enforced here, not just in the frontend picker, so a malformed/bypassed
+   * request can't violate it.
+   *
+   * Exception: this only applies to the three categories every board is guaranteed to have
+   * at least one stage of (TODO/STARTED/COMPLETED — enforced on every board save, see
+   * mutators.ts's board.update validation). PAUSED and CANCELLED are optional categories a
+   * source board may have zero stages of, so an old stage in either of those categories may
+   * be remapped to a new stage of ANY category — otherwise a source board without e.g. a
+   * CANCELLED stage could never resolve a target's CANCELLED-category tickets at all.
+   */
+  private resolveRemapPlan(
+    oldStages: OldStageInfo[],
+    newStages: NewStagePreview[],
+    overrides: StageRemapOverride[],
+  ): { mapping: Map<string, string>; requiresExplicit: string[]; invalidCategoryOverrides: string[] } {
+    const overrideByOldStage = new Map(overrides.map(o => [o.oldStageId, o.newStageId]));
+    const newStageBySourceId = new Map(newStages.map(s => [s.sourceStageId, s]));
+    const mapping = new Map<string, string>();
+    const requiresExplicit: string[] = [];
+    const invalidCategoryOverrides: string[] = [];
+
+    for (const old of oldStages) {
+      if (old.ticketCount === 0) continue;
+
+      const override = overrideByOldStage.get(old.id);
+      if (!override) {
+        requiresExplicit.push(old.id);
+        continue;
+      }
+
+      const overrideStage = newStageBySourceId.get(override);
+      if (!overrideStage) {
+        invalidCategoryOverrides.push(old.id);
+        continue;
+      }
+      const categoryIsCompulsory = COMPULSORY_TICKET_STATUS_CATEGORIES.has(old.defaultTicketStatusV2);
+      if (categoryIsCompulsory && overrideStage.defaultTicketStatusV2 !== old.defaultTicketStatusV2) {
+        invalidCategoryOverrides.push(old.id);
+        continue;
+      }
+      mapping.set(old.id, override);
+    }
+
+    return { mapping, requiresExplicit, invalidCategoryOverrides };
+  }
+
+  // ─── Custom-field helpers ───────────────────────────────────────────────
+
+  private parseFieldOptions(raw: string): Array<{ id: string; value: string }> | undefined {
+    try {
+      return JSON.parse(raw) as Array<{ id: string; value: string }>;
+    } catch (error) {
+      logger.warn(`${TAG} Failed to parse fieldOptions JSON — dropping options for this field`, { error });
+      return undefined;
+    }
+  }
+
+  /**
+   * `fieldOrder` entries are `{fieldId, fieldType: 'core'|'custom'}`. Core entries are keyed
+   * by field NAME (stable, safe to copy as-is). Custom entries are keyed by a resolved field
+   * id that only means something on the form it was resolved from — rewritten through
+   * `idMap` (old field id -> new field id on the cloned form), or dropped if unresolvable.
+   */
+  private remapFieldOrder(raw: unknown, idMap: Map<string, string>): unknown {
+    if (!Array.isArray(raw)) return raw;
+    const result: Array<{ fieldId: string; fieldType: string }> = [];
+    for (const entry of raw) {
+      if (!entry || typeof entry !== 'object') continue;
+      const e = entry as { fieldId?: unknown; fieldType?: unknown };
+      if (typeof e.fieldId !== 'string' || typeof e.fieldType !== 'string') continue;
+      if (e.fieldType !== 'custom') {
+        result.push({ fieldId: e.fieldId, fieldType: e.fieldType });
+        continue;
+      }
+      const newId = idMap.get(e.fieldId);
+      if (newId) result.push({ fieldId: newId, fieldType: 'custom' });
+    }
+    return result;
+  }
+
+  /** Rewrites a Record<fieldId, T> (e.g. customFieldVisibility) through idMap, dropping keys with no match. */
+  private remapFieldKeyedRecord(raw: unknown, idMap: Map<string, string>): unknown {
+    if (!raw || typeof raw !== 'object') return raw;
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+      const newKey = idMap.get(key);
+      if (newKey) result[newKey] = value;
+    }
+    return result;
+  }
+
+  /**
+   * Clones the source board's ticket custom-fields form. Stays on Prisma (and stays
+   * server-side) because `formsRepository.createWithFields` owns global-field dedup, branch
+   * validation and sequence allocation that several other features depend on — reproducing
+   * it as a Zero mutator would mean maintaining a second copy of that logic.
+   *
+   * Creates the new Form only; binding it to the target board is left to the caller's
+   * `formContextMapping.upsert` mutation, so the clone is inert until the client commits.
+   */
+  private async cloneSourceCustomFieldsForm(
+    sourceBoard: { id: string; projectId: string; workspaceId: string },
+    targetBoardId: string,
+    actorUserId: string,
+  ): Promise<{
+    clonedFormId: string | null;
+    sourceOldToNewFieldId: Map<string, string>;
+    targetOldFormId: string | null;
+    fieldRepoints: BoardConfigCopyFieldRepoint[];
+    warnings: string[];
+  }> {
+    const warnings: string[] = [];
+    const sourceOldToNewFieldId = new Map<string, string>();
+    const fieldRepoints: BoardConfigCopyFieldRepoint[] = [];
+    let targetOldFormId: string | null = null;
+
+    const sourceMapping = await db.formContextMapping.findFirst({
+      where: { contextId: sourceBoard.id, contextType: FormContextType.BOARD, entityType: FormEntityType.TICKET },
+    });
+    if (!sourceMapping) return { clonedFormId: null, sourceOldToNewFieldId, targetOldFormId, fieldRepoints, warnings };
+
+    const sourceForm = await repositories.forms.findFormWithFields(sourceMapping.formId);
+    if (!sourceForm) return { clonedFormId: null, sourceOldToNewFieldId, targetOldFormId, fieldRepoints, warnings };
+
+    const newForm = await repositories.forms.createWithFields({
+      formName: `${sourceForm.formName} Copy`,
+      ...(sourceForm.formDescription ? { formDescription: sourceForm.formDescription } : {}),
+      contextType: FormContextType.BOARD,
+      entityType: FormEntityType.TICKET,
+      workspaceId: sourceBoard.workspaceId,
+      createdBy: actorUserId,
+      projectId: sourceBoard.projectId,
+      fields: sourceForm.fields.map(f => {
+        const parsedOptions = f.fieldOptions ? this.parseFieldOptions(f.fieldOptions) : undefined;
+        return {
+          fieldName: f.fieldName,
+          fieldType: f.fieldType,
+          ...(parsedOptions !== undefined ? { fieldOptions: parsedOptions } : {}),
+          isOptional: f.isOptional,
+          ...(f.parentOptionId !== undefined ? { parentOptionId: f.parentOptionId } : {}),
+        };
+      }),
+    });
+
+    // createWithFields is never given an explicit fieldId, so a cloned field lands on
+    // whichever GlobalField already exists for (projectId, fieldName, fieldType) —
+    // normally the SAME id the source used (same project), but a fresh id when the
+    // source field predates the global-field system (a "legacy" field). Resolve the
+    // real mapping from what was actually created, rather than assuming ids survived.
+    const newFormWithFields = await repositories.forms.findFormWithFields(newForm.id);
+    if (!newFormWithFields) {
+      return { clonedFormId: newForm.id, sourceOldToNewFieldId, targetOldFormId, fieldRepoints, warnings };
+    }
+
+    for (const oldField of sourceForm.fields) {
+      const match = newFormWithFields.fields.find(
+        nf => nf.fieldName === oldField.fieldName && nf.fieldType === oldField.fieldType,
+      );
+      if (match) sourceOldToNewFieldId.set(oldField.id, match.id);
+    }
+
+    // Match the target's OLD form (about to be unbound) against the same new form, by
+    // normalized name — this is what lets a field that exists on both boards keep its
+    // ticket values editable after the swap. The repointing itself is per-ticket data, so
+    // it is deferred to the migration job rather than done here.
+    const targetMapping = await db.formContextMapping.findFirst({
+      where: { contextId: targetBoardId, contextType: FormContextType.BOARD, entityType: FormEntityType.TICKET },
+    });
+    if (targetMapping) {
+      const targetOldForm = await repositories.forms.findFormWithFields(targetMapping.formId);
+      if (targetOldForm) {
+        targetOldFormId = targetOldForm.id;
+        for (const oldField of targetOldForm.fields) {
+          const normalizedName = oldField.fieldName.trim().toLowerCase();
+          const match = newFormWithFields.fields.find(
+            nf => nf.fieldName.trim().toLowerCase() === normalizedName,
+          );
+          if (!match) continue; // unique to the target — left as-is, shown read-only
+          if (match.fieldType !== oldField.fieldType) {
+            warnings.push(
+              `Field "${oldField.fieldName}" exists on both boards with different types — its existing ticket values were left as-is rather than risk showing a value of the wrong type.`,
+            );
+            continue;
+          }
+          fieldRepoints.push({ oldFieldId: oldField.id, newFieldId: match.id });
+        }
+      }
+    }
+
+    return { clonedFormId: newForm.id, sourceOldToNewFieldId, targetOldFormId, fieldRepoints, warnings };
+  }
+
+  // ─── Prepare (server-side work only; the client commits the config) ─────
+
+  /**
+   * Single entry point for both halves of a copy request.
+   *
+   * Always returns the descriptive plan — old/new stages, ticket counts, a suggested
+   * mapping, and which old stages still need an explicit target — which is what the remap
+   * picker renders from. When the plan is fully resolved and the caller asked to commit
+   * (`dryRun: false`), it additionally performs the two steps a browser can't (writing the
+   * pre-copy snapshot and cloning the custom-fields form) and returns `prepared`: the exact
+   * arguments the dashboard feeds to the ordinary Zero mutators.
+   *
+   * Nothing is written on a call that can't yet commit — whether the caller said so
+   * (`dryRun: true`) or simply hasn't supplied every required override — so the picker can
+   * call this as often as it likes without burning snapshots or orphaning cloned forms.
+   *
+   * Deliberately writes NO board configuration itself: stages, transitions, form binding
+   * and metadata are all committed by the client, exactly like an ordinary board edit. Any
+   * ticket-level work (stage remap, custom-field value repointing) is stashed as a pending
+   * migration plan and picked up by `startTicketMigration` once those mutations land.
+   */
+  async prepareCopy(
+    input: PrepareCopyInput,
+    actorUserId: string,
+    workspaceId: string,
+  ): Promise<PrepareCopyResult> {
+    const { errors, sourceBoard, targetBoard } = await this.validateBoards(
+      input.sourceBoardId,
+      input.targetBoardId,
+      workspaceId,
+    );
+    if (errors.length > 0 || !sourceBoard || !targetBoard) {
+      return { errors, warnings: [] };
+    }
+
+    const result: PrepareCopyResult = {
+      errors: [],
+      warnings: [],
+      sourceBoard: { id: sourceBoard.id, name: sourceBoard.name, boardType: sourceBoard.boardType },
+      targetBoard: { id: targetBoard.id, name: targetBoard.name, boardType: targetBoard.boardType },
+    };
+
+    // ── Plan half: what this copy would do, and what still needs deciding ──
+    let sourceStages: SourceStageRow[] = [];
+    let oldStages: OldStageInfo[] = [];
+    let mapping = new Map<string, string>();
+
+    if (input.categories.stages) {
+      sourceStages = await this.getSourceStagesOrdered(sourceBoard.id);
+      oldStages = await this.getOldStagesWithTicketCounts(targetBoard.id);
+      const newStagesPreview: NewStagePreview[] = sourceStages.map(s => ({
+        sourceStageId: s.id,
+        name: s.name,
+        defaultTicketStatusV2: s.defaultTicketStatusV2,
+        sequenceNumber: s.sequenceNumber,
+      }));
+
+      const resolved = this.resolveRemapPlan(oldStages, newStagesPreview, input.stageRemapOverrides ?? []);
+      mapping = resolved.mapping;
+
+      result.newStages = newStagesPreview;
+      result.oldStages = oldStages;
+      result.suggestedMapping = this.computeSuggestedMapping(oldStages, newStagesPreview);
+      result.requiresExplicit = resolved.requiresExplicit;
+
+      if (sourceBoard.boardType !== targetBoard.boardType) {
+        result.warnings.push(
+          `Target board type will change from ${targetBoard.boardType} to ${sourceBoard.boardType} to match the source board.`,
+        );
+      }
+
+      // A supplied-but-wrong mapping is a genuine error rather than "still deciding" — the
+      // caller picked a target in the wrong status category and needs telling, not a picker.
+      if (resolved.invalidCategoryOverrides.length > 0) {
+        throw new BoardConfigCopyValidationError(
+          [
+            'Some stage mappings target a stage with a different status than the tickets being moved — ' +
+              'a ticket can only be remapped to a new stage of the same status.',
+          ],
+          resolved.invalidCategoryOverrides,
+        );
+      }
+
+      // Choices still outstanding → hand back the picker data and stop. Nothing is written:
+      // the caller is deciding, not committing.
+      if (resolved.requiresExplicit.length > 0) return result;
+    }
+
+    // An explicit look-don't-touch call stops in the same place, with the same shape.
+    if (input.dryRun) return result;
+
+    // ── Prepare half: the two server-only steps, plus the payloads the client commits ──
+    const targetMetadata: Record<string, unknown> = {
+      ...((targetBoard.metadata as Record<string, unknown> | null) ?? {}),
+    };
+    const sourceMetadata = (sourceBoard.metadata as Record<string, unknown> | null) ?? {};
+
+    let preparedStages: PreparedStage[] | undefined;
+    let prStatusMappingIds: Record<string, string> | undefined;
+    let preparedTransitions: PreparedTransition[] | null = null;
+    const ticketRemap: BoardConfigCopyTicketRemap[] = [];
+
+    if (input.categories.stages) {
+      const sourceStageIdToNewStageId = new Map(
+        sourceStages.map(s => [s.id, this.deriveDeterministicId('board-config-copy-stage', targetBoard.id, s.id)]),
+      );
+
+      preparedStages = sourceStages.map(s => ({
+        id: sourceStageIdToNewStageId.get(s.id)!,
+        name: s.name,
+        ...(s.eta !== null ? { eta: s.eta } : {}),
+        sequenceNumber: s.sequenceNumber,
+        defaultTicketStatusV2: s.defaultTicketStatusV2,
+        requestApprovalOnEntry: s.requestApprovalOnEntry,
+        prStatuses: s.prStatuses,
+        approvers: s.approvers,
+        ...(s.formId ? { formId: s.formId } : {}),
+      }));
+
+      // board.update requires a caller-supplied id for every PR-status mapping it inserts,
+      // keyed "<sequenceNumber>-<prStatus>".
+      prStatusMappingIds = {};
+      for (const stage of preparedStages) {
+        for (const prStatus of stage.prStatuses) {
+          prStatusMappingIds[`${stage.sequenceNumber}-${prStatus}`] = this.deriveDeterministicId(
+            'board-config-copy-pr-mapping',
+            stage.id,
+            prStatus,
+          );
+        }
+      }
+
+      if (sourceBoard.boardType === BoardType.NON_LINEAR) {
+        const sourceTransitions = await this.getSourceTransitions(sourceBoard.id);
+        preparedTransitions = sourceTransitions.map(t => {
+          const fromStageId = t.fromStageId ? (sourceStageIdToNewStageId.get(t.fromStageId) ?? null) : null;
+          const toStageId = sourceStageIdToNewStageId.get(t.toStageId)!;
+          return {
+            id: this.deriveDeterministicId(
+              'board-config-copy-transition',
+              targetBoard.id,
+              fromStageId ?? 'ROOT',
+              toStageId,
+            ),
+            fromStageId,
+            toStageId,
+            ...(t.formId ? { formId: t.formId } : {}),
+            requiresApproval: t.requiresApproval,
+            bypassApprovalForAutomation: t.bypassApprovalForAutomation,
+            requestApprovalOnEntry: t.requestApprovalOnEntry,
+            ...(t.visitSlaMode ? { visitSlaMode: t.visitSlaMode } : {}),
+            ...(t.fixedEtaHours !== undefined && t.fixedEtaHours !== null ? { fixedEtaHours: t.fixedEtaHours } : {}),
+            ...(t.onReenter ? { onReenter: t.onReenter } : {}),
+            approvers: t.approvers.map(a => ({
+              id: this.deriveDeterministicId('board-config-copy-approver', toStageId, a.approverId, a.approverType),
+              approverId: a.approverId,
+              approverType: a.approverType,
+            })),
+          };
+        });
+      }
+
+      // Every old stage's landing target, resolved now. The old Stage rows are deleted the
+      // moment the client's board.update lands, so this is the only surviving record of
+      // where each ticket belongs — including a same-category fallback for stages that were
+      // empty at prepare time but could receive a ticket in the meantime.
+      const futureStagesEtaHoursByNewStageId: Record<string, number> = {};
+      if (sourceBoard.boardType !== BoardType.NON_LINEAR) {
+        for (const stage of preparedStages) {
+          futureStagesEtaHoursByNewStageId[stage.id] = preparedStages
+            .filter(s => s.sequenceNumber > stage.sequenceNumber)
+            .reduce((sum, s) => sum + (s.eta ?? 0), 0);
+        }
+      } else {
+        for (const stage of preparedStages) futureStagesEtaHoursByNewStageId[stage.id] = 0;
+      }
+
+      const orderedNewStages = [...preparedStages].sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+      const newStageNames = new Set(preparedStages.map(s => s.name));
+
+      for (const old of oldStages) {
+        // A name the new stage set still provides needs no migration — the ticket's
+        // stageName text already resolves to the freshly-upserted stage.
+        if (newStageNames.has(old.name)) continue;
+
+        const mappedSourceStageId = mapping.get(old.id);
+        const target = mappedSourceStageId
+          ? preparedStages.find(s => s.id === sourceStageIdToNewStageId.get(mappedSourceStageId))
+          : (orderedNewStages.find(s => s.defaultTicketStatusV2 === old.defaultTicketStatusV2) ??
+            orderedNewStages[0]);
+        if (!target) continue;
+
+        ticketRemap.push({
+          oldStageId: old.id,
+          oldStageName: old.name,
+          newStageId: target.id,
+          newStageName: target.name,
+          newStageEta: target.eta ?? null,
+          newStageStatusV2: target.defaultTicketStatusV2,
+          futureStagesEtaHours: futureStagesEtaHoursByNewStageId[target.id] ?? 0,
+        });
+      }
+    }
+
+    // ── Custom fields & roles → board metadata ───────────────────────────
+    let clonedFormId: string | null = null;
+    let targetOldFormId: string | null = null;
+    let fieldRepoints: BoardConfigCopyFieldRepoint[] = [];
+    let customFieldsCopied = false;
+    let rolesCopied = false;
+
+    if (input.categories.customFields) {
+      const clone = await this.cloneSourceCustomFieldsForm(
+        { id: sourceBoard.id, projectId: sourceBoard.projectId, workspaceId: sourceBoard.workspaceId },
+        targetBoard.id,
+        actorUserId,
+      );
+      clonedFormId = clone.clonedFormId;
+      targetOldFormId = clone.targetOldFormId;
+      fieldRepoints = clone.fieldRepoints;
+      result.warnings.push(...clone.warnings);
+
+      if (clonedFormId) targetMetadata['customFieldsFormId'] = clonedFormId;
+      targetMetadata['fieldOrder'] = this.remapFieldOrder(sourceMetadata['fieldOrder'], clone.sourceOldToNewFieldId);
+      targetMetadata['ticketFormConfig'] = sourceMetadata['ticketFormConfig'];
+      targetMetadata['customFieldVisibility'] = this.remapFieldKeyedRecord(
+        sourceMetadata['customFieldVisibility'],
+        clone.sourceOldToNewFieldId,
+      );
+      customFieldsCopied = true;
+    }
+
+    if (input.categories.roles) {
+      targetMetadata['assignmentRoles'] = sourceMetadata['assignmentRoles'] ?? [];
+      targetMetadata['ticketControlRoleIds'] = sourceMetadata['ticketControlRoleIds'] ?? [];
+      targetMetadata['bitbucketEventRoles'] = sourceMetadata['bitbucketEventRoles'] ?? {};
+      rolesCopied = true;
+    }
+
+    const boardUpdate: PreparedBoardUpdate = {
+      boardId: targetBoard.id,
+      boardType: sourceBoard.boardType,
+      metadata: targetMetadata,
+      ...(preparedStages ? { stages: preparedStages, prStatusMappingIds } : {}),
+    };
+
+    const boardFormMapping: PreparedBoardFormMapping | null = clonedFormId
+      ? {
+          contextId: targetBoard.id,
+          contextType: FormContextType.BOARD,
+          entityType: FormEntityType.TICKET,
+          formId: clonedFormId,
+          mappingId: this.deriveDeterministicId('board-config-copy-form-mapping', targetBoard.id, clonedFormId),
+        }
+      : null;
+
+    // Snapshot before handing anything back — the client is about to mutate the board, so
+    // there must already be a restore point. Fail closed: no snapshot, no copy.
+    let snapshotPath: string;
+    try {
+      const snapshot = await boardConfigCopySnapshotService.captureSnapshot({
+        targetBoardId: targetBoard.id,
+        sourceBoardId: sourceBoard.id,
+        workspaceId,
+        actorUserId,
+      });
+      snapshotPath = snapshot.path;
+    } catch (error) {
+      logger.error(`${TAG} Snapshot failed for board ${targetBoard.id} — aborting before any change`, error);
+      // The form clone committed independently; drop it rather than leave it orphaned.
+      if (clonedFormId) {
+        await db.form.delete({ where: { id: clonedFormId } }).catch(cleanupError => {
+          logger.error(`${TAG} Failed to clean up orphaned form ${clonedFormId} after a failed snapshot`, cleanupError);
+        });
+      }
+      throw new BoardConfigCopyValidationError([
+        'Could not back up the target board before copying, so nothing was changed. Please retry.',
+      ]);
+    }
+    void boardConfigCopySnapshotService.sweepExpiredSnapshots();
+
+    const needsMigration = ticketRemap.length > 0 || fieldRepoints.length > 0;
+
+    result.prepared = {
+      snapshotPath,
+      customFieldsCopied,
+      rolesCopied,
+      newStageCount: preparedStages?.length ?? 0,
+      deletedOldStageCount: preparedStages ? oldStages.length : 0,
+      ticketsToMigrate: oldStages.reduce((sum, s) => sum + s.ticketCount, 0),
+      boardUpdate,
+      boardFormMapping,
+      transitions: preparedTransitions,
+      // Handed back rather than stashed server-side: the client passes it straight to
+      // startTicketMigration once its config mutations land, and that call re-checks every
+      // claim in it against the board's real state (see there). Round-tripping it keeps the
+      // plan alive for exactly as long as the client needs it, with no expiry to miss.
+      ticketMigration: needsMigration
+        ? {
+            targetBoardId: targetBoard.id,
+            workspaceId,
+            actorUserId,
+            ticketRemap,
+            fieldRepoints,
+            targetOldFormId,
+            clonedFormId,
+            snapshotPath,
+          }
+        : null,
+    };
+
+    return result;
+  }
+
+  /**
+   * Enqueues the ticket migration a prepared copy left pending, once the client's config
+   * mutations have landed.
+   *
+   * The plan arrives via the browser, so nothing in it is taken on trust: every destination
+   * is re-checked against the stages that actually exist on the board right now, and the
+   * workspace/actor are taken from the authenticated request rather than the payload. The
+   * effect is that a tampered plan can only ever describe a move the board already permits
+   * — it can't invent a destination, reach another workspace, or repoint field values onto
+   * a form this board isn't bound to.
+   */
+  async startTicketMigration(
+    plan: BoardConfigCopyJobData,
+    actorUserId: string,
+    workspaceId: string,
+  ): Promise<{ jobId: string }> {
+    const board = await db.board.findFirst({
+      where: { id: plan.targetBoardId, workspaceId },
+      select: { id: true },
+    });
+    if (!board) {
+      throw new BoardConfigCopyValidationError(['Target board not found in this workspace']);
+    }
+
+    const stages = await db.stage.findMany({
+      where: { boardId: plan.targetBoardId },
+      select: { id: true, name: true },
+    });
+    const stageById = new Map(stages.map(s => [s.id, s]));
+    const liveStageNames = new Set(stages.map(s => s.name));
+
+    for (const remap of plan.ticketRemap) {
+      // Tickets may only land on a stage that exists on this board right now, under the
+      // name that stage actually carries.
+      const destination = stageById.get(remap.newStageId);
+      if (!destination || destination.name !== remap.newStageName) {
+        throw new BoardConfigCopyValidationError([
+          'This migration plan points at a stage that no longer exists on the board. Re-run the copy.',
+        ]);
+      }
+      // ...and may only be moved OFF a name the new configuration actually retired, so a
+      // plan can't be used to sweep tickets off a stage that is still in use.
+      if (liveStageNames.has(remap.oldStageName)) {
+        throw new BoardConfigCopyValidationError([
+          `"${remap.oldStageName}" is still an active stage on this board, so tickets cannot be migrated off it.`,
+        ]);
+      }
+    }
+
+    if (plan.fieldRepoints.length > 0) {
+      if (!plan.clonedFormId || !plan.targetOldFormId) {
+        throw new BoardConfigCopyValidationError(['This migration plan is missing the forms its field mapping refers to.']);
+      }
+      // Values may only be repointed onto the form the board is currently bound to.
+      const mapping = await db.formContextMapping.findFirst({
+        where: {
+          contextId: plan.targetBoardId,
+          contextType: FormContextType.BOARD,
+          entityType: FormEntityType.TICKET,
+        },
+        select: { formId: true },
+      });
+      if (!mapping || mapping.formId !== plan.clonedFormId) {
+        throw new BoardConfigCopyValidationError([
+          'This board is not bound to the form this migration plan expects. Re-run the copy.',
+        ]);
+      }
+      const oldForm = await db.form.findFirst({
+        where: { id: plan.targetOldFormId, workspaceId },
+        select: { id: true },
+      });
+      if (!oldForm) {
+        throw new BoardConfigCopyValidationError(['The previous form this migration plan refers to was not found.']);
+      }
+    }
+
+    // Identity comes from the authenticated request, never the payload.
+    const jobData: BoardConfigCopyJobData = { ...plan, workspaceId, actorUserId };
+
+    const { enqueued, reason } = await boardConfigCopyQueue.addJob(jobData);
+    if (!enqueued) {
+      throw new BoardConfigCopyConflictError(reason ?? 'A migration is already in progress for this board');
+    }
+    return { jobId: plan.targetBoardId };
+  }
+
+  // ─── Worker-facing: per-ticket work only ─────────────────────────────────
+
+  async findTicketsOnOldStages(
+    targetBoardId: string,
+    oldStageNames: string[],
+    cursor: string | null,
+    take: number,
+  ): Promise<Array<{ id: string; stageName: string }>> {
+    return db.ticket.findMany({
+      where: {
+        boardId: targetBoardId,
+        stageName: { in: oldStageNames },
+        ...(cursor ? { id: { gt: cursor } } : {}),
+      },
+      select: { id: true, stageName: true },
+      orderBy: { id: 'asc' },
+      take,
+    });
+  }
+
+  /**
+   * Moves a single ticket off its old stage onto the resolved new stage. Idempotent —
+   * guarded by `stageName: oldStageName` so a retry after a partial run is a safe no-op
+   * for tickets that already moved.
+   */
+  async applyStageRemap(
+    ticketId: string,
+    targetBoardId: string,
+    oldStageId: string,
+    oldStageName: string,
+    target: { newStageId: string; newStageName: string; newStageEta: number | null; newStageStatusV2: string; futureStagesEtaHours: number },
+    actorUserId: string,
+  ): Promise<'updated' | 'skipped'> {
+    return db.$transaction(async tx => {
+      const ticket = await tx.ticket.findFirst({
+        where: { id: ticketId, boardId: targetBoardId, stageName: oldStageName },
+        select: { id: true, workspaceId: true, statusV2: true },
+      });
+      if (!ticket) return 'skipped';
+
+      const now = new Date();
+
+      const targetStageEta =
+        target.newStageEta !== null && target.newStageEta > 0 ? calculateETADeadline(now, target.newStageEta) : now;
+      const recomputedEta = recomputeOverallTicketEta(targetStageEta, now, target.futureStagesEtaHours);
+      const statusChanged = ticket.statusV2 !== target.newStageStatusV2;
+
+      // Compare-and-swap: re-assert `stageName: oldStageName` at write time instead of
+      // trusting the read above. If a user moved this ticket through the UI in between,
+      // Postgres re-evaluates the predicate against their committed row and matches zero
+      // rows — the human's change wins and the job leaves it alone. This runs before the
+      // ETA-ledger writes so the lost-the-race path has no side effects to undo.
+      const { count } = await tx.ticket.updateMany({
+        where: { id: ticket.id, boardId: targetBoardId, stageName: oldStageName },
+        data: {
+          stageName: target.newStageName,
+          statusV2: target.newStageStatusV2,
+          ...(statusChanged ? { statusUpdatedAt: now } : {}),
+          ...(recomputedEta ? { eta: recomputedEta } : {}),
+          updatedBy: actorUserId,
+          updatedAt: now,
+        },
+      });
+      if (count === 0) return 'skipped';
+
+      await tx.ticketStageEta.updateMany({
+        where: { ticketId: ticket.id, stageId: oldStageId, stageLeftAt: null },
+        data: { stageLeftAt: now, updatedAt: now, updatedBy: actorUserId },
+      });
+
+      const existing = await tx.ticketStageEta.findFirst({
+        where: { ticketId: ticket.id, stageId: target.newStageId },
+      });
+      if (existing) {
+        await tx.ticketStageEta.update({
+          where: { id: existing.id },
+          data: {
+            stageEnteredAt: now,
+            stageLeftAt: null,
+            ...(target.newStageEta !== null && target.newStageEta > 0 ? { stageEta: targetStageEta } : {}),
+            updatedAt: now,
+            updatedBy: actorUserId,
+          },
+        });
+      } else if (target.newStageEta !== null && target.newStageEta > 0) {
+        await tx.ticketStageEta.create({
+          data: {
+            ticketId: ticket.id,
+            workspaceId: ticket.workspaceId,
+            stageId: target.newStageId,
+            stageEnteredAt: now,
+            stageLeftAt: null,
+            stageEta: targetStageEta,
+            updatedBy: actorUserId,
+          },
+        });
+      }
+
+      // updateMany doesn't return the row, so re-read it for the markdown sync.
+      const updatedTicket = await tx.ticket.findUnique({ where: { id: ticket.id } });
+      if (updatedTicket) await syncConversationTicketMdFromPrismaTicket(tx, updatedTicket);
+
+      return 'updated';
+    });
+  }
+
+  /**
+   * Repoints existing ticket custom-field values from the target board's old form onto the
+   * cloned one, for fields both boards share — otherwise they'd become stale rows against
+   * an unbound form, surfacing as un-editable "prefill" values that collide on save.
+   *
+   * Per-ticket data (one row per ticket per field), so it belongs to the migration job
+   * rather than the client's config mutation — but it's a bulk UPDATE per field, not a
+   * per-ticket round trip. Each field is independent: a failure is logged and skipped, and
+   * the untouched rows stay exactly where they were.
+   */
+  async repointFormEntityValues(
+    targetBoardId: string,
+    targetOldFormId: string,
+    clonedFormId: string,
+    fieldRepoints: BoardConfigCopyFieldRepoint[],
+    actorUserId: string,
+  ): Promise<{ repointed: number; warnings: string[] }> {
+    const warnings: string[] = [];
+    let repointed = 0;
+
+    for (const { oldFieldId, newFieldId } of fieldRepoints) {
+      try {
+        const { count } = await db.formEntityValues.updateMany({
+          where: {
+            fieldId: oldFieldId,
+            formId: targetOldFormId,
+            entityType: FormEntityType.TICKET,
+            contextId: targetBoardId,
+          },
+          data: { fieldId: newFieldId, formId: clonedFormId, updatedAt: new Date() },
+        });
+        repointed += count;
+      } catch (error) {
+        logger.error(`${TAG} Failed to repoint ticket values for field ${oldFieldId} -> ${newFieldId}`, error);
+        warnings.push(
+          'Some existing ticket values for a shared custom field could not be repointed to the new form — they may need to be re-entered.',
+        );
+      }
+    }
+
+    logger.info(`${TAG} Repointed ${repointed} custom-field value(s) on board ${targetBoardId} for ${actorUserId}`);
+    return { repointed, warnings };
+  }
+}
+
+export const boardConfigCopyService = new BoardConfigCopyService();

--- a/apps/backend/src/services/boardConfigCopySnapshotService.ts
+++ b/apps/backend/src/services/boardConfigCopySnapshotService.ts
@@ -1,0 +1,244 @@
+import { once } from 'node:events';
+import { createGzip } from 'node:zlib';
+import { FormContextType } from '@xyne/shared';
+import { db } from '@/database/client';
+import { storageService } from '@/services/storage';
+import { logger } from '@/utils/logger';
+
+const TAG = '[BoardConfigCopySnapshot]';
+
+/**
+ * Object-storage prefix every snapshot lives under. Kept as a single top-level folder so
+ * a bucket lifecycle rule can target it with one `matchesPrefix` condition.
+ */
+export const SNAPSHOT_PREFIX = 'board-config-copy-snapshots';
+
+/** Snapshots are a short-lived undo buffer for a destructive admin action, not an archive. */
+export const SNAPSHOT_RETENTION_DAYS = 7;
+
+const SNAPSHOT_FORMAT_VERSION = 1;
+const TICKET_BATCH_SIZE = 50;
+// Mirrors boardConfigCopyWorker.ts's batch delay — spreads DB load out for large boards
+// instead of firing every batch back-to-back.
+const DELAY_MS = 1000;
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+interface CaptureSnapshotParams {
+  targetBoardId: string;
+  sourceBoardId: string;
+  workspaceId: string;
+  actorUserId: string;
+}
+
+export interface BoardSnapshotResult {
+  path: string;
+  sizeBytes: number;
+  ticketCount: number;
+}
+
+/**
+ * Captures the pre-copy state of a board so a bad copy can be reconstructed by hand.
+ *
+ * Written as gzipped NDJSON — one JSON record per line, each tagged with a `type` — so the
+ * writer never has to hold the whole document in memory and a reader can stream it back
+ * record by record. Rows are read in batches and piped straight to object storage as they're
+ * compressed — nothing accumulates in process memory, compressed or not.
+ */
+class BoardConfigCopySnapshotService {
+  async captureSnapshot(params: CaptureSnapshotParams): Promise<BoardSnapshotResult> {
+    const { targetBoardId, sourceBoardId, workspaceId, actorUserId } = params;
+    const startedAt = new Date();
+    const path = `${SNAPSHOT_PREFIX}/${workspaceId}/${targetBoardId}/${startedAt.toISOString().replace(/[:.]/g, '-')}.ndjson.gz`;
+
+    const gzip = createGzip();
+
+    // Pipe straight to object storage instead of buffering the whole compressed file in
+    // process memory — a large board's snapshot could otherwise be tens to hundreds of MB
+    // held in the API server's heap. Attached before any writes so backpressure on `gzip`
+    // is actually relieved by a real consumer, and given a no-op .catch() up front so a
+    // write-side failure below (which never awaits this promise) can't surface as an
+    // unhandled rejection.
+    const uploadPromise = storageService.uploadStreamToPath(gzip, { path, contentType: 'application/gzip' });
+    uploadPromise.catch(() => {});
+
+    const writeRecord = async (type: string, data: unknown): Promise<void> => {
+      if (!gzip.write(`${JSON.stringify({ type, data })}\n`)) {
+        await once(gzip, 'drain');
+      }
+    };
+
+    const stages = await db.stage.findMany({ where: { boardId: targetBoardId } });
+    const stageIds = stages.map(s => s.id);
+    const transitions = await db.stageTransition.findMany({ where: { boardId: targetBoardId } });
+    const transitionIds = transitions.map(t => t.id);
+
+    let ticketCount = 0;
+
+    try {
+      await writeRecord('meta', {
+        formatVersion: SNAPSHOT_FORMAT_VERSION,
+        takenAt: startedAt.toISOString(),
+        targetBoardId,
+        sourceBoardId,
+        workspaceId,
+        actorUserId,
+      });
+
+      const board = await db.board.findUnique({ where: { id: targetBoardId } });
+      if (board) await writeRecord('board', board);
+
+      for (const stage of stages) await writeRecord('stage', stage);
+      for (const transition of transitions) await writeRecord('stageTransition', transition);
+
+      // Approvers hang off either a stage or a transition, and the copy deletes both kinds.
+      const approverFilters = [
+        ...(stageIds.length > 0 ? [{ stageId: { in: stageIds } }] : []),
+        ...(transitionIds.length > 0 ? [{ transitionId: { in: transitionIds } }] : []),
+      ];
+      if (approverFilters.length > 0) {
+        const approvers = await db.stageApprovers.findMany({ where: { OR: approverFilters } });
+        for (const approver of approvers) await writeRecord('stageApprover', approver);
+      }
+
+      if (stageIds.length > 0) {
+        const prMappings = await db.stagePRStatusMapping.findMany({ where: { stageId: { in: stageIds } } });
+        for (const mapping of prMappings) await writeRecord('stagePRStatusMapping', mapping);
+      }
+
+      // Both the board-level ticket form binding (replaced by the customFields category)
+      // and the per-stage form bindings (dropped with their stages).
+      const formMappings = await db.formContextMapping.findMany({
+        where: {
+          OR: [
+            { contextId: targetBoardId, contextType: FormContextType.BOARD },
+            ...(stageIds.length > 0 ? [{ contextId: { in: stageIds }, contextType: FormContextType.STAGE }] : []),
+          ],
+        },
+      });
+      for (const mapping of formMappings) await writeRecord('formContextMapping', mapping);
+
+      // Tickets are captured on every run, not only when the stages category is selected.
+      // The snapshot is the sole undo path for a destructive admin action, so it records
+      // the whole board rather than guessing which parts this particular run will touch.
+      ticketCount = await this.writeTickets(targetBoardId, writeRecord);
+      if (stageIds.length > 0) await this.writeTicketStageEtas(stageIds, writeRecord);
+
+      gzip.end();
+    } catch (error) {
+      gzip.destroy();
+      throw error;
+    }
+
+    const uploadResult = await uploadPromise;
+
+    logger.info(`${TAG} Wrote snapshot for board ${targetBoardId}`, {
+      path,
+      sizeBytes: uploadResult.size,
+      ticketCount,
+      stageCount: stages.length,
+    });
+
+    return { path, sizeBytes: uploadResult.size, ticketCount };
+  }
+
+  /** Only the columns the copy actually rewrites, plus enough identity to match rows back up. */
+  private async writeTickets(
+    targetBoardId: string,
+    writeRecord: (type: string, data: unknown) => Promise<void>,
+  ): Promise<number> {
+    let cursor: string | null = null;
+    let count = 0;
+
+    for (;;) {
+      const tickets = await this.fetchTicketBatch(targetBoardId, cursor);
+      if (tickets.length === 0) break;
+
+      for (const ticket of tickets) await writeRecord('ticket', ticket);
+      count += tickets.length;
+
+      const nextCursor = tickets[tickets.length - 1]?.id ?? null;
+      if (!nextCursor) break;
+      cursor = nextCursor;
+
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+
+    return count;
+  }
+
+  // Split out of the paging loop so the cursor is a plain parameter — inferring the row
+  // type inline would make it depend on a variable the loop body assigns from it.
+  private fetchTicketBatch(targetBoardId: string, after: string | null) {
+    return db.ticket.findMany({
+      where: { boardId: targetBoardId, ...(after ? { id: { gt: after } } : {}) },
+      select: {
+        id: true,
+        xyneId: true,
+        boardId: true,
+        stageName: true,
+        statusV2: true,
+        statusUpdatedAt: true,
+        eta: true,
+        updatedAt: true,
+        updatedBy: true,
+      },
+      orderBy: { id: 'asc' },
+      take: TICKET_BATCH_SIZE,
+    });
+  }
+
+  /** The per-stage-visit SLA ledger rows that the remap closes out or rewrites. */
+  private async writeTicketStageEtas(
+    stageIds: string[],
+    writeRecord: (type: string, data: unknown) => Promise<void>,
+  ): Promise<void> {
+    let cursor: string | null = null;
+
+    for (;;) {
+      const rows = await this.fetchTicketStageEtaBatch(stageIds, cursor);
+      if (rows.length === 0) break;
+
+      for (const row of rows) await writeRecord('ticketStageEta', row);
+
+      const nextCursor = rows[rows.length - 1]?.id ?? null;
+      if (!nextCursor) break;
+      cursor = nextCursor;
+
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+
+  private fetchTicketStageEtaBatch(stageIds: string[], after: string | null) {
+    return db.ticketStageEta.findMany({
+      where: { stageId: { in: stageIds }, ...(after ? { id: { gt: after } } : {}) },
+      orderBy: { id: 'asc' },
+      take: TICKET_BATCH_SIZE,
+    });
+  }
+
+  /**
+   * Deletes snapshots past the retention window. Best-effort and non-fatal: this is a
+   * convenience so the prefix doesn't grow without bound in environments where no bucket
+   * lifecycle rule has been configured. Where one exists it does the same job on a
+   * guaranteed schedule and this simply finds nothing to remove.
+   */
+  async sweepExpiredSnapshots(): Promise<void> {
+    try {
+      const cutoff = Date.now() - SNAPSHOT_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+      const files = await storageService.listFiles(`${SNAPSHOT_PREFIX}/`);
+
+      for (const file of files) {
+        if (!file.updated || file.updated.getTime() >= cutoff) continue;
+        await storageService.deleteFile(file.name);
+        logger.info(`${TAG} Removed expired snapshot ${file.name}`);
+      }
+    } catch (error) {
+      logger.warn(`${TAG} Failed to sweep expired snapshots`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+export const boardConfigCopySnapshotService = new BoardConfigCopySnapshotService();

--- a/apps/backend/src/utils/etaCalculation.ts
+++ b/apps/backend/src/utils/etaCalculation.ts
@@ -44,3 +44,23 @@ export function calculateWorkingDurationMs(startUtc: Date, endUtc: Date): number
 export function getWorkingHoursConfig(): { start: number; end: number; perDay: number; offset: number } {
   return sharedGetWorkingHoursConfig(workingHoursConfig);
 }
+
+/**
+ * Recompute the overall Ticket.eta from the current stage's own deadline plus the hours
+ * budgeted for stages still ahead of it, so Ticket.eta can never land before the current
+ * stage's deadline (calculateETADeadline only ever moves forward in time).
+ *
+ * Returns null when neither the current stage nor any future stage has an ETA configured —
+ * callers should leave Ticket.eta untouched in that case rather than overwriting it with `now`.
+ */
+export function recomputeOverallTicketEta(
+  currentStageEta: Date,
+  stageEnteredAt: Date,
+  futureStagesEtaHours: number,
+): Date | null {
+  const currentStageHasEta = currentStageEta.getTime() > stageEnteredAt.getTime();
+  if (!currentStageHasEta && futureStagesEtaHours <= 0) {
+    return null;
+  }
+  return calculateETADeadline(currentStageEta, futureStagesEtaHours);
+}

--- a/apps/backend/src/workers/boardConfigCopyWorker.ts
+++ b/apps/backend/src/workers/boardConfigCopyWorker.ts
@@ -1,0 +1,228 @@
+import { logger } from '@/utils/logger';
+import { runAsServiceActor } from '@/database/tenant/context';
+import {
+  boardConfigCopyQueue,
+  BoardConfigCopyJobData,
+  BoardConfigCopySummary,
+  BoardConfigCopyTicketRemap,
+} from '@/queues/boardConfigCopyQueue';
+import { boardConfigCopyService } from '@/services/boardConfigCopyService';
+
+const TAG = '[BoardConfigCopyWorker]';
+const BATCH_SIZE = 50;
+const DELAY_MS = 1000;
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Ticket-migration half of "Copy Board Configuration".
+ *
+ * The board's configuration — stages, transitions, form binding, roles, metadata — is
+ * already committed by the time this runs: the dashboard applies it through the same Zero
+ * mutators as an ordinary board edit (`board.update`, `formContextMapping.upsert`,
+ * `nonLinear.syncTransitions`). The old stages are therefore already gone, which is exactly
+ * why the job payload carries a fully-resolved remap: there is nothing left on the board to
+ * derive "where should this ticket go" from.
+ *
+ * This worker exists solely because the remaining work is per-ticket and unbounded — every
+ * ticket on the board may need its stage rewritten, and every ticket may hold custom-field
+ * values that must follow the new form.
+ */
+class BoardConfigCopyWorker {
+  private isStarted = false;
+
+  /**
+   * Registers the job processor on the already-initialized queue. Intentionally run
+   * inside the same process as the API server (not the separate worker.ts process) —
+   * this is an occasional, admin-triggered operation, not a high-throughput hot path,
+   * so it doesn't need its own scaled worker deployment.
+   */
+  start(): void {
+    if (this.isStarted) return;
+
+    const queue = boardConfigCopyQueue.getQueue();
+    // The Bull processor runs outside any HTTP request, so there is no ambient tenant
+    // context — every db.* call inside processJob would otherwise run fully unscoped (see
+    // acl-extension.ts's no-context fallback). runAsServiceActor opens one bound to the
+    // job's own workspace, matching etaDeadlineWorker.ts / autoDraftWorker.ts.
+    queue.process(async job =>
+      runAsServiceActor(job.data.actorUserId, job.data.workspaceId, () => this.processJob(job.data)),
+    );
+    this.isStarted = true;
+    logger.info(`${TAG} Started, ready to process jobs`);
+  }
+
+  /**
+   * Cursor-paginated sweep that moves every ticket currently sitting on one of the retired
+   * stage names onto its resolved destination. Safe to run repeatedly — a ticket that has
+   * already moved simply no longer matches the query, and `applyStageRemap` itself
+   * re-checks the stage name at write time. Returns how many tickets it actually moved.
+   *
+   * `phase` only labels the log lines: the same pass runs as the main migration and again
+   * as the straggler sweep, and without it the two are indistinguishable in the log.
+   */
+  private async remapPass(
+    data: BoardConfigCopyJobData,
+    destinations: Map<string, BoardConfigCopyTicketRemap>,
+    summary: BoardConfigCopySummary,
+    phase: string,
+  ): Promise<number> {
+    const stageNames = [...destinations.keys()];
+    if (stageNames.length === 0) return 0;
+
+    const startedAt = Date.now();
+    let movedInPass = 0;
+    let batchesInPass = 0;
+    let cursor: string | null = null;
+    let hasMore = true;
+
+    logger.info(`${TAG} [${phase}] Started for board ${data.targetBoardId}`, {
+      retiredStages: stageNames,
+    });
+
+    while (hasMore) {
+      const tickets = await boardConfigCopyService.findTicketsOnOldStages(
+        data.targetBoardId,
+        stageNames,
+        cursor,
+        BATCH_SIZE,
+      );
+
+      if (tickets.length === 0) {
+        hasMore = false;
+        continue;
+      }
+      summary.batches += 1;
+      batchesInPass += 1;
+
+      for (const ticket of tickets) {
+        summary.processed += 1;
+        const destination = destinations.get(ticket.stageName);
+        if (!destination) {
+          summary.errors += 1;
+          summary.failedTicketIds.push(ticket.id);
+          continue;
+        }
+
+        try {
+          const result = await boardConfigCopyService.applyStageRemap(
+            ticket.id,
+            data.targetBoardId,
+            destination.oldStageId,
+            destination.oldStageName,
+            destination,
+            data.actorUserId,
+          );
+          if (result === 'updated') {
+            summary.updated += 1;
+            movedInPass += 1;
+          } else {
+            // Either already moved by an earlier pass, or a user moved it out from under
+            // us mid-transaction. Both are fine — their change wins.
+            summary.skipped += 1;
+          }
+        } catch (error) {
+          summary.errors += 1;
+          summary.failedTicketIds.push(ticket.id);
+          logger.warn(`${TAG} [${phase}] Failed to remap ticket ${ticket.id}`, {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      cursor = tickets[tickets.length - 1]?.id ?? null;
+
+      // One line per batch. With BATCH_SIZE tickets and DELAY_MS between batches this is
+      // at most ~1 line/sec, which is what makes a long run legible while it's happening —
+      // without it, a board with thousands of tickets is silent for minutes.
+      logger.info(`${TAG} [${phase}] Batch ${batchesInPass} done for board ${data.targetBoardId}`, {
+        movedInPass,
+        processedTotal: summary.processed,
+        updatedTotal: summary.updated,
+        skippedTotal: summary.skipped,
+        errorsTotal: summary.errors,
+        elapsedMs: Date.now() - startedAt,
+      });
+
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+
+    logger.info(`${TAG} [${phase}] Finished for board ${data.targetBoardId}`, {
+      batchesInPass,
+      movedInPass,
+      elapsedMs: Date.now() - startedAt,
+    });
+
+    return movedInPass;
+  }
+
+  private async processJob(data: BoardConfigCopyJobData): Promise<BoardConfigCopySummary> {
+    const jobStartedAt = Date.now();
+    logger.info(`${TAG} Starting ticket migration for board ${data.targetBoardId}`, {
+      retiredStageCount: data.ticketRemap.length,
+      fieldRepointCount: data.fieldRepoints.length,
+    });
+
+    const summary: BoardConfigCopySummary = {
+      batches: 0,
+      processed: 0,
+      updated: 0,
+      skipped: 0,
+      errors: 0,
+      failedTicketIds: [],
+      fieldValuesRepointed: 0,
+      snapshotPath: data.snapshotPath,
+      warnings: [],
+    };
+
+    // Custom-field values first: a bulk UPDATE per shared field, independent of the stage
+    // remap below, and cheap enough that doing it up front keeps pre-existing tickets
+    // editable as early as possible.
+    if (data.fieldRepoints.length > 0 && data.targetOldFormId && data.clonedFormId) {
+      const repointStartedAt = Date.now();
+      logger.info(`${TAG} [REPOINT_FIELD_VALUES] Started for board ${data.targetBoardId}`, {
+        fieldCount: data.fieldRepoints.length,
+      });
+      const { repointed, warnings } = await boardConfigCopyService.repointFormEntityValues(
+        data.targetBoardId,
+        data.targetOldFormId,
+        data.clonedFormId,
+        data.fieldRepoints,
+        data.actorUserId,
+      );
+      summary.fieldValuesRepointed = repointed;
+      summary.warnings.push(...warnings);
+      logger.info(`${TAG} [REPOINT_FIELD_VALUES] Finished for board ${data.targetBoardId}`, {
+        repointed,
+        elapsedMs: Date.now() - repointStartedAt,
+      });
+    }
+
+    const destinations = new Map(data.ticketRemap.map(remap => [remap.oldStageName, remap]));
+
+    if (destinations.size > 0) {
+      await this.remapPass(data, destinations, summary, 'REMAP_TICKETS');
+
+      // One final sweep for anything created on a retired stage name while the main pass
+      // was running. Those stages no longer exist, so nothing new can legitimately land on
+      // them — this only catches writes that were already in flight when the config changed.
+      const healed = await this.remapPass(data, destinations, summary, 'STRAGGLER_SWEEP');
+      if (healed > 0) {
+        summary.warnings.push(
+          `${healed} ticket(s) were still being written to a retired stage as it was removed, and were moved onto the new stage set.`,
+        );
+      }
+    }
+
+    logger.info(`${TAG} Completed ticket migration for board ${data.targetBoardId}`, {
+      ...summary,
+      // Bounded: a badly-wrong run could otherwise dump thousands of ids into the log line.
+      failedTicketIds: summary.failedTicketIds.slice(0, 20),
+      failedTicketIdCount: summary.failedTicketIds.length,
+      elapsedMs: Date.now() - jobStartedAt,
+    });
+    return summary;
+  }
+}
+
+export const boardConfigCopyWorker = new BoardConfigCopyWorker();

--- a/apps/dashboard/src/components/Board/BoardConfigCopyScreen/BoardConfigCopyScreen.tsx
+++ b/apps/dashboard/src/components/Board/BoardConfigCopyScreen/BoardConfigCopyScreen.tsx
@@ -1,0 +1,540 @@
+import { ReactElement, useCallback, useMemo, useState } from 'react';
+import { ArrowLeft, X } from 'lucide-react';
+import { BoardType, FormContextType, FormEntityType, PRStatusEvent } from '@xyne/shared';
+import { toast } from 'sonner';
+import { mutators } from '../../../zero/mutators';
+import { queries } from '../../../zero/queries';
+import { useZero } from '../../../hooks/useZero';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useConfirmDialog } from '../../../hooks/useConfirmDialog';
+import { Button } from '../../../components/ui/Button';
+import { Badge } from '../../../components/ui/Badge/Badge';
+import { EntitySelector } from '../../ui/EntitySelector/EntitySelector';
+import type { SelectorOption } from '../../ui/EntitySelector/EntitySelector.types';
+import { apiInstance } from '../../../services/clients/apiClient';
+import { StageRemapTable } from './StageRemapTable';
+import type {
+  ApiEnvelope,
+  CopyCategorySelection,
+  CopyResultSummary,
+  PrepareCopyResult,
+} from './BoardConfigCopyScreen.types';
+
+interface BoardConfigCopyScreenProps {
+  targetBoardId: string;
+  targetBoardName?: string;
+  projectId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onDone?: () => void;
+}
+
+type Step = 'select' | 'remap' | 'result';
+
+const extractErrorMessage = (error: unknown, fallback: string): string => {
+  const withResponse = error as {
+    response?: { data?: { error?: string | { message?: string }; message?: string } };
+  };
+  const data = withResponse?.response?.data;
+  if (typeof data?.error === 'string') return data.error;
+  if (data?.error && typeof data.error === 'object' && data.error.message)
+    return data.error.message;
+  if (data?.message) return data.message;
+  if (error instanceof Error) return error.message;
+  return fallback;
+};
+
+const BoardConfigCopyScreen = ({
+  targetBoardId,
+  targetBoardName,
+  projectId,
+  isOpen,
+  onClose,
+  onDone,
+}: BoardConfigCopyScreenProps): ReactElement | null => {
+  const { confirm, ConfirmDialog } = useConfirmDialog();
+  const zero = useZero();
+
+  const [projectBoards] = useCachedQuery(
+    queries.boardsListByProject({ projectId: projectId || '' }),
+    {
+      enabled: !!projectId,
+    },
+  );
+
+  const [step, setStep] = useState<Step>('select');
+  const [sourceBoardId, setSourceBoardId] = useState<string | null>(null);
+  const [categories, setCategories] = useState<CopyCategorySelection>({
+    customFields: false,
+    roles: false,
+    stages: false,
+  });
+
+  const [plan, setPlan] = useState<PrepareCopyResult | null>(null);
+  const [planLoading, setPlanLoading] = useState(false);
+  const [planError, setPlanError] = useState<string | null>(null);
+
+  const [remapOverrides, setRemapOverrides] = useState<Record<string, string>>({});
+
+  const [executing, setExecuting] = useState(false);
+  const [summary, setSummary] = useState<CopyResultSummary | null>(null);
+  const [resultError, setResultError] = useState<string | null>(null);
+  // Whether the just-started ticket migration is still running in the background — there is
+  // no status/progress endpoint to poll, so this is shown once and never updated.
+  const [migrationPending, setMigrationPending] = useState(false);
+
+  const sourceOptions: SelectorOption[] = useMemo(
+    () =>
+      (projectBoards ?? [])
+        .filter(board => board.id !== targetBoardId && board.boardType !== BoardType.RELEASE)
+        .map(board => ({ value: board.id, label: board.name, icon: null })),
+    [projectBoards, targetBoardId],
+  );
+
+  const resetForClose = (): void => {
+    setStep('select');
+    setSourceBoardId(null);
+    setCategories({ customFields: false, roles: false, stages: false });
+    setPlan(null);
+    setPlanError(null);
+    setRemapOverrides({});
+    setExecuting(false);
+    setSummary(null);
+    setResultError(null);
+    setMigrationPending(false);
+  };
+
+  const handleClose = (): void => {
+    resetForClose();
+    onClose();
+  };
+
+  /**
+   * Plan-only call: `dryRun: true` makes /prepare describe the copy (stages, counts,
+   * suggested mapping) without writing a snapshot or cloning a form, so the remap picker
+   * can be rendered — and re-rendered — without side effects.
+   */
+  const fetchPlan = useCallback(async (): Promise<PrepareCopyResult | null> => {
+    if (!sourceBoardId) return null;
+    setPlanLoading(true);
+    setPlanError(null);
+    try {
+      const response = await apiInstance.post<ApiEnvelope<PrepareCopyResult>>(
+        '/admin/board-config-copy/prepare',
+        { sourceBoardId, targetBoardId, categories, dryRun: true },
+      );
+      const result = response.data.data;
+      if (!result) {
+        setPlanError(response.data.error ?? 'Failed to load copy plan');
+        return null;
+      }
+      setPlan(result);
+      if (result.errors.length > 0) {
+        setPlanError(result.errors.join(' '));
+      }
+      const seeded: Record<string, string> = { ...(result.suggestedMapping ?? {}) };
+      setRemapOverrides(prev => ({ ...seeded, ...prev }));
+      return result;
+    } catch (error) {
+      // Validation failures (e.g. mismatched project) come back as HTTP 400 with the
+      // result still attached under `data.data` — surface it if present so the UI can show
+      // the structured `errors` list, not just a generic message.
+      const withResponse = error as {
+        response?: { data?: ApiEnvelope<PrepareCopyResult> };
+      };
+      const attached = withResponse?.response?.data?.data;
+      if (attached) {
+        setPlan(attached);
+        setPlanError(
+          attached.errors.join(' ') || extractErrorMessage(error, 'Failed to load copy plan'),
+        );
+        return attached;
+      }
+      const message = extractErrorMessage(error, 'Failed to load copy plan');
+      setPlanError(message);
+      return null;
+    } finally {
+      setPlanLoading(false);
+    }
+  }, [sourceBoardId, targetBoardId, categories]);
+
+  const handleContinueFromSelect = async (): Promise<void> => {
+    if (!sourceBoardId) {
+      toast.error('Select a source board first');
+      return;
+    }
+    if (!categories.customFields && !categories.roles && !categories.stages) {
+      toast.error('Select at least one category to copy');
+      return;
+    }
+    if (!categories.stages) {
+      await runExecute();
+      return;
+    }
+
+    const result = await fetchPlan();
+    if (!result || result.errors.length > 0) return;
+
+    const hasTicketsToRemap = (result.oldStages ?? []).some(stage => stage.ticketCount > 0);
+    if (hasTicketsToRemap) {
+      setStep('remap');
+    } else {
+      await runExecute();
+    }
+  };
+
+  const visibleRemapRows = useMemo(() => {
+    if (!plan) return [];
+    return (plan.oldStages ?? []).filter(stage => stage.ticketCount > 0);
+  }, [plan]);
+
+  const newStageOptions = useMemo(
+    () =>
+      (plan?.newStages ?? []).map(stage => ({
+        // `sourceStageId` (not a real, not-yet-created stage id) is what the backend uses to
+        // key `suggestedMapping`/`requiresExplicit` and expects back in `StageRemapOverride.newStageId`.
+        id: stage.sourceStageId,
+        name: stage.name,
+        defaultStatus: stage.defaultTicketStatusV2,
+      })),
+    [plan],
+  );
+
+  const remapComplete = useMemo(
+    () => visibleRemapRows.every(row => Boolean(remapOverrides[row.id])),
+    [visibleRemapRows, remapOverrides],
+  );
+
+  /**
+   * Awaits a Zero mutator's authoritative server result. Zero resolves (never rejects) on
+   * application errors, so a bare `void zero.mutate(...)` would silently roll the
+   * optimistic write back and let the copy continue on a board that was never updated.
+   */
+  const commitMutation = async (
+    mutation: { server: Promise<{ type?: string; error?: { message?: string } } | undefined> },
+    failureMessage: string,
+  ): Promise<void> => {
+    const res = await mutation.server;
+    if (res?.type === 'error') {
+      throw new Error(res.error?.message ?? failureMessage);
+    }
+  };
+
+  const runExecute = async (overrides?: Record<string, string>): Promise<void> => {
+    const confirmed = await confirm({
+      title: 'Copy board configuration?',
+      description: categories.stages
+        ? 'This will copy the selected configuration and remap any affected tickets onto the new stages. This cannot be undone automatically.'
+        : 'This will copy the selected configuration onto the target board. This cannot be undone automatically.',
+      confirmLabel: 'Copy configuration',
+    });
+    if (!confirmed) return;
+
+    setExecuting(true);
+    setResultError(null);
+    // Clear any stale summary carried over from a PRIOR run within this same still-mounted
+    // session — a fresh run must never render leftover numbers from a different copy.
+    setSummary(null);
+    setMigrationPending(false);
+    try {
+      const stageRemapOverrides = categories.stages
+        ? Object.entries(overrides ?? remapOverrides).map(([oldStageId, newStageId]) => ({
+            oldStageId,
+            newStageId,
+          }))
+        : undefined;
+
+      // 1. Server-only half: validation, pre-copy snapshot, and the custom-fields form
+      //    clone. Deliberately writes no board configuration — it just hands back the
+      //    arguments for the mutations below.
+      const response = await apiInstance.post<ApiEnvelope<PrepareCopyResult>>(
+        '/admin/board-config-copy/prepare',
+        {
+          sourceBoardId,
+          targetBoardId,
+          categories,
+          ...(categories.stages && { stageRemapOverrides }),
+          dryRun: false,
+        },
+      );
+      const result = response.data.data;
+      if (!result) throw new Error(response.data.error ?? 'Copy could not be prepared');
+      // No `prepared` means the plan still has unresolved stage mappings — the caller
+      // reached here without completing the remap step, so nothing was written.
+      const prepared = result.prepared;
+      if (!prepared) throw new Error('Every old stage with tickets needs a target stage first');
+
+      // 2. Commit the configuration through the ordinary board mutators — the same path a
+      //    hand-edited board save takes. `board.update` carries the whole change: it
+      //    upserts the copied stages, deletes every target stage absent from that list
+      //    (with their approvers/PR-status/form mappings), and replaces board metadata and
+      //    type in one atomic mutation.
+      await commitMutation(
+        zero.mutate(
+          mutators.board.update({
+            ...prepared.boardUpdate,
+            boardType: prepared.boardUpdate.boardType as BoardType,
+            stages: prepared.boardUpdate.stages?.map(stage => ({
+              ...stage,
+              prStatuses: stage.prStatuses as PRStatusEvent[],
+            })),
+            timestamp: Date.now(),
+          }),
+        ),
+        'Failed to apply the copied board configuration',
+      );
+
+      if (prepared.boardFormMapping) {
+        await commitMutation(
+          zero.mutate(
+            mutators.formContextMapping.upsert({
+              ...prepared.boardFormMapping,
+              contextType: prepared.boardFormMapping.contextType as FormContextType,
+              entityType: prepared.boardFormMapping.entityType as FormEntityType,
+            }),
+          ),
+          'Failed to bind the copied custom fields to this board',
+        );
+      }
+
+      if (prepared.transitions) {
+        await commitMutation(
+          zero.mutate(
+            mutators.nonLinear.syncTransitions({
+              boardId: targetBoardId,
+              transitions: prepared.transitions,
+              now: Date.now(),
+            }),
+          ),
+          'Failed to copy stage transitions',
+        );
+      }
+
+      const configSummary: CopyResultSummary = {
+        customFieldsCopied: prepared.customFieldsCopied,
+        rolesCopied: prepared.rolesCopied,
+        newStageCount: prepared.newStageCount,
+        deletedOldStageCount: prepared.deletedOldStageCount,
+        warnings: result.warnings,
+        snapshotPath: prepared.snapshotPath,
+      };
+
+      // 3. Hand the remaining per-ticket work (stage remap, custom-field value repointing)
+      //    to the background job and move on — there is no status endpoint to watch it
+      //    with, so this is fire-and-forget from here. The plan is /prepare's own payload
+      //    passed straight back; the server re-checks every destination in it against the
+      //    stages that now exist, so this side never inspects or edits it.
+      setSummary(configSummary);
+      if (prepared.ticketMigration) {
+        const migrationResponse = await apiInstance.post<ApiEnvelope<{ jobId: string }>>(
+          '/admin/board-config-copy/start-ticket-migration',
+          prepared.ticketMigration,
+        );
+        if (!migrationResponse.data.data?.jobId) {
+          throw new Error(migrationResponse.data.error ?? 'Ticket migration did not start');
+        }
+        setMigrationPending(true);
+      }
+      setStep('result');
+      toast.success('Board configuration copied');
+    } catch (error) {
+      const message = extractErrorMessage(error, 'Failed to copy board configuration');
+      toast.error('Copy failed', { description: message, duration: 5000 });
+      setResultError(message);
+      setStep('result');
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const handleContinueFromRemap = async (): Promise<void> => {
+    if (!remapComplete) {
+      toast.error('Every listed stage needs a mapping before continuing');
+      return;
+    }
+    await runExecute(remapOverrides);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
+      <div className='bg-background flex flex-col w-[90vw] max-w-3xl h-[85vh] rounded-lg shadow-xl overflow-hidden border border-border'>
+        <header className='flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0'>
+          <div className='flex items-center gap-2 min-w-0'>
+            {step === 'remap' && (
+              <Button variant='ghost' size='sm' onClick={() => setStep('select')}>
+                <ArrowLeft size={15} /> Back
+              </Button>
+            )}
+            <span className='text-sm font-medium text-foreground truncate'>
+              Copy board configuration
+            </span>
+            {targetBoardName && <Badge variant='secondary'>into {targetBoardName}</Badge>}
+          </div>
+          <Button variant='ghost' size='iconSm' onClick={handleClose} aria-label='Close'>
+            <X size={16} />
+          </Button>
+        </header>
+
+        <div className='flex-1 overflow-y-auto p-4 space-y-4'>
+          {step === 'select' && (
+            <>
+              <div>
+                <p className='text-sm font-medium text-foreground mb-1.5 block'>
+                  Copy configuration from
+                </p>
+                <EntitySelector
+                  options={sourceOptions}
+                  selectedValue={sourceBoardId}
+                  onSelect={setSourceBoardId}
+                  placeholder='Select source board'
+                  searchPlaceholder='Search boards...'
+                  showSearch={true}
+                  width='100%'
+                  testId='copy-config-source-board-picker'
+                />
+              </div>
+
+              <div className='space-y-2'>
+                <p className='text-sm font-medium text-foreground block'>What to copy</p>
+                {[
+                  { key: 'customFields' as const, label: 'Custom fields & settings' },
+                  { key: 'roles' as const, label: 'Roles' },
+                  { key: 'stages' as const, label: 'Stages' },
+                ].map(item => (
+                  <label
+                    key={item.key}
+                    htmlFor={`copy-config-category-${item.key}`}
+                    className='flex items-center gap-2 px-3 py-2 border border-border rounded-md cursor-pointer hover:bg-muted/40'
+                  >
+                    <input
+                      id={`copy-config-category-${item.key}`}
+                      type='checkbox'
+                      checked={categories[item.key]}
+                      onChange={e =>
+                        setCategories(prev => ({ ...prev, [item.key]: e.target.checked }))
+                      }
+                      data-track-category='BOARD_CONFIG_COPY'
+                      data-track-name='TOGGLE_CATEGORY'
+                    />
+                    <span className='text-sm text-foreground'>{item.label}</span>
+                  </label>
+                ))}
+              </div>
+
+              {planError && <p className='text-sm text-destructive'>{planError}</p>}
+            </>
+          )}
+
+          {step === 'remap' && plan && (
+            <>
+              <div className='space-y-1'>
+                {plan.warnings.map(warning => (
+                  <p
+                    key={warning}
+                    className='text-xs text-muted-foreground bg-muted/40 border border-border rounded-md px-3 py-2'
+                  >
+                    {warning}
+                  </p>
+                ))}
+              </div>
+
+              <p className='text-sm text-muted-foreground'>
+                Every old stage below has existing tickets — choose which new stage each should land
+                on. A stage can only be mapped to a new stage of the same status.
+              </p>
+
+              {planLoading ? (
+                <p className='text-sm text-muted-foreground'>Loading...</p>
+              ) : (
+                <StageRemapTable
+                  rows={visibleRemapRows.map(stage => ({
+                    oldStageId: stage.id,
+                    oldStageName: stage.name,
+                    ticketCount: stage.ticketCount,
+                    defaultStatus: stage.defaultTicketStatusV2,
+                  }))}
+                  newStageOptions={newStageOptions}
+                  value={remapOverrides}
+                  onChange={(oldStageId, newStageId) =>
+                    setRemapOverrides(prev => ({ ...prev, [oldStageId]: newStageId }))
+                  }
+                />
+              )}
+            </>
+          )}
+
+          {step === 'result' && (
+            <div className='space-y-3'>
+              {resultError && <p className='text-sm text-destructive'>{resultError}</p>}
+              {summary && (
+                <div className='space-y-2 text-sm'>
+                  <p className='text-foreground'>Copied successfully.</p>
+                  {migrationPending && (
+                    <p className='text-xs text-muted-foreground bg-muted/40 border border-border rounded-md px-3 py-2'>
+                      Existing tickets are being moved onto the new stages in the background.
+                    </p>
+                  )}
+                  {summary.warnings.length > 0 && (
+                    <div className='space-y-1'>
+                      {summary.warnings.map(warning => (
+                        <p
+                          key={warning}
+                          className='text-xs text-muted-foreground bg-muted/40 border border-border rounded-md px-3 py-2'
+                        >
+                          {warning}
+                        </p>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <footer className='flex items-center justify-end gap-2 px-4 py-3 border-t border-border flex-shrink-0'>
+          {step === 'result' ? (
+            <Button
+              variant='secondary'
+              onClick={() => {
+                onDone?.();
+                handleClose();
+              }}
+            >
+              Close
+            </Button>
+          ) : (
+            <>
+              <Button variant='secondary' onClick={handleClose}>
+                Cancel
+              </Button>
+              {step === 'select' && (
+                <Button
+                  className='bg-[#185FA5] hover:bg-[#0C447C] text-white'
+                  onClick={() => void handleContinueFromSelect()}
+                  disabled={planLoading || executing}
+                >
+                  {planLoading || executing ? 'Working…' : 'Continue'}
+                </Button>
+              )}
+              {step === 'remap' && (
+                <Button
+                  className='bg-[#185FA5] hover:bg-[#0C447C] text-white'
+                  onClick={() => void handleContinueFromRemap()}
+                  disabled={!remapComplete || executing}
+                >
+                  {executing ? 'Working…' : 'Copy configuration'}
+                </Button>
+              )}
+            </>
+          )}
+        </footer>
+      </div>
+      <ConfirmDialog />
+    </div>
+  );
+};
+
+export default BoardConfigCopyScreen;

--- a/apps/dashboard/src/components/Board/BoardConfigCopyScreen/BoardConfigCopyScreen.types.ts
+++ b/apps/dashboard/src/components/Board/BoardConfigCopyScreen/BoardConfigCopyScreen.types.ts
@@ -1,0 +1,147 @@
+import type { TicketStatusV2 } from '@xyne/shared';
+
+// Mirrors the backend's `ApiResponse<T>` envelope (apps/backend/src/types/express.ts) —
+// every board-config-copy endpoint wraps its payload as `data`, not the response body itself.
+export interface ApiEnvelope<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+  error?: string;
+  timestamp: string;
+}
+
+export interface CopyCategorySelection {
+  customFields: boolean;
+  roles: boolean;
+  stages: boolean;
+}
+
+export interface StageRemapOverride {
+  oldStageId: string;
+  newStageId: string;
+}
+
+export interface OldStageInfo {
+  id: string;
+  name: string;
+  defaultTicketStatusV2: TicketStatusV2;
+  ticketCount: number;
+}
+
+export interface NewStageInfo {
+  // Id of the SOURCE board's stage this translated stage was copied from — the new stage
+  // itself doesn't exist yet at plan time, so this doubles as the identifier used in
+  // `suggestedMapping`/`requiresExplicit`/`StageRemapOverride.newStageId`.
+  sourceStageId: string;
+  name: string;
+  defaultTicketStatusV2: TicketStatusV2;
+  sequenceNumber: number;
+}
+
+export interface BoardSummary {
+  id: string;
+  name: string;
+  boardType: string;
+}
+
+// ─── Prepared mutation payloads ───────────────────────────────────────────
+// `/prepare` does only what a browser can't (the pre-copy snapshot and the custom-fields
+// form clone) and hands these back. The screen passes them straight into the SAME Zero
+// mutators the board editor uses, so copying a configuration commits through exactly the
+// same path as editing one by hand. Mirrors apps/backend/src/services/boardConfigCopyService.ts.
+
+export interface PreparedStage {
+  id: string;
+  name: string;
+  eta?: number;
+  sequenceNumber: number;
+  defaultTicketStatusV2: string;
+  requestApprovalOnEntry: boolean;
+  prStatuses: string[];
+  approvers: Array<{ approverId: string; approverType: 'USER' | 'ROLE' }>;
+  formId?: string;
+}
+
+export interface PreparedBoardUpdate {
+  boardId: string;
+  boardType: string;
+  // Complete replacement blob — `board.update` overwrites metadata rather than merging.
+  metadata: Record<string, unknown>;
+  // Absent when stages weren't selected. When present this is the board's complete desired
+  // stage set: `board.update` upserts these and deletes every stage not listed, which is
+  // what retires the target's old stages.
+  stages?: PreparedStage[];
+  prStatusMappingIds?: Record<string, string>;
+}
+
+export interface PreparedBoardFormMapping {
+  contextId: string;
+  contextType: string;
+  entityType: string;
+  formId: string;
+  mappingId: string;
+}
+
+export interface PreparedTransition {
+  id: string;
+  fromStageId: string | null;
+  toStageId: string;
+  formId?: string;
+  requiresApproval: boolean;
+  bypassApprovalForAutomation: boolean;
+  requestApprovalOnEntry: boolean;
+  visitSlaMode?: string;
+  fixedEtaHours?: number | null;
+  onReenter?: string;
+  approvers: Array<{ id: string; approverId: string; approverType: string }>;
+}
+
+/** The committable half — present only once the plan is fully resolved and `dryRun` is false. */
+export interface PreparedCopy {
+  // Object-storage path of the pre-copy backup of the target board, kept for 7 days.
+  snapshotPath: string;
+  customFieldsCopied: boolean;
+  rolesCopied: boolean;
+  newStageCount: number;
+  deletedOldStageCount: number;
+  ticketsToMigrate: number;
+  boardUpdate: PreparedBoardUpdate;
+  boardFormMapping: PreparedBoardFormMapping | null;
+  transitions: PreparedTransition[] | null;
+  // The per-ticket work left over, or null when there is none. Passed back verbatim to
+  // /start-ticket-migration after the configuration mutations land — the server re-validates
+  // every destination in it, so the screen treats it as an opaque blob.
+  ticketMigration: Record<string, unknown> | null;
+}
+
+/**
+ * One response covering both halves of `/prepare`. The descriptive fields are always
+ * returned once the board pair validates — they're what the remap picker renders from —
+ * while `prepared` is added only on a call that actually committed to the server-side work.
+ * Mirrors apps/backend/src/services/boardConfigCopyService.ts's `PrepareCopyResult`.
+ */
+export interface PrepareCopyResult {
+  errors: string[];
+  warnings: string[];
+  sourceBoard?: BoardSummary;
+  targetBoard?: BoardSummary;
+  newStages?: NewStageInfo[];
+  oldStages?: OldStageInfo[];
+  suggestedMapping?: Record<string, string>;
+  requiresExplicit?: string[];
+  prepared?: PreparedCopy;
+}
+
+/**
+ * What the result step renders — the config half returned by /prepare, applied through the
+ * Zero mutators. There is no ticket-migration result: that job runs in the background with
+ * no status endpoint to report through, by design (see BoardConfigCopyScreen.tsx).
+ */
+export interface CopyResultSummary {
+  customFieldsCopied: boolean;
+  rolesCopied: boolean;
+  snapshotPath?: string;
+  newStageCount: number;
+  deletedOldStageCount: number;
+  warnings: string[];
+}

--- a/apps/dashboard/src/components/Board/BoardConfigCopyScreen/StageRemapTable.tsx
+++ b/apps/dashboard/src/components/Board/BoardConfigCopyScreen/StageRemapTable.tsx
@@ -1,0 +1,113 @@
+import { ReactElement } from 'react';
+import { TicketStatusV2 } from '@xyne/shared';
+import { EntitySelector } from '../../ui/EntitySelector/EntitySelector';
+import type { SelectorOption } from '../../ui/EntitySelector/EntitySelector.types';
+
+// The only categories every board is guaranteed to have at least one stage of (enforced by
+// the backend's board.update validation). PAUSED/CANCELLED old stages aren't guaranteed a
+// same-category match on the source board, so they may map to a new stage of any category.
+const COMPULSORY_STATUS_CATEGORIES = new Set<string>([
+  TicketStatusV2.TODO,
+  TicketStatusV2.STARTED,
+  TicketStatusV2.COMPLETED,
+]);
+
+export interface StageRemapRow {
+  oldStageId: string;
+  oldStageName: string;
+  ticketCount: number;
+  defaultStatus: string;
+}
+
+export interface StageRemapNewStageOption {
+  id: string;
+  name: string;
+  defaultStatus: string;
+}
+
+interface StageRemapTableProps {
+  rows: StageRemapRow[];
+  newStageOptions: StageRemapNewStageOption[];
+  value: Record<string, string>;
+  onChange: (oldStageId: string, newStageId: string) => void;
+}
+
+export const StageRemapTable = ({
+  rows,
+  newStageOptions,
+  value,
+  onChange,
+}: StageRemapTableProps): ReactElement => {
+  // A ticket may only land on a new stage of the SAME status category it's already in
+  // (e.g. a ticket in a STARTED-category old stage may only be mapped to a STARTED-category
+  // new stage) — so each row gets its own filtered option list, not the full new-stage set.
+  // Exception: PAUSED/CANCELLED aren't guaranteed to exist on the source board (unlike
+  // TODO/STARTED/COMPLETED, which every board must have), so those rows offer every new
+  // stage regardless of category rather than potentially having nowhere to go at all.
+  const optionsByStatus = (status: string): SelectorOption[] =>
+    newStageOptions
+      .filter(stage => !COMPULSORY_STATUS_CATEGORIES.has(status) || stage.defaultStatus === status)
+      .map(stage => ({
+        value: stage.id,
+        label: stage.name,
+        icon: null,
+        subtitle: stage.defaultStatus,
+      }));
+
+  if (rows.length === 0) {
+    return (
+      <p className='text-sm text-muted-foreground py-3'>
+        No tickets on this board need an explicit mapping.
+      </p>
+    );
+  }
+
+  return (
+    <div className='border border-border rounded-md overflow-hidden'>
+      <table className='w-full text-sm'>
+        <thead className='bg-muted/40'>
+          <tr>
+            <th className='text-left px-3 py-2 font-medium text-muted-foreground'>Old stage</th>
+            <th className='text-left px-3 py-2 font-medium text-muted-foreground'>Tickets</th>
+            <th className='text-left px-3 py-2 font-medium text-muted-foreground'>New stage</th>
+          </tr>
+        </thead>
+        <tbody className='divide-y divide-border'>
+          {rows.map(row => {
+            const options = optionsByStatus(row.defaultStatus);
+            return (
+              <tr key={row.oldStageId}>
+                <td className='px-3 py-2 align-top'>
+                  <div className='font-medium text-foreground'>{row.oldStageName}</div>
+                  <div className='text-xs text-muted-foreground'>{row.defaultStatus}</div>
+                </td>
+                <td className='px-3 py-2 align-top text-muted-foreground'>{row.ticketCount}</td>
+                <td className='px-3 py-2 align-top'>
+                  {options.length === 0 ? (
+                    <p className='text-xs text-destructive'>
+                      No {row.defaultStatus} stage exists on the source board — this copy cannot
+                      proceed until one does.
+                    </p>
+                  ) : (
+                    <EntitySelector
+                      options={options}
+                      selectedValue={value[row.oldStageId] ?? null}
+                      onSelect={newStageId => {
+                        if (newStageId) onChange(row.oldStageId, newStageId);
+                      }}
+                      placeholder='Select new stage'
+                      searchPlaceholder='Search stages...'
+                      showSearch={true}
+                      width='220px'
+                      testId={`stage-remap-${row.oldStageId}`}
+                    />
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/Board/BoardConfigCopyScreen/index.ts
+++ b/apps/dashboard/src/components/Board/BoardConfigCopyScreen/index.ts
@@ -1,0 +1,1 @@
+export { default as BoardConfigCopyScreen } from './BoardConfigCopyScreen';

--- a/apps/dashboard/src/components/Board/BoardsTable/BoardsTable.tsx
+++ b/apps/dashboard/src/components/Board/BoardsTable/BoardsTable.tsx
@@ -19,6 +19,7 @@ interface BoardsTableProps {
   boards: readonly BoardWithStages[] | undefined;
   onEdit: (board: BoardWithStages) => void;
   onClone?: (board: BoardWithStages) => void;
+  onCopyConfig?: (board: BoardWithStages) => void;
   applicationBoardIds?: Set<string>;
 }
 
@@ -26,6 +27,7 @@ export const BoardsTable = ({
   boards,
   onEdit,
   onClone,
+  onCopyConfig,
   applicationBoardIds,
 }: BoardsTableProps): ReactElement => {
   const [copiedBoardId, setCopiedBoardId] = useState<string | null>(null);
@@ -158,6 +160,22 @@ export const BoardsTable = ({
                       <Edit2 size={14} />
                       {getBoardEditLabel(board, applicationBoardIds)}
                     </Button>
+                    {onCopyConfig && (
+                      <Button
+                        variant='secondary'
+                        onClick={() => onCopyConfig(board)}
+                        data-testid='copy-board-config-button'
+                        data-track-category='Board'
+                        data-track-name='Copy_Board_Config_Table'
+                        data-track-metadata={JSON.stringify({
+                          boardId: board.id,
+                          boardName: board.name,
+                        })}
+                      >
+                        <Copy size={14} />
+                        Copy config
+                      </Button>
+                    )}
                   </div>
                 </td>
               </tr>

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -23,6 +23,7 @@ import {
   ArrowRight,
   Archive,
   GitBranch,
+  Lock,
 } from 'lucide-react';
 import type { QueryResultType } from '@rocicorp/zero';
 import type {
@@ -113,7 +114,9 @@ import type { TicketClassificationData } from '../../../types/classification';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 import {
   resolveBoardAdditionalFields,
+  resolveLeftoverFieldValues,
   type ResolvedBoardAdditionalField,
+  type LeftoverFieldValue,
 } from '../../../utils/board/boardFormEntityValues';
 
 type SubTicketTreeMapping = QueryResultType<typeof queries.subTicketMappingsForTickets>[number];
@@ -310,6 +313,40 @@ const getFormEntityFieldEnum = (
     fieldValue.formField?.fieldEnum;
   const options = parseFieldOptionValues(fieldEnum);
   return options.length > 0 ? options : undefined;
+};
+
+/** Plain-text formatting for a retired field's read-only value — no edit affordance, so no need for the richer per-type widgets EditableFormField uses. */
+const formatLeftoverFieldValue = (
+  field: LeftoverFieldValue,
+  userById: ReadonlyMap<string, { id: string; name?: string | null; email?: string | null }>,
+): string => {
+  const raw = field.actualFieldValue ?? field.fieldValue;
+  if (raw === null || raw === undefined || raw === '') return '—';
+
+  if (field.fieldType === FormFieldType.BOOLEAN) {
+    if (typeof raw === 'boolean') return raw ? 'Yes' : 'No';
+    if (typeof raw === 'string') {
+      const normalized = raw.trim().toLowerCase();
+      if (normalized === 'true' || normalized === 'yes') return 'Yes';
+      if (normalized === 'false' || normalized === 'no') return 'No';
+    }
+  }
+
+  if (field.fieldType === FormFieldType.USER) {
+    const ids = Array.isArray(raw) ? raw.map(String) : typeof raw === 'string' ? [raw] : [];
+    if (ids.length === 0) return '—';
+    return ids
+      .map(id => {
+        const normalizedId = id.startsWith('user:') ? id.slice('user:'.length) : id;
+        const user = userById.get(normalizedId);
+        return user ? getUserDisplayName(user) : id;
+      })
+      .join(', ');
+  }
+
+  if (Array.isArray(raw)) return raw.map(String).join(', ') || '—';
+  if (typeof raw === 'object') return JSON.stringify(raw);
+  return String(raw);
 };
 
 // ── Stage Form Submissions Component ──────────────────────────────────────────
@@ -1400,6 +1437,25 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
       return isFieldActive({ parentOptionId }, allFieldDefs, getFieldEffectiveValue);
     });
   }, [formMapping, formEntityValues, ticketId, ticket?.boardId, ticket?.workspaceId]);
+
+  // Values this ticket has saved for fields no longer part of the board's current form —
+  // e.g. left behind by a "Copy Board Configuration" run that swapped in another board's
+  // form. Never deleted, just unreachable through the lookup above; shown separately and
+  // read-only rather than silently dropped.
+  const leftoverFieldValues = useMemo(
+    () =>
+      resolveLeftoverFieldValues({
+        formMapping: formMapping ?? undefined,
+        formEntityValues: formEntityValues as FormEntityValueWithField[] | undefined,
+        boardId: ticket?.boardId,
+      }),
+    [formMapping, formEntityValues, ticket?.boardId],
+  );
+
+  const leftoverFieldUserById = useMemo(() => {
+    const list = Array.isArray(users) ? users : [];
+    return new Map(list.map(user => [user.id, user]));
+  }, [users]);
 
   // Group form values by stage+version — shared with the Messages thread (StageMoveFormBlock)
   // so both surfaces render the exact same "Form submission" block.
@@ -3823,8 +3879,12 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
           </div>
         )}
 
-        {/* Additional Form Fields */}
-        {allFormFields && allFormFields.length > 0 && (
+        {/* Additional Form Fields — current, editable fields plus (marked with a trailing
+            "*") any values the ticket has for fields no longer part of the board's current
+            configuration (e.g. left behind by a config copy from another board). Those are
+            read-only rather than editable, since the field itself no longer exists in the
+            board's schema. */}
+        {(allFormFields.length > 0 || leftoverFieldValues.length > 0) && (
           <div className='border border-border bg-muted rounded-lg p-4 my-4'>
             <h3 className='text-base font-semibold text-foreground mb-4'>Additional Form Fields</h3>
             <div className='space-y-4'>
@@ -3844,6 +3904,20 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                     )
                   }
                 />
+              ))}
+              {leftoverFieldValues.map(field => (
+                <div key={field.resolvedFieldId} className='flex items-start gap-2 w-full'>
+                  <span
+                    className='flex items-center gap-1 text-sm text-muted-foreground w-[120px] flex-shrink-0 pt-0.5 overflow-x-auto whitespace-nowrap'
+                    title={`${field.fieldName} — no longer part of this board's configuration, read-only`}
+                  >
+                    {field.fieldName}
+                    <Lock size={11} className='flex-shrink-0 text-muted-foreground' />
+                  </span>
+                  <span className='flex-1 text-sm text-foreground break-all pt-0.5'>
+                    {formatLeftoverFieldValue(field, leftoverFieldUserById)}
+                  </span>
+                </div>
               ))}
             </div>
           </div>

--- a/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
@@ -8,6 +8,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import BoardEditScreen from '../../components/Board/BoardEditScreen/BoardEditScreen';
 import BoardStageConfigScreen from '../../components/Board/BoardStageConfigScreen/BoardStageConfigScreen';
 import { BoardRolesConfigScreen } from '../../components/Board/BoardRolesConfigScreen';
+import { BoardConfigCopyScreen } from '../../components/Board/BoardConfigCopyScreen';
 import BoardCreateScreen from '../../components/Board/BoardCreateScreen/BoardCreateScreen';
 import { BoardTypeChooserDialog } from '../../components/Board/BoardTypeChooserDialog/BoardTypeChooserDialog';
 import { FlowBoardCreateScreen } from '../../components/Board/FlowBoardCreateScreen/FlowBoardCreateScreen';
@@ -83,6 +84,7 @@ const ProjectDetailScreen = (): ReactElement => {
     useState<BoardWithStages | null>(null);
   const [configuringRolesForBoardId, setConfiguringRolesForBoardId] = useState<string | null>(null);
   const [boardIdToEdit, setBoardIdToEdit] = useState<string | null>(null);
+  const [copyConfigTargetBoard, setCopyConfigTargetBoard] = useState<BoardWithStages | null>(null);
 
   // Fetch project details
   const [project] = useCachedQuery(queries.projectById({ projectId: projectId || '' }), {
@@ -358,6 +360,7 @@ const ProjectDetailScreen = (): ReactElement => {
                   boards={boards}
                   onEdit={handleEditBoard}
                   onClone={board => setCloningFlowBoard(board)}
+                  onCopyConfig={board => setCopyConfigTargetBoard(board)}
                   applicationBoardIds={applicationBoardIds}
                 />
               </Tabs.Content>
@@ -637,6 +640,18 @@ const ProjectDetailScreen = (): ReactElement => {
             setConfiguringStagesForBoard(null);
             setBoardIdToEdit(null);
           }}
+        />
+      )}
+
+      {/* Copy Board Configuration Modal */}
+      {copyConfigTargetBoard && projectId && (
+        <BoardConfigCopyScreen
+          targetBoardId={copyConfigTargetBoard.id}
+          targetBoardName={copyConfigTargetBoard.name}
+          projectId={projectId}
+          isOpen={true}
+          onClose={() => setCopyConfigTargetBoard(null)}
+          onDone={() => setCopyConfigTargetBoard(null)}
         />
       )}
 

--- a/apps/dashboard/src/utils/board/boardFormEntityValues.ts
+++ b/apps/dashboard/src/utils/board/boardFormEntityValues.ts
@@ -82,6 +82,12 @@ export type ResolvedBoardAdditionalField = FormEntityValueRow & {
   isPlaceholder: boolean;
 };
 
+export type LeftoverFieldValue = FormEntityValueRow & {
+  resolvedFieldId: string;
+  fieldName: string;
+  fieldType: FormFieldType;
+};
+
 export const resolveBoardAdditionalFields = ({
   formMapping,
   formEntityValues,
@@ -154,4 +160,55 @@ export const resolveBoardAdditionalFields = ({
       isPlaceholder: true,
     };
   });
+};
+
+/**
+ * A ticket's own saved values for fields that are no longer part of the board's current
+ * form — e.g. a field the board had before a "Copy Board Configuration" run replaced its
+ * form with another board's. The value rows are never touched by a copy, only unreachable
+ * through the normal current-form-driven lookup above; this recovers them directly (via
+ * their own `formField`/`globalField` relation, exactly like `resolveFormFieldId` does) so
+ * they can still be shown — read-only, since they're no longer part of the form's schema.
+ */
+export const resolveLeftoverFieldValues = ({
+  formMapping,
+  formEntityValues,
+  boardId,
+}: {
+  formMapping: FormMappingLike | null | undefined;
+  formEntityValues: readonly FormEntityValueRow[] | undefined;
+  boardId: string | null | undefined;
+}): LeftoverFieldValue[] => {
+  const membershipRows = formMapping?.formFields;
+  const currentFieldIds = new Set(
+    formMapping?.formId && membershipRows
+      ? resolveDisplayFormFields(formMapping.formId, [...membershipRows]).map(field => field.id)
+      : [],
+  );
+  const values = formEntityValues ?? [];
+
+  // No entityType filter, matching resolveBoardAdditionalFields's sibling helpers above —
+  // formEntityValues is already scoped to this ticket by the caller's entityId query, so
+  // entityType filtering here would be redundant.
+  const latestByField = new Map<string, FormEntityValueRow>();
+  values
+    .filter(value => isBoardContextValue(value, boardId) && !currentFieldIds.has(value.fieldId))
+    .forEach(value => {
+      const current = latestByField.get(value.fieldId);
+      if (!current || (value.updatedAt ?? 0) > (current.updatedAt ?? 0)) {
+        latestByField.set(value.fieldId, value);
+      }
+    });
+
+  const resolved: LeftoverFieldValue[] = [];
+  for (const [resolvedFieldId, value] of latestByField) {
+    const fieldName = value.globalField?.fieldName ?? value.formField?.fieldName;
+    const fieldType = value.globalField?.fieldType ?? value.formField?.fieldType;
+    // Definition is gone too (e.g. a legacy field's row was hard-deleted) — nothing left
+    // to label this value with, so there's nothing safe to show.
+    if (!fieldName || !fieldType) continue;
+    resolved.push({ ...value, resolvedFieldId, fieldName, fieldType });
+  }
+
+  return resolved.sort((a, b) => a.fieldName.localeCompare(b.fieldName));
 };

--- a/apps/dashboard/src/utils/board/index.ts
+++ b/apps/dashboard/src/utils/board/index.ts
@@ -41,7 +41,9 @@ export {
 export {
   resolveBoardAdditionalFields,
   buildLatestEntityWideValueByField,
+  resolveLeftoverFieldValues,
   type ResolvedBoardAdditionalField,
+  type LeftoverFieldValue,
 } from './boardFormEntityValues';
 
 export {


### PR DESCRIPTION
feat: XYNE-55325 remove options

feat: XYNE-55325 resolve comments

Services-Requiring-Redeployment:
  - backend

feat: XYNE-55325 relax mapping condition

feat: XYNE-55325 typecheck

Services-Requiring-Redeployment:
  - backend

feat: XYNE-55325 resolve some comments

Services-Requiring-Redeployment:
  - backend
  - dashboard

feat: XYNE-55325 snapshot and other changes

Services-Requiring-Redeployment:
  - backend
  - dashboard

feat: XYNE-55325 add phase-0 in worker

Services-Requiring-Redeployment:
  - backend

feat: XYNE-55325 move api to zero

Services-Requiring-Redeployment:
  - backend
  - dashboard

feat: XYNE-55325 sec comments

Services-Requiring-Redeployment:
  - backend

feat: XYNE-55325 dont show info to user

Services-Requiring-Redeployment:
  - dashboard

feat: XYNE-55325 remove plan api

Services-Requiring-Redeployment:
  - backend
  - dashboard

feat: XYNE-55325 add logs

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
