### PR TITLE
fix: stop Gmail watches before source deactivation

### DIFF
--- a/apps/backend/src/integrations/routes/desk-integration.ts
+++ b/apps/backend/src/integrations/routes/desk-integration.ts
@@ -26,8 +26,8 @@ import { db } from '@/database/client';
 import { decrypt } from '@/services/encryptionService';
 import { logger } from '@/utils/logger';
 import { microsoftDeskService } from '@/services/microsoftDeskService';
-import { GoogleService } from '@/services/googleService';
 import { ExternalSourcePlatform } from '../core/types';
+import { stopGmailWatchBeforeDeactivation } from '@/services/gmailWatchStopService';
 import { extractEmailAddress } from '@/utils/email';
 // Reuse the OAuth primitives from the route files that own them — keeps
 // connect and reconnect on the exact same scopes, OAuth client config, and
@@ -85,7 +85,7 @@ async function findActiveSourceForChannel(
   channelId: string,
 ): Promise<{ id: string; sourceType: string; displayName: string; credentials: string } | null> {
   return db.externalSource.findFirst({
-    where: { channelId, isActive: true },
+    where: { channelId, isActive: true, NOT: { name: { startsWith: 'google-dl-sync' } } },
     select: { id: true, sourceType: true, displayName: true, credentials: true },
     orderBy: { createdAt: 'desc' },
   });
@@ -161,21 +161,8 @@ router.post(
         return;
       }
 
-      // Best-effort: stop Gmail publishing this mailbox's events to the topic.
-      // Must run BEFORE the OAuth revoke below, since stop() needs a valid
-      // OAuth token. A failure here just means the watch will time out
-      // naturally within 7 days — disconnect continues either way.
-      if (source.sourceType === ExternalSourcePlatform.GOOGLE && source.credentials) {
-        try {
-          const svc = GoogleService.fromEncryptedCredentials(source.credentials, source.id);
-          await svc.stopGmailWatch();
-        } catch (err) {
-          logger.warn(`${TAG} Best-effort Gmail watch stop failed`, {
-            sourceId: source.id,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
+      // Must run BEFORE the OAuth revoke below, since stop() needs a valid token.
+      await stopGmailWatchBeforeDeactivation(source, TAG);
 
       // Best-effort token revocation at the provider. Don't let a revoke
       // failure block the local disconnect — the source is being marked

--- a/apps/backend/src/integrations/routes/workspace-desk.ts
+++ b/apps/backend/src/integrations/routes/workspace-desk.ts
@@ -21,6 +21,7 @@ import { db } from '@/database/client';
 import { decrypt } from '@/services/encryptionService';
 import { ChannelEmailAliasService } from '@/services/channelEmailAliasService';
 import { logger } from '@/utils/logger';
+import { stopGmailWatchBeforeDeactivation } from '@/services/gmailWatchStopService';
 
 const TAG = '[WorkspaceDesk]';
 const router = express.Router();
@@ -102,6 +103,9 @@ router.post(
         res.status(404).json({ error: 'No shared mailbox configured for this workspace' });
         return;
       }
+
+      // Must run BEFORE the OAuth revoke below, since stop() needs a valid token.
+      await stopGmailWatchBeforeDeactivation(source, TAG);
 
       // Best-effort token revocation at the provider.
       try {

--- a/apps/backend/src/services/gmailWatchStopService.ts
+++ b/apps/backend/src/services/gmailWatchStopService.ts
@@ -1,0 +1,39 @@
+import { GoogleService } from '@/services/googleService';
+import { logger } from '@/utils/logger';
+import { ExternalSourcePlatform } from '@/integrations/core/types';
+
+export type GmailWatchSource = {
+  id: string;
+  sourceType: string;
+  credentials: unknown;
+};
+
+/**
+ * Best-effort stop for Gmail Pub/Sub watches before a Google mailbox source is
+ * deactivated or credentials are cleared. Reconnect/setup paths call
+ * users.watch() again, so all reconnect-required deactivation paths should first
+ * ask Gmail to stop publishing this mailbox's events to the shared topic.
+ */
+export async function stopGmailWatchBeforeDeactivation(
+  source: GmailWatchSource | null | undefined,
+  tag: string,
+): Promise<void> {
+  if (
+    !source
+    || source.sourceType !== ExternalSourcePlatform.GOOGLE
+    || typeof source.credentials !== 'string'
+    || !source.credentials
+  ) {
+    return;
+  }
+
+  try {
+    const svc = GoogleService.fromEncryptedCredentials(source.credentials, source.id);
+    await svc.stopGmailWatch();
+  } catch (err) {
+    logger.warn(`${tag} Best-effort Gmail watch stop failed`, {
+      sourceId: source.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared best-effort Gmail watch stop helper for Google desk mailbox sources
- call it before credentials are cleared/revoked in per-channel desk disconnect and workspace shared-mailbox disconnect
- make per-channel desk disconnect ignore temporary `google-dl-sync...` sources when selecting the active source, so DL member sync rows cannot be disconnected/revoked instead of the real desk source

## Validation
- `git diff --check` passed
- targeted ESLint passed for touched backend files
- full backend `pnpm typecheck` was attempted earlier and fails on pre-existing unrelated shared-contract errors; no errors referenced touched files

## Notes
- temporary DL member sync sources do not register Gmail watches, so this PR intentionally does not call `gmail.users.stop()` from DL-sync cleanup
- Gmail renewal permanent-auth-error deactivation also intentionally does not call `gmail.users.stop()` because credentials are already invalid and the stop would only add failing Google API round trips/warnings
- reconnect/setup paths call `users.watch()` again, so stopping the watch during explicit desk disconnect remains safe and prevents disconnected mailbox Pub/Sub pushes from lingering until natural Gmail watch expiry.