### PR TITLE
Feature/redirect fix

### DIFF
--- a/apps/backend/prisma/migrations/20260812133000_add_email_to_questionnaire_responses/migration.sql
+++ b/apps/backend/prisma/migrations/20260812133000_add_email_to_questionnaire_responses/migration.sql
@@ -3,5 +3,8 @@
 ALTER TABLE "non_zero"."questionnaire_responses"
 ADD COLUMN "email" TEXT;
 
-CREATE UNIQUE INDEX "questionnaire_responses_questionnaireType_email_key"
-ON "non_zero"."questionnaire_responses"("questionnaireType", "email");
+CREATE UNIQUE INDEX "questionnaire_responses_email_questionnaireType_key"
+ON "non_zero"."questionnaire_responses"("email", "questionnaireType");
+
+CREATE INDEX "questionnaire_responses_userId_idx"
+ON "non_zero"."questionnaire_responses"("userId");

--- a/apps/backend/prisma/migrations/20260812133000_add_email_to_questionnaire_responses/migration.sql
+++ b/apps/backend/prisma/migrations/20260812133000_add_email_to_questionnaire_responses/migration.sql
@@ -1,0 +1,7 @@
+-- Add nullable email for person-level onboarding responses while keeping
+-- workspace/user-scoped questionnaire responses intact.
+ALTER TABLE "non_zero"."questionnaire_responses"
+ADD COLUMN "email" TEXT;
+
+CREATE UNIQUE INDEX "questionnaire_responses_questionnaireType_email_key"
+ON "non_zero"."questionnaire_responses"("questionnaireType", "email");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -922,12 +922,14 @@ model QuestionnaireResponse {
   workspaceId       String
   id                String   @id @default(cuid())
   userId            String
+  email             String?
   questionnaireType String
   payload           Json
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
   @@unique([workspaceId, questionnaireType, userId])
+  @@unique([questionnaireType, email])
   @@map("questionnaire_responses")
   @@schema("non_zero")
 }

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -929,7 +929,8 @@ model QuestionnaireResponse {
   updatedAt         DateTime @updatedAt
 
   @@unique([workspaceId, questionnaireType, userId])
-  @@unique([questionnaireType, email])
+  @@unique([email, questionnaireType])
+  @@index([userId])
   @@map("questionnaire_responses")
   @@schema("non_zero")
 }

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -28,6 +28,7 @@ import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper'
 import { redisService } from '@/services/redisService';
 import { randomUUID } from 'crypto';
 import { aiProvisioningService } from '@/services/aiProvisioningService';
+import { setOnboardingCookie } from '@/utils/onboardingCookie';
 
 /**
  * Result type for single workspace auto-login
@@ -45,6 +46,7 @@ type AutoLoginResult = {
   };
   sessionId: string | null;
   jwtToken: string;
+  isNewUser: boolean;
 };
 
 export class AuthV2Controller {
@@ -139,7 +141,7 @@ export class AuthV2Controller {
     platform: 'web' | 'mobile' | 'electron'
   ): Promise<AutoLoginResult> {
     // Create/get workspace user
-    const { user: workspaceUser } = await this.userService.createOrGetWorkspaceUser({
+    const { user: workspaceUser, isNewUser } = await this.userService.createOrGetWorkspaceUser({
       providerUserId: googleUserData.googleId,
       email: googleUserData.email,
       name: googleUserData.name,
@@ -188,7 +190,7 @@ export class AuthV2Controller {
       memberId: workspaceUser.orgMemberId,
     });
 
-    return { workspaceUser, sessionId, jwtToken };
+    return { workspaceUser, sessionId, jwtToken, isNewUser };
   }
 
   /**
@@ -600,7 +602,7 @@ export class AuthV2Controller {
         const workspaceId = workspaces[0]!.id;
         logger.info(`[${requestId}] Single workspace detected - auto-logging in to ${workspaceId}`);
 
-        const { sessionId, jwtToken } = await this.performSingleWorkspaceAutoLogin(
+        const { sessionId, jwtToken, isNewUser } = await this.performSingleWorkspaceAutoLogin(
           googleUserData,
           workspaceId,
           refresh_token,
@@ -627,6 +629,11 @@ export class AuthV2Controller {
         res.cookie(`xyne_ws_${workspaceId}_token`, jwtToken, {
           ...cookieBase,
           maxAge: 24 * 60 * 60 * 1000,
+        });
+
+        setOnboardingCookie(res, isNewUser, {
+          secure: isProduction,
+          sameSite: 'lax' as const,
         });
 
         // Legacy cookie for backward compatibility with older dashboards
@@ -955,7 +962,7 @@ export class AuthV2Controller {
         const workspaceId = workspaces[0]!.id;
         logger.info(`[${requestId}] Single workspace detected - auto-logging in to ${workspaceId}`);
 
-        const { sessionId, jwtToken } = await this.performSingleWorkspaceAutoLogin(
+        const { sessionId, jwtToken, isNewUser } = await this.performSingleWorkspaceAutoLogin(
           googleUserData,
           workspaceId,
           refresh_token,
@@ -980,6 +987,11 @@ export class AuthV2Controller {
         res.cookie(`xyne_ws_${workspaceId}_token`, jwtToken, {
           ...cookieBase,
           maxAge: 24 * 60 * 60 * 1000,
+        });
+
+        setOnboardingCookie(res, isNewUser, {
+          secure: isProduction,
+          sameSite: 'strict' as const,
         });
 
         res.cookie('user_session_id', sessionId, {
@@ -1238,7 +1250,7 @@ export class AuthV2Controller {
         const workspaceId = workspaces[0]!.id;
         logger.info(`[${requestId}] Single workspace detected - auto-logging in to ${workspaceId}`);
 
-        const { workspaceUser, sessionId, jwtToken } = await this.performSingleWorkspaceAutoLogin(
+        const { workspaceUser, sessionId, jwtToken, isNewUser } = await this.performSingleWorkspaceAutoLogin(
           googleUserData,
           workspaceId,
           refresh_token,
@@ -1263,6 +1275,11 @@ export class AuthV2Controller {
         res.cookie(`xyne_ws_${workspaceId}_token`, jwtToken, {
           ...cookieBase,
           maxAge: 24 * 60 * 60 * 1000,
+        });
+
+        setOnboardingCookie(res, isNewUser, {
+          secure: isProduction || isMobileNative,
+          sameSite: (isMobileNative ? 'none' : 'lax') as 'none' | 'lax',
         });
 
         if (sessionId) {
@@ -1595,15 +1612,11 @@ export class AuthV2Controller {
         });
       }
 
-      // Set is_new_user cookie for new users (readable by frontend)
+      setOnboardingCookie(res, isNewUser, {
+        secure: isProduction,
+        sameSite: 'strict' as const,
+      });
       if (isNewUser) {
-        res.cookie('is_new_user', 'true', {
-          httpOnly: false,
-          secure: isProduction,
-          sameSite: 'strict' as const,
-          path: '/',
-          maxAge: 30 * 24 * 60 * 60 * 1000,
-        });
         logger.info(`[LOGIN-WORKSPACE] Set is_new_user cookie for new user: ${workspaceUser.email}`);
       }
 
@@ -1690,7 +1703,7 @@ export class AuthV2Controller {
         picture: oauthUserData.picture,
       };
 
-      const { organization, workspace, workspaceUser } = await this.userService.createOrganizationWithUser(
+      const { organization, workspace, workspaceUser, isNewUser } = await this.userService.createOrganizationWithUser(
         userData,
         orgName,
         workspaceName,
@@ -1782,13 +1795,10 @@ export class AuthV2Controller {
         maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
       });
 
-      // Set is_new_user cookie for new users (readable by frontend)
-      res.cookie('is_new_user', 'true', {
-        httpOnly: false,
+      setOnboardingCookie(res, isNewUser, {
         secure: isProduction,
         sameSite: 'strict' as const,
-        path: '/',
-        maxAge: 24 * 60 * 60 * 1000, // 24 hours
+        maxAge: 24 * 60 * 60 * 1000,
       });
 
       // Clear pending auth cookie
@@ -1818,7 +1828,7 @@ export class AuthV2Controller {
           role: workspaceUser.role,
           workspaceId: workspaceUser.workspaceId
         },
-        isNewUser: true,
+        isNewUser,
         selfDmChannelId,
         landingChannelId: workspaceRecord?.landingChannelId ?? null,
       });
@@ -2149,11 +2159,11 @@ export class AuthV2Controller {
           maxAge: 30 * 24 * 60 * 60 * 1000,
         });
 
-        res.cookie('is_new_user', 'true', {
-          httpOnly: false,
+        const isNewUser = !(await this.userService.hasCompletedOnboarding(userData.email));
+
+        setOnboardingCookie(res, isNewUser, {
           secure: isProduction,
           sameSite: 'strict' as const,
-          path: '/',
           maxAge: 24 * 60 * 60 * 1000,
         });
 
@@ -2294,8 +2304,11 @@ export class AuthV2Controller {
         res.cookie('user_session_id', newSessionId, { ...cookieBase, maxAge: config.session.expiryDays * 24 * 60 * 60 * 1000 });
       }
       res.cookie('xyne_last_workspace', targetWorkspaceId, { ...cookieBase, maxAge: 30 * 24 * 60 * 60 * 1000 });
-      res.cookie('is_new_user', 'true', {
-        httpOnly: false, secure: isProduction, sameSite: 'strict' as const, path: '/', maxAge: 24 * 60 * 60 * 1000,
+      const isNewUser = !(await this.userService.hasCompletedOnboarding(fullUser.email));
+      setOnboardingCookie(res, isNewUser, {
+        secure: isProduction,
+        sameSite: 'strict' as const,
+        maxAge: 24 * 60 * 60 * 1000,
       });
 
       logger.info(`[CREATE-WORKSPACE-AUTH] Created org ${organization.orgId} / workspace ${workspace.id} for ${currentUser.email}`);
@@ -2310,7 +2323,7 @@ export class AuthV2Controller {
           picture: workspaceUser.picture,
           workspaceId: workspaceUser.workspaceId,
         },
-        isNewUser: true,
+        isNewUser,
         selfDmChannelId,
         landingChannelId: workspaceRecord?.landingChannelId ?? null,
       });

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -27,7 +27,6 @@ import {
 import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper';
 import { redisService } from '@/services/redisService';
 import { randomUUID } from 'crypto';
-import { aiProvisioningService } from '@/services/aiProvisioningService';
 import { setOnboardingCookie } from '@/utils/onboardingCookie';
 
 /**
@@ -1513,18 +1512,6 @@ export class AuthV2Controller {
         workspaceId,
         authProvider: provider,
       });
-
-      if (isNewUser) {
-        try {
-          await aiProvisioningService.enqueueUserSync(workspaceUser.orgMemberId);
-        } catch (error) {
-          logger.error('[LOGIN-WORKSPACE] Failed to enqueue AI user provisioning', {
-            userId: workspaceUser.id,
-            workspaceId,
-            error,
-          });
-        }
-      }
 
       // Check if user is inactive or has left the workspace
       if (workspaceUser.status === UserStatus.INACTIVE || workspaceUser.leftAt !== null) {

--- a/apps/backend/src/controllers/communityWorkspaceController.ts
+++ b/apps/backend/src/controllers/communityWorkspaceController.ts
@@ -16,6 +16,7 @@ import { channelService } from '@/services/channelService';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 import { redisService } from '@/services/redisService';
+import { setOnboardingCookie } from '@/utils/onboardingCookie';
 
 type PendingAuth = {
   userData: {
@@ -133,15 +134,10 @@ export class CommunityWorkspaceController {
           maxAge: config.session.expiryDays * 24 * 60 * 60 * 1000,
         });
       }
-      if (joinResult.isNewUser) {
-        res.cookie('is_new_user', 'true', {
-          httpOnly: false,
-          secure: isProduction,
-          sameSite: 'strict' as const,
-          path: '/',
-          maxAge: 30 * 24 * 60 * 60 * 1000,
-        });
-      }
+      setOnboardingCookie(res, Boolean(joinResult.isNewUser), {
+        secure: isProduction,
+        sameSite: 'strict' as const,
+      });
       if (pendingAuth.tokenKey) {
         await redisService.del(
           `${config.pendingOAuthTokens.redisKeyPrefix}${pendingAuth.tokenKey}`,

--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { AuthProvider } from '@xyne/shared';
+import { AuthProvider, OrgRole, WorkspaceRole } from '@xyne/shared';
 import jwt from 'jsonwebtoken';
 import { Request, Response } from 'express';
 import { UserSessionService } from '../services/userSessionService';
@@ -35,6 +35,7 @@ interface RegistrationPendingPayload {
   passwordHash: string;
   name: string;
   workspaceId?: string;
+  invitationId?: string;
 }
 
 const LOGIN_MAX_FAILED_ATTEMPTS = 5;
@@ -57,6 +58,10 @@ export class EmailAuthController {
   constructor() {
     this.userSessionService = new UserSessionService();
     this.userService = new UserService();
+  }
+
+  private getPreAcceptanceOrgRole(role: string): OrgRole {
+    return role === WorkspaceRole.GUEST ? OrgRole.GUEST : OrgRole.COMMUNITY_MEMBER;
   }
 
   /**
@@ -772,6 +777,9 @@ export class EmailAuthController {
     try {
       const { email, hashedPassword, name } = req.body;
       const workspaceId: string | undefined = req.body.workspaceId;
+      const invitationId: string | undefined = typeof req.body.invitationId === 'string'
+        ? req.body.invitationId.trim()
+        : undefined;
 
       if (!email || !hashedPassword || !name) {
         res.status(400).json({
@@ -810,9 +818,34 @@ export class EmailAuthController {
         return;
       }
 
-      // If workspaceId is provided, verify the workspace exists and is active
+      // If invitationId is provided, this registration is only for accepting
+      // that existing workspace invitation. Do not let it fall through to the
+      // normal create-org onboarding path after verification.
       let workspaceName: string | null = null;
-      if (workspaceId) {
+      let invitationWorkspaceId: string | null = null;
+      if (invitationId) {
+        const invitation = await this.prisma.invitation.findFirst({
+          where: {
+            invitationId,
+            email: normalizedEmail,
+            acceptedAt: null,
+            expiredAt: { gt: new Date() },
+          },
+          include: {
+            workspace: {
+              select: { id: true, name: true, status: true },
+            },
+          },
+        });
+
+        if (!invitation || !invitation.workspace || invitation.workspace.status !== 'ACTIVE') {
+          res.status(400).json({ error: 'Invalid or expired invitation' });
+          return;
+        }
+
+        workspaceName = invitation.workspace.name;
+        invitationWorkspaceId = invitation.workspace.id;
+      } else if (workspaceId) {
         const workspace = await this.prisma.workspace.findUnique({
           where: { id: workspaceId },
           select: { id: true, name: true, status: true },
@@ -863,7 +896,12 @@ export class EmailAuthController {
         email: normalizedEmail,
         passwordHash,
         name: trimmedName,
-        ...(workspaceId ? { workspaceId } : {}),
+        ...(invitationWorkspaceId
+          ? { workspaceId: invitationWorkspaceId }
+          : workspaceId
+            ? { workspaceId }
+            : {}),
+        ...(invitationId ? { invitationId } : {}),
       };
 
       await Promise.all([
@@ -978,7 +1016,7 @@ export class EmailAuthController {
       }
 
       // Code verified — retrieve pending data
-      const { passwordHash, name, workspaceId } = payload;
+      const { passwordHash, name, workspaceId, invitationId } = payload;
 
       const existingIdentity = await this.userService.findAuthIdentityByEmail(normalizedEmail);
       if (existingIdentity && existingIdentity.authProvider !== AuthProvider.EMAIL) {
@@ -996,7 +1034,31 @@ export class EmailAuthController {
       // - If neither, don't create OrgMember yet — defer to create-org flow
       let orgId: string | null = null;
 
-      if (workspaceId) {
+      let invitationOrgRole: OrgRole | null = null;
+
+      if (invitationId) {
+        const invitation = await this.prisma.invitation.findFirst({
+          where: {
+            invitationId,
+            email: normalizedEmail,
+            acceptedAt: null,
+            expiredAt: { gt: new Date() },
+          },
+          include: {
+            workspace: {
+              select: { orgId: true, status: true },
+            },
+          },
+        });
+
+        if (!invitation || !invitation.workspace || invitation.workspace.status !== 'ACTIVE') {
+          res.status(400).json({ error: 'Invalid or expired invitation' });
+          return;
+        }
+
+        orgId = invitation.orgId ?? invitation.workspace.orgId;
+        invitationOrgRole = this.getPreAcceptanceOrgRole(invitation.role);
+      } else if (workspaceId) {
         const workspace = await this.prisma.workspace.findUnique({
           where: { id: workspaceId },
           select: { orgId: true, status: true },
@@ -1020,22 +1082,26 @@ export class EmailAuthController {
       // pick it up when creating the OrgMember.
       const existingOrgMember = await this.prisma.orgMember.findUnique({
         where: { email: normalizedEmail },
-        select: { memberId: true, orgId: true },
+        select: { memberId: true, orgId: true, role: true },
       });
 
       if (existingOrgMember) {
         if (orgId && existingOrgMember.orgId !== orgId) {
-          res.status(409).json({
-            error: 'Organization conflict',
-            message: 'This email is already associated with a different organization.',
-          });
-          return;
+          if (existingOrgMember.role !== OrgRole.COMMUNITY_MEMBER) {
+            res.status(409).json({
+              error: 'Organization conflict',
+              message: 'This email is already associated with a different organization.',
+            });
+            return;
+          }
         }
         await this.prisma.orgMember.update({
           where: { email: normalizedEmail },
           data: {
             passwordHash,
             leftAt: null,
+            ...(orgId && existingOrgMember.orgId !== orgId ? { orgId } : {}),
+            ...(invitationOrgRole ? { role: invitationOrgRole } : {}),
           },
         });
       } else if (orgId) {
@@ -1043,7 +1109,7 @@ export class EmailAuthController {
           data: {
             orgId,
             email: normalizedEmail,
-            role: 'COMMUNITY_MEMBER',
+            role: invitationOrgRole ?? OrgRole.COMMUNITY_MEMBER,
             passwordHash,
           },
         });
@@ -1108,6 +1174,7 @@ export class EmailAuthController {
       if (workspaceId) {
         res.status(200).json({
           success: true,
+          ...(invitationId ? { invitationPending: true, invitationId } : {}),
           workspaces: [],
           pendingUserData: { email: normalizedEmail, name: userName },
           userExistsButRemoved: false,

--- a/apps/backend/src/controllers/invitationController.ts
+++ b/apps/backend/src/controllers/invitationController.ts
@@ -8,7 +8,7 @@ import { Request, Response } from 'express';
 import { invitationService } from '@/services/invitationService';
 import { redisService } from '@/services/redisService';
 import { DatabaseClient } from '@/database/client';
-import { withWorkspaceScope } from '@/database/tenant/context';
+import { withWorkspaceScope, runAsSystem } from '@/database/tenant/context';
 import { logger } from '@/utils/logger';
 import { config } from '@/config/env';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
@@ -572,13 +572,17 @@ export class InvitationController {
       await unifiedBotUserService.syncAllBotUsers(workspace.id);
 
       // Create invitation outside the transaction (sends email — non-DB side-effect)
-      const invitation = await invitationService.createInvitation({
-        email: normalizedOwnerEmail,
-        role: WorkspaceRole.OWNER,
-        workspaceId: workspace.id,
-        orgId: org.orgId,
-        invitedBy,
-      });
+      // Run as system because the new org/workspace is not the caller's own —
+      // the OrganizationsACL would filter out the org lookup inside createInvitation.
+      const invitation = await runAsSystem(() =>
+        invitationService.createInvitation({
+          email: normalizedOwnerEmail,
+          role: WorkspaceRole.OWNER,
+          workspaceId: workspace.id,
+          orgId: org.orgId,
+          invitedBy,
+        }),
+      );
       invitationId = invitation.invitationId ?? invitation.id;
 
       const provisionInvitationLink = await buildInvitationLink({ req, workspaceId: workspace.id, invitationId });

--- a/apps/backend/src/controllers/microsoftAuthController.ts
+++ b/apps/backend/src/controllers/microsoftAuthController.ts
@@ -22,6 +22,7 @@ import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper'
 import { signMicrosoftInvitationPendingAuthToken } from '@/utils/microsoftPendingAuth';
 import { redisService } from '@/services/redisService';
 import { randomUUID } from 'crypto';
+import { setOnboardingCookie } from '@/utils/onboardingCookie';
 
 export class MicrosoftAuthController {
   private oauthClient: AuthorizationCode | undefined;
@@ -695,13 +696,11 @@ export class MicrosoftAuthController {
           });
         }
 
-        // Set new user cookie for onboarding
-        if (isNewUser) {
-          res.cookie('is_new_user', 'true', {
-            ...cookieOptions,
-            maxAge: 24 * 60 * 60 * 1000, // 24 hours
-          });
-        }
+        setOnboardingCookie(res, isNewUser, {
+          secure: isProduction,
+          sameSite: 'lax' as const,
+          maxAge: 24 * 60 * 60 * 1000,
+        });
 
         // Redirect to frontend with success
         const frontendUrl = peekedState?.redirectTo ?? getFrontendUrl(req);
@@ -1089,15 +1088,11 @@ export class MicrosoftAuthController {
           });
         }
 
-        if (isNewUser) {
-          res.cookie('is_new_user', 'true', {
-            httpOnly: false,
-            secure: isProduction,
-            sameSite: 'strict',
-            path: '/',
-            maxAge: 24 * 60 * 60 * 1000,
-          });
-        }
+        setOnboardingCookie(res, isNewUser, {
+          secure: isProduction,
+          sameSite: 'strict' as const,
+          maxAge: 24 * 60 * 60 * 1000,
+        });
 
         const tokenKey = await this.storePendingOAuthTokens(
           refreshToken,
@@ -1212,15 +1207,11 @@ export class MicrosoftAuthController {
         });
       }
 
-      if (isNewUser) {
-        res.cookie('is_new_user', 'true', {
-          httpOnly: false,
-          secure: isProduction,
-          sameSite: 'strict',
-          path: '/',
-          maxAge: 24 * 60 * 60 * 1000,
-        });
-      }
+      setOnboardingCookie(res, isNewUser, {
+        secure: isProduction,
+        sameSite: 'strict' as const,
+        maxAge: 24 * 60 * 60 * 1000,
+      });
 
       logger.info(`[${requestId}] Multiple workspaces (${workspaces.length}) detected - returning to selector`);
       res.status(200).json({
@@ -1483,12 +1474,11 @@ export class MicrosoftAuthController {
         });
       }
 
-      if (isNewUser) {
-        res.cookie('is_new_user', 'true', {
-          ...cookieOptions,
-          maxAge: 24 * 60 * 60 * 1000,
-        });
-      }
+      setOnboardingCookie(res, isNewUser, {
+        secure: isProduction,
+        sameSite: 'lax' as const,
+        maxAge: 24 * 60 * 60 * 1000,
+      });
 
       res.json({
         success: true,

--- a/apps/backend/src/controllers/organizationController.ts
+++ b/apps/backend/src/controllers/organizationController.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express';
-import { OrganizationRepository, CreateOrganizationInput } from '../database/repositories/organizationRepository';
+import { OrganizationRepository } from '../database/repositories/organizationRepository';
 import { UserRepository } from '../database/repositories/users';
 import { DatabaseClient } from '../database/client';
-import { withWorkspaceScope } from '../database/tenant/context';
+import { runAsSystem } from '../database/tenant/context';
 import { logger } from '@/utils/logger';
 import { invitationService } from '@/services/invitationService';
 import { WorkspaceJoinPolicy, WorkspaceType, OrgRole, ProjectType, WorkspaceRole, Status } from '@xyne/shared';
@@ -178,78 +178,82 @@ export class OrganizationController {
         throw error;
       }
 
-      const { organization, workspace } = await db.$transaction(async (tx) => {
-        const orgData: CreateOrganizationInput = {
-          name: name.trim(),
-          description: description?.trim(),
-          createdBy: userId,
-        };
-        const organization = await tx.organization.create({
-          data: {
-            orgId,
-            name: orgData.name,
-            description: orgData.description,
-            createdBy: orgData.createdBy,
-          },
-        });
+      // The new workspace/org has no relation to the caller's own workspace, so
+      // tenant ACLs would filter out provisioning reads. Run as system and keep
+      // the DB provisioning writes atomic.
+      const { organization, workspace } = await runAsSystem(async () =>
+        db.$transaction(async (tx) => {
+          // 1. Create organization
+          const organization = await tx.organization.create({
+            data: {
+              orgId,
+              name: name.trim(),
+              description: description?.trim(),
+              createdBy: userId,
+              status: Status.ACTIVE,
+            },
+          });
 
-        const workspace = await tx.workspace.create({
-          data: {
-            orgId: organization.orgId,
-            name: workspaceName.trim(),
-            createdBy: userId,
-            status: Status.ACTIVE,
-            workspaceType: WorkspaceType.ENTERPRISE,
-            joinPolicy: WorkspaceJoinPolicy.INVITE_ONLY,
-          },
-        });
+          // 2. Create workspace for the org
+          const workspace = await tx.workspace.create({
+            data: {
+              orgId: organization.orgId,
+              name: workspaceName.trim(),
+              createdBy: userId,
+              status: Status.ACTIVE,
+              workspaceType: WorkspaceType.ENTERPRISE,
+              joinPolicy: WorkspaceJoinPolicy.INVITE_ONLY,
+            },
+          });
 
-        await getEncryptionProvider().provisionEntity({
-          entityId: workspace.id,
-          orgId: workspace.orgId,
-          entityType: 'WORKSPACE',
-        });
+          await getEncryptionProvider().provisionEntity({
+            entityId: workspace.id,
+            orgId: workspace.orgId,
+            entityType: 'WORKSPACE',
+          });
 
-        await tx.project.create({
-          data: {
-            name: 'Direct Messages',
-            code: 'DM',
-            description: 'DM project for direct message channels',
-            type: ProjectType.DM,
+          // 3. Create DM project for the workspace (required by the system)
+          await tx.project.create({
+            data: {
+              name: 'Direct Messages',
+              code: 'DM',
+              description: 'DM project for direct message channels',
+              type: ProjectType.DM,
+              workspaceId: workspace.id,
+              createdBy: userId,
+            },
+          });
+
+          // 4. Link workspace to organization
+          await tx.workspaceOrganization.create({
+            data: {
+              orgId: organization.orgId,
+              workspaceId: workspace.id,
+              role: WorkspaceRole.ADMIN,
+            },
+          });
+
+          // 4b. Seed general channel + default project + board/stages
+          await createCommunityWorkspaceDefaults({
+            db: tx,
             workspaceId: workspace.id,
+            workspaceName: workspace.name,
             createdBy: userId,
-          },
-        });
+          });
 
-        await tx.workspaceOrganization.create({
-          data: {
-            orgId: organization.orgId,
-            workspaceId: workspace.id,
-            role: WorkspaceRole.ADMIN,
-          },
-        });
-
-        await createCommunityWorkspaceDefaults({
-          db: tx,
-          workspaceId: workspace.id,
-          workspaceName: workspace.name,
-          createdBy: userId,
-        });
-
-        // Provisioning writes the owner row for the newly created org, not the caller's own.
-        await withWorkspaceScope(() =>
-          tx.orgMember.create({
+          // 5. Add ownerEmail as org OWNER (email-only, no user account yet)
+          await tx.orgMember.create({
             data: {
               orgId: organization.orgId,
               email: ownerEmail.trim().toLowerCase(),
               role: OrgRole.OWNER,
               invitedBy: userId,
             },
-          }),
-        );
+          });
 
-        return { organization, workspace };
-      });
+          return { organization, workspace };
+        }),
+      );
 
       await organizationDomainService.createDomainMappingForOrg({
         orgId: organization.orgId,
@@ -257,14 +261,15 @@ export class OrganizationController {
         verifiedByUserId: userId,
       });
 
-      // 6. Create and send invitation to the workspace
-      const invitation = await invitationService.createInvitation({
-        email: ownerEmail.trim().toLowerCase(),
-        role: WorkspaceRole.OWNER,
-        workspaceId: workspace.id,
-        invitedBy: userId,
-        orgId: organization.orgId,
-      });
+      const invitation = await runAsSystem(() =>
+        invitationService.createInvitation({
+          email: ownerEmail.trim().toLowerCase(),
+          role: WorkspaceRole.OWNER,
+          workspaceId: workspace.id,
+          invitedBy: userId,
+          orgId: organization.orgId,
+        }),
+      );
 
       await invitationService.sendInvitationEmail({
         to: ownerEmail.trim(),

--- a/apps/backend/src/controllers/userManagementController.ts
+++ b/apps/backend/src/controllers/userManagementController.ts
@@ -1017,6 +1017,52 @@ export class UserManagementController {
       const type = questionnaireType.trim();
       const questionnairePayload = payload as Prisma.InputJsonValue;
       const prisma = DatabaseClient.getInstance();
+      const normalizedEmail =
+        type === 'onboarding'
+          ? (
+              await prisma.user.findUnique({
+                where: { id: userId },
+                select: { email: true },
+              })
+            )?.email.toLowerCase().trim()
+          : undefined;
+
+      if (type === 'onboarding' && !normalizedEmail) {
+        res.status(400).json({ error: 'User email is required for onboarding questionnaire' });
+        return;
+      }
+
+      if (type === 'onboarding') {
+        const saved = await prisma.questionnaireResponse.upsert({
+          where: {
+            questionnaireType_email: {
+              questionnaireType: type,
+              email: normalizedEmail!,
+            },
+          },
+          update: {
+            workspaceId,
+            userId,
+            payload: questionnairePayload,
+            updatedAt: new Date(),
+          },
+          create: {
+            workspaceId,
+            userId,
+            email: normalizedEmail,
+            questionnaireType: type,
+            payload: questionnairePayload,
+          },
+        });
+
+        res.status(200).json({
+          id: saved.id,
+          questionnaireType: saved.questionnaireType,
+          payload: saved.payload,
+        });
+        return;
+      }
+
       const saved = await prisma.questionnaireResponse.upsert({
         where: {
           workspaceId_questionnaireType_userId: {
@@ -1032,6 +1078,7 @@ export class UserManagementController {
         create: {
           workspaceId,
           userId,
+          email: null,
           questionnaireType: type,
           payload: questionnairePayload,
         },

--- a/apps/backend/src/controllers/userManagementController.ts
+++ b/apps/backend/src/controllers/userManagementController.ts
@@ -1035,9 +1035,9 @@ export class UserManagementController {
       if (type === 'onboarding') {
         const saved = await prisma.questionnaireResponse.upsert({
           where: {
-            questionnaireType_email: {
-              questionnaireType: type,
+            email_questionnaireType: {
               email: normalizedEmail!,
+              questionnaireType: type,
             },
           },
           update: {

--- a/apps/backend/src/services/communityWorkspaceService.ts
+++ b/apps/backend/src/services/communityWorkspaceService.ts
@@ -24,6 +24,7 @@ import { organizationDomainService } from '@/services/organizationDomainService'
 import { repositories } from '@/database/repositories';
 import { ensureUserInGeneralChannel as joinUserToGeneralChannel } from '@/utils/workspaceGeneralChannel';
 import { withWorkspaceScope } from '@/database/tenant/context';
+import { UserService } from '@/services/userService';
 
 const COMMUNITY_MEMBER_WORKSPACE_ROLE = 'COMMUNITY_MEMBER' as WorkspaceRole;
 const TEMPLATE_TOKEN_PATTERN = /{{\s*(workspaceName|workspaceId|joinLink|email)\s*}}/g;
@@ -88,6 +89,7 @@ type CommunityWorkspace = {
 
 export class CommunityWorkspaceService {
   private prisma = DatabaseClient.getInstance();
+  private userService = new UserService();
 
   async listCommunityWorkspaces(): Promise<CommunityWorkspaceOrganization[]> {
     const organizations = await this.prisma.organization.findMany({
@@ -329,6 +331,8 @@ export class CommunityWorkspaceService {
         });
       }
 
+      const hasCompletedOnboarding = await this.userService.hasCompletedOnboarding(email);
+
       let workspaceUser = await tx.user.findUnique({
         where: {
           email_workspaceId: {
@@ -338,7 +342,7 @@ export class CommunityWorkspaceService {
         },
       });
 
-      let isNewUser = false;
+      const isNewUser = !hasCompletedOnboarding;
       if (workspaceUser) {
         workspaceUser = await tx.user.update({
           where: { id: workspaceUser.id },
@@ -352,7 +356,6 @@ export class CommunityWorkspaceService {
           },
         });
       } else {
-        isNewUser = true;
         workspaceUser = await tx.user.create({
           data: {
             providerUserId: params.userData.providerUserId,

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -7,6 +7,7 @@ import { PrismaClient, Invitation, User } from '@prisma/client';
 import {
   GuestEntity,
   WorkspaceRole,
+  WorkspaceType,
   AuthProvider,
   ChannelRole,
   CanvasRole,
@@ -56,10 +57,11 @@ export class InvitationService {
     this.channelUserStatusRepository = new ChannelUserStatusRepository();
   }
 
-  private toEnterpriseOrgRole(role: WorkspaceRole): 'OWNER' | 'ADMIN' | 'MEMBER' {
-    if (role === WorkspaceRole.OWNER) return 'OWNER';
-    if (role === WorkspaceRole.ADMIN) return 'ADMIN';
-    return 'MEMBER';
+  private toEnterpriseOrgRole(role: WorkspaceRole): OrgRole {
+    if (role === WorkspaceRole.OWNER) return OrgRole.OWNER;
+    if (role === WorkspaceRole.ADMIN) return OrgRole.ADMIN;
+    if (role === WorkspaceRole.COMMUNITY_MEMBER) return OrgRole.COMMUNITY_MEMBER;
+    return OrgRole.MEMBER;
   }
 
   /**
@@ -93,7 +95,7 @@ export class InvitationService {
       orgId = derivedOrgId;
 
       // Ensure the invitee exists in the org_members table (any org)
-      if (role !== 'GUEST') {
+      if (role !== WorkspaceRole.GUEST && role !== WorkspaceRole.COMMUNITY_MEMBER) {
         // Looks the invitee up across any org, not just the caller's, so it runs above the caller's own scope.
         // The query MUST be awaited inside the closure: Prisma promises are lazy, so awaiting
         // outside would execute the query after withWorkspaceScope has exited — back in the
@@ -128,8 +130,24 @@ export class InvitationService {
     // Validate role — provision flow (explicit orgId) allows OWNER; normal flow allows ADMIN/MEMBER
     const validRoles: WorkspaceRole[] = explicitOrgId
       ? [WorkspaceRole.OWNER, WorkspaceRole.ADMIN, WorkspaceRole.MEMBER]
-      : [WorkspaceRole.ADMIN, WorkspaceRole.MEMBER, WorkspaceRole.GUEST];
-    const invitationRole = role && validRoles.includes(role) ? role : 'MEMBER';
+      : [
+          WorkspaceRole.ADMIN,
+          WorkspaceRole.MEMBER,
+          WorkspaceRole.GUEST,
+          WorkspaceRole.COMMUNITY_MEMBER,
+        ];
+    const invitationRole = role && validRoles.includes(role) ? role : WorkspaceRole.MEMBER;
+
+    if (invitationRole === WorkspaceRole.COMMUNITY_MEMBER) {
+      const workspace = await this.prisma.workspace.findUnique({
+        where: { id: workspaceId },
+        select: { workspaceType: true },
+      });
+
+      if (workspace?.workspaceType !== WorkspaceType.COMMUNITY) {
+        throw new Error('Community member invitations are only supported for community workspaces');
+      }
+    }
 
     if (invitationRole === 'GUEST' && (!params.entityId || !params.entityType)) {
       throw new Error('Guest invitations must target a project, channel, or canvas');

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -624,47 +624,46 @@ export class InvitationService {
       name: string;
       providerUserId: string;
       authProvider: string;
-    }
+    },
+    tx: TxClient,
   ): Promise<{ user: User; redirectPath: string | null }> {
-    return this.prisma.$transaction(async (tx) => {
-      const orgMember = await tx.orgMember.findUnique({
-        where: { email: userData.email.toLowerCase() },
-      });
-
-      if (orgMember && orgMember.leftAt) {
-        throw new Error(`Cannot accept invitation — ${userData.email} is no longer part of the organization`);
-      }
-
-      const activeOrgMember = orgMember ?? await tx.orgMember.create({
-        data: {
-          orgId: invitation.orgId!,
-          email: userData.email.toLowerCase(),
-          role: OrgRole.GUEST,
-        },
-      });
-
-      if (!orgMember) {
-        logger.info(`[DEBUG] [handleGuestAcceptance] Created new orgMember with GUEST role id=${activeOrgMember.memberId}`);
-      }
-
-      const newWorkspaceUser = await tx.user.create({
-        data: {
-          email: userData.email,
-          name: userData.name,
-          providerUserId: userData.providerUserId,
-          authProvider: userData.authProvider as AuthProvider,
-          workspaceId: invitation.workspaceId!,
-          role: invitation.role,
-          status: UserStatus.ACTIVE,
-          orgMemberId: activeOrgMember.memberId,
-        },
-      });
-      logger.info(`[DEBUG] [handleGuestAcceptance] Created new workspace GUEST user id=${newWorkspaceUser.id}`);
-
-      const redirectPath = await this.grantGuestEntityAccess(newWorkspaceUser.id, invitation, tx);
-
-      return { user: newWorkspaceUser, redirectPath };
+    const orgMember = await tx.orgMember.findUnique({
+      where: { email: userData.email.toLowerCase() },
     });
+
+    if (orgMember && orgMember.leftAt) {
+      throw new Error(`Cannot accept invitation — ${userData.email} is no longer part of the organization`);
+    }
+
+    const activeOrgMember = orgMember ?? await tx.orgMember.create({
+      data: {
+        orgId: invitation.orgId!,
+        email: userData.email.toLowerCase(),
+        role: OrgRole.GUEST,
+      },
+    });
+
+    if (!orgMember) {
+      logger.info(`[DEBUG] [handleGuestAcceptance] Created new orgMember with GUEST role id=${activeOrgMember.memberId}`);
+    }
+
+    const newWorkspaceUser = await tx.user.create({
+      data: {
+        email: userData.email,
+        name: userData.name,
+        providerUserId: userData.providerUserId,
+        authProvider: userData.authProvider as AuthProvider,
+        workspaceId: invitation.workspaceId!,
+        role: invitation.role,
+        status: UserStatus.ACTIVE,
+        orgMemberId: activeOrgMember.memberId,
+      },
+    });
+    logger.info(`[DEBUG] [handleGuestAcceptance] Created new workspace GUEST user id=${newWorkspaceUser.id}`);
+
+    const redirectPath = await this.grantGuestEntityAccess(newWorkspaceUser.id, invitation, tx);
+
+    return { user: newWorkspaceUser, redirectPath };
   }
 
   /**
@@ -730,11 +729,19 @@ export class InvitationService {
     });
     logger.info(`[DEBUG] [acceptInvitation] User providerUserId=${userData.providerUserId} already in workspace ${invitation.workspaceId}: ${!!existingWorkspaceUser}`);
 
-    let newWorkspaceUser;
+    let newWorkspaceUser: User;
     let redirectPath: string | null = null;
+    let upgradeCommunityMemberId: string | null = null;
 
     if (!existingWorkspaceUser && invitation.role === 'GUEST') {
-      const guestResult = await this.handleGuestAcceptance(invitation, userData);
+      const guestResult = await this.prisma.$transaction(async (tx) => {
+        const result = await this.handleGuestAcceptance(invitation, userData, tx);
+        await tx.invitation.update({
+          where: { invitationId },
+          data: { acceptedAt: new Date() },
+        });
+        return result;
+      });
       newWorkspaceUser = guestResult.user;
       redirectPath = guestResult.redirectPath;
     } else if (existingWorkspaceUser) {
@@ -760,111 +767,136 @@ export class InvitationService {
             },
           });
           const path = await this.grantGuestEntityAccess(reactivatedUser.id, invitation, tx);
+          await tx.invitation.update({
+            where: { invitationId },
+            data: { acceptedAt: new Date() },
+          });
           return { user: reactivatedUser, redirectPath: path };
         });
         newWorkspaceUser = guestResult.user;
         redirectPath = guestResult.redirectPath;
         logger.info(`[DEBUG] [acceptInvitation] Granted existing guest user id=${newWorkspaceUser.id} access to invitation entity`);
       } else {
-        // User exists - reactivate them if they were removed (leftAt is set)
-        newWorkspaceUser = await this.prisma.user.update({
-          where: { id: existingWorkspaceUser.id },
-          data: {
-            leftAt: null,
-            role: invitation.role,
-            status: UserStatus.ACTIVE,
-          },
+        // User exists - reactivate + orgMember upsert + invitation accept in one transaction
+        newWorkspaceUser = await this.prisma.$transaction(async (tx) => {
+          const reactivatedUser = await tx.user.update({
+            where: { id: existingWorkspaceUser.id },
+            data: {
+              leftAt: null,
+              role: invitation.role,
+              status: UserStatus.ACTIVE,
+            },
+          });
+
+          if (resolvedOrgId) {
+            await tx.orgMember.upsert({
+              where: { email: userData.email.toLowerCase() },
+              create: {
+                orgId: resolvedOrgId,
+                email: userData.email.toLowerCase(),
+                role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
+              },
+              update: {
+                leftAt: null,
+                orgId: resolvedOrgId,
+                role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
+              },
+            });
+          }
+
+          await tx.invitation.update({
+            where: { invitationId },
+            data: { acceptedAt: new Date() },
+          });
+
+          return reactivatedUser;
         });
         logger.info(`[DEBUG] [acceptInvitation] Reactivated existing user id=${newWorkspaceUser.id}`);
       }
     } else {
+      // New user — orgMember create/update + user create + invitation accept in one transaction
       if (resolvedOrgId) {
         await organizationDomainService.assertOrgMemberLimit(resolvedOrgId, userData.email);
       }
 
-      // Fetch existing orgMember by email
-      const existingOrgMember = await this.prisma.orgMember.findUnique({
-        where: { email: userData.email.toLowerCase() },
-        select: { memberId: true, role: true }
+      newWorkspaceUser = await this.prisma.$transaction(async (tx) => {
+        const existingOrgMember = await tx.orgMember.findUnique({
+          where: { email: userData.email.toLowerCase() },
+          select: { memberId: true, role: true },
+        });
+
+        let orgMemberId: string;
+
+        if (!existingOrgMember) {
+          if (!resolvedOrgId) {
+            throw new Error(`orgMember not found for email ${userData.email}. User must be invited to the organization first.`);
+          }
+
+          const created = await tx.orgMember.create({
+            data: {
+              orgId: resolvedOrgId,
+              email: userData.email.toLowerCase(),
+              role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
+            },
+            select: { memberId: true },
+          });
+          orgMemberId = created.memberId;
+        } else if (resolvedOrgId) {
+          const wasCommunityMember = existingOrgMember.role === 'COMMUNITY_MEMBER';
+          const updated = await tx.orgMember.update({
+            where: { memberId: existingOrgMember.memberId },
+            data: {
+              leftAt: null,
+              orgId: resolvedOrgId,
+              role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
+            },
+            select: { memberId: true },
+          });
+          orgMemberId = updated.memberId;
+
+          if (wasCommunityMember) {
+            upgradeCommunityMemberId = orgMemberId;
+          }
+        } else {
+          orgMemberId = existingOrgMember.memberId;
+        }
+
+        const createdUser = await tx.user.create({
+          data: {
+            email: userData.email,
+            name: userData.name,
+            providerUserId: userData.providerUserId,
+            authProvider: userData.authProvider as AuthProvider,
+            workspaceId: invitation.workspaceId!,
+            role: invitation.role,
+            status: UserStatus.ACTIVE,
+            orgMemberId,
+          },
+        });
+        logger.info(`[DEBUG] [acceptInvitation] Created new workspace user id=${createdUser.id}`);
+
+        await tx.invitation.update({
+          where: { invitationId },
+          data: { acceptedAt: new Date() },
+        });
+
+        return createdUser;
       });
+    }
 
-      let orgMember: { memberId: string };
+    // ── Post-commit side effects (best-effort, must not roll back the
+    //    transaction above). These are idempotent or error-swallowing. ──
 
-      if (!existingOrgMember) {
-        if (!resolvedOrgId) {
-          throw new Error(`orgMember not found for email ${userData.email}. User must be invited to the organization first.`);
-        }
-
-        orgMember = await this.prisma.orgMember.create({
-          data: {
-            orgId: resolvedOrgId,
-            email: userData.email.toLowerCase(),
-            role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
-          },
-          select: { memberId: true },
+    if (upgradeCommunityMemberId) {
+      try {
+        await aiProvisioningService.upgradeCommunityToEnterpriseBudget(upgradeCommunityMemberId);
+      } catch (error) {
+        logger.error('[InvitationService] Failed to upgrade community budget', {
+          memberId: upgradeCommunityMemberId,
+          error,
         });
-      } else if (resolvedOrgId) {
-        const wasCommunityMember = existingOrgMember.role === 'COMMUNITY_MEMBER';
-        orgMember = await this.prisma.orgMember.update({
-          where: { memberId: existingOrgMember.memberId },
-          data: {
-            leftAt: null,
-            orgId: resolvedOrgId,
-            role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
-          },
-          select: { memberId: true },
-        });
-
-        if (wasCommunityMember) {
-          await aiProvisioningService.upgradeCommunityToEnterpriseBudget(orgMember.memberId);
-        }
-      } else {
-        orgMember = { memberId: existingOrgMember.memberId };
       }
-
-      // Create new user in the workspace
-      newWorkspaceUser = await this.prisma.user.create({
-        data: {
-          email: userData.email,
-          name: userData.name,
-          providerUserId: userData.providerUserId,
-          authProvider: userData.authProvider as AuthProvider,
-          workspaceId: invitation.workspaceId!,
-          role: invitation.role,
-          status: UserStatus.ACTIVE,
-          orgMemberId: orgMember.memberId,
-        },
-      });
-      logger.info(`[DEBUG] [acceptInvitation] Created new workspace user id=${newWorkspaceUser.id}`);
     }
-
-    // Ensure an OrgMember entry exists for this email (upsert by email - now globally unique)
-    if (resolvedOrgId && invitation.role !== 'GUEST') {
-      await this.prisma.orgMember.upsert({
-        where: { email: userData.email.toLowerCase() },
-        create: {
-          orgId: resolvedOrgId,
-          email: userData.email.toLowerCase(),
-          role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
-        },
-        update: {
-          leftAt: null,
-          orgId: resolvedOrgId,
-          role: this.toEnterpriseOrgRole(invitation.role as WorkspaceRole),
-        }, // reactivate and update orgId/role if needed
-      });
-      logger.info(`[DEBUG] [acceptInvitation] OrgMember upserted for email=${userData.email} orgId=${resolvedOrgId}`);
-    } else if (invitation.role !== 'GUEST') {
-      logger.warn(`[DEBUG] [acceptInvitation] ⚠️ Could not resolve orgId — OrgMember NOT created for email=${userData.email}`);
-    }
-
-    // Update invitation with acceptedAt timestamp instead of deleting
-    await this.prisma.invitation.update({
-      where: { invitationId: invitationId },
-      data: {
-        acceptedAt: new Date(),
-      },
-    });
 
     // Grant role-based resource permissions via the centralized permission matrix
     await grantPermissionsForRole(

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -64,6 +64,20 @@ export class InvitationService {
     return OrgRole.MEMBER;
   }
 
+  private async markInvitationAccepted(tx: TxClient, invitationId: string): Promise<void> {
+    const result = await tx.invitation.updateMany({
+      where: {
+        invitationId,
+        acceptedAt: null,
+      },
+      data: { acceptedAt: new Date() },
+    });
+
+    if (result.count !== 1) {
+      throw new Error('Invitation has already been accepted');
+    }
+  }
+
   /**
    * Create a new invitation
    */
@@ -721,6 +735,11 @@ export class InvitationService {
       throw new Error('Email does not match the invitation');
     }
 
+    if (invitation.acceptedAt) {
+      logger.warn(`[DEBUG] [acceptInvitation] Invitation ${invitationId} was already accepted at ${invitation.acceptedAt.toISOString()}`);
+      throw new Error('Invitation has already been accepted');
+    }
+
     logger.info(`[DEBUG] [acceptInvitation] Invitation valid. workspaceId=${invitation.workspaceId} orgId=${invitation.orgId ?? 'null'} role=${invitation.role}`);
 
     // Resolve orgId before user creation so a COMMUNITY_MEMBER org row can be
@@ -753,11 +772,8 @@ export class InvitationService {
 
     if (!existingWorkspaceUser && invitation.role === 'GUEST') {
       const guestResult = await this.prisma.$transaction(async (tx) => {
+        await this.markInvitationAccepted(tx, invitationId);
         const result = await this.handleGuestAcceptance(invitation, userData, tx);
-        await tx.invitation.update({
-          where: { invitationId },
-          data: { acceptedAt: new Date() },
-        });
         return result;
       });
       newWorkspaceUser = guestResult.user;
@@ -777,6 +793,7 @@ export class InvitationService {
         }
 
         const guestResult = await this.prisma.$transaction(async (tx) => {
+          await this.markInvitationAccepted(tx, invitationId);
           const reactivatedUser = await tx.user.update({
             where: { id: existingWorkspaceUser.id },
             data: {
@@ -785,10 +802,6 @@ export class InvitationService {
             },
           });
           const path = await this.grantGuestEntityAccess(reactivatedUser.id, invitation, tx);
-          await tx.invitation.update({
-            where: { invitationId },
-            data: { acceptedAt: new Date() },
-          });
           return { user: reactivatedUser, redirectPath: path };
         });
         newWorkspaceUser = guestResult.user;
@@ -797,6 +810,7 @@ export class InvitationService {
       } else {
         // User exists - reactivate + orgMember upsert + invitation accept in one transaction
         newWorkspaceUser = await this.prisma.$transaction(async (tx) => {
+          await this.markInvitationAccepted(tx, invitationId);
           const reactivatedUser = await tx.user.update({
             where: { id: existingWorkspaceUser.id },
             data: {
@@ -822,11 +836,6 @@ export class InvitationService {
             });
           }
 
-          await tx.invitation.update({
-            where: { invitationId },
-            data: { acceptedAt: new Date() },
-          });
-
           return reactivatedUser;
         });
         logger.info(`[DEBUG] [acceptInvitation] Reactivated existing user id=${newWorkspaceUser.id}`);
@@ -838,6 +847,7 @@ export class InvitationService {
       }
 
       newWorkspaceUser = await this.prisma.$transaction(async (tx) => {
+        await this.markInvitationAccepted(tx, invitationId);
         const existingOrgMember = await tx.orgMember.findUnique({
           where: { email: userData.email.toLowerCase() },
           select: { memberId: true, role: true },
@@ -892,11 +902,6 @@ export class InvitationService {
           },
         });
         logger.info(`[DEBUG] [acceptInvitation] Created new workspace user id=${createdUser.id}`);
-
-        await tx.invitation.update({
-          where: { invitationId },
-          data: { acceptedAt: new Date() },
-        });
 
         return createdUser;
       });

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -222,6 +222,17 @@ export class UserService {
         `Created new user: ${user.email} (${user.id}) without assigning to a default group.`
       );
 
+      try {
+        await aiProvisioningService.enqueueUserSync(user.orgMemberId);
+      } catch (error) {
+        logger.error('[UserService] Failed to enqueue AI user provisioning for created user', {
+          userId: user.id,
+          workspaceId: user.workspaceId,
+          orgMemberId: user.orgMemberId,
+          error,
+        });
+      }
+
       // grantPermissionsForRole swallows errors internally — user creation must not rollback on grant failure
       await grantPermissionsForRole(user.id, user.email, WorkspaceRole.MEMBER, user.workspaceId);
 
@@ -900,6 +911,17 @@ export class UserService {
           orgMember: { connect: { memberId: orgMember.memberId } },
         }
       });
+
+      try {
+        await aiProvisioningService.enqueueUserSync(workspaceUser.orgMemberId);
+      } catch (error) {
+        logger.error('[UserService] Failed to enqueue AI user provisioning for workspace user', {
+          userId: workspaceUser.id,
+          workspaceId: workspaceUser.workspaceId,
+          orgMemberId: workspaceUser.orgMemberId,
+          error,
+        });
+      }
 
       // Grant permissions based on invitation role (fixes V2 auth zero-permissions bug)
       await grantPermissionsForRole(workspaceUser.id, workspaceUser.email, role as WorkspaceRole, userData.workspaceId);

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -53,6 +53,21 @@ export class UserService {
     this.prisma = DatabaseClient.getInstance();
   }
 
+  async hasCompletedOnboarding(email: string): Promise<boolean> {
+    const normalizedEmail = email.toLowerCase().trim();
+    return await runAsSystem(async () => {
+      const onboardingResponse = await this.prisma.questionnaireResponse.findFirst({
+        where: {
+          questionnaireType: 'onboarding',
+          email: normalizedEmail,
+        },
+        select: { id: true },
+      });
+
+      return Boolean(onboardingResponse);
+    });
+  }
+
   /**
    * Get org role by memberId
    */
@@ -772,13 +787,14 @@ export class UserService {
       }
 
       const normalizedAuthProvider = (userData.authProvider?.toUpperCase() as AuthProvider) || AuthProvider.GOOGLE;
+      const hasCompletedOnboarding = await this.hasCompletedOnboarding(userData.email);
 
       if (workspaceUser) {
         workspaceUser = await this.prisma.user.update({
           where: { id: workspaceUser.id },
           data: { authProvider: normalizedAuthProvider }
         });
-        return { user: workspaceUser, isNewUser: false };
+        return { user: workspaceUser, isNewUser: !hasCompletedOnboarding };
       }
 
       // Also check by email (for users created by seed script or when providerUserId is unavailable)
@@ -900,7 +916,7 @@ export class UserService {
       });
 
       logger.info(`Created workspace user for ${userData.email} in workspace ${userData.workspaceId}`);
-      return { user: workspaceUser, isNewUser: true };
+      return { user: workspaceUser, isNewUser: !hasCompletedOnboarding };
     } catch (error) {
       logger.error('Error creating workspace user:', error);
       throw error instanceof Error ? error : new Error('Failed to create workspace user');
@@ -996,6 +1012,8 @@ export class UserService {
       // Step 4: Add/upgrade user as OrgMember first so they can create additional workspaces later.
       // A COMMUNITY_MEMBER row is the only global OrgMember row public users have before
       // joining/creating an enterprise workspace. Move that row to the enterprise org.
+      const hasCompletedOnboarding = await this.hasCompletedOnboarding(userData.email);
+
       const existingOrgMember = await this.prisma.orgMember.findUnique({
         where: { email: userData.email },
       });
@@ -1103,7 +1121,7 @@ export class UserService {
       }
 
       logger.info(`Created organization ${orgName} with workspace ${workspaceName} for ${userData.email}`);
-      return { organization, workspace, workspaceUser, isNewUser: true };
+      return { organization, workspace, workspaceUser, isNewUser: !hasCompletedOnboarding };
     } catch (error) {
       logger.error('Error creating organization:', error);
       if (isOrganizationPolicyError(error) || (error as Error & { statusCode?: number }).statusCode) {

--- a/apps/backend/src/utils/onboardingCookie.ts
+++ b/apps/backend/src/utils/onboardingCookie.ts
@@ -1,0 +1,27 @@
+import type { CookieOptions, Response } from 'express';
+
+type OnboardingCookieOptions = Pick<CookieOptions, 'secure' | 'sameSite'> & {
+  maxAge?: number;
+};
+
+export const ONBOARDING_COOKIE_NAME = 'is_new_user';
+export const DEFAULT_ONBOARDING_COOKIE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function setOnboardingCookie(
+  res: Response,
+  isNewUser: boolean,
+  options: OnboardingCookieOptions,
+): void {
+  if (!isNewUser) {
+    res.clearCookie(ONBOARDING_COOKIE_NAME, { path: '/' });
+    return;
+  }
+
+  res.cookie(ONBOARDING_COOKIE_NAME, 'true', {
+    httpOnly: false,
+    secure: options.secure,
+    sameSite: options.sameSite,
+    path: '/',
+    maxAge: options.maxAge ?? DEFAULT_ONBOARDING_COOKIE_MAX_AGE_MS,
+  });
+}

--- a/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
+++ b/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
@@ -1,10 +1,9 @@
-import { ReactElement, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, ArrowRight, SearchBig, Share01, CheckTickSingle } from '@xyne/icons';
+import { ReactElement } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, SearchBig } from '@xyne/icons';
 import { invokeShortcut } from '../../shortcuts';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
-import { toast } from 'sonner';
 
 const buttonClass = cn(
   'size-7 flex items-center justify-center rounded-[10px] border border-transparent transition-colors',
@@ -18,23 +17,6 @@ const buttonClass = cn(
  */
 const AppNavigator = (): ReactElement => {
   const navigate = useNavigate();
-  const { workspaceId } = useParams<{ workspaceId?: string }>();
-  const [copied, setCopied] = useState(false);
-
-  const handleShareWorkspace = async (): Promise<void> => {
-    if (!workspaceId) return;
-
-    const shareUrl = `${window.location.origin}/auth?workspaceId=${encodeURIComponent(workspaceId)}`;
-
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      setCopied(true);
-      toast.success('Workspace link copied to clipboard');
-      window.setTimeout(() => setCopied(false), 1800);
-    } catch {
-      toast.error('Failed to copy workspace link');
-    }
-  };
 
   return (
     <div
@@ -42,19 +24,6 @@ const AppNavigator = (): ReactElement => {
       style={APP_DRAG_STYLE}
     >
       <div className='flex items-center' style={APP_NO_DRAG_STYLE}>
-        {workspaceId && (
-          <button
-            type='button'
-            aria-label='Share workspace link'
-            onClick={() => void handleShareWorkspace()}
-            // Temporarily hidden — drop the `hidden` class to bring it back.
-            className={cn(buttonClass, 'hidden')}
-            data-track-category='APP_NAVIGATOR'
-            data-track-name='SHARE_WORKSPACE'
-          >
-            {copied ? <CheckTickSingle size={16} /> : <Share01 size={16} />}
-          </button>
-        )}
         <button
           type='button'
           aria-label='Back'

--- a/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
@@ -24,7 +24,9 @@ import {
   InformationCircle,
   AlertCircle,
   TicketToken,
+  UserPlus,
 } from '@xyne/icons';
+import { WorkspaceType } from '@xyne/shared';
 
 import Avatar from '../ui/Avatar/Avatar';
 import { Popover } from '../ui/Popover/Popover';
@@ -44,6 +46,8 @@ import { useAllUnreadCount } from '../../hooks/useUnreadCount';
 import { reactNativeBridge } from '../../utils/reactNativeBridge';
 import { useVisibleNavigationItems } from '../../hooks/useVisibleNavigationItems';
 import { useToolbarItems } from '../../hooks/useToolbarItems';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
 import type { NavigationItem } from './navigationConfig';
 import {
   RAIL_SHORTCUT_LIMIT,
@@ -60,6 +64,7 @@ import { isDMChannel } from '../Chat/ChatDirectory/ChatDirectory.utils';
 import { SupportRail } from './SupportRail';
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 import { ZeroConnectionStatus } from '../ZeroConnectionStatus/ZeroConnectionStatus';
+import WorkspaceInviteDialog from './WorkspaceInviteDialog';
 
 const mobileNavigationItems = [
   {
@@ -160,6 +165,10 @@ const AppSidebar = (): ReactElement => {
   const { isMobile } = usePlatform();
   const visibleChannels = useAllVisibleChannels();
   const unreadCounts = useAllUnreadCount();
+  const [workspace] = useCachedQuery(queries.getWorkspaceById({ workspaceId: workspaceId || '' }), {
+    enabled: !!workspaceId,
+  });
+  const isCommunityWorkspace = workspace?.workspaceType === WorkspaceType.COMMUNITY;
 
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
@@ -200,6 +209,7 @@ const AppSidebar = (): ReactElement => {
   const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
   const [isSettingsPopoverOpen, setIsSettingsPopoverOpen] = useState(false);
   const [isSupportOpen, setIsSupportOpen] = useState(false);
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
   const [isErrorReportOpen, setIsErrorReportOpen] = useState(false);
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const [isPreferencesOpen, setIsPreferencesOpen] = useState(false);
@@ -503,6 +513,28 @@ const AppSidebar = (): ReactElement => {
         >
           <ZeroConnectionStatus className='mb-2' />
 
+          {isCommunityWorkspace && (
+            <Tooltip content='Invite people' side='right' delayDuration={0}>
+              <button
+                type='button'
+                aria-label='Invite people to workspace'
+                title='Invite people'
+                onClick={() => setIsInviteDialogOpen(true)}
+                data-testid='nav-invite-people'
+                data-track-category='App_Sidebar'
+                data-track-name='Sidebar_InvitePeople_Open'
+                className={cn(
+                  'size-8 mb-2 translate-y-[10px] flex items-center justify-center rounded-lg cursor-pointer border border-transparent transition-colors',
+                  isInviteDialogOpen
+                    ? 'bg-sidebar-accent border-sidebar-border text-sidebar-accent-foreground'
+                    : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                )}
+              >
+                <UserPlus size={18} variant='Solid' className='text-black' />
+              </button>
+            </Tooltip>
+          )}
+
           <Popover
             open={isSupportOpen}
             onOpenChange={setIsSupportOpen}
@@ -625,6 +657,12 @@ const AppSidebar = (): ReactElement => {
 
         {/* Error Report Modal — opened from the Support rail button */}
         <ErrorReportModal isOpen={isErrorReportOpen} onClose={() => setIsErrorReportOpen(false)} />
+
+        <WorkspaceInviteDialog
+          open={isInviteDialogOpen}
+          onOpenChange={setIsInviteDialogOpen}
+          workspaceId={workspaceId}
+        />
 
         {/* Status Update Modal */}
         <UpdateStatusModal

--- a/apps/dashboard/src/components/AppSidebar/WorkspaceInviteDialog.tsx
+++ b/apps/dashboard/src/components/AppSidebar/WorkspaceInviteDialog.tsx
@@ -1,0 +1,251 @@
+import { FormEvent, ReactElement, useMemo, useState } from 'react';
+import axios from 'axios';
+import { CheckTickSingle, CopyDefault } from '@xyne/icons';
+import { WorkspaceRole } from '@xyne/shared';
+import { toast } from 'sonner';
+import Dialog from '../ui/Dialog';
+import { apiInstance } from '../../services/clients/apiClient';
+import { cn } from '../../utils/classNames';
+
+interface WorkspaceInviteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string | undefined;
+}
+
+const EMAIL_SPLIT_PATTERN = /[\s,;]+/;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const getWorkspaceInviteUrl = (workspaceId: string): string =>
+  `${window.location.origin}/auth?workspaceId=${encodeURIComponent(workspaceId)}`;
+
+const parseEmails = (value: string): string[] =>
+  Array.from(
+    new Set(
+      value
+        .split(EMAIL_SPLIT_PATTERN)
+        .map(email => email.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+
+const getInviteErrorMessage = (error: unknown): string => {
+  if (axios.isAxiosError<{ error?: string; message?: string }>(error)) {
+    return (
+      error.response?.data?.error ??
+      error.response?.data?.message ??
+      error.message ??
+      'Failed to send invitation'
+    );
+  }
+
+  return error instanceof Error ? error.message : 'Failed to send invitation';
+};
+
+interface InviteResult {
+  email: string;
+  error?: string;
+}
+
+export const WorkspaceInviteDialog = ({
+  open,
+  onOpenChange,
+  workspaceId,
+}: WorkspaceInviteDialogProps): ReactElement => {
+  const [emailsInput, setEmailsInput] = useState('');
+  const [isInviting, setIsInviting] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const inviteUrl = useMemo(
+    () => (workspaceId ? getWorkspaceInviteUrl(workspaceId) : ''),
+    [workspaceId],
+  );
+
+  const handleCopyLink = async (): Promise<void> => {
+    if (!inviteUrl) {
+      toast.error('No workspace selected');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      toast.success('Workspace link copied to clipboard');
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      toast.error('Failed to copy workspace link');
+    }
+  };
+
+  const handleInvite = async (event?: FormEvent<HTMLFormElement>): Promise<void> => {
+    event?.preventDefault();
+
+    if (!workspaceId) {
+      toast.error('No workspace selected');
+      return;
+    }
+
+    const emails = parseEmails(emailsInput);
+
+    if (!emails.length) {
+      toast.error('Please enter an email address');
+      return;
+    }
+
+    const invalidEmail = emails.find(email => !EMAIL_PATTERN.test(email));
+    if (invalidEmail) {
+      toast.error(`Invalid email address: ${invalidEmail}`);
+      return;
+    }
+
+    setIsInviting(true);
+    try {
+      const results = await Promise.all(
+        emails.map(async (email): Promise<InviteResult> => {
+          try {
+            await apiInstance.post('/invitations', {
+              email,
+              role: WorkspaceRole.COMMUNITY_MEMBER,
+              workspaceId,
+            });
+            return { email };
+          } catch (error) {
+            return { email, error: getInviteErrorMessage(error) };
+          }
+        }),
+      );
+
+      const failed = results.filter(result => result.error);
+      const sentCount = results.length - failed.length;
+
+      if (sentCount > 0) {
+        toast.success(
+          sentCount === 1
+            ? `Invitation sent to ${results.find(result => !result.error)?.email}`
+            : `${sentCount} invitations sent`,
+        );
+      }
+
+      if (failed.length > 0) {
+        const firstFailed = failed[0];
+        setEmailsInput(failed.map(result => result.email).join(', '));
+        toast.error(
+          failed.length === 1
+            ? (firstFailed?.error ?? 'Failed to send invitation')
+            : `${failed.length} invitations failed`,
+          {
+            description:
+              failed.length === 1
+                ? firstFailed?.email
+                : failed
+                    .slice(0, 3)
+                    .map(result => `${result.email}: ${result.error}`)
+                    .join('\n'),
+          },
+        );
+        return;
+      }
+
+      setEmailsInput('');
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen) {
+      setCopied(false);
+      setIsInviting(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title='Invite people to Workspace'
+      description='Invite people by email or copy a workspace link.'
+      className='max-w-[460px] rounded-[18px] border border-border/70 bg-background p-0 shadow-2xl'
+      testId='workspace-invite-dialog'
+    >
+      <form onSubmit={event => void handleInvite(event)} className='px-5 pb-5 pt-4'>
+        <div className='mb-7 flex items-start justify-between gap-4'>
+          <h2 className='text-[20px] font-semibold leading-tight tracking-normal text-foreground'>
+            Invite people to Workspace
+          </h2>
+          <button
+            type='button'
+            aria-label='Close invite dialog'
+            onClick={() => handleOpenChange(false)}
+            className='-mr-1 flex size-6 items-center justify-center rounded-md text-[30px] font-light leading-none text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+            data-track-category='WorkspaceInviteDialog'
+            data-track-name='Close'
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className='space-y-3'>
+          <label
+            htmlFor='workspace-invite-emails'
+            className='block text-[15px] font-medium leading-none text-muted-foreground'
+          >
+            Invite via Email
+          </label>
+          <div className='flex flex-col gap-3 sm:flex-row'>
+            <input
+              id='workspace-invite-emails'
+              type='text'
+              value={emailsInput}
+              onChange={event => setEmailsInput(event.target.value)}
+              placeholder='jane@acme.com, jhon@acme.com'
+              disabled={isInviting}
+              className='h-10 min-w-0 flex-1 rounded-[13px] border border-border bg-background px-3.5 text-[15px] font-medium text-foreground shadow-none outline-none transition-colors placeholder:text-muted-foreground/70 focus:border-muted-foreground/60 focus:ring-2 focus:ring-ring/10 disabled:cursor-not-allowed disabled:opacity-60'
+              data-track-category='WorkspaceInviteDialog'
+              data-track-name='EmailsInput'
+            />
+            <button
+              type='submit'
+              disabled={isInviting || !emailsInput.trim()}
+              className='h-10 shrink-0 rounded-[12px] bg-[#ff6368] px-6 text-[15px] font-semibold text-white transition-colors hover:bg-[#f2555b] disabled:cursor-not-allowed disabled:opacity-70'
+              data-track-category='WorkspaceInviteDialog'
+              data-track-name='InviteByEmail'
+            >
+              {isInviting ? 'Inviting...' : 'Invite'}
+            </button>
+          </div>
+        </div>
+
+        <div className='my-5 h-px bg-border' />
+
+        <div className='space-y-3'>
+          <p className='text-[15px] font-medium leading-none text-muted-foreground'>
+            Invite via Link
+          </p>
+          <div className='flex gap-1.5'>
+            <div className='flex h-10 min-w-0 flex-1 items-center rounded-[7px] bg-muted px-3.5 text-[15px] font-semibold text-foreground'>
+              <span className='truncate'>{inviteUrl}</span>
+            </div>
+            <button
+              type='button'
+              aria-label={copied ? 'Workspace link copied' : 'Copy workspace link'}
+              onClick={() => void handleCopyLink()}
+              disabled={!inviteUrl}
+              className={cn(
+                'flex size-10 shrink-0 items-center justify-center rounded-[7px] bg-muted text-foreground transition-colors hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-60',
+                copied && 'text-green-600',
+              )}
+              data-track-category='WorkspaceInviteDialog'
+              data-track-name='CopyInviteLink'
+            >
+              {copied ? <CheckTickSingle size={21} /> : <CopyDefault size={21} />}
+            </button>
+          </div>
+        </div>
+      </form>
+    </Dialog>
+  );
+};
+
+export default WorkspaceInviteDialog;

--- a/apps/dashboard/src/hooks/useAuth.ts
+++ b/apps/dashboard/src/hooks/useAuth.ts
@@ -41,6 +41,7 @@ export interface UseAuthReturn {
     password: string,
     name: string,
     workspaceId?: string,
+    invitationId?: string,
   ) => Promise<{ success: boolean; message?: string; error?: string }>;
   verifyEmailCode: (
     email: string,
@@ -172,12 +173,19 @@ export const useAuth = (): UseAuthReturn => {
       password: string,
       name: string,
       workspaceId?: string,
+      invitationId?: string,
     ): Promise<{ success: boolean; message?: string; error?: string }> => {
       try {
         const hashedPassword = await hashPasswordForAuth(password);
         const response = await apiInstance.post(
           '/v2/auth/email/register',
-          { email, hashedPassword, name, ...(workspaceId ? { workspaceId } : {}) },
+          {
+            email,
+            hashedPassword,
+            name,
+            ...(workspaceId ? { workspaceId } : {}),
+            ...(invitationId ? { invitationId } : {}),
+          },
           { timeout: 30000 },
         );
         const data = response.data as { success: boolean; message?: string };
@@ -217,6 +225,8 @@ export const useAuth = (): UseAuthReturn => {
           pendingUserData?: { email: string; name: string; picture?: string };
           userExistsButRemoved?: boolean;
           autoLoginWorkspace?: string;
+          invitationPending?: boolean;
+          invitationId?: string;
           domainConflictError?: string;
           publicEmailDomainError?: string;
           enterpriseJoinOrgName?: string;
@@ -225,6 +235,16 @@ export const useAuth = (): UseAuthReturn => {
 
         if (!data.success) {
           return { success: false, error: 'Verification failed' };
+        }
+
+        if (data.invitationPending && data.invitationId) {
+          const emailForRedirect = data.pendingUserData?.email ?? email;
+          window.location.replace(
+            `/invite?invitationId=${encodeURIComponent(data.invitationId)}` +
+              `&loginComplete=true` +
+              `&loggedInEmail=${encodeURIComponent(emailForRedirect)}`,
+          );
+          return { success: true, status: data.status ?? 'INVITATION_PENDING' };
         }
 
         // Dispatch to auth machine — same as OAuth callback.

--- a/apps/dashboard/src/routes/AuthScreen/AuthScreen.tsx
+++ b/apps/dashboard/src/routes/AuthScreen/AuthScreen.tsx
@@ -459,6 +459,10 @@ const AuthScreen = (): ReactElement | null => {
       searchParams.get('workspaceId')?.trim() ||
       localStorage.getItem(PENDING_WORKSPACE_ID_KEY)?.trim() ||
       undefined;
+    const pendingInvitationId =
+      localStorage.getItem('pending_invitation_id')?.trim() ||
+      searchParams.get('invitationId')?.trim() ||
+      undefined;
 
     regSubmitLockRef.current = true;
     setRegLoading(true);
@@ -468,6 +472,7 @@ const AuthScreen = (): ReactElement | null => {
         regPassword,
         regName.trim(),
         pendingWorkspaceId,
+        pendingInvitationId,
       );
       if (result.success) {
         setRegMessage(result.message || 'Verification code sent to your email.');


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
