### PR TITLE
fix: XYNE-56067 Fix Schedule Call delete functionality

### DIFF
--- a/apps/backend/src/validators/callValidator.ts
+++ b/apps/backend/src/validators/callValidator.ts
@@ -236,7 +236,7 @@ export type UpdateRecurringSeriesInput = z.infer<typeof UpdateRecurringSeriesSch
  * Validation schema for cancelling a single scheduled call instance.
  * No body required — callId comes from URL params.
  */
-export const CancelScheduledCallSchema = z.object({});
+export const CancelScheduledCallSchema = z.object({}).default({});
 
 export type CancelScheduledCallInput = z.infer<typeof CancelScheduledCallSchema>;
 
@@ -244,6 +244,6 @@ export type CancelScheduledCallInput = z.infer<typeof CancelScheduledCallSchema>
  * Validation schema for cancelling an entire recurring series.
  * No body required — seriesId comes from URL params.
  */
-export const CancelRecurringSeriesSchema = z.object({});
+export const CancelRecurringSeriesSchema = z.object({}).default({});
 
 export type CancelRecurringSeriesInput = z.infer<typeof CancelRecurringSeriesSchema>;


### PR DESCRIPTION
Cherry-pick of commit 317bfc1 (from PR #549) onto the release branch.

Adds `.default({})` to the empty `CancelScheduledCallSchema` and `CancelRecurringSeriesSchema` Zod objects in `apps/backend/src/validators/callValidator.ts`, fixing validation failures when deleting/cancelling scheduled calls.

Services-Requiring-Redeployment:
  - backend