### PR TITLE
fix: XYNE-54288 mail dedupe in all tab fix

### DIFF
--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -82,8 +82,6 @@ function parseVespaResults(children: any[]): { grouped: boolean; groups?: any[];
 }
 
 const MAX_FILTER_VALUES = 50;
-// Vespa rejects any query asking for more than this many hits ("N hits
-// requested, configured limit: 400"), so every computed fetch window clamps here.
 const MAX_VESPA_HITS = 400;
 
 /**
@@ -880,12 +878,6 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
 
     const isMailOnlySearch =
       searchApps.length === 1 && searchApps[0].trim().toLowerCase() === 'mail';
-    const effectiveGroupBy =
-      options.groupBy === undefined ? 'docType' : options.groupBy;
-    const isFlatMultiAppMailSearch =
-      effectiveGroupBy === '' &&
-      searchApps.length > 1 &&
-      searchApps.some(app => app.trim().toLowerCase() === 'mail');
     const mailGroupOffset = isMailOnlySearch
       ? Math.max(Number(offset) || 0, 0)
       : 0;
@@ -896,13 +888,6 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
     if (isMailOnlySearch && mailGroupOffset > 0) {
       options.offset = 0;
       options.limit = Math.min(MAX_VESPA_HITS, mailGroupOffset + effectiveLimit);
-    }
-
-    // Requires mail to carry `isParentMail`, which is only set on documents fed
-    // after that field was added: the corpus must be re-fed before this ships,
-    // or the All tab returns no mail at all.
-    if (isFlatMultiAppMailSearch) {
-      options.mail.parentMailOnly = true;
     }
 
     // Call vespa search
@@ -976,8 +961,6 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       // Return flat results (backward compatible)
       // flat results will have matchFeatures returned by vespa.
       // No need to add.
-      // No mail dedupe here: the only flat search that reaches mail is the All
-      // tab, and `isParentMail` already limits it to one hit per conversation.
       const pageResults = await transformVespaResults(
         parsedResults.hits || [],
         db,

--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -82,7 +82,9 @@ function parseVespaResults(children: any[]): { grouped: boolean; groups?: any[];
 }
 
 const MAX_FILTER_VALUES = 50;
-const MAX_VESPA_RESULT_WINDOW = 1000;
+// Vespa rejects any query asking for more than this many hits ("N hits
+// requested, configured limit: 400"), so every computed fetch window clamps here.
+const MAX_VESPA_HITS = 400;
 
 /**
  * Keep every non-mail hit, but only the highest-ranked mail hit for each Desk
@@ -887,28 +889,20 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
     const mailGroupOffset = isMailOnlySearch
       ? Math.max(Number(offset) || 0, 0)
       : 0;
-    const flatSearchOffset = isFlatMultiAppMailSearch
-      ? Math.max(Number(offset) || 0, 0)
-      : 0;
 
     // Vespa's top-level offset paginates hits, not grouping buckets. Desk mail
     // results are grouped by threadId, so fetch the ranked group prefix and
     // slice the requested page after parsing the grouping response.
     if (isMailOnlySearch && mailGroupOffset > 0) {
       options.offset = 0;
-      options.limit = mailGroupOffset + effectiveLimit;
+      options.limit = Math.min(MAX_VESPA_HITS, mailGroupOffset + effectiveLimit);
     }
 
-    // For flat All-tab searches, fetch from the start so mail threads can be
-    // deduplicated consistently across pages. Over-fetch to compensate for
-    // conversations that have several matching mail documents.
+    // Requires mail to carry `isParentMail`, which is only set on documents fed
+    // after that field was added: the corpus must be re-fed before this ships,
+    // or the All tab returns no mail at all.
     if (isFlatMultiAppMailSearch) {
-      const requestedUniquePrefix = flatSearchOffset + effectiveLimit;
-      options.offset = 0;
-      options.limit = Math.min(
-        MAX_VESPA_RESULT_WINDOW,
-        requestedUniquePrefix * 4,
-      );
+      options.mail.parentMailOnly = true;
     }
 
     // Call vespa search
@@ -982,19 +976,13 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       // Return flat results (backward compatible)
       // flat results will have matchFeatures returned by vespa.
       // No need to add.
-      const transformedResults = dedupeMailResults(
-        await transformVespaResults(
-          dedupeMailHits(parsedResults.hits || []),
-          db,
-          wantDebugInfo,
-        ),
+      // No mail dedupe here: the only flat search that reaches mail is the All
+      // tab, and `isParentMail` already limits it to one hit per conversation.
+      const pageResults = await transformVespaResults(
+        parsedResults.hits || [],
+        db,
+        wantDebugInfo,
       );
-      const pageResults = isFlatMultiAppMailSearch
-        ? transformedResults.slice(
-            flatSearchOffset,
-            flatSearchOffset + effectiveLimit,
-          )
-        : transformedResults;
 
       res.json({
         success: true,

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -458,6 +458,7 @@ export interface VespaSamTranscriptDocument extends VespaDocument {
 export interface VespaMailDocument extends VespaDocument {
   threadId: string;
   parentThreadId?: string;
+  isParentMail?: boolean;
   mailId?: string;
   xyneId?: string;
   ticketFormFields?: TicketFormFields;

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -293,6 +293,7 @@ export interface VespaTicketDocument extends Omit<VespaDocument, 'orgId' | 'work
   assignedToName: string;
   closedByName: string;
   projectName: string;
+  projectCode: string;
   ticketMentions: string[];
   threadMentions: string[];
   threadSenders: string[];
@@ -458,7 +459,6 @@ export interface VespaSamTranscriptDocument extends VespaDocument {
 export interface VespaMailDocument extends VespaDocument {
   threadId: string;
   parentThreadId?: string;
-  isParentMail?: boolean;
   mailId?: string;
   xyneId?: string;
   ticketFormFields?: TicketFormFields;

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -119,6 +119,7 @@ export interface MailFilters {
   createdAfter?: string;
   createdOn?: string;
   createdRange?: string;
+  parentMailOnly?: boolean;
 }
 
 export interface CallFilters {
@@ -1252,6 +1253,11 @@ export class YqlBuilder {
     const conditions: string[] = [`entity contains "support_desk"`];
 
     conditions.push(`permissions contains ${params.bind('permissions', userId)}`);
+
+    //All tab mail filter
+    if (filters.parentMailOnly) {
+      conditions.push(`isParentMail = true`);
+    }
 
     if (filters.channelId && filters.channelId.length > 0) {
       const channels = filters.channelId

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -119,7 +119,6 @@ export interface MailFilters {
   createdAfter?: string;
   createdOn?: string;
   createdRange?: string;
-  parentMailOnly?: boolean;
 }
 
 export interface CallFilters {
@@ -1253,11 +1252,6 @@ export class YqlBuilder {
     const conditions: string[] = [`entity contains "support_desk"`];
 
     conditions.push(`permissions contains ${params.bind('permissions', userId)}`);
-
-    //All tab mail filter
-    if (filters.parentMailOnly) {
-      conditions.push(`isParentMail = true`);
-    }
 
     if (filters.channelId && filters.channelId.length > 0) {
       const channels = filters.channelId

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -634,7 +634,7 @@ export const mapTicket = async (args: InsertValue<TicketsSchema>): Promise<Vespa
     }),
     db.project.findUnique({
       where: { id: args.projectId },
-      select: { name: true }
+      select: { name: true, code: true }
     }),
     db.user.findUnique({
       where: { id: args.createdBy },
@@ -732,6 +732,7 @@ export const mapTicket = async (args: InsertValue<TicketsSchema>): Promise<Vespa
     assignedToName: assignedToUser?.name || '',
     closedByName: closedByUser?.name || '',
     projectName: project?.name || '',
+    projectCode: project?.code || '',
     ticketMentions: descriptionMentions?.map(v => v.username) || [],
     threadMentions: threadMentions,
     threadSenders: threadSenders,
@@ -1499,19 +1500,11 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
   const plainBody = extractPlainTextFromHtml(email.body || '') || email.subject;
   const chunks = chunkPlainText(plainBody);
 
-  //checking if the mail is parent mail or not
-  const parentMail = await db.email.findFirst({
-    where: { conversationId: email.conversationId },
-    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-    select: { id: true },
-  });
-
   return {
     docId: email.id,
     docType: VespaDocType.MAIL,
     threadId: email.conversationId,
     parentThreadId: email.externalThreadId || undefined,
-    isParentMail: parentMail ? parentMail.id === email.id : true,
     mailId: email.externalMessageId || undefined,
     xyneId: ticket?.xyneId ?? undefined,
     ticketFormFields,

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -1499,11 +1499,19 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
   const plainBody = extractPlainTextFromHtml(email.body || '') || email.subject;
   const chunks = chunkPlainText(plainBody);
 
+  //checking if the mail is parent mail or not
+  const parentMail = await db.email.findFirst({
+    where: { conversationId: email.conversationId },
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    select: { id: true },
+  });
+
   return {
     docId: email.id,
     docType: VespaDocType.MAIL,
     threadId: email.conversationId,
     parentThreadId: email.externalThreadId || undefined,
+    isParentMail: parentMail ? parentMail.id === email.id : true,
     mailId: email.externalMessageId || undefined,
     xyneId: ticket?.xyneId ?? undefined,
     ticketFormFields,

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -1221,13 +1221,12 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
               const currentSessionId = searchSessionId || '';
               const vespaResponse = await searchService.vespaSearch({
                 ...searchFilters,
-                // The `unified` profile normalizes every schema's score into the same
-                // 0-1 range, so its hits are directly comparable across doc types.
-                // Grouping would bucket that single global ranking back into per-type
-                // lists (<=10 each), so opt out with an explicit empty groupBy — the
-                // backend falls back to 'docType' when the param is absent entirely.
+                //unified rank profile filters
                 ...(effectiveRankProfile === 'unified'
-                  ? { groupBy: '' }
+                  ? {
+                      groupBy: '',
+                      apps: `${VespaApps.CHAT},${VespaApps.TICKET},${VespaApps.FILE}`,
+                    }
                   : options.groupByDocType && { groupBy: 'docType' }),
                 searchId: currentSessionId,
                 presentationSummary: 'lean',
@@ -1478,7 +1477,11 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
           apps: `${VespaApps.CHAT},${VespaApps.TICKET},${VespaApps.FILE},${VespaApps.MAIL}`,
           // ALL-tab load-more only runs when the initial search was flat (grouped=false),
           // so force a flat continuation; without this the multi-app query re-groups.
-          ...(activeTab === TabType.ALL && { groupBy: '' }),
+          // Mail is left out for the same reason page 1 leaves it out.
+          ...(activeTab === TabType.ALL && {
+            groupBy: '',
+            apps: `${VespaApps.CHAT},${VespaApps.TICKET},${VespaApps.FILE}`,
+          }),
           offset: currentOffset,
           // Fixed-size window: constant limit, advancing offset (standard pagination).
           limit: pageSize,


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
