### PR TITLE
fix: XYNE-56020-Decouple-call-recording-from-summary-generation

### DIFF
--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -142,17 +142,43 @@ class NoteTakerTranscriptService {
       const formattedTranscript = await this.getFormattedTranscript(callId, entries);
       if (!formattedTranscript) return;
 
-      await this.generateAndSaveSummary(call, formattedTranscript);
-      const detailedSummary = await this.generateDetailedSummaryCanvas(call, formattedTranscript);
-      const labelIds = await this.generateAndSaveLabels(call, formattedTranscript);
-      const markedItems = await this.generateMarkedItemsList(call, formattedTranscript);
+      // These workloads are independent once the transcript is available, so
+      // start them together. generateDetailedSummaryCanvas preserves its own
+      // ordered dependency chain: template selection -> prompt generation when
+      // needed -> detailed-summary streaming.
+      const summaryPromise = this.generateAndSaveSummary(call, formattedTranscript);
+      const detailedSummaryPromise = this.generateDetailedSummaryCanvas(call, formattedTranscript);
+      const labelsPromise = this.generateAndSaveLabels(call, formattedTranscript);
+      const markedItemsPromise = this.generateMarkedItemsList(call, formattedTranscript);
+
+      const saveLabelsPromise = labelsPromise.then(async (labelIds) => {
+        if (labelIds.length === 0) return labelIds;
+        try {
+          await repositories.calls.update(call.id, { labels: labelIds });
+          logger.info(`[${callId}] call_record_updated`, { fields_updated: 'labels', path: 'note_taker' });
+        } catch (error) {
+          logger.error(`[${callId}] labels_save_failed`, { error, path: 'note_taker' });
+        }
+        return labelIds;
+      });
+      const saveMarkedItemsPromise = markedItemsPromise.then(async (markedItems) => {
+        if (markedItems.length > 0) {
+          await this.finalizeCallUpdates(call, { markedItems });
+        }
+        return markedItems;
+      });
+
+      const [, detailedSummary] = await Promise.all([
+        summaryPromise,
+        detailedSummaryPromise,
+        saveLabelsPromise,
+        saveMarkedItemsPromise,
+      ]);
       await this.finalizeCallUpdates(call, {
         metadata: {
           transcriptEntryCount: entries.length,
           detailedSummaryCanvasId: detailedSummary?.canvasId,
         },
-        labels: labelIds,
-        markedItems,
         summaryTemplateId: detailedSummary?.summaryTemplateId,
       });
       await this.queueVespaIndexing(call);
@@ -349,76 +375,67 @@ class NoteTakerTranscriptService {
     // The tokens stay inline in the stored aiSummary and are parsed client-side.
     const { numbered: numberedTranscript } = numberTranscriptSegments(formattedTranscript);
 
-    const [summary, generatedTitle] = await Promise.all([
-      transcriptService.generateCallSummary(numberedTranscript, callId).catch((err) => {
+    const summaryPromise = transcriptService.generateCallSummary(numberedTranscript, callId).catch((err) => {
         logger.error(`[${callId}] generate_summary_threw`, {
           path: 'note_taker',
           error: err,
           stack: err instanceof Error ? err.stack : undefined,
         });
         return null;
-      }),
-      call.title
-        ? Promise.resolve(null)
-        : transcriptService.generateCallTitle(formattedTranscript, callId).catch((err) => {
+      });
+    const titlePromise = call.title
+      ? Promise.resolve(null)
+      : transcriptService.generateCallTitle(formattedTranscript, callId).catch((err) => {
             logger.error(`[${callId}] generate_title_threw`, {
               path: 'note_taker',
               error: err,
               stack: err instanceof Error ? err.stack : undefined,
             });
             return null;
-          }),
-    ]);
+          });
 
-    const title = generatedTitle
-      ?.split(/\r?\n/, 1)[0]
-      ?.trim()
-      .replace(/^['"]|['"]$/g, '')
-      .slice(0, 100);
-
-    if (!summary && !title) {
-      logger.error(`[${callId}] ai_summary_skipped`, { reason: 'generation_failed', path: 'note_taker' });
-      return;
-    }
-
-    // `call` was snapshotted when processing started, which by now can be a minute
-    // ago — long enough for the user to have renamed the recording while the LLM was
-    // working. Re-read the title so the generated one never lands on a name they typed.
-    const titleToSave =
-      title && !(await repositories.calls.findByExternalId(callId))?.title ? title : null;
-
-    if (!summary && !titleToSave) {
-      logger.info(`[${callId}] ai_title_discarded`, {
-        reason: 'renamed_during_processing',
-        path: 'note_taker',
-      });
-      return;
-    }
-
-    try {
-      await repositories.calls.update(call.id, {
-        ...(summary ? { aiSummary: summary } : {}),
-        ...(titleToSave ? { title: titleToSave } : {}),
-      });
-      logger.info(`[${callId}] call_record_updated`, {
-        fields_updated: [summary ? 'aiSummary' : '', titleToSave ? 'title' : '']
-          .filter(Boolean)
-          .join(','),
-        path: 'note_taker',
-      });
-    } catch (updateError) {
-      // P2025: call was deleted while summary was being generated — ignore gracefully
-      if (updateError instanceof Prisma.PrismaClientKnownRequestError && updateError.code === 'P2025') {
-        logger.warn(`[${callId}] call_deleted_before_summary_save | skipping update`);
-        return;
+    const saveSummaryPromise = summaryPromise.then(async (summary) => {
+      if (!summary) return false;
+      try {
+        await repositories.calls.update(call.id, { aiSummary: summary });
+        logger.info(`[${callId}] call_record_updated`, { fields_updated: 'aiSummary', path: 'note_taker' });
+        return true;
+      } catch (error) {
+        logger.error(`[${callId}] call_record_update_failed`, {
+          stage: 'summary_save', path: 'note_taker', error,
+        });
+        return false;
       }
-      logger.error(`[${callId}] call_record_update_failed`, {
-        stage: 'call_record_update',
-        path: 'note_taker',
-        error: updateError,
-        stack: updateError instanceof Error ? updateError.stack : undefined,
-      });
-      return;
+    });
+
+    const saveTitlePromise = titlePromise.then(async (generatedTitle) => {
+      const title = generatedTitle
+        ?.split(/\r?\n/, 1)[0]
+        ?.trim()
+        .replace(/^['"]|['"]$/g, '')
+        .slice(0, 100);
+      if (!title) return false;
+
+      // Re-read the title so a user rename made while the LLM was working wins.
+      if ((await repositories.calls.findByExternalId(callId))?.title) {
+        logger.info(`[${callId}] ai_title_discarded`, { reason: 'renamed_during_processing', path: 'note_taker' });
+        return false;
+      }
+      try {
+        await repositories.calls.update(call.id, { title });
+        logger.info(`[${callId}] call_record_updated`, { fields_updated: 'title', path: 'note_taker' });
+        return true;
+      } catch (error) {
+        logger.error(`[${callId}] call_record_update_failed`, {
+          stage: 'title_save', path: 'note_taker', error,
+        });
+        return false;
+      }
+    });
+
+    const [savedSummary, savedTitle] = await Promise.all([saveSummaryPromise, saveTitlePromise]);
+    if (!savedSummary && !savedTitle) {
+      logger.error(`[${callId}] ai_summary_skipped`, { reason: 'generation_failed', path: 'note_taker' });
     }
   }
 

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -1915,7 +1915,14 @@ Output ONLY the processed transcript, nothing else.`;
         callMessage.conversationId,
         undefined,
         { callTitlePromise },
-      );
+      ).catch((error) => {
+        logger.error(`[${callId}] detailed_summary_failed`, {
+          stage: 'detailed_summary_generation',
+          error,
+          stack: error instanceof Error ? error.stack : undefined,
+        });
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      });
 
       const summaryUiPromise = summaryPromise.then(async (summary) => {
         if (!summary) return null;

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -1448,15 +1448,13 @@ Output ONLY the processed transcript, nothing else.`;
    * @param conversationId - The conversation ID of the call message
    * @param callId - The external call ID
    * @param markdownSummary - The AI-generated Markdown summary
-   * @param _createdByUserId - The user who initiated the call (no longer used as sender)
    * @param ticketSuggestions - Optional array of ticket suggestions to append as markdown
    */
   async postSummaryAsReply(
     conversationId: string,
     callId: string,
-    markdownSummary: string,
-    _createdByUserId: string,
-    ticketSuggestions?: TicketSuggestion[]
+    markdownSummary: string | null,
+    ticketSuggestions?: TicketSuggestion[],
   ) {
     logger.info(
       `[postSummaryAsReply] Starting for callId: ${callId}, conversationId: ${conversationId}`
@@ -1493,9 +1491,10 @@ Output ONLY the processed transcript, nothing else.`;
     );
 
     // ── 1. Post / update the AI summary as its own standalone message ──────────
-    const existingSummary = await repositories.messages.findSummaryByCallId(conversationId, callId);
+    if (markdownSummary) {
+      const existingSummary = await repositories.messages.findSummaryByCallId(conversationId, callId);
 
-    if (existingSummary) {
+      if (existingSummary) {
       const existingMetadata = existingSummary.metadata as any;
       const currentVersion = existingMetadata?.version || 1;
 
@@ -1515,7 +1514,7 @@ Output ONLY the processed transcript, nothing else.`;
       logger.info(
         `[postSummaryAsReply] Updated existing summary message ${existingSummary.messageId} to version ${currentVersion + 1}`
       );
-    } else {
+      } else {
       const summaryMessage = await repositories.messages.create({
         conversationId,
         senderId: xyneAutomaticBot.id,
@@ -1537,6 +1536,7 @@ Output ONLY the processed transcript, nothing else.`;
       logger.info(
         `[postSummaryAsReply] Summary message created: ${summaryMessage.messageId} in conversation ${conversationId}`
       );
+    }
     }
 
     // ── 3. Post ticket suggestions as batched separate messages ──────────────
@@ -1906,23 +1906,100 @@ Output ONLY the processed transcript, nothing else.`;
         return [];
       });
 
-      // Preserve the existing requirement that the short summary succeeds, but
-      // do not wait for title/ticket generation before starting the detailed
-      // summary stream. This keeps peak LLM concurrency at three: the detailed
-      // request takes the short-summary slot as soon as that request finishes.
-      const summary = await summaryPromise;
-      pendingDetailedSummary = summary
-        ? callDocumentService.generateAndPostDetailedSummary(
-            callId,
-            formattedTranscript,
-            callMessage.conversationId,
-            undefined,
-            { callTitlePromise },
-          )
-        : null;
-      const [title, ticketSuggestions] = await Promise.all([
-        callTitlePromise,
-        ticketSuggestionsPromise,
+      // Start all four post-call LLM operations immediately. Detailed-summary
+      // streaming remains unchanged; title, summary, and tickets persist their
+      // own result as soon as it is ready rather than waiting on one another.
+      pendingDetailedSummary = callDocumentService.generateAndPostDetailedSummary(
+        callId,
+        formattedTranscript,
+        callMessage.conversationId,
+        undefined,
+        { callTitlePromise },
+      );
+
+      const summaryUiPromise = summaryPromise.then(async (summary) => {
+        if (!summary) return null;
+        try {
+          await repositories.calls.update(call.id, { aiSummary: summary });
+          logger.info(`[${callId}] call_record_updated`, { fields_updated: 'aiSummary' });
+        } catch (updateError) {
+          if (updateError instanceof Prisma.PrismaClientKnownRequestError && updateError.code === 'P2025') {
+            logger.warn(`[${callId}] call_deleted_before_summary_save | skipping update`);
+            return null;
+          }
+          logger.error(`[${callId}] call_record_update_failed`, {
+            stage: 'call_record_update', error: updateError,
+            stack: updateError instanceof Error ? updateError.stack : undefined,
+          });
+        }
+
+        try {
+          await this.postSummaryAsReply(callMessage.conversationId, callId, summary);
+        } catch (replyError) {
+          logger.error(`[${callId}] post_summary_reply_failed`, {
+            stage: 'post_summary_reply', error: replyError,
+            stack: replyError instanceof Error ? replyError.stack : undefined,
+          });
+        }
+        return summary;
+      });
+
+      const titleUiPromise = callTitlePromise.then(async (title) => {
+        if (!title) return null;
+        try {
+          if (!call.title) {
+            await repositories.calls.update(call.id, { title });
+            void callRecordingService.updateRecordingFilename(callId, title);
+          }
+
+          // Serialize with first-chunk Canvas URL attachment: both merge the
+          // call-message metadata, so neither can discard the other's fields.
+          await db.$transaction(async (tx) => {
+            const [message] = await tx.$queryRaw<Array<{ content: string; metadata: unknown }>>`
+              SELECT "content", "metadata" FROM "messages" WHERE "messageId" = ${messageId} FOR UPDATE
+            `;
+            if (!message) {
+              logger.warn(`Call message ${messageId} not found for title update`);
+              return;
+            }
+            await tx.message.update({
+              where: { messageId },
+              data: {
+                content: title,
+                metadata: {
+                  ...(message.metadata as any),
+                  callTitle: title,
+                  callEndedText: message.content,
+                },
+              },
+            });
+          });
+          logger.info(`[${callId}] call_title_updated`);
+        } catch (error) {
+          logger.error(`[${callId}] call_title_update_failed`, { error });
+        }
+        return title;
+      });
+
+      const ticketsUiPromise = ticketSuggestionsPromise.then(async (ticketSuggestions) => {
+        if (ticketSuggestions.length === 0) return ticketSuggestions;
+        try {
+          await this.postSummaryAsReply(
+            callMessage.conversationId, callId, null, ticketSuggestions,
+          );
+        } catch (ticketError) {
+          logger.error(`[${callId}] post_ticket_suggestions_failed`, {
+            error: ticketError,
+            stack: ticketError instanceof Error ? ticketError.stack : undefined,
+          });
+        }
+        return ticketSuggestions;
+      });
+
+      const [summary, title, ticketSuggestions] = await Promise.all([
+        summaryUiPromise,
+        titleUiPromise,
+        ticketsUiPromise,
       ]);
 
       const duration = Date.now() - startTime;
@@ -1938,85 +2015,6 @@ Output ONLY the processed transcript, nothing else.`;
       }
 
       if (summary) {
-        // Save summary and title to call record.
-        // Skip title update for HEADLESS recordings to preserve user-provided title.
-        // Only set title from AI if the call doesn't already have one (scheduled calls have a pre-set title).
-        const effectiveTitle = (title && !call.title) ? title : (call.title ?? null);
-        // Wrap individually so a DB failure here is distinguishable from a transcript
-        // post failure or a summary-post failure in the outer catch.
-        try {
-          await repositories.calls.update(call.id, {
-            aiSummary: summary,
-            ...(title && !call.title ? { title } : {}),
-          });
-          logger.info(`[${callId}] call_record_updated`, { fields_updated: 'aiSummary' });
-        } catch (updateError) {
-          // P2025: call was deleted while summary was being generated — ignore gracefully
-          if (updateError instanceof Prisma.PrismaClientKnownRequestError && updateError.code === 'P2025') {
-            logger.warn(`[${callId}] call_deleted_before_summary_save | skipping update`);
-            return;
-          }
-          logger.error(`[${callId}] call_record_update_failed`, { stage: 'call_record_update', error: updateError, stack: updateError instanceof Error ? updateError.stack : undefined });
-        }
-
-        // Update recording attachment filename to use call title
-        if (effectiveTitle) {
-          void callRecordingService.updateRecordingFilename(callId, effectiveTitle);
-        }
-
-        // Update the call system message with the title (if generated)
-        if (title) {
-          try {
-            // Serialize with first-chunk Canvas URL attachment. Both operations
-            // merge message metadata, so the row lock prevents either concurrent
-            // writer from replacing the other's newly-added keys.
-            await db.$transaction(async (tx) => {
-              const [message] = await tx.$queryRaw<Array<{ content: string; metadata: unknown }>>`
-                SELECT "content", "metadata"
-                FROM "messages"
-                WHERE "messageId" = ${messageId}
-                FOR UPDATE
-              `;
-
-              if (message) {
-                // Swap storage: message.content = AI description, metadata.callEndedText = original call text
-                await tx.message.update({
-                  where: { messageId },
-                  data: {
-                    content: title,
-                    metadata: {
-                      ...(message.metadata as any),
-                      callTitle: title,
-                      callEndedText: message.content,
-                    },
-                  },
-                });
-
-                logger.info(`Updated call message ${messageId} with AI description as content, original text stored in metadata`);
-              } else {
-                logger.warn(`Call message ${messageId} not found for title update`);
-              }
-            });
-          } catch (error) {
-            logger.error(`Failed to update call message with title:`, error);
-            // Don't fail the whole process if message update fails
-          }
-        }
-
-        // Wrap individually — a bot-user-not-found or DB error here produces
-        // post_summary_reply_failed rather than the generic process_call_with_summary_failed.
-        try {
-          await this.postSummaryAsReply(
-            callMessage.conversationId,
-            callId,
-            summary,
-            call.createdByUserId,
-            ticketSuggestions
-          );
-        } catch (replyError) {
-          logger.error(`[${callId}] post_summary_reply_failed`, { stage: 'post_summary_reply', error: replyError, stack: replyError instanceof Error ? replyError.stack : undefined });
-        }
-
         // Pulse block — completely separate from Xyne tickets.
         // Only activates when the call's channel is in PULSE_ENABLED_CHANNELS.
         if (config.pulse.enabledChannels.length > 0) {


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
