### PR TITLE
fix: XYNE-56054 desk acl refetch fix

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -1771,7 +1771,11 @@ export const queries: AnyQueryRegistry = defineQueries({
     }
   ),
   getEmailsForConversations: defineQuery(
-    z.object({ conversationIds: z.array(z.string()) }),
+    z.object({
+      conversationIds: z.array(z.string()),
+      channelId: z.string(),
+      isMember: z.boolean(),
+    }),
     ({ args: { conversationIds } }) => {
       // An empty `IN []` predicate is invalid in Zero/SQL, and this query body
       // runs during hash construction (before the caller's `enabled` flag can
@@ -1789,7 +1793,11 @@ export const queries: AnyQueryRegistry = defineQueries({
   ),
 
   getDraftForConversation: defineQuery(
-    z.object({ conversationId: z.string() }),
+    z.object({
+      conversationId: z.string(),
+      channelId: z.string(),
+      isMember: z.boolean(),
+    }),
     ({ ctx, args: { conversationId } }) => {
       return zql.email_drafts
         .where('conversationId', conversationId)

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -1770,7 +1770,21 @@ export const queries: AnyQueryRegistry = defineQueries({
       return zql.emails.where('conversationId', conversationId);
     }
   ),
+  // @deprecated Use getEmailsForConversationsV2 when channel membership is known.
   getEmailsForConversations: defineQuery(
+    z.object({ conversationIds: z.array(z.string()) }),
+    ({ args: { conversationIds } }) => {
+      if (conversationIds.length === 0) {
+        return zql.emails
+          .where('conversationId', '__no_match__')
+          .related('attachments');
+      }
+      return zql.emails
+        .where('conversationId', 'IN', conversationIds)
+        .related('attachments');
+    }
+  ),
+  getEmailsForConversationsV2: defineQuery(
     z.object({
       conversationIds: z.array(z.string()),
       channelId: z.string(),
@@ -1792,7 +1806,19 @@ export const queries: AnyQueryRegistry = defineQueries({
     }
   ),
 
+  // @deprecated Use getDraftForConversationV2 when channel membership is known.
   getDraftForConversation: defineQuery(
+    z.object({ conversationId: z.string() }),
+    ({ ctx, args: { conversationId } }) => {
+      return zql.email_drafts
+        .where('conversationId', conversationId)
+        .where(({ or, cmp }) =>
+          or(cmp('userId', '=', ctx.userID), cmp('userId', 'IS', null)),
+        )
+        .orderBy('updatedAt', 'desc');
+    }
+  ),
+  getDraftForConversationV2: defineQuery(
     z.object({
       conversationId: z.string(),
       channelId: z.string(),

--- a/apps/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
@@ -51,6 +51,13 @@ const buildPurifier = (): DOMPurifyInstance => {
   return purifier;
 };
 
+let emailBodyPurifier: DOMPurifyInstance | undefined;
+
+const getEmailBodyPurifier = (): DOMPurifyInstance => {
+  emailBodyPurifier ??= buildPurifier();
+  return emailBodyPurifier;
+};
+
 const isRemoteUrl = (value: string): boolean => {
   const trimmed = value.trim().toLowerCase();
   if (!trimmed) return false;
@@ -345,7 +352,7 @@ const buildIframeSrcdoc = (
     ? preprocessed
     : `<pre style="white-space:pre-wrap;font-family:inherit;margin:0;">${escapeHtml(preprocessed)}</pre>`;
 
-  const purifier = buildPurifier();
+  const purifier = getEmailBodyPurifier();
   const sanitized = purifier.sanitize(htmlInput, { RETURN_DOM_FRAGMENT: false });
   const cidResolved = rewriteCidRefs(sanitized);
 

--- a/apps/dashboard/src/hooks/useEmailDraft.ts
+++ b/apps/dashboard/src/hooks/useEmailDraft.ts
@@ -58,9 +58,17 @@ function sameStringList(a: string[] | null | undefined, b: string[] | null | und
 /**
  * Returns all drafts visible to the current user for a conversation from Zero cache.
  */
-export function useEmailDrafts(conversationId: string | null | undefined): EmailDraftRecord[] {
+export function useEmailDrafts(
+  conversationId: string | null | undefined,
+  channelId: string,
+  isMember: boolean,
+): EmailDraftRecord[] {
   const [dbDrafts] = useCachedQuery(
-    queries.getDraftForConversation({ conversationId: conversationId || '' }),
+    queries.getDraftForConversation({
+      conversationId: conversationId || '',
+      channelId,
+      isMember,
+    }),
     { enabled: !!conversationId },
   );
   return useMemo(() => {

--- a/apps/dashboard/src/hooks/useEmailDraft.ts
+++ b/apps/dashboard/src/hooks/useEmailDraft.ts
@@ -64,7 +64,7 @@ export function useEmailDrafts(
   isMember: boolean,
 ): EmailDraftRecord[] {
   const [dbDrafts] = useCachedQuery(
-    queries.getDraftForConversation({
+    queries.getDraftForConversationV2({
       conversationId: conversationId || '',
       channelId,
       isMember,

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -3622,7 +3622,7 @@ export const SupportTicketDetail = ({
   );
 
   const [allEmails] = useCachedQuery(
-    queries.getEmailsForConversations({
+    queries.getEmailsForConversationsV2({
       conversationIds: allConversationIds,
       channelId: routeChannelId,
       isMember,

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -646,7 +646,7 @@ const SupportScreen = (): ReactElement => {
   );
   const channelPreference = channelPreferenceList?.[0];
   const deskBoardId = channelPreference?.boardId || channelBoardId;
-  const [channelBoardDetail] = useCachedQuery(
+  const [channelBoardDetail, channelBoardDetailDetails] = useCachedQuery(
     queries.boardDetailById({ boardId: deskBoardId || '' }),
     { enabled: !!deskBoardId },
   );
@@ -781,21 +781,13 @@ const SupportScreen = (): ReactElement => {
     return fromMappings;
   }, [classificationMappings]);
 
-  // deskBoardId (channel preference first) rather than the row-derived
-  // channelBoardId, so stage options load on first visit before any ticket row.
-  const [boardStages, boardStagesDetails] = useCachedQuery(
-    queries.stagesByBoard({ boardId: deskBoardId ?? '' }),
-    {
-      enabled: !!deskBoardId,
-    },
-  );
   const availableStages = useMemo(
     () =>
-      boardStages?.map(s => ({
+      channelBoardDetail?.stages.map(s => ({
         name: s.name,
         status: s.defaultTicketStatusV2,
       })) ?? [],
-    [boardStages],
+    [channelBoardDetail?.stages],
   );
 
   const hasAssigneeFilter = !!(filters.assignee && filters.assignee.length > 0);
@@ -2646,7 +2638,9 @@ const SupportScreen = (): ReactElement => {
                                   handleFilterChange('stages', stages)
                                 }
                                 availableStages={availableStages}
-                                isLoading={!!deskBoardId && boardStagesDetails.type !== 'complete'}
+                                isLoading={
+                                  !!deskBoardId && channelBoardDetailDetails.type !== 'complete'
+                                }
                               />
                             </Popover.Content>
                           </Popover.Root>
@@ -3571,7 +3565,7 @@ export const SupportTicketDetail = ({
     { enabled: (!!ticketId || !!ticketIdParam) && !!routeChannelId },
   );
   const detailConversationId = ticket?.conversationId ?? stateConversationId;
-  const ticketEmailDrafts = useEmailDrafts(detailConversationId);
+  const ticketEmailDrafts = useEmailDrafts(detailConversationId, routeChannelId, isMember);
 
   // Start the primary email query from router state while ticket metadata loads,
   // then include any merged-ticket conversations once the detail query resolves.
@@ -3628,7 +3622,11 @@ export const SupportTicketDetail = ({
   );
 
   const [allEmails] = useCachedQuery(
-    queries.getEmailsForConversations({ conversationIds: allConversationIds }),
+    queries.getEmailsForConversations({
+      conversationIds: allConversationIds,
+      channelId: routeChannelId,
+      isMember,
+    }),
     { enabled: allConversationIds.length > 0 },
   );
 
@@ -3636,11 +3634,10 @@ export const SupportTicketDetail = ({
   const emailCollapseState = useEmailCollapseState(emails);
 
   const initiator = useMemo(() => {
-    if (emails.length === 0) return null;
-    const first = [...emails].sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))[0];
+    const first = emailCollapseState.sortedEmails[0];
     if (!first?.from) return null;
     return parseFromField(first.from);
-  }, [emails]);
+  }, [emailCollapseState.sortedEmails]);
 
   // When arriving via a mail deep-link (`?mail=<id>`), un-collapse the target
   // email so it's visible, then scroll to it with a brief yellow flash.
@@ -3671,21 +3668,9 @@ export const SupportTicketDetail = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targetMailId, emails]);
 
-  const channelId = ticket?.channelId || '';
+  const channelId = ticket?.channelId || routeChannelId;
   const conversationId = ticket?.conversationId ?? stateConversationId;
   const title = ticket?.title ?? null;
-  const [threadConversation] = useCachedQuery(
-    queries.threadConversationV2({
-      conversationId: conversationId || '',
-      channelId: channelId || undefined,
-      isMember,
-    }),
-    { enabled: !!conversationId && !!channelId },
-  );
-  const messages = useMemo(
-    () => [...(threadConversation?.messages ?? [])],
-    [threadConversation?.messages],
-  );
   // DB ticket id (not the xyneId) for per-user mailbox actions; router state carries it
   // on list navigation, else it comes from the fetched ticket row.
   const mailboxTicketId = ticket?.id ?? ticketId ?? null;
@@ -4067,23 +4052,6 @@ export const SupportTicketDetail = ({
   );
 
   const targetMessageId = searchParams.get('messageId');
-  useEffect(() => {
-    if (!targetMessageId || !conversationId) return;
-    if (!messages || messages.length === 0) return;
-    const raf = requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const target = document.getElementById(
-          `thread-message-${conversationId}-${targetMessageId}`,
-        );
-        if (target) {
-          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          target.classList.add('bg-yellow-50');
-          setTimeout(() => target.classList.remove('bg-yellow-50'), 2500);
-        }
-      });
-    });
-    return () => cancelAnimationFrame(raf);
-  }, [targetMessageId, conversationId, messages]);
 
   // Get channel info and user status
   const channel = useChannel(channelId);

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -1502,7 +1502,11 @@ export const queries = defineQueries({
     },
   ),
   getEmailsForConversations: defineQuery(
-    z.object({ conversationIds: z.array(z.string()) }),
+    z.object({
+      conversationIds: z.array(z.string()),
+      channelId: z.string(),
+      isMember: z.boolean(),
+    }),
     ({ args: { conversationIds } }) => {
       // An empty `IN []` predicate is invalid in Zero/SQL, and this query body
       // runs during hash construction (before the caller's `enabled` flag can
@@ -1519,7 +1523,11 @@ export const queries = defineQueries({
     },
   ),
   getDraftForConversation: defineQuery(
-    z.object({ conversationId: z.string() }),
+    z.object({
+      conversationId: z.string(),
+      channelId: z.string(),
+      isMember: z.boolean(),
+    }),
     ({ ctx, args: { conversationId } }) => {
       return zql.email_drafts
         .where('conversationId', conversationId)

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -1501,7 +1501,21 @@ export const queries = defineQueries({
       return zql.emails.where('conversationId', conversationId);
     },
   ),
+  // @deprecated Use getEmailsForConversationsV2 when channel membership is known.
   getEmailsForConversations: defineQuery(
+    z.object({ conversationIds: z.array(z.string()) }),
+    ({ args: { conversationIds } }) => {
+      if (conversationIds.length === 0) {
+        return zql.emails
+          .where('conversationId', '__no_match__')
+          .related('attachments');
+      }
+      return zql.emails
+        .where('conversationId', 'IN', conversationIds)
+        .related('attachments');
+    },
+  ),
+  getEmailsForConversationsV2: defineQuery(
     z.object({
       conversationIds: z.array(z.string()),
       channelId: z.string(),
@@ -1522,7 +1536,19 @@ export const queries = defineQueries({
         .related('attachments');
     },
   ),
+  // @deprecated Use getDraftForConversationV2 when channel membership is known.
   getDraftForConversation: defineQuery(
+    z.object({ conversationId: z.string() }),
+    ({ ctx, args: { conversationId } }) => {
+      return zql.email_drafts
+        .where('conversationId', conversationId)
+        .where(({ or, cmp }) =>
+          or(cmp('userId', '=', ctx.userID), cmp('userId', 'IS', null)),
+        )
+        .orderBy('updatedAt', 'desc');
+    },
+  ),
+  getDraftForConversationV2: defineQuery(
     z.object({
       conversationId: z.string(),
       channelId: z.string(),


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
