### PR TITLE
Feature/UI widgets main

### DIFF
--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -141,8 +141,8 @@ function getFlowJsonRawTextForMentions(content: string): string | null {
  * Friendly notification label for a flow CARD (plan, etc.) whose todos/title
  * don't live in text `content` props — so extractTextFromFlowJson returns ''
  * and the preview would otherwise fall back to the meaningless "Flow JSON" text
- * node. Currently handles the `plan` component; returns null for other flows so
- * the caller keeps its existing extraction.
+ * node. Handles plan and user-question artifacts; returns null for other flows
+ * so the caller keeps its existing extraction.
  */
 function getFlowCardNotificationLabel(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
@@ -159,11 +159,22 @@ function getFlowCardNotificationLabel(content: string): string | null {
     const plan = Array.isArray(flow.components)
       ? flow.components.find((c) => c?.type === 'plan')
       : undefined;
-    if (!plan) return null;
-    const rawTitle = plan.props?.['title'];
-    const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
-    const verb = plan.props?.['phase'] === 'proposed' ? 'Proposed a plan' : 'Shared a plan';
-    return title ? `📋 ${verb}: ${title}` : `📋 ${verb}`;
+    if (plan) {
+      const rawTitle = plan.props?.['title'];
+      const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
+      const verb = plan.props?.['phase'] === 'proposed' ? 'Proposed a plan' : 'Shared a plan';
+      return title ? `📋 ${verb}: ${title}` : `📋 ${verb}`;
+    }
+    const questionSet = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'user_question')
+      : undefined;
+    if (!questionSet) return null;
+    const questions = questionSet.props?.['questions'];
+    const count = Array.isArray(questions) ? questions.length : 0;
+    const phase = questionSet.props?.['phase'];
+    if (phase === 'answered') return `✅ Answered ${count || 'agent'} question${count === 1 ? '' : 's'}`;
+    if (phase === 'declined') return 'Question request declined';
+    return count > 1 ? `💬 Agent wants to ask you ${count} questions` : '💬 Agent wants to ask you a question';
   } catch {
     return null;
   }

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -141,8 +141,8 @@ function getFlowJsonRawTextForMentions(content: string): string | null {
  * Friendly notification label for a flow CARD (plan, etc.) whose todos/title
  * don't live in text `content` props — so extractTextFromFlowJson returns ''
  * and the preview would otherwise fall back to the meaningless "Flow JSON" text
- * node. Handles plan and user-question artifacts; returns null for other flows
- * so the caller keeps its existing extraction.
+ * node. Handles plan, diff, code, ticket, chart and user-question artifacts;
+ * returns null for other flows so the caller keeps its existing extraction.
  */
 function getFlowCardNotificationLabel(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
@@ -164,6 +164,41 @@ function getFlowCardNotificationLabel(content: string): string | null {
       const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
       const verb = plan.props?.['phase'] === 'proposed' ? 'Proposed a plan' : 'Shared a plan';
       return title ? `📋 ${verb}: ${title}` : `📋 ${verb}`;
+    }
+    const diff = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'diff')
+      : undefined;
+    if (diff) {
+      const rawPath = diff.props?.['path'];
+      const path = typeof rawPath === 'string' ? rawPath.trim() : '';
+      return path ? `📝 Shared a diff: ${path}` : '📝 Shared a diff';
+    }
+    const code = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'code')
+      : undefined;
+    if (code) {
+      const rawLanguage = code.props?.['language'];
+      const language = typeof rawLanguage === 'string' ? rawLanguage.trim() : '';
+      return language ? `💻 Shared ${language} code` : '💻 Shared a code snippet';
+    }
+    const ticket = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'ticket')
+      : undefined;
+    if (ticket) {
+      const rawXyneId = ticket.props?.['xyneId'];
+      const rawTitle = ticket.props?.['title'];
+      const xyneId = typeof rawXyneId === 'string' ? rawXyneId.trim() : '';
+      const title = typeof rawTitle === 'string' ? rawTitle.trim() : '';
+      if (xyneId && title) return `🎫 Filed ${xyneId}: ${title}`;
+      return xyneId ? `🎫 Filed ${xyneId}` : '🎫 Filed a ticket';
+    }
+    const chart = Array.isArray(flow.components)
+      ? flow.components.find((c) => c?.type === 'chart')
+      : undefined;
+    if (chart) {
+      const rawCaption = chart.props?.['caption'];
+      const caption = typeof rawCaption === 'string' ? rawCaption.trim() : '';
+      return caption ? `📊 ${caption}` : '📊 Shared a chart';
     }
     const questionSet = Array.isArray(flow.components)
       ? flow.components.find((c) => c?.type === 'user_question')

--- a/apps/dashboard/src/components/flowUI/nodes/ArtifactRenderBoundary.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ArtifactRenderBoundary.tsx
@@ -20,6 +20,7 @@ export class ArtifactRenderBoundary extends Component<
   }
 
   public override componentDidCatch(error: Error, info: ErrorInfo): void {
+    /* eslint-disable no-console */
     console.error('[flowUI] artifact failed to render', error, info.componentStack);
   }
 

--- a/apps/dashboard/src/components/flowUI/nodes/ArtifactRenderBoundary.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ArtifactRenderBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ArtifactRenderBoundaryProps {
+  children: ReactNode;
+  fallbackText: string;
+}
+
+interface ArtifactRenderBoundaryState {
+  failed: boolean;
+}
+
+export class ArtifactRenderBoundary extends Component<
+  ArtifactRenderBoundaryProps,
+  ArtifactRenderBoundaryState
+> {
+  public override state: ArtifactRenderBoundaryState = { failed: false };
+
+  public static getDerivedStateFromError(): ArtifactRenderBoundaryState {
+    return { failed: true };
+  }
+
+  public override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[flowUI] artifact failed to render', error, info.componentStack);
+  }
+
+  public override render(): ReactNode {
+    if (this.state.failed) {
+      return (
+        <pre className='overflow-x-auto whitespace-pre-wrap p-4 font-mono text-xs text-muted-foreground'>
+          {this.props.fallbackText}
+        </pre>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/dashboard/src/components/flowUI/nodes/ChartBody.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ChartBody.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ChartProps } from '@xyne/shared';
+import { ChartTooltip } from '../../DynamicDashboard/ComponentGrid/renderers/ChartTooltip';
+import {
+  CHART_GRID_DASH,
+  CHART_MARGIN,
+} from '../../DynamicDashboard/ComponentGrid/renderers/constants';
+
+const AXIS_TEXT_COLOR = 'hsl(var(--muted-foreground))';
+const GRID_STROKE_COLOR = 'hsl(var(--border))';
+const CURSOR_FILL_COLOR = 'hsl(var(--accent))';
+const TICK_STYLE = {
+  fill: AXIS_TEXT_COLOR,
+  fontSize: 11,
+  fontFamily: '"Geist Mono", monospace',
+} as const;
+
+const SERIES_COLORS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+];
+const seriesColor = (index: number): string =>
+  SERIES_COLORS[index % SERIES_COLORS.length] ?? SERIES_COLORS[0]!;
+
+const VALUE_LABEL_STYLE = { fill: AXIS_TEXT_COLOR, fontSize: 11 } as const;
+const LEGEND_STYLE = { fontSize: 11, color: AXIS_TEXT_COLOR } as const;
+
+function compactValue(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}m`;
+  if (abs >= 1_000) return `${(value / 1_000).toFixed(1).replace(/\.0$/, '')}k`;
+  return String(value);
+}
+
+function pivotSeries(rows: ReadonlyArray<{ x: string; y: number; series?: string | undefined }>): {
+  data: Array<Record<string, string | number>>;
+  names: string[];
+} {
+  const names: string[] = [];
+  const byX = new Map<string, Record<string, string | number>>();
+  for (const row of rows) {
+    const name = row.series ?? 'value';
+    if (!names.includes(name)) names.push(name);
+    const existing = byX.get(row.x) ?? { x: row.x };
+    existing[name] = row.y;
+    byX.set(row.x, existing);
+  }
+  return { data: [...byX.values()], names };
+}
+
+const axisProps = { tick: TICK_STYLE, tickLine: false, axisLine: false } as const;
+const gridProps = {
+  strokeDasharray: CHART_GRID_DASH,
+  stroke: GRID_STROKE_COLOR,
+  vertical: false,
+} as const;
+
+const ChartBody: React.FC<{ props: ChartProps; height: number }> = ({ props, height }) => {
+  if (props.type === 'line' || props.type === 'area') {
+    const { data, names } = pivotSeries(props.series);
+    const multi = names.length > 1;
+    return (
+      <ResponsiveContainer width='100%' height={height}>
+        {props.type === 'line' ? (
+          <LineChart data={data} margin={CHART_MARGIN}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey='x' {...axisProps} />
+            <YAxis {...axisProps} width={40} tickFormatter={compactValue} />
+            <Tooltip content={<ChartTooltip />} />
+            {multi && <Legend wrapperStyle={LEGEND_STYLE} />}
+            {names.map((name, index) => (
+              <Line
+                key={name}
+                type='monotone'
+                dataKey={name}
+                stroke={seriesColor(index)}
+                strokeWidth={2}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </LineChart>
+        ) : (
+          <AreaChart data={data} margin={CHART_MARGIN}>
+            <CartesianGrid {...gridProps} />
+            <XAxis dataKey='x' {...axisProps} />
+            <YAxis {...axisProps} width={40} tickFormatter={compactValue} />
+            <Tooltip content={<ChartTooltip />} />
+            {multi && <Legend wrapperStyle={LEGEND_STYLE} />}
+            {names.map((name, index) => (
+              <Area
+                key={name}
+                type='monotone'
+                dataKey={name}
+                stroke={seriesColor(index)}
+                fill={seriesColor(index)}
+                fillOpacity={0.2}
+                strokeWidth={2}
+                isAnimationActive={false}
+              />
+            ))}
+          </AreaChart>
+        )}
+      </ResponsiveContainer>
+    );
+  }
+
+  if (props.type === 'pie' || props.type === 'donut') {
+    return (
+      <ResponsiveContainer width='100%' height={height}>
+        <PieChart>
+          <Tooltip content={<ChartTooltip />} />
+          <Legend wrapperStyle={LEGEND_STYLE} />
+          <Pie
+            data={props.points}
+            dataKey='value'
+            nameKey='label'
+            innerRadius={props.type === 'donut' ? '55%' : 0}
+            outerRadius='80%'
+            isAnimationActive={false}
+          >
+            {props.points.map((point, index) => (
+              <Cell
+                key={point.label}
+                fill={seriesColor(index)}
+                stroke='hsl(var(--card))'
+                strokeWidth={2}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width='100%' height={height}>
+      <BarChart data={props.points} margin={CHART_MARGIN}>
+        <CartesianGrid {...gridProps} />
+        <XAxis dataKey='label' {...axisProps} />
+        <YAxis hide />
+        <Tooltip content={<ChartTooltip />} cursor={{ fill: CURSOR_FILL_COLOR, opacity: 0.4 }} />
+        <Bar
+          dataKey='value'
+          fill={seriesColor(0)}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={48}
+          isAnimationActive={false}
+        >
+          <LabelList
+            dataKey='value'
+            position='top'
+            formatter={compactValue}
+            style={VALUE_LABEL_STYLE}
+          />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default ChartBody;

--- a/apps/dashboard/src/components/flowUI/nodes/ChartBody.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ChartBody.tsx
@@ -19,10 +19,10 @@ import {
 } from 'recharts';
 import type { ChartProps } from '@xyne/shared';
 import { ChartTooltip } from '../../DynamicDashboard/ComponentGrid/renderers/ChartTooltip';
-import {
-  CHART_GRID_DASH,
-  CHART_MARGIN,
-} from '../../DynamicDashboard/ComponentGrid/renderers/constants';
+import { CHART_GRID_DASH } from '../../DynamicDashboard/ComponentGrid/renderers/constants';
+
+const CHART_MARGIN = { top: 8, right: 8, left: 0, bottom: 0 } as const;
+const Y_AXIS_WIDTH = 32;
 
 const AXIS_TEXT_COLOR = 'hsl(var(--muted-foreground))';
 const GRID_STROKE_COLOR = 'hsl(var(--border))';
@@ -86,7 +86,7 @@ const ChartBody: React.FC<{ props: ChartProps; height: number }> = ({ props, hei
           <LineChart data={data} margin={CHART_MARGIN}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey='x' {...axisProps} />
-            <YAxis {...axisProps} width={40} tickFormatter={compactValue} />
+            <YAxis {...axisProps} width={Y_AXIS_WIDTH} tickFormatter={compactValue} />
             <Tooltip content={<ChartTooltip />} />
             {multi && <Legend wrapperStyle={LEGEND_STYLE} />}
             {names.map((name, index) => (
@@ -105,7 +105,7 @@ const ChartBody: React.FC<{ props: ChartProps; height: number }> = ({ props, hei
           <AreaChart data={data} margin={CHART_MARGIN}>
             <CartesianGrid {...gridProps} />
             <XAxis dataKey='x' {...axisProps} />
-            <YAxis {...axisProps} width={40} tickFormatter={compactValue} />
+            <YAxis {...axisProps} width={Y_AXIS_WIDTH} tickFormatter={compactValue} />
             <Tooltip content={<ChartTooltip />} />
             {multi && <Legend wrapperStyle={LEGEND_STYLE} />}
             {names.map((name, index) => (

--- a/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
@@ -1,0 +1,51 @@
+import React, { Suspense } from 'react';
+import type { ChartProps, FlowComponent } from '@xyne/shared';
+import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+
+const ChartBody = React.lazy(() => import('./ChartBody'));
+
+const CHART_HEIGHT_PX = 220;
+
+export const ChartNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as ChartProps | undefined;
+  if (!props?.type) return null;
+  const hasData =
+    props.type === 'line' || props.type === 'area'
+      ? props.series.length > 0
+      : props.points.length > 0;
+  if (!hasData) return null;
+
+  const fallbackText =
+    props.type === 'line' || props.type === 'area'
+      ? props.series.map(point => `${point.x}: ${point.y}`).join('\n')
+      : props.points.map(point => `${point.label}: ${point.value}`).join('\n');
+
+  return (
+    <section
+      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className='px-4 pb-2 pt-4'>
+        <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+          Chart
+        </span>
+      </div>
+
+      <div className='border-t border-border px-2 pt-3'>
+        <ArtifactRenderBoundary fallbackText={fallbackText}>
+          <Suspense fallback={<div style={{ height: CHART_HEIGHT_PX }} />}>
+            <ChartBody props={props} height={CHART_HEIGHT_PX} />
+          </Suspense>
+        </ArtifactRenderBoundary>
+      </div>
+
+      {props.caption && (
+        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
+          <p className='text-xs leading-[1.2] text-muted-foreground'>{props.caption}</p>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
@@ -27,13 +27,13 @@ export const ChartNode: React.FC<{ node: FlowComponent; children?: React.ReactNo
       className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
       style={node.style}
     >
-      <div className='px-4 pb-2 pt-4'>
+      <div className='px-4 py-3'>
         <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
           Chart
         </span>
       </div>
 
-      <div className='border-t border-border px-2 pt-3'>
+      <div className='border-t border-border px-2 py-3'>
         <ArtifactRenderBoundary fallbackText={fallbackText}>
           <Suspense fallback={<div style={{ height: CHART_HEIGHT_PX }} />}>
             <ChartBody props={props} height={CHART_HEIGHT_PX} />

--- a/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ChartNode.tsx
@@ -1,15 +1,25 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useContext, useState } from 'react';
+import { MaximizeFourArrow } from '@xyne/icons';
 import type { ChartProps, FlowComponent } from '@xyne/shared';
+import { useFlow } from '../FlowContext';
 import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+import { InsideWidgetPreviewContext, WidgetPreview } from './WidgetPreview';
 
 const ChartBody = React.lazy(() => import('./ChartBody'));
 
 const CHART_HEIGHT_PX = 220;
+const CHART_PREVIEW_HEIGHT_PX = 420;
 
 export const ChartNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
   node,
 }) => {
   const props = node.props as ChartProps | undefined;
+  const { conversationId } = useFlow();
+  // A copy of this card lives inside its own widget-preview thread panel; hide the
+  // Maximize there so it can't open a nested preview.
+  const insidePreview = useContext(InsideWidgetPreviewContext);
+  const [expanded, setExpanded] = useState(false);
+
   if (!props?.type) return null;
   const hasData =
     props.type === 'line' || props.type === 'area'
@@ -22,30 +32,62 @@ export const ChartNode: React.FC<{ node: FlowComponent; children?: React.ReactNo
       ? props.series.map(point => `${point.x}: ${point.y}`).join('\n')
       : props.points.map(point => `${point.label}: ${point.value}`).join('\n');
 
+  const chartView = (height: number): React.ReactNode => (
+    <ArtifactRenderBoundary fallbackText={fallbackText}>
+      <Suspense fallback={<div style={{ height }} />}>
+        <ChartBody props={props} height={height} />
+      </Suspense>
+    </ArtifactRenderBoundary>
+  );
+
   return (
     <section
       className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
       style={node.style}
     >
-      <div className='px-4 py-3'>
+      <div className='flex items-center justify-between gap-2 px-4 py-3'>
         <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
           Chart
         </span>
+        {!insidePreview && (
+          <button
+            type='button'
+            onClick={() => setExpanded(true)}
+            aria-label='Expand chart'
+            className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+            data-track-category='CHART_ARTIFACT'
+            data-track-name='EXPAND_CHART'
+          >
+            <MaximizeFourArrow size={16} className='shrink-0' />
+          </button>
+        )}
       </div>
 
-      <div className='border-t border-border px-2 py-3'>
-        <ArtifactRenderBoundary fallbackText={fallbackText}>
-          <Suspense fallback={<div style={{ height: CHART_HEIGHT_PX }} />}>
-            <ChartBody props={props} height={CHART_HEIGHT_PX} />
-          </Suspense>
-        </ArtifactRenderBoundary>
-      </div>
+      <div className='border-t border-border px-2 py-3'>{chartView(CHART_HEIGHT_PX)}</div>
 
       {props.caption && (
         <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
           <p className='text-xs leading-[1.2] text-muted-foreground'>{props.caption}</p>
         </div>
       )}
+
+      <WidgetPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        idPrefix='chart-preview'
+        label='Chart'
+        title={props.caption ?? 'Chart'}
+        description={props.caption ?? `${props.type} chart`}
+        conversationId={conversationId ?? undefined}
+        tracking={{ category: 'CHART_ARTIFACT', closeName: 'CLOSE_CHART_PREVIEW' }}
+      >
+        <div className='rounded-xl border border-border px-2 py-3'>
+          {chartView(CHART_PREVIEW_HEIGHT_PX)}
+        </div>
+        {props.caption && (
+          <p className='text-xs leading-[1.2] text-muted-foreground'>{props.caption}</p>
+        )}
+      </WidgetPreview>
     </section>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { File } from '@pierre/diffs/react';
+import { CopyCopied, CopyDefault } from '@xyne/icons';
+import type { CodeProps, FlowComponent } from '@xyne/shared';
+import { useCopyButton } from '../../../hooks/useCopyButton';
+import { useDiffsTheme } from './useDiffsTheme';
+import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+
+export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as CodeProps | undefined;
+  const { copied, copy } = useCopyButton();
+  const themeOptions = useDiffsTheme();
+
+  if (!props?.code) return null;
+  const { code, language } = props;
+
+  return (
+    <section
+      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className='flex items-center justify-between gap-2 px-4 pb-2 pt-4'>
+        <div className='flex items-center gap-2'>
+          <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+            Code
+          </span>
+          {language && (
+            <span className='flex h-[18px] items-center'>
+              <span className='rounded bg-muted px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] text-muted-foreground'>
+                {language}
+              </span>
+            </span>
+          )}
+        </div>
+        <button
+          type='button'
+          onClick={() => copy(code)}
+          aria-label={copied ? 'Copied' : 'Copy code'}
+          className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+          data-track-category='CODE_ARTIFACT'
+          data-track-name='COPY_CODE'
+        >
+          {copied ? (
+            <CopyCopied size={16} className='shrink-0' />
+          ) : (
+            <CopyDefault size={16} className='shrink-0' />
+          )}
+        </button>
+      </div>
+
+      <div className='max-h-[420px] overflow-auto border-t border-border text-xs'>
+        <ArtifactRenderBoundary fallbackText={code}>
+          <File
+            file={{ name: 'snippet', contents: code, ...(language ? { lang: language } : {}) }}
+            options={{
+              ...themeOptions,
+              disableFileHeader: true,
+              disableLineNumbers: true,
+              overflow: 'scroll',
+            }}
+            disableWorkerPool
+          />
+        </ArtifactRenderBoundary>
+      </div>
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import { File } from '@pierre/diffs/react';
-import { CopyCopied, CopyDefault } from '@xyne/icons';
+import { Code, CopyCopied, CopyDefault, MaximizeFourArrow } from '@xyne/icons';
 import type { CodeProps, FlowComponent } from '@xyne/shared';
 import { useCopyButton } from '../../../hooks/useCopyButton';
+import { useFlow } from '../FlowContext';
 import { useDiffsTheme } from './useDiffsTheme';
 import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+import { InsideWidgetPreviewContext, WidgetPreview } from './WidgetPreview';
 
 export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
   node,
@@ -12,9 +14,29 @@ export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
   const props = node.props as CodeProps | undefined;
   const { copied, copy } = useCopyButton();
   const themeOptions = useDiffsTheme();
+  const { conversationId } = useFlow();
+  // A copy of this card lives inside its own widget-preview thread panel; hide the
+  // Maximize there so it can't open a nested preview.
+  const insidePreview = useContext(InsideWidgetPreviewContext);
+  const [expanded, setExpanded] = useState(false);
 
   if (!props?.code) return null;
   const { code, language } = props;
+
+  const fileView = (
+    <ArtifactRenderBoundary fallbackText={code}>
+      <File
+        file={{ name: 'snippet', contents: code, ...(language ? { lang: language } : {}) }}
+        options={{
+          ...themeOptions,
+          disableFileHeader: true,
+          disableLineNumbers: true,
+          overflow: 'scroll',
+        }}
+        disableWorkerPool
+      />
+    </ArtifactRenderBoundary>
+  );
 
   return (
     <section
@@ -23,9 +45,7 @@ export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
     >
       <div className='flex items-center justify-between gap-2 px-4 py-3'>
         <div className='flex items-center gap-2'>
-          <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
-            Code
-          </span>
+          <Code size={16} aria-label='Code' className='shrink-0 text-muted-foreground' />
           {language && (
             <span className='flex h-[18px] items-center'>
               <span className='rounded bg-muted px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] text-muted-foreground'>
@@ -34,36 +54,54 @@ export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
             </span>
           )}
         </div>
-        <button
-          type='button'
-          onClick={() => copy(code)}
-          aria-label={copied ? 'Copied' : 'Copy code'}
-          className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-          data-track-category='CODE_ARTIFACT'
-          data-track-name='COPY_CODE'
-        >
-          {copied ? (
-            <CopyCopied size={16} className='shrink-0' />
-          ) : (
-            <CopyDefault size={16} className='shrink-0' />
+        <div className='flex shrink-0 items-center gap-2'>
+          <button
+            type='button'
+            onClick={() => copy(code)}
+            aria-label={copied ? 'Copied' : 'Copy code'}
+            className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+            data-track-category='CODE_ARTIFACT'
+            data-track-name='COPY_CODE'
+          >
+            {copied ? (
+              <CopyCopied size={16} className='shrink-0' />
+            ) : (
+              <CopyDefault size={16} className='shrink-0' />
+            )}
+          </button>
+          {!insidePreview && (
+            <button
+              type='button'
+              onClick={() => setExpanded(true)}
+              aria-label='Expand code'
+              className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='CODE_ARTIFACT'
+              data-track-name='EXPAND_CODE'
+            >
+              <MaximizeFourArrow size={16} className='shrink-0' />
+            </button>
           )}
-        </button>
+        </div>
       </div>
 
       <div className='max-h-[420px] overflow-auto border-t border-border text-xs [--diffs-gap-inline:16px]'>
-        <ArtifactRenderBoundary fallbackText={code}>
-          <File
-            file={{ name: 'snippet', contents: code, ...(language ? { lang: language } : {}) }}
-            options={{
-              ...themeOptions,
-              disableFileHeader: true,
-              disableLineNumbers: true,
-              overflow: 'scroll',
-            }}
-            disableWorkerPool
-          />
-        </ArtifactRenderBoundary>
+        {fileView}
       </div>
+
+      <WidgetPreview
+        open={expanded}
+        onOpenChange={setExpanded}
+        idPrefix='code-preview'
+        label='Code'
+        title={language ? `${language} snippet` : 'Code snippet'}
+        description='Code snippet'
+        conversationId={conversationId ?? undefined}
+        tracking={{ category: 'CODE_ARTIFACT', closeName: 'CLOSE_CODE_PREVIEW' }}
+      >
+        <div className='overflow-auto rounded-xl border border-border text-xs [--diffs-gap-inline:16px]'>
+          {fileView}
+        </div>
+      </WidgetPreview>
     </section>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/CodeNode.tsx
@@ -21,7 +21,7 @@ export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
       className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
       style={node.style}
     >
-      <div className='flex items-center justify-between gap-2 px-4 pb-2 pt-4'>
+      <div className='flex items-center justify-between gap-2 px-4 py-3'>
         <div className='flex items-center gap-2'>
           <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
             Code
@@ -50,7 +50,7 @@ export const CodeNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
         </button>
       </div>
 
-      <div className='max-h-[420px] overflow-auto border-t border-border text-xs'>
+      <div className='max-h-[420px] overflow-auto border-t border-border text-xs [--diffs-gap-inline:16px]'>
         <ArtifactRenderBoundary fallbackText={code}>
           <File
             file={{ name: 'snippet', contents: code, ...(language ? { lang: language } : {}) }}

--- a/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
@@ -1,0 +1,122 @@
+import React, { useMemo, useState } from 'react';
+import { PatchDiff } from '@pierre/diffs/react';
+import { MaximizeFourArrow, MultipleCrossCancelDefault } from '@xyne/icons';
+import type { DiffProps, FlowComponent } from '@xyne/shared';
+import Dialog from '../../ui/Dialog';
+import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
+import { useDiffsTheme } from './useDiffsTheme';
+
+function diffStat(patch: string): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  let inHunk = false;
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('@@')) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith('+')) added++;
+    else if (line.startsWith('-')) removed++;
+  }
+  return { added, removed };
+}
+
+const DiffStat: React.FC<{ added: number; removed: number }> = ({ added, removed }) => (
+  <span className='shrink-0 font-mono text-xs tabular-nums'>
+    <span className='text-[var(--diff-stat-add-fg)]'>+{added}</span>{' '}
+    <span className='text-[var(--diff-stat-del-fg)]'>−{removed}</span>
+  </span>
+);
+
+export const DiffNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as DiffProps | undefined;
+  const [expanded, setExpanded] = useState(false);
+  const themeOptions = useDiffsTheme();
+  const stat = useMemo(() => diffStat(props?.patch ?? ''), [props?.patch]);
+
+  if (!props?.patch || !props.path) return null;
+  const { path, patch } = props;
+
+  const diffOptions = {
+    ...themeOptions,
+    disableFileHeader: true,
+    diffStyle: 'unified' as const,
+    overflow: 'scroll' as const,
+  };
+
+  return (
+    <>
+      <section
+        className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+        style={node.style}
+      >
+        <div className='flex items-center justify-between gap-2 px-4 pb-2 pt-4'>
+          <div className='flex min-w-0 items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+              Diff
+            </span>
+            <span className='truncate font-mono text-xs text-foreground' title={path}>
+              {path}
+            </span>
+          </div>
+          <div className='flex shrink-0 items-center gap-2'>
+            <DiffStat added={stat.added} removed={stat.removed} />
+            <button
+              type='button'
+              onClick={() => setExpanded(true)}
+              aria-label='Expand diff'
+              className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='DIFF_ARTIFACT'
+              data-track-name='EXPAND_DIFF'
+            >
+              <MaximizeFourArrow size={16} className='shrink-0' />
+            </button>
+          </div>
+        </div>
+
+        <div className='max-h-[420px] overflow-auto border-t border-border text-xs'>
+          <ArtifactRenderBoundary fallbackText={patch}>
+            <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
+          </ArtifactRenderBoundary>
+        </div>
+      </section>
+
+      <Dialog
+        open={expanded}
+        onOpenChange={setExpanded}
+        title={path}
+        description='Proposed change'
+        className='max-w-4xl overflow-hidden'
+      >
+        <div className='flex flex-col'>
+          <div className='flex items-center justify-between gap-3 px-5 py-4 pb-0'>
+            <div className='flex min-w-0 items-center gap-2'>
+              <span className='truncate font-mono text-sm text-foreground' title={path}>
+                {path}
+              </span>
+              <DiffStat added={stat.added} removed={stat.removed} />
+            </div>
+            <button
+              type='button'
+              onClick={() => setExpanded(false)}
+              aria-label='Close'
+              className='rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+              data-track-category='DIFF_ARTIFACT'
+              data-track-name='CLOSE_DIFF_DIALOG'
+            >
+              <MultipleCrossCancelDefault size={18} />
+            </button>
+          </div>
+          <div className='max-h-[70vh] overflow-auto px-5 py-4 text-xs'>
+            <ArtifactRenderBoundary fallbackText={patch}>
+              <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
+            </ArtifactRenderBoundary>
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
@@ -53,7 +53,7 @@ export const DiffNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
         className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
         style={node.style}
       >
-        <div className='flex items-center justify-between gap-2 px-4 pb-2 pt-4'>
+        <div className='flex items-center justify-between gap-2 px-4 py-3'>
           <div className='flex min-w-0 items-center gap-2'>
             <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
               Diff
@@ -77,7 +77,7 @@ export const DiffNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
           </div>
         </div>
 
-        <div className='max-h-[420px] overflow-auto border-t border-border text-xs'>
+        <div className='max-h-[420px] overflow-auto border-t border-border text-xs [--diffs-gap-inline:16px]'>
           <ArtifactRenderBoundary fallbackText={patch}>
             <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
           </ArtifactRenderBoundary>

--- a/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/DiffNode.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { PatchDiff } from '@pierre/diffs/react';
-import { MaximizeFourArrow, MultipleCrossCancelDefault } from '@xyne/icons';
+import { GitCompare, MaximizeFourArrow } from '@xyne/icons';
 import type { DiffProps, FlowComponent } from '@xyne/shared';
-import Dialog from '../../ui/Dialog';
+import { useFlow } from '../FlowContext';
 import { ArtifactRenderBoundary } from './ArtifactRenderBoundary';
 import { useDiffsTheme } from './useDiffsTheme';
+import { InsideWidgetPreviewContext, WidgetPreview } from './WidgetPreview';
 
 function diffStat(patch: string): { added: number; removed: number } {
   let added = 0;
@@ -35,6 +36,10 @@ export const DiffNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
   const props = node.props as DiffProps | undefined;
   const [expanded, setExpanded] = useState(false);
   const themeOptions = useDiffsTheme();
+  const { conversationId } = useFlow();
+  // A copy of this card lives inside its own widget-preview thread panel; hide the
+  // Maximize there so it can't open a nested preview.
+  const insidePreview = useContext(InsideWidgetPreviewContext);
   const stat = useMemo(() => diffStat(props?.patch ?? ''), [props?.patch]);
 
   if (!props?.patch || !props.path) return null;
@@ -47,23 +52,27 @@ export const DiffNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
     overflow: 'scroll' as const,
   };
 
+  const patchView = (
+    <ArtifactRenderBoundary fallbackText={patch}>
+      <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
+    </ArtifactRenderBoundary>
+  );
+
   return (
-    <>
-      <section
-        className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
-        style={node.style}
-      >
-        <div className='flex items-center justify-between gap-2 px-4 py-3'>
-          <div className='flex min-w-0 items-center gap-2'>
-            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
-              Diff
-            </span>
-            <span className='truncate font-mono text-xs text-foreground' title={path}>
-              {path}
-            </span>
-          </div>
-          <div className='flex shrink-0 items-center gap-2'>
-            <DiffStat added={stat.added} removed={stat.removed} />
+    <section
+      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className='flex items-center justify-between gap-2 px-4 py-3'>
+        <div className='flex min-w-0 items-center gap-2'>
+          <GitCompare size={16} aria-label='Diff' className='shrink-0 text-muted-foreground' />
+          <span className='truncate font-mono text-xs text-foreground' title={path}>
+            {path}
+          </span>
+        </div>
+        <div className='flex shrink-0 items-center gap-2'>
+          <DiffStat added={stat.added} removed={stat.removed} />
+          {!insidePreview && (
             <button
               type='button'
               onClick={() => setExpanded(true)}
@@ -74,49 +83,34 @@ export const DiffNode: React.FC<{ node: FlowComponent; children?: React.ReactNod
             >
               <MaximizeFourArrow size={16} className='shrink-0' />
             </button>
-          </div>
+          )}
         </div>
+      </div>
 
-        <div className='max-h-[420px] overflow-auto border-t border-border text-xs [--diffs-gap-inline:16px]'>
-          <ArtifactRenderBoundary fallbackText={patch}>
-            <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
-          </ArtifactRenderBoundary>
-        </div>
-      </section>
+      <div className='max-h-[420px] overflow-auto border-t border-border text-xs [--diffs-gap-inline:16px]'>
+        {patchView}
+      </div>
 
-      <Dialog
+      <WidgetPreview
         open={expanded}
         onOpenChange={setExpanded}
+        idPrefix='diff-preview'
+        label='Diff'
         title={path}
         description='Proposed change'
-        className='max-w-4xl overflow-hidden'
+        conversationId={conversationId ?? undefined}
+        tracking={{ category: 'DIFF_ARTIFACT', closeName: 'CLOSE_DIFF_PREVIEW' }}
       >
-        <div className='flex flex-col'>
-          <div className='flex items-center justify-between gap-3 px-5 py-4 pb-0'>
-            <div className='flex min-w-0 items-center gap-2'>
-              <span className='truncate font-mono text-sm text-foreground' title={path}>
-                {path}
-              </span>
-              <DiffStat added={stat.added} removed={stat.removed} />
-            </div>
-            <button
-              type='button'
-              onClick={() => setExpanded(false)}
-              aria-label='Close'
-              className='rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-              data-track-category='DIFF_ARTIFACT'
-              data-track-name='CLOSE_DIFF_DIALOG'
-            >
-              <MultipleCrossCancelDefault size={18} />
-            </button>
-          </div>
-          <div className='max-h-[70vh] overflow-auto px-5 py-4 text-xs'>
-            <ArtifactRenderBoundary fallbackText={patch}>
-              <PatchDiff patch={patch} options={diffOptions} disableWorkerPool />
-            </ArtifactRenderBoundary>
-          </div>
+        <div className='flex min-w-0 items-center justify-between gap-2'>
+          <span className='truncate font-mono text-sm text-foreground' title={path}>
+            {path}
+          </span>
+          <DiffStat added={stat.added} removed={stat.removed} />
         </div>
-      </Dialog>
-    </>
+        <div className='overflow-auto rounded-xl border border-border text-xs [--diffs-gap-inline:16px]'>
+          {patchView}
+        </div>
+      </WidgetPreview>
+    </section>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -16,6 +16,7 @@ import { LinkNode } from './LinkNode';
 import { PlanNode } from './PlanNode';
 import { PrNode } from './PrNode';
 import { CallScheduleNode } from './CallScheduleNode';
+import { UserQuestionNode } from './UserQuestionNode';
 import { AgentNode } from './AgentNode';
 import { McpConfigureNode } from './McpConfigureNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
@@ -66,6 +67,7 @@ NodeRegistry.register('plan', PlanNode);
 NodeRegistry.register('pr', PrNode);
 // NodeRegistry.register('pr_approval', PrApprovalNode); // unlinked for now
 NodeRegistry.register('call_schedule', CallScheduleNode);
+NodeRegistry.register('user_question', UserQuestionNode);
 NodeRegistry.register('agent', AgentNode);
 NodeRegistry.register('mcpConfigure', McpConfigureNode);
 

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -17,6 +17,10 @@ import { PlanNode } from './PlanNode';
 import { PrNode } from './PrNode';
 import { CallScheduleNode } from './CallScheduleNode';
 import { UserQuestionNode } from './UserQuestionNode';
+import { CodeNode } from './CodeNode';
+import { DiffNode } from './DiffNode';
+import { TicketNode } from './TicketNode';
+import { ChartNode } from './ChartNode';
 import { AgentNode } from './AgentNode';
 import { McpConfigureNode } from './McpConfigureNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
@@ -68,6 +72,10 @@ NodeRegistry.register('pr', PrNode);
 // NodeRegistry.register('pr_approval', PrApprovalNode); // unlinked for now
 NodeRegistry.register('call_schedule', CallScheduleNode);
 NodeRegistry.register('user_question', UserQuestionNode);
+NodeRegistry.register('code', CodeNode);
+NodeRegistry.register('diff', DiffNode);
+NodeRegistry.register('ticket', TicketNode);
+NodeRegistry.register('chart', ChartNode);
 NodeRegistry.register('agent', AgentNode);
 NodeRegistry.register('mcpConfigure', McpConfigureNode);
 

--- a/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
+import { CircleCheck, CircleDashed, CircleDot, CirclePause, CircleX } from 'lucide-react';
 import type { FlowComponent, TicketProps } from '@xyne/shared';
+import { TicketPriority } from '@xyne/shared';
+import { formatEta, getPriorityIcon } from '../../Tickets/TicketCard/TicketCard.utils';
 import { cn } from '../../../utils/classNames';
 
-const STATUS_META: Record<TicketProps['status'], { label: string; className: string }> = {
-  TODO: { label: 'Todo', className: 'bg-orange-500/15 text-orange-600' },
-  STARTED: { label: 'Started', className: 'bg-blue-500/15 text-blue-600' },
-  PAUSED: { label: 'Paused', className: 'bg-teal-500/15 text-teal-600' },
-  CANCELLED: { label: 'Cancelled', className: 'bg-red-500/15 text-red-600' },
-  COMPLETED: { label: 'Completed', className: 'bg-green-500/15 text-green-600' },
+const STATUS_META: Record<
+  TicketProps['status'],
+  { label: string; color: string; Icon: React.FC<{ size?: number; color?: string }> }
+> = {
+  TODO: { label: 'Todo', color: 'var(--status-pending)', Icon: CircleDashed },
+  STARTED: { label: 'Started', color: 'var(--status-scheduled)', Icon: CircleDot },
+  PAUSED: { label: 'Paused', color: 'var(--status-paused)', Icon: CirclePause },
+  CANCELLED: { label: 'Cancelled', color: 'var(--status-failure)', Icon: CircleX },
+  COMPLETED: { label: 'Completed', color: 'var(--status-success)', Icon: CircleCheck },
 };
 
-const PRIORITY_META: Record<TicketProps['priority'], { label: string; className: string }> = {
-  LOW: { label: 'Low', className: 'text-muted-foreground' },
-  MEDIUM: { label: 'Medium', className: 'text-[var(--status-pending)]' },
-  HIGH: { label: 'High', className: 'text-[var(--diff-stat-del-fg)]' },
-  CRITICAL: { label: 'Critical', className: 'text-destructive' },
+const PRIORITY_LABEL: Record<TicketProps['priority'], string> = {
+  LOW: 'Low',
+  MEDIUM: 'Medium',
+  HIGH: 'High',
+  CRITICAL: 'Critical',
 };
 
-function formatEta(eta: string): string | null {
-  const parsed = new Date(eta);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
-}
+const TERMINAL_STATUSES: ReadonlyArray<TicketProps['status']> = ['COMPLETED', 'CANCELLED'];
 
 export const TicketNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
   node,
@@ -30,49 +32,55 @@ export const TicketNode: React.FC<{ node: FlowComponent; children?: React.ReactN
   if (!props?.xyneId || !props.title) return null;
 
   const status = STATUS_META[props.status];
-  const priority = PRIORITY_META[props.priority];
-  const eta = props.eta ? formatEta(props.eta) : null;
+  const etaMs = props.eta ? new Date(props.eta).getTime() : NaN;
+  const eta = Number.isNaN(etaMs) ? null : formatEta(etaMs);
+  const etaOverdue =
+    !!eta && etaMs < new Date().setHours(0, 0, 0, 0) && !TERMINAL_STATUSES.includes(props.status);
 
   return (
-    <section
-      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+    <a
+      href={props.url}
       style={node.style}
+      className='flow-artifact-wide block w-full overflow-hidden rounded-xl border border-border bg-background !no-underline transition-colors hover:bg-muted/40'
+      data-track-category='TICKET_ARTIFACT'
+      data-track-name='OPEN_TICKET'
     >
-      <div className='flex flex-col gap-2 px-4 pb-3 pt-4'>
-        <div className='flex flex-wrap items-center gap-2'>
-          <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-foreground'>
-            {props.xyneId}
-          </span>
-          <span
-            className={cn(
-              'rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px]',
-              status.className,
-            )}
-          >
+      <div className='flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-2.5'>
+        <span className='font-mono text-sm text-muted-foreground'>{props.xyneId}</span>
+
+        <div className='ml-auto flex items-center gap-4'>
+          <span className='flex items-center gap-1.5 text-sm text-foreground'>
+            <status.Icon size={14} color={status.color} />
             {status.label}
           </span>
-          <span className={cn('text-xs font-semibold leading-[18px]', priority.className)}>
-            {priority.label}
+
+          <span className='flex items-center gap-1 text-sm text-foreground'>
+            {getPriorityIcon(props.priority as TicketPriority)}
+            {PRIORITY_LABEL[props.priority]}
           </span>
+
           {eta && (
-            <span className='ml-auto shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
+            <span className='flex items-center gap-1.5 text-sm tabular-nums text-foreground'>
+              <span
+                className='size-3 shrink-0 rounded-[3px]'
+                style={{
+                  background: etaOverdue ? 'var(--status-failure)' : 'var(--status-success)',
+                }}
+              />
               {eta}
             </span>
           )}
         </div>
-        <p className='text-sm leading-[1.35] text-foreground'>{props.title}</p>
       </div>
 
-      <div className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
-        <a
-          href={props.url}
-          className='rounded-lg border border-border bg-background px-2 py-1.5 text-sm font-medium leading-[1.2] !text-foreground !no-underline hover:bg-muted'
-          data-track-category='TICKET_ARTIFACT'
-          data-track-name='OPEN_TICKET'
-        >
-          Open in tracker
-        </a>
-      </div>
-    </section>
+      <p
+        className={cn(
+          'border-t border-border px-4 py-3 text-sm leading-[1.35] text-foreground',
+          props.status === 'COMPLETED' && 'line-through decoration-muted-foreground',
+        )}
+      >
+        {props.title}
+      </p>
+    </a>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import type { FlowComponent, TicketProps } from '@xyne/shared';
+import { cn } from '../../../utils/classNames';
+
+const STATUS_META: Record<TicketProps['status'], { label: string; className: string }> = {
+  TODO: { label: 'Todo', className: 'bg-orange-500/15 text-orange-600' },
+  STARTED: { label: 'Started', className: 'bg-blue-500/15 text-blue-600' },
+  PAUSED: { label: 'Paused', className: 'bg-teal-500/15 text-teal-600' },
+  CANCELLED: { label: 'Cancelled', className: 'bg-red-500/15 text-red-600' },
+  COMPLETED: { label: 'Completed', className: 'bg-green-500/15 text-green-600' },
+};
+
+const PRIORITY_META: Record<TicketProps['priority'], { label: string; className: string }> = {
+  LOW: { label: 'Low', className: 'text-muted-foreground' },
+  MEDIUM: { label: 'Medium', className: 'text-[var(--status-pending)]' },
+  HIGH: { label: 'High', className: 'text-[var(--diff-stat-del-fg)]' },
+  CRITICAL: { label: 'Critical', className: 'text-destructive' },
+};
+
+function formatEta(eta: string): string | null {
+  const parsed = new Date(eta);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+}
+
+export const TicketNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as TicketProps | undefined;
+  if (!props?.xyneId || !props.title) return null;
+
+  const status = STATUS_META[props.status];
+  const priority = PRIORITY_META[props.priority];
+  const eta = props.eta ? formatEta(props.eta) : null;
+
+  return (
+    <section
+      className='flow-artifact-wide flex w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className='flex flex-col gap-2 px-4 pb-3 pt-4'>
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-foreground'>
+            {props.xyneId}
+          </span>
+          <span
+            className={cn(
+              'rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px]',
+              status.className,
+            )}
+          >
+            {status.label}
+          </span>
+          <span className={cn('text-xs font-semibold leading-[18px]', priority.className)}>
+            {priority.label}
+          </span>
+          {eta && (
+            <span className='ml-auto shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
+              {eta}
+            </span>
+          )}
+        </div>
+        <p className='text-sm leading-[1.35] text-foreground'>{props.title}</p>
+      </div>
+
+      <div className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
+        <a
+          href={props.url}
+          className='rounded-lg border border-border bg-background px-2 py-1.5 text-sm font-medium leading-[1.2] !text-foreground !no-underline hover:bg-muted'
+          data-track-category='TICKET_ARTIFACT'
+          data-track-name='OPEN_TICKET'
+        >
+          Open in tracker
+        </a>
+      </div>
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/TicketNode.tsx
@@ -1,19 +1,38 @@
-import React from 'react';
-import { CircleCheck, CircleDashed, CircleDot, CirclePause, CircleX } from 'lucide-react';
-import type { FlowComponent, TicketProps } from '@xyne/shared';
-import { TicketPriority } from '@xyne/shared';
-import { formatEta, getPriorityIcon } from '../../Tickets/TicketCard/TicketCard.utils';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  CircleCheck,
+  CircleDashed,
+  CircleDotDashed,
+  CirclePause,
+  CircleSlash,
+  NotebookText,
+  User,
+} from 'lucide-react';
+import type { FlowAction, FlowComponent, TicketProps } from '@xyne/shared';
+import { TicketPriority, TicketStatusV2 } from '@xyne/shared';
+import { useFlow } from '../FlowContext';
+import { Button } from '../../ui/Button/Button';
+import Avatar from '../../ui/Avatar/Avatar';
+import Tooltip from '../../ui/Tooltip';
+import { getPriorityIcon } from '../../Tickets/TicketCard/TicketCard.utils';
+import { TicketCardV2 } from '../../Tickets/TicketCardV2/TicketCardV2';
+import { useNavigate } from '../../../hooks/useWorkspaceNavigate';
 import { cn } from '../../../utils/classNames';
+
+const ACCENT = '#EB5F3A';
+const CALENDAR_GREEN = '#4F9E7F';
+const CORNER_RADIUS = 10;
+const NOTCH_RADIUS = 8;
 
 const STATUS_META: Record<
   TicketProps['status'],
-  { label: string; color: string; Icon: React.FC<{ size?: number; color?: string }> }
+  { label: string; icon: React.ElementType; className?: string; color?: string }
 > = {
-  TODO: { label: 'Todo', color: 'var(--status-pending)', Icon: CircleDashed },
-  STARTED: { label: 'Started', color: 'var(--status-scheduled)', Icon: CircleDot },
-  PAUSED: { label: 'Paused', color: 'var(--status-paused)', Icon: CirclePause },
-  CANCELLED: { label: 'Cancelled', color: 'var(--status-failure)', Icon: CircleX },
-  COMPLETED: { label: 'Completed', color: 'var(--status-success)', Icon: CircleCheck },
+  TODO: { label: 'Todo', icon: CircleDashed, color: ACCENT },
+  STARTED: { label: 'Started', icon: CircleDotDashed, className: 'text-blue-500' },
+  PAUSED: { label: 'Paused', icon: CirclePause, className: 'text-teal-500' },
+  CANCELLED: { label: 'Cancelled', icon: CircleSlash, className: 'text-destructive' },
+  COMPLETED: { label: 'Completed', icon: CircleCheck, className: 'text-green-600' },
 };
 
 const PRIORITY_LABEL: Record<TicketProps['priority'], string> = {
@@ -23,64 +42,231 @@ const PRIORITY_LABEL: Record<TicketProps['priority'], string> = {
   CRITICAL: 'Critical',
 };
 
-const TERMINAL_STATUSES: ReadonlyArray<TicketProps['status']> = ['COMPLETED', 'CANCELLED'];
+function formatEta(eta: string): string | null {
+  const parsed = new Date(eta);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+}
+
+function outlinePath(w: number, h: number): string {
+  const inset = 0.75;
+  const left = inset;
+  const top = inset;
+  const right = w - inset;
+  const bottom = h - inset;
+  const mid = h / 2;
+  const r = CORNER_RADIUS;
+  const n = NOTCH_RADIUS;
+  return [
+    `M ${left + r} ${top}`,
+    `H ${right - r}`,
+    `A ${r} ${r} 0 0 1 ${right} ${top + r}`,
+    `V ${mid - n}`,
+    `A ${n} ${n} 0 0 0 ${right} ${mid + n}`,
+    `V ${bottom - r}`,
+    `A ${r} ${r} 0 0 1 ${right - r} ${bottom}`,
+    `H ${left + r}`,
+    `A ${r} ${r} 0 0 1 ${left} ${bottom - r}`,
+    `V ${mid + n}`,
+    `A ${n} ${n} 0 0 0 ${left} ${mid - n}`,
+    `V ${top + r}`,
+    `A ${r} ${r} 0 0 1 ${left + r} ${top}`,
+    'Z',
+  ].join(' ');
+}
+
+const CalendarGlyph: React.FC = () => (
+  <svg viewBox='0 0 24 24' className='size-4 shrink-0' fill='none' aria-hidden='true'>
+    <path
+      d='M8 2.4v3.2M16 2.4v3.2'
+      stroke={CALENDAR_GREEN}
+      strokeWidth='2.6'
+      strokeLinecap='round'
+    />
+    <rect x='2.5' y='4' width='19' height='17.6' rx='5.5' fill={CALENDAR_GREEN} />
+    <rect x='2.5' y='9.4' width='19' height='2.2' fill='#fff' />
+  </svg>
+);
 
 export const TicketNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
   node,
 }) => {
   const props = node.props as TicketProps | undefined;
-  if (!props?.xyneId || !props.title) return null;
+  const { executeAction, isSubmitting } = useFlow();
+  const navigate = useNavigate();
+  const [pending, setPending] = useState<string | null>(null);
+  const [box, setBox] = useState({ w: 0, h: 0 });
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return undefined;
+    const observer = new ResizeObserver(() => setBox({ w: el.offsetWidth, h: el.offsetHeight }));
+    observer.observe(el);
+    return (): void => observer.disconnect();
+  }, []);
+
+  if (!props?.title) return null;
+
+  const proposed = props.phase === 'proposed';
+
+  if (!proposed) {
+    const etaMs = props.eta ? Date.parse(props.eta) : Number.NaN;
+    const ticketUrl = props.url;
+    return (
+      <section className='flow-artifact-wide flex w-full flex-col'>
+        <TicketCardV2
+          isConversation
+          ticket={{
+            id: props.ticketId ?? props.xyneId ?? '',
+            xyneId: props.xyneId ?? null,
+            title: props.title,
+            statusV2: props.status as TicketStatusV2,
+            priority: props.priority as TicketPriority,
+            stageName: props.stageName ?? null,
+            assignedTo: props.assigneeId ?? null,
+            eta: Number.isNaN(etaMs) ? null : etaMs,
+            channelId: props.channelId ?? null,
+            conversationId: props.conversationId ?? null,
+          }}
+          {...(ticketUrl
+            ? {
+                onClick: (): void => {
+                  void navigate(ticketUrl);
+                },
+              }
+            : {})}
+        />
+      </section>
+    );
+  }
 
   const status = STATUS_META[props.status];
-  const etaMs = props.eta ? new Date(props.eta).getTime() : NaN;
-  const eta = Number.isNaN(etaMs) ? null : formatEta(etaMs);
-  const etaOverdue =
-    !!eta && etaMs < new Date().setHours(0, 0, 0, 0) && !TERMINAL_STATUSES.includes(props.status);
+  const StatusIcon = status.icon;
+  const eta = props.eta ? formatEta(props.eta) : null;
 
-  return (
-    <a
-      href={props.url}
+  const run = (action: TicketProps['approveAction'], key: string): void => {
+    if (!action) return;
+    setPending(key);
+    void executeAction(action as FlowAction).finally(() => setPending(null));
+  };
+
+  const card = (
+    <div
+      ref={cardRef}
+      className='relative flex w-full flex-col gap-3.5 rounded-[10px] bg-background px-4 py-3.5'
       style={node.style}
-      className='flow-artifact-wide block w-full overflow-hidden rounded-xl border border-border bg-background !no-underline transition-colors hover:bg-muted/40'
-      data-track-category='TICKET_ARTIFACT'
-      data-track-name='OPEN_TICKET'
     >
-      <div className='flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-2.5'>
-        <span className='font-mono text-sm text-muted-foreground'>{props.xyneId}</span>
+      {box.w > 0 && (
+        <svg
+          className='pointer-events-none absolute inset-0 text-muted-foreground/45'
+          width={box.w}
+          height={box.h}
+          viewBox={`0 0 ${box.w} ${box.h}`}
+          fill='none'
+          aria-hidden='true'
+        >
+          <path
+            d={outlinePath(box.w, box.h)}
+            stroke='currentColor'
+            strokeWidth={1.5}
+            strokeDasharray='4 4'
+          />
+        </svg>
+      )}
 
-        <div className='ml-auto flex items-center gap-4'>
-          <span className='flex items-center gap-1.5 text-sm text-foreground'>
-            <status.Icon size={14} color={status.color} />
+      <div className='flex flex-wrap items-center justify-between gap-x-6 gap-y-2'>
+        <span className='flex items-center gap-2 font-mono text-[13px] tracking-[0.6px] text-foreground/80'>
+          <NotebookText className='size-4 shrink-0 text-muted-foreground' strokeWidth={1.75} />
+          {props.xyneId ?? 'Draft'}
+        </span>
+
+        <span className='flex items-center gap-6'>
+          <span className='flex items-center gap-2 text-sm text-foreground'>
+            <StatusIcon
+              className={cn('size-4 shrink-0', status.className)}
+              {...(status.color ? { color: status.color } : {})}
+              strokeWidth={2}
+            />
             {status.label}
           </span>
 
-          <span className='flex items-center gap-1 text-sm text-foreground'>
+          <span className='flex items-center gap-2 text-sm text-foreground'>
             {getPriorityIcon(props.priority as TicketPriority)}
             {PRIORITY_LABEL[props.priority]}
           </span>
 
           {eta && (
-            <span className='flex items-center gap-1.5 text-sm tabular-nums text-foreground'>
-              <span
-                className='size-3 shrink-0 rounded-[3px]'
-                style={{
-                  background: etaOverdue ? 'var(--status-failure)' : 'var(--status-success)',
-                }}
-              />
+            <span className='flex items-center gap-2 text-sm tabular-nums text-foreground'>
+              <CalendarGlyph />
               {eta}
             </span>
           )}
-        </div>
+
+          {props.assigneeId ? (
+            <Avatar userId={props.assigneeId} size='sm' showActiveStatus={false} />
+          ) : (
+            <Tooltip content='Unassigned'>
+              <span className='flex size-5 items-center justify-center rounded-full border border-dashed border-muted-foreground'>
+                <User className='size-3 text-muted-foreground' strokeWidth={1.5} />
+              </span>
+            </Tooltip>
+          )}
+        </span>
       </div>
 
-      <p
-        className={cn(
-          'border-t border-border px-4 py-3 text-sm leading-[1.35] text-foreground',
-          props.status === 'COMPLETED' && 'line-through decoration-muted-foreground',
-        )}
-      >
-        {props.title}
-      </p>
-    </a>
+      <p className='text-[15px] leading-[1.4] text-foreground'>{props.title}</p>
+    </div>
+  );
+
+  return (
+    <section className='flow-artifact-wide flex w-full flex-col'>
+      {card}
+
+      {(props.approveAction || props.approveContinueAction || props.declineAction) && (
+        <div className='flex items-center justify-end gap-2 pt-3'>
+          {props.declineAction && (
+            <Button
+              variant='ghost'
+              size='sm'
+              disabled={isSubmitting}
+              loading={pending === 'decline'}
+              onClick={() => run(props.declineAction, 'decline')}
+              data-track-category='TICKET_ARTIFACT'
+              data-track-name='DECLINE_TICKET'
+            >
+              Decline
+            </Button>
+          )}
+          {props.approveAction && (
+            <Button
+              variant='outline'
+              size='sm'
+              disabled={isSubmitting}
+              loading={pending === 'approve'}
+              onClick={() => run(props.approveAction, 'approve')}
+              data-track-category='TICKET_ARTIFACT'
+              data-track-name='APPROVE_TICKET'
+            >
+              Approve
+            </Button>
+          )}
+          {props.approveContinueAction && (
+            <Button
+              size='sm'
+              style={{ backgroundColor: ACCENT }}
+              className='text-white hover:brightness-95'
+              disabled={isSubmitting}
+              loading={pending === 'approve-continue'}
+              onClick={() => run(props.approveContinueAction, 'approve-continue')}
+              data-track-category='TICKET_ARTIFACT'
+              data-track-name='APPROVE_TICKET_AND_CONTINUE'
+            >
+              Accept &amp; start task
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
@@ -1,0 +1,228 @@
+import React, { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useFlow } from '../FlowContext';
+import type { FlowAction, FlowComponent, UserQuestionItem } from '@xyne/shared';
+
+interface UserQuestionNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+type Answers = Record<string, string | string[]>;
+const SKIP_QUESTION_OPTION = 'Skip this question';
+
+/**
+ * The thread counterpart to PlanNode: one self-contained FlowJSON artifact
+ * instead of a trail of button messages. A tab selects the prompt to answer;
+ * answers remain in FlowRenderer state, so switching tabs never loses input.
+ */
+export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
+  const props = node.props as
+    | {
+        title: string;
+        questions: UserQuestionItem[];
+        phase?: 'pending' | 'answered' | 'declined';
+        answers?: Answers;
+        notes?: Record<string, string>;
+        submitAction?: FlowAction;
+        dismissAction?: FlowAction;
+      }
+    | undefined;
+  const { state, updateFieldValue, executeAction } = useFlow();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // Question-set cards posted before terminal phases were introduced do not
+  // have `phase`. Treat them as pending so opening an older thread never tries
+  // to read a non-existent persisted `answers` object.
+  const phase = props?.phase ?? 'pending';
+  const terminal = phase !== 'pending';
+  const answers = (terminal ? props?.answers ?? {} : state.values.answers ?? {}) as Answers;
+  const notes = (terminal ? props?.notes ?? {} : state.values.notes ?? {}) as Record<string, string>;
+  const activeQuestion = props?.questions[activeIndex];
+  const requiredQuestions = useMemo(
+    () => props?.questions.filter(question => question.required !== false) ?? [],
+    [props?.questions],
+  );
+
+  if (!props || !activeQuestion) return null;
+
+  const updateAnswer = (questionId: string, value: string | string[]) => {
+    updateFieldValue('answers', { ...answers, [questionId]: value });
+  };
+
+  const toggleMultipleChoice = (option: string, checked: boolean) => {
+    const selected = Array.isArray(answers[activeQuestion.id])
+      ? (answers[activeQuestion.id] as string[])
+      : [];
+    if (option === SKIP_QUESTION_OPTION && checked) {
+      updateAnswer(activeQuestion.id, [SKIP_QUESTION_OPTION]);
+      return;
+    }
+    updateAnswer(
+      activeQuestion.id,
+      checked
+        ? [...selected.filter(value => value !== SKIP_QUESTION_OPTION), option]
+        : selected.filter(value => value !== option),
+    );
+  };
+
+  const hasAnswer = (question: UserQuestionItem) => {
+    const answer = answers[question.id];
+    return Array.isArray(answer)
+      ? answer.length > 0
+      : typeof answer === 'string' && answer.trim().length > 0;
+  };
+
+  const isQuestionComplete = (question: UserQuestionItem) =>
+    hasAnswer(question) || Boolean(notes[question.id]?.trim());
+
+  const submit = () => {
+    const unanswered = requiredQuestions.find(question => !isQuestionComplete(question));
+    if (unanswered) {
+      const index = props.questions.findIndex(question => question.id === unanswered.id);
+      setActiveIndex(Math.max(0, index));
+      toast.error('Please answer each required question before submitting.');
+      return;
+    }
+    if (props.submitAction) void executeAction(props.submitAction);
+  };
+
+  const selectedAnswer = answers[activeQuestion.id];
+  return (
+    <section
+      className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
+      style={node.style}
+    >
+      <div className={`flex flex-col gap-3 p-4 ${terminal ? 'opacity-60' : ''}`}>
+      <div className='flex items-center justify-between gap-2'>
+        <div className='flex items-center gap-2'>
+        <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>Question</span>
+        {terminal && <span className={`rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] ${phase === 'answered' ? 'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]' : 'bg-destructive/10 text-destructive'}`}>{phase === 'answered' ? 'Answered' : 'Declined'}</span>}
+        </div>
+        {props.questions.length > 1 && <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>{activeIndex + 1}/{props.questions.length}</span>}
+      </div>
+      <div className='flex gap-2 overflow-x-auto border-b border-border'>
+        {props.questions.map((question, index) => (
+          <button
+            key={question.id}
+            type='button'
+            onClick={() => setActiveIndex(index)}
+            disabled={state.submitting}
+            className={`shrink-0 rounded-t-xl px-3 py-2 text-sm font-medium transition-colors ${
+              activeIndex === index
+                ? 'bg-muted text-foreground'
+                : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+            }`}
+          >
+            {isQuestionComplete(question) && <span className='mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle' aria-label='Answered or noted' />}
+            {props.questions.length === 1
+              ? props.title
+              : (question.label ?? question.id)}
+          </button>
+        ))}
+      </div>
+
+      <div className='space-y-5'>
+        <h3 className='text-lg font-semibold leading-[1.2] text-foreground'>
+          {activeQuestion.question}
+        </h3>
+
+        {activeQuestion.type === 'open_ended' && (
+          <div className='space-y-2'>
+            <textarea
+              value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
+              onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
+              placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
+              disabled={state.submitting || terminal}
+              rows={4}
+              className='w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+            />
+            {!terminal && <button type='button' onClick={() => updateAnswer(activeQuestion.id, 'Skip this question')} className='text-xs font-medium text-muted-foreground hover:text-foreground'>Skip this question</button>}
+          </div>
+        )}
+
+        {activeQuestion.type === 'single_choice' && (
+          <div className='space-y-3'>
+            {activeQuestion.options.map(option => (
+              <label
+                key={option}
+                className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+              >
+                <input
+                  type='radio'
+                  name={activeQuestion.id}
+                  checked={selectedAnswer === option}
+                  disabled={state.submitting || terminal}
+                  onChange={() => updateAnswer(activeQuestion.id, option)}
+                  className='h-4 w-4 border-border text-primary focus:ring-ring'
+                />
+                {option}
+              </label>
+            ))}
+          </div>
+        )}
+
+        {activeQuestion.type === 'multiple_choice' && (
+          <div className='space-y-3'>
+            {activeQuestion.options.map(option => {
+              const selected = Array.isArray(selectedAnswer) && selectedAnswer.includes(option);
+              return (
+                <label
+                  key={option}
+                  className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+                >
+                  <input
+                    type='checkbox'
+                    checked={selected}
+                    disabled={state.submitting || terminal}
+                    onChange={event => toggleMultipleChoice(option, event.target.checked)}
+                    className='h-4 w-4 rounded border-border text-primary focus:ring-ring'
+                  />
+                  {option}
+                </label>
+              );
+            })}
+          </div>
+        )}
+
+        <div className='border-t border-dashed border-border pt-4'>
+          <textarea
+            value={notes[activeQuestion.id] ?? ''}
+            onChange={event => updateFieldValue('notes', { ...notes, [activeQuestion.id]: event.target.value })}
+            placeholder='+ Add notes (optional)'
+            disabled={state.submitting || terminal}
+            rows={2}
+            className='w-full resize-y rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+          />
+        </div>
+      </div>
+      </div>
+      {phase === 'answered' && (
+        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
+          <p className='text-xs leading-[1.2] text-muted-foreground'>Answers submitted</p>
+        </div>
+      )}
+      {phase === 'declined' && <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'><p className='text-xs leading-[1.2] text-muted-foreground'>Question declined.</p></div>}
+      {!terminal && <footer className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
+        <button
+          type='button'
+          onClick={submit}
+          disabled={state.submitting}
+          className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60'
+        >
+          Submit answers
+        </button>
+        {props.dismissAction && (
+          <button
+            type='button'
+            onClick={() => void executeAction(props.dismissAction!)}
+            disabled={state.submitting}
+            className='rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+          >
+            Dismiss
+          </button>
+        )}
+      </footer>}
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
@@ -36,8 +36,11 @@ export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
   // to read a non-existent persisted `answers` object.
   const phase = props?.phase ?? 'pending';
   const terminal = phase !== 'pending';
-  const answers = (terminal ? props?.answers ?? {} : state.values.answers ?? {}) as Answers;
-  const notes = (terminal ? props?.notes ?? {} : state.values.notes ?? {}) as Record<string, string>;
+  const answers = (terminal ? (props?.answers ?? {}) : (state.values['answers'] ?? {})) as Answers;
+  const notes = (terminal ? (props?.notes ?? {}) : (state.values['notes'] ?? {})) as Record<
+    string,
+    string
+  >;
   const activeQuestion = props?.questions[activeIndex];
   const requiredQuestions = useMemo(
     () => props?.questions.filter(question => question.required !== false) ?? [],
@@ -94,135 +97,182 @@ export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
       style={node.style}
     >
       <div className={`flex flex-col gap-3 p-4 ${terminal ? 'opacity-60' : ''}`}>
-      <div className='flex items-center justify-between gap-2'>
-        <div className='flex items-center gap-2'>
-        <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>Question</span>
-        {terminal && <span className={`rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] ${phase === 'answered' ? 'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]' : 'bg-destructive/10 text-destructive'}`}>{phase === 'answered' ? 'Answered' : 'Declined'}</span>}
-        </div>
-        {props.questions.length > 1 && <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>{activeIndex + 1}/{props.questions.length}</span>}
-      </div>
-      <div className='flex gap-2 overflow-x-auto border-b border-border'>
-        {props.questions.map((question, index) => (
-          <button
-            key={question.id}
-            type='button'
-            onClick={() => setActiveIndex(index)}
-            disabled={state.submitting}
-            className={`shrink-0 rounded-t-xl px-3 py-2 text-sm font-medium transition-colors ${
-              activeIndex === index
-                ? 'bg-muted text-foreground'
-                : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-            }`}
-          >
-            {isQuestionComplete(question) && <span className='mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle' aria-label='Answered or noted' />}
-            {props.questions.length === 1
-              ? props.title
-              : (question.label ?? question.id)}
-          </button>
-        ))}
-      </div>
-
-      <div className='space-y-5'>
-        <h3 className='text-lg font-semibold leading-[1.2] text-foreground'>
-          {activeQuestion.question}
-        </h3>
-
-        {activeQuestion.type === 'open_ended' && (
-          <div className='space-y-2'>
-            <textarea
-              value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
-              onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
-              placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
-              disabled={state.submitting || terminal}
-              rows={4}
-              className='w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
-            />
-            {!terminal && <button type='button' onClick={() => updateAnswer(activeQuestion.id, 'Skip this question')} className='text-xs font-medium text-muted-foreground hover:text-foreground'>Skip this question</button>}
-          </div>
-        )}
-
-        {activeQuestion.type === 'single_choice' && (
-          <div className='space-y-3'>
-            {activeQuestion.options.map(option => (
-              <label
-                key={option}
-                className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+        <div className='flex items-center justify-between gap-2'>
+          <div className='flex items-center gap-2'>
+            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
+              Question
+            </span>
+            {terminal && (
+              <span
+                className={`rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] ${phase === 'answered' ? 'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]' : 'bg-destructive/10 text-destructive'}`}
               >
-                <input
-                  type='radio'
-                  name={activeQuestion.id}
-                  checked={selectedAnswer === option}
-                  disabled={state.submitting || terminal}
-                  onChange={() => updateAnswer(activeQuestion.id, option)}
-                  className='h-4 w-4 border-border text-primary focus:ring-ring'
-                />
-                {option}
-              </label>
-            ))}
+                {phase === 'answered' ? 'Answered' : 'Declined'}
+              </span>
+            )}
           </div>
-        )}
+          {props.questions.length > 1 && (
+            <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
+              {activeIndex + 1}/{props.questions.length}
+            </span>
+          )}
+        </div>
+        <div className='flex gap-2 overflow-x-auto border-b border-border'>
+          {props.questions.map((question, index) => (
+            <button
+              key={question.id}
+              type='button'
+              data-track-category='USER_QUESTION_ARTIFACT'
+              data-track-name='SELECT_QUESTION_TAB'
+              onClick={() => setActiveIndex(index)}
+              disabled={state.submitting}
+              className={`shrink-0 rounded-t-xl px-3 py-2 text-sm font-medium transition-colors ${
+                activeIndex === index
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+              }`}
+            >
+              {isQuestionComplete(question) && (
+                <span
+                  className='mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle'
+                  aria-label='Answered or noted'
+                />
+              )}
+              {props.questions.length === 1 ? props.title : (question.label ?? question.id)}
+            </button>
+          ))}
+        </div>
 
-        {activeQuestion.type === 'multiple_choice' && (
-          <div className='space-y-3'>
-            {activeQuestion.options.map(option => {
-              const selected = Array.isArray(selectedAnswer) && selectedAnswer.includes(option);
-              return (
+        <div className='space-y-5'>
+          <h3 className='text-lg font-semibold leading-[1.2] text-foreground'>
+            {activeQuestion.question}
+          </h3>
+
+          {activeQuestion.type === 'open_ended' && (
+            <div className='space-y-2'>
+              <textarea
+                value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
+                data-track-category='USER_QUESTION_ARTIFACT'
+                data-track-name='EDIT_OPEN_ENDED_ANSWER'
+                onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
+                placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
+                disabled={state.submitting || terminal}
+                rows={4}
+                className='w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+              />
+              {!terminal && (
+                <button
+                  type='button'
+                  data-track-category='USER_QUESTION_ARTIFACT'
+                  data-track-name='SKIP_QUESTION'
+                  onClick={() => updateAnswer(activeQuestion.id, 'Skip this question')}
+                  className='text-xs font-medium text-muted-foreground hover:text-foreground'
+                >
+                  Skip this question
+                </button>
+              )}
+            </div>
+          )}
+
+          {activeQuestion.type === 'single_choice' && (
+            <div className='space-y-3'>
+              {activeQuestion.options.map(option => (
                 <label
                   key={option}
                   className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
                 >
                   <input
-                    type='checkbox'
-                    checked={selected}
+                    type='radio'
+                    data-track-category='USER_QUESTION_ARTIFACT'
+                    data-track-name='SELECT_SINGLE_CHOICE'
+                    name={activeQuestion.id}
+                    checked={selectedAnswer === option}
                     disabled={state.submitting || terminal}
-                    onChange={event => toggleMultipleChoice(option, event.target.checked)}
-                    className='h-4 w-4 rounded border-border text-primary focus:ring-ring'
+                    onChange={() => updateAnswer(activeQuestion.id, option)}
+                    className='h-4 w-4 border-border text-primary focus:ring-ring'
                   />
                   {option}
                 </label>
-              );
-            })}
-          </div>
-        )}
+              ))}
+            </div>
+          )}
 
-        <div className='border-t border-dashed border-border pt-4'>
-          <textarea
-            value={notes[activeQuestion.id] ?? ''}
-            onChange={event => updateFieldValue('notes', { ...notes, [activeQuestion.id]: event.target.value })}
-            placeholder='+ Add notes (optional)'
-            disabled={state.submitting || terminal}
-            rows={2}
-            className='w-full resize-y rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
-          />
+          {activeQuestion.type === 'multiple_choice' && (
+            <div className='space-y-3'>
+              {activeQuestion.options.map(option => {
+                const selected = Array.isArray(selectedAnswer) && selectedAnswer.includes(option);
+                return (
+                  <label
+                    key={option}
+                    className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+                  >
+                    <input
+                      type='checkbox'
+                      data-track-category='USER_QUESTION_ARTIFACT'
+                      data-track-name='TOGGLE_MULTIPLE_CHOICE'
+                      checked={selected}
+                      disabled={state.submitting || terminal}
+                      onChange={event => toggleMultipleChoice(option, event.target.checked)}
+                      className='h-4 w-4 rounded border-border text-primary focus:ring-ring'
+                    />
+                    {option}
+                  </label>
+                );
+              })}
+            </div>
+          )}
+
+          <div className='border-t border-dashed border-border pt-4'>
+            <textarea
+              value={notes[activeQuestion.id] ?? ''}
+              data-track-category='USER_QUESTION_ARTIFACT'
+              data-track-name='EDIT_QUESTION_NOTES'
+              onChange={event =>
+                updateFieldValue('notes', { ...notes, [activeQuestion.id]: event.target.value })
+              }
+              placeholder='+ Add notes (optional)'
+              disabled={state.submitting || terminal}
+              rows={2}
+              className='w-full resize-y rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
+            />
+          </div>
         </div>
-      </div>
       </div>
       {phase === 'answered' && (
         <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
           <p className='text-xs leading-[1.2] text-muted-foreground'>Answers submitted</p>
         </div>
       )}
-      {phase === 'declined' && <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'><p className='text-xs leading-[1.2] text-muted-foreground'>Question declined.</p></div>}
-      {!terminal && <footer className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
-        <button
-          type='button'
-          onClick={submit}
-          disabled={state.submitting}
-          className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60'
-        >
-          Submit answers
-        </button>
-        {props.dismissAction && (
+      {phase === 'declined' && (
+        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
+          <p className='text-xs leading-[1.2] text-muted-foreground'>Question declined.</p>
+        </div>
+      )}
+      {!terminal && (
+        <footer className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
           <button
             type='button'
-            onClick={() => void executeAction(props.dismissAction!)}
+            data-track-category='USER_QUESTION_ARTIFACT'
+            data-track-name='SUBMIT_ANSWERS'
+            onClick={submit}
             disabled={state.submitting}
-            className='rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+            className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60'
           >
-            Dismiss
+            Submit answers
           </button>
-        )}
-      </footer>}
+          {props.dismissAction && (
+            <button
+              type='button'
+              data-track-category='USER_QUESTION_ARTIFACT'
+              data-track-name='DISMISS_QUESTION'
+              onClick={() => void executeAction(props.dismissAction!)}
+              disabled={state.submitting}
+              className='rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+            >
+              Dismiss
+            </button>
+          )}
+        </footer>
+      )}
     </section>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
@@ -1,7 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Check, PencilLine } from 'lucide-react';
 import { toast } from 'sonner';
 import { useFlow } from '../FlowContext';
-import type { FlowAction, FlowComponent, UserQuestionItem } from '@xyne/shared';
+import Avatar from '../../ui/Avatar/Avatar';
+import { useUser } from '../../../hooks/useUsers';
+import { cn } from '../../../utils/classNames';
+import type { FlowAction, FlowComponent, UserQuestionItem, UserQuestionOption } from '@xyne/shared';
 
 interface UserQuestionNodeProps {
   node: FlowComponent;
@@ -11,10 +15,32 @@ interface UserQuestionNodeProps {
 type Answers = Record<string, string | string[]>;
 const SKIP_QUESTION_OPTION = 'Skip this question';
 
+const optionLabel = (option: UserQuestionOption): string =>
+  typeof option === 'string' ? option : option.label;
+const optionDescription = (option: UserQuestionOption): string | undefined =>
+  typeof option === 'string' ? undefined : option.description;
+
+/** 14px square tick box — unchecked outline, or filled with the inverse check. */
+const OptionCheck: React.FC<{ checked: boolean }> = ({ checked }) => (
+  <span className='flex size-5 shrink-0 items-center justify-center'>
+    <span
+      className={cn(
+        'flex size-3.5 items-center justify-center rounded',
+        checked
+          ? 'border-[0.875px] border-foreground/10 bg-foreground text-background'
+          : 'border-[1.2px] border-foreground/40',
+      )}
+    >
+      {checked && <Check className='size-3' strokeWidth={2.75} />}
+    </span>
+  </span>
+);
+
 /**
  * The thread counterpart to PlanNode: one self-contained FlowJSON artifact
- * instead of a trail of button messages. A tab selects the prompt to answer;
- * answers remain in FlowRenderer state, so switching tabs never loses input.
+ * instead of a trail of button messages. One prompt is shown at a time and
+ * Back/Next page through the set; answers live in FlowRenderer state, so
+ * paging never loses input.
  */
 export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
   const props = node.props as
@@ -28,251 +54,327 @@ export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
         dismissAction?: FlowAction;
       }
     | undefined;
-  const { state, updateFieldValue, executeAction } = useFlow();
+  const { state, data, updateFieldValue, executeAction } = useFlow();
   const [activeIndex, setActiveIndex] = useState(0);
+  // Tracks prompts whose "Something else…" row is open but still empty; a row
+  // with text is derived from `notes` instead so it survives paging.
+  const [customOpen, setCustomOpen] = useState<Record<string, boolean>>({});
+  // Skip-then-submit writes an answer and submits in one click. Deferring the
+  // submit to an effect lets the field write commit first, so executeAction
+  // never reads the pre-skip values.
+  const [submitRequested, setSubmitRequested] = useState(false);
+  const customInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Question-set cards posted before terminal phases were introduced do not
   // have `phase`. Treat them as pending so opening an older thread never tries
   // to read a non-existent persisted `answers` object.
   const phase = props?.phase ?? 'pending';
   const terminal = phase !== 'pending';
-  const answers = (terminal ? (props?.answers ?? {}) : (state.values['answers'] ?? {})) as Answers;
-  const notes = (terminal ? (props?.notes ?? {}) : (state.values['notes'] ?? {})) as Record<
-    string,
-    string
-  >;
-  const activeQuestion = props?.questions[activeIndex];
-  const requiredQuestions = useMemo(
-    () => props?.questions.filter(question => question.required !== false) ?? [],
-    [props?.questions],
+  const answers = useMemo(
+    () => (terminal ? (props?.answers ?? {}) : (state.values['answers'] ?? {})) as Answers,
+    [terminal, props?.answers, state.values],
+  );
+  const notes = useMemo(
+    () =>
+      (terminal ? (props?.notes ?? {}) : (state.values['notes'] ?? {})) as Record<string, string>,
+    [terminal, props?.notes, state.values],
+  );
+  const questions = useMemo(() => props?.questions ?? [], [props?.questions]);
+  const activeQuestion = questions[activeIndex];
+  const submitterId = typeof data['userId'] === 'string' ? data['userId'] : '';
+  const submitter = useUser(submitterId);
+
+  const isQuestionComplete = useCallback(
+    (question: UserQuestionItem) => {
+      const answer = answers[question.id];
+      const answered = Array.isArray(answer)
+        ? answer.length > 0
+        : typeof answer === 'string' && answer.trim().length > 0;
+      return answered || Boolean(notes[question.id]?.trim());
+    },
+    [answers, notes],
   );
 
-  if (!props || !activeQuestion) return null;
-
-  const updateAnswer = (questionId: string, value: string | string[]) => {
-    updateFieldValue('answers', { ...answers, [questionId]: value });
-  };
-
-  const toggleMultipleChoice = (option: string, checked: boolean) => {
-    const selected = Array.isArray(answers[activeQuestion.id])
-      ? (answers[activeQuestion.id] as string[])
-      : [];
-    if (option === SKIP_QUESTION_OPTION && checked) {
-      updateAnswer(activeQuestion.id, [SKIP_QUESTION_OPTION]);
-      return;
-    }
-    updateAnswer(
-      activeQuestion.id,
-      checked
-        ? [...selected.filter(value => value !== SKIP_QUESTION_OPTION), option]
-        : selected.filter(value => value !== option),
+  useEffect(() => {
+    if (!submitRequested) return;
+    setSubmitRequested(false);
+    const unanswered = questions.find(
+      question => question.required !== false && !isQuestionComplete(question),
     );
-  };
-
-  const hasAnswer = (question: UserQuestionItem) => {
-    const answer = answers[question.id];
-    return Array.isArray(answer)
-      ? answer.length > 0
-      : typeof answer === 'string' && answer.trim().length > 0;
-  };
-
-  const isQuestionComplete = (question: UserQuestionItem) =>
-    hasAnswer(question) || Boolean(notes[question.id]?.trim());
-
-  const submit = () => {
-    const unanswered = requiredQuestions.find(question => !isQuestionComplete(question));
     if (unanswered) {
-      const index = props.questions.findIndex(question => question.id === unanswered.id);
-      setActiveIndex(Math.max(0, index));
+      setActiveIndex(
+        Math.max(
+          0,
+          questions.findIndex(question => question.id === unanswered.id),
+        ),
+      );
       toast.error('Please answer each required question before submitting.');
       return;
     }
-    if (props.submitAction) void executeAction(props.submitAction);
+    if (props?.submitAction) void executeAction(props.submitAction);
+  }, [submitRequested, questions, isQuestionComplete, props?.submitAction, executeAction]);
+
+  if (!props || !activeQuestion) return null;
+
+  const total = questions.length;
+  const isLast = activeIndex === total - 1;
+  const disabled = state.submitting;
+  const selectedAnswer = answers[activeQuestion.id];
+  const customValue = notes[activeQuestion.id] ?? '';
+  const customActive = Boolean(customOpen[activeQuestion.id]) || customValue.length > 0;
+  // The tool appends a stock skip option; the footer's Skip button is its home
+  // in this layout, so it never renders as a row.
+  const choices =
+    activeQuestion.type === 'open_ended'
+      ? []
+      : activeQuestion.options.filter(option => optionLabel(option) !== SKIP_QUESTION_OPTION);
+
+  const updateAnswer = (questionId: string, value: string | string[]): void => {
+    updateFieldValue('answers', { ...answers, [questionId]: value });
   };
 
-  const selectedAnswer = answers[activeQuestion.id];
-  return (
-    <section
-      className='flex w-[450px] max-w-full flex-col overflow-hidden rounded-xl border border-border bg-muted/40'
-      style={node.style}
-    >
-      <div className={`flex flex-col gap-3 p-4 ${terminal ? 'opacity-60' : ''}`}>
-        <div className='flex items-center justify-between gap-2'>
-          <div className='flex items-center gap-2'>
-            <span className='font-mono text-sm leading-[18px] tracking-[0.2px] text-muted-foreground'>
-              Question
-            </span>
-            {terminal && (
-              <span
-                className={`rounded px-1 py-px text-xs font-semibold leading-[18px] tracking-[0.2px] ${phase === 'answered' ? 'bg-[var(--plan-chip-approved-bg)] text-[var(--plan-chip-approved-fg)]' : 'bg-destructive/10 text-destructive'}`}
-              >
-                {phase === 'answered' ? 'Answered' : 'Declined'}
-              </span>
-            )}
-          </div>
-          {props.questions.length > 1 && (
-            <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
-              {activeIndex + 1}/{props.questions.length}
-            </span>
-          )}
-        </div>
-        <div className='flex gap-2 overflow-x-auto border-b border-border'>
-          {props.questions.map((question, index) => (
-            <button
-              key={question.id}
-              type='button'
-              data-track-category='USER_QUESTION_ARTIFACT'
-              data-track-name='SELECT_QUESTION_TAB'
-              onClick={() => setActiveIndex(index)}
-              disabled={state.submitting}
-              className={`shrink-0 rounded-t-xl px-3 py-2 text-sm font-medium transition-colors ${
-                activeIndex === index
-                  ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-              }`}
-            >
-              {isQuestionComplete(question) && (
-                <span
-                  className='mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle'
-                  aria-label='Answered or noted'
-                />
-              )}
-              {props.questions.length === 1 ? props.title : (question.label ?? question.id)}
-            </button>
+  const updateNote = (questionId: string, value: string): void => {
+    updateFieldValue('notes', { ...notes, [questionId]: value });
+  };
+
+  const chooseOption = (option: string): void => {
+    if (activeQuestion.type === 'multiple_choice') {
+      const selected = Array.isArray(selectedAnswer) ? selectedAnswer : [];
+      updateAnswer(
+        activeQuestion.id,
+        selected.includes(option)
+          ? selected.filter(value => value !== option)
+          : [...selected, option],
+      );
+      return;
+    }
+    updateAnswer(activeQuestion.id, selectedAnswer === option ? '' : option);
+  };
+
+  const isChosen = (option: string): boolean =>
+    Array.isArray(selectedAnswer) ? selectedAnswer.includes(option) : selectedAnswer === option;
+
+  const skip = (): void => {
+    updateAnswer(
+      activeQuestion.id,
+      activeQuestion.type === 'multiple_choice' ? [SKIP_QUESTION_OPTION] : SKIP_QUESTION_OPTION,
+    );
+    if (isLast) setSubmitRequested(true);
+    else setActiveIndex(activeIndex + 1);
+  };
+
+  const advance = (): void => {
+    if (isLast) setSubmitRequested(true);
+    else setActiveIndex(activeIndex + 1);
+  };
+
+  const answerSummary = (question: UserQuestionItem): string => {
+    const answer = answers[question.id];
+    const parts = Array.isArray(answer)
+      ? answer.filter(Boolean)
+      : typeof answer === 'string' && answer.trim()
+        ? [answer.trim()]
+        : [];
+    const note = notes[question.id]?.trim();
+    if (note) parts.push(note);
+    return parts.length ? parts.join(', ') : '—';
+  };
+
+  if (terminal) {
+    return (
+      <section
+        className='flex w-[428px] max-w-full flex-col rounded-2xl bg-foreground/[0.06]'
+        style={node.style}
+      >
+        <div className='flex flex-col gap-4 rounded-2xl border border-foreground/[0.06] bg-background px-4 py-3'>
+          {questions.map((question, index) => (
+            <React.Fragment key={question.id}>
+              {index > 0 && <div className='h-px w-full shrink-0 bg-foreground/10' />}
+              <div className='flex flex-col gap-2'>
+                <p className='text-sm font-medium leading-5 tracking-[-0.07px] text-foreground/80'>
+                  {question.question}
+                </p>
+                <p className='text-sm font-semibold leading-5 text-foreground'>
+                  {phase === 'answered' ? answerSummary(question) : 'Dismissed'}
+                </p>
+              </div>
+            </React.Fragment>
           ))}
         </div>
+        <div className='flex items-center gap-1.5 px-4 py-2'>
+          <span className='text-xs font-semibold leading-5 text-foreground/60'>
+            {phase === 'answered' ? 'Submitted by' : 'Dismissed by'}
+          </span>
+          <div className='flex items-center gap-1.5'>
+            {submitterId && (
+              <Avatar userId={submitterId} size='xs' showActiveStatus={false} className='rounded' />
+            )}
+            <span className='text-xs font-semibold leading-5 text-foreground'>
+              {submitter?.name ?? 'You'}
+            </span>
+          </div>
+        </div>
+      </section>
+    );
+  }
 
-        <div className='space-y-5'>
-          <h3 className='text-lg font-semibold leading-[1.2] text-foreground'>
-            {activeQuestion.question}
-          </h3>
-
-          {activeQuestion.type === 'open_ended' && (
-            <div className='space-y-2'>
-              <textarea
-                value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
-                data-track-category='USER_QUESTION_ARTIFACT'
-                data-track-name='EDIT_OPEN_ENDED_ANSWER'
-                onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
-                placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
-                disabled={state.submitting || terminal}
-                rows={4}
-                className='w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
-              />
-              {!terminal && (
-                <button
-                  type='button'
-                  data-track-category='USER_QUESTION_ARTIFACT'
-                  data-track-name='SKIP_QUESTION'
-                  onClick={() => updateAnswer(activeQuestion.id, 'Skip this question')}
-                  className='text-xs font-medium text-muted-foreground hover:text-foreground'
-                >
-                  Skip this question
-                </button>
+  return (
+    <section
+      className='flex w-[428px] max-w-full flex-col rounded-2xl bg-foreground/[0.06]'
+      style={node.style}
+    >
+      <div className='flex items-start rounded-2xl border border-foreground/[0.06] bg-background p-3'>
+        <div className='flex min-w-0 flex-1 flex-col gap-4'>
+          <div className='flex h-6 items-center pl-1'>
+            <div className='flex items-center gap-1 text-sm font-semibold leading-5 text-foreground/60'>
+              <span className='tracking-[-0.5px]'>Question</span>
+              {total > 1 && (
+                <span className='tabular-nums tracking-[-0.2px]'>
+                  {activeIndex + 1}/{total}
+                </span>
               )}
             </div>
-          )}
+          </div>
 
-          {activeQuestion.type === 'single_choice' && (
-            <div className='space-y-3'>
-              {activeQuestion.options.map(option => (
-                <label
-                  key={option}
-                  className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
-                >
-                  <input
-                    type='radio'
-                    data-track-category='USER_QUESTION_ARTIFACT'
-                    data-track-name='SELECT_SINGLE_CHOICE'
-                    name={activeQuestion.id}
-                    checked={selectedAnswer === option}
-                    disabled={state.submitting || terminal}
-                    onChange={() => updateAnswer(activeQuestion.id, option)}
-                    className='h-4 w-4 border-border text-primary focus:ring-ring'
-                  />
-                  {option}
-                </label>
-              ))}
-            </div>
-          )}
+          <div className='flex flex-col gap-4'>
+            <p className='pl-1 text-sm font-medium leading-5 tracking-[-0.07px] text-foreground'>
+              {activeQuestion.question}
+            </p>
 
-          {activeQuestion.type === 'multiple_choice' && (
-            <div className='space-y-3'>
-              {activeQuestion.options.map(option => {
-                const selected = Array.isArray(selectedAnswer) && selectedAnswer.includes(option);
+            <div className='flex flex-col gap-2'>
+              {activeQuestion.type === 'open_ended' && (
+                <textarea
+                  value={typeof selectedAnswer === 'string' ? selectedAnswer : ''}
+                  data-track-category='USER_QUESTION_ARTIFACT'
+                  data-track-name='EDIT_OPEN_ENDED_ANSWER'
+                  onChange={event => updateAnswer(activeQuestion.id, event.target.value)}
+                  placeholder={activeQuestion.placeholder ?? 'Type your answer…'}
+                  disabled={disabled}
+                  rows={3}
+                  className='w-full resize-y rounded-lg border border-foreground/10 bg-transparent px-1.5 py-1.5 text-sm font-medium leading-5 text-foreground outline-none placeholder:text-foreground/40 focus:border-foreground/20 disabled:cursor-not-allowed disabled:opacity-60'
+                />
+              )}
+
+              {choices.map(option => {
+                const label = optionLabel(option);
+                const description = optionDescription(option);
+                const chosen = isChosen(label);
                 return (
-                  <label
-                    key={option}
-                    className='flex cursor-pointer items-center gap-3 text-sm text-foreground'
+                  <button
+                    key={label}
+                    type='button'
+                    data-track-category='USER_QUESTION_ARTIFACT'
+                    data-track-name='SELECT_QUESTION_OPTION'
+                    onClick={() => chooseOption(label)}
+                    disabled={disabled}
+                    className={cn(
+                      'flex w-full items-start gap-1.5 rounded-lg border p-1.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+                      chosen
+                        ? 'border-foreground/10 bg-foreground/[0.08]'
+                        : 'border-foreground/10 hover:border-foreground/[0.06] hover:bg-foreground/[0.04]',
+                    )}
                   >
-                    <input
-                      type='checkbox'
-                      data-track-category='USER_QUESTION_ARTIFACT'
-                      data-track-name='TOGGLE_MULTIPLE_CHOICE'
-                      checked={selected}
-                      disabled={state.submitting || terminal}
-                      onChange={event => toggleMultipleChoice(option, event.target.checked)}
-                      className='h-4 w-4 rounded border-border text-primary focus:ring-ring'
-                    />
-                    {option}
-                  </label>
+                    <OptionCheck checked={chosen} />
+                    <span className='flex min-w-0 flex-1 flex-col gap-1'>
+                      <span className='text-sm font-semibold leading-5 text-foreground'>
+                        {label}
+                      </span>
+                      {description && (
+                        <span className='text-xs font-normal leading-5 text-foreground/60'>
+                          {description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
                 );
               })}
-            </div>
-          )}
 
-          <div className='border-t border-dashed border-border pt-4'>
-            <textarea
-              value={notes[activeQuestion.id] ?? ''}
-              data-track-category='USER_QUESTION_ARTIFACT'
-              data-track-name='EDIT_QUESTION_NOTES'
-              onChange={event =>
-                updateFieldValue('notes', { ...notes, [activeQuestion.id]: event.target.value })
-              }
-              placeholder='+ Add notes (optional)'
-              disabled={state.submitting || terminal}
-              rows={2}
-              className='w-full resize-y rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-60'
-            />
+              {activeQuestion.type !== 'open_ended' &&
+                (customActive ? (
+                  <div className='flex w-full items-start gap-1.5 rounded-lg border border-foreground/10 bg-foreground/[0.08] p-1.5'>
+                    <OptionCheck checked />
+                    <textarea
+                      ref={customInputRef}
+                      value={customValue}
+                      data-track-category='USER_QUESTION_ARTIFACT'
+                      data-track-name='EDIT_CUSTOM_ANSWER'
+                      onChange={event => {
+                        event.target.style.height = 'auto';
+                        event.target.style.height = `${event.target.scrollHeight}px`;
+                        updateNote(activeQuestion.id, event.target.value);
+                      }}
+                      onBlur={() => {
+                        if (!customValue.trim()) {
+                          setCustomOpen({ ...customOpen, [activeQuestion.id]: false });
+                        }
+                      }}
+                      placeholder='Type your own answer…'
+                      disabled={disabled}
+                      rows={1}
+                      className='min-w-0 flex-1 resize-none self-center bg-transparent text-sm font-semibold leading-5 text-foreground outline-none placeholder:font-semibold placeholder:text-foreground/60 disabled:cursor-not-allowed'
+                    />
+                  </div>
+                ) : (
+                  <button
+                    type='button'
+                    data-track-category='USER_QUESTION_ARTIFACT'
+                    data-track-name='OPEN_CUSTOM_ANSWER'
+                    onClick={() => {
+                      setCustomOpen({ ...customOpen, [activeQuestion.id]: true });
+                      window.requestAnimationFrame(() => customInputRef.current?.focus());
+                    }}
+                    disabled={disabled}
+                    className='flex w-full items-start gap-1.5 rounded-lg border border-dashed border-foreground/10 px-1.5 py-2 text-left transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-60'
+                  >
+                    <span className='flex size-5 shrink-0 items-center justify-center'>
+                      <PencilLine className='size-3.5 text-foreground/60' strokeWidth={2} />
+                    </span>
+                    <span className='text-sm font-semibold leading-5 text-foreground/60'>
+                      Something else...
+                    </span>
+                  </button>
+                ))}
+            </div>
           </div>
         </div>
       </div>
-      {phase === 'answered' && (
-        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
-          <p className='text-xs leading-[1.2] text-muted-foreground'>Answers submitted</p>
-        </div>
-      )}
-      {phase === 'declined' && (
-        <div className='border-t border-border bg-foreground/[0.03] px-4 py-3'>
-          <p className='text-xs leading-[1.2] text-muted-foreground'>Question declined.</p>
-        </div>
-      )}
-      {!terminal && (
-        <footer className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
-          <button
-            type='button'
-            data-track-category='USER_QUESTION_ARTIFACT'
-            data-track-name='SUBMIT_ANSWERS'
-            onClick={submit}
-            disabled={state.submitting}
-            className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60'
-          >
-            Submit answers
-          </button>
-          {props.dismissAction && (
+
+      <footer className='flex items-center justify-between px-3 py-2'>
+        <button
+          type='button'
+          data-track-category='USER_QUESTION_ARTIFACT'
+          data-track-name='SKIP_QUESTION'
+          onClick={skip}
+          disabled={disabled}
+          className='flex h-7 items-center rounded-[10px] px-1.5 text-sm font-semibold leading-5 text-foreground transition-colors hover:bg-foreground/[0.06] disabled:cursor-not-allowed disabled:opacity-60'
+        >
+          <span className='px-1'>Skip</span>
+        </button>
+        <div className='flex items-center gap-2'>
+          {activeIndex > 0 && (
             <button
               type='button'
               data-track-category='USER_QUESTION_ARTIFACT'
-              data-track-name='DISMISS_QUESTION'
-              onClick={() => void executeAction(props.dismissAction!)}
-              disabled={state.submitting}
-              className='rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+              data-track-name='PREVIOUS_QUESTION'
+              onClick={() => setActiveIndex(activeIndex - 1)}
+              disabled={disabled}
+              className='flex h-7 items-center rounded-[10px] px-1.5 text-sm font-semibold leading-5 text-foreground transition-colors hover:bg-foreground/[0.06] disabled:cursor-not-allowed disabled:opacity-60'
             >
-              Dismiss
+              <span className='px-1'>Back</span>
             </button>
           )}
-        </footer>
-      )}
+          <button
+            type='button'
+            data-track-category='USER_QUESTION_ARTIFACT'
+            data-track-name={isLast ? 'SUBMIT_ANSWERS' : 'NEXT_QUESTION'}
+            onClick={advance}
+            disabled={disabled}
+            className='flex h-7 items-center rounded-lg border border-foreground/10 bg-background px-1.5 text-sm font-semibold leading-5 text-foreground transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-60'
+          >
+            <span className='px-1'>{isLast ? 'Submit' : 'Next'}</span>
+          </button>
+        </div>
+      </footer>
     </section>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/useDiffsTheme.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/useDiffsTheme.ts
@@ -1,0 +1,30 @@
+import { useMemo, useSyncExternalStore } from 'react';
+
+function subscribeToThemeAttribute(onStoreChange: () => void): () => void {
+  if (typeof document === 'undefined') return () => {};
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+  return () => observer.disconnect();
+}
+
+function getThemeAttribute(): string {
+  if (typeof document === 'undefined') return 'classic';
+  return document.documentElement.getAttribute('data-theme') ?? 'classic';
+}
+
+export function useDiffsTheme(): {
+  theme: { light: string; dark: string };
+  themeType: 'light' | 'dark';
+} {
+  const theme = useSyncExternalStore(subscribeToThemeAttribute, getThemeAttribute, () => 'classic');
+  return useMemo(
+    () => ({
+      theme: { light: 'github-light', dark: 'github-dark' },
+      themeType: theme === 'midnight' ? ('dark' as const) : ('light' as const),
+    }),
+    [theme],
+  );
+}

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -110,6 +110,9 @@
     --pr-badge-danger-bg: #faebeb;
     --pr-badge-danger-fg: #ff0f0f;
 
+    --diff-stat-add-fg: #16a34a;
+    --diff-stat-del-fg: #dc2626;
+
     /* Workflow status colors - accessible on light bg */
     --status-new: #6b7280;
     --status-pending: #d97706;
@@ -241,6 +244,8 @@
     --pr-badge-merged-fg: #3716a3;
     --pr-badge-danger-bg: #faebeb;
     --pr-badge-danger-fg: #ff0f0f;
+    --diff-stat-add-fg: #16a34a;
+    --diff-stat-del-fg: #dc2626;
     --status-failure: #dc2626;
     --status-paused: #7c3aed;
     --ticket-accent: #445bb2;
@@ -373,6 +378,9 @@
     --pr-badge-merged-fg: #a78bfa;
     --pr-badge-danger-bg: #2a1414;
     --pr-badge-danger-fg: #f87171;
+
+    --diff-stat-add-fg: #4ade80;
+    --diff-stat-del-fg: #f87171;
 
     /* Workflow status colors - accessible on dark bg */
     --status-new: #b0b4ba;
@@ -1685,6 +1693,15 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: normal;
+}
+
+.jp-message-html:has(.flow-artifact-wide) {
+  display: block;
+  width: 100%;
+}
+
+.flow-ui-container:has(.flow-artifact-wide) {
+  max-width: none;
 }
 
 /* Make inline emojis larger than surrounding text */

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -28,6 +28,10 @@ export type FlowComponentType =
   | 'pr_approval'
   | 'call_schedule'
   | 'user_question'
+  | 'code'
+  | 'diff'
+  | 'ticket'
+  | 'chart'
   | 'agent'
   | 'mcpConfigure';
 

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -27,6 +27,7 @@ export type FlowComponentType =
   | 'pr'
   | 'pr_approval'
   | 'call_schedule'
+  | 'user_question'
   | 'agent'
   | 'mcpConfigure';
 
@@ -191,4 +192,3 @@ export function isFlowDefinition(obj: unknown): obj is FlowDefinition {
     Array.isArray((obj as Record<string, unknown>).components)
   );
 }
-

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -526,9 +526,15 @@ export type DurationMinutes = z.infer<typeof durationMinutesSchema>;
 export type CallScheduleProps = z.infer<typeof callSchedulePropsSchema>;
 export type CallSchedulePhase = CallScheduleProps['phase'];
 
+/** A bare label, or a label plus the secondary line the option card renders under it. */
+export const userQuestionOptionSchema = z.union([
+  z.string().min(1),
+  z.object({ label: z.string().min(1), description: z.string().min(1).optional() }).strict(),
+]);
+
 export const userQuestionItemSchema = z.discriminatedUnion('type', [
-  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('single_choice'), options: z.array(z.string().min(1)).min(2).max(9), required: z.boolean().optional() }).strict(),
-  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('multiple_choice'), options: z.array(z.string().min(1)).min(2).max(9), required: z.boolean().optional() }).strict(),
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('single_choice'), options: z.array(userQuestionOptionSchema).min(2).max(9), required: z.boolean().optional() }).strict(),
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('multiple_choice'), options: z.array(userQuestionOptionSchema).min(2).max(9), required: z.boolean().optional() }).strict(),
   z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('open_ended'), placeholder: z.string().optional(), required: z.boolean().optional() }).strict(),
 ]);
 
@@ -548,6 +554,7 @@ export const userQuestionPropsSchema = z.object({
 
 export const userQuestionComponentSchema = baseComponentSchema.extend({ type: z.literal('user_question'), props: userQuestionPropsSchema });
 export type UserQuestionItem = z.infer<typeof userQuestionItemSchema>;
+export type UserQuestionOption = z.infer<typeof userQuestionOptionSchema>;
 export type UserQuestionProps = z.infer<typeof userQuestionPropsSchema>;
 
 export const codePropsSchema = z
@@ -579,12 +586,22 @@ export const ticketPrioritySchema = z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']
 
 export const ticketPropsSchema = z
   .object({
-    xyneId: z.string().min(1),
+    xyneId: z.string().min(1).optional(),
+    ticketId: z.string().min(1).optional(),
     title: z.string().min(1),
+    description: z.string().optional(),
     status: ticketStatusSchema,
     priority: ticketPrioritySchema,
+    stageName: z.string().min(1).optional(),
     eta: z.string().optional(),
-    url: z.string().min(1),
+    url: z.string().min(1).optional(),
+    channelId: z.string().min(1).optional(),
+    conversationId: z.string().min(1).optional(),
+    assigneeId: z.string().min(1).optional(),
+    phase: z.enum(['proposed', 'created']).optional(),
+    approveAction: flowActionSchema.optional(),
+    approveContinueAction: flowActionSchema.optional(),
+    declineAction: flowActionSchema.optional(),
   })
   .strict();
 

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -550,6 +550,104 @@ export const userQuestionComponentSchema = baseComponentSchema.extend({ type: z.
 export type UserQuestionItem = z.infer<typeof userQuestionItemSchema>;
 export type UserQuestionProps = z.infer<typeof userQuestionPropsSchema>;
 
+export const codePropsSchema = z
+  .object({
+    code: z.string().min(1),
+    language: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const codeComponentSchema = baseComponentSchema.extend({
+  type: z.literal('code'),
+  props: codePropsSchema,
+});
+
+export const diffPropsSchema = z
+  .object({
+    path: z.string().min(1),
+    patch: z.string().min(1),
+  })
+  .strict();
+
+export const diffComponentSchema = baseComponentSchema.extend({
+  type: z.literal('diff'),
+  props: diffPropsSchema,
+});
+
+export const ticketStatusSchema = z.enum(['TODO', 'STARTED', 'PAUSED', 'CANCELLED', 'COMPLETED']);
+export const ticketPrioritySchema = z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
+
+export const ticketPropsSchema = z
+  .object({
+    xyneId: z.string().min(1),
+    title: z.string().min(1),
+    status: ticketStatusSchema,
+    priority: ticketPrioritySchema,
+    eta: z.string().optional(),
+    url: z.string().min(1),
+  })
+  .strict();
+
+export const ticketComponentSchema = baseComponentSchema.extend({
+  type: z.literal('ticket'),
+  props: ticketPropsSchema,
+});
+
+export const chartPointSchema = z
+  .object({ label: z.string().min(1), value: z.number().finite() })
+  .strict();
+
+export const chartSeriesPointSchema = z
+  .object({
+    x: z.string().min(1),
+    y: z.number().finite(),
+    series: z.string().min(1).optional(),
+  })
+  .strict();
+
+const CHART_MAX_POINTS = 200;
+
+const categoryChartSchema = <T extends 'bar' | 'pie' | 'donut'>(type: T) =>
+  z
+    .object({
+      type: z.literal(type),
+      points: z.array(chartPointSchema).min(1).max(24),
+      caption: z.string().min(1).optional(),
+    })
+    .strict();
+
+const seriesChartSchema = <T extends 'line' | 'area'>(type: T) =>
+  z
+    .object({
+      type: z.literal(type),
+      series: z.array(chartSeriesPointSchema).min(1).max(CHART_MAX_POINTS),
+      caption: z.string().min(1).optional(),
+    })
+    .strict();
+
+export const chartPropsSchema = z.discriminatedUnion('type', [
+  categoryChartSchema('bar'),
+  categoryChartSchema('pie'),
+  categoryChartSchema('donut'),
+  seriesChartSchema('line'),
+  seriesChartSchema('area'),
+]);
+
+export const chartComponentSchema = baseComponentSchema.extend({
+  type: z.literal('chart'),
+  props: chartPropsSchema,
+});
+
+export type CodeProps = z.infer<typeof codePropsSchema>;
+export type DiffProps = z.infer<typeof diffPropsSchema>;
+export type TicketProps = z.infer<typeof ticketPropsSchema>;
+export type TicketArtifactStatus = z.infer<typeof ticketStatusSchema>;
+export type TicketArtifactPriority = z.infer<typeof ticketPrioritySchema>;
+export type ChartProps = z.infer<typeof chartPropsSchema>;
+export type ChartType = ChartProps['type'];
+export type ChartPoint = z.infer<typeof chartPointSchema>;
+export type ChartSeriesPoint = z.infer<typeof chartSeriesPointSchema>;
+
 // ── Agent artifact ────────────────────────────────────────────────────────────
 // ONE node renders every agent surface. The identity block (name / slug /
 // description / model / capabilities / system prompt) is INVARIANT across
@@ -731,6 +829,10 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     prApprovalComponentSchema,
     callScheduleComponentSchema,
     userQuestionComponentSchema,
+    codeComponentSchema,
+    diffComponentSchema,
+    ticketComponentSchema,
+    chartComponentSchema,
     agentComponentSchema,
     mcpConfigureComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -526,6 +526,30 @@ export type DurationMinutes = z.infer<typeof durationMinutesSchema>;
 export type CallScheduleProps = z.infer<typeof callSchedulePropsSchema>;
 export type CallSchedulePhase = CallScheduleProps['phase'];
 
+export const userQuestionItemSchema = z.discriminatedUnion('type', [
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('single_choice'), options: z.array(z.string().min(1)).min(2).max(9), required: z.boolean().optional() }).strict(),
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('multiple_choice'), options: z.array(z.string().min(1)).min(2).max(9), required: z.boolean().optional() }).strict(),
+  z.object({ id: z.string().min(1), label: z.string().min(1).optional(), question: z.string().min(1), type: z.literal('open_ended'), placeholder: z.string().optional(), required: z.boolean().optional() }).strict(),
+]);
+
+export const userQuestionPropsSchema = z.object({
+  title: z.string().min(1),
+  questions: z.array(userQuestionItemSchema).min(1).max(8),
+  // Absent on cards posted before terminal question states were introduced;
+  // the renderer interprets absence as `pending`.
+  phase: z.enum(['pending', 'answered', 'declined']).optional(),
+  answers: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+  /** Optional notes are scoped to the individual prompt id. */
+  notes: z.record(z.string()).optional(),
+  decidedAt: z.string().optional(),
+  submitAction: flowActionSchema.optional(),
+  dismissAction: flowActionSchema.optional(),
+}).strict();
+
+export const userQuestionComponentSchema = baseComponentSchema.extend({ type: z.literal('user_question'), props: userQuestionPropsSchema });
+export type UserQuestionItem = z.infer<typeof userQuestionItemSchema>;
+export type UserQuestionProps = z.infer<typeof userQuestionPropsSchema>;
+
 // ── Agent artifact ────────────────────────────────────────────────────────────
 // ONE node renders every agent surface. The identity block (name / slug /
 // description / model / capabilities / system prompt) is INVARIANT across
@@ -706,6 +730,7 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     prComponentSchema,
     prApprovalComponentSchema,
     callScheduleComponentSchema,
+    userQuestionComponentSchema,
     agentComponentSchema,
     mcpConfigureComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
