### PR TITLE
Fix/header layout shift

### DIFF
--- a/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
+++ b/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
@@ -37,14 +37,18 @@ const AppNavigator = (): ReactElement => {
   };
 
   return (
-    <div className='h-full w-full flex items-center justify-end gap-2 px-4' style={APP_DRAG_STYLE}>
+    <div
+      className='h-full w-full flex items-center justify-between gap-2 px-4'
+      style={APP_DRAG_STYLE}
+    >
       <div className='flex items-center' style={APP_NO_DRAG_STYLE}>
         {workspaceId && (
           <button
             type='button'
             aria-label='Share workspace link'
             onClick={() => void handleShareWorkspace()}
-            className={buttonClass}
+            // Temporarily hidden — drop the `hidden` class to bring it back.
+            className={cn(buttonClass, 'hidden')}
             data-track-category='APP_NAVIGATOR'
             data-track-name='SHARE_WORKSPACE'
           >
@@ -71,6 +75,8 @@ const AppNavigator = (): ReactElement => {
         >
           <ArrowRight size={16} />
         </button>
+      </div>
+      <div className='flex items-center' style={APP_NO_DRAG_STYLE}>
         <button
           type='button'
           aria-label='Search'

--- a/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
@@ -285,7 +285,7 @@ const ConversationHeader = ({
                 setInfoDefaultTab('about');
                 setIsInfoOpen(true);
               }}
-              className='text-base font-semibold tracking-[-0.32px] flex items-center gap-2 min-w-0 px-1.5 py-0.5 rounded-md hover:bg-muted transition-colors duration-100'
+              className='text-base font-semibold tracking-[-0.32px] flex items-center gap-2 min-w-0 h-7 px-1.5 rounded-md hover:bg-muted transition-colors duration-100'
               style={APP_NO_DRAG_STYLE}
               data-testid='channel-info-trigger'
               data-track-category='CHANNELS'
@@ -295,9 +295,7 @@ const ConversationHeader = ({
               <span className='shrink-0 inline-flex items-center leading-none'>
                 <ChannelIcon channel={channel} />
               </span>
-              <span className={cn('visual-regression-hide truncate', isChannelDM && 'pt-1')}>
-                {displayName}
-              </span>
+              <span className='visual-regression-hide truncate'>{displayName}</span>
               {isDM && (
                 <StatusIndicator
                   statusEmoji={dmUser?.statusEmoji}

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
@@ -878,11 +878,13 @@ const CallHistoryScreen = (): ReactElement => {
           pins it to the top-left instead while contributing no layout height, so
           the list still starts where it did. z-[60] clears the sticky header's
           z-50 for the widths where the centred column reaches the left edge. */}
-      <div className='sticky left-0 top-0 z-[60] h-0 w-fit'>
-        <div className='h-[52px] w-fit'>
-          <AppNavigator />
+      {!isMobile && (
+        <div className='sticky left-0 top-0 z-[60] hidden h-0 w-fit md:block'>
+          <div className='h-[52px] w-fit'>
+            <AppNavigator />
+          </div>
         </div>
-      </div>
+      )}
       <div
         className={cn(
           'w-full flex flex-col items-center px-4',

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
@@ -31,6 +31,7 @@ import {
 } from '@xyne/shared';
 import { logger, Event } from '../../utils/logger';
 import { dataLoadDuration, safeRecordMetric } from '../../services/otel';
+import AppNavigator from '../../components/AppNavigator/AppNavigator';
 import { CallConfirmationModal } from '../../components/Call/CallConfirmationModal';
 import { DeleteCallModal } from '../../components/Call/DeleteCallModal';
 import { InstantCallModal } from '../../components/Call/InstantCallModal/InstantCallModal';
@@ -872,6 +873,16 @@ const CallHistoryScreen = (): ReactElement => {
         viewMode === 'calendar' ? 'overflow-hidden' : 'overflow-y-auto',
       )}
     >
+      {/* This root is itself the scroll container, so an absolutely positioned
+          navigator would scroll away with the list. A zero-height sticky wrapper
+          pins it to the top-left instead while contributing no layout height, so
+          the list still starts where it did. z-[60] clears the sticky header's
+          z-50 for the widths where the centred column reaches the left edge. */}
+      <div className='sticky left-0 top-0 z-[60] h-0 w-fit'>
+        <div className='h-[52px] w-fit'>
+          <AppNavigator />
+        </div>
+      </div>
       <div
         className={cn(
           'w-full flex flex-col items-center px-4',

--- a/apps/dashboard/src/routes/RecordingDetailScreen/RecordingDetailScreen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailScreen/RecordingDetailScreen.tsx
@@ -5,6 +5,8 @@
 import { ReactElement, useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import axios from 'axios';
+import AppNavigator from '../../components/AppNavigator/AppNavigator';
+import { usePlatform } from '../../hooks/usePlatform';
 import { recordingService, RecordingDetail } from '../../services/Recording/recordingService';
 import { useShortcut } from '../../shortcuts';
 import {
@@ -112,6 +114,7 @@ function RecordingNotesSection({ notesCanvasId }: { notesCanvasId: string }): Re
 }
 
 export default function RecordingDetailScreen(): ReactElement {
+  const { isMobile } = usePlatform();
   const { recordingId } = useParams<{ recordingId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
@@ -311,6 +314,15 @@ export default function RecordingDetailScreen(): ReactElement {
 
   return (
     <div className='h-full overflow-auto bg-muted'>
+      {/* This root is itself the scroll container, so a zero-height sticky wrapper
+          pins the navigator without contributing layout height. */}
+      {!isMobile && (
+        <div className='sticky left-0 top-0 z-30 hidden h-0 w-fit md:block'>
+          <div className='h-[52px] w-fit'>
+            <AppNavigator />
+          </div>
+        </div>
+      )}
       <div className='max-w-4xl mx-auto p-6'>
         {/* Header */}
         <div className='mb-6'>

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -27,6 +27,8 @@ import {
   isSummaryRequested,
   markSummaryRequested,
 } from '../../utils/recordingSummaryRequest';
+import AppNavigator from '../../components/AppNavigator/AppNavigator';
+import { usePlatform } from '../../hooks/usePlatform';
 import { useSpeakerIdentificationEnabled } from '../../components/SpeakerIdentification/useSpeakerIdentificationEnabled';
 import {
   Spinner,
@@ -120,6 +122,7 @@ function isSameRecordingSnapshot(a: RecordingDetail, b: RecordingDetail): boolea
 }
 
 export default function RecordingDetailV2Screen(): ReactElement {
+  const { isMobile } = usePlatform();
   const { recordingId } = useParams<{ recordingId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
@@ -768,6 +771,13 @@ export default function RecordingDetailV2Screen(): ReactElement {
       data-testid='recording-detail-v2-page'
       className='relative flex h-full w-full flex-col overflow-hidden bg-background shadow-md md:rounded-2xl'
     >
+      {/* Outside the scroller below, so it stays pinned. z-30 clears the sticky
+          header's z-20 at widths where the centred column reaches the left edge. */}
+      {!isMobile && (
+        <div className='absolute left-0 top-0 z-30 hidden h-[52px] w-fit md:block'>
+          <AppNavigator />
+        </div>
+      )}
       {/* layoutScroll: the tab indicator animates inside this scroller, so Motion has
           to account for its scroll offset when measuring positions. */}
       <motion.div

--- a/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
 import { v4 as uuidv4 } from 'uuid';
 import AppNavigator from '../../components/AppNavigator/AppNavigator';
+import { usePlatform } from '../../hooks/usePlatform';
 import { ResizableGroup, Panel, Separator } from '../../components/ui/Resizable/Resizable';
 import { recordingService } from '../../services/Recording/recordingService';
 import { canvasService } from '../../services/Canvas/canvasService';
@@ -123,6 +124,7 @@ const CanvasCreationFallback = ({
 const MAX_ASK_AI_SELECTION = 5;
 
 export default function RecordingsScreen(): ReactElement {
+  const { isMobile } = usePlatform();
   const [error, setError] = useState<string | null>(null);
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const [showTitleModal, setShowTitleModal] = useState(false);
@@ -510,9 +512,11 @@ export default function RecordingsScreen(): ReactElement {
       {/* Floated rather than in-flow so the list keeps the full viewport height.
           `w-fit` gives the shrink-to-fit box a definite width for the navigator's
           own `w-full`. */}
-      <div className='absolute left-0 top-0 z-30 h-[52px] w-fit'>
-        <AppNavigator />
-      </div>
+      {!isMobile && (
+        <div className='absolute left-0 top-0 z-30 hidden h-[52px] w-fit md:block'>
+          <AppNavigator />
+        </div>
+      )}
       {/* ─── Main Area (list + workspace overlay) ───── */}
       <div className='flex-1 relative overflow-hidden'>
         {/* List View — always rendered, stays behind the workspace overlay */}

--- a/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
@@ -11,6 +11,7 @@ import { ReactElement, useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
 import { v4 as uuidv4 } from 'uuid';
+import AppNavigator from '../../components/AppNavigator/AppNavigator';
 import { ResizableGroup, Panel, Separator } from '../../components/ui/Resizable/Resizable';
 import { recordingService } from '../../services/Recording/recordingService';
 import { canvasService } from '../../services/Canvas/canvasService';
@@ -506,6 +507,12 @@ export default function RecordingsScreen(): ReactElement {
       data-testid='recordings-page'
       className='flex flex-col h-full relative bg-background md:rounded-2xl overflow-hidden shadow-md'
     >
+      {/* Floated rather than in-flow so the list keeps the full viewport height.
+          `w-fit` gives the shrink-to-fit box a definite width for the navigator's
+          own `w-full`. */}
+      <div className='absolute left-0 top-0 z-30 h-[52px] w-fit'>
+        <AppNavigator />
+      </div>
       {/* ─── Main Area (list + workspace overlay) ───── */}
       <div className='flex-1 relative overflow-hidden'>
         {/* List View — always rendered, stays behind the workspace overlay */}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -13,6 +13,7 @@ import {
   usePaginatedOatsRecordings,
   type OatsRecordingEntry,
 } from '../../hooks/usePaginatedOatsRecordings';
+import { usePlatform } from '../../hooks/usePlatform';
 import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
 import { useSelf, useUsers } from '../../hooks/useUsers';
@@ -47,6 +48,7 @@ import { SummaryTemplatesModal } from '../RecordingDetailV2Screen/components/Sum
 import { useSummaryTemplates } from '../../hooks/useSummaryTemplates';
 
 const RecordingsV2Screen = (): ReactElement => {
+  const { isMobile } = usePlatform();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const shouldReduceMotion = useReducedMotion();
@@ -284,9 +286,11 @@ const RecordingsV2Screen = (): ReactElement => {
           `w-fit` gives the shrink-to-fit box a definite width for the navigator's
           own `w-full`; z-30 keeps it above the sticky header (z-20), which
           otherwise covers it once the centred column reaches the left edge. */}
-      <div className='absolute left-0 top-0 z-30 h-[52px] w-fit'>
-        <AppNavigator />
-      </div>
+      {!isMobile && (
+        <div className='absolute left-0 top-0 z-30 hidden h-[52px] w-fit md:block'>
+          <AppNavigator />
+        </div>
+      )}
       <div ref={setScrollContainer} className='h-full w-full overflow-y-scroll'>
         <div className='flex min-h-full w-full flex-col items-center px-4'>
           <header className='max-w-[860px] w-full sticky top-0 bg-background z-20 pt-6 pb-6 sm:pb-3'>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -5,6 +5,7 @@ import { Spinner } from '@xyne/icons';
 import { CallStatus } from '@xyne/shared';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { PanelsTopLeft } from 'lucide-react';
+import AppNavigator from '../../components/AppNavigator/AppNavigator';
 import { XyneAIStar } from '../../components/icons/xyne-ai';
 import { Button } from '../../components/ui/Button/Button';
 import { Dialog } from '../../components/ui/Dialog';
@@ -279,6 +280,13 @@ const RecordingsV2Screen = (): ReactElement => {
       className='relative flex h-full w-full flex-col overflow-hidden bg-background shadow-md md:rounded-2xl'
       aria-labelledby='xyne-scribe-heading'
     >
+      {/* Floated rather than in-flow so the list keeps the full viewport height.
+          `w-fit` gives the shrink-to-fit box a definite width for the navigator's
+          own `w-full`; z-30 keeps it above the sticky header (z-20), which
+          otherwise covers it once the centred column reaches the left edge. */}
+      <div className='absolute left-0 top-0 z-30 h-[52px] w-fit'>
+        <AppNavigator />
+      </div>
       <div ref={setScrollContainer} className='h-full w-full overflow-y-scroll'>
         <div className='flex min-h-full w-full flex-col items-center px-4'>
           <header className='max-w-[860px] w-full sticky top-0 bg-background z-20 pt-6 pb-6 sm:pb-3'>


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
