### PR TITLE
fix: XYNE-56042 fix analytics data

### DIFF
--- a/apps/backend/src/database/repositories/analyticsRepository.ts
+++ b/apps/backend/src/database/repositories/analyticsRepository.ts
@@ -1528,7 +1528,7 @@ export class AnalyticsRepository {
     // Get all user IDs from different activity types using Promise.all for parallel execution
     const [reactionUsers, attachmentUsers, ticketCreators, ticketActivityUsers, canvasCreators, canvasParticipants] = await Promise.all([
       // Users who posted reactions
-      withWorkspaceScope(() => this.prisma.reaction.findMany({
+      withWorkspaceScope(async () => await this.prisma.reaction.findMany({
         where: { createdAt: dateCondition, userId: { in: userIds } },
         select: { userId: true },
         distinct: ['userId'],
@@ -1563,7 +1563,7 @@ export class AnalyticsRepository {
       }),
 
       // Users who edited canvas
-      withWorkspaceScope(() => this.prisma.canvasParticipant.findMany({
+      withWorkspaceScope(async () => await this.prisma.canvasParticipant.findMany({
         where: { updatedAt: dateCondition, userId: { in: userIds } },
         select: { userId: true},
         distinct: ['userId'],
@@ -1721,16 +1721,16 @@ export class AnalyticsRepository {
 
     // Get all channelIds from valid messages
     const conversationIds = Array.from(new Set(validMessages.map(m => m.conversationId)));
-    const conversations = await withWorkspaceScope(() => this.prisma.conversation.findMany({
+    const conversations = await withWorkspaceScope(async () => await this.prisma.conversation.findMany({
       where: { conversationId: { in: conversationIds } },
       select: { conversationId: true, channelId: true }
     }));
 
     const channelIds = Array.from(new Set(conversations.map(c => c.channelId)));
-    const channels = await this.prisma.channel.findMany({
+    const channels = await withWorkspaceScope(async () => await this.prisma.channel.findMany({
       where: { id: { in: channelIds }, workspaceId },
       select: { id: true, scopeType: true }
-    });
+    }));
 
     // Create lookup maps for efficient processing
     const conversationToChannelMap = new Map(conversations.map(c => [c.conversationId, c.channelId]));
@@ -1850,7 +1850,7 @@ export class AnalyticsRepository {
 
     // Get other activity types (reactions, attachments, tickets, ticket activities, canvas, canvas participants)
     const [reactionUsers, attachmentUsers, ticketCreators, ticketActivityUsers, canvasCreators, canvasParticipants] = await Promise.all([
-      withWorkspaceScope(() => this.prisma.reaction.findMany({
+      withWorkspaceScope(async () => await this.prisma.reaction.findMany({
         where: { createdAt: dateCondition, userId: { in: userIds } },
         select: { userId: true, createdAt: true },
       })),
@@ -1878,7 +1878,7 @@ export class AnalyticsRepository {
       }),
 
       // Users who edited canvas
-      withWorkspaceScope(() => this.prisma.canvasParticipant.findMany({
+      withWorkspaceScope(async () => await this.prisma.canvasParticipant.findMany({
         where: { updatedAt: dateCondition, userId: { in: userIds } },
         select: { userId: true, updatedAt: true },
       }))
@@ -2026,7 +2026,7 @@ export class AnalyticsRepository {
     // Get unique conversationIds
     const validConversationIds = Array.from(new Set(validMessages.map(m => m.conversationId)));
     // Get channels for valid conversations
-    const conversations = await withWorkspaceScope(() => this.prisma.conversation.findMany({
+    const conversations = await withWorkspaceScope(async () => await this.prisma.conversation.findMany({
       where: {
         conversationId: { in: validConversationIds }
       },
@@ -2038,7 +2038,7 @@ export class AnalyticsRepository {
     }
 
     // Get channels with DEFAULT scope type
-    const channels = await this.prisma.channel.findMany({
+    const channels = await withWorkspaceScope(async () => await this.prisma.channel.findMany({
       where: {
         id: { in: channelIds },
         scopeType: ChannelScopeType.DEFAULT,
@@ -2047,7 +2047,7 @@ export class AnalyticsRepository {
       select: {
         id: true
       }
-    });
+    }));
 
     return channels.length;
   }
@@ -2072,16 +2072,16 @@ export class AnalyticsRepository {
 
     // Get all channelIds from valid messages
     const conversationIds = Array.from(new Set(validMessages.map(m => m.conversationId)));
-    const conversations = await withWorkspaceScope(() => this.prisma.conversation.findMany({
+    const conversations = await withWorkspaceScope(async () => await this.prisma.conversation.findMany({
       where: { conversationId: { in: conversationIds } },
       select: { conversationId: true, channelId: true }
     }));
     const conversationToChannelMap = new Map(conversations.map(c => [c.conversationId, c.channelId]));
     const channelIds = Array.from(new Set(conversations.map(c => c.channelId)));
-    const channels = await this.prisma.channel.findMany({
+    const channels = await withWorkspaceScope(async () => await this.prisma.channel.findMany({
       where: { id: { in: channelIds }, scopeType: ChannelScopeType.DEFAULT, workspaceId },
       select: { id: true }
-    });
+    }));
     const defaultChannelIds = new Set(channels.map(c => c.id));
 
     // Generate time buckets based on groupBy
@@ -2440,7 +2440,7 @@ export class AnalyticsRepository {
       : { gte: dateFilter };
 
     // Get all calls in the date range
-    const calls = await withWorkspaceScope(() => this.prisma.call.findMany({
+    const calls = await withWorkspaceScope(async () => await this.prisma.call.findMany({
       where: {
         startedAt: dateCondition,
         ...this.getCallWorkspaceFilter(workspaceId, userIds)
@@ -2536,7 +2536,7 @@ export class AnalyticsRepository {
       : { gte: dateFilter };
 
     // Get calls that have both start and end times
-    const calls = await withWorkspaceScope(() => this.prisma.call.findMany({
+    const calls = await withWorkspaceScope(async () => await this.prisma.call.findMany({
       where: {
         startedAt: dateCondition,
         endedAt: { not: null },
@@ -2580,7 +2580,7 @@ export class AnalyticsRepository {
     const { startDate, endDate } = this.getDateRange(dateCondition);
 
     // Get calls that have both start and end times
-    const calls = await withWorkspaceScope(() => this.prisma.call.findMany({
+    const calls = await withWorkspaceScope(async () => await this.prisma.call.findMany({
       where: {
         startedAt: dateCondition,
         endedAt: { not: null },

--- a/apps/backend/src/database/repositories/analyticsRepository.ts
+++ b/apps/backend/src/database/repositories/analyticsRepository.ts
@@ -126,6 +126,8 @@ type FilteredMessage = {
   messageId: string;
   senderId: string;
   conversationId: string;
+  channelId: string;
+  channelScopeType: string;
   createdAt: Date;
 };
 const MINUTE_MS = 60 * 1000;
@@ -264,6 +266,8 @@ export class AnalyticsRepository {
         m."messageId", 
         m."senderId", 
         m."conversationId", 
+        c."channelId",
+        ch."scopeType" AS "channelScopeType",
         m."createdAt"
       FROM "public"."messages_without_content" m
       INNER JOIN "public"."conversations" c 
@@ -1694,16 +1698,22 @@ export class AnalyticsRepository {
 
     if (validMessageIds.length === 0) return 0;
 
-    const filesSharedCount = await this.prisma.messageAttachment.count({
-      where: {
-        entityId: { in: validMessageIds },
-        entityType: AttachmentEntityType.CHAT,
-        workspaceId,
-        createdBy: { notIn: ['Unified Alerts', 'system'] }
-      }
-    });
+    const [{ count }] = await this.prisma.$queryRaw<{ count: number }[]>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      ${this.chatAttachmentsFrom(validMessageIds, workspaceId)}
+    `);
 
-    return filesSharedCount;
+    return count;
+  }
+
+  private chatAttachmentsFrom(messageIds: string[], workspaceId: string): Prisma.Sql {
+    return Prisma.sql`
+      FROM "public"."message_attachments" a
+      WHERE a."entityId" = ANY(${messageIds}::text[])
+        AND a."entityType" = ${AttachmentEntityType.CHAT}
+        AND a."workspaceId" = ${workspaceId}
+        AND a."createdBy" NOT IN ('Unified Alerts', 'system')
+    `;
   }
 
   /**
@@ -1716,25 +1726,9 @@ export class AnalyticsRepository {
     const dateCondition = typeof dateFilter === 'object' && 'gte' in dateFilter ? dateFilter : { gte: dateFilter };
     const { startDate, endDate } = this.getDateRange(dateCondition);
 
-    // Use centralized helper for filtering
+    // Use centralized helper for filtering. Channel + scopeType ride along on each
+    // message, so no per-conversation follow-up query (and no unbounded IN list).
     const validMessages = await this.getFilteredMessages(dateCondition, workspaceId);
-
-    // Get all channelIds from valid messages
-    const conversationIds = Array.from(new Set(validMessages.map(m => m.conversationId)));
-    const conversations = await withWorkspaceScope(async () => await this.prisma.conversation.findMany({
-      where: { conversationId: { in: conversationIds } },
-      select: { conversationId: true, channelId: true }
-    }));
-
-    const channelIds = Array.from(new Set(conversations.map(c => c.channelId)));
-    const channels = await withWorkspaceScope(async () => await this.prisma.channel.findMany({
-      where: { id: { in: channelIds }, workspaceId },
-      select: { id: true, scopeType: true }
-    }));
-
-    // Create lookup maps for efficient processing
-    const conversationToChannelMap = new Map(conversations.map(c => [c.conversationId, c.channelId]));
-    const channelToScopeMap = new Map(channels.map(c => [c.id, c.scopeType]));
 
     // Generate complete time buckets for the date range based on groupBy
     const timeBuckets = groupBy === 'hour' 
@@ -1749,10 +1743,8 @@ export class AnalyticsRepository {
 
     // Aggregate valid messages
     validMessages.forEach(message => {
-      const channelId = conversationToChannelMap.get(message.conversationId);
-      if (!channelId) return;
       const dateKey = this.getBucketKey(message.createdAt, groupBy);
-      const scopeType = channelToScopeMap.get(channelId);
+      const scopeType = message.channelScopeType;
       if (bucketData.has(dateKey)) {
         const bucket = bucketData.get(dateKey)!;
         bucket.total += 1;
@@ -2023,33 +2015,16 @@ export class AnalyticsRepository {
     if (validMessages.length === 0) {
       return 0;
     }
-    // Get unique conversationIds
-    const validConversationIds = Array.from(new Set(validMessages.map(m => m.conversationId)));
-    // Get channels for valid conversations
-    const conversations = await withWorkspaceScope(async () => await this.prisma.conversation.findMany({
-      where: {
-        conversationId: { in: validConversationIds }
-      },
-      select: { conversationId: true, channelId: true }
-    }));
-    const channelIds = Array.from(new Set(conversations.map(c => c.channelId)));
-    if (channelIds.length === 0) {
-      return 0;
-    }
 
-    // Get channels with DEFAULT scope type
-    const channels = await withWorkspaceScope(async () => await this.prisma.channel.findMany({
-      where: {
-        id: { in: channelIds },
-        scopeType: ChannelScopeType.DEFAULT,
-        workspaceId
-      },
-      select: {
-        id: true
-      }
-    }));
+    // Count the distinct DEFAULT-scope channels the messages belong to. The scope
+    // rides along on each message, so no conversation/channel lookups by id list.
+    const activeChannelIds = new Set(
+      validMessages
+        .filter(m => m.channelScopeType === ChannelScopeType.DEFAULT)
+        .map(m => m.channelId)
+    );
 
-    return channels.length;
+    return activeChannelIds.size;
   }
 
   /**
@@ -2067,22 +2042,9 @@ export class AnalyticsRepository {
     // Extract start and end dates using centralized helper method
     const { startDate, endDate } = this.getDateRange(dateCondition);
 
-    // Use centralized helper for filtering
+    // Use centralized helper for filtering. Channel + scopeType ride along on each
+    // message, so no per-conversation follow-up query (and no unbounded IN list).
     const validMessages = await this.getFilteredMessages(dateCondition, workspaceId);
-
-    // Get all channelIds from valid messages
-    const conversationIds = Array.from(new Set(validMessages.map(m => m.conversationId)));
-    const conversations = await withWorkspaceScope(async () => await this.prisma.conversation.findMany({
-      where: { conversationId: { in: conversationIds } },
-      select: { conversationId: true, channelId: true }
-    }));
-    const conversationToChannelMap = new Map(conversations.map(c => [c.conversationId, c.channelId]));
-    const channelIds = Array.from(new Set(conversations.map(c => c.channelId)));
-    const channels = await withWorkspaceScope(async () => await this.prisma.channel.findMany({
-      where: { id: { in: channelIds }, scopeType: ChannelScopeType.DEFAULT, workspaceId },
-      select: { id: true }
-    }));
-    const defaultChannelIds = new Set(channels.map(c => c.id));
 
     // Generate time buckets based on groupBy
     const timeBuckets = groupBy === 'hour'
@@ -2097,11 +2059,10 @@ export class AnalyticsRepository {
 
     // Group valid channels by time buckets based on valid message activity
     validMessages.forEach(message => {
-      const channelId = conversationToChannelMap.get(message.conversationId);
-      if (!channelId || !defaultChannelIds.has(channelId)) return;
+      if (message.channelScopeType !== ChannelScopeType.DEFAULT) return;
       const bucketKey = this.getBucketKey(message.createdAt, groupBy);
       if (bucketData.has(bucketKey)) {
-        bucketData.get(bucketKey)!.add(channelId);
+        bucketData.get(bucketKey)!.add(message.channelId);
       }
     });
 
@@ -2696,15 +2657,10 @@ export class AnalyticsRepository {
     const validMessageIds = validMessages.map(m => m.messageId);
 
     // Get file attachments for valid (non-migrated) messages only
-    const attachments = validMessageIds.length === 0 ? [] : await this.prisma.messageAttachment.findMany({
-      where: {
-        entityId: { in: validMessageIds },
-        entityType: AttachmentEntityType.CHAT,
-        workspaceId,
-        createdBy: { notIn: ['Unified Alerts', 'system'] }
-      },
-      select: { createdAt: true },
-    });
+    const attachments = validMessageIds.length === 0 ? [] : await this.prisma.$queryRaw<{ createdAt: Date }[]>(Prisma.sql`
+      SELECT a."createdAt"
+      ${this.chatAttachmentsFrom(validMessageIds, workspaceId)}
+    `);
 
     // Generate time buckets based on groupBy
     const timeBuckets = groupBy === 'hour'


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Issue 1 - Panels showing less data (user scoped only)

Root cause - withWorkspaceScope(() => prisma.x.findMany(...)) closed its AsyncLocalStorage scope before the lazy Prisma promise ever executed, so the ACL saw an ordinary logged-in user and applied per-user filtering.

Fix - Changed call sites in analyticsRepository.ts to withWorkspaceScope(async () => await this.prisma...), forcing the query to run while the scope is still open.


Issue 2 - 
Analytics panel crash on large date ranges.

Root cause - Each fetched messages, then ran a second query with WHERE id IN (all those IDs). Postgres caps a query at 32,767 values. Enough messages → over the cap → crash.

Fix - The message query already joins conversations and channels, so it now returns the channel info directly — the second query is gone entirely. For files-shared, where the ID list was unavoidable, the list goes as
one array parameter instead of one parameter per ID.


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
