### PR TITLE
feat: Add Clear All button to call participants selection modal

### DIFF
--- a/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
+++ b/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
@@ -226,7 +226,29 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
         </div>
         <div className='p-5 space-y-5'>
           <div className='space-y-2'>
-            <p className='text-[#788187] text-[13px] leading-5'>Add Participants</p>
+            <div className='flex items-center justify-between'>
+              <p className='text-[#788187] text-[13px] leading-5'>Add Participants</p>
+              {selectedUsers.length > 0 && (
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  className='h-auto p-0 text-[13px] text-muted-foreground hover:text-foreground'
+                  onClick={() => {
+                    hasUserModifiedRef.current = true;
+                    setSelectedParticipants([]);
+                  }}
+                  data-track-category='CALL_PARTICIPANTS_SELECTION_MODAL'
+                  data-track-name='ClearAllCallParticipants'
+                  data-track-metadata={JSON.stringify({
+                    count: selectedUsers.length,
+                    channelId,
+                    conversationId,
+                  })}
+                >
+                  Clear All
+                </Button>
+              )}
+            </div>
             {/* Selected participants list - horizontal with wrap */}
             {selectedUsers.length > 0 && (
               <div className='flex flex-wrap gap-2 mb-3'>


### PR DESCRIPTION
## Summary
When participants are selected in the Instant Call modal, a "Clear All" ghost button now appears next to the "Add Participants" label, allowing users to remove all selected participants in one click instead of removing them individually.

## Changes
- Added a "Clear All" button to the `CallParticipantsSelectionModal` header area, visible only when participants are selected
- Button clears `selectedParticipants` state and sets `hasUserModifiedRef` to prevent pre-population from re-filling
- Fires analytics event `ClearAllCallParticipants` with participant count, channelId, and conversationId metadata
- Styled as a ghost button matching existing design language

## File Changed
- `apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx`

## Testing
- TypeScript compilation verified (no errors on the file)
- Manual visual verification pending — sandbox environment had connectivity issues preventing live UI testing; reviewers can verify locally