### PR TITLE
feat: show formatting toolbar on text selection

### DIFF
--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -632,6 +632,10 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       },
       onSelectionUpdate: ({ editor }) => {
         setIsInCodeBlock(editor.isActive('codeBlock'));
+
+        if (features.richText && !isMobile && !editor.state.selection.empty) {
+          setShowFormatToolbar(true);
+        }
       },
       onUpdate: ({ editor }) => {
         const textContent = editor.getText().trim();


### PR DESCRIPTION
1. Problem Description:
Users can select text inside the chat/thread message composer, but the existing formatting toolbar stays hidden unless they manually click the Aa / Show formatting button.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Spaces thread after PR #457 merged. The expected behavior is selection-driven display of the existing static composer formatting toolbar, not an anchored floating toolbar.

3. Explain the solution implemented in the PR:
Updated the Tiptap InputBox selectionUpdate handler so that when rich text is enabled, the desktop composer is active, and the editor selection is non-empty, the existing EditorToolbar row is opened by setting showFormatToolbar to true. This reuses the same toolbar rendered by the Show formatting button and preserves the user’s ability to hide/show it manually.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Verified PR #457 is merged into main at 5fdd4c877c5b7b6bf5eb148c9765dd428b334829.
- pnpm -C apps/dashboard exec tsc --noEmit --pretty false
- pnpm -C apps/dashboard exec eslint src/components/ui/InputBox/InputBox.tsx (existing warnings only)
- Attempted local screenshot capture, but the sandbox test-auth/UI route did not render the composer reliably in this session; no screenshot attached for this PR.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A