### PR TITLE
feat: add agent own status spaces tool

### DIFF
--- a/apps/backend/scripts/seed-app-permissions.ts
+++ b/apps/backend/scripts/seed-app-permissions.ts
@@ -20,6 +20,7 @@ const APP_PERMISSION_SCOPES = [
   { scope: 'tickets:write', description: 'Create and update tickets from apps' },
   { scope: 'usergroups:read', description: 'Read user groups from apps' },
   { scope: 'users:read', description: 'Read user profile information from apps' },
+  { scope: 'users:write', description: 'Update the installing app user’s own profile status from apps' },
 ];
 
 async function main() {

--- a/apps/backend/scripts/seed-claw-agent-apps.ts
+++ b/apps/backend/scripts/seed-claw-agent-apps.ts
@@ -13,6 +13,7 @@ const CLAW_APP_PERMISSIONS = [
   'chat:write',
   'channels:read',
   'users:read',
+  'users:write',
   'usergroups:read',
   'tickets:read',
   'tickets:write',

--- a/apps/backend/src/apps/controllers/userController.ts
+++ b/apps/backend/src/apps/controllers/userController.ts
@@ -2,18 +2,139 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 import { logger } from '@/utils/logger';
 import { getUserData } from '../core/userUtils';
+import { DatabaseClient } from '@/database/client';
+import { UserPresenceStatus } from '@xyne/shared';
 
 const GetUserQuerySchema = z.object({
   userId: z.string().min(1, 'User ID is required').trim(),
 });
 
+const SetOwnStatusBodySchema = z
+  .object({
+    statusEmoji: z.string().max(100).nullable().optional(),
+    statusContent: z.string().max(280).nullable().optional(),
+    statusExpiryAt: z.coerce.date().nullable().optional(),
+    assignmentUnavailableUntil: z.coerce.date().nullable().optional(),
+    notificationsPausedUntil: z.coerce.date().nullable().optional(),
+  })
+  .refine((data) => Object.values(data).some((value) => value !== undefined), {
+    message: 'At least one status field must be provided',
+  });
+
+const prisma = DatabaseClient.getInstance();
+
+function decodeStatusEmoji(statusEmoji: string | null | undefined): string | null | undefined {
+  if (statusEmoji === undefined || statusEmoji === null) return statusEmoji;
+  try {
+    const decoded = decodeURIComponent(statusEmoji);
+    if (!decoded.trim()) return null;
+    if (decoded.length > 100) throw new Error('Invalid emoji encoding');
+    return decoded;
+  } catch (error) {
+    if (error instanceof URIError) throw new Error('Invalid emoji encoding');
+    throw error;
+  }
+}
+
 export class UserController {
+  setOwnStatus = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const bodyResult = SetOwnStatusBodySchema.safeParse(req.body);
+      if (!bodyResult.success) {
+        res.status(400).json({
+          error: 'Validation error',
+          code: 'VALIDATION_ERROR',
+        });
+        return;
+      }
+
+      const userId = req.user?.id;
+      const workspaceId = req.user?.workspaceId;
+      if (!userId || !workspaceId) {
+        res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+        return;
+      }
+
+      const {
+        statusEmoji,
+        statusContent,
+        statusExpiryAt,
+        assignmentUnavailableUntil,
+        notificationsPausedUntil,
+      } = bodyResult.data;
+      const validatedEmoji = decodeStatusEmoji(statusEmoji);
+      const now = new Date();
+
+      const result = await prisma.$transaction(async (tx) => {
+        const existingPresence = await tx.userPresence.findUnique({ where: { userId } });
+        const presence = await tx.userPresence.upsert({
+          where: { userId },
+          create: {
+            userId,
+            workspaceId,
+            status: UserPresenceStatus.OFFLINE,
+            lastActiveAt: now,
+            lastSeenAt: now,
+            isManual: false,
+            ...(statusEmoji !== undefined && { statusEmoji: validatedEmoji }),
+            ...(statusContent !== undefined && { statusContent }),
+            ...(statusExpiryAt !== undefined && { statusExpiryAt }),
+            ...(assignmentUnavailableUntil !== undefined && { assignmentUnavailableUntil }),
+            ...(notificationsPausedUntil !== undefined && { notificationsPausedUntil }),
+          },
+          update: {
+            lastActiveAt: now,
+            lastSeenAt: now,
+            status: existingPresence?.status ?? UserPresenceStatus.OFFLINE,
+            ...(statusEmoji !== undefined && { statusEmoji: validatedEmoji }),
+            ...(statusContent !== undefined && { statusContent }),
+            ...(statusExpiryAt !== undefined && { statusExpiryAt }),
+            ...(assignmentUnavailableUntil !== undefined && { assignmentUnavailableUntil }),
+            ...(notificationsPausedUntil !== undefined && { notificationsPausedUntil }),
+          },
+        });
+
+        await tx.user.update({
+          where: { id: userId },
+          data: {
+            lastActiveAt: now,
+            ...(statusEmoji !== undefined && { statusEmoji: validatedEmoji }),
+            ...(statusContent !== undefined && { statusContent }),
+            ...(statusExpiryAt !== undefined && { statusExpiryAt }),
+            ...(assignmentUnavailableUntil !== undefined && { assignmentUnavailableUntil }),
+            ...(notificationsPausedUntil !== undefined && { notificationsPausedUntil }),
+          },
+        });
+
+        return presence;
+      });
+
+      res.status(200).json({
+        userId,
+        statusEmoji: result.statusEmoji,
+        statusContent: result.statusContent,
+        statusExpiryAt: result.statusExpiryAt,
+        assignmentUnavailableUntil: result.assignmentUnavailableUntil,
+        notificationsPausedUntil: result.notificationsPausedUntil,
+      });
+    } catch (error) {
+      logger.error('Error setting own user status:', error);
+
+      if (error instanceof Error && error.message.includes('Invalid emoji')) {
+        res.status(400).json({ error: error.message, code: 'VALIDATION_ERROR' });
+        return;
+      }
+
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
   getUserInfo = async (req: Request, res: Response): Promise<void> => {
     try {
       const queryResult = GetUserQuerySchema.safeParse(req.query);
-      
+
       if (!queryResult.success) {
-        res.status(400).json({ 
+        res.status(400).json({
           error: 'Validation error',
           code: 'VALIDATION_ERROR',
         });

--- a/apps/backend/src/apps/routes/user.ts
+++ b/apps/backend/src/apps/routes/user.ts
@@ -6,5 +6,6 @@ const router = Router();
 const userController = new UserController();
 
 router.get('/info', requirePermission('users:read'), userController.getUserInfo);
+router.post('/status', requirePermission('users:write'), userController.setOwnStatus);
 
 export default router;

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-spaces-app-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-spaces-app-tools.ts
@@ -25,7 +25,7 @@ export const xyneSpacesAppToolsAdapter: StdioMcpAdapter = {
   // per-user tool-sync. See routes/tools.ts:185-196 — the picker unions
   // adapter writeTools + staticTools. NOT a HITL gate; this tool stays
   // autonomous (the whole point of the app-tools server).
-  staticTools: ["apps-send-message"],
+  staticTools: ["apps-send-message", "apps-set-own-status"],
   credentialFields: [],
   buildCommand(credentials) {
     const appToken = (credentials["app_token"] as string | undefined) ?? "";

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-app-tools-server.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-app-tools-server.ts
@@ -141,8 +141,27 @@ const SEND_MESSAGE_TOOL = {
   },
 };
 
+const SET_STATUS_TOOL = {
+  name: "apps-set-own-status",
+  description:
+    "Set the bot/agent's OWN Xyne Spaces profile status using the agent app token. " +
+    "This tool never accepts a userId and cannot update any human or other agent status. " +
+    "Use it when the agent needs to advertise its current availability or operating state in Spaces. " +
+    "Pass null for a field to clear that field. statusExpiryAt, assignmentUnavailableUntil, and notificationsPausedUntil must be ISO-8601 timestamps when provided.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      statusEmoji: { type: ["string", "null"], description: "Emoji to show next to the bot status; pass null to clear." },
+      statusContent: { type: ["string", "null"], description: "Short status text, max 280 characters; pass null to clear." },
+      statusExpiryAt: { type: ["string", "null"], description: "ISO timestamp when the status should expire; pass null to clear." },
+      assignmentUnavailableUntil: { type: ["string", "null"], description: "ISO timestamp until the bot should be treated as assignment-unavailable; pass null to clear." },
+      notificationsPausedUntil: { type: ["string", "null"], description: "ISO timestamp until bot notifications are paused; pass null to clear." },
+    },
+  },
+};
+
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [PING_TOOL, SEND_MESSAGE_TOOL],
+  tools: [PING_TOOL, SEND_MESSAGE_TOOL, SET_STATUS_TOOL],
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
@@ -150,6 +169,38 @@ server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToo
 
   if (name === "ping") {
     return { content: [{ type: "text", text: "ok" }] };
+  }
+
+  if (name === "apps-set-own-status") {
+    if (!APP_TOKEN || !SPACES_URL) {
+      return {
+        content: [{ type: "text", text: "XYNE_SPACES_APP_TOKEN or XYNE_SPACES_URL not set — server misconfigured." }],
+        isError: true,
+      };
+    }
+    try {
+      const input = (args ?? {}) as Record<string, unknown>;
+      const allowedKeys = [
+        "statusEmoji",
+        "statusContent",
+        "statusExpiryAt",
+        "assignmentUnavailableUntil",
+        "notificationsPausedUntil",
+      ];
+      const body: Record<string, unknown> = {};
+      for (const key of allowedKeys) {
+        if (Object.prototype.hasOwnProperty.call(input, key)) body[key] = input[key];
+      }
+      if (Object.keys(body).length === 0) {
+        return { content: [{ type: "text", text: "Provide at least one status field to set or clear." }], isError: true };
+      }
+
+      const result = await spacesAppFetch("/user/status", body);
+      return { content: [{ type: "text", text: `Own Spaces status updated: ${JSON.stringify(result)}` }] };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { content: [{ type: "text", text: `apps-set-own-status error: ${msg}` }], isError: true };
+    }
   }
 
   // Accept legacy `spaces-send-message` name as an alias so any agent or

--- a/apps/xyne-claw/skills/spaces-tools-guide.md
+++ b/apps/xyne-claw/skills/spaces-tools-guide.md
@@ -49,6 +49,7 @@ For multi-part user tasks, mix — do simple parts yourself, farm deep sub-queri
 | Updating a ticket | `spaces-update-ticket` (write) |
 | Scheduling a meeting | `spaces-schedule-call` (write) |
 | Posting in a different thread/channel as the user | `user-send-message` (write) |
+| Setting the agent/bot's own Spaces status | `apps-set-own-status` (write, bot/app identity only) |
 | Creating a canvas | `spaces-create-canvas` (write) |
 | Editing a canvas | `spaces-edit-canvas` (write) |
 
@@ -113,6 +114,24 @@ The org is full of look-alike content. Stay anchored to **exactly** what was ask
 # Per-tool argument reference
 
 Read the section for the tool you're about to call. Every `Required` line is enforced — calls without those fields error out.
+
+---
+
+## apps-set-own-status
+
+Sets the current agent/bot app user's own Spaces profile status. This uses the bot/app identity, never a human user token, and the tool does not accept `userId`; it cannot update another user or another agent.
+
+**Required:** at least one status field.
+
+**Args:**
+
+- **statusEmoji** (string or null) — Emoji to show, or `null` to clear.
+- **statusContent** (string or null, max 280 chars) — Short status text, or `null` to clear.
+- **statusExpiryAt** (ISO timestamp or null) — When the visible status expires, or `null` to clear.
+- **assignmentUnavailableUntil** (ISO timestamp or null) — When the bot becomes available for assignment again, or `null` to clear.
+- **notificationsPausedUntil** (ISO timestamp or null) — Pause bot notifications until this time, or `null` to clear.
+
+Use this only when changing the agent's own advertised status in Spaces. Do not use it for normal replies or for changing a human user's status.
 
 ---
 


### PR DESCRIPTION
1. Problem Description:
Agents need a Spaces tool to update their own visible Spaces status without being able to set another user's or another agent's status.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Xyne Spaces thread by Harsh Sharma.

3. Explain the solution implemented in the PR:
- Added `apps-set-own-status` to the `xyne-spaces-app-tools` MCP server.
- Added `POST /api/apps/user/status`, authenticated by app JWT and scoped to the token's own app user (`req.user.id`); the request body does not accept `userId`.
- Dual-writes status fields to `user_presence` and `users`, matching the existing Zero userPresence mutator pattern.
- Added `users:write` to app permission seeding and claw agent app permissions.
- Documented the tool in the Spaces tools guide.

4. Documentation (link to docs created/updated for this change):
Updated `apps/xyne-claw/skills/spaces-tools-guide.md`.

5. DB Alter Details (if any):
No schema change. Adds a seeded app permission scope: `users:write`.

6. Data fix Details (if any):
Existing Claw app installations need the `users:write` permission granted/activated before the new route is callable for non-legacy installs.

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter xyne-spaces-backend exec eslint src/apps/controllers/userController.ts src/apps/routes/user.ts` passed.
- `pnpm --filter xyne-spaces-backend typecheck` initially OOMed at default heap; with 4GB heap it reached pre-existing shared/Zero type errors unrelated to this change.
- `pnpm --filter xyne-claw-auth typecheck` is currently blocked by pre-existing Prisma client generation/type errors.

9. Services to which this change is to be deployed:
backend, xyne-claw-auth

10. Main PR link (if this PR is raised against a release branch):
N/A