### PR TITLE
revert: drop client-sent instant flag ahead of claw deployment

### DIFF
--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -92,11 +92,6 @@ const XyneAIRequestSchemaV2 = z.object({
   web_search_enabled: z.boolean().optional().default(false),
   deepResearchEnabled: z.boolean().optional().default(false),
   deep_research_enabled: z.boolean().optional().default(false),
-  // Single search + single answer pass instead of the full agentic tool
-  // loop — see xyne-claw-auth's run-stream.ts POST / instant branch. Single
-  // word, so camelCase and snake_case are identical — no dual key needed
-  // (unlike webSearchEnabled/web_search_enabled above).
-  instant: z.boolean().optional().default(false),
   researchContext: ResearchContextSchema.optional().nullable(),
   research_context: ResearchContextSchema.optional().nullable(),
   attachments: z
@@ -234,7 +229,6 @@ export class XyneAIControllerV2 {
       web_search_enabled: webSearchEnabledSC,
       deepResearchEnabled: deepResearchEnabledCC,
       deep_research_enabled: deepResearchEnabledSC,
-      instant,
       researchContext,
       research_context,
       attachments,
@@ -426,7 +420,6 @@ export class XyneAIControllerV2 {
           messageAttachmentIds,
           webSearchEnabled,
           deepResearchEnabled,
-          instant,
           researchContext: effectiveResearchContext,
           createCanvasEnabled,
           generateFollowUpSuggestions: true,

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -68,9 +68,6 @@ export interface ClawRunRequest {
   messageAttachmentIds?: string[];
   webSearchEnabled: boolean;
   deepResearchEnabled: boolean;
-  /** Single search + single answer pass instead of the full agentic tool
-   *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
-  instant?: boolean;
   researchContext?: { type: string; id?: string; name: string } | null;
   createCanvasEnabled: boolean;
   sessionId?: string;
@@ -143,12 +140,6 @@ export interface AccessibleClawAgent {
     fileId: string | null;
     rootCollectionId: string;
   }>;
-  /** From claw-auth's `agent.config.instantAgent` (see agents.ts's
-   *  lightAgentProjection). When true, every chat request to this agent
-   *  always runs the single-search/single-answer instant KB path — the
-   *  askAI composer shows a locked "Instant" indicator instead of its
-   *  normal per-message toggle for such agents, and never for others. */
-  instantAgent?: boolean;
 }
 
 export interface ClawConversationSummary {
@@ -562,7 +553,6 @@ export async function runClawAgentStream(
     }),
     ...(request.webSearchEnabled && { webSearchEnabled: true }),
     ...(request.deepResearchEnabled && { deepResearchEnabled: true }),
-    ...(request.instant && { instant: true }),
     ...(request.researchContext && { researchContext: request.researchContext }),
     agentConfig: {
       webSearchEnabled: String(request.webSearchEnabled),
@@ -859,9 +849,6 @@ interface RawClawAgent {
   /** Claw-auth's `INCLUDE_TOOLS_SKILLS` always loads collections + kbScope. */
   kbScope?: string;
   collections?: Array<{ id: string; agentId: string; collectionId: string; fileId: string | null }>;
-  /** Top-level in the light-list response (agents.ts's lightAgentProjection
-   *  derives it from config.instantAgent, but doesn't expose config itself). */
-  instantAgent?: boolean;
 }
 
 export async function listAccessibleClawAgents(req: {
@@ -942,7 +929,6 @@ export async function listAccessibleClawAgents(req: {
         fileId: c.fileId,
         rootCollectionId: rootByCollectionId.get(c.collectionId) ?? c.collectionId,
       })),
-      instantAgent: agent.instantAgent === true,
     };
   });
 

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -27,7 +27,6 @@ import {
   Mic,
   Hash,
   Lock,
-  Zap,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
@@ -42,8 +41,6 @@ import {
   type ContextSelections,
 } from '../Chat/XyneAISidebar/components/ContextPickerPanel';
 import { EMPTY_COMPOSER_CONTEXT, type ComposerContext } from './composerContext';
-import { fetchAccessibleClawAgents } from '../../services/clawAgentListService';
-import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 
 export interface AIComposerAttachment {
   id: string;
@@ -151,15 +148,10 @@ function ContextPill({
   );
 }
 
-// Ghost toolbar button matching the /ai composer's look. `visibleText` is
-// opt-in — when set, the button widens into a pill with the icon plus a text
-// node instead of the default icon-only circle (used for the Instant toggle
-// so it reads as a named mode, not just an icon other buttons could be
-// mistaken for).
+// Ghost toolbar button matching the /ai composer's look.
 function ToolbarButton({
   icon,
   label,
-  visibleText,
   onClick,
   active,
   activeClass,
@@ -168,7 +160,6 @@ function ToolbarButton({
 }: {
   icon: ReactElement;
   label: string;
-  visibleText?: string;
   onClick: () => void;
   active?: boolean;
   activeClass?: string;
@@ -184,8 +175,7 @@ function ToolbarButton({
       title={label}
       aria-pressed={active}
       className={cn(
-        'inline-flex h-8 shrink-0 items-center justify-center rounded-full transition',
-        visibleText ? 'gap-1 px-2.5' : 'w-8',
+        'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition',
         active
           ? (activeClass ?? 'bg-secondary text-foreground')
           : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
@@ -195,7 +185,6 @@ function ToolbarButton({
       data-track-name={trackName}
     >
       {icon}
-      {visibleText && <span className='text-xs font-medium'>{visibleText}</span>}
     </button>
   );
 }
@@ -237,24 +226,6 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
   const [deepResearchEnabled, setDeepResearchEnabled] = useState(() => seed.deepResearchEnabled);
   const [createCanvasEnabled, setCreateCanvasEnabled] = useState(() => seed.createCanvasEnabled);
 
-  // Locked, not a toggle — see xyne-claw-auth's AgentDetailLeftColumn.tsx
-  // "Instant Agent" setting and ChatPageV3.tsx's matching indicator. Every
-  // request to an instant agent always runs instant (enforced server-side
-  // regardless of what this composer sends), so there's no per-message
-  // choice; the same `['accessible-claw-agents']` query the agent selector
-  // uses is free here via the React Query cache.
-  const { selectedAgentSlug } = useSelectedAgent();
-  const { data: composerAgents } = useQuery({
-    queryKey: ['accessible-claw-agents'],
-    queryFn: fetchAccessibleClawAgents,
-    staleTime: 5 * 60 * 1000,
-  });
-  const selectedAgent = useMemo(
-    () => composerAgents?.find(a => a.slug === selectedAgentSlug) ?? null,
-    [composerAgents, selectedAgentSlug],
-  );
-  const instant = selectedAgent?.instantAgent === true;
-
   const { data: configData } = useQuery<XyneAIConfigResponse>({
     queryKey: ['xyne-ai-config'],
     queryFn: async (): Promise<XyneAIConfigResponse> => {
@@ -279,7 +250,6 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       webSearchEnabled: webSearchAccessible ? webSearchEnabled : false,
       deepResearchEnabled: deepResearchAccessible ? deepResearchEnabled : false,
       createCanvasEnabled,
-      instant,
     }),
     [
       selections,
@@ -288,7 +258,6 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       webSearchEnabled,
       deepResearchEnabled,
       createCanvasEnabled,
-      instant,
       webSearchAccessible,
       deepResearchAccessible,
     ],
@@ -782,24 +751,6 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
                 activeClass='bg-secondary text-primary'
                 trackName='TOGGLE_CREATE_CANVAS'
               />
-              {/* Locked indicator, not a toggle — only rendered when the
-                  selected agent is configured as an "Instant Agent"
-                  (agent.config.instantAgent, see xyne-claw-auth's
-                  AgentDetailLeftColumn.tsx). Every request to such an
-                  agent always runs instant (enforced server-side in
-                  agent-chat.ts/run-stream.ts regardless of what this
-                  composer sends), so there's nothing to toggle — other
-                  agents show no instant affordance at all. */}
-              {instant && (
-                <div
-                  title='This agent always answers instantly from the Knowledge Base'
-                  aria-label='Instant agent'
-                  className='inline-flex h-8 shrink-0 cursor-default items-center justify-center gap-1 rounded-full bg-secondary px-2.5 text-status-pending'
-                >
-                  <Zap className='h-4 w-4' aria-hidden strokeWidth={1.75} />
-                  <span className='text-xs font-medium'>Instant</span>
-                </div>
-              )}
             </div>
 
             <div className='flex shrink-0 items-center gap-1.5'>

--- a/apps/dashboard/src/components/AIScreen/composerContext.ts
+++ b/apps/dashboard/src/components/AIScreen/composerContext.ts
@@ -32,9 +32,6 @@ export interface ComposerContext {
   webSearchEnabled: boolean;
   deepResearchEnabled: boolean;
   createCanvasEnabled: boolean;
-  /** Single search + single answer pass instead of the full agentic tool
-   *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
-  instant: boolean;
 }
 
 export const EMPTY_COMPOSER_CONTEXT: ComposerContext = {
@@ -49,7 +46,6 @@ export const EMPTY_COMPOSER_CONTEXT: ComposerContext = {
   webSearchEnabled: false,
   deepResearchEnabled: false,
   createCanvasEnabled: false,
-  instant: false,
 };
 
 /** True when the snapshot carries any context/toggle worth sending as overrides. */
@@ -65,8 +61,7 @@ export function hasComposerContext(ctx: ComposerContext): boolean {
     ctx.research !== null ||
     ctx.webSearchEnabled ||
     ctx.deepResearchEnabled ||
-    ctx.createCanvasEnabled ||
-    ctx.instant
+    ctx.createCanvasEnabled
   );
 }
 
@@ -94,7 +89,6 @@ export function toStreamOverrides(ctx: ComposerContext): StreamOverrides {
     webSearchEnabled: ctx.webSearchEnabled,
     deepResearchEnabled: ctx.deepResearchEnabled,
     createCanvasEnabled: ctx.createCanvasEnabled,
-    instant: ctx.instant,
     researchContext: ctx.research,
   };
 }

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/AskAIDebugPanel.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/AskAIDebugPanel.tsx
@@ -2044,7 +2044,7 @@ function FollowUpDiagnosticsSection({ diagnostic }: { diagnostic: FollowUpDiagno
           {diagnostic.agentContextDescription}
         </p>
       )}
-      {(diagnostic.suggestions?.length ?? 0) > 0 && (
+      {diagnostic.suggestions.length > 0 && (
         <ol className='list-decimal space-y-1 pl-4 text-[11px] leading-relaxed text-xyne-fg-secondary'>
           {diagnostic.suggestions.map(suggestion => (
             <li key={suggestion}>{suggestion}</li>

--- a/apps/dashboard/src/hooks/useXyneAIStream.ts
+++ b/apps/dashboard/src/hooks/useXyneAIStream.ts
@@ -25,9 +25,6 @@ export interface StreamOverrides {
   webSearchEnabled?: boolean;
   deepResearchEnabled?: boolean;
   createCanvasEnabled?: boolean;
-  /** Single search + single answer pass instead of the full agentic tool
-   *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
-  instant?: boolean;
   researchContext?: ResearchContext | null;
   ticketIds?: string[];
   canvasIds?: string[];
@@ -52,7 +49,6 @@ interface UseXyneAIStreamParams {
   collectionIds?: string[];
   fileIds?: string[];
   createCanvasEnabled?: boolean;
-  instant?: boolean;
   isV2?: boolean;
   channelId?: string | undefined; // Added for thread ID construction
   ticketIds?: string[];
@@ -118,7 +114,6 @@ export const useXyneAIStream = ({
   collectionIds,
   fileIds,
   createCanvasEnabled = false,
-  instant = false,
   isV2 = false,
   channelId,
   ticketIds,
@@ -289,7 +284,6 @@ export const useXyneAIStream = ({
         ov && 'deepResearchEnabled' in ov ? !!ov.deepResearchEnabled : deepResearchEnabled;
       const eCreateCanvasEnabled =
         ov && 'createCanvasEnabled' in ov ? !!ov.createCanvasEnabled : createCanvasEnabled;
-      const eInstant = ov && 'instant' in ov ? !!ov.instant : instant;
       const eResearchContext =
         ov && 'researchContext' in ov ? (ov.researchContext ?? null) : researchContext;
       const eChannelIds = ov?.channelIds ?? channelIds;
@@ -411,7 +405,6 @@ export const useXyneAIStream = ({
           webSearchEnabled: eWebSearchEnabled,
           deepResearchEnabled: eDeepResearchEnabled,
           createCanvasEnabled: eCreateCanvasEnabled,
-          instant: eInstant,
           researchContext: eResearchContext,
           attachments,
           parentMessageId,
@@ -449,7 +442,6 @@ export const useXyneAIStream = ({
       webSearchEnabled,
       deepResearchEnabled,
       createCanvasEnabled,
-      instant,
       isV2,
       syncMessagesRef,
       ticketIds,

--- a/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
+++ b/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
@@ -89,9 +89,6 @@ export interface StreamRequest {
   webSearchEnabled: boolean;
   deepResearchEnabled?: boolean;
   createCanvasEnabled?: boolean;
-  /** Single search + single answer pass instead of the full agentic tool
-   *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
-  instant?: boolean;
   researchContext?: ResearchContext | null | undefined;
   attachments: MessageAttachment[];
   parentMessageId?: string | undefined;
@@ -1001,7 +998,6 @@ class XyneAIStreamManager {
           webSearchEnabled: request.webSearchEnabled,
           deepResearchEnabled: request.deepResearchEnabled ?? false,
           createCanvasEnabled: request.createCanvasEnabled ?? false,
-          instant: request.instant ?? false,
           researchContext: request.researchContext
             ? request.researchContext.id
               ? {

--- a/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
+++ b/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
@@ -34,9 +34,6 @@ export interface WorkerStartStreamMessage {
       webSearchEnabled: boolean;
       deepResearchEnabled?: boolean;
       createCanvasEnabled?: boolean;
-      /** Single search + single answer pass instead of the full agentic tool
-       *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
-      instant?: boolean;
       researchContext?: { type: string; id?: string; name: string } | null;
       canvasId?: string;
       messageAttachmentIds?: string[];
@@ -152,7 +149,6 @@ async function executeStream(
         web_search_enabled: requestBody.webSearchEnabled,
         deep_research_enabled: requestBody.deepResearchEnabled ?? false,
         create_canvas_enabled: requestBody.createCanvasEnabled ?? false,
-        instant: requestBody.instant ?? false,
         research_context: requestBody.researchContext ?? null,
         ...(requestBody.canvasId && {
           canvas_id: requestBody.canvasId,

--- a/apps/dashboard/src/services/clawAgentListService.ts
+++ b/apps/dashboard/src/services/clawAgentListService.ts
@@ -28,10 +28,6 @@ export interface AccessibleClawAgent {
     fileId: string | null;
     rootCollectionId: string;
   }>;
-  /** When true, every chat request to this agent always runs the single-
-   *  search/single-answer instant KB path — the composer shows a locked
-   *  "Instant" indicator for it instead of the normal per-message toggle. */
-  instantAgent?: boolean;
 }
 
 export async function fetchAccessibleClawAgents(): Promise<AccessibleClawAgent[]> {


### PR DESCRIPTION
Precautionary partial revert of #470: undoes only the `instant` plumbing (ComposerContext -> useXyneAIStream -> XyneAIStreamManager -> worker -> XyneAIControllerV2 -> clawAgentService -> claw-auth, plus the composer's "Instant" badge and its instantAgent field on the agent listing). None of this can currently do anything — no agent can have config.instantAgent=true yet since the toggle UI lives in the not-yet-deployed xyne-claw-auth frontend, and claw-auth's currently deployed /agents endpoint doesn't return instantAgent either, so selectedAgent?.instantAgent is always false — but landing spaces without waiting on claw removes any doubt rather than relying on that analysis.

Deliberately keeps everything else from #470: the workspaceId ACL fixes (CollectionsACL, CollectionItemsACL, listAccessibleRootCollections) are real, standalone security fixes with no dependency on claw, and the AskAIDebugPanel.tsx null-check fixes a genuine crash in follow-up diagnostics unrelated to instant mode specifically.

Re-landing this is just re-applying #470's diff for these 8 files once xyne-claw / xyne-claw-auth are deployed with matching support.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
