### PR TITLE
fix: XYNE-17198 entity extraction

### DIFF
--- a/apps/backend/src/vespa/src/services/crudService.ts
+++ b/apps/backend/src/vespa/src/services/crudService.ts
@@ -1,10 +1,32 @@
 import { type ILogger, type VespaConfig, type VespaDependencies } from '@xyne/vespa-ts';
 import type vespaClient from '../client';
-import type { InsertDocument, VespaSchema } from '../types';
+import {
+  channelSchema,
+  messageSchema,
+  ticketSchema,
+  type InsertDocument,
+  type VespaSchema,
+} from '../types';
 import type { BatchResult } from '../client/vespaClient';
 import type VespaClient from '../client/vespaClient';
 import { getErrorMessage } from '../utils';
 import { ErrorPerformingSearch } from '../error';
+
+/**
+ * Fields owned by entity extraction, not by any mapper: the extractor resolves entities
+ * onto messages and tickets, claw assigns a channel's approved types, and both write
+ * with partial updates. A feed is a Vespa *put*, so an unrelated re-index (a message
+ * edit, a ticket update, a channel_stats bump) would erase them. They are read back off
+ * the indexed document and re-attached to the payload instead.
+ */
+const EXTRACTED_ENTITY_FIELDS = ['entityIds', 'entityNames', 'entitySurfaceForms'] as const;
+
+const EXTERNALLY_OWNED_FIELDS: Partial<Record<VespaSchema, readonly string[]>> = {
+  [messageSchema]: EXTRACTED_ENTITY_FIELDS,
+  [ticketSchema]: EXTRACTED_ENTITY_FIELDS,
+  // Not extracted entities but the channel's approved types, which claw publishes.
+  [channelSchema]: ['entityTypes', 'entityTypeDefs'],
+};
 
 export class CRUDService {
   private logger: ILogger;
@@ -18,7 +40,14 @@ export class CRUDService {
 
   insert = async (documents: InsertDocument[], schema: VespaSchema): Promise<BatchResult[]> => {
     try {
-      return this.vespa.feedBatch(documents, {
+      // Only chat_message, ticket and chat_container carry externally owned fields; every
+      // other schema feeds straight through without an extra read.
+      const owned = EXTERNALLY_OWNED_FIELDS[schema];
+      const payload = owned
+        ? await this.withExternallyOwnedFields(documents, schema, owned)
+        : documents;
+
+      return this.vespa.feedBatch(payload, {
         namespace: this.config.namespace,
         cluster: this.config.cluster,
         schema,
@@ -29,6 +58,49 @@ export class CRUDService {
       );
       throw error;
     }
+  };
+
+  /**
+   * Re-attach the entity fields listed in EXTERNALLY_OWNED_FIELDS from the currently
+   * indexed document, for the schemas that have them. Only fields the caller left
+   * unset are carried over, so a writer that does mean to change them still wins.
+   */
+  private withExternallyOwnedFields = async (
+    documents: InsertDocument[],
+    schema: VespaSchema,
+    owned: readonly string[],
+  ): Promise<InsertDocument[]> => {
+    return Promise.all(
+      documents.map(async (document) => {
+        const provided = document as unknown as Record<string, unknown>;
+        const missing = owned.filter((field) => provided[field] === undefined);
+        if (missing.length === 0) return document;
+
+        try {
+          const indexed = await this.getDocument(document.docId, schema);
+          const fields = indexed?.fields as Record<string, unknown> | undefined;
+          if (!fields) return document;
+
+          const carried = Object.fromEntries(
+            missing
+              .filter((field) => fields[field] !== undefined && fields[field] !== null)
+              .map((field) => [field, fields[field]]),
+          );
+          if (Object.keys(carried).length === 0) return document;
+
+          this.logger.info(
+            `Preserving [${Object.keys(carried).join(', ')}] on "${schema}" document "${document.docId}"`,
+          );
+          return { ...document, ...carried } as InsertDocument;
+        } catch (error) {
+          // Failing the feed would be worse than losing the carry-over.
+          this.logger.error(
+            `Could not read "${schema}" document "${document.docId}" to preserve entity fields: ${getErrorMessage(error)}`,
+          );
+          return document;
+        }
+      }),
+    );
   };
 
   update = async (


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
