### PR TITLE
fix: delete empty table on Backspace in chat input

### DIFF
--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -761,7 +761,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
             // being empty so normal editing of a populated table is untouched.
             for (let depth = $from.depth; depth > 0; depth--) {
               const ancestor = $from.node(depth);
-              if (ancestor.type.spec.tableRole === 'table') {
+              if (ancestor.type.spec['tableRole'] === 'table') {
                 if (ancestor.textContent.trim() === '') {
                   event.preventDefault();
                   editor.chain().focus().deleteTable().run();
@@ -779,7 +779,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
               const nodeBefore = view.state.doc.resolve(blockStart).nodeBefore;
               if (
                 nodeBefore &&
-                nodeBefore.type.spec.tableRole === 'table' &&
+                nodeBefore.type.spec['tableRole'] === 'table' &&
                 nodeBefore.textContent.trim() === ''
               ) {
                 event.preventDefault();

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -746,6 +746,50 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
             }
           }
 
+          // Empty-table cleanup. prosemirror-tables refuses to delete a table
+          // via Backspace from inside a cell, so once a user erases all the text
+          // from a pasted table they are left with an empty, undeletable table
+          // box (editor.isEmpty is even true, so the placeholder/empty logic
+          // treats the input as empty while the table node lingers). Detect that
+          // state and remove the whole table on Backspace.
+          if (event.key === 'Backspace' && editor) {
+            const { selection } = view.state;
+            const { $from } = selection;
+
+            // Case A: the cursor/selection sits inside a table whose cells are
+            // all blank -> delete the entire table. Guarded on the whole table
+            // being empty so normal editing of a populated table is untouched.
+            for (let depth = $from.depth; depth > 0; depth--) {
+              const ancestor = $from.node(depth);
+              if (ancestor.type.spec.tableRole === 'table') {
+                if (ancestor.textContent.trim() === '') {
+                  event.preventDefault();
+                  editor.chain().focus().deleteTable().run();
+                  return true;
+                }
+                break;
+              }
+            }
+
+            // Case B: the cursor is at the very start of the block immediately
+            // after an empty table (e.g. the trailing paragraph a pasted table
+            // leaves behind) -> remove that empty table.
+            if (selection.empty && $from.parentOffset === 0) {
+              const blockStart = $from.before($from.depth);
+              const nodeBefore = view.state.doc.resolve(blockStart).nodeBefore;
+              if (
+                nodeBefore &&
+                nodeBefore.type.spec.tableRole === 'table' &&
+                nodeBefore.textContent.trim() === ''
+              ) {
+                event.preventDefault();
+                const from = blockStart - nodeBefore.nodeSize;
+                editor.chain().focus().deleteRange({ from, to: blockStart }).run();
+                return true;
+              }
+            }
+          }
+
           if (event.key === 'Escape' && onCancel) {
             event.preventDefault();
             onCancel();


### PR DESCRIPTION
## Problem
When a user pastes content copied from a table into the chat input, it renders as a table (TipTap `Table` / prosemirror-tables node). If they then backspace through all the cell text, the text is erased but an empty table box remains and cannot be removed — prosemirror-tables intentionally refuses to delete a table via Backspace from inside a cell. Worse, an empty table reports `editor.isEmpty === true` and `getText()` returns only whitespace, so the placeholder/empty logic treats the input as empty while the table node visibly lingers and is stuck.

## Fix
Add a Backspace branch to `InputBox` `editorProps.handleKeyDown` (`apps/dashboard/src/components/ui/InputBox/InputBox.tsx`):
- **Case A** — cursor/selection is inside a table whose cells are all blank → `deleteTable()`. Guarded on the *entire* table being empty (`table.textContent.trim() === ''`), so editing a populated table is untouched.
- **Case B** — cursor is at the start of the block immediately after an empty table (e.g. the trailing paragraph a pasted table leaves behind) → delete that empty table via a ranged delete.

## Verification
Reproduced the stuck state headlessly with the same TipTap table packages: default Backspace (`deleteSelection` + `joinBackward` + `selectNodeBackward`) leaves the `<table>` in place; the fix's detection + `deleteTable()` resets the doc to `<p></p>`. `tsc --noEmit` is clean for the changed file.

Scope: single-file frontend change, no schema/API/behavioral change to populated tables.