### PR TITLE
fix: XYNE-56087 allow user join scheduled call early before the scheduled time

### DIFF
--- a/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
@@ -5,7 +5,6 @@ import { CallStatus } from '@xyne/shared';
 import {
   getPreviewParticipantUserIds,
   getCallParticipantCount,
-  isScheduledCallJoinable,
   type Call,
 } from '../../../routes/CallHistoryScreen/callHistoryItem.utils';
 import Button from '../../ui/Button';
@@ -32,7 +31,7 @@ export function CallRow({
   onEditCall,
   onCancelCall,
 }: CallRowProps): React.JSX.Element {
-  const joinable = isScheduledCallJoinable(call);
+  const isActive = call.status === CallStatus.ACTIVE || call.status === CallStatus.IN_PROGRESS;
   const isEnded = call.status === CallStatus.ENDED;
   const title = call.title || 'Scheduled Call';
   const startTime = call.startsAt ? format(new Date(call.startsAt), 'h:mm a') : '';
@@ -68,7 +67,7 @@ export function CallRow({
         <div
           className={cn(
             'absolute left-0 top-0 bottom-0 w-1 rounded-full',
-            joinable ? 'bg-status-success' : 'bg-primary/40',
+            isActive ? 'bg-status-success' : 'bg-primary/40',
           )}
         />
         <p className='text-sm font-medium text-foreground truncate'>{title}</p>
@@ -87,7 +86,7 @@ export function CallRow({
           }}
           className={cn(
             'shrink-0 text-sm',
-            joinable
+            isActive
               ? 'border-status-success text-status-success hover:bg-accent'
               : 'border-border text-muted-foreground hover:bg-accent hover:text-foreground',
           )}

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallsList.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallsList.tsx
@@ -1,9 +1,7 @@
 import { format } from 'date-fns';
+import { CallStatus } from '@xyne/shared';
 import { cn } from '../../../utils/classNames';
-import {
-  isScheduledCallJoinable,
-  type Call,
-} from '../../../routes/CallHistoryScreen/callHistoryItem.utils';
+import { type Call } from '../../../routes/CallHistoryScreen/callHistoryItem.utils';
 import Button from '../../ui/Button';
 import { GroupedList } from './GroupedList';
 
@@ -54,7 +52,8 @@ export function UpcomingCallsList({
         const startsAt = call.startsAt ? new Date(call.startsAt) : new Date();
         const endsAt = call.endsAt ? new Date(call.endsAt) : null;
         const title = call.title ?? 'Scheduled Call';
-        const joinable = isScheduledCallJoinable(call);
+        const isActive =
+          call.status === CallStatus.ACTIVE || call.status === CallStatus.IN_PROGRESS;
 
         const startTime = format(startsAt, 'h:mm a');
         const endTime = endsAt ? format(endsAt, 'h:mm a') : null;
@@ -65,7 +64,7 @@ export function UpcomingCallsList({
             className={cn(
               'group flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4',
               'pl-3 border-l-2 transition-colors duration-150 rounded-r-sm',
-              joinable ? 'border-status-success' : 'border-primary/25 hover:border-primary/50',
+              isActive ? 'border-status-success' : 'border-primary/25 hover:border-primary/50',
             )}
           >
             <div className='flex min-w-0 flex-1 items-center gap-2 overflow-hidden py-1 sm:py-2'>
@@ -84,12 +83,12 @@ export function UpcomingCallsList({
               variant='outline'
               size='sm'
               onClick={() => onJoinCall(call)}
-              tabIndex={joinable ? 0 : -1}
+              tabIndex={0}
               className={cn(
                 'w-full justify-center sm:w-auto sm:shrink-0 transition-opacity duration-150',
-                joinable
+                isActive
                   ? 'border-status-success text-status-success hover:bg-accent opacity-100'
-                  : 'opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto',
+                  : 'border-border text-muted-foreground hover:bg-accent hover:text-foreground',
               )}
             >
               Join Call

--- a/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
@@ -30,7 +30,7 @@ import {
   getPreviewParticipantUserIds,
   isGoogleCalendarCall,
   isMicrosoftCalendarCall,
-  isScheduledCallJoinable,
+  canJoinCall,
   isScheduledCallManageable,
 } from './callHistoryItem.utils';
 import Button from '../../components/ui/Button';
@@ -588,8 +588,9 @@ const CalendarCallPopup = ({
   const liveStartedLabel =
     isLive && startedAtTime !== null ? formatRelativeTime(startedAtTime) : null;
 
-  const isUnavailableUntilScheduledStart = !isScheduledCallJoinable(call, now);
-  const isJoinDisabled = isCurrentUserInCall || isUnavailableUntilScheduledStart;
+  const isCallUnavailable = !canJoinCall(call);
+  const isJoinDisabled = isCurrentUserInCall || isCallUnavailable;
+  const shouldUsePrimaryJoinStyle = isLive || hasReachedScheduledStart;
   const isManageableScheduledCall = isScheduledCallManageable(call, currentUserId);
 
   const canEdit = isManageableScheduledCall && !!onEditClick;
@@ -880,12 +881,14 @@ const CalendarCallPopup = ({
                 'w-full mt-3 h-10 flex items-center justify-center gap-1.5 rounded-xl text-sm font-medium transition-opacity',
                 isJoinDisabled
                   ? 'bg-muted text-muted-foreground cursor-not-allowed'
-                  : 'bg-action-primary text-action-primary-foreground hover:opacity-90 cursor-pointer',
+                  : shouldUsePrimaryJoinStyle
+                    ? 'bg-primary text-action-primary-foreground hover:opacity-90 cursor-pointer'
+                    : 'border border-border text-foreground hover:bg-muted cursor-pointer',
               )}
             >
               {isCurrentUserInCall ? (
                 <AudioLines className='size-4' />
-              ) : isUnavailableUntilScheduledStart ? (
+              ) : isCallUnavailable ? (
                 <CalendarFold className='size-4' />
               ) : (
                 <Headset className='size-4' />
@@ -894,8 +897,8 @@ const CalendarCallPopup = ({
               <span>
                 {isCurrentUserInCall
                   ? 'Already joined'
-                  : isUnavailableUntilScheduledStart
-                    ? 'Available at scheduled time'
+                  : isCallUnavailable
+                    ? 'Unavailable'
                     : 'Join Call'}
               </span>
             </button>

--- a/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
@@ -590,7 +590,7 @@ const CalendarCallPopup = ({
 
   const isCallUnavailable = !canJoinCall(call);
   const isJoinDisabled = isCurrentUserInCall || isCallUnavailable;
-  const shouldUsePrimaryJoinStyle = isLive || hasReachedScheduledStart;
+  const shouldUsePrimaryJoinStyle = isLive;
   const isManageableScheduledCall = isScheduledCallManageable(call, currentUserId);
 
   const canEdit = isManageableScheduledCall && !!onEditClick;

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
@@ -25,7 +25,7 @@ import {
   getStatusText,
   hasAnyoneJoined,
   hasPreviewParticipantJoined,
-  isScheduledCallJoinable,
+  canJoinCall,
 } from './callHistoryItem.utils';
 import { cn } from '../../utils/classNames';
 import { ReactElement } from 'react';
@@ -107,7 +107,7 @@ export const CallCard = ({
       ? participantUsers.map(user => user.name || user.email || 'Unknown')
       : fallbackParticipantData.displayNames;
 
-  const isCallJoinable = isScheduledCallJoinable(call);
+  const isCallJoinable = canJoinCall(call);
   const isActiveState = call.status === CallStatus.ACTIVE;
 
   const currentCallId = useSelector(roomActor, state => state.context.externalId);

--- a/apps/dashboard/src/routes/CallHistoryScreen/callHistoryItem.utils.ts
+++ b/apps/dashboard/src/routes/CallHistoryScreen/callHistoryItem.utils.ts
@@ -328,6 +328,14 @@ export function isScheduledCallJoinable(call: Call, now = Date.now()): boolean {
   return now >= new Date(call.startsAt).getTime();
 }
 
+export function canJoinCall(call: Call): boolean {
+  return (
+    call.status === CallStatus.SCHEDULED ||
+    call.status === CallStatus.ACTIVE ||
+    call.status === CallStatus.IN_PROGRESS
+  );
+}
+
 export function isScheduledCallManageable(call: Call, currentUserId: string | undefined): boolean {
   if (!currentUserId || call.status !== CallStatus.SCHEDULED) return false;
 

--- a/apps/dashboard/src/routes/CallHistoryScreen/useCallHistory.ts
+++ b/apps/dashboard/src/routes/CallHistoryScreen/useCallHistory.ts
@@ -15,7 +15,7 @@ import {
   isMissedCallForUser,
   isExternalCalendarEvent,
   isExternalCalendarEventForUser,
-  isScheduledCallJoinable,
+  canJoinCall,
   shouldShowInCallLists,
   shouldShowInScheduledList,
   type Call,
@@ -416,17 +416,8 @@ export function useCallHistory(userId: string | undefined): UseCallHistoryReturn
   };
 
   const handleCallRowClick = (call: Call): void => {
-    if (call.status === CallStatus.SCHEDULED) {
-      if (!isScheduledCallJoinable(call)) {
-        toast.info('Call has not started yet', {
-          description: 'You can join at the scheduled start time.',
-          duration: 3000,
-        });
-        return;
-      }
-      handleJoinCall(call);
-    } else if (call.status === CallStatus.ACTIVE || call.status === CallStatus.IN_PROGRESS) {
-      // For active/in-progress calls, join them
+    if (canJoinCall(call)) {
+      // Scheduled calls can be joined before their start time as well.
       handleJoinCall(call);
     } else {
       // For ended calls, restart them


### PR DESCRIPTION

## When a scheduled call is joinable

A user can join a call when its status is any of the following:

- `SCHEDULED`
- `ACTIVE`
- `IN_PROGRESS`

The scheduled start time does not block joining. A user can join a `SCHEDULED` call before `startsAt`.

`canJoinCall` contains this permission check. `isScheduledCallJoinable` remains a separate time-based check used for filtering and sorting calls whose scheduled start time has arrived.

| Call condition | Can join | Call is active | Popup button | Upcoming-list button |
| --- | --- | --- | --- | --- |
| `SCHEDULED`, before `startsAt` | Yes | No | Neutral | Neutral |
| `SCHEDULED`, at or after `startsAt` | Yes | No | Primary | Neutral |
| `ACTIVE` or `IN_PROGRESS` | Yes | Yes | Primary | Green |
| `ENDED` or `CANCELLED` | No | No | Unavailable | Not joinable |

## POT: [Early Scheduled Call Joinable Tested ](https://drive.google.com/file/d/1DPKe60P0G-sIuCHgiEbF3iHrjbOwu3W7/view?usp=sharing)

Services-Requiring-Redeployment:

- dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: No special rollout order or data migration required. -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: None. -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

Reviewed the scheduled-call flow across dashboard join handling, LiveKit room connection, and the backend activation webhook.

Verified the following conditions:

- A future `SCHEDULED` call is joinable and uses neutral styling.
- A `SCHEDULED` call at or after `startsAt` remains neutral and joinable.
- An `ACTIVE` or `IN_PROGRESS` call is joinable and uses primary/green styling.
- `ENDED` and `CANCELLED` calls are not treated as joinable.
- A scheduled call transitions to `ACTIVE` only after a real participant connects.

Validation run:

- Dashboard TypeScript typecheck
- Prettier checks for modified files
- ESLint on modified dashboard files — no errors; existing warnings remain
- `git diff --check`

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — no focused automated coverage currently exists for scheduled-call button state and styling

### Manual

**Users**

- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**

- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**

- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero

- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**

- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` — no new dependencies
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind