### PR TITLE
fix: unstar channel when moving it into a custom section

### DIFF
--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -2243,11 +2243,6 @@ export function createMutators(
             id: userStatus.id,
             sectionId,
             sectionPosition: sectionId ? position : null,
-            // A channel assigned to a custom section must not also be starred:
-            // the sidebar renders Starred with absolute priority (a starred channel
-            // is skipped from every other bucket), so leaving isStarred set would
-            // keep the channel pinned in Starred and hidden from its new section.
-            // Clearing it here enforces the invariant for every caller (dialogs + DnD).
             ...(sectionId ? { isStarred: false } : {}),
             updatedAt: timestamp,
           });

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -2243,6 +2243,12 @@ export function createMutators(
             id: userStatus.id,
             sectionId,
             sectionPosition: sectionId ? position : null,
+            // A channel assigned to a custom section must not also be starred:
+            // the sidebar renders Starred with absolute priority (a starred channel
+            // is skipped from every other bucket), so leaving isStarred set would
+            // keep the channel pinned in Starred and hidden from its new section.
+            // Clearing it here enforces the invariant for every caller (dialogs + DnD).
+            ...(sectionId ? { isStarred: false } : {}),
             updatedAt: timestamp,
           });
         },

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -1290,11 +1290,6 @@ export const mutators = defineMutators({
           id: userStatus.id,
           sectionId,
           sectionPosition: sectionId ? position : null,
-          // A channel assigned to a custom section must not also be starred:
-          // the sidebar renders Starred with absolute priority (a starred channel
-          // is skipped from every other bucket), so leaving isStarred set would
-          // keep the channel pinned in Starred and hidden from its new section.
-          // Clearing it here enforces the invariant for every caller (dialogs + DnD).
           ...(sectionId ? { isStarred: false } : {}),
           updatedAt: timestamp,
         });

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -1290,6 +1290,12 @@ export const mutators = defineMutators({
           id: userStatus.id,
           sectionId,
           sectionPosition: sectionId ? position : null,
+          // A channel assigned to a custom section must not also be starred:
+          // the sidebar renders Starred with absolute priority (a starred channel
+          // is skipped from every other bucket), so leaving isStarred set would
+          // keep the channel pinned in Starred and hidden from its new section.
+          // Clearing it here enforces the invariant for every caller (dialogs + DnD).
+          ...(sectionId ? { isStarred: false } : {}),
           updatedAt: timestamp,
         });
       },


### PR DESCRIPTION
## Problem
When a channel or DM was already in the **Starred** section and the user added it to a new custom section (via the *Create Section* or *Manage Section* dialogs), the channel stayed in Starred and never appeared in the new section.

Root cause: the sidebar grouping (`groupChannelsByScope` in `apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.utils.ts`) renders **Starred with absolute priority** — a channel with `isStarred=true` is pushed into Starred and `continue`s, skipping every other bucket including custom sections. The `moveToSection` mutator only set `sectionId`/`sectionPosition` and never cleared `isStarred`. So a starred channel assigned to a section kept `isStarred=true` and stayed pinned in Starred, invisible in its new section.

The drag-and-drop path already worked because `useChannelSectionDnd.moveChannelToSection` explicitly calls `toggleStarred` before `moveToSection`. The two dialog paths (`CreateSectionDialog.handleAddChannels` and the `ManageSectionChannelsDialog` onSave `toAdd` loop) did not.

## Fix
Enforce the invariant "a channel assigned to a custom section is not starred" at the write boundary instead of in each UI caller. `moveToSection` now clears `isStarred` whenever it assigns a non-null `sectionId`. This fixes all three callers (both dialogs + DnD) at once and prevents future drift. When `sectionId` is null (removing from a section) the star flag is left untouched, so drag-into-Starred still works.

Applied to **both** mutator copies to keep optimistic and authoritative state in sync:
- `packages/shared/src/zero/mutators.ts` (client-optimistic)
- `apps/backend/src/zero/mutators.ts` (server-authoritative)

## Testing
- `pnpm run build` on `packages/shared` passes (dist rebuilt).
- Manual: star a channel/DM, create a new section and add it — it now leaves Starred and appears in the new section. Same via Manage Section dialog and drag-and-drop.