### PR TITLE
feat: XYNE-55834 added isOverdue column in tickets

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -100,6 +100,7 @@ export const ticketTable = table("tickets")
     userGroupId: string().optional(),
     boardId: string(),
     stageName: string(),
+    isStageOverdue: boolean().optional(),
     ticketType: string().optional(),
     isArchived: boolean(),
     kanbanPosition: string().optional(),

--- a/apps/backend/prisma/migrations/20260806120000_add_is_stage_overdue_to_tickets/migration.sql
+++ b/apps/backend/prisma/migrations/20260806120000_add_is_stage_overdue_to_tickets/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."tickets"
+ADD COLUMN "isStageOverdue" BOOLEAN ;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -141,6 +141,7 @@ model Ticket {
   userGroupId      String?            // User group to which the ticket belongs
   boardId          String            // Board to which the ticket belongs
   stageName        String            // Current stage of the ticket
+  isStageOverdue   Boolean?          // Derived from the active ticket_stage_eta row for the current stage
   ticketType       String?
   isArchived       Boolean           @default(false)
   kanbanPosition   String?

--- a/apps/backend/src/apps/controllers/ticketController.ts
+++ b/apps/backend/src/apps/controllers/ticketController.ts
@@ -56,6 +56,7 @@ import {
   type CustomFieldWritePayload,
 } from '@/services/ticketCustomFieldService';
 import { emitTicketUpdated } from '@/automations/triggers/ticket-updated.trigger';
+import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
 
 const externalSourceRepo = new ExternalSourceRepository();
 const emailChannelPreferenceRepo = new EmailChannelPreferenceRepository();
@@ -404,6 +405,8 @@ const transferTicketToBoard = async (params: {
         },
       });
     }
+
+    await syncStageOverdueFlag(tx, ticketId, now);
 
     await syncConversationTicketMdFromPrismaTicket(tx, updatedTicket);
   });

--- a/apps/backend/src/database/repositories/ticketRepository.ts
+++ b/apps/backend/src/database/repositories/ticketRepository.ts
@@ -31,6 +31,7 @@ import { dualWriteTicketTag, dualWriteTicketTags } from '@/services/ticketTagDua
 import type { TicketLike } from '@/automations/triggers/ticket-context';
 import { dispatchCommittedTicketStatusChange } from '@/services/flowStatusChangeDispatcher';
 import { updateWhileFlowRunActive } from '@/services/flowActiveRunGuard';
+import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
 //import { queueTicketIngestion } from '@/queues/vespaQueue';
 
 const prisma = DatabaseClient.getInstance();
@@ -53,6 +54,7 @@ const makeFallbackCountsSnapshot = (ticket: {
   createdBy: string;
   userGroupId: string | null;
   ticketType: string | null;
+  isStageOverdue?: boolean | null;
   eta: Date | null;
   createdAt: Date;
 }) => ({
@@ -67,6 +69,7 @@ const makeFallbackCountsSnapshot = (ticket: {
   createdBy: ticket.createdBy,
   userGroupId: ticket.userGroupId,
   ticketType: ticket.ticketType,
+  isStageOverdue: ticket.isStageOverdue ?? false,
   eta: ticket.eta?.getTime() ?? null,
   createdAt: ticket.createdAt.getTime(),
   prReviewers: [],
@@ -515,6 +518,8 @@ export class TicketRepository {
           updatedAt: new Date()
         }
       }));
+
+    await syncStageOverdueFlag(prisma, ticketId, now);
 
     if (statusChanged && options.cascadeFlow !== false) {
       await dispatchCommittedTicketStatusChange({

--- a/apps/backend/src/services/stageReconstructionService.ts
+++ b/apps/backend/src/services/stageReconstructionService.ts
@@ -6,6 +6,7 @@ import { withWorkspaceScope } from '@/database/tenant/context';
 import { syncConversationTicketMdFromPrismaTicket } from '@/utils/ticketMd';
 import { calculateETADeadline } from '@/utils/etaCalculation';
 import { logger } from '@/utils/logger';
+import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
 
 type PrismaTransaction = Omit<
   PrismaClient,
@@ -478,6 +479,8 @@ export class StageReconstructionService {
             });
           }
         }
+
+        await syncStageOverdueFlag(tx, ticket.id, now);
 
         await tx.ticketActivity.create({
           data: {

--- a/apps/backend/src/services/stageTransition/ticketStageTransitionService.ts
+++ b/apps/backend/src/services/stageTransition/ticketStageTransitionService.ts
@@ -8,6 +8,7 @@ import { FormEntityType, BoardType, VisitSlaMode, ReenterMode, TicketStageReques
 import { formService } from '@/services/formService';
 import { decideVisitVersion, foldFormRowsToValues } from './visitVersioning';
 import { maybeCreateEntryApprovalRequest } from './stageEntryApproval';
+import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
 
 const prisma = DatabaseClient.getInstance();
 
@@ -438,6 +439,8 @@ export class TicketStageTransitionService {
           updatedAt: now,
         },
       });
+
+      await syncStageOverdueFlag(tx, ticketId, now);
 
       // 8f. Persist form values (scoped to stage + visitIndex)
       if (formValues && transition?.formId) {

--- a/apps/backend/src/services/tickets/kanbanCountsSnapshotService.ts
+++ b/apps/backend/src/services/tickets/kanbanCountsSnapshotService.ts
@@ -14,6 +14,7 @@ export type KanbanCountsSnapshot = {
   createdBy: string | null;
   userGroupId: string | null;
   ticketType: string | null;
+  isStageOverdue: boolean;
   eta: number | null;
   createdAt: number;
   tags: string[];
@@ -43,10 +44,19 @@ export const buildKanbanCountsSnapshot = async (
       createdBy: true,
       userGroupId: true,
       ticketType: true,
+      isStageOverdue: true,
       eta: true,
       createdAt: true,
     },
-  });
+  }) as (KanbanCountsSnapshot & {
+    assignedTo: string | null;
+    createdBy: string | null;
+    userGroupId: string | null;
+    ticketType: string | null;
+    eta: Date | null;
+    createdAt: Date;
+    isStageOverdue?: boolean | null;
+  }) | null;
 
   if (!ticket) return null;
 
@@ -113,6 +123,7 @@ export const buildKanbanCountsSnapshot = async (
     createdBy: ticket.createdBy,
     userGroupId: ticket.userGroupId,
     ticketType: ticket.ticketType,
+    isStageOverdue: Boolean(ticket.isStageOverdue),
     eta: toMillis(ticket.eta),
     createdAt: ticket.createdAt.getTime(),
     tags: tags.map(tag => tag.name),

--- a/apps/backend/src/services/tickets/kanbanQueryBuilder.ts
+++ b/apps/backend/src/services/tickets/kanbanQueryBuilder.ts
@@ -265,15 +265,10 @@ export const buildKanbanTicketWhere = (
       hasItems(filters.stages) ? { stageName: { in: [...filters.stages] } } : undefined,
       hasItems(filters.ticketTypes) ? { ticketType: { in: [...filters.ticketTypes] } } : undefined,
       context.showOverdueOnly
-        ? {
+        ? ({
             statusV2: { notIn: [TicketStatusV2.COMPLETED, TicketStatusV2.CANCELLED] },
-            stageEtaEntries: {
-              some: {
-                stageLeftAt: null,
-                stageEta: { lt: new Date() },
-              },
-            },
-          }
+            isStageOverdue: true,
+          } as Prisma.TicketWhereInput)
         : undefined,
     ]),
   };

--- a/apps/backend/src/services/tickets/syncStageOverdueFlag.ts
+++ b/apps/backend/src/services/tickets/syncStageOverdueFlag.ts
@@ -1,0 +1,56 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+import { OPEN_STATUSES } from '@/utils/etaNotificationUtils';
+
+type StageOverdueDbClient = PrismaClient | Prisma.TransactionClient;
+const OPEN_STATUS_SET = new Set<string>(OPEN_STATUSES);
+
+export async function syncStageOverdueFlag(
+  db: StageOverdueDbClient,
+  ticketId: string,
+  now: Date = new Date(),
+): Promise<void> {
+  const ticket = await db.ticket.findUnique({
+    where: { id: ticketId },
+    select: {
+      statusV2: true,
+      isArchived: true,
+      stageName: true,
+      isStageOverdue: true,
+    },
+  });
+
+  if (!ticket) return;
+
+  let shouldBeOverdue = false;
+
+  if (!ticket.isArchived && OPEN_STATUS_SET.has(ticket.statusV2)) {
+    const activeStageEntry = await db.ticketStageEta.findFirst({
+      where: {
+        ticketId,
+        stageLeftAt: null,
+      },
+      select: {
+        stageEta: true,
+        stage: {
+          select: {
+            name: true,
+          },
+        },
+      },
+    });
+
+    shouldBeOverdue =
+      activeStageEntry !== null &&
+      activeStageEntry.stage.name === ticket.stageName &&
+      activeStageEntry.stageEta <= now;
+  }
+
+  if (ticket.isStageOverdue === shouldBeOverdue) return;
+
+  await db.ticket.update({
+    where: { id: ticketId },
+    data: {
+      isStageOverdue: shouldBeOverdue,
+    },
+  });
+}

--- a/apps/backend/src/workers/stageEtaDeadlineWorker.ts
+++ b/apps/backend/src/workers/stageEtaDeadlineWorker.ts
@@ -1,40 +1,16 @@
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
-import { runAsServiceActor } from '@/database/tenant/context';
 import { stageEtaDeadlineQueue } from '@/queues/stageEtaDeadlineQueue';
-import { TicketsSideEffectHandler } from '@/zero/side-effects/tables/tickets-handler';
-import { ActivityType } from '@xyne/shared';
-import {
-  getUsersToNotifyForTicket,
-  getTicketBotActorId,
-  isSameTimeDaily,
-  calculateDaysOverdueExact,
-  createEtaSystemMessage,
-  TicketWithStageInfo,
-  OPEN_STATUSES,
-} from '@/utils/etaNotificationUtils';
+import { OPEN_STATUSES } from '@/utils/etaNotificationUtils';
 
-// Window for initial breach notification (30 minutes)
-const BREACH_WINDOW_MS = 30 * 60 * 1000;
-const STAGE_ETA_REMINDER_BATCH_SIZE = 50;
-const STAGE_ETA_REMINDER_BATCH_DELAY_MS = 1000;
+const BATCH_SIZE = parseInt(process.env.STAGE_ETA_DEADLINE_BATCH_SIZE || '15', 10);
+const BATCH_SLEEP_MS = parseInt(process.env.STAGE_ETA_DEADLINE_BATCH_SLEEP_MS || '1000', 10);
 
-const chunkArray = <T>(items: T[], chunkSize: number): T[][] => {
-  if (chunkSize <= 0) return [items];
-  const chunks: T[][] = [];
-  for (let index = 0; index < items.length; index += chunkSize) {
-    chunks.push(items.slice(index, index + chunkSize));
-  }
-  return chunks;
-};
-
-const sleep = async (ms: number): Promise<void> => {
-  if (ms <= 0) return;
-  await new Promise(resolve => setTimeout(resolve, ms));
-};
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
 class StageEtaDeadlineWorker {
   private isInitialized = false;
+  private isProcessing = false;
 
   async start(): Promise<void> {
     if (this.isInitialized) return;
@@ -44,6 +20,12 @@ class StageEtaDeadlineWorker {
     const queue = stageEtaDeadlineQueue.getQueue();
 
     queue.process('check-stage-eta-deadlines', async () => {
+      if (this.isProcessing) {
+        logger.warn(
+          '[STAGE-ETA-DEADLINE-WORKER] Skipping job: previous job still in progress',
+        );
+        return;
+      }
       return this.processJob();
     });
 
@@ -59,159 +41,59 @@ class StageEtaDeadlineWorker {
   }
 
   private async processJob(): Promise<void> {
-    logger.info(
-      '[STAGE-ETA-DEADLINE-WORKER] Processing stage ETA deadline check job',
-    );
-    await this.checkAndNotifyStageEtaDeadlines();
-    logger.info('[STAGE-ETA-DEADLINE-WORKER] Stage ETA deadline check completed');
-  }
-
-  private async checkAndNotifyStageEtaDeadlines(): Promise<void> {
-    const now = new Date();
-
+    this.isProcessing = true;
     try {
-      // 1. Get open tickets with stage info, excluding tickets where overall ETA is breached
-      const tickets = await this.getOpenTickets(now);
-      
-      if (tickets.length === 0) return;
-
-      // 3. Check stage ETA for remaining tickets and create activities
-      await this.checkAndNotifyForStageEta(tickets, now);
+      logger.info(
+        '[STAGE-ETA-DEADLINE-WORKER] Processing stage ETA deadline check job',
+      );
+      await this.syncStageOverdueFlags();
+      logger.info('[STAGE-ETA-DEADLINE-WORKER] Stage ETA deadline check completed');
     } catch (error) {
       logger.error('[STAGE-ETA-DEADLINE-WORKER] Error checking stage ETA deadlines:', error);
       throw error;
+    } finally {
+      this.isProcessing = false;
     }
   }
 
-  private async getOpenTickets(now: Date): Promise<TicketWithStageInfo[]> {
-    // Get today at midnight for date comparison
-    const todayMidnight = new Date(now);
-    todayMidnight.setHours(0, 0, 0, 0);
+  private async syncStageOverdueFlags(now: Date = new Date()): Promise<void> {
+    const overdueTicketIds = await this.getOverdueTicketIds(now);
 
-    return await db.ticket.findMany({
-      where: {
-        statusV2: { in: OPEN_STATUSES },
-        // Exclude tickets where overall ETA is breached (eta < today at midnight)
-        OR: [
-          { eta: null },
-          { eta: { gte: todayMidnight } },
-        ],
-      },
-      select: {
-        id: true,
-        xyneId: true,
-        assignedTo: true,
-        createdBy: true,
-        channelId: true,
-        conversationId: true,
-        stageName: true,
-        eta: true,
-        workspaceId: true,
-      },
-    });
+    if (overdueTicketIds.length === 0) return;
+
+    for (let i = 0; i < overdueTicketIds.length; i += BATCH_SIZE) {
+      await db.ticket.updateMany({
+        where: {
+          id: { in: overdueTicketIds.slice(i, i + BATCH_SIZE) },
+          isStageOverdue: false,
+        } as any,
+        data: { isStageOverdue: true } as any,
+      });
+      if (i + BATCH_SIZE < overdueTicketIds.length) {
+        await sleep(BATCH_SLEEP_MS);
+      }
+    }
   }
 
-  private async checkAndNotifyForStageEta(
-    tickets: TicketWithStageInfo[],
-    now: Date
-  ): Promise<void> {
-    // Get active stage entries for these tickets
-    const activeStageEntries = await db.ticketStageEta.findMany({
+  private async getOverdueTicketIds(now: Date): Promise<string[]> {
+    const overdueEntries = await db.ticketStageEta.findMany({
       where: {
-        ticketId: { in: tickets.map(t => t.id) },
         stageLeftAt: null,
         stageEta: { lte: now },
+        ticket: {
+          statusV2: { in: OPEN_STATUSES },
+        },
+      },
+      select: {
+        ticketId: true,
+        stage: { select: { name: true } },
+        ticket: { select: { stageName: true } },
       },
     });
 
-    if (activeStageEntries.length === 0) return;
-
-    // Get stage info
-    const stageIds = [...new Set(activeStageEntries.map(e => e.stageId))];
-    const stages = await db.stage.findMany({
-      where: { id: { in: stageIds } },
-      select: { id: true, name: true, eta: true },
-    });
-
-    const ticketMap = new Map(tickets.map(t => [t.id, t]));
-    const stageMap = new Map(stages.map(s => [s.id, s]));
-
-    const entryBatches = chunkArray(activeStageEntries, STAGE_ETA_REMINDER_BATCH_SIZE);
-
-    for (let batchIndex = 0; batchIndex < entryBatches.length; batchIndex += 1) {
-      const entryBatch = entryBatches[batchIndex]!;
-
-      logger.info(
-        `[STAGE-ETA-DEADLINE-WORKER] Processing stage ETA batch ${batchIndex + 1}/${entryBatches.length} (${entryBatch.length} entries)`
-      );
-
-      for (const entry of entryBatch) {
-        const ticket = ticketMap.get(entry.ticketId);
-        const stage = stageMap.get(entry.stageId);
-
-        if (!ticket || !stage) continue;
-
-        const actorId = await getTicketBotActorId(ticket.workspaceId);
-
-        // Skip if stage ETA is not set on the board (ETA was disabled after entry was created)
-        if (stage.eta === null || stage.eta === 0) continue;
-
-        // Get stage name from stage entry and compare with ticket's current stage
-        if (stage.name !== ticket.stageName) continue;
-
-        const stageEta = new Date(entry.stageEta!);
-        if (stageEta > now) continue;
-
-        const timeSinceBreach = now.getTime() - stageEta.getTime();
-        const daysOverdue = calculateDaysOverdueExact(stageEta, now);
-        const isInitialBreach = timeSinceBreach <= BREACH_WINDOW_MS;
-        const isFollowUpTime = timeSinceBreach > BREACH_WINDOW_MS && isSameTimeDaily(stageEta, now);
-
-        if (!isInitialBreach && !isFollowUpTime) continue;
-
-        const overdueText = daysOverdue === 0 ? 'due today' : `overdue (${daysOverdue} days)`;
-        const message = isInitialBreach
-          ? `Ticket ${ticket.xyneId} stage "${stage.name}" is ${overdueText}`
-          : `Reminder: Ticket ${ticket.xyneId} stage "${stage.name}" is still ${overdueText}`;
-
-        const usersToNotify = await getUsersToNotifyForTicket(
-          ticket.id,
-          ticket.assignedTo,
-          ticket.createdBy
-        );
-
-        await TicketsSideEffectHandler.createEtaBreachActivities({
-          ticketId: ticket.id,
-          xyneId: ticket.xyneId,
-          channelId: ticket.channelId,
-          userIds: usersToNotify,
-          actorAction: 'stage_eta_breach',
-          actorId,
-          stageName: stage.name,
-          daysOverdue,
-        });
-
-        if (ticket.conversationId) {
-          await runAsServiceActor('stage-eta-deadline-worker', ticket.workspaceId,
-            () => createEtaSystemMessage({
-              conversationId: ticket.conversationId!,
-              content: message,
-              createdAt: now,
-              activityType: ActivityType.STAGE_ETA,
-              stageId: stage.id,
-            }),
-          );
-        }
-
-        logger.info(
-          `[STAGE-ETA-DEADLINE-WORKER] ${isInitialBreach ? 'Initial breach' : 'Follow-up'} reminder for ticket ${ticket.xyneId} stage "${stage.name}" (${daysOverdue} days overdue)`
-        );
-      }
-
-      if (batchIndex < entryBatches.length - 1) {
-        await sleep(STAGE_ETA_REMINDER_BATCH_DELAY_MS);
-      }
-    }
+    return overdueEntries
+      .filter(entry => entry.stage.name === entry.ticket.stageName)
+      .map(entry => entry.ticketId);
   }
 
   async shutdown(): Promise<void> {

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -105,8 +105,6 @@ const kanbanTicketsPageArgsSchema = z.object({
     .optional(),
   filters: kanbanTicketPageFiltersSchema.optional(),
   formEntityValueFieldIds: z.array(z.string()).optional(),
-  showOverdueOnly: z.boolean().optional(),
-  overdueReferenceTime: z.number().optional(),
 });
 
 type KanbanTicketsPageArgs = z.infer<typeof kanbanTicketsPageArgsSchema>;
@@ -120,9 +118,15 @@ const kanbanTicketPageV2FiltersSchema = kanbanTicketPageFiltersSchema.extend({
 const kanbanTicketsPageV2ArgsSchema = kanbanTicketsPageArgsSchema.extend({
   filters: kanbanTicketPageV2FiltersSchema.optional(),
   dir: z.literal('forward').or(z.literal('backward')).optional(),
+  showOverdueOnly: z.boolean().optional(),
+  overdueReferenceTime: z.number().optional(),
 });
 
 type KanbanTicketsPageV2Args = z.infer<typeof kanbanTicketsPageV2ArgsSchema>;
+
+const kanbanTicketsPageV3ArgsSchema = kanbanTicketsPageV2ArgsSchema;
+
+type KanbanTicketsPageV3Args = z.infer<typeof kanbanTicketsPageV3ArgsSchema>;
 
 const prefixedKanbanIdentityValues = (id: string): string[] => [
   id,
@@ -230,8 +234,6 @@ const applyKanbanTicketPageConditions = (
     vespaTicketIds,
     dynamicFieldScalarFilters,
     filters,
-    showOverdueOnly,
-    overdueReferenceTime,
   } = args;
 
   if (stageName) {
@@ -420,19 +422,6 @@ const applyKanbanTicketPageConditions = (
     });
   }
 
-  if (showOverdueOnly) {
-    const overdueBefore = overdueReferenceTime ?? Date.now();
-    query = query.where((helpers: any) =>
-      helpers.and(
-        helpers.cmp('statusV2', '!=', TicketStatusV2.COMPLETED),
-        helpers.cmp('statusV2', '!=', TicketStatusV2.CANCELLED),
-        helpers.exists('stageEtaEntries', (stageEtaEntry: any) =>
-          stageEtaEntry.where('stageLeftAt', 'IS', null).where('stageEta', '<', overdueBefore),
-        ),
-      ),
-    );
-  }
-
   if (vespaTicketIds) {
     if (vespaTicketIds.length === 0) {
       return query.where('id', '__kanban_vespa_no_match__');
@@ -480,7 +469,28 @@ const applyKanbanTicketPageConditions = (
   return query;
 };
 
-const applyKanbanTicketPageV2Conditions = (
+const applyOverdueStageEtaFilter = <
+  TArgs extends { showOverdueOnly?: boolean; overdueReferenceTime?: number }
+>(
+  query: any,
+  args: TArgs,
+) => {
+  if (!args.showOverdueOnly) return query;
+
+  const overdueBefore = args.overdueReferenceTime ?? Date.now();
+  return query.where((helpers: any) =>
+    helpers.and(
+      helpers.cmp('statusV2', '!=', TicketStatusV2.COMPLETED),
+      helpers.cmp('statusV2', '!=', TicketStatusV2.CANCELLED),
+      helpers.exists('stageEtaEntries', (stageEtaEntry: any) =>
+        stageEtaEntry.where('stageLeftAt', 'IS', null).where('stageEta', '<', overdueBefore),
+      ),
+    ),
+  );
+};
+
+// Shared logic for V2 extended filters (role assignments) - does NOT include overdue filtering
+const applyKanbanTicketPageV2BaseConditions = (
   query: any,
   ctx: { userID: string },
   args: KanbanTicketsPageV2Args,
@@ -494,6 +504,37 @@ const applyKanbanTicketPageV2Conditions = (
         assignment.where('roleId', roleAssignment.roleId).where('userId', 'IN', roleAssignment.userIds),
       );
     }
+  }
+
+  return query;
+};
+
+// V2: Uses stageEtaEntries relation for overdue filtering (same as main branch)
+const applyKanbanTicketPageV2Conditions = (
+  query: any,
+  ctx: { userID: string },
+  args: KanbanTicketsPageV2Args,
+) => {
+  query = applyKanbanTicketPageV2BaseConditions(query, ctx, args);
+  return applyOverdueStageEtaFilter(query, args);
+};
+
+// V3: Uses isStageOverdue column instead of stageEtaEntries relation
+const applyKanbanTicketPageV3Conditions = (
+  query: any,
+  ctx: { userID: string },
+  args: KanbanTicketsPageV3Args,
+) => {
+  query = applyKanbanTicketPageV2BaseConditions(query, ctx, args);
+
+  if (args.showOverdueOnly) {
+    query = query.where((helpers: any) =>
+      helpers.and(
+        helpers.cmp('statusV2', '!=', TicketStatusV2.COMPLETED),
+        helpers.cmp('statusV2', '!=', TicketStatusV2.CANCELLED),
+        helpers.cmp('isStageOverdue', true),
+      ),
+    );
   }
 
   return query;
@@ -1086,6 +1127,33 @@ export const queries: AnyQueryRegistry = defineQueries({
         .limit(args.limit)
         .related('assignments', (a: any) => a.related('role'))
         .related('stageEtaEntries')
+        .related('tagMappings');
+
+      if (args.formEntityValueFieldIds?.length) {
+        finalQuery = finalQuery.related('formEntityValues', (fev: any) =>
+          fev.where('fieldId', 'IN', args.formEntityValueFieldIds ?? []).related('formField').related('globalField'),
+        );
+      }
+
+      return finalQuery;
+    },
+  ),
+
+  kanbanTicketsPageV3: defineQuery(
+    kanbanTicketsPageV3ArgsSchema,
+    ({ ctx, args }) => {
+      const dir = args.dir ?? 'forward';
+      let query = applyKanbanTicketPageV3Conditions(zql.tickets, ctx, args)
+        .orderBy('createdAt', dir === 'forward' ? 'desc' : 'asc')
+        .orderBy('id', dir === 'forward' ? 'asc' : 'desc');
+
+      if (args.start) {
+        query = query.start({ createdAt: args.start.createdAt, id: args.start.id }, { inclusive: false });
+      }
+
+      let finalQuery = query
+        .limit(args.limit)
+        .related('assignments', (a: any) => a.related('role'))
         .related('tagMappings');
 
       if (args.formEntityValueFieldIds?.length) {

--- a/apps/backend/src/zero/side-effects/tables/ticket-stage-eta-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/ticket-stage-eta-handler.ts
@@ -3,9 +3,16 @@ import { ActivityClassification } from '@xyne/shared';
 import type { SideEffectJobConfig, TicketStageEtaPreviousValue } from '../types';
 import { db } from '@/database/client';
 import { activityService } from '@/services/activity/activityService';
+import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
 import { logger } from '@/utils/logger';
 
 export class TicketStageEtaSideEffectHandler extends BaseSideEffectHandler {
+  async onInsert(job: SideEffectJobConfig): Promise<void> {
+    const ticketId = this.getTicketId(job);
+    if (!ticketId) return;
+    await syncStageOverdueFlag(db, ticketId);
+  }
+
   async onUpdate(job: SideEffectJobConfig): Promise<void> {
     const { entityId: ticketStageEtaId, args, previousValue } = job;
 
@@ -17,6 +24,8 @@ export class TicketStageEtaSideEffectHandler extends BaseSideEffectHandler {
     const prev = previousValue as TicketStageEtaPreviousValue;
     const actorId = this.ctx.userID;
 
+    await syncStageOverdueFlag(db, prev.ticketId);
+
     // Only track stageEta changes
     const stageEtaChanged = args.stageEta !== undefined && args.stageEta !== prev.stageEta;
 
@@ -25,7 +34,6 @@ export class TicketStageEtaSideEffectHandler extends BaseSideEffectHandler {
     }
 
     try {
-      
       // Fetch ticket details for activity creation
       const ticket = await db.ticket.findUnique({
         where: { id: prev.ticketId },
@@ -67,5 +75,22 @@ export class TicketStageEtaSideEffectHandler extends BaseSideEffectHandler {
     } catch (error) {
       logger.error(`[TicketStageEtaSideEffectHandler] Failed to create activities:`, error);
     }
+  }
+
+  async onDelete(job: SideEffectJobConfig): Promise<void> {
+    const ticketId = this.getTicketId(job);
+    if (!ticketId) return;
+    await syncStageOverdueFlag(db, ticketId);
+  }
+
+  async onUpsert(job: SideEffectJobConfig): Promise<void> {
+    const ticketId = this.getTicketId(job);
+    if (!ticketId) return;
+    await syncStageOverdueFlag(db, ticketId);
+  }
+
+  private getTicketId(job: SideEffectJobConfig): string | null {
+    const previousValue = job.previousValue as TicketStageEtaPreviousValue | undefined;
+    return job.args?.ticketId ?? previousValue?.ticketId ?? null;
   }
 }

--- a/apps/backend/src/zero/side-effects/tables/tickets-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/tickets-handler.ts
@@ -124,6 +124,7 @@ export class TicketsSideEffectHandler extends BaseSideEffectHandler {
           createdBy: fullTicket.createdBy,
           userGroupId: fullTicket.userGroupId,
           ticketType: fullTicket.ticketType,
+          isStageOverdue: Boolean((fullTicket as typeof fullTicket & { isStageOverdue?: boolean | null }).isStageOverdue),
           eta: fullTicket.eta?.getTime() ?? null,
           createdAt: fullTicket.createdAt.getTime(),
           tags: [],

--- a/apps/backend/src/zero/side-effects/types.ts
+++ b/apps/backend/src/zero/side-effects/types.ts
@@ -154,7 +154,7 @@ export const SIDE_EFFECT_OPERATION_CONFIG: SideEffectOperationConfigMap = {
   calls: ['update'],
   tickets: ['update'],
   ticket_assignments: ['insert', 'update'],
-  ticket_stage_eta: ['update'],
+  ticket_stage_eta: ['insert', 'update', 'delete', 'upsert'],
   rcas: ['insert', 'update'],
   ticket_sub_ticket_mappings: ['insert'],
   ticket_reference_mappings: ['insert', 'delete'],

--- a/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
@@ -8,7 +8,7 @@ import {
   TicketStatusV2,
   addSlaHours,
 } from '@xyne/shared';
-import { getPriorityIcon, formatEta, isEtaUrgent, isStageEtaOverdue } from './TicketCard.utils';
+import { getPriorityIcon, formatEta, isEtaUrgent, isStageOverdue } from './TicketCard.utils';
 import { cn } from '../../../utils/classNames';
 import { useUser, useUsers, useSelf } from '../../../hooks/useUsers';
 import { TicketStatusWithStages } from '../TicketStatus/TicketStatusIcon';
@@ -243,7 +243,7 @@ export const TicketCard: React.FC<TicketCardProps> = ({
     !!userReadRow &&
     userReadRow.lastReadEmailAt >= lastEmailAt;
 
-  const isStageOverdue = isStageEtaOverdue(ticket);
+  const hasStageOverdue = isStageOverdue(ticket);
   const hasDueDate = !!ticket.eta;
   const hasTags = tags && tags.length > 0;
 
@@ -720,7 +720,7 @@ export const TicketCard: React.FC<TicketCardProps> = ({
                   </div>
                 )}
                 {/* Stage Overdue Badge */}
-                {isStageOverdue && (
+                {hasStageOverdue && (
                   <div className='flex items-center gap-1 px-2 py-0.5 rounded-md bg-red-50 border border-red-200'>
                     <svg
                       width='12'

--- a/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.utils.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.utils.tsx
@@ -113,23 +113,8 @@ export const isEtaUrgent = (eta?: number | null, status?: TicketStatusV2): boole
   return isOverdue && !isTerminalState;
 };
 
-export const isStageEtaOverdue = (
-  ticket: Ticket & {
-    stageEtaEntries?: Array<{
-      stageLeftAt: number | null;
-      stageEta: number | null;
-    }> | null;
-  },
-): boolean => {
-  const currentStageEntry = ticket.stageEtaEntries?.find(entry => entry.stageLeftAt === null);
-
-  if (!currentStageEntry?.stageEta) return false;
-
-  const now = Date.now();
-  const isOverdue = now > currentStageEntry.stageEta;
+export const isStageOverdue = (ticket: Ticket & { isStageOverdue?: boolean | null }): boolean => {
   const isTerminalState =
-    ticket.statusV2 === TicketStatusV2.COMPLETED || ticket.statusV2 === TicketStatusV2.CANCELLED;
-
-  // Only show as overdue if stage ETA has passed AND ticket is NOT in a terminal state
-  return isOverdue && !isTerminalState;
+    ticket.statusV2 === TicketStatusV2.CANCELLED || ticket.statusV2 === TicketStatusV2.COMPLETED;
+  return Boolean(ticket.isStageOverdue) && !isTerminalState;
 };

--- a/apps/dashboard/src/components/Tickets/TicketCardV2/TicketCardV2.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCardV2/TicketCardV2.tsx
@@ -59,6 +59,7 @@ const buildTicketFromSummary = (summary: TicketCardSummary, workspaceId: string)
     userGroupId: '',
     boardId: '',
     stageName: summary.stageName ?? '',
+    isStageOverdue: false,
     ticketType: summary.ticketType ?? null,
     isArchived: false,
     kanbanPosition: null,

--- a/apps/dashboard/src/hooks/useBoardTicketNav.ts
+++ b/apps/dashboard/src/hooks/useBoardTicketNav.ts
@@ -61,16 +61,19 @@ export function useBoardTicketNav(ticketId: string): BoardTicketNavState {
   const fetchPage = useCallback(
     async (start: Cursor, dir: 'forward' | 'backward', limit: number): Promise<NavRow[]> => {
       if (!baseArgs) return [];
+      const queryArgs = {
+        ...baseArgs,
+        overdueReferenceTime: baseArgs.overdueReferenceTime ?? undefined,
+        columnType,
+        stageName: '',
+        start: { createdAt: start.createdAt, id: start.id },
+        dir,
+        limit,
+      };
       const rows = (await zero.run(
-        queries.kanbanTicketsPageV2({
-          ...baseArgs,
-          overdueReferenceTime: baseArgs.overdueReferenceTime ?? undefined,
-          columnType,
-          stageName: '',
-          start: { createdAt: start.createdAt, id: start.id },
-          dir,
-          limit,
-        }),
+        queries.kanbanTicketsPageV3({
+          ...queryArgs,
+        } as Parameters<typeof queries.kanbanTicketsPageV3>[0]),
         { type: 'complete' },
       )) as KanbanTicketsPageRow[];
       return rows.map(r => ({

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -174,7 +174,7 @@ import { flowGroupCoverId } from '../../components/Board/FlowRun/useFlowRunGraph
 import Avatar from '../../components/ui/Avatar/Avatar';
 import {
   getPriorityIcon,
-  isStageEtaOverdue,
+  isStageOverdue,
 } from '../../components/Tickets/TicketCard/TicketCard.utils';
 import {
   TicketPriority,
@@ -1909,7 +1909,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
     // Filter for stage overdue tickets
     if (showOverdueOnly) {
-      tickets = tickets.filter(ticket => isStageEtaOverdue(ticket));
+      tickets = tickets.filter(ticket => isStageOverdue(ticket));
     }
 
     return tickets;

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanCounts.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanCounts.ts
@@ -53,6 +53,7 @@ type TicketCountsSnapshot = {
   createdBy: string | null;
   userGroupId: string | null;
   ticketType: string | null;
+  isStageOverdue: boolean;
   eta: number | null;
   createdAt: number;
   tags: string[];
@@ -330,8 +331,7 @@ const matchesRequest = (
       snapshot.statusV2 === TicketStatusV2.COMPLETED ||
       snapshot.statusV2 === TicketStatusV2.CANCELLED;
     if (isTerminal) return false;
-    if (snapshot.eta === null || snapshot.eta === undefined || snapshot.eta >= Date.now())
-      return false;
+    if (!snapshot.isStageOverdue) return false;
   }
 
   return true;

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -62,7 +62,7 @@ type KanbanCursor = {
 };
 
 type KanbanTicketsPageQueryArgs = Omit<
-  Parameters<typeof queries.kanbanTicketsPageV2>[0],
+  Parameters<typeof queries.kanbanTicketsPageV3>[0],
   'start'
 > & {
   start: KanbanCursor | null;
@@ -468,15 +468,15 @@ export const useKanbanTicketsPage = (
   const fetchCursor = fetchCursorState?.queryKey === queryKey ? fetchCursorState.cursor : null;
   const tickets = ticketsState.queryKey === queryKey ? ticketsState.tickets : [];
   const pageArgs = buildKanbanTicketsPageArgs(pageOptions, fetchCursor);
-  const [page, pageDetails] = useCachedQuery(
-    queries.kanbanTicketsPageV2(pageArgs as Parameters<typeof queries.kanbanTicketsPageV2>[0]),
-    {
-      enabled:
-        (options.enabled ?? true) &&
-        !shouldUseDirectVespaRows &&
-        (!requiresVespaTicketIds || vespaTicketSearch.searchResults !== null),
-    },
+  const pageQuery = queries.kanbanTicketsPageV3(
+    pageArgs as Parameters<typeof queries.kanbanTicketsPageV3>[0],
   );
+  const [page, pageDetails] = useCachedQuery(pageQuery, {
+    enabled:
+      (options.enabled ?? true) &&
+      !shouldUseDirectVespaRows &&
+      (!requiresVespaTicketIds || vespaTicketSearch.searchResults !== null),
+  });
   const effectivePage = shouldUseDirectVespaRows ? directVespaPage : page;
   const effectivePageDetailsType = shouldUseDirectVespaRows
     ? directVespaPage === null

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -104,8 +104,6 @@ const kanbanTicketsPageArgsSchema = z.object({
     .optional(),
   filters: kanbanTicketPageFiltersSchema.optional(),
   formEntityValueFieldIds: z.array(z.string()).optional(),
-  showOverdueOnly: z.boolean().optional(),
-  overdueReferenceTime: z.number().optional(),
 });
 
 type KanbanTicketsPageArgs = z.infer<typeof kanbanTicketsPageArgsSchema>;
@@ -116,12 +114,14 @@ const kanbanTicketPageV2FiltersSchema = kanbanTicketPageFiltersSchema.extend({
     .optional(),
 });
 
-const kanbanTicketsPageV2ArgsSchema = kanbanTicketsPageArgsSchema.extend({
+const kanbanTicketsPageV3ArgsSchema = kanbanTicketsPageArgsSchema.extend({
   filters: kanbanTicketPageV2FiltersSchema.optional(),
   dir: z.literal('forward').or(z.literal('backward')).optional(),
+  showOverdueOnly: z.boolean().optional(),
+  overdueReferenceTime: z.number().optional(),
 });
 
-type KanbanTicketsPageV2Args = z.infer<typeof kanbanTicketsPageV2ArgsSchema>;
+type KanbanTicketsPageV3Args = z.infer<typeof kanbanTicketsPageV3ArgsSchema>;
 
 const prefixedKanbanIdentityValues = (id: string): string[] => [
   id,
@@ -230,8 +230,6 @@ const applyKanbanTicketPageConditions = (
     vespaTicketIds,
     dynamicFieldScalarFilters,
     filters,
-    showOverdueOnly,
-    overdueReferenceTime,
   } = args;
 
   if (stageName) {
@@ -428,19 +426,6 @@ const applyKanbanTicketPageConditions = (
     });
   }
 
-  if (showOverdueOnly) {
-    const overdueBefore = overdueReferenceTime ?? Date.now();
-    query = query.where((helpers: any) =>
-      helpers.and(
-        helpers.cmp('statusV2', '!=', TicketStatusV2.COMPLETED),
-        helpers.cmp('statusV2', '!=', TicketStatusV2.CANCELLED),
-        helpers.exists('stageEtaEntries', (stageEtaEntry: any) =>
-          stageEtaEntry.where('stageLeftAt', 'IS', null).where('stageEta', '<', overdueBefore),
-        ),
-      ),
-    );
-  }
-
   if (vespaTicketIds) {
     if (vespaTicketIds.length === 0) {
       return query.where('id', '__kanban_vespa_no_match__');
@@ -488,10 +473,10 @@ const applyKanbanTicketPageConditions = (
   return query;
 };
 
-const applyKanbanTicketPageV2Conditions = (
+const applyKanbanTicketPageV3Conditions = (
   query: any,
   ctx: { userID: string },
-  args: KanbanTicketsPageV2Args,
+  args: KanbanTicketsPageV3Args,
 ) => {
   query = applyKanbanTicketPageConditions(query, ctx, args);
 
@@ -502,6 +487,16 @@ const applyKanbanTicketPageV2Conditions = (
         assignment.where('roleId', roleAssignment.roleId).where('userId', 'IN', roleAssignment.userIds),
       );
     }
+  }
+
+  if (args.showOverdueOnly) {
+    query = query.where((helpers: any) =>
+      helpers.and(
+        helpers.cmp('statusV2', '!=', TicketStatusV2.COMPLETED),
+        helpers.cmp('statusV2', '!=', TicketStatusV2.CANCELLED),
+        helpers.cmp('isStageOverdue', true),
+      ),
+    );
   }
 
   return query;
@@ -1041,11 +1036,11 @@ export const queries = defineQueries({
     },
   ),
 
-  kanbanTicketsPageV2: defineQuery(
-    kanbanTicketsPageV2ArgsSchema,
+  kanbanTicketsPageV3: defineQuery(
+    kanbanTicketsPageV3ArgsSchema,
     ({ ctx, args }) => {
       const dir = args.dir ?? 'forward';
-      let query = applyKanbanTicketPageV2Conditions(zql.tickets, ctx, args)
+      let query = applyKanbanTicketPageV3Conditions(zql.tickets, ctx, args)
         .orderBy('createdAt', dir === 'forward' ? 'desc' : 'asc')
         .orderBy('id', dir === 'forward' ? 'asc' : 'desc');
 
@@ -1056,7 +1051,6 @@ export const queries = defineQueries({
       let finalQuery = query
         .limit(args.limit)
         .related('assignments', (a: any) => a.related('role'))
-        .related('stageEtaEntries')
         .related('tagMappings');
 
       if (args.formEntityValueFieldIds?.length) {

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -184,6 +184,7 @@ export const ticketTable = table('tickets')
     userGroupId: string(),
     boardId: string(),
     stageName: string(),
+    isStageOverdue: boolean().optional(),
     ticketType: string().optional(),
     isArchived: boolean(),
     kanbanPosition: string().optional(),


### PR DESCRIPTION
Migration-Changes:
  - added isOverdue filter

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
added isOverdue column in tickets

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [x] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
