### PR TITLE
fix: XYNE-55848 Fix canvas access issue for calls

### DIFF
--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -9,10 +9,10 @@ import { DatabaseClient } from '@/database/client';
 import { withWorkspaceScope } from '@/database/tenant/context';
 import { repositories } from '@/database/repositories';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
-import { DEFAULT_SUMMARY_FIELDS, MessageType, CanvasRole, CanvasVisibility } from '@xyne/shared';
+import { CallOrigin, DEFAULT_SUMMARY_FIELDS, MessageType, CanvasRole, CanvasVisibility } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 import { formatToISTLocaleString } from '@/utils/dateUtils';
-import type { SummaryTemplate } from '@prisma/client';
+import type { Prisma, SummaryTemplate } from '@prisma/client';
 import { ServerBlockNoteEditor } from '@blocknote/server-util';
 import { getCanvasUrl, findExistingDetailedSummaryCanvas } from '@/services/canvasService';
 import { CanvasSideEffectHandler } from '@/zero/side-effects/tables/canvas-handler';
@@ -1098,6 +1098,72 @@ export class CallDocumentService {
   }
 
   /**
+   * Grant the standard access policy for a canvas generated from a call.
+   */
+  private async createCallCanvasAccess(
+    tx: Prisma.TransactionClient,
+    params: {
+      canvasId: string;
+      workspaceId: string;
+      callId: string;
+      createdByUserId: string;
+      callCreatorUserId: string;
+      channelId: string | null;
+      now: Date;
+    },
+  ): Promise<string> {
+    const { canvasId, workspaceId, callId, createdByUserId, callCreatorUserId, channelId, now } = params;
+    const call = await tx.call.findUnique({
+      where: { externalId: callId },
+      select: { id: true, callOrigin: true },
+    });
+    const isChannelThreadCall = call?.callOrigin === CallOrigin.CONVERSATION && channelId !== null;
+
+    await tx.canvasParticipant.create({
+      data: {
+        id: uuidv4(), canvasId, workspaceId, userId: createdByUserId, role: CanvasRole.OWNER,
+        joinedAt: now, updatedAt: now,
+      },
+    });
+    await tx.canvasParticipant.create({
+      data: {
+        id: uuidv4(), canvasId, workspaceId, userId: callCreatorUserId, role: CanvasRole.OWNER,
+        joinedAt: now, updatedAt: now,
+      },
+    });
+
+    if (isChannelThreadCall && call) {
+      const callParticipants = await tx.callParticipant.findMany({
+        where: { callId: call.id, isExternal: false },
+        select: { userId: true },
+      });
+      const editorUserIds = [...new Set(callParticipants.map(({ userId }) => userId))]
+        .filter((userId) => userId !== createdByUserId && userId !== callCreatorUserId);
+      if (editorUserIds.length > 0) {
+        await tx.canvasParticipant.createMany({
+          data: editorUserIds.map((userId) => ({
+            id: uuidv4(), canvasId, workspaceId, userId, role: CanvasRole.EDITOR,
+            joinedAt: now, updatedAt: now,
+          })),
+        });
+      }
+    }
+
+    if (channelId) {
+      await tx.canvasParticipant.create({
+        data: {
+          id: uuidv4(), canvasId, workspaceId, channelId,
+          role: isChannelThreadCall ? CanvasRole.VIEWER : CanvasRole.EDITOR,
+          joinedAt: now, updatedAt: now,
+        },
+      });
+    }
+
+    if (isChannelThreadCall) return 'thread participants as editors and channel as viewer';
+    return channelId ? 'channel as editor' : 'private access';
+  }
+
+  /**
    * Create PRD Canvas in database
    */
   async createPRDCanvas(
@@ -1113,61 +1179,47 @@ export class CallDocumentService {
       const now = new Date();
 
       const canvasId = uuidv4();
-      const participantId = uuidv4();
       const workspaceId = await repositories.channels.getWorkspaceId(channelId);
 
       const title = `📋 PRD: ${prd.title}`;
       const content = formatPRDToBlockNote(prd, callId);
 
-      // Create canvas with empty content (Y-Sweet is source of truth)
-      await prisma.canvas.create({
-        data: {
-          id: canvasId,
-          title,
-          content: [],
-          channelId,
-          workspaceId,
-          createdBy: createdByUserId,
-          visibility: CanvasVisibility.PUBLIC,
-          isTemplate: false,
-          isCollaborative: true,
-          lastEditedBy: createdByUserId,
-          lastEditedAt: now,
-          createdAt: now,
-          updatedAt: now,
-          metadata: {
-            source: 'call_prd',
-            callId,
-            conversationId,
-            generatedAt: now.toISOString(),
+      let accessMode = 'private access';
+      await prisma.$transaction(async (tx) => {
+        // Keep PRD canvases private and grant the same explicit access as
+        // detailed-summary canvases generated from this call.
+        await tx.canvas.create({
+          data: {
+            id: canvasId,
+            title,
+            content: [],
+            channelId,
+            workspaceId,
+            createdBy: createdByUserId,
+            visibility: CanvasVisibility.PRIVATE,
+            isTemplate: false,
+            isCollaborative: true,
+            lastEditedBy: createdByUserId,
+            lastEditedAt: now,
+            createdAt: now,
+            updatedAt: now,
+            metadata: {
+              source: 'call_prd',
+              callId,
+              conversationId,
+              generatedAt: now.toISOString(),
+            },
           },
-        },
-      });
-
-      // Add creator (Xyne Automatic bot) as OWNER
-      await prisma.canvasParticipant.create({
-        data: {
-          id: participantId,
+        });
+        accessMode = await this.createCallCanvasAccess(tx, {
           canvasId,
           workspaceId,
-          userId: createdByUserId,
-          role: CanvasRole.OWNER,
-          joinedAt: now,
-          updatedAt: now,
-        },
-      });
-
-      // Add call initiator as OWNER
-      await prisma.canvasParticipant.create({
-        data: {
-          id: uuidv4(),
-          canvasId,
-          workspaceId,
-          userId: callCreatorUserId,
-          role: CanvasRole.OWNER,
-          joinedAt: now,
-          updatedAt: now,
-        },
+          callId,
+          createdByUserId,
+          callCreatorUserId,
+          channelId,
+          now,
+        });
       });
 
       // Initialize Y-Sweet for collaborative editing
@@ -1176,7 +1228,7 @@ export class CallDocumentService {
         logger.warn(`[CallDocumentService] Y-Sweet init failed for PRD canvas ${canvasId}`);
       }
 
-      logger.info(`[CallDocumentService] Created collaborative PRD canvas ${canvasId} for call ${callId} with Xyne Automatic and call initiator as owners`);
+      logger.info(`[CallDocumentService] Created collaborative PRD canvas ${canvasId} for call ${callId} with ${accessMode}, plus Xyne Automatic and call initiator as owners`);
 
       // Fetch workspaceId from channel for Vespa job routing
       const channel = await db.channel.findUnique({ where: { id: channelId }, select: { workspaceId: true } });
@@ -1212,7 +1264,6 @@ export class CallDocumentService {
       const now = new Date();
 
       const canvasId = uuidv4();
-      const participantId = uuidv4();
       const workspaceId = workspaceIdOverride ?? (channelId ? await repositories.channels.getWorkspaceId(channelId) : undefined);
       if (!workspaceId) {
         throw new Error(`Cannot resolve workspaceId for detailed summary canvas (call ${callId})`);
@@ -1227,8 +1278,10 @@ export class CallDocumentService {
         citationCtx
       );
 
-      // Create canvas with empty content (Y-Sweet is source of truth).
-      // PRIVATE — note-taker recordings are shared per-user/group/channel via
+      // Create a private canvas with explicit access for its call context:
+      // DM attendees edit, direct channel calls grant channel edit access, and
+      // channel-thread calls grant attendees edit plus channel view access.
+      // Additional recording shares are managed per-user/group/channel via
       // entity_access, and the recording sharing API updates canvas_participants
       // in the same transaction.
       //
@@ -1240,6 +1293,7 @@ export class CallDocumentService {
       // the per-request tenant ACL (CanvasParticipantsACL.canCreate would
       // otherwise deny the second insert since the requester isn't a
       // participant yet); regular canvas access after this stays ACL-gated.
+      let accessMode = 'private access';
       await prisma.$transaction(async (tx) => {
         await tx.canvas.create({
           data: {
@@ -1268,30 +1322,14 @@ export class CallDocumentService {
           },
         });
 
-        // Add Xyne Automatic bot as OWNER
-        await tx.canvasParticipant.create({
-          data: {
-            id: participantId,
-            canvasId,
-            workspaceId,
-            userId: createdByUserId,
-            role: CanvasRole.OWNER,
-            joinedAt: now,
-            updatedAt: now,
-          },
-        });
-
-        // Add call creator as OWNER
-        await tx.canvasParticipant.create({
-          data: {
-            id: uuidv4(),
-            canvasId,
-            workspaceId,
-            userId: callCreatorUserId,
-            role: CanvasRole.OWNER,
-            joinedAt: now,
-            updatedAt: now,
-          },
+        accessMode = await this.createCallCanvasAccess(tx, {
+          canvasId,
+          workspaceId,
+          callId,
+          createdByUserId,
+          callCreatorUserId,
+          channelId,
+          now,
         });
       });
 
@@ -1301,7 +1339,7 @@ export class CallDocumentService {
         logger.warn(`[CallDocumentService] Y-Sweet init failed for detailed summary canvas ${canvasId}`);
       }
 
-      logger.info(`[CallDocumentService] Created collaborative detailed summary canvas ${canvasId} for call ${callId} with Xyne Automatic and call creator as owners`);
+      logger.info(`[CallDocumentService] Created collaborative detailed summary canvas ${canvasId} for call ${callId} with ${accessMode}, plus Xyne Automatic and call creator as owners`);
 
       // A streaming canvas is created from its first content delta. Defer
       // creation activity, mention notifications, and indexing until the final


### PR DESCRIPTION
<img width="1715" height="291" alt="Screenshot 2026-08-12 at 6 56 28 PM" src="https://github.com/user-attachments/assets/d585f13d-70c5-4670-9e08-0fc29cfa09c9" />

Services-Requiring-Redeployment:
  - backend


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
