### PR TITLE
feat: XYNE-56066 Add Pingdom and GCP monitoring support

### DIFF
--- a/apps/backend/src/apps/controllers/alertWebhookShared.ts
+++ b/apps/backend/src/apps/controllers/alertWebhookShared.ts
@@ -1,0 +1,191 @@
+import type { FlowComponent, FlowState } from '@xyne/shared';
+
+/**
+ * Helpers shared by the alert incoming-webhook parsers (Amazon SNS, Pingdom,
+ * GCP Cloud Monitoring).
+ *
+ * Each provider owns its payload types and field mapping; everything here is
+ * provider-agnostic — value coercion, the label deny-list, and the card
+ * primitives that make the three sources render identically in a channel.
+ */
+
+export type AlertSeverity = 'critical' | 'warning' | 'info' | 'ok';
+
+export const MAX_FIELDS = 16;
+export const MAX_FIELD_VALUE_LENGTH = 400;
+export const MAX_DESCRIPTION_LENGTH = 2000;
+
+/**
+ * Labels that add noise rather than signal in a chat card.
+ *
+ * Ported from infra-switch's `BLACKLISTED_VM_LABELS`
+ * (`src/InfraSwitch/Config.hs:274`), including its default list, and overridable
+ * through the environment the same way.
+ */
+export const DEFAULT_BLACKLISTED_LABELS =
+  'uuid,node,instance,job,metrics_path,prometheus,prometheus_replica,severity,' +
+  'endpoint,alert_id,alert,alertgroup,alertname,user,older_receiver';
+
+export function emptyFlowState(): FlowState {
+  return {
+    values: {},
+    touched: {},
+    errors: {},
+    submitting: false,
+    submitted: false,
+    history: [],
+    loadingComponentIds: [],
+  };
+}
+
+export function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+/** Coerce an arbitrary JSON value into a single-line display string. */
+export function toDisplayValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'N/A';
+  }
+  if (typeof value === 'string') {
+    return truncate(value.trim() || 'N/A', MAX_FIELD_VALUE_LENGTH);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    return truncate(JSON.stringify(value), MAX_FIELD_VALUE_LENGTH);
+  } catch {
+    return 'N/A';
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** A value that renders as a readable single line rather than a JSON blob. */
+export function isScalar(value: unknown): boolean {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+/** Drop empty/placeholder entries and cap the table length. */
+export function buildFields(entries: Array<[string, unknown]>): Array<[string, string]> {
+  return entries
+    .map(([label, value]) => [label, toDisplayValue(value)] as [string, string])
+    .filter(([, value]) => value !== 'N/A' && value !== '')
+    .slice(0, MAX_FIELDS);
+}
+
+export function blacklistedLabels(): Set<string> {
+  // Deliberately `||`, not `??`: an unset var and the empty value that ships in
+  // .env.example must both fall back to the default rather than disable the list.
+  // ALERT_BLACKLISTED_LABELS covers every alert webhook type; SNS_BLACKLISTED_LABELS
+  // is kept as a fallback so existing deployments keep their configured list.
+  const raw =
+    process.env.ALERT_BLACKLISTED_LABELS?.trim() ||
+    process.env.SNS_BLACKLISTED_LABELS?.trim() ||
+    DEFAULT_BLACKLISTED_LABELS;
+  return new Set(
+    raw
+      .split(',')
+      .map(label => label.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Every label that is not blacklisted, keyed uppercase.
+ *
+ * infra-switch renders the label bag as a deny-list rather than an allow-list
+ * (`convertLabelsToSlackBlock`, `src/AlertProxy/Utils/Common.hs:477-482`), so
+ * team-specific labels reach the card instead of being silently dropped.
+ */
+export function passthroughLabels(labels: Record<string, unknown>): Array<[string, unknown]> {
+  const blacklist = blacklistedLabels();
+  return Object.entries(labels)
+    .filter(([key]) => !blacklist.has(key.toLowerCase()))
+    .map(([key, value]) => [key.toUpperCase(), value] as [string, unknown]);
+}
+
+export function isHttpUrl(value: string | null | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Left-edge stripe colour per severity.
+ *
+ * infra-switch drives this off `SlackAttachment.color`
+ * (`src/AlertProxy/Utils/Common.hs:447-449`): green when the alert state maps to
+ * OK/RESOLVED/UP, red otherwise. The warning and info shades come from Slack's
+ * named palette as resolved in `slackBlockKitToFlowJSON.ts:449-454`, so alerts
+ * arriving straight from a provider match ones relayed through infra-switch.
+ */
+export const SEVERITY_STRIPE: Record<AlertSeverity, string> = {
+  critical: '#d91009',
+  warning: '#ECB22E',
+  ok: '#04ba1c',
+  info: '#d1d5db',
+};
+
+/**
+ * Wrap card content in the Slack-style coloured left border.
+ * Mirrors `withColorStripe` (`slackBlockKitToFlowJSON.ts:482-489`).
+ */
+export function withColorStripe(
+  id: string,
+  children: FlowComponent[],
+  color: string,
+): FlowComponent {
+  return {
+    id,
+    type: 'column',
+    style: { borderLeft: `4px solid ${color}`, padding: '2px 0 2px 10px' },
+    children,
+  };
+}
+
+/**
+ * Lay fields out as a 2-column grid that wraps onto new rows, the way Slack
+ * renders `section.fields`. Mirrors `fieldsToGrid`
+ * (`slackBlockKitToFlowJSON.ts:497-509`) — a grid rather than a label/value
+ * table, so the render paths agree.
+ *
+ * `idPrefix` namespaces the generated component ids per provider (`sns`,
+ * `pingdom`, `gcp`), since flow component ids must be unique within a screen.
+ */
+export function fieldsToGrid(
+  fields: Array<[string, string]>,
+  idPrefix: string,
+  columns = 2,
+): FlowComponent {
+  const rows: FlowComponent[] = [];
+
+  for (let i = 0; i < fields.length; i += columns) {
+    const cells: FlowComponent[] = fields.slice(i, i + columns).map(([label, value], cell) => ({
+      id: `${idPrefix}-field-${i + cell}`,
+      type: 'column',
+      children: [
+        {
+          id: `${idPrefix}-field-${i + cell}-label`,
+          type: 'text',
+          props: { content: label, bold: true },
+        },
+        { id: `${idPrefix}-field-${i + cell}-value`, type: 'text', props: { content: value } },
+      ],
+    }));
+    rows.push({ id: `${idPrefix}-field-row-${i / columns}`, type: 'row', children: cells });
+  }
+
+  return rows.length === 1
+    ? rows[0]
+    : { id: `${idPrefix}-fields`, type: 'column', children: rows };
+}

--- a/apps/backend/src/apps/controllers/amazonSnsWebhookParser.ts
+++ b/apps/backend/src/apps/controllers/amazonSnsWebhookParser.ts
@@ -1,4 +1,19 @@
-import type { FlowComponent, FlowDefinition, FlowState } from '@xyne/shared';
+import type { FlowComponent, FlowDefinition } from '@xyne/shared';
+import {
+  MAX_DESCRIPTION_LENGTH,
+  SEVERITY_STRIPE,
+  buildFields,
+  emptyFlowState,
+  fieldsToGrid,
+  isHttpUrl,
+  isRecord,
+  isScalar,
+  passthroughLabels,
+  toDisplayValue,
+  truncate,
+  withColorStripe,
+} from './alertWebhookShared';
+import type { AlertSeverity } from './alertWebhookShared';
 
 /**
  * Amazon SNS incoming-webhook parser.
@@ -42,7 +57,8 @@ export type SnsAlertSource =
   | 'eventbridge'
   | 'generic';
 
-export type SnsSeverity = 'critical' | 'warning' | 'info' | 'ok';
+/** Alias kept so existing SNS-specific imports keep working. */
+export type SnsSeverity = AlertSeverity;
 
 export interface SnsNormalizedPayload {
   source: SnsAlertSource;
@@ -64,99 +80,6 @@ export interface SnsNormalizedPayload {
  * has no outbound webhookUrl to proxy to.
  */
 export const SNS_CONFIRM_ACTION_ID = 'sns_confirm_subscription';
-
-const MAX_FIELDS = 16;
-const MAX_FIELD_VALUE_LENGTH = 400;
-const MAX_DESCRIPTION_LENGTH = 2000;
-
-/**
- * Labels that add noise rather than signal in a chat card.
- *
- * Ported from infra-switch's `BLACKLISTED_VM_LABELS`
- * (`src/InfraSwitch/Config.hs:274`), including its default list, and overridable
- * through the environment the same way.
- */
-const DEFAULT_BLACKLISTED_LABELS =
-  'uuid,node,instance,job,metrics_path,prometheus,prometheus_replica,severity,' +
-  'endpoint,alert_id,alert,alertgroup,alertname,user,older_receiver';
-
-function emptyFlowState(): FlowState {
-  return {
-    values: {},
-    touched: {},
-    errors: {},
-    submitting: false,
-    submitted: false,
-    history: [],
-    loadingComponentIds: [],
-  };
-}
-
-function truncate(value: string, max: number): string {
-  return value.length > max ? `${value.slice(0, max)}…` : value;
-}
-
-/** Coerce an arbitrary JSON value into a single-line display string. */
-function toDisplayValue(value: unknown): string {
-  if (value === null || value === undefined) {
-    return 'N/A';
-  }
-  if (typeof value === 'string') {
-    return truncate(value.trim() || 'N/A', MAX_FIELD_VALUE_LENGTH);
-  }
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return String(value);
-  }
-  try {
-    return truncate(JSON.stringify(value), MAX_FIELD_VALUE_LENGTH);
-  } catch {
-    return 'N/A';
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-/** A value that renders as a readable single line rather than a JSON blob. */
-function isScalar(value: unknown): boolean {
-  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
-}
-
-
-/** Drop empty/placeholder entries and cap the table length. */
-function buildFields(entries: Array<[string, unknown]>): Array<[string, string]> {
-  return entries
-    .map(([label, value]) => [label, toDisplayValue(value)] as [string, string])
-    .filter(([, value]) => value !== 'N/A' && value !== '')
-    .slice(0, MAX_FIELDS);
-}
-
-function blacklistedLabels(): Set<string> {
-  // Deliberately `||`, not `??`: an unset var and the empty value that ships in
-  // .env.example must both fall back to the default rather than disable the list.
-  const raw = process.env.SNS_BLACKLISTED_LABELS?.trim() || DEFAULT_BLACKLISTED_LABELS;
-  return new Set(
-    raw
-      .split(',')
-      .map(label => label.trim().toLowerCase())
-      .filter(Boolean),
-  );
-}
-
-/**
- * Every label that is not blacklisted, keyed uppercase.
- *
- * infra-switch renders the label bag as a deny-list rather than an allow-list
- * (`convertLabelsToSlackBlock`, `src/AlertProxy/Utils/Common.hs:477-482`), so
- * team-specific labels reach the card instead of being silently dropped.
- */
-function passthroughLabels(labels: Record<string, unknown>): Array<[string, unknown]> {
-  const blacklist = blacklistedLabels();
-  return Object.entries(labels)
-    .filter(([key]) => !blacklist.has(key.toLowerCase()))
-    .map(([key, value]) => [key.toUpperCase(), value] as [string, unknown]);
-}
 
 /**
  * Split an SNS topic ARN into its region and account id.
@@ -437,27 +360,6 @@ export function parseSnsMessage(envelope: SnsEnvelope): SnsNormalizedPayload {
 // FLOW BUILDERS
 // ============================================================================
 
-function isHttpUrl(value: string | null): value is string {
-  if (!value) {
-    return false;
-  }
-  try {
-    const url = new URL(value);
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Left-edge stripe colour per severity.
- *
- * infra-switch drives this off `SlackAttachment.color`
- * (`src/AlertProxy/Utils/Common.hs:447-449`): green when the alert state maps to
- * OK/RESOLVED/UP, red otherwise. The warning and info shades come from Slack's
- * named palette as resolved in `slackBlockKitToFlowJSON.ts:449-454`, so alerts
- * arriving straight from SNS match ones relayed through infra-switch.
- */
 /**
  * Leading text of the header line, per source. infra-switch renders
  * `<Source> Alert | <name> | <account>` as a single hyperlink
@@ -480,50 +382,6 @@ function buildHeaderLabel(payload: SnsNormalizedPayload): string {
   return [`🚨 ${SOURCE_HEADER[payload.source]}`, payload.title, account]
     .filter(Boolean)
     .join(' | ');
-}
-
-const SEVERITY_STRIPE: Record<SnsSeverity, string> = {
-  critical: '#d91009',
-  warning: '#ECB22E',
-  ok: '#04ba1c',
-  info: '#d1d5db',
-};
-
-/**
- * Wrap card content in the Slack-style coloured left border.
- * Mirrors `withColorStripe` (`slackBlockKitToFlowJSON.ts:482-489`).
- */
-function withColorStripe(id: string, children: FlowComponent[], color: string): FlowComponent {
-  return {
-    id,
-    type: 'column',
-    style: { borderLeft: `4px solid ${color}`, padding: '2px 0 2px 10px' },
-    children,
-  };
-}
-
-/**
- * Lay fields out as a 2-column grid that wraps onto new rows, the way Slack
- * renders `section.fields`. Mirrors `fieldsToGrid`
- * (`slackBlockKitToFlowJSON.ts:497-509`) — a grid rather than our previous
- * label/value table, so the two render paths agree.
- */
-function fieldsToGrid(fields: Array<[string, string]>, columns = 2): FlowComponent {
-  const rows: FlowComponent[] = [];
-
-  for (let i = 0; i < fields.length; i += columns) {
-    const cells: FlowComponent[] = fields.slice(i, i + columns).map(([label, value], cell) => ({
-      id: `sns-field-${i + cell}`,
-      type: 'column',
-      children: [
-        { id: `sns-field-${i + cell}-label`, type: 'text', props: { content: label, bold: true } },
-        { id: `sns-field-${i + cell}-value`, type: 'text', props: { content: value } },
-      ],
-    }));
-    rows.push({ id: `sns-field-row-${i / columns}`, type: 'row', children: cells });
-  }
-
-  return rows.length === 1 ? rows[0] : { id: 'sns-fields', type: 'column', children: rows };
 }
 
 export function buildAmazonSnsFlow(payload: SnsNormalizedPayload): FlowDefinition {
@@ -552,7 +410,7 @@ export function buildAmazonSnsFlow(payload: SnsNormalizedPayload): FlowDefinitio
   }
 
   if (payload.fields.length > 0) {
-    children.push(fieldsToGrid(payload.fields));
+    children.push(fieldsToGrid(payload.fields, 'sns'));
   }
 
   return {
@@ -595,7 +453,7 @@ export function buildSubscriptionConfirmationFlow(envelope: SnsEnvelope): FlowDe
           : 'A topic asked to deliver alerts to this channel. Alerts will not arrive until an admin confirms the subscription.',
       },
     },
-    fieldsToGrid([['Topic', envelope.TopicArn]]),
+    fieldsToGrid([['Topic', envelope.TopicArn]], 'sns'),
   ];
 
   if (isHttpUrl(envelope.SubscribeURL ?? null)) {
@@ -694,7 +552,7 @@ export function buildUnsubscribeConfirmationFlow(envelope: SnsEnvelope): FlowDef
                   variant: 'warning',
                 },
               },
-              fieldsToGrid([['Topic', envelope.TopicArn]]),
+              fieldsToGrid([['Topic', envelope.TopicArn]], 'sns'),
             ],
             SEVERITY_STRIPE.info,
           ),

--- a/apps/backend/src/apps/controllers/gcpWebhookParser.test.ts
+++ b/apps/backend/src/apps/controllers/gcpWebhookParser.test.ts
@@ -1,0 +1,239 @@
+import { buildGcpFlow, mergeGcpLabels, normalizeGcp, parseGcpPayload } from './gcpWebhookParser';
+import type { GcpIncident, GcpPayload } from './gcpWebhookParser';
+import { SEVERITY_STRIPE } from './alertWebhookShared';
+
+const OPEN_INCIDENT: GcpPayload = {
+  version: '1.2',
+  incident: {
+    incident_id: '0.abcd1234efgh',
+    scoping_project_id: 'my-proj',
+    scoping_project_number: 123456789012,
+    url: 'https://console.cloud.google.com/monitoring/alerting/incidents/0.abcd1234efgh',
+    state: 'open',
+    started_at: 1698043056,
+    policy_name: 'High CPU',
+    policy_user_labels: { team: 'infra', alert_id: 'c604216c-c099-42be-acbb-cb3efd56d148' },
+    condition_name: 'CPU utilization above threshold',
+    summary: 'CPU for instance-1 is above 0.8 with a value of 0.95',
+    documentation: { content: 'Runbook: restart the instance', mime_type: 'text/markdown' },
+    metric: {
+      type: 'compute.googleapis.com/instance/cpu/utilization',
+      displayName: 'CPU utilization',
+      labels: { team: 'metric-team', instance_name: 'instance-1' },
+    },
+    resource: {
+      type: 'gce_instance',
+      labels: { team: 'resource-team', zone: 'asia-south1-a' },
+    },
+    metadata: { user_labels: { team: 'metadata-team', env: 'prod' } },
+    observed_value: '0.95',
+  },
+};
+
+const CLOSED_INCIDENT: GcpPayload = {
+  ...OPEN_INCIDENT,
+  incident: { ...OPEN_INCIDENT.incident, state: 'closed', ended_at: 1698046656 },
+};
+
+function fieldMap(fields: Array<[string, string]>): Record<string, string> {
+  return Object.fromEntries(fields);
+}
+
+describe('parseGcpPayload', () => {
+  it('accepts a full incident', () => {
+    expect(parseGcpPayload(OPEN_INCIDENT)).not.toBeNull();
+  });
+
+  it.each([
+    ['an empty object', {}],
+    ['null', null],
+    ['a bare string', 'open'],
+    ['a payload with no incident', { version: '1.2' }],
+    [
+      'an incident missing state',
+      { incident: { policy_name: 'p', condition_name: 'c' } },
+    ],
+    [
+      'an incident missing policy_name',
+      { incident: { state: 'open', condition_name: 'c' } },
+    ],
+    [
+      'an incident missing condition_name',
+      { incident: { state: 'open', policy_name: 'p' } },
+    ],
+  ])('rejects %s', (_label, input) => {
+    expect(parseGcpPayload(input)).toBeNull();
+  });
+});
+
+describe('mergeGcpLabels', () => {
+  it('applies infra-switch label precedence on collision', () => {
+    const labels = mergeGcpLabels(OPEN_INCIDENT.incident);
+
+    // policy_user_labels > resource.labels > metadata.user_labels > metric.labels
+    expect(labels.team).toBe('infra');
+    expect(labels.zone).toBe('asia-south1-a');
+    expect(labels.env).toBe('prod');
+    expect(labels.instance_name).toBe('instance-1');
+  });
+
+  it('falls back through the bags when the winner is absent', () => {
+    const incident: GcpIncident = {
+      ...OPEN_INCIDENT.incident,
+      policy_user_labels: undefined,
+    };
+
+    expect(mergeGcpLabels(incident).team).toBe('resource-team');
+  });
+
+  it('returns an empty bag when the incident carries no labels', () => {
+    expect(
+      mergeGcpLabels({ state: 'open', policy_name: 'p', condition_name: 'c' }),
+    ).toEqual({});
+  });
+
+  it('drops non-string label values rather than stringifying them', () => {
+    const labels = mergeGcpLabels({
+      state: 'open',
+      policy_name: 'p',
+      condition_name: 'c',
+      resource: { labels: { ok: 'yes', bad: 42 as unknown as string } },
+    });
+
+    expect(labels).toEqual({ ok: 'yes' });
+  });
+});
+
+describe('normalizeGcp', () => {
+  it('maps an open incident to FIRING with epoch timestamps converted', () => {
+    const payload = normalizeGcp(OPEN_INCIDENT);
+
+    expect(payload.status).toBe('FIRING');
+    expect(payload.severity).toBe('critical');
+    expect(payload.title).toBe('High CPU');
+    expect(payload.projectId).toBe('my-proj');
+    expect(payload.incidentId).toBe('0.abcd1234efgh');
+    expect(payload.timestamp).toBe('2023-10-23T06:37:36.000Z');
+
+    const fields = fieldMap(payload.fields);
+    expect(fields['Alarm State']).toBe('FIRING');
+    expect(fields['Condition']).toBe('CPU utilization above threshold');
+    expect(fields['Resource']).toBe('gce_instance');
+    expect(fields['Metric']).toBe('CPU utilization');
+    expect(fields['Observed Value']).toBe('0.95');
+    expect(fields['Started At']).toBe('2023-10-23T06:37:36.000Z');
+    // Merged labels reach the card with policy_user_labels winning...
+    expect(fields['TEAM']).toBe('infra');
+    // ...and the shared deny-list still suppresses alert_id.
+    expect(fields).not.toHaveProperty('ALERT_ID');
+  });
+
+  it('maps a closed incident to RESOLVED and prefers ended_at for the timestamp', () => {
+    const payload = normalizeGcp(CLOSED_INCIDENT);
+
+    expect(payload.status).toBe('RESOLVED');
+    expect(payload.severity).toBe('ok');
+    expect(payload.timestamp).toBe('2023-10-23T07:37:36.000Z');
+    expect(fieldMap(payload.fields)['Ended At']).toBe('2023-10-23T07:37:36.000Z');
+  });
+
+  it('prefers summary over documentation.content for the description', () => {
+    expect(normalizeGcp(OPEN_INCIDENT).description).toBe(
+      'CPU for instance-1 is above 0.8 with a value of 0.95',
+    );
+  });
+
+  it('falls back to documentation.content when there is no summary', () => {
+    const payload = normalizeGcp({
+      incident: { ...OPEN_INCIDENT.incident, summary: undefined },
+    });
+
+    expect(payload.description).toBe('Runbook: restart the instance');
+  });
+
+  it('leaves the description null when neither is present', () => {
+    const payload = normalizeGcp({
+      incident: { ...OPEN_INCIDENT.incident, summary: undefined, documentation: undefined },
+    });
+
+    expect(payload.description).toBeNull();
+  });
+
+  it.each([
+    ['CRITICAL', 'critical'],
+    ['ERROR', 'critical'],
+    ['WARNING', 'warning'],
+    ['INFO', 'info'],
+  ])('maps incident severity %s to %s', (raw, expected) => {
+    const payload = normalizeGcp({
+      incident: { ...OPEN_INCIDENT.incident, severity: raw },
+    });
+
+    expect(payload.severity).toBe(expected);
+  });
+
+  it('falls back to the severity user label when the incident has no severity', () => {
+    const payload = normalizeGcp({
+      incident: {
+        ...OPEN_INCIDENT.incident,
+        policy_user_labels: { severity: 'WARNING' },
+      },
+    });
+
+    expect(payload.severity).toBe('warning');
+  });
+
+  it('ignores payload severity entirely once the incident has closed', () => {
+    const payload = normalizeGcp({
+      incident: { ...CLOSED_INCIDENT.incident, severity: 'CRITICAL' },
+    });
+
+    expect(payload.severity).toBe('ok');
+  });
+
+  it('drops a zero ended_at rather than rendering the epoch', () => {
+    const payload = normalizeGcp({
+      incident: { ...OPEN_INCIDENT.incident, ended_at: 0 },
+    });
+
+    expect(fieldMap(payload.fields)).not.toHaveProperty('Ended At');
+    expect(payload.timestamp).toBe('2023-10-23T06:37:36.000Z');
+  });
+});
+
+describe('buildGcpFlow', () => {
+  it('renders a red-striped card headed by a link to the console', () => {
+    const flow = buildGcpFlow(normalizeGcp(OPEN_INCIDENT));
+
+    expect(flow.version).toBe('2.0');
+    expect(flow.title).toBe('High CPU');
+
+    const stripe = flow.components[0].children?.[0];
+    expect(stripe?.style?.borderLeft).toBe(`4px solid ${SEVERITY_STRIPE.critical}`);
+
+    const header = stripe?.children?.[0];
+    expect(header?.type).toBe('link');
+    expect(header?.props?.label).toBe('🚨 GCP Alert | High CPU | my-proj');
+    expect(header?.props?.href).toBe(OPEN_INCIDENT.incident.url);
+  });
+
+  it('renders a green stripe once the incident closes', () => {
+    const flow = buildGcpFlow(normalizeGcp(CLOSED_INCIDENT));
+
+    expect(flow.components[0].children?.[0]?.style?.borderLeft).toBe(
+      `4px solid ${SEVERITY_STRIPE.ok}`,
+    );
+  });
+
+  it('falls back to a heading when the incident carries no console url', () => {
+    const flow = buildGcpFlow(
+      normalizeGcp({
+        incident: { ...OPEN_INCIDENT.incident, url: undefined, scoping_project_id: undefined },
+      }),
+    );
+    const header = flow.components[0].children?.[0]?.children?.[0];
+
+    expect(header?.type).toBe('heading');
+    expect(header?.props?.content).toBe('🚨 GCP Alert | High CPU');
+  });
+});

--- a/apps/backend/src/apps/controllers/gcpWebhookParser.ts
+++ b/apps/backend/src/apps/controllers/gcpWebhookParser.ts
@@ -1,0 +1,289 @@
+import type { FlowComponent, FlowDefinition } from '@xyne/shared';
+import {
+  MAX_DESCRIPTION_LENGTH,
+  SEVERITY_STRIPE,
+  buildFields,
+  emptyFlowState,
+  fieldsToGrid,
+  isHttpUrl,
+  isRecord,
+  toDisplayValue,
+  truncate,
+  withColorStripe,
+} from './alertWebhookShared';
+import type { AlertSeverity } from './alertWebhookShared';
+
+/**
+ * GCP Cloud Monitoring incoming-webhook parser.
+ *
+ * A `webhook_basicauth` / `webhook_tokenauth` notification channel POSTs
+ * `{ version, incident }` directly — no envelope and no base64, unlike a
+ * Pub/Sub push subscription, which is not handled here. The shape and the field
+ * mapping are ported from infra-switch
+ * (`src/AlertProxy/Types/API/GcpTrigger.hs` for the wire shape,
+ * `src/AlertProxy/Types/API/UnifiedAlertTrigger.hs:115-142` for status/labels,
+ * `src/AlertProxy/Utils/Common.hs:259-275` and `:416-441` for the rendering).
+ *
+ * See https://cloud.google.com/monitoring/support/notification-options#webhooks
+ */
+
+export interface GcpDocumentation {
+  content?: string;
+  mime_type?: string;
+}
+
+export interface GcpMetric {
+  type?: string;
+  displayName?: string;
+  labels?: Record<string, string>;
+}
+
+export interface GcpResource {
+  type?: string;
+  labels?: Record<string, string>;
+}
+
+export interface GcpMetadata {
+  system_labels?: Record<string, string>;
+  user_labels?: Record<string, string>;
+}
+
+export interface GcpIncident {
+  incident_id?: string;
+  scoping_project_id?: string;
+  scoping_project_number?: number;
+  url?: string;
+  resource_id?: string;
+  resource_name?: string;
+  /** `open` | `closed`. */
+  state: string;
+  /** Unix epoch seconds. */
+  started_at?: number;
+  /** Unix epoch seconds. */
+  ended_at?: number;
+  policy_name: string;
+  policy_user_labels?: Record<string, string>;
+  condition_name: string;
+  condition?: unknown;
+  summary?: string;
+  documentation?: GcpDocumentation;
+  metric?: GcpMetric;
+  resource?: GcpResource;
+  metadata?: GcpMetadata;
+  observed_value?: string;
+  /**
+   * Not present in infra-switch's Haskell record, which therefore ignores it.
+   * GCP does send it on newer policies, and it is the only severity signal in
+   * the payload, so it is read here.
+   */
+  severity?: string;
+}
+
+export interface GcpPayload {
+  version?: string;
+  incident: GcpIncident;
+}
+
+export interface GcpNormalizedPayload {
+  title: string;
+  /** Drives the card's left stripe colour. */
+  severity: AlertSeverity;
+  /** The severity as rendered in the card body, e.g. `CRITICAL`. */
+  severityLabel: string;
+  status: string;
+  fields: Array<[label: string, value: string]>;
+  description: string | null;
+  consoleUrl: string | null;
+  incidentId: string | null;
+  projectId: string | null;
+  owner: string | null;
+  timestamp: string | null;
+}
+
+/**
+ * Structural validation only, mirroring `parseSnsEnvelope`. The three enforced
+ * incident fields are exactly the non-`Maybe` ones of infra-switch's
+ * `GcpIncident` (`src/AlertProxy/Types/API/GcpTrigger.hs:51-72`).
+ */
+export function parseGcpPayload(raw: unknown): GcpPayload | null {
+  if (!isRecord(raw) || !isRecord(raw.incident)) {
+    return null;
+  }
+
+  const incident = raw.incident;
+  if (
+    typeof incident.state !== 'string' ||
+    typeof incident.policy_name !== 'string' ||
+    typeof incident.condition_name !== 'string'
+  ) {
+    return null;
+  }
+
+  return raw as unknown as GcpPayload;
+}
+
+function labelBag(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const entries = Object.entries(value).filter(([, val]) => typeof val === 'string');
+  return Object.fromEntries(entries) as Record<string, string>;
+}
+
+/**
+ * Union of every label bag on the incident.
+ *
+ * Port of `getLabels` (`src/AlertProxy/Types/API/UnifiedAlertTrigger.hs:121-137`),
+ * whose `Map.unions` is left-biased, giving the precedence
+ * `policy_user_labels > resource.labels > metadata.user_labels > metric.labels`.
+ * Spread order below is the reverse of that, so higher-precedence bags overwrite.
+ */
+export function mergeGcpLabels(incident: GcpIncident): Record<string, string> {
+  return {
+    ...labelBag(incident.metric?.labels),
+    ...labelBag(incident.metadata?.user_labels),
+    ...labelBag(incident.resource?.labels),
+    ...labelBag(incident.policy_user_labels),
+  };
+}
+
+/**
+ * The severity infra-switch renders is the one stored on its alert row, whose
+ * vocabulary is `INFO | WARNING | ERROR | CRITICAL`
+ * (`src/AlertManager/Types/Alerts.hs:129`). Anything unrecognised is treated as
+ * critical, matching `parseGcpSeverity`'s default
+ * (`src/AlertManager/App/Alerts/WorkflowStages/Transformer.hs:522-528`).
+ */
+function normalizeSeverityName(raw: string | undefined): string | null {
+  const upper = String(raw ?? '').trim().toUpperCase();
+  return ['CRITICAL', 'ERROR', 'WARNING', 'INFO'].includes(upper) ? upper : null;
+}
+
+/** Card stripe colour for a firing incident, from its rendered severity label. */
+function stripeSeverity(severityLabel: string): AlertSeverity {
+  switch (severityLabel) {
+    case 'WARNING':
+      return 'warning';
+    case 'INFO':
+      return 'info';
+    default:
+      return 'critical';
+  }
+}
+
+function epochSecondsToIso(value: unknown): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  const date = new Date(value * 1000);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export function normalizeGcp(payload: GcpPayload): GcpNormalizedPayload {
+  const incident = payload.incident;
+  const labels = mergeGcpLabels(incident);
+
+  // `open` fires, anything else resolves — the mapping `getStatus` and the three
+  // inline re-derivations in infra-switch all agree on.
+  const isOpen = incident.state === 'open';
+  const status = isOpen ? 'FIRING' : 'RESOLVED';
+
+  // infra-switch reads the severity off its DB alert row, which has no analog
+  // here, so fall back through the payload's own signals. Like the Haskell, this
+  // is independent of the firing state — a closed incident still reports its
+  // configured severity and only the stripe colour flips to green.
+  const severityLabel =
+    normalizeSeverityName(incident.severity) ??
+    normalizeSeverityName(incident.policy_user_labels?.severity) ??
+    normalizeSeverityName(labels.severity) ??
+    'CRITICAL';
+  const severity: AlertSeverity = isOpen ? stripeSeverity(severityLabel) : 'ok';
+
+  // `summary` then `documentation.content` — the `getAnnotations` precedence at
+  // `src/AlertProxy/Types/API/UnifiedAlertTrigger.hs:139-142`.
+  const description = toDisplayValue(incident.summary ?? incident.documentation?.content);
+  const startedAt = epochSecondsToIso(incident.started_at);
+  const endedAt = epochSecondsToIso(incident.ended_at);
+  // infra-switch stamps the owner into the policy's user labels when it syncs
+  // the alert (`.../Transformer.hs:497`), which is where it reads back here.
+  const owner = (incident.policy_user_labels?.owner ?? labels.owner)?.trim() || null;
+
+  return {
+    title: incident.policy_name,
+    severity,
+    severityLabel,
+    status,
+    // Exactly the four rows of the Slack card's fields section
+    // (`src/AlertProxy/Utils/Common.hs:427-432`). Owner drops out when the
+    // policy carries no owner label.
+    fields: buildFields([
+      ['Alarm State', status],
+      ['Severity', severityLabel],
+      ['Condition', incident.condition_name],
+      ['Owner', owner],
+    ]),
+    description: description === 'N/A' ? null : truncate(description, MAX_DESCRIPTION_LENGTH),
+    consoleUrl: typeof incident.url === 'string' ? incident.url : null,
+    incidentId: typeof incident.incident_id === 'string' ? incident.incident_id : null,
+    projectId: typeof incident.scoping_project_id === 'string'
+      ? incident.scoping_project_id
+      : null,
+    owner,
+    timestamp: endedAt ?? startedAt,
+  };
+}
+
+/**
+ * `🚨 GCP Alert | High CPU | my-proj`, the project omitted when the incident did
+ * not carry it. Mirrors infra-switch's Slack heading
+ * (`src/AlertProxy/Utils/Common.hs:421`), using the scoping project where it
+ * uses the DB alert's account.
+ */
+function buildHeaderLabel(payload: GcpNormalizedPayload): string {
+  return ['🚨 GCP Alert', payload.title, payload.projectId].filter(Boolean).join(' | ');
+}
+
+export function buildGcpFlow(payload: GcpNormalizedPayload): FlowDefinition {
+  const headerLabel = buildHeaderLabel(payload);
+
+  // The header doubles as the link to the incident in the Cloud console.
+  // `link.props.href` is validated with z.string().url(), so fall back to a
+  // plain heading when there is no usable URL.
+  const header: FlowComponent = isHttpUrl(payload.consoleUrl)
+    ? {
+        id: 'gcp-header',
+        type: 'link',
+        props: { href: payload.consoleUrl, label: headerLabel, external: true },
+      }
+    : { id: 'gcp-header', type: 'heading', props: { content: headerLabel, level: 3 } };
+
+  const children: FlowComponent[] = [header];
+
+  if (payload.description) {
+    children.push({
+      id: 'gcp-description',
+      type: 'text',
+      props: { content: payload.description, variant: 'muted' },
+    });
+  }
+
+  if (payload.fields.length > 0) {
+    children.push(fieldsToGrid(payload.fields, 'gcp'));
+  }
+
+  return {
+    version: '2.0',
+    screenId: `gcp-${Date.now()}`,
+    // `FIRING | High CPU`, the line infra-switch puts above the Slack
+    // attachment. The header link below keeps the bare policy name.
+    title: `${payload.status} | ${payload.title}`,
+    components: [
+      {
+        id: 'gcp-card',
+        type: 'card',
+        children: [withColorStripe('gcp-stripe', children, SEVERITY_STRIPE[payload.severity])],
+      },
+    ],
+    state: emptyFlowState(),
+  };
+}

--- a/apps/backend/src/apps/controllers/incomingWebhookController.ts
+++ b/apps/backend/src/apps/controllers/incomingWebhookController.ts
@@ -29,6 +29,8 @@ import {
   parseSnsEnvelope,
   parseSnsMessage,
 } from './amazonSnsWebhookParser';
+import { buildPingdomFlow, normalizePingdom, parsePingdomPayload } from './pingdomWebhookParser';
+import { buildGcpFlow, normalizeGcp, parseGcpPayload } from './gcpWebhookParser';
 import { validateFlowDefinition } from '@xyne/shared';
 import type { FlowDefinition } from '@xyne/shared';
 
@@ -120,6 +122,12 @@ class IncomingWebhookController {
     }
     if (type === AppIncomingWebhookType.AMAZON_SNS) {
       return `/api/apps/webhooks/sns/${safeWorkspaceId}/${installedAppId}/${secret}`;
+    }
+    if (type === AppIncomingWebhookType.PINGDOM) {
+      return `/api/apps/webhooks/pingdom/${safeWorkspaceId}/${installedAppId}/${secret}`;
+    }
+    if (type === AppIncomingWebhookType.GCP) {
+      return `/api/apps/webhooks/gcp/${safeWorkspaceId}/${installedAppId}/${secret}`;
     }
 
     return `/api/apps/webhooks/${safeWorkspaceId}/${installedAppId}/${secret}`;
@@ -505,6 +513,111 @@ class IncomingWebhookController {
     }
   };
 
+  handlePingdomIncoming = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const context = await this.resolveWebhookContext(req, AppIncomingWebhookType.PINGDOM);
+      if (!context) {
+        res.status(400).send('invalid_payload');
+        return;
+      }
+
+      const payload = parsePingdomPayload(context.body);
+      if (!payload) {
+        logger.warn('[Incoming-Webhook] Body is not a Pingdom check notification', {
+          workspaceId: context.workspaceId,
+          appId: context.appId,
+        });
+        res.status(400).send('invalid_payload');
+        return;
+      }
+
+      // No signature check: the encrypted secret in the URL is the only
+      // credential here, as it is for the Slack and Amazon SNS webhook types.
+
+      // Unauthenticated webhook: no req.user, so open an explicit tenant scope from the
+      // validated :workspaceId URL param so the workspaceId stamper fills downstream writes.
+      await runAsServiceActor('incoming-webhook', context.workspaceId, async () => {
+        const content = this.encodeFlowContent(buildPingdomFlow(normalizePingdom(payload)));
+        if (!content) {
+          res.status(400).send('invalid_payload');
+          return;
+        }
+
+        await findOrCreateConversation(
+          context.channelId,
+          context.installedApp.userId,
+          content,
+          false,
+          undefined,
+          undefined,
+          MessageType.BOT,
+          {},
+        );
+
+        res.status(200).send('ok');
+      });
+    } catch (error) {
+      logger.error('[Incoming-Webhook] Error handling Pingdom webhook', {
+        params: req.params,
+        error,
+      });
+      res.status(500).send('rollup_error');
+    }
+  };
+
+  handleGcpIncoming = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const context = await this.resolveWebhookContext(req, AppIncomingWebhookType.GCP);
+      if (!context) {
+        res.status(400).send('invalid_payload');
+        return;
+      }
+
+      const payload = parseGcpPayload(context.body);
+      if (!payload) {
+        logger.warn('[Incoming-Webhook] Body is not a GCP Monitoring incident', {
+          workspaceId: context.workspaceId,
+          appId: context.appId,
+        });
+        res.status(400).send('invalid_payload');
+        return;
+      }
+
+      // No signature check: the encrypted secret in the URL is the only
+      // credential here, replacing the HTTP Basic auth infra-switch uses on its
+      // shared /alertProxy/gcp endpoint.
+
+      // Unauthenticated webhook: no req.user, so open an explicit tenant scope from the
+      // validated :workspaceId URL param so the workspaceId stamper fills downstream writes.
+      await runAsServiceActor('incoming-webhook', context.workspaceId, async () => {
+        const content = this.encodeFlowContent(buildGcpFlow(normalizeGcp(payload)));
+        if (!content) {
+          res.status(400).send('invalid_payload');
+          return;
+        }
+
+        await findOrCreateConversation(
+          context.channelId,
+          context.installedApp.userId,
+          content,
+          false,
+          undefined,
+          undefined,
+          MessageType.BOT,
+          {},
+        );
+
+        res.status(200).send('ok');
+      });
+    } catch (error) {
+      logger.error('[Incoming-Webhook] Error handling GCP Monitoring webhook', {
+        params: req.params,
+        error,
+      });
+      res.status(500).send('rollup_error');
+    }
+  };
+
   createWebhook = async (req: Request, res: Response): Promise<void> => {
     try {
       const bodyResult = CreateWebhookBodySchema.safeParse(req.body);
@@ -568,10 +681,15 @@ class IncomingWebhookController {
 
       // Only SentinelOne supports ticket creation today; the other sources always
       // post a message.
-      const normalizedAction: IncomingWebhookAction =
-        type === AppIncomingWebhookType.SLACK || type === AppIncomingWebhookType.AMAZON_SNS
-          ? AppIncomingWebhookAction.MESSAGE
-          : action;
+      const messageOnlyTypes: IncomingWebhookType[] = [
+        AppIncomingWebhookType.SLACK,
+        AppIncomingWebhookType.AMAZON_SNS,
+        AppIncomingWebhookType.PINGDOM,
+        AppIncomingWebhookType.GCP,
+      ];
+      const normalizedAction: IncomingWebhookAction = messageOnlyTypes.includes(type)
+        ? AppIncomingWebhookAction.MESSAGE
+        : action;
       const effectiveBoardId =
         normalizedAction === AppIncomingWebhookAction.TICKET ? boardId : undefined;
 

--- a/apps/backend/src/apps/controllers/pingdomWebhookParser.ts
+++ b/apps/backend/src/apps/controllers/pingdomWebhookParser.ts
@@ -1,0 +1,283 @@
+import type { FlowComponent, FlowDefinition } from '@xyne/shared';
+import {
+  MAX_DESCRIPTION_LENGTH,
+  SEVERITY_STRIPE,
+  buildFields,
+  emptyFlowState,
+  fieldsToGrid,
+  isHttpUrl,
+  isRecord,
+  toDisplayValue,
+  truncate,
+  withColorStripe,
+} from './alertWebhookShared';
+import type { AlertSeverity } from './alertWebhookShared';
+
+/**
+ * Pingdom incoming-webhook parser.
+ *
+ * Pingdom POSTs a single flat JSON object per check state change — no envelope
+ * and no inner encoding, unlike SNS. The field mapping is ported from
+ * infra-switch's Pingdom branch (`src/AlertProxy/Types/API/PingdomTrigger.hs`
+ * for the wire shape, `src/AlertProxy/Utils/Common.hs:198-216` and `:340-365`
+ * for the rendered fields).
+ *
+ * See https://www.pingdom.com/resources/webhooks/
+ */
+
+export interface PingdomProbe {
+  ip?: string;
+  ipv6?: string;
+  location?: string;
+}
+
+export interface PingdomCheckParams {
+  basic_auth?: boolean;
+  encryption?: boolean;
+  full_url?: string;
+  header?: string;
+  hostname?: string;
+  ipv6?: boolean;
+  port?: number;
+  responsetime_threshold?: number;
+  url?: string;
+  verify_certificate?: boolean;
+}
+
+export interface PingdomPayload {
+  version?: number;
+  check_id: number;
+  check_name: string;
+  check_type?: string;
+  check_params?: PingdomCheckParams;
+  tags?: string[];
+  importance_level?: string;
+  custom_message?: string;
+  previous_state?: string;
+  current_state: string;
+  /** Unix epoch seconds. */
+  state_changed_timestamp?: number;
+  /** `2023-10-23T06:37:36` — Pingdom omits the trailing `Z`. */
+  state_changed_utc_time?: string;
+  long_description?: string;
+  description?: string;
+  first_probe?: PingdomProbe;
+  second_probe?: PingdomProbe;
+}
+
+export interface PingdomNormalizedPayload {
+  title: string;
+  /** Drives the card's left stripe colour. */
+  severity: AlertSeverity;
+  /** The severity as rendered in the card body, e.g. `CRITICAL`. */
+  severityLabel: string;
+  status: string;
+  fields: Array<[label: string, value: string]>;
+  description: string | null;
+  consoleUrl: string | null;
+  checkId: number;
+  hostname: string | null;
+  owner: string | null;
+  timestamp: string | null;
+}
+
+/**
+ * States that infra-switch's `makeAlertState`
+ * (`src/AlertProxy/Utils/Common.hs:680-685`) treats as recovered. Everything
+ * else — `DOWN` included — counts as firing.
+ */
+const RESOLVED_STATES = new Set(['UP', 'OK', 'RESOLVED']);
+
+/**
+ * Pingdom carries no structured metadata beyond tags, so infra-switch encodes
+ * `severity`, `owner` and friends into them as `key---value`
+ * (`src/AlertManager/App/Alerts/WorkflowStages/Transformer.hs:168-173`) and
+ * decodes them on sync (`.../Common.hs:289-301`). Checks tagged by hand — and
+ * the webhook sample in `sample/alert-proxy/pingdom-http-trigger.json` — use
+ * `key::value` instead, so both separators are accepted.
+ */
+function parseTags(tags: string[] | undefined): Record<string, string> {
+  if (!Array.isArray(tags)) {
+    return {};
+  }
+
+  const parsed: Record<string, string> = {};
+  for (const tag of tags) {
+    if (typeof tag !== 'string') {
+      continue;
+    }
+    const match = /^([^:-]+)(?:---|::)(.+)$/.exec(tag.trim());
+    if (match) {
+      parsed[match[1].toLowerCase()] = match[2];
+    }
+  }
+  return parsed;
+}
+
+/**
+ * The severity infra-switch shows is the one stored on its alert row, seeded
+ * from the check's `severity` tag at sync time. Fall back to the webhook's own
+ * `importance_level` when the check carries no tag. Note this is independent of
+ * the firing state — a recovered check still reports its configured severity,
+ * matching infra-switch, while only the stripe colour flips to green.
+ */
+function resolveSeverityLabel(
+  tags: Record<string, string>,
+  importanceLevel: string | undefined,
+): string {
+  const fromTag = tags.severity?.trim();
+  if (fromTag) {
+    return fromTag.toUpperCase();
+  }
+  return String(importanceLevel ?? '').toUpperCase() === 'LOW' ? 'WARNING' : 'CRITICAL';
+}
+
+/** Card stripe colour for a firing check, from its rendered severity label. */
+function stripeSeverity(severityLabel: string): AlertSeverity {
+  switch (severityLabel) {
+    case 'WARNING':
+      return 'warning';
+    case 'INFO':
+      return 'info';
+    default:
+      return 'critical';
+  }
+}
+
+/**
+ * Structural validation only, mirroring `parseSnsEnvelope`. Pingdom marks most
+ * of its payload as required, but the abridged bodies real checks emit (see
+ * infra-switch `sample/alert-proxy/pingdom-http-trigger.json`) carry only the
+ * identity, state and description fields — those must still render rather than
+ * 400, so only those are enforced here.
+ */
+export function parsePingdomPayload(raw: unknown): PingdomPayload | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const { check_id, check_name, current_state } = raw as Partial<PingdomPayload>;
+  if (typeof check_id !== 'number' || !Number.isFinite(check_id)) {
+    return null;
+  }
+  if (typeof check_name !== 'string' || typeof current_state !== 'string') {
+    return null;
+  }
+
+  return raw as unknown as PingdomPayload;
+}
+
+/** `2023-10-23T06:37:36` → `2023-10-23T06:37:36Z`, else the epoch fallback. */
+function resolveTimestamp(payload: PingdomPayload): string | null {
+  const utcTime = payload.state_changed_utc_time;
+  if (typeof utcTime === 'string' && utcTime.trim()) {
+    return /[Zz]|[+-]\d{2}:?\d{2}$/.test(utcTime) ? utcTime : `${utcTime}Z`;
+  }
+  if (typeof payload.state_changed_timestamp === 'number') {
+    const date = new Date(payload.state_changed_timestamp * 1000);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  return null;
+}
+
+export function normalizePingdom(payload: PingdomPayload): PingdomNormalizedPayload {
+  const status = payload.current_state.toUpperCase();
+  const params = isRecord(payload.check_params)
+    ? (payload.check_params as PingdomCheckParams)
+    : {};
+  const tags = parseTags(payload.tags);
+  const severityLabel = resolveSeverityLabel(tags, payload.importance_level);
+
+  // UP/OK/RESOLVED are recovery; anything else is firing. Only the stripe
+  // colour tracks the state — the rendered severity stays as configured.
+  const severity: AlertSeverity = RESOLVED_STATES.has(status)
+    ? 'ok'
+    : stripeSeverity(severityLabel);
+
+  // `long_description` is infra-switch's "Reason" field and Slack description
+  // block; `description` is the shorter variant it falls back to.
+  const description = toDisplayValue(payload.long_description ?? payload.description);
+  const hostname = typeof params.hostname === 'string' ? params.hostname : null;
+  const owner = tags.owner?.trim() || null;
+
+  return {
+    title: payload.check_name,
+    severity,
+    severityLabel,
+    status,
+    // Exactly the rows infra-switch's Slack card carries
+    // (`src/AlertProxy/Utils/Common.hs:352-360`). Owner and Message are dropped
+    // by buildFields when absent, as they are in the Haskell.
+    fields: buildFields([
+      ['Alarm State', status],
+      ['Severity', severityLabel],
+      ['Description', description],
+      ['Owner', owner],
+      ['Message', payload.custom_message],
+    ]),
+    description: description === 'N/A' ? null : truncate(description, MAX_DESCRIPTION_LENGTH),
+    consoleUrl: `https://my.pingdom.com/reports/uptime#check=${payload.check_id}`,
+    checkId: payload.check_id,
+    hostname,
+    owner,
+    timestamp: resolveTimestamp(payload),
+  };
+}
+
+/**
+ * `🚨 Pingdom Alert | pingdom test alert | api.juspay.in`, the hostname omitted
+ * when the check params did not carry it. infra-switch renders the equivalent
+ * line as a single hyperlink (`src/AlertProxy/Utils/Common.hs:344`), using the
+ * DB alert's account where we use the checked hostname.
+ */
+function buildHeaderLabel(payload: PingdomNormalizedPayload): string {
+  return ['🚨 Pingdom Alert', payload.title, payload.hostname].filter(Boolean).join(' | ');
+}
+
+export function buildPingdomFlow(payload: PingdomNormalizedPayload): FlowDefinition {
+  const headerLabel = buildHeaderLabel(payload);
+
+  // The header doubles as the link to the check, as it does in infra-switch's
+  // Slack card. `link.props.href` is validated with z.string().url(), so fall
+  // back to a plain heading when there is no usable URL.
+  const header: FlowComponent = isHttpUrl(payload.consoleUrl)
+    ? {
+        id: 'pingdom-header',
+        type: 'link',
+        props: { href: payload.consoleUrl, label: headerLabel, external: true },
+      }
+    : { id: 'pingdom-header', type: 'heading', props: { content: headerLabel, level: 3 } };
+
+  const children: FlowComponent[] = [header];
+
+  if (payload.description) {
+    children.push({
+      id: 'pingdom-description',
+      type: 'text',
+      props: { content: payload.description, variant: 'muted' },
+    });
+  }
+
+  if (payload.fields.length > 0) {
+    children.push(fieldsToGrid(payload.fields, 'pingdom'));
+  }
+
+  return {
+    version: '2.0',
+    screenId: `pingdom-${Date.now()}`,
+    // `DOWN | Cards MEA offers list API`, the line infra-switch puts above the
+    // Slack attachment (`src/AlertProxy/Utils/Common.hs:361`). The header link
+    // below keeps the bare check name, as it does there.
+    title: `${payload.status} | ${payload.title}`,
+    components: [
+      {
+        id: 'pingdom-card',
+        type: 'card',
+        children: [
+          withColorStripe('pingdom-stripe', children, SEVERITY_STRIPE[payload.severity]),
+        ],
+      },
+    ],
+    state: emptyFlowState(),
+  };
+}

--- a/apps/backend/src/apps/routes/apps.ts
+++ b/apps/backend/src/apps/routes/apps.ts
@@ -39,6 +39,8 @@ router.post('/webhooks/sentinel/:workspaceId/:appId/:secret', webhookLimiter, in
 // express.json() ignores — parse the body as text here and JSON.parse it in the
 // controller.
 router.post('/webhooks/sns/:workspaceId/:appId/:secret', express.text({ type: '*/*', limit: '1mb' }), webhookLimiter, incomingWebhookController.handleAmazonSnsIncoming);
+router.post('/webhooks/pingdom/:workspaceId/:appId/:secret', express.text({ type: '*/*', limit: '1mb' }), webhookLimiter, incomingWebhookController.handlePingdomIncoming);
+router.post('/webhooks/gcp/:workspaceId/:appId/:secret', express.text({ type: '*/*', limit: '1mb' }), webhookLimiter, incomingWebhookController.handleGcpIncoming);
 router.post('/webhooks/:workspaceId/:appId/:secret', webhookLimiter, incomingWebhookController.handleIncoming);
 const commandController = new CommandController();
 

--- a/apps/dashboard/src/services/Apps/appsService.ts
+++ b/apps/dashboard/src/services/Apps/appsService.ts
@@ -47,7 +47,7 @@ export interface IncomingWebhook {
   channelVisibility: string;
   boardId?: string | null;
   boardName?: string | null;
-  type: 'SLACK' | 'SENTINELONE' | 'AMAZON_SNS';
+  type: 'SLACK' | 'SENTINELONE' | 'AMAZON_SNS' | 'PINGDOM' | 'GCP';
   action: AppIncomingWebhookAction;
   isActive: boolean;
   createdAt: string;
@@ -59,7 +59,7 @@ export interface CreateIncomingWebhookRequest {
   channelId: string;
   boardId?: string;
   name: string;
-  type: 'SLACK' | 'SENTINELONE' | 'AMAZON_SNS';
+  type: 'SLACK' | 'SENTINELONE' | 'AMAZON_SNS' | 'PINGDOM' | 'GCP';
   action?: AppIncomingWebhookAction;
 }
 

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -473,6 +473,8 @@ export enum AppIncomingWebhookType {
   SLACK = 'SLACK',
   SENTINELONE = 'SENTINELONE',
   AMAZON_SNS = 'AMAZON_SNS',
+  PINGDOM = 'PINGDOM',
+  GCP = 'GCP',
 }
 
 // @ts-ignore TS1294


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
