### PR TITLE
fix: XYNE-54416 navigate see more in full screen search, close menu on file preview

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -1845,19 +1845,23 @@ const ChannelCommandMenu = ({
     });
   }, [syncEnterIntent, markNavigated]);
 
-  const handleFilePreview = useCallback((result: DisplaySearchResult): void => {
-    // Handle attachment preview - show file preview modal
-    if (result.type !== 'attachment' || !result.searchContext?.internalUrl) {
-      return;
-    }
+  const handleFilePreview = useCallback(
+    (result: DisplaySearchResult): void => {
+      // Handle attachment preview - show file preview modal
+      if (result.type !== 'attachment' || !result.searchContext?.internalUrl) {
+        return;
+      }
 
-    setPreviewFile({
-      fileName: result.title,
-      fileUrl: result.searchContext.internalUrl,
-      mimeType: result.searchContext.mimeType || 'application/octet-stream',
-      fileSize: result.searchContext.fileSize || 0,
-    });
-  }, []);
+      setPreviewFile({
+        fileName: result.title,
+        fileUrl: result.searchContext.internalUrl,
+        mimeType: result.searchContext.mimeType || 'application/octet-stream',
+        fileSize: result.searchContext.fileSize || 0,
+      });
+      onOpenChange(false);
+    },
+    [onOpenChange],
+  );
 
   // Handle mouse hover over ticket and Desk items to show preview
   const handleTicketMouseEnter = useCallback(
@@ -2442,6 +2446,7 @@ const ChannelCommandMenu = ({
           const items = groupedChannels['channels'];
           const category = ChannelCategory.CHANNELS;
           const isExpanded = expandedCategories.has(category);
+          const routeSeeMore = searchMode === 'screen';
           const hasMore = items.length > DISPLAY_LIMIT;
           const displayItems = !isExpanded && hasMore ? items.slice(0, DISPLAY_LIMIT) : items;
           const hiddenCount = items.length - DISPLAY_LIMIT;
@@ -2471,11 +2476,17 @@ const ChannelCommandMenu = ({
               {hasMore && (
                 <SeeMoreItem
                   value={`__see-more-group-dm-${category as string}__`}
-                  label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
-                  onSelect={() => toggleCategoryExpansion(category)}
+                  label={!routeSeeMore && isExpanded ? 'See less' : `See ${hiddenCount} more`}
+                  onSelect={() =>
+                    routeSeeMore
+                      ? handleSeeMoreNavigate('channels')
+                      : toggleCategoryExpansion(category)
+                  }
                   hoverable={!isMobile}
-                  trackCategory='CHANNEL_SEARCH'
-                  trackName='TOGGLE_GROUP_DM_CATEGORY_EXPANSION'
+                  trackCategory={routeSeeMore ? 'SEARCH' : 'CHANNEL_SEARCH'}
+                  trackName={
+                    routeSeeMore ? 'SEE_MORE_SECTION' : 'TOGGLE_GROUP_DM_CATEGORY_EXPANSION'
+                  }
                   trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
                 />
               )}
@@ -2498,6 +2509,7 @@ const ChannelCommandMenu = ({
           const items = groupedChannels['starred'];
           const category = ChannelCategory.STARRED;
           const isExpanded = expandedCategories.has(category);
+          const routeSeeMore = searchMode === 'screen';
           const hasMore = items.length > DISPLAY_LIMIT;
           const displayItems = !isExpanded && hasMore ? items.slice(0, DISPLAY_LIMIT) : items;
           const hiddenCount = items.length - DISPLAY_LIMIT;
@@ -2527,11 +2539,17 @@ const ChannelCommandMenu = ({
               {hasMore && (
                 <SeeMoreItem
                   value={`__see-more-channel-${category as string}__`}
-                  label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
-                  onSelect={() => toggleCategoryExpansion(category)}
+                  label={!routeSeeMore && isExpanded ? 'See less' : `See ${hiddenCount} more`}
+                  onSelect={() =>
+                    routeSeeMore
+                      ? handleSeeMoreNavigate('channels')
+                      : toggleCategoryExpansion(category)
+                  }
                   hoverable={!isMobile}
-                  trackCategory='CHANNEL_SEARCH'
-                  trackName='TOGGLE_CHANNEL_CATEGORY_EXPANSION'
+                  trackCategory={routeSeeMore ? 'SEARCH' : 'CHANNEL_SEARCH'}
+                  trackName={
+                    routeSeeMore ? 'SEE_MORE_SECTION' : 'TOGGLE_CHANNEL_CATEGORY_EXPANSION'
+                  }
                   trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
                 />
               )}
@@ -2567,6 +2585,7 @@ const ChannelCommandMenu = ({
           // per-keystroke render + cmdk bookkeeping cost.
           const category = ChannelCategory.GROUP_DMS;
           const isExpanded = expandedCategories.has(category);
+          const routeSeeMore = searchMode === 'screen';
           const hasMore = localGroupDMs.length > DISPLAY_LIMIT;
           const displayItems =
             !isExpanded && hasMore ? localGroupDMs.slice(0, DISPLAY_LIMIT) : localGroupDMs;
@@ -2597,11 +2616,17 @@ const ChannelCommandMenu = ({
                 {hasMore && (
                   <SeeMoreItem
                     value={`__see-more-group-dm-${category as string}__`}
-                    label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
-                    onSelect={() => toggleCategoryExpansion(category)}
+                    label={!routeSeeMore && isExpanded ? 'See less' : `See ${hiddenCount} more`}
+                    onSelect={() =>
+                      routeSeeMore
+                        ? handleSeeMoreNavigate('channels')
+                        : toggleCategoryExpansion(category)
+                    }
                     hoverable={!isMobile}
-                    trackCategory='CHANNEL_SEARCH'
-                    trackName='TOGGLE_GROUP_DM_CATEGORY_EXPANSION'
+                    trackCategory={routeSeeMore ? 'SEARCH' : 'CHANNEL_SEARCH'}
+                    trackName={
+                      routeSeeMore ? 'SEE_MORE_SECTION' : 'TOGGLE_GROUP_DM_CATEGORY_EXPANSION'
+                    }
                     trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
                   />
                 )}
@@ -2751,6 +2776,16 @@ const ChannelCommandMenu = ({
       {channelCallConfirm}
       {recordingActiveDialog}
       {resultActionsMenu}
+      {!inline && previewFile && (
+        <FilePreviewModal
+          isOpen={!!previewFile}
+          onClose={() => setPreviewFile(null)}
+          fileName={stripHtmlTags(previewFile.fileName)}
+          fileUrl={previewFile.fileUrl}
+          mimeType={previewFile.mimeType}
+          fileSize={previewFile.fileSize}
+        />
+      )}
     </>
   );
 
@@ -3603,6 +3638,7 @@ const ChannelCommandMenu = ({
               // container (Chrome can keyboard-focus scrollers) — both outline. Row
               // position is communicated by aria-selected, never by a ring here.
               'flex-1 overflow-y-auto px-4 pt-3 pb-6 focus:outline-none focus-visible:outline-none',
+              '[&_[cmdk-item]]:scroll-mb-[30px]',
               suppressHover && '[&_[cmdk-item]]:pointer-events-none',
             )}
             ref={el => {
@@ -4460,18 +4496,6 @@ const ChannelCommandMenu = ({
             ) : null}
           </div>
         </div>
-      )}
-
-      {/* File Preview Modal */}
-      {!inline && previewFile && (
-        <FilePreviewModal
-          isOpen={!!previewFile}
-          onClose={() => setPreviewFile(null)}
-          fileName={stripHtmlTags(previewFile.fileName)}
-          fileUrl={previewFile.fileUrl}
-          mimeType={previewFile.mimeType}
-          fileSize={previewFile.fileSize}
-        />
       )}
 
       {/* Desk Ticket Merge Dialog */}


### PR DESCRIPTION


Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- 'see more' navigates to full screen route in full search mode
- opening file preview will now close the command menu
- minor ui fix: added scroll margin for navigation items to not overlap with the fade effect

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
