### PR TITLE
fix: scope DM existence lookup to workspace to stop duplicate Automations DMs

### DIFF
--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -227,17 +227,10 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
   }
 
   async getDMChannel(userId1: string, userId2: string): Promise<Channel | null> {
-    // "Does a DM already exist for this pair?" is a WORKSPACE-level question, not a
-    // "my rows" question. The default db client ANDs the per-user channel ACL onto every
-    // read (PUBLIC OR participants.some.userId = caller). A caller who is not a participant
-    // of the target DM — e.g. an automation submitter probing an admin's bot DM during the
-    // approval fan-out — would therefore never see the existing PRIVATE DM, get null back,
-    // and mint a duplicate. Run the existence probe under withWorkspaceScope so it executes
-    // as a service actor (workspace scope only, per-user predicate dropped). Tenant
-    // isolation is unchanged; only the participant filter is skipped.
-    //
-    // orderBy createdAt asc makes resolution deterministic: if duplicates already exist,
-    // every caller collapses onto the SAME (oldest) canonical DM instead of a random one.
+    // Run the existence probe under withWorkspaceScope (service actor) so the per-user
+    // channel ACL is dropped and only workspace scope applies — otherwise a non-participant
+    // caller (e.g. an automation submitter probing an admin's bot DM) never sees the existing
+    // PRIVATE DM and mints a duplicate. orderBy asc pins the oldest as the canonical match.
     return withWorkspaceScope(async () => {
       // Self-DM: channel name is stored as single userId, scopeType DM
       if (userId1 === userId2) {

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -3,6 +3,7 @@ import { Channel } from '@prisma/client';
 import { ChannelScopeType, ChannelVisibility, ChannelType, ProjectType } from '@xyne/shared';
 import { QueryOptions } from '@/types/database';
 import { logger } from '@/utils/logger';
+import { withWorkspaceScope } from '@/database/tenant/context';
 import { formatDateTimeShort } from '@/utils/dateUtils';
 //import { queueChannelIngestion } from '@/queues/vespaQueue';
 
@@ -226,16 +227,31 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
   }
 
   async getDMChannel(userId1: string, userId2: string): Promise<Channel | null> {
-    // Self-DM: channel name is stored as single userId, scopeType DM
-    if (userId1 === userId2) {
+    // "Does a DM already exist for this pair?" is a WORKSPACE-level question, not a
+    // "my rows" question. The default db client ANDs the per-user channel ACL onto every
+    // read (PUBLIC OR participants.some.userId = caller). A caller who is not a participant
+    // of the target DM — e.g. an automation submitter probing an admin's bot DM during the
+    // approval fan-out — would therefore never see the existing PRIVATE DM, get null back,
+    // and mint a duplicate. Run the existence probe under withWorkspaceScope so it executes
+    // as a service actor (workspace scope only, per-user predicate dropped). Tenant
+    // isolation is unchanged; only the participant filter is skipped.
+    //
+    // orderBy createdAt asc makes resolution deterministic: if duplicates already exist,
+    // every caller collapses onto the SAME (oldest) canonical DM instead of a random one.
+    return withWorkspaceScope(async () => {
+      // Self-DM: channel name is stored as single userId, scopeType DM
+      if (userId1 === userId2) {
+        return await this.db.channel.findFirst({
+          where: { name: userId1, scopeType: ChannelScopeType.DM },
+          orderBy: { createdAt: 'asc' },
+        });
+      }
+      // For 1:1 DM channels, name is sorted user IDs joined by comma
+      const name = [userId1, userId2].sort().join(",");
       return await this.db.channel.findFirst({
-        where: { name: userId1, scopeType: ChannelScopeType.DM },
+        where: { name },
+        orderBy: { createdAt: 'asc' },
       });
-    }
-    // For 1:1 DM channels, name is sorted user IDs joined by comma
-    const name = [userId1, userId2].sort().join(",");
-    return await this.db.channel.findFirst({
-      where: { name },
     });
   }
 
@@ -274,14 +290,18 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
   }
 
   async getGroupChannelByMembers(memberIds: string[]): Promise<Channel | null> {
-    // Get all GROUP_DM scope channels
+    // Same rationale as getDMChannel: the existence probe must not be filtered by the
+    // caller's participation, and must resolve to a single canonical (oldest) row.
     const name = memberIds.sort().join(",");
-    return await this.db.channel.findFirst({
-      where: {
-        scopeType: ChannelScopeType.GROUP_DM,
-        name: name
-      }
-    });
+    return withWorkspaceScope(async () =>
+      this.db.channel.findFirst({
+        where: {
+          scopeType: ChannelScopeType.GROUP_DM,
+          name: name,
+        },
+        orderBy: { createdAt: 'asc' },
+      }),
+    );
   }
 
   async checkDuplicateName(name: string, workspaceId: string): Promise<boolean> {


### PR DESCRIPTION
## Problem
Duplicate "Automations" DMs are accumulating (~11 per user across ~38 users, still growing). Root cause: the "does a DM already exist for this pair?" existence probe (`getDMChannel` / `getGroupChannelByMembers` in `apps/backend/src/database/repositories/channelRepository.ts`) runs through the default ACL-filtered Prisma client, which ANDs the per-user channel ACL — `PUBLIC OR participants.some.userId = caller` (`database/acl/tables/channels-acl.ts`) — onto the `findFirst`.

When the caller is **not** a participant of the target DM — e.g. the automation submitter fanning out approval notifications to admins in `notifyAdminsOfSubmission` (`automations/services/approval-notifications.ts`), which runs in the submitter's request context (`actor: 'user'`) — the existing PRIVATE admin↔bot DM is filtered out, `findFirst` returns null, and a brand-new DM is minted. Once per admin, per submission, unbounded.

## Fix
Run the existence probe under `withWorkspaceScope()` (`database/tenant/context.ts`), which re-enters the current context as a `service` actor: workspace scope only, per-user participant predicate dropped. Tenant isolation is unchanged (still workspace-bounded). Because the fix is in the shared repository primitive, it corrects every caller at once — approval fan-out, `send-message.step.ts`, `make-call.step.ts`, and the call controllers.

Also add `orderBy: { createdAt: 'asc' }` to the `findFirst` so that when duplicates already exist, every caller deterministically collapses onto the same oldest canonical DM instead of a random row.

## Scope
- `getDMChannel` (1:1 + self-DM) and `getGroupChannelByMembers` (group DM) wrapped in `withWorkspaceScope` + `orderBy createdAt asc`.
- No schema change in this PR.

## Validation
- `tsc --noEmit`: no new type errors introduced by this change (the changed file has 0 errors; the repo's pre-existing Zero generated-schema drift errors are unrelated and present on `main` too).

## Follow-ups (not in this PR)
- Backfill/cleanup of the already-accumulated duplicate DMs (keep oldest per pair, delete empties, re-point messages).
- Add a partial unique index `channels(name) WHERE scopeType IN ('DM','GROUP_DM')` as a DB-level backstop against future un-scoped/racing creators.