### PR TITLE
fix: XYNE-54759 KB citation chunk mapping, PDF highlight, and chat re…

### DIFF
--- a/apps/backend/src/controllers/collectionController.ts
+++ b/apps/backend/src/controllers/collectionController.ts
@@ -37,9 +37,43 @@ import {
  */
 const HIGHLIGHT_SNIPPET_BASE_WORDS = 30;
 const HIGHLIGHT_SNIPPET_HARD_WORDS = 80;
+/**
+ * Drop the heading breadcrumb Docling prepends to a chunk — the document title
+ * and section path ("# <title>", "## CHAPTER – IV …") that precede the prose.
+ * Those lines come from the outline and are never contiguous with the body in
+ * the PDF's text layer, so a find window starting with them (as the 30-word one
+ * always did) matches nothing and no highlight appears.
+ *
+ * Returns the original text when a chunk is nothing but headings (a
+ * table-of-contents chunk), so the caller still has something to work with.
+ */
+function stripLeadingHeadings(raw: string): string {
+    const lines = raw.split(/\r?\n/);
+    let i = 0;
+    const isSkippable = (line: string): boolean => {
+        const t = line.trim();
+        if (t.length === 0) return true;
+        if (/^#{1,6}\s/.test(t)) return true; // markdown heading
+        if (/^[-–—*_]{3,}$/.test(t)) return true; // horizontal rule
+        // A line that is ENTIRELY bold/emphasis is a heading in disguise
+        // ("**RESERVE BANK OF INDIA**"). A bold-PREFIXED paragraph
+        // ("**26.** (1) An RE should…") is real prose — keep it.
+        if (/^\*\*[^*]+\*\*$/.test(t)) return true;
+        return false;
+    };
+    while (i < lines.length && isSkippable(lines[i]!)) i++;
+    const body = lines.slice(i).join('\n').trim();
+    return body.length > 0 ? body : raw;
+}
+
 function buildHighlightSnippet(raw: string | undefined | null): string | null {
-    const cleaned = String(raw ?? '')
-        .replace(/^\[Pages?\s+\d+(?:[-,\s\d]*)?\]\s*/i, '') // drop leading [Page N] / [Pages 1, 2, 3] marker
+    // Page marker FIRST: ingestion prepends it inline ("[Page 6] # Title…"), so
+    // the heading test below only fires once it's gone.
+    const withoutPageMarker = String(raw ?? '').replace(
+        /^\[Pages?\s+\d+(?:[-,\s\d]*)?\]\s*/i,
+        '',
+    );
+    const cleaned = stripLeadingHeadings(withoutPageMarker)
         .replace(/<[^>]+>/g, ' ')                      // strip HTML tags
         .replace(/&[a-z]+;|&#\d+;/gi, ' ')             // strip HTML entities
         .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')       // unwrap markdown links

--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -498,16 +498,18 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
             return '';
           };
           const snippetForIdx = (chunkIndex: number): string => {
+            // `chunks` on a hit is pruned by `select-elements-by: best_chunks`,
+            // so it holds the top-scoring chunks RE-NUMBERED from 0.
+            // `chunks_pos_summary` is `chunks_pos` pruned by the same selector,
+            // so it maps a document chunk index to its slot in that array.
+            // Indexing `chunks` by the document index instead served one chunk's
+            // text under another chunk's page — the reason every citation came
+            // back as chunk 0. Unplaceable text is dropped, not guessed at.
             const at = chunksPosSummary.indexOf(chunkIndex);
-            const fromSummary =
-              at >= 0 ? chunksSummary[at] : chunksSummary[chunkIndex];
-            const fromSummaryText = pickToText(fromSummary);
-            if (fromSummaryText) return fromSummaryText;
+            if (at < 0) return '';
             // Strip the [Page N] ingestion prefix to match kb-get-chunks output.
-            return pickToText(chunksFull[chunkIndex]).replace(
-              /^\[Page \d+(-\d+)?\]\s*/,
-              '',
-            );
+            return (pickToText(chunksSummary[at]) || pickToText(chunksFull[at]))
+              .replace(/^\[Page \d+(-\d+)?\]\s*/, '');
           };
           for (const r of ranked) {
             if (hits.length >= limitParsed) break;

--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -113,6 +113,12 @@ interface AIChatThreadProps {
   /** Bubbled up from the composer so the parent can preserve the user's
    *  selections when switching to a recent chat. */
   onContextChange?: ((context: ComposerContext) => void) | undefined;
+  /** Fired once the landing query has actually been submitted, so the parent can
+   *  drop it. The in-component guard is a `useRef`, which resets on remount — if
+   *  the parent keeps handing the same `initialQuery` back, ANY remount re-sends
+   *  it and opens yet another conversation. Clearing it at the source is the
+   *  guard that survives a remount. */
+  onInitialQueryConsumed?: (() => void) | undefined;
 }
 
 export interface AIChatThreadHandle {
@@ -1309,6 +1315,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
     onConversationChange,
     onAgentChange,
     onContextChange,
+    onInitialQueryConsumed,
   },
   ref,
 ): ReactElement {
@@ -1760,8 +1767,9 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
     };
   }, [sessionId, threadId, onConversationChange, effectiveAgentSlug, isV2]);
 
-  // Auto-submit initialQuery once on mount, applying the landing composer's
-  // chosen context/toggles to this first turn.
+  // Auto-submit initialQuery once, applying the landing composer's chosen
+  // context/toggles to this first turn. The ref guard resets on remount, so the
+  // parent is told to drop the query too — see `onInitialQueryConsumed`.
   useEffect(() => {
     if (initialQuery && !hasAutoSubmitted.current) {
       hasAutoSubmitted.current = true;
@@ -1778,8 +1786,11 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
         undefined,
         initialExtras ? toStreamOverrides(initialExtras) : undefined,
       );
+      // After the call, so "consumed" means "actually submitted" and the
+      // attachments above are read before the parent drops them.
+      onInitialQueryConsumed?.();
     }
-  }, [initialQuery, initialAttachments, initialExtras, submitQuery]);
+  }, [initialQuery, initialAttachments, initialExtras, submitQuery, onInitialQueryConsumed]);
 
   // Notify parent when conversationId changes (draft -> real session)
   useEffect(() => {

--- a/apps/dashboard/src/components/AIScreen/CitationDocsPanel.tsx
+++ b/apps/dashboard/src/components/AIScreen/CitationDocsPanel.tsx
@@ -177,26 +177,44 @@ export function CitationDocsPanel(): ReactElement | null {
 /**
  * Wraps the chat thread. When one or more citation docs are open, it splits the
  * area into a resizable chat column (left) + the citation docs panel (right).
- * With no docs open it renders the chat full-width. Must be rendered inside a
- * `CitationDocsProvider`.
+ * With no docs open the chat panel is alone and fills the width. Must be
+ * rendered inside a `CitationDocsProvider`.
+ *
+ * The group and the chat Panel render UNCONDITIONALLY; only the separator and
+ * docs Panel are appended. That is load-bearing: this used to return a bare
+ * `<>{children}</>` until a doc opened, which moved `children` to a different
+ * position in the element tree — React then remounts the whole subtree, and
+ * AIChatThread keeps the conversation in local state, so opening a citation
+ * wiped every message.
  */
 export function ChatWithCitationDocs({ children }: { children: ReactNode }): ReactElement {
   const ctx = useCitationDocs();
   const hasDocs = !!ctx && ctx.docs.length > 0;
-  if (!hasDocs) return <>{children}</>;
   return (
     <ResizableGroup
       orientation='horizontal'
       autoSaveId='ai-citation-docs'
+      // Which Panels are actually mounted, so the persisted layout restores
+      // against the right set instead of the last one written.
+      panelIds={hasDocs ? ['ai-chat', 'ai-citation-docs'] : ['ai-chat']}
       className='h-full w-full'
     >
-      <Panel id='ai-chat' defaultSize='55%' minSize='30%' className='min-w-0'>
+      <Panel
+        id='ai-chat'
+        defaultSize={hasDocs ? '55%' : '100%'}
+        minSize={hasDocs ? '30%' : '100%'}
+        className='min-w-0'
+      >
         {children}
       </Panel>
-      <Separator className='w-px bg-border transition-colors hover:bg-primary/40 active:bg-primary/60' />
-      <Panel id='ai-citation-docs' defaultSize='45%' minSize='25%' className='min-w-0'>
-        <CitationDocsPanel />
-      </Panel>
+      {hasDocs && (
+        <>
+          <Separator className='w-px bg-border transition-colors hover:bg-primary/40 active:bg-primary/60' />
+          <Panel id='ai-citation-docs' defaultSize='45%' minSize='25%' className='min-w-0'>
+            <CitationDocsPanel />
+          </Panel>
+        </>
+      )}
     </ResizableGroup>
   );
 }

--- a/apps/dashboard/src/components/AIScreen/ComposerCollectionPicker.tsx
+++ b/apps/dashboard/src/components/AIScreen/ComposerCollectionPicker.tsx
@@ -169,9 +169,12 @@ export function ComposerCollectionPicker({
         title='Select collections'
         className={cn(
           'inline-flex h-8 w-8 items-center justify-center rounded-full transition',
-          collections.length > 0
+          // Accent only while something is actually scoped — idle matches the
+          // neighbouring ToolbarButtons so the row reads as one set. Files count
+          // as a selection too: this picker sets both.
+          collections.length > 0 || fileScopes.length > 0
             ? 'bg-secondary text-[#7C3AED]'
-            : 'text-[#7C3AED] hover:bg-secondary',
+            : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
         )}
         data-track-category='XyneAI'
         data-track-name='OPEN_COLLECTION_SELECTOR'

--- a/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
@@ -165,6 +165,16 @@ const AIScreen = (): ReactElement => {
     lastContextRef.current = context;
   }, []);
 
+  // The thread has fired the landing query — drop it so it can never be
+  // auto-submitted twice. Without this the thread's `useRef` guard resets on any
+  // remount and the same query is sent again as a NEW conversation.
+  // `initialExtras` is deliberately kept: it seeds the chat composer's context
+  // selections for the whole conversation, not just the first turn.
+  const handleInitialQueryConsumed = useCallback((): void => {
+    setInitialQuery('');
+    setInitialAttachments(undefined);
+  }, []);
+
   const handleComposerSubmit = useCallback(
     (text: string, attachments?: AIComposerAttachment[], context?: ComposerContext): void => {
       setInitialQuery(text);
@@ -245,6 +255,7 @@ const AIScreen = (): ReactElement => {
               onConversationChange={handleConversationChange}
               onAgentChange={handleAgentChange}
               onContextChange={handleContextChange}
+              onInitialQueryConsumed={handleInitialQueryConsumed}
             />
           </ChatWithCitationDocs>
         ) : (


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-54759 — Knowledge Base citations were unusable: every chip resolved to the same
chunk, nothing highlighted, and clicking one threw away the conversation.

**1. Every citation resolved to chunk 0.** `snippetForIdx` looked the chunk text up in
`fields.chunks_summary`, which exists in neither schema, so the slot it had just resolved
from `chunks_pos_summary` was discarded and it fell through to `chunks[chunkIndex]`. On a
search hit `chunks` is pruned by `select-elements-by: best_chunks` and re-numbered from 0,
so indexing it by a document index returned nothing for almost every hit — and, for index
0, the top-ranked chunk's text under a different chunk's page number. Across three captured
runs only ~5% of hits carried any text, all on the chunk-0 row, so the model could only ever
cite `#0`. Now mapped through the position array; text that cannot be placed is dropped
rather than guessed at. Scope: `kb-search-within-doc` only — it is the sole caller that
reaches this branch (`kb-get-chunks` uses the unpruned document fetch, and regular search
never sets `includeChunkLevel`).

**2. Nothing ever highlighted.** Docling prepends the heading breadcrumb (document title,
chapter, section) to each chunk and the highlight window started there — fragments that are
never contiguous in the PDF's text layer, so pdf.js's literal find matched nothing. The
snippet now starts at the first prose line.

**3. Clicking a citation reset the chat.** `ChatWithCitationDocs` returned a bare fragment
until a doc opened and then switched to a resizable group, moving `children` in the element
tree; React remounts that subtree, and the thread holds its messages in local state. The
group and chat panel now render unconditionally.

**4. That remount re-sent the landing query as a NEW conversation,** because the
`hasAutoSubmitted` ref resets on mount and the parent never cleared `initialQuery`. The
thread now reports consumption so the parent drops it.

Also: the collection picker's book icon was accented in both states; it is now grey until a
collection or file is actually scoped.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

Response *shape* is unchanged — `hits[].snippet` is populated correctly instead of being
empty or carrying another chunk's text.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind