### PR TITLE
feat: agent sandbox and preview url artifacts

### DIFF
--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -24,6 +24,7 @@ import { ChartNode } from './ChartNode';
 import { AgentNode } from './AgentNode';
 import { McpConfigureNode } from './McpConfigureNode';
 import { SlashCommandArtifactNode } from '../../Chat/SlashCommandArtifacts';
+import { SandboxNode } from './SandboxNode';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
 // is kept in ./PrApprovalNode.tsx but unlinked so 'pr_approval' isn't a live artifact.
 
@@ -80,6 +81,7 @@ NodeRegistry.register('chart', ChartNode);
 NodeRegistry.register('agent', AgentNode);
 NodeRegistry.register('mcpConfigure', McpConfigureNode);
 NodeRegistry.register('slash_command_artifact', SlashCommandArtifactNode);
+NodeRegistry.register('sandbox', SandboxNode);
 
 /**
  * Kept for backward compatibility with existing callers/imports.

--- a/apps/dashboard/src/components/flowUI/nodes/SandboxNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/SandboxNode.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { toast } from 'sonner';
+import { FileCode, EyeScan, CopyDefault } from '@xyne/icons';
+import type { FlowComponent, SandboxProps } from '@xyne/shared';
+import { CardShell } from './cardPrimitives';
+import { openLink } from '../../../utils/openLink';
+import { copyTextToClipboard } from '../../../utils/clipboardUtils';
+
+/**
+ * Sandbox artifact — one line of prose, then a read-only list of the resources
+ * the agent's kata sandbox exposes. One row per resource: glyph, label, a copy-
+ * link button, and an "Open" link.
+ *
+ * The flow carries NO title (buildSandboxFlow omits it) — FlowRenderer prints a
+ * flow title as an <h2> above the components, and this card is meant to read as
+ * message prose + attachment, not a headed panel. `desc` is that prose, and is
+ * also what the DM/channel list preview shows (utils/flowPreview reads `desc`).
+ *
+ * Presentation is DERIVED here, never shipped on the wire: the emitter sends
+ * URLs only, and this file owns the label + glyph for each. A row renders
+ * exactly when its URL is present and is an http(s) target — `previewUrl` is
+ * required by the schema (it is why the card exists), `codeUrl` is optional, so
+ * a sandbox with no code server shows one row instead of a dead link.
+ *
+ * Rows carry `bg-background` (the design's white) over CardShell's muted fill,
+ * and hairline separators come from `border-t` on every row but the first —
+ * matching the design's stacked, overflow-clipped row borders.
+ *
+ * The "Open" links live INSIDE the `.jp-message-html` container, so they need
+ * `!text-foreground !no-underline` to beat the global `.jp-message-html a` rule
+ * (blue + underline) that otherwise wins by specificity — same treatment as
+ * PrNode's FooterLink.
+ *
+ * ── Wire contract (backend emits this) ───────────────────────────────────────
+ * The sandbox is one component inside a FlowJSON FlowDefinition. Source of truth
+ * + zod validation: shared/src/validation/flowSchema.ts (`sandboxComponentSchema`).
+ * The whole FlowDefinition is JSON-stringified, `"`→`&quot;` escaped, and stored
+ * in messages.content as: <div data-flow-json="…">Flow JSON</div>. Built by
+ * `buildSandboxFlow` (xyne-claw-shared) and posted by claw-auth's
+ * /webhook/progress sandbox-preview branch.
+ *
+ *   { version: '2.0', screenId: 'agent-sandbox-<sandboxId>',   // no title
+ *     state: { values:{}, touched:{}, errors:{}, submitting:false,
+ *              submitted:false, history:[], loadingComponentIds:[] },  // always empty
+ *     components: [{
+ *       id: 'sandbox', type: 'sandbox',
+ *       props: {
+ *         previewUrl: string,   // required — noVNC session
+ *         codeUrl?: string,     // optional — code browser
+ *         desc?: string,        // optional — the line above the rows
+ *       },
+ *     }] }
+ *
+ * props is .strict() — unknown keys are rejected at chatController validation.
+ */
+interface SandboxNodeProps {
+  node: FlowComponent;
+  children?: React.ReactNode;
+}
+
+// Only http(s) targets are rendered — mirrors LinkNode's guard so a
+// payload-supplied URL can't inject a javascript: target.
+const isHttpUrl = (url?: string): url is string => !!url && /^https?:\/\//i.test(url);
+
+export const SandboxNode: React.FC<SandboxNodeProps> = ({ node }) => {
+  const props = node.props as SandboxProps | undefined;
+
+  const previewUrl = isHttpUrl(props?.previewUrl) ? props.previewUrl : undefined;
+  const codeUrl = isHttpUrl(props?.codeUrl) ? props.codeUrl : undefined;
+  if (!previewUrl && !codeUrl) return null;
+
+  const desc = props?.desc?.trim();
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {desc && (
+        <p className='text-[15px] font-medium leading-[1.5] tracking-[-0.1px] text-foreground'>
+          {desc}
+        </p>
+      )}
+      <CardShell style={node.style}>
+        {codeUrl && (
+          <ResourceRow
+            icon={<FileCode variant='Duo Solid' size={20} />}
+            label='Code Changes'
+            href={codeUrl}
+            trackName='CLICK_OPEN_CODE'
+            copyTrackName='CLICK_COPY_CODE_LINK'
+          />
+        )}
+        {previewUrl && (
+          <ResourceRow
+            icon={<EyeScan variant='Contrast' size={20} />}
+            label='Live preview'
+            href={previewUrl}
+            trackName='CLICK_OPEN_PREVIEW'
+            copyTrackName='CLICK_COPY_PREVIEW_LINK'
+          />
+        )}
+      </CardShell>
+    </div>
+  );
+};
+
+const ResourceRow: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  href: string;
+  trackName: string;
+  copyTrackName: string;
+}> = ({ icon, label, href, trackName, copyTrackName }) => {
+  // `force: 'external'` — a sandbox is a live noVNC/code session, so it always
+  // belongs in the system browser: Electron's shell.openExternal, the RN
+  // bridge, or a new web tab. Without the force, openLink honours the user's
+  // "open links in app" preference and Electron would hand the URL to the
+  // in-app browser panel (and ⌘-click would invert it) instead.
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
+    event.preventDefault();
+    openLink(href, event, { force: 'external' });
+  };
+
+  // copyTextToClipboard rather than navigator.clipboard.writeText directly: it
+  // is async, so a missing Clipboard API (insecure context) surfaces as a
+  // rejection the error toast can catch instead of an uncaught TypeError.
+  const handleCopy = (): void => {
+    void copyTextToClipboard(href).then(
+      () => toast.success(`${label} link copied`),
+      () => toast.error(`Couldn't copy ${label} link`),
+    );
+  };
+
+  return (
+    <div className='flex items-center justify-between gap-3 border-t border-border bg-background p-4 first:border-t-0'>
+      <div className='flex min-w-0 items-center gap-3'>
+        {/* Both glyphs are two-tone in one accent hue, so they take a single
+            colour token and render their tint from its own opacity. */}
+        <span className='flex shrink-0 items-center text-[var(--sandbox-icon)]'>{icon}</span>
+        <p className='truncate text-[15px] font-medium leading-[1.2] text-foreground'>{label}</p>
+      </div>
+      <div className='flex shrink-0 items-center gap-2'>
+        <button
+          type='button'
+          onClick={handleCopy}
+          aria-label={`Copy ${label} link`}
+          title={`Copy ${label} link`}
+          className='shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+          data-track-category='SANDBOX_ARTIFACT'
+          data-track-name={copyTrackName}
+        >
+          <CopyDefault size={16} />
+        </button>
+        {/* Kept a real anchor so middle-click and "copy link address" still work;
+            the primary click is intercepted above. */}
+        <a
+          href={href}
+          target='_blank'
+          rel='noopener noreferrer'
+          onClick={handleClick}
+          className='shrink-0 rounded-[10px] border border-border px-2 py-1 text-sm font-medium leading-[1.2] !text-foreground !no-underline transition-colors hover:bg-accent hover:!text-foreground'
+          data-track-category='SANDBOX_ARTIFACT'
+          data-track-name={trackName}
+        >
+          Open
+        </a>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -112,6 +112,10 @@
 
     --diff-stat-add-fg: #16a34a;
     --diff-stat-del-fg: #dc2626;
+    /* Sandbox artifact resource glyphs (SandboxNode). One accent hue for both
+       rows — each icon renders its own tint from this via opacity, so a single
+       token is enough. */
+    --sandbox-icon: #9f4e6f;
 
     /* Workflow status colors - accessible on light bg */
     --status-new: #6b7280;
@@ -259,6 +263,8 @@
     --pr-badge-danger-fg: #ff0f0f;
     --diff-stat-add-fg: #16a34a;
     --diff-stat-del-fg: #dc2626;
+    /* Sandbox artifact glyphs — see classic block. */
+    --sandbox-icon: #9f4e6f;
     --status-failure: #dc2626;
     --status-paused: #7c3aed;
     --ticket-accent: #445bb2;
@@ -407,6 +413,8 @@
 
     --diff-stat-add-fg: #4ade80;
     --diff-stat-del-fg: #f87171;
+    /* Lifted mauve — the light-theme #9f4e6f goes muddy against the dark card. */
+    --sandbox-icon: #d491ab;
 
     /* Workflow status colors - accessible on dark bg */
     --status-new: #b0b4ba;

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -120,6 +120,8 @@ import {
   hashSkillContent,
   buildPrFlow,
   prScreenId,
+  buildSandboxFlow,
+  sandboxScreenId,
   isTwinDelivery,
   SDLC_REQUIRED_TOOLS,
   type PrProvider,
@@ -239,6 +241,12 @@ const USE_EPHEMERAL_PROGRESS = true;
 // run-recovery re-delivers the same payload. Bounded (FIFO) so it can't grow
 // unbounded over the process lifetime — every announced sessionId used to be
 // retained forever.
+/** Sandbox-router paths are served from the bare prefix, so a URL without the
+ *  trailing slash 404s. Idempotent. */
+function withTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
 const announcedSandboxPreviews = new Set<string>();
 const ANNOUNCED_PREVIEWS_MAX = 5000;
 function rememberAnnouncedPreview(sessionId: string): void {
@@ -7356,12 +7364,29 @@ router.post("/progress", requireStrictS2S, async (req: Request, res: Response) =
     if (!ctx || ctx.responseMode !== "conversation") return;
     const log = createLogger("webhook/progress", ctx.traceId ?? sessionId.slice(0, 8));
     try {
+      // The sandbox-router serves these paths from the bare prefix, so both URLs
+      // need the trailing slash. claw builds the preview URL with one and the
+      // code URL without (the old markdown announce appended it inline) — do it
+      // here so the card never ships a URL that 404s.
+      const flow = buildSandboxFlow(
+        {
+          previewUrl: withTrailingSlash(sandboxPreviewUrl),
+          ...(sandboxCodePreviewUrl ? { codeUrl: withTrailingSlash(sandboxCodePreviewUrl) } : {}),
+        },
+        {
+          screenId: sandboxScreenId(sandboxId),
+          data: {
+            ...(ctx.agentSlug ? { agentSlug: ctx.agentSlug } : {}),
+            conversationId: ctx.conversationId,
+            channelId: ctx.channelId,
+          },
+        },
+      );
       await spacesAppFetch("/chat/postMessage", {
         channelId: ctx.channelId,
         conversationId: ctx.conversationId,
-        markdownText: `🖥️ **Live preview** — agent is working in this room. Anyone in this channel can watch (and drive) chromium over noVNC.\n\n👉 ${sandboxPreviewUrl}${sandboxCodePreviewUrl ? `\n\nCode Changes available at ${sandboxCodePreviewUrl}/` : ""}`,
+        flow,
         userId: ctx.spacesAppUserId,
-        metadata: { contentFormat: "markdown" },
       }, ctx.appToken);
       log.info(`Sandbox preview announced: ${sandboxPreviewUrl} (sandboxId=${sandboxId})`);
     } catch (err) {

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -34,7 +34,8 @@ export type FlowComponentType =
   | 'chart'
   | 'agent'
   | 'mcpConfigure'
-  | 'slash_command_artifact';
+  | 'slash_command_artifact'
+  | 'sandbox';
 
 export interface FlowComponent {
   id: string;

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -890,6 +890,40 @@ export const mcpConfigureComponentSchema = baseComponentSchema.extend({
 export type McpCredentialField = z.infer<typeof mcpCredentialFieldSchema>;
 export type McpConfigureProps = z.infer<typeof mcpConfigurePropsSchema>;
 
+// ── Sandbox artifact (read-only resource links) ─────────────────────────────
+// The agent acquired a kata sandbox: one card listing the resources it exposes,
+// each row an icon + label + "Open". Read-only — no flow-action round-trip.
+//
+// There is no discriminant and no status: every row carries the same shape, and
+// a row exists exactly when its URL does. Row labels and glyphs are DERIVED in
+// the renderer (SandboxNode) from the field name, never shipped on the wire —
+// the emitter has no business naming "Live preview".
+//
+// `previewUrl` is required because the card exists to announce the live preview;
+// `codeUrl` is optional so a sandbox without a code server renders one row
+// rather than a dead link.
+export const sandboxPropsSchema = z
+  .object({
+    /** noVNC preview — the human-drivable chromium session. */
+    previewUrl: z.string().min(1),
+    /** Code-server / diff browser for the sandbox workspace. */
+    codeUrl: z.string().min(1).optional(),
+    /** One line of prose above the rows, e.g. what the agent is doing and who
+     *  can join in. Prose, not presentation — it is also what the DM/channel
+     *  list preview shows for this message (utils/flowPreview reads `desc`),
+     *  which is why the card carries no flow title. */
+    desc: z.string().optional(),
+  })
+  .strict();
+
+export const sandboxComponentSchema = baseComponentSchema.extend({
+  type: z.literal('sandbox'),
+  props: sandboxPropsSchema,
+});
+
+// TS mirror inferred from the schema so the two can't drift.
+export type SandboxProps = z.infer<typeof sandboxPropsSchema>;
+
 // Recursive container schemas need z.lazy
 export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
   z.discriminatedUnion('type', [
@@ -918,6 +952,7 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     agentComponentSchema,
     mcpConfigureComponentSchema,
     slashCommandArtifactComponentSchema,
+    sandboxComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema
     baseComponentSchema.extend({
       type: z.literal('row'),
@@ -954,7 +989,8 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
 const KNOWN_COMPONENT_TYPES = new Set([
   'text', 'heading', 'input', 'textarea', 'dropdown', 'select', 'multiselect',
   'date', 'button', 'divider', 'image', 'link', 'table', 'plan', 'pr',
-  'pr_approval', 'call_schedule', 'agent', 'mcpConfigure', 'row', 'column', 'card',
+  'pr_approval', 'call_schedule', 'user_question', 'code', 'diff', 'ticket', 'chart',
+  'agent', 'mcpConfigure', 'slash_command_artifact', 'sandbox', 'row', 'column', 'card',
 ]);
 
 const unknownComponentSchema = baseComponentSchema

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -30,7 +30,8 @@ type FlowComponentType =
   | 'plan'
   | 'agent'
   | 'mcpConfigure'
-  | 'pr';
+  | 'pr'
+  | 'sandbox';
 
 interface FlowComponentStyle {
   padding?: string;

--- a/packages/xyne-claw-shared/src/flow/sandbox-flow.ts
+++ b/packages/xyne-claw-shared/src/flow/sandbox-flow.ts
@@ -1,0 +1,89 @@
+/**
+ * Sandbox card — renders the resources a kata sandbox exposes as a FlowUI v2.0
+ * `sandbox` component (dashboard: components/flowUI/nodes/SandboxNode.tsx).
+ *
+ * One row per resource — "Code Changes" and "Live preview", each with an Open
+ * link. Row labels and glyphs are DERIVED in the renderer; this builder ships
+ * only the URLs, so the wire never carries presentation.
+ *
+ * The screenId is keyed on the sandbox id, so the card can later be re-rendered
+ * in place via updateMessage (e.g. to drop the links once the sandbox is torn
+ * down) without the emitter having to remember a message id.
+ *
+ * Emitted by the claw-auth /webhook/progress sandbox-preview branch, which fires
+ * once per run the first time a sandbox tool succeeds. Source-of-truth schema +
+ * zod validation lives in @xyne/shared: shared/src/validation/flowSchema.ts
+ * (`sandboxComponentSchema`).
+ */
+
+import { FlowBuilder, type FlowComponent, type FlowDefinition } from './builder.js';
+
+/** Stable component id — kept stable across updates so the card reconciles in place. */
+export const SANDBOX_COMPONENT_ID = 'sandbox';
+
+/** The resources a sandbox exposes. `previewUrl` is the noVNC session (always
+ *  present — it is why the card is posted); `codeUrl` is the code browser, which
+ *  a sandbox may not run. */
+export interface SandboxCardInput {
+  previewUrl: string;
+  codeUrl?: string;
+  /** Overrides the default line of prose above the rows. */
+  desc?: string;
+}
+
+/** The line above the rows. Says what is happening and that the session is
+ *  shared — the two things a reader needs before deciding to click Open. Kept
+ *  free of jargon (no noVNC/chromium) since the row labels already name what
+ *  each link is. */
+const DEFAULT_DESC = 'Working in a sandbox — anyone here can watch, or drive the browser.';
+
+/** Deterministic screenId keyed on the sandbox id, so the post and any later
+ *  update collapse into ONE card. Falls back to the bare id when no sandbox id
+ *  is known (never invalid, just not update-able). */
+export function sandboxScreenId(sandboxId?: string): string {
+  const slug = (sandboxId ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug ? `agent-sandbox-${slug}` : 'agent-sandbox';
+}
+
+/**
+ * Build the sandbox card as a single `sandbox` component. Deterministic (pure).
+ *
+ * `opts.screenId` should normally be `sandboxScreenId(sandboxId)`. `opts.data`
+ * carries flow-level routing that webhook.ts wraps with withSpacesAppId — the
+ * card is read-only, so this is informational.
+ */
+export function buildSandboxFlow(
+  sandbox: SandboxCardInput,
+  opts?: {
+    screenId?: string;
+    /** Sandbox id used to derive the screenId when `screenId` is not passed. */
+    sandboxId?: string;
+    data?: Record<string, unknown>;
+  },
+): FlowDefinition {
+  const screenId = opts?.screenId ?? sandboxScreenId(opts?.sandboxId);
+
+  const props: Record<string, unknown> = {
+    previewUrl: sandbox.previewUrl,
+    ...(sandbox.codeUrl ? { codeUrl: sandbox.codeUrl } : {}),
+    desc: sandbox.desc ?? DEFAULT_DESC,
+  };
+
+  const component: FlowComponent = { id: SANDBOX_COMPONENT_ID, type: 'sandbox', props };
+
+  // Human-readable notification fallback — Spaces shows this wherever the
+  // widget isn't rendered (notifications, unsupported clients). Default is a
+  // generic "Flow JSON", so ship a meaningful one. Read by chatController.
+  const fallbackText = props['desc'] as string;
+
+  // No .setTitle: FlowRenderer prints any flow title as an <h2> above the
+  // components, and the card is meant to read as message prose + attachment —
+  // a "Sandbox" heading on top of it is chrome the design does not have.
+  return new FlowBuilder(screenId)
+    .addComponent(component)
+    .setData({ kind: 'sandbox', fallbackText, ...(opts?.data ?? {}) })
+    .build();
+}

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -40,6 +40,8 @@ export type {
 export type { Todo, TodoStatus, PlanPhase, PlanTodoInput } from "./flow/plan-flow.js";
 export { buildPrFlow, prScreenId, PR_COMPONENT_ID } from "./flow/pr-flow.js";
 export type { PrProvider, PrStatus, PrCardInput, PrIdentity } from "./flow/pr-flow.js";
+export { buildSandboxFlow, sandboxScreenId, SANDBOX_COMPONENT_ID } from "./flow/sandbox-flow.js";
+export type { SandboxCardInput } from "./flow/sandbox-flow.js";
 export { todoTools, todoWriteTool, todoReadTool, getPlan, clearPlan, PLAN_TOOL_SLUGS, isPlanToolSlug } from "./tools/todo/todo-tools.js";
 export { isReadOnlyJob } from "./tools/sandbox/repo-configs.js";
 export * from "./tools/sdlc-registry.js";


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard
  - backend
  - xyne-claw-auth

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When an agent acquires a kata sandbox, claw-auth announces it in the channel. That announce was a markdown message with two bare URLs:

> 🖥️ **Live preview** — agent is working in this room. Anyone in this channel can watch (and drive) chromium over noVNC.
> 👉 https://…/claw-preview/…
> Code Changes available at https://…/claw-code/…

This replaces it with a `sandbox` FlowUI component, so the links render as an artifact card matching the [Agent Responses design](https://www.figma.com/design/4t5wSZg0LEjNaioKw2dkxO/Agent-Responses?node-id=168-10923&m=dev) — one row per resource, each with a copy-link button and an Open button.

**What's in the diff**

| Package | Change |
| --- | --- |
| `packages/shared` | `sandboxComponentSchema` added to the flow component union — `previewUrl` required, `codeUrl` and `desc` optional, `.strict()`. `'sandbox'` added to `FlowComponentType`. |
| `packages/xyne-claw-shared` | `buildSandboxFlow` / `sandboxScreenId`, plus `'sandbox'` in the builder's mirrored type union. |
| `apps/dashboard` | `SandboxNode` + registry entry; `--sandbox-icon` token in all three themes. |
| `apps/xyne-claw-auth` | `/webhook/progress` posts `flow` instead of `markdownText`. |

**Decisions worth a reviewer's attention**

- **No flow title.** `FlowRenderer` prints a flow title as an `<h2>` above the components, which put a stray "Sandbox" heading on the card. `buildSandboxFlow` omits it; the `desc` prop is the prose line above the rows instead, and is also what the DM/channel list preview (`utils/flowPreview` reads `desc`) and the notification fallback show.
- **Open always goes to the system browser.** A sandbox is a live noVNC/code session, so `openLink(href, e, { force: 'external' })` — without the force, Electron hands external URLs to the in-app browser panel and ⌘-click inverts it. Still a real `<a href target="_blank">` so middle-click and "copy link address" work.
- **`screenId` is keyed on the sandbox id**, so a follow-up can `updateMessage` the same card in place (e.g. drop the links once the sandbox is torn down) without the emitter tracking a message id.
- **Presentation stays out of the wire.** The emitter sends URLs and prose only; row labels and glyphs are derived in `SandboxNode`. Icons are `FileCode` ("Duo Solid") and `EyeScan` ("Contrast") from `@xyne/icons` — path data identical to the Figma export, so no committed assets.
- **`codeUrl` is optional** so a sandbox with no code server renders one row instead of a dead link. See the caveat below.

**Not included from the design:** the download icon and the `HTML · 20 MB` subtitle, both intentionally dropped.

⚠️ **Pre-existing issue, not fixed here:** `/claw-code/` has no route handler anywhere in this repo — `sandbox-router-ws/sandbox_router.py` only handles `/claw-preview/`. claw already emitted that URL before this PR, so this is not a regression, but the "Code Changes" row will 404 until the route lands. `codeUrl` being optional means gating the emit is a one-line change if we want it hidden meanwhile.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

<!-- Rollout / rollback notes: -->

**Deploy order matters.** The card needs three services to agree, and the failure modes are silent:

1. **backend** — validates every posted flow via `validateFlowDefinition`. Without the rebuilt `@xyne/shared`, it returns `Invalid flowJSON` and **no message posts at all**.
2. **dashboard** — without `SandboxNode` registered, `FlowRenderer` logs `Unknown component type: sandbox` and renders **blank**.
3. **xyne-claw-auth** — the emitter.

Ship backend and dashboard before or with claw-auth. Reversed, agents lose the announce entirely rather than degrading to text. Rollback is safe in any order: reverting claw-auth alone restores the markdown announce.

Non-dashboard surfaces degrade fine — notifications and list previews read `desc`, so they show the prose line instead of a card.

## Config, Environment & URLs

- [x] No config changes — **skip this section**

(Reuses the existing `SANDBOX_PREVIEW_BASE_URL`; setting it empty still disables the announce entirely, as before.)

## API Contract

- [x] No API changes

The `/webhook/progress` payload is unchanged — claw still sends `sandboxPreviewUrl` / `sandboxCodePreviewUrl` / `sandboxId`. What changed is what claw-auth then posts to `/chat/postMessage` (`flow` instead of `markdownText`). The new FlowJSON component type is an additive union member; see the deploy-order note above for why that still needs sequencing.

---

## How did you test it?

**Verified programmatically**

- `pnpm run build:shared` passes.
- Backend `tsc --noEmit` — clean (0 errors). This is the one that matters most, since the backend is what rejects an unknown flow component at post time.
- Dashboard `typecheck` clean; `eslint --quiet` clean on the touched files.
- `xyne-claw-shared` `typecheck` clean.
- claw-auth backend `tsc --noEmit` — 2 errors, both pre-existing in `src/routes/agent-chat.ts` and `src/routes/agents.ts`, untouched by this PR.
- Ran the output of `buildSandboxFlow` through `validateFlowDefinition`: both the two-row and preview-only variants validate; an unknown prop and a missing `previewUrl` are both rejected by `.strict()`; the emitted JSON carries no `title`.

**Rendering**

Three cards were seeded into a local `#xyne-spaces` channel (two-row, preview-only, and a second two-row) and the card was eyeballed in the dashboard. The seed scripts were deliberately left out of this commit.

**Still to verify** — ticking the boxes below once done:

- Electron desktop, specifically that Open reaches the system browser rather than the in-app browser panel
- Dark theme and narrow viewport (the `--sandbox-icon` dark value is a lifted mauve, unverified against the real card)
- Copy button toasts on both success and the failure path

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- Renderer + a pure flow builder; the repo has no test harness for FlowUI nodes and no existing tests for the sibling plan/PR cards. The schema is exercised at runtime by validateFlowDefinition on every post. -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` passes <!-- build not run -->
- [x] Dashboard `lint:errors-only` + `typecheck` pass <!-- build not run -->
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- n/a — no new deps -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*` <!-- branch is feature/sandbox-artifact-card; no ticket id -->
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind


<img width="1660" height="428" alt="image" src="https://github.com/user-attachments/assets/84522aaa-0e55-4643-8654-9367b1cf0121" />

<img width="618" height="199" alt="image" src="https://github.com/user-attachments/assets/06898c2e-2fd0-4d22-8b2f-c2779584a288" />

