### PR TITLE
feat: add document title framework

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -16,6 +16,7 @@ import {
   XYNE_THEME_COMPONENT_TOKENS_DARK,
 } from './themes/componentTokens';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { DocumentTitleSync } from './components/DocumentTitleSync';
 import { useTheme } from './hooks/useTheme';
 import { ShortcutsProvider } from './shortcuts';
 import { TooltipProvider } from './components/ui/Tooltip';
@@ -106,6 +107,7 @@ const App = (): ReactElement => {
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <KeyboardProvider>
+          <DocumentTitleSync />
           <AuthProvider>
             <AnalyticsProvider>
               <ThemeProvider

--- a/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
+++ b/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
@@ -30,6 +30,8 @@ import { useRouteContext } from '../../../hooks/useRouteContext';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useIsInPanelWebview } from '../../../hooks/useIsInPanelWebview';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
+import { useDocumentTitleContribution } from '../../../hooks/useDocumentTitleContribution';
+import { DOCUMENT_TITLE_PRIORITIES } from '../../../machines/documentTitleMachine';
 import { CallExternalChatPanel } from '../../Call/CallExternalChatPanel/CallExternalChatPanel';
 
 interface ChatScreenContext {
@@ -75,20 +77,26 @@ const ChatView = (): ReactElement => {
   );
   const bounds = useMeasure({ ref: chatViewContainerRef, observeResize: true });
 
-  // When rendered inside the browser-panel webview, reflect the current
-  // channel/DM name in `document.title`. The webview's host listens for
-  // `page-title-updated` (see BrowserTabsScreen.tsx:196) and uses it as the
-  // tab label. Scoped to the webview so the main Electron window's title
-  // isn't touched.
-  useEffect(() => {
-    if (!isInPanelWebview) return;
-    if (!channelDisplayName) return;
-    const previous = document.title;
-    document.title = channelDisplayName;
-    return () => {
-      document.title = previous;
-    };
-  }, [isInPanelWebview, channelDisplayName]);
+  // Keep the browser tab / panel-webview title aligned with the active
+  // channel or DM. A central title actor arbitrates this against higher-priority
+  // surfaces such as ticket detail and special pages.
+  useDocumentTitleContribution(
+    channelDisplayName
+      ? {
+          id: 'chat.active-channel',
+          priority: DOCUMENT_TITLE_PRIORITIES.entity,
+          scope: isInPanelWebview ? 'panel-webview' : 'main',
+          entity: {
+            type:
+              channel?.scopeType === ChannelScopeType.DM ||
+              channel?.scopeType === ChannelScopeType.GROUP_DM
+                ? 'dm'
+                : 'channel',
+            label: channelDisplayName,
+          },
+        }
+      : null,
+  );
 
   // Check for group panel from URL params
   const { groupId } = useParams<{ groupId?: string }>();

--- a/apps/dashboard/src/components/DocumentTitleSync/DocumentTitleSync.tsx
+++ b/apps/dashboard/src/components/DocumentTitleSync/DocumentTitleSync.tsx
@@ -1,0 +1,35 @@
+import { useSelector } from '@xstate/react';
+import { ReactElement, useEffect, useMemo } from 'react';
+import { useAllUnreadCount } from '../../hooks/useUnreadCount';
+import { useIsInPanelWebview } from '../../hooks/useIsInPanelWebview';
+import { documentTitleActor, formatDocumentTitle } from '../../machines/documentTitleMachine';
+
+export const DocumentTitleSync = (): ReactElement | null => {
+  const unreadCounts = useAllUnreadCount();
+  const isInPanelWebview = useIsInPanelWebview();
+  const title = useSelector(documentTitleActor, snapshot => formatDocumentTitle(snapshot.context));
+
+  const unreadTotal = useMemo(
+    () => Object.values(unreadCounts).reduce((sum, count) => sum + (count > 0 ? count : 0), 0),
+    [unreadCounts],
+  );
+
+  useEffect(() => {
+    documentTitleActor.send({
+      type: 'SET_SCOPE',
+      scope: isInPanelWebview ? 'panel-webview' : 'main',
+    });
+  }, [isInPanelWebview]);
+
+  useEffect(() => {
+    documentTitleActor.send({ type: 'SET_BADGE_COUNT', count: unreadTotal });
+  }, [unreadTotal]);
+
+  useEffect(() => {
+    if (document.title !== title) {
+      document.title = title;
+    }
+  }, [title]);
+
+  return null;
+};

--- a/apps/dashboard/src/components/DocumentTitleSync/index.ts
+++ b/apps/dashboard/src/components/DocumentTitleSync/index.ts
@@ -1,0 +1,1 @@
+export { DocumentTitleSync } from './DocumentTitleSync';

--- a/apps/dashboard/src/components/Tickets/TicketView/TicketView.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketView/TicketView.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useRef } from 'react';
+import { ReactElement, useMemo, useRef } from 'react';
 import useMeasure from '../../../hooks/useMeasure';
 import { ResizableGroup, Panel, Separator } from '../../ui/Resizable/Resizable';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -7,6 +7,9 @@ import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { TicketDetails } from '../TicketDetails/TicketDetails';
 import ThreadMessages from '../../Chat/ThreadPannel';
 import { ChevronLeft, X } from 'lucide-react';
+import { useDocumentTitleContribution } from '../../../hooks/useDocumentTitleContribution';
+import { DOCUMENT_TITLE_PRIORITIES } from '../../../machines/documentTitleMachine';
+import { htmlToPlainText } from '../../../utils/sanitizer';
 
 const TicketView = (): ReactElement => {
   const ticketViewContainerRef = useRef<HTMLDivElement>(null);
@@ -22,6 +25,22 @@ const TicketView = (): ReactElement => {
   const [ticket] = useCachedQuery(queries.ticketByIdV2({ ticketId: ticketId || '' }), {
     enabled: !!ticketId,
   });
+
+  const ticketTitleLabel = useMemo(() => {
+    if (!ticket) return '';
+    const title = htmlToPlainText(ticket.title ?? '').trim();
+    return [ticket.xyneId, title].filter(Boolean).join(' ');
+  }, [ticket]);
+
+  useDocumentTitleContribution(
+    ticketTitleLabel
+      ? {
+          id: 'ticket.active-detail',
+          priority: DOCUMENT_TITLE_PRIORITIES.detail,
+          entity: { type: 'ticket', label: ticketTitleLabel },
+        }
+      : null,
+  );
 
   const bounds = useMeasure({ ref: ticketViewContainerRef, observeResize: true });
   const shouldStack = bounds.width < 700;

--- a/apps/dashboard/src/hooks/useDocumentTitleContribution.ts
+++ b/apps/dashboard/src/hooks/useDocumentTitleContribution.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import {
+  documentTitleActor,
+  type DocumentTitleContribution,
+} from '../machines/documentTitleMachine';
+
+export const useDocumentTitleContribution = (
+  contribution: DocumentTitleContribution | null | undefined,
+): void => {
+  const id = contribution?.id;
+  const priority = contribution?.priority;
+  const scope = contribution?.scope;
+  const entityType = contribution?.entity.type;
+  const entityLabel = contribution?.entity.label;
+
+  useEffect(() => {
+    if (!id || priority === undefined || !entityType || entityLabel === undefined) return;
+
+    documentTitleActor.send({
+      type: 'UPSERT_CONTRIBUTION',
+      contribution: {
+        id,
+        priority,
+        ...(scope && { scope }),
+        entity: {
+          type: entityType,
+          label: entityLabel,
+        },
+      },
+    });
+
+    return (): void => {
+      documentTitleActor.send({ type: 'REMOVE_CONTRIBUTION', id });
+    };
+  }, [id, priority, scope, entityType, entityLabel]);
+};

--- a/apps/dashboard/src/machines/documentTitleMachine.ts
+++ b/apps/dashboard/src/machines/documentTitleMachine.ts
@@ -1,0 +1,136 @@
+import { assign, createActor, setup } from 'xstate';
+
+export type DocumentTitleEntityType =
+  | 'channel'
+  | 'dm'
+  | 'ticket'
+  | 'thread'
+  | 'canvas'
+  | 'project'
+  | 'page';
+
+export type DocumentTitleScope = 'main' | 'panel-webview';
+
+export type DocumentTitleContribution = {
+  id: string;
+  priority: number;
+  scope?: DocumentTitleScope;
+  entity: {
+    type: DocumentTitleEntityType;
+    label: string;
+  };
+};
+
+export type DocumentTitleContext = {
+  contributions: Record<string, DocumentTitleContribution>;
+  badgeCount: number;
+  appName: string;
+  scope: DocumentTitleScope;
+};
+
+type DocumentTitleEvent =
+  | { type: 'UPSERT_CONTRIBUTION'; contribution: DocumentTitleContribution }
+  | { type: 'REMOVE_CONTRIBUTION'; id: string }
+  | { type: 'SET_BADGE_COUNT'; count: number }
+  | { type: 'SET_SCOPE'; scope: DocumentTitleScope }
+  | { type: 'RESET' };
+
+export const DOCUMENT_TITLE_PRIORITIES = {
+  page: 10,
+  section: 30,
+  entity: 50,
+  detail: 70,
+  blocking: 90,
+} as const;
+
+const normalizeLabel = (label: string): string => label.replace(/\s+/g, ' ').trim();
+
+export const getWinningDocumentTitleContribution = (
+  context: DocumentTitleContext,
+): DocumentTitleContribution | undefined => {
+  return Object.values(context.contributions)
+    .filter(contribution => {
+      return (
+        (!contribution.scope || contribution.scope === context.scope) &&
+        normalizeLabel(contribution.entity.label).length > 0
+      );
+    })
+    .sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id))[0];
+};
+
+export const formatDocumentTitle = (context: DocumentTitleContext): string => {
+  const winningContribution = getWinningDocumentTitleContribution(context);
+  const badge =
+    context.badgeCount > 0 ? `(${context.badgeCount > 99 ? '99+' : context.badgeCount}) ` : '';
+
+  if (!winningContribution) {
+    return `${badge}${context.appName}`;
+  }
+
+  const label = normalizeLabel(winningContribution.entity.label);
+  if (!label || label === context.appName) {
+    return `${badge}${context.appName}`;
+  }
+
+  return `${badge}${label} · ${context.appName}`;
+};
+
+export const documentTitleMachine = setup({
+  types: {
+    context: {} as DocumentTitleContext,
+    events: {} as DocumentTitleEvent,
+  },
+  actions: {
+    upsertContribution: assign({
+      contributions: ({ context, event }) => {
+        if (event.type !== 'UPSERT_CONTRIBUTION') return context.contributions;
+        return {
+          ...context.contributions,
+          [event.contribution.id]: event.contribution,
+        };
+      },
+    }),
+    removeContribution: assign({
+      contributions: ({ context, event }) => {
+        if (event.type !== 'REMOVE_CONTRIBUTION') return context.contributions;
+        const next = { ...context.contributions };
+        delete next[event.id];
+        return next;
+      },
+    }),
+    setBadgeCount: assign({
+      badgeCount: ({ context, event }) => {
+        if (event.type !== 'SET_BADGE_COUNT') return context.badgeCount;
+        return Math.max(0, Math.floor(event.count));
+      },
+    }),
+    setScope: assign({
+      scope: ({ context, event }) => {
+        if (event.type !== 'SET_SCOPE') return context.scope;
+        return event.scope;
+      },
+    }),
+    reset: assign({
+      contributions: () => ({}),
+      badgeCount: () => 0,
+      scope: () => 'main' as DocumentTitleScope,
+    }),
+  },
+}).createMachine({
+  id: 'documentTitle',
+  context: {
+    contributions: {},
+    badgeCount: 0,
+    appName: 'Xyne Spaces',
+    scope: 'main',
+  },
+  on: {
+    UPSERT_CONTRIBUTION: { actions: 'upsertContribution' },
+    REMOVE_CONTRIBUTION: { actions: 'removeContribution' },
+    SET_BADGE_COUNT: { actions: 'setBadgeCount' },
+    SET_SCOPE: { actions: 'setScope' },
+    RESET: { actions: 'reset' },
+  },
+});
+
+export const documentTitleActor = createActor(documentTitleMachine).start();

--- a/apps/dashboard/src/routes/NotFoundScreen/NotFoundScreen.tsx
+++ b/apps/dashboard/src/routes/NotFoundScreen/NotFoundScreen.tsx
@@ -1,18 +1,18 @@
-import { useEffect, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from '@xyne/icons';
 import { Button } from '../../components/ui/Button/Button';
+import { useDocumentTitleContribution } from '../../hooks/useDocumentTitleContribution';
+import { DOCUMENT_TITLE_PRIORITIES } from '../../machines/documentTitleMachine';
 
 const NotFoundScreen = (): ReactElement => {
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const previous = document.title;
-    document.title = 'Page not found';
-    return (): void => {
-      document.title = previous;
-    };
-  }, []);
+  useDocumentTitleContribution({
+    id: 'page.not-found',
+    priority: DOCUMENT_TITLE_PRIORITIES.blocking,
+    entity: { type: 'page', label: 'Page not found' },
+  });
 
   // `window.history.length` counts entries from before the app loaded (other sites
   // visited in the same tab), so it can't tell us whether there is anywhere in-app to


### PR DESCRIPTION
1. Problem Description:
The dashboard currently has a static HTML title (`Xyne Spaces`) and feature-level direct `document.title` writes for a few surfaces. We need a centralized, low-overhead way for active channel, ticket, unread badge, and special page states to update the browser tab title without feature components fighting over DOM writes.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Enhancement requested in Spaces thread: dynamic document/tab title for active channel, active ticket, and notification/activity badge use cases.

3. Explain the solution implemented in the PR:
Adds a small XState `documentTitleMachine` actor that stores structured title contributions, badge count, app name, and current scope. Adds `DocumentTitleSync` as the single DOM writer, `useDocumentTitleContribution` for feature usage, and initial integrations for active channel/DM, ticket detail, unread badge, and 404 page title.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Focused eslint on changed dashboard files: passed with existing warnings only.
- Dashboard typecheck was attempted; it is currently blocked by unrelated pre-existing TypeScript errors in automation/board/etc. files, with no errors reported for document-title files.
- Captured screenshots for base fallback, active channel, active ticket priority, unread badge, 99+ cap, and not-found title cases; attached in Spaces thread.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A
