### PR TITLE
fix: remove updatedBy column from channel_board_mappings zero schema.ts

### DIFF
--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -792,7 +792,6 @@ export const channelBoardMappingTable = table('channel_board_mappings' /* Channe
     workspaceId: string(),
     isDefault: boolean(),
     createdBy: string(),
-    updatedBy: string().optional(),
     createdAt: number(),
     updatedAt: number(),
   })


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removes a phantom `updatedBy` column from the `channel_board_mappings` definition in the hand-written Zero schema. It is a one-line deletion.

### Symptom

Every `POST /api/zero/query-fallback` returned **500**:

```
Schema incompatibility detected between your zero schema definition and the database:

  - Column "updatedBy" in table "channel_board_mappings" is defined in your zero
    schema but does not exist in the database.
```

Stack: `handleGetQueriesFallback` → `handleQueriesFallback` → `fetchServerSchema` (`apps/backend/src/zero/server.ts:67`) → `getServerSchema` → `assert`.

### Root cause

Introduced by **#482** (`fix: channel board mapping tables`, squash commit `989cefd02`). That PR added the `ChannelBoardMapping` table in four places, but only one of them received an `updatedBy` column:

| Source | `updatedBy`? |
| --- | --- |
| `packages/shared/src/zero/schema.ts` (hand-written, loaded at runtime) | ✅ present |
| `apps/backend/prisma/schema.prisma` | ❌ |
| `migrations/20260811120000_add_channel_board_mappings/migration.sql` | ❌ |
| `apps/backend/prisma/generated/zero/schema.ts` (generated from Prisma) | ❌ |
| Postgres | ❌ |

`packages/shared/src/zero/schema.ts` is mirrored by hand rather than generated — `prisma generate` only writes `apps/backend/prisma/generated/zero/schema.ts`, which nothing imports. So the extra column could not be corrected by regenerating, and `prisma db push` / `migrate` correctly never created it. Zero's `getServerSchema()` asserts that every column in the Zero schema exists in Postgres, so the fallback path failed on every request.

### Why remove rather than add the column

Nothing reads or writes `updatedBy` on this table anywhere in `apps/backend/src`, `apps/dashboard/src`, or `packages/shared/src`. Adding it to Prisma plus a migration would introduce a dead column; removing it restores agreement with the Prisma model, the migration, the generated schema, and the database.

### Note for a follow-up (not in this PR)

`scripts/validate-schema-migrations.sh:266` is the guard meant to catch Prisma↔Zero drift, but it only asserts that a **new model** has some matching `table()` in the Zero schema:

```bash
if ! grep -qi "table(.*${model}" "$zero_schema"; then
```

It never compares columns, so a hand-typed extra column passes CI. Worth extending separately.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [x] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts` — no new tables
- [x] Matching Prisma model + migration, client regenerated — this PR is precisely what restores that match; no Prisma or migration change is needed

## Schema & Data Changes

- [x] No schema changes — **skip this section** (Zero TS definition only; no Prisma, migration, or database change)
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots

---

## How did you test it?

**1. Confirmed the database genuinely lacks the column**

```
\d public.channel_board_mappings
→ id, channelId, boardId, workspaceId, isDefault, createdBy, createdAt, updatedAt   (8 columns, no updatedBy)
```

**2. Reproduced the assertion, then confirmed it passes after the fix.** Replicated `fetchServerSchema` (`server.ts:65-72`) against the local database using the rebuilt shared schema:

```
PASS: getServerSchema() validated the zero schema against the database
  tables validated: 123
  channel_board_mappings: id, channelId, boardId, workspaceId, isDefault, createdBy, createdAt, updatedAt
```

This is the exact call that was throwing, so the 500 is resolved at its source.

**3. Swept for any other drift of the same kind.** Parsed all 115 `table()` definitions out of `packages/shared/src/zero/schema.ts` and diffed every column against `information_schema.columns`:

```
OK: all 115 zero tables match the database
```

So this was the only such mismatch — the fallback endpoint will not fail on a different column next.

**4.** `pnpm --filter @xyne/shared run build` passes.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — this is a schema-definition change with no behaviour to unit test. The invariant is enforced at runtime by Zero's `getServerSchema()` assertion, which is what step 2 above exercises directly.

### Manual

**Users**
- [x] Single user

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass — not run locally; no backend source touched
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass — not run locally; no dashboard source touched
- [x] Formatting clean in the packages I touched
- [x] No new deps
- [x] Branch is `fix/*` — commit subject carries no `XYNE-` id as there is no ticket for this regression
- [x] No debug logging or commented-out code left behind

## Deployment

Services-Requiring-Redeployment:
  - backend
  - dashboard

Zero caches the server schema per process (`serverSchemaCache` in `server.ts:63`), so the backend must be restarted for this to take effect.
