### PR TITLE
feat: XYNE-55833 added support for amazon-sns alert type (#496)

### DIFF
--- a/apps/backend/src/apps/controllers/amazonSnsWebhookParser.ts
+++ b/apps/backend/src/apps/controllers/amazonSnsWebhookParser.ts
@@ -1,0 +1,706 @@
+import type { FlowComponent, FlowDefinition, FlowState } from '@xyne/shared';
+
+/**
+ * Amazon SNS incoming-webhook parser.
+ *
+ * SNS wraps every delivery in an envelope whose `Message` field is itself a
+ * JSON *string*, so the payload has to be parsed twice. The inner shape varies
+ * by publisher (CloudWatch, Prometheus/VictoriaMetrics, RDS event
+ * subscriptions, EventBridge), and is not tagged — we discriminate structurally
+ * in a fixed order, falling back to a generic card so nothing is ever dropped.
+ *
+ * See https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.prepare.html
+ */
+
+export const SNS_MESSAGE_TYPES = [
+  'Notification',
+  'SubscriptionConfirmation',
+  'UnsubscribeConfirmation',
+] as const;
+
+export type SnsMessageType = (typeof SNS_MESSAGE_TYPES)[number];
+
+export interface SnsEnvelope {
+  Type: SnsMessageType;
+  MessageId?: string;
+  TopicArn: string;
+  Subject?: string | null;
+  Message: string;
+  Timestamp?: string;
+  SubscribeURL?: string;
+  Token?: string;
+  SignatureVersion?: string;
+  Signature?: string;
+  SigningCertURL?: string;
+  UnsubscribeURL?: string;
+}
+
+export type SnsAlertSource =
+  | 'cloudwatch'
+  | 'prometheus'
+  | 'rds'
+  | 'eventbridge'
+  | 'generic';
+
+export type SnsSeverity = 'critical' | 'warning' | 'info' | 'ok';
+
+export interface SnsNormalizedPayload {
+  source: SnsAlertSource;
+  title: string;
+  severity: SnsSeverity;
+  status: string;
+  fields: Array<[label: string, value: string]>;
+  description: string | null;
+  consoleUrl: string | null;
+  topicArn: string;
+  region: string | null;
+  accountId: string | null;
+  timestamp: string | null;
+}
+
+/**
+ * actionId on the "Do Confirmation" button. flowController intercepts this
+ * instead of proxying the action to an app backend, because an incoming webhook
+ * has no outbound webhookUrl to proxy to.
+ */
+export const SNS_CONFIRM_ACTION_ID = 'sns_confirm_subscription';
+
+const MAX_FIELDS = 16;
+const MAX_FIELD_VALUE_LENGTH = 400;
+const MAX_DESCRIPTION_LENGTH = 2000;
+
+/**
+ * Labels that add noise rather than signal in a chat card.
+ *
+ * Ported from infra-switch's `BLACKLISTED_VM_LABELS`
+ * (`src/InfraSwitch/Config.hs:274`), including its default list, and overridable
+ * through the environment the same way.
+ */
+const DEFAULT_BLACKLISTED_LABELS =
+  'uuid,node,instance,job,metrics_path,prometheus,prometheus_replica,severity,' +
+  'endpoint,alert_id,alert,alertgroup,alertname,user,older_receiver';
+
+function emptyFlowState(): FlowState {
+  return {
+    values: {},
+    touched: {},
+    errors: {},
+    submitting: false,
+    submitted: false,
+    history: [],
+    loadingComponentIds: [],
+  };
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+/** Coerce an arbitrary JSON value into a single-line display string. */
+function toDisplayValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'N/A';
+  }
+  if (typeof value === 'string') {
+    return truncate(value.trim() || 'N/A', MAX_FIELD_VALUE_LENGTH);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    return truncate(JSON.stringify(value), MAX_FIELD_VALUE_LENGTH);
+  } catch {
+    return 'N/A';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** A value that renders as a readable single line rather than a JSON blob. */
+function isScalar(value: unknown): boolean {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+
+/** Drop empty/placeholder entries and cap the table length. */
+function buildFields(entries: Array<[string, unknown]>): Array<[string, string]> {
+  return entries
+    .map(([label, value]) => [label, toDisplayValue(value)] as [string, string])
+    .filter(([, value]) => value !== 'N/A' && value !== '')
+    .slice(0, MAX_FIELDS);
+}
+
+function blacklistedLabels(): Set<string> {
+  // Deliberately `||`, not `??`: an unset var and the empty value that ships in
+  // .env.example must both fall back to the default rather than disable the list.
+  const raw = process.env.SNS_BLACKLISTED_LABELS?.trim() || DEFAULT_BLACKLISTED_LABELS;
+  return new Set(
+    raw
+      .split(',')
+      .map(label => label.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+/**
+ * Every label that is not blacklisted, keyed uppercase.
+ *
+ * infra-switch renders the label bag as a deny-list rather than an allow-list
+ * (`convertLabelsToSlackBlock`, `src/AlertProxy/Utils/Common.hs:477-482`), so
+ * team-specific labels reach the card instead of being silently dropped.
+ */
+function passthroughLabels(labels: Record<string, unknown>): Array<[string, unknown]> {
+  const blacklist = blacklistedLabels();
+  return Object.entries(labels)
+    .filter(([key]) => !blacklist.has(key.toLowerCase()))
+    .map(([key, value]) => [key.toUpperCase(), value] as [string, unknown]);
+}
+
+/**
+ * Split an SNS topic ARN into its region and account id.
+ * Ported from infra-switch `src/AlertProxy/App/Helper.hs:455-458`.
+ */
+export function parseSnsTopicArn(arn: string): { region: string | null; accountId: string | null } {
+  const parts = (arn ?? '').split(':');
+  if (parts.length >= 6 && parts[0] === 'arn' && parts[2] === 'sns') {
+    return { region: parts[3] || null, accountId: parts[4] || null };
+  }
+  return { region: null, accountId: null };
+}
+
+/** CloudWatch's `Region` field is a display name, so take the code from the ARN. */
+function regionCodeFromArn(arn: string | undefined, fallback: string | null): string | null {
+  const parts = (arn ?? '').split(':');
+  return parts.length >= 4 && parts[0] === 'arn' ? parts[3] || fallback : fallback;
+}
+
+export function parseSnsEnvelope(raw: unknown): SnsEnvelope | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const { Type, Message, TopicArn } = raw as Partial<SnsEnvelope>;
+  if (typeof Type !== 'string' || !SNS_MESSAGE_TYPES.includes(Type as SnsMessageType)) {
+    return null;
+  }
+  if (typeof Message !== 'string' || typeof TopicArn !== 'string') {
+    return null;
+  }
+
+  return raw as unknown as SnsEnvelope;
+}
+
+// ============================================================================
+// INNER MESSAGE PARSERS
+// ============================================================================
+
+function parseCloudWatch(
+  message: Record<string, unknown>,
+  envelope: SnsEnvelope,
+): SnsNormalizedPayload {
+  const { region, accountId } = parseSnsTopicArn(envelope.TopicArn);
+  const alarmName = toDisplayValue(message.AlarmName);
+  const newState = String(message.NewStateValue ?? 'UNKNOWN');
+
+  // ALARM → critical, OK → ok, INSUFFICIENT_DATA → warning.
+  // Mirrors infra-switch `Types/API/UnifiedAlertTrigger.hs:38-41`.
+  const severity: SnsSeverity =
+    newState === 'ALARM' ? 'critical' : newState === 'OK' ? 'ok' : 'warning';
+
+  const trigger = isRecord(message.Trigger) ? message.Trigger : {};
+  const alarmArn = typeof message.AlarmArn === 'string' ? message.AlarmArn : undefined;
+  const regionCode = regionCodeFromArn(alarmArn, region);
+
+  const consoleUrl =
+    regionCode && alarmName !== 'N/A'
+      ? `https://${regionCode}.console.aws.amazon.com/cloudwatch/home?region=${regionCode}#alarmsV2:alarm/${encodeURIComponent(alarmName)}`
+      : null;
+
+  return {
+    source: 'cloudwatch',
+    // Just the alarm name: the state is its own field and the header line
+    // carries the source and account, matching infra-switch's Slack layout.
+    title: alarmName,
+    severity,
+    status: newState,
+    fields: buildFields([
+      ['Alarm State', newState],
+      ['Metric', trigger.MetricName],
+      ['Namespace', trigger.Namespace],
+      ['Threshold', trigger.Threshold],
+      ['AWS Account', message.AWSAccountId],
+      ['Region', message.Region],
+      ['Changed At', message.StateChangeTime],
+    ]),
+    description: truncate(
+      toDisplayValue(message.NewStateReason ?? message.AlarmDescription),
+      MAX_DESCRIPTION_LENGTH,
+    ),
+    consoleUrl,
+    topicArn: envelope.TopicArn,
+    region: regionCode,
+    accountId: toDisplayValue(message.AWSAccountId) !== 'N/A'
+      ? String(message.AWSAccountId)
+      : accountId,
+    timestamp: typeof message.StateChangeTime === 'string' ? message.StateChangeTime : null,
+  };
+}
+
+function parsePrometheus(
+  message: Record<string, unknown>,
+  envelope: SnsEnvelope,
+): SnsNormalizedPayload {
+  const { region, accountId } = parseSnsTopicArn(envelope.TopicArn);
+  const alerts = Array.isArray(message.alerts) ? message.alerts : [];
+  const first = isRecord(alerts[0]) ? alerts[0] : {};
+  const labels = isRecord(first.labels) ? first.labels : {};
+  const annotations = isRecord(first.annotations) ? first.annotations : {};
+
+  const status = String(message.status ?? first.status ?? 'unknown');
+  const labelSeverity = String(labels.severity ?? '').toLowerCase();
+  const severity: SnsSeverity =
+    status === 'resolved'
+      ? 'ok'
+      : labelSeverity === 'critical'
+        ? 'critical'
+        : labelSeverity === 'warning'
+          ? 'warning'
+          : 'info';
+
+  const alertName = toDisplayValue(labels.alertname ?? annotations.summary ?? 'Prometheus alert');
+  const alertCount = alerts.length;
+
+  return {
+    source: 'prometheus',
+    title: alertCount > 1 ? `${alertName} (+${alertCount - 1} more)` : alertName,
+    severity,
+    status,
+    // Curated rows first, then every label the deny-list lets through. The
+    // alert name is already the card heading, and instance/job/alert_id are
+    // blacklisted, so neither is repeated here.
+    fields: buildFields([
+      ['Alarm State', status.toUpperCase()],
+      ['Severity', labels.severity],
+      ['Summary', annotations.summary],
+      ['Firing Since', first.startsAt],
+      ...passthroughLabels(labels),
+    ]),
+    description: truncate(toDisplayValue(annotations.description), MAX_DESCRIPTION_LENGTH),
+    consoleUrl: typeof first.generatorURL === 'string' ? first.generatorURL : null,
+    topicArn: envelope.TopicArn,
+    region,
+    accountId,
+    timestamp: typeof first.startsAt === 'string' ? first.startsAt : null,
+  };
+}
+
+function parseRds(
+  message: Record<string, unknown>,
+  envelope: SnsEnvelope,
+): SnsNormalizedPayload {
+  const { region, accountId } = parseSnsTopicArn(envelope.TopicArn);
+  const sourceId = toDisplayValue(message['Source ID']);
+  const eventMessage = toDisplayValue(message['Event Message']);
+  const identifierLink = message['Identifier Link'];
+
+  return {
+    source: 'rds',
+    title: `RDS — ${sourceId}`,
+    severity: 'info',
+    status: 'info',
+    fields: buildFields([
+      ['Source', message['Source ID']],
+      ['Event Source', message['Event Source']],
+      ['Event ID', message['Event ID']],
+      ['Event Time', message['Event Time']],
+      ['Source ARN', message['Source ARN']],
+    ]),
+    description: truncate(eventMessage, MAX_DESCRIPTION_LENGTH),
+    consoleUrl: typeof identifierLink === 'string' ? identifierLink : null,
+    topicArn: envelope.TopicArn,
+    region,
+    accountId: toDisplayValue(message.accountId) !== 'N/A' ? String(message.accountId) : accountId,
+    timestamp: typeof message['Event Time'] === 'string' ? message['Event Time'] : null,
+  };
+}
+
+function parseEventBridge(
+  message: Record<string, unknown>,
+  envelope: SnsEnvelope,
+): SnsNormalizedPayload {
+  const { region: topicRegion, accountId: topicAccountId } = parseSnsTopicArn(envelope.TopicArn);
+  const detail = isRecord(message.detail) ? message.detail : {};
+  const detailType = toDisplayValue(message['detail-type']);
+  const eventName = toDisplayValue(detail.eventName ?? detailType);
+  const requestParameters = isRecord(detail.requestParameters) ? detail.requestParameters : {};
+
+  return {
+    source: 'eventbridge',
+    title: `${toDisplayValue(message.source)} — ${eventName}`,
+    severity: 'info',
+    status: 'info',
+    fields: buildFields([
+      ['Event', detail.eventName],
+      ['Detail Type', message['detail-type']],
+      ['Event Source', detail.eventSource ?? message.source],
+      ['Region', message.region],
+      ['Account', message.account],
+      ['Replication Group', requestParameters.replicationGroupId],
+      ['Node Group', requestParameters.nodeGroupId],
+      ['Event Time', detail.eventTime ?? message.time],
+    ]),
+    description: null,
+    consoleUrl: null,
+    topicArn: envelope.TopicArn,
+    region: typeof message.region === 'string' ? message.region : topicRegion,
+    accountId: typeof message.account === 'string' ? message.account : topicAccountId,
+    timestamp:
+      typeof message.time === 'string'
+        ? message.time
+        : typeof detail.eventTime === 'string'
+          ? detail.eventTime
+          : null,
+  };
+}
+
+function parseGeneric(
+  message: Record<string, unknown> | null,
+  rawMessage: string,
+  envelope: SnsEnvelope,
+): SnsNormalizedPayload {
+  const { region, accountId } = parseSnsTopicArn(envelope.TopicArn);
+  const subject = typeof envelope.Subject === 'string' ? envelope.Subject.trim() : '';
+
+  // Structured but unrecognised → surface the top-level keys as fields, but only
+  // the scalar ones. Nested objects and arrays (CloudWatch's Trigger, OKActions,
+  // AlarmActions …) stringify into unreadable JSON blobs that swamp the card, so
+  // they are dropped rather than dumped.
+  const fields = message
+    ? buildFields(Object.entries(message).filter(([, value]) => isScalar(value)))
+    : buildFields([['Topic', envelope.TopicArn]]);
+
+  return {
+    source: 'generic',
+    title: subject || 'Amazon SNS notification',
+    severity: 'info',
+    status: 'info',
+    fields,
+    description: message ? null : truncate(rawMessage.trim(), MAX_DESCRIPTION_LENGTH) || null,
+    consoleUrl: null,
+    topicArn: envelope.TopicArn,
+    region,
+    accountId,
+    timestamp: typeof envelope.Timestamp === 'string' ? envelope.Timestamp : null,
+  };
+}
+
+/**
+ * Parse the inner `Message` payload and normalise it.
+ *
+ * Never returns null and never throws — an unrecognised or non-JSON message
+ * degrades to a `generic` card. Discrimination is structural and order matters,
+ * mirroring infra-switch `src/AlertProxy/Types/API/Common.hs:54-66`.
+ */
+export function parseSnsMessage(envelope: SnsEnvelope): SnsNormalizedPayload {
+  let message: Record<string, unknown> | null = null;
+  try {
+    const parsed: unknown = JSON.parse(envelope.Message);
+    message = isRecord(parsed) ? parsed : null;
+  } catch {
+    message = null;
+  }
+
+  if (!message) {
+    return parseGeneric(null, envelope.Message, envelope);
+  }
+
+  if (message.AlarmName !== undefined && message.NewStateValue !== undefined) {
+    return parseCloudWatch(message, envelope);
+  }
+  if (Array.isArray(message.alerts)) {
+    return parsePrometheus(message, envelope);
+  }
+  // RDS event-subscription payloads use keys containing spaces.
+  if (message['Event Source'] !== undefined) {
+    return parseRds(message, envelope);
+  }
+  if (message['detail-type'] !== undefined && message.detail !== undefined) {
+    return parseEventBridge(message, envelope);
+  }
+
+  return parseGeneric(message, envelope.Message, envelope);
+}
+
+// ============================================================================
+// FLOW BUILDERS
+// ============================================================================
+
+function isHttpUrl(value: string | null): value is string {
+  if (!value) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Left-edge stripe colour per severity.
+ *
+ * infra-switch drives this off `SlackAttachment.color`
+ * (`src/AlertProxy/Utils/Common.hs:447-449`): green when the alert state maps to
+ * OK/RESOLVED/UP, red otherwise. The warning and info shades come from Slack's
+ * named palette as resolved in `slackBlockKitToFlowJSON.ts:449-454`, so alerts
+ * arriving straight from SNS match ones relayed through infra-switch.
+ */
+/**
+ * Leading text of the header line, per source. infra-switch renders
+ * `<Source> Alert | <name> | <account>` as a single hyperlink
+ * (`src/AlertProxy/Utils/Common.hs:317`).
+ */
+const SOURCE_HEADER: Record<SnsAlertSource, string> = {
+  cloudwatch: 'Cloudwatch Alarm',
+  prometheus: 'Metrics Alert',
+  rds: 'RDS Event',
+  eventbridge: 'EventBridge Event',
+  generic: 'SNS Notification',
+};
+
+/**
+ * `Cloudwatch Alarm | 5XX Warning | 123456789012::ap-south-1`, the account and
+ * region omitted when the ARN did not carry them.
+ */
+function buildHeaderLabel(payload: SnsNormalizedPayload): string {
+  const account = [payload.accountId, payload.region].filter(Boolean).join('::');
+  return [`🚨 ${SOURCE_HEADER[payload.source]}`, payload.title, account]
+    .filter(Boolean)
+    .join(' | ');
+}
+
+const SEVERITY_STRIPE: Record<SnsSeverity, string> = {
+  critical: '#d91009',
+  warning: '#ECB22E',
+  ok: '#04ba1c',
+  info: '#d1d5db',
+};
+
+/**
+ * Wrap card content in the Slack-style coloured left border.
+ * Mirrors `withColorStripe` (`slackBlockKitToFlowJSON.ts:482-489`).
+ */
+function withColorStripe(id: string, children: FlowComponent[], color: string): FlowComponent {
+  return {
+    id,
+    type: 'column',
+    style: { borderLeft: `4px solid ${color}`, padding: '2px 0 2px 10px' },
+    children,
+  };
+}
+
+/**
+ * Lay fields out as a 2-column grid that wraps onto new rows, the way Slack
+ * renders `section.fields`. Mirrors `fieldsToGrid`
+ * (`slackBlockKitToFlowJSON.ts:497-509`) — a grid rather than our previous
+ * label/value table, so the two render paths agree.
+ */
+function fieldsToGrid(fields: Array<[string, string]>, columns = 2): FlowComponent {
+  const rows: FlowComponent[] = [];
+
+  for (let i = 0; i < fields.length; i += columns) {
+    const cells: FlowComponent[] = fields.slice(i, i + columns).map(([label, value], cell) => ({
+      id: `sns-field-${i + cell}`,
+      type: 'column',
+      children: [
+        { id: `sns-field-${i + cell}-label`, type: 'text', props: { content: label, bold: true } },
+        { id: `sns-field-${i + cell}-value`, type: 'text', props: { content: value } },
+      ],
+    }));
+    rows.push({ id: `sns-field-row-${i / columns}`, type: 'row', children: cells });
+  }
+
+  return rows.length === 1 ? rows[0] : { id: 'sns-fields', type: 'column', children: rows };
+}
+
+export function buildAmazonSnsFlow(payload: SnsNormalizedPayload): FlowDefinition {
+  const headerLabel = buildHeaderLabel(payload);
+
+  // The header doubles as the link to the source, as it does in infra-switch's
+  // Slack card. `link.props.href` is validated with z.string().url(), so fall
+  // back to a plain heading when there is no usable URL.
+  const header: FlowComponent = isHttpUrl(payload.consoleUrl)
+    ? {
+        id: 'sns-header',
+        type: 'link',
+        props: { href: payload.consoleUrl, label: headerLabel, external: true },
+      }
+    : { id: 'sns-header', type: 'heading', props: { content: headerLabel, level: 3 } };
+
+  const children: FlowComponent[] = [header];
+
+  // Description sits directly under the header, above the field grid.
+  if (payload.description) {
+    children.push({
+      id: 'sns-description',
+      type: 'text',
+      props: { content: payload.description, variant: 'muted' },
+    });
+  }
+
+  if (payload.fields.length > 0) {
+    children.push(fieldsToGrid(payload.fields));
+  }
+
+  return {
+    version: '2.0',
+    screenId: `sns-${payload.source}-${Date.now()}`,
+    title: payload.title,
+    components: [
+      {
+        id: 'sns-card',
+        type: 'card',
+        children: [withColorStripe('sns-stripe', children, SEVERITY_STRIPE[payload.severity])],
+      },
+    ],
+    state: emptyFlowState(),
+  };
+}
+
+/**
+ * SNS delivers nothing until the SubscribeURL is visited. We post the link into
+ * the channel and let a human click it rather than issuing the request
+ * server-side, which keeps an attacker-supplied URL from becoming an SSRF
+ * vector. The signature check upstream is what makes the posted link
+ * trustworthy.
+ */
+export function buildSubscriptionConfirmationFlow(envelope: SnsEnvelope): FlowDefinition {
+  const children: FlowComponent[] = [
+    {
+      id: 'sns-confirm-title',
+      type: 'heading',
+      props: { content: 'Amazon SNS subscription pending', level: 3 },
+    },
+    {
+      id: 'sns-confirm-body',
+      type: 'text',
+      props: {
+        // Render what SNS actually sent. Its own wording already tells the reader
+        // to visit the SubscribeURL, which is the link rendered below.
+        content: envelope.Message
+          ? truncate(envelope.Message, MAX_DESCRIPTION_LENGTH)
+          : 'A topic asked to deliver alerts to this channel. Alerts will not arrive until an admin confirms the subscription.',
+      },
+    },
+    fieldsToGrid([['Topic', envelope.TopicArn]]),
+  ];
+
+  if (isHttpUrl(envelope.SubscribeURL ?? null)) {
+    const subscribeUrl = envelope.SubscribeURL;
+
+    // Two buttons side by side: copy is handled entirely in the browser, while
+    // confirm submits SNS_CONFIRM_ACTION_ID, handled in incomingWebhookController.
+    children.push({
+      id: 'sns-confirm-actions',
+      type: 'row',
+      style: { gap: '8px' },
+      children: [
+        {
+          id: 'sns-confirm-submit',
+          type: 'button',
+          props: {
+            label: 'Do Confirmation',
+            variant: 'primary',
+            action: {
+              type: 'submit',
+              actionId: SNS_CONFIRM_ACTION_ID,
+              successMessage: 'Subscription confirmed',
+              errorMessage: 'Could not confirm the subscription',
+            },
+          },
+        },
+        {
+          id: 'sns-confirm-copy',
+          type: 'button',
+          props: {
+            label: 'Copy Subscribe URL',
+            variant: 'secondary',
+            action: {
+              type: 'copy',
+              value: subscribeUrl,
+              successMessage: 'Subscribe URL copied',
+            },
+          },
+        },
+      ],
+    });
+  } else {
+    children.push({
+      id: 'sns-confirm-missing',
+      type: 'text',
+      props: { content: 'No SubscribeURL was present in the request.', variant: 'warning' },
+    });
+  }
+
+  return {
+    version: '2.0',
+    screenId: `sns-subscription-${Date.now()}`,
+    title: 'Amazon SNS subscription pending',
+    // Amber: nothing is broken, but a human has to act before alerts arrive.
+    components: [
+      {
+        id: 'sns-confirm-card',
+        type: 'card',
+        children: [withColorStripe('sns-confirm-stripe', children, SEVERITY_STRIPE.warning)],
+      },
+    ],
+    // The submit action posts state.values back, which is how the SubscribeURL
+    // reaches the confirm handler without a second lookup.
+    state: {
+      ...emptyFlowState(),
+      values: { subscribeUrl: envelope.SubscribeURL ?? '' },
+    },
+  };
+}
+
+export function buildUnsubscribeConfirmationFlow(envelope: SnsEnvelope): FlowDefinition {
+  return {
+    version: '2.0',
+    screenId: `sns-unsubscribe-${Date.now()}`,
+    title: 'Amazon SNS subscription removed',
+    components: [
+      {
+        id: 'sns-unsub-card',
+        type: 'card',
+        children: [
+          withColorStripe(
+            'sns-unsub-stripe',
+            [
+              {
+                id: 'sns-unsub-title',
+                type: 'heading',
+                props: { content: 'Amazon SNS subscription removed', level: 3 },
+              },
+              {
+                id: 'sns-unsub-body',
+                type: 'text',
+                props: {
+                  content: envelope.Message
+                    ? truncate(envelope.Message, MAX_DESCRIPTION_LENGTH)
+                    : 'This channel will no longer receive alerts from the topic below.',
+                  variant: 'warning',
+                },
+              },
+              fieldsToGrid([['Topic', envelope.TopicArn]]),
+            ],
+            SEVERITY_STRIPE.info,
+          ),
+        ],
+      },
+    ],
+    state: emptyFlowState(),
+  };
+}

--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -4,6 +4,8 @@ import { repositories } from '@/database/repositories';
 import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
 import { signWebhookPayload } from '@/apps/core/eventSubscriptionUtils';
 import { decrypt } from '@/services/encryptionService';
+import { SNS_CONFIRM_ACTION_ID } from './amazonSnsWebhookParser';
+import { incomingWebhookController } from './incomingWebhookController';
 import {
   validateActionRequest,
   validateFlowDefinition,
@@ -48,6 +50,13 @@ export class FlowController {
         error: 'Invalid flowJSON in context',
         details: formatValidationErrors(flowResult),
       });
+      return;
+    }
+
+    // 2b. Amazon SNS confirmation is owned by the incoming-webhook controller,
+    // not proxied: an incoming webhook has no outbound webhookUrl to proxy to.
+    if (actionId === SNS_CONFIRM_ACTION_ID) {
+      res.status(200).json(await incomingWebhookController.confirmSnsSubscription(values));
       return;
     }
 

--- a/apps/backend/src/apps/controllers/incomingWebhookController.ts
+++ b/apps/backend/src/apps/controllers/incomingWebhookController.ts
@@ -22,6 +22,15 @@ import {
   formatSentinelOneTicketText,
   parseExactSentinelPayload,
 } from './sentinelWebhookParser';
+import {
+  buildAmazonSnsFlow,
+  buildSubscriptionConfirmationFlow,
+  buildUnsubscribeConfirmationFlow,
+  parseSnsEnvelope,
+  parseSnsMessage,
+} from './amazonSnsWebhookParser';
+import { validateFlowDefinition } from '@xyne/shared';
+import type { FlowDefinition } from '@xyne/shared';
 
 const WEBHOOK_NAME_MAX_LENGTH = 84;
 type IncomingWebhookType = AppIncomingWebhookType;
@@ -109,6 +118,9 @@ class IncomingWebhookController {
     if (type === AppIncomingWebhookType.SENTINELONE) {
       return `/api/apps/webhooks/sentinel/${safeWorkspaceId}/${installedAppId}/${secret}`;
     }
+    if (type === AppIncomingWebhookType.AMAZON_SNS) {
+      return `/api/apps/webhooks/sns/${safeWorkspaceId}/${installedAppId}/${secret}`;
+    }
 
     return `/api/apps/webhooks/${safeWorkspaceId}/${installedAppId}/${secret}`;
   };
@@ -123,6 +135,21 @@ class IncomingWebhookController {
         return JSON.parse(req.body.toString('utf8'));
       } catch (error) {
         logger.warn('[Incoming-Webhook] Failed to parse buffered webhook body', {
+          workspaceId,
+          appId,
+          error,
+        });
+        return null;
+      }
+    }
+
+    // Amazon SNS posts JSON under `Content-Type: text/plain`, so its route parses
+    // the body with express.text() and hands us a raw string.
+    if (typeof req.body === 'string') {
+      try {
+        return JSON.parse(req.body);
+      } catch (error) {
+        logger.warn('[Incoming-Webhook] Failed to parse text webhook body', {
           workspaceId,
           appId,
           error,
@@ -384,6 +411,100 @@ class IncomingWebhookController {
     }
   };
 
+  /**
+   * Serialize a flow into the message-content form the dashboard renders.
+   * Mirrors the encoding used by chatController for app-authored flow messages.
+   */
+  private encodeFlowContent(flow: FlowDefinition): string | null {
+    const result = validateFlowDefinition(flow);
+    if (!result.success) {
+      logger.warn('[Incoming-Webhook] Built an invalid flow definition', {
+        issues: result.error.issues,
+      });
+      return null;
+    }
+
+    const escapedJSON = JSON.stringify(result.data).replace(/"/g, '&quot;');
+    return `<div data-flow-json="${escapedJSON}">Flow JSON</div>`;
+  }
+
+  handleAmazonSnsIncoming = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const context = await this.resolveWebhookContext(req, AppIncomingWebhookType.AMAZON_SNS);
+      if (!context) {
+        res.status(400).send('invalid_payload');
+        return;
+      }
+
+      const envelope = parseSnsEnvelope(context.body);
+      if (!envelope) {
+        logger.warn('[Incoming-Webhook] Body is not an Amazon SNS envelope', {
+          workspaceId: context.workspaceId,
+          appId: context.appId,
+        });
+        res.status(400).send('invalid_payload');
+        return;
+      }
+
+      // No signature check: the encrypted secret in the URL is the only
+      // credential here, as it is for the Slack and SentinelOne webhook types.
+
+      // Unauthenticated webhook: no req.user, so open an explicit tenant scope from the
+      // validated :workspaceId URL param so the workspaceId stamper fills downstream writes.
+      await runAsServiceActor('incoming-webhook', context.workspaceId,
+        async () => {
+          let flow: FlowDefinition;
+          switch (envelope.Type) {
+            case 'SubscriptionConfirmation':
+              // SNS delivers nothing until SubscribeURL is visited. Post the link
+              // and let an admin click it rather than fetching it server-side.
+              logger.info('[Incoming-Webhook] SNS subscription confirmation received', {
+                workspaceId: context.workspaceId,
+                topicArn: envelope.TopicArn,
+              });
+              flow = buildSubscriptionConfirmationFlow(envelope);
+              break;
+            case 'UnsubscribeConfirmation':
+              logger.info('[Incoming-Webhook] SNS unsubscribe confirmation received', {
+                workspaceId: context.workspaceId,
+                topicArn: envelope.TopicArn,
+              });
+              flow = buildUnsubscribeConfirmationFlow(envelope);
+              break;
+            default:
+              flow = buildAmazonSnsFlow(parseSnsMessage(envelope));
+              break;
+          }
+
+          const content = this.encodeFlowContent(flow);
+          if (!content) {
+            res.status(400).send('invalid_payload');
+            return;
+          }
+
+          await findOrCreateConversation(
+            context.channelId,
+            context.installedApp.userId,
+            content,
+            false,
+            undefined,
+            undefined,
+            MessageType.BOT,
+            {},
+          );
+
+          res.status(200).send('ok');
+        },
+      );
+    } catch (error) {
+      logger.error('[Incoming-Webhook] Error handling Amazon SNS webhook', {
+        params: req.params,
+        error,
+      });
+      res.status(500).send('rollup_error');
+    }
+  };
+
   createWebhook = async (req: Request, res: Response): Promise<void> => {
     try {
       const bodyResult = CreateWebhookBodySchema.safeParse(req.body);
@@ -445,8 +566,12 @@ class IncomingWebhookController {
         return;
       }
 
+      // Only SentinelOne supports ticket creation today; the other sources always
+      // post a message.
       const normalizedAction: IncomingWebhookAction =
-        type === AppIncomingWebhookType.SLACK ? AppIncomingWebhookAction.MESSAGE : action;
+        type === AppIncomingWebhookType.SLACK || type === AppIncomingWebhookType.AMAZON_SNS
+          ? AppIncomingWebhookAction.MESSAGE
+          : action;
       const effectiveBoardId =
         normalizedAction === AppIncomingWebhookAction.TICKET ? boardId : undefined;
 
@@ -735,6 +860,51 @@ class IncomingWebhookController {
       });
       res.status(500).json({ error: 'Internal server error' });
     }
+  };
+
+  /**
+   * Complete the SNS handshake for the "Do Confirmation" button.
+   *
+   * The submit lands on /api/apps/flow/action, which flowController routes here
+   * rather than proxying — an incoming webhook has no outbound webhookUrl to
+   * proxy to. The card is left as-is; the renderer toasts on success.
+   *
+   * Always returns `ack`, so a failure never raises an error toast. Only a 200
+   * carries a `message`, and only a message produces a toast — the reason for a
+   * failure is logged rather than shown.
+   */
+  confirmSnsSubscription = async (
+    values: Record<string, unknown>,
+  ): Promise<{ type: 'ack'; message?: string }> => {
+    const subscribeUrl = values['subscribeUrl'];
+
+    if (typeof subscribeUrl !== 'string' || !subscribeUrl) {
+      logger.warn('[Incoming-Webhook] SNS confirm called without a SubscribeURL');
+      return { type: 'ack' };
+    }
+
+    try {
+      const response = await fetch(subscribeUrl, {
+        method: 'GET',
+        // A redirect would take this somewhere we never intended, so treat one
+        // as a failure rather than following it.
+        redirect: 'manual',
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (response.status === 200) {
+        logger.info('[Incoming-Webhook] SNS subscription confirmed');
+        return { type: 'ack', message: 'Confirmation done' };
+      }
+
+      // 400 usually means the token expired (they last 3 days) or the
+      // subscription was already confirmed.
+      logger.warn('[Incoming-Webhook] SNS confirmation rejected', { status: response.status });
+    } catch (error) {
+      logger.error('[Incoming-Webhook] SNS confirmation request failed', { error });
+    }
+
+    return { type: 'ack' };
   };
 }
 

--- a/apps/backend/src/apps/routes/apps.ts
+++ b/apps/backend/src/apps/routes/apps.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import express, { Router } from 'express';
 import { AccessType } from '@xyne/shared';
 import { AppController } from '../controllers/appController';
 import { incomingWebhookController } from '../controllers/incomingWebhookController';
@@ -32,7 +32,13 @@ const platformRegistry = new PlatformAdapterRegistry();
 
 platformRegistry.register(new SlackAdapter());
 
+// Type-prefixed webhook routes must stay ABOVE the 3-segment catch-all below,
+// otherwise the prefix is captured as :workspaceId.
 router.post('/webhooks/sentinel/:workspaceId/:appId/:secret', webhookLimiter, incomingWebhookController.handleSentinelIncoming);
+// Amazon SNS posts JSON with `Content-Type: text/plain`, which the global
+// express.json() ignores — parse the body as text here and JSON.parse it in the
+// controller.
+router.post('/webhooks/sns/:workspaceId/:appId/:secret', express.text({ type: '*/*', limit: '1mb' }), webhookLimiter, incomingWebhookController.handleAmazonSnsIncoming);
 router.post('/webhooks/:workspaceId/:appId/:secret', webhookLimiter, incomingWebhookController.handleIncoming);
 const commandController = new CommandController();
 

--- a/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
@@ -161,6 +161,19 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
         setState(prev => ({ ...prev, values: { ...prev.values, ...action.stateUpdates } }));
         return;
       }
+      if (action.type === 'copy') {
+        const { value, successMessage } = action as { value: string; successMessage?: string };
+        try {
+          // navigator.clipboard is undefined outside a secure context (plain http
+          // on a non-localhost host), so report failure rather than throwing.
+          await navigator.clipboard.writeText(value);
+          toast.success(successMessage ?? 'Copied to clipboard');
+        } catch (error) {
+          console.error('[FlowRenderer] clipboard write failed:', error);
+          toast.error('Could not copy — select the URL in the message instead.');
+        }
+        return;
+      }
       if (action.type === 'close_screen' || action.type === 'navigate') {
         const closeAction = action as { type: string; finalMessage?: string };
         const closeResponse: AppActionResponse = closeAction.finalMessage

--- a/apps/dashboard/src/components/flowUI/FlowScreenManager.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowScreenManager.tsx
@@ -103,6 +103,9 @@ export const FlowScreenManager: React.FC<FlowScreenManagerProps> = ({
         }
 
         case 'ack':
+          // `ack` carries an optional message; only show a toast when one is set,
+          // so a handler can acknowledge silently.
+          if (response.message) toast.success(response.message);
           break;
 
         case 'error':

--- a/apps/dashboard/src/services/Apps/appsService.ts
+++ b/apps/dashboard/src/services/Apps/appsService.ts
@@ -47,7 +47,7 @@ export interface IncomingWebhook {
   channelVisibility: string;
   boardId?: string | null;
   boardName?: string | null;
-  type: 'SLACK' | 'SENTINELONE';
+  type: 'SLACK' | 'SENTINELONE' | 'AMAZON_SNS';
   action: AppIncomingWebhookAction;
   isActive: boolean;
   createdAt: string;
@@ -59,7 +59,7 @@ export interface CreateIncomingWebhookRequest {
   channelId: string;
   boardId?: string;
   name: string;
-  type: 'SLACK' | 'SENTINELONE';
+  type: 'SLACK' | 'SENTINELONE' | 'AMAZON_SNS';
   action?: AppIncomingWebhookAction;
 }
 

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -69,7 +69,8 @@ export type FlowAction =
   | { type: 'inputChange'; actionId: string; debounceMs?: number }
   | { type: 'update_state'; stateUpdates: Record<string, unknown>; successMessage?: string }
   | { type: 'close_screen'; finalMessage?: string }
-  | { type: 'navigate'; target: string };
+  | { type: 'navigate'; target: string }
+  | { type: 'copy'; value: string; successMessage?: string };
 
 // ============================================================================
 // VALIDATION RULES

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -51,6 +51,12 @@ export const flowActionSchema = z.discriminatedUnion('type', [
     type: z.literal('navigate'),
     target: z.string(),
   }),
+  // Client-only: writes `value` to the clipboard. No network call, no app backend.
+  z.object({
+    type: z.literal('copy'),
+    value: z.string(),
+    successMessage: z.string().optional(),
+  }),
 ]);
 
 // ============================================================================

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -464,6 +464,7 @@ export enum UserType {
 export enum AppIncomingWebhookType {
   SLACK = 'SLACK',
   SENTINELONE = 'SENTINELONE',
+  AMAZON_SNS = 'AMAZON_SNS',
 }
 
 // @ts-ignore TS1294


### PR DESCRIPTION
* feat: XYNE-55833 added support for amazon-sns alert type

Migration-Changes:
  - added new alert type

Services-Requiring-Redeployment:
  - backend
  - dashboard

* feat: XYNE-55833 added support for amazon-sns alert type

Migration-Changes:
  - removed the migration

Services-Requiring-Redeployment:
  - backend
  - dashboard

* feat: XYNE-55833 added support for amazon-sns alert type

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
