### PR TITLE
feat: mention who created the call in the detailed summary participants list

### DIFF
--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -416,6 +416,11 @@ MARKDOWN TEMPLATE:
 - If a name in the transcript seems close to a participant name, use the correct version from the list
 - For @mentions in Action Items, use the full correct name (e.g., @Mayank Bansal)
 
+**CALL CREATOR:**
+- In the CALL PARTICIPANTS list above, the person who created/initiated the call is annotated with "(call creator)".
+- In the Call Overview Participants line, keep that "(call creator)" annotation next to their name so it is clear who set up the call.
+- Do not add a "(call creator)" note to anyone who is not annotated as such in the list above.
+
 **INSTRUCTIONS:**
 - Determine call length from transcript and use appropriate number of phases (1-7)
 - Short/quick calls should have FEWER phases - don't force many phases on a brief discussion
@@ -1030,8 +1035,15 @@ export class CallDocumentService {
       }
     }
 
+    // Annotate the participant who created/initiated the call so the summary
+    // (Call Overview → Participants) can surface who set up the meeting.
+    const callCreatorUserId = call?.createdByUserId;
     const participantList = Array.from(participantMap.values())
-      .map(p => `- ${p.username}`)
+      .map(p =>
+        callCreatorUserId && p.userId === callCreatorUserId
+          ? `- ${p.username} (call creator)`
+          : `- ${p.username}`,
+      )
       .join('\n');
 
     const sanitizedTranscript = sanitizeInput(transcript);

--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -349,6 +349,21 @@ export async function buildParticipantMap(channelId: string): Promise<Map<string
   return participantMap;
 }
 
+/** Return the distinct people who actually contributed speech to a formatted transcript. */
+function extractTranscriptSpeakers(transcript: string): string[] {
+  const speakers = new Map<string, string>();
+  const speakerLine = /^\s*(?:\[\d+\]\s*)?\[[^\]]+\]\s*([^:\n]+):/gm;
+
+  for (const match of transcript.matchAll(speakerLine)) {
+    const speaker = match[1].trim();
+    if (speaker && speaker.toLowerCase() !== 'unknown') {
+      speakers.set(speaker.toLowerCase(), speaker);
+    }
+  }
+
+  return Array.from(speakers.values());
+}
+
 // PRD Generation prompt
 const PRD_GENERATION_PROMPT = `You are a senior product manager creating a Product Requirements Document (PRD) from a call transcript.
 
@@ -417,9 +432,9 @@ MARKDOWN TEMPLATE:
 - For @mentions in Action Items, use the full correct name (e.g., @Mayank Bansal)
 
 **CALL CREATOR:**
-- In the CALL PARTICIPANTS list above, the person who created/initiated the call is annotated with "(call creator)".
-- In the Call Overview Participants line, keep that "(call creator)" annotation next to their name so it is clear who set up the call.
-- Do not add a "(call creator)" note to anyone who is not annotated as such in the list above.
+- In the CALL PARTICIPANTS list above, the person who created/initiated the call is annotated with "{HOST}".
+- In the Call Overview Participants line, keep that "{HOST}" marker immediately after their name.
+- Do not add a "{HOST}" marker to anyone who is not annotated as such in the list above.
 
 **INSTRUCTIONS:**
 - Determine call length from transcript and use appropriate number of phases (1-7)
@@ -1015,35 +1030,31 @@ export class CallDocumentService {
     defaultSummaryFields = DEFAULT_SUMMARY_FIELDS,
     onDelta?: (accumulatedContent: string) => void | Promise<void>,
   ): Promise<string | null> {
-    // Resolve channelId and build participant map once (expensive DB lookups)
+    // Use people who actually spoke in the transcript. A channel roster can contain
+    // members who never joined or contributed to this particular call.
     const call = await repositories.calls.findByExternalId(callId);
-    const channelId = call?.channelId;
+    const spokenParticipantNames = extractTranscriptSpeakers(transcript);
+    const callParticipants = await repositories.calls.getCallParticipantsWithUserDetails(callId);
+    const participantByName = new Map(
+      callParticipants.map((participant) => [participant.userName.toLowerCase(), participant]),
+    );
+    const callCreator = call
+      ? await repositories.users.findById(call.createdByUserId)
+      : null;
 
-    const participantMap: Map<string, ParticipantInfo> = channelId
-      ? await buildParticipantMap(channelId)
-      : new Map<string, ParticipantInfo>();
-
-    if (!channelId && call) {
-      const callParticipants = await repositories.calls.getCallParticipantsWithUserDetails(callId);
-      for (const participant of callParticipants) {
-        participantMap.set(participant.userName.toLowerCase(), {
-          userId: participant.userId,
-          username: participant.userName,
-          userEmail: participant.userEmail,
-          userPicture: participant.userPicture || undefined,
-        });
-      }
-    }
-
-    // Annotate the participant who created/initiated the call so the summary
-    // (Call Overview → Participants) can surface who set up the meeting.
+    // Resolve transcript labels to known user names when possible, then annotate
+    // the creator only when they were one of the speakers.
     const callCreatorUserId = call?.createdByUserId;
-    const participantList = Array.from(participantMap.values())
-      .map(p =>
-        callCreatorUserId && p.userId === callCreatorUserId
-          ? `- ${p.username} (call creator)`
-          : `- ${p.username}`,
-      )
+    const participantList = spokenParticipantNames
+      .map((speaker) => {
+        const participant = participantByName.get(speaker.toLowerCase());
+        const isCallCreator = participant?.userId === callCreatorUserId
+          || (!participant
+            && callCreator
+            && speaker.toLowerCase() === (callCreator.displayName || callCreator.name).toLowerCase());
+        const name = participant?.userName || speaker;
+        return `- ${name}${isCallCreator ? ' {HOST}' : ''}`;
+      })
       .join('\n');
 
     const sanitizedTranscript = sanitizeInput(transcript);

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -75,6 +75,11 @@ CITATION RULES:
 - Do NOT cite the Summary overview section — it is too high-level for precise citations
 - Do NOT invent segment numbers — only use numbers that appear in the transcript
 
+CALL PARTICIPANTS:
+- The call creator is: {callCreator}
+- In the Participants section, append "{HOST}" immediately after that person's name if they are listed.
+- Do not add the call creator to the Participants section if they are not otherwise a participant.
+
 MARKDOWN TEMPLATE (FOLLOW EXACTLY):
 
 ## Summary:
@@ -1103,7 +1108,10 @@ Output ONLY the processed transcript, nothing else.`;
    * Generate AI summary from the formatted transcript with explicit retry loop.
    */
   async generateCallSummary(transcript: string, callId?: string): Promise<string | null> {
-    const prompt = CALL_SUMMARY_PROMPT.replace('{transcript}', transcript);
+    const callCreator = await this.getCallCreatorName(callId);
+    const prompt = CALL_SUMMARY_PROMPT
+      .replace('{callCreator}', callCreator || 'Unknown')
+      .replace('{transcript}', transcript);
 
     const extracted = await executeCallLlmWithRetry(
       () => this.createAgent(callId),
@@ -1117,6 +1125,14 @@ Output ONLY the processed transcript, nothing else.`;
     }
 
     return extracted.content;
+  }
+
+  /** Resolve the creator's display name for the short-summary prompt. */
+  private async getCallCreatorName(callId?: string): Promise<string | null> {
+    if (!callId) return null;
+    const call = await repositories.calls.findByExternalId(callId);
+    const callCreator = call ? await repositories.users.findById(call.createdByUserId) : null;
+    return callCreator?.displayName || callCreator?.name || null;
   }
 
   /**

--- a/packages/shared/src/templates/callSummary.ts
+++ b/packages/shared/src/templates/callSummary.ts
@@ -16,7 +16,7 @@ export const DEFAULT_SUMMARY_FIELDS = `### 💡 Key Takeaways
 
 ### Call Overview
 **Estimated Duration**: [Short/Medium/Long based on transcript length]
-**Participants**: [List all participants mentioned]
+**Participants**: [List all participants mentioned; keep the "(call creator)" annotation on the person who created the call]
 **Primary Focus**: [1-2 sentence summary of main purpose]
 
 ---

--- a/packages/shared/src/templates/callSummary.ts
+++ b/packages/shared/src/templates/callSummary.ts
@@ -16,7 +16,7 @@ export const DEFAULT_SUMMARY_FIELDS = `### 💡 Key Takeaways
 
 ### Call Overview
 **Estimated Duration**: [Short/Medium/Long based on transcript length]
-**Participants**: [List all participants mentioned; keep the "(call creator)" annotation on the person who created the call]
+**Participants**: [List all participants mentioned; keep the "{HOST}" marker immediately after the name of the person who created the call]
 **Primary Focus**: [1-2 sentence summary of main purpose]
 
 ---


### PR DESCRIPTION

<img width="926" height="996" alt="Screenshot 2026-08-14 at 2 05 01 PM" src="https://github.com/user-attachments/assets/46097499-e58b-4eac-93c3-e78a86ae1f6b" />
<img width="1108" height="567" alt="Screenshot 2026-08-14 at 2 05 12 PM" src="https://github.com/user-attachments/assets/a8612f33-1b7b-4cf3-ba2b-95d6b2180fef" />


## What
Adds the call creator to the call **detailed summary** so the Participants list makes clear who created/initiated the call. Requested from the detailed-summary UI: "Can we also mention who created the call in this list?"

## How
1. `apps/backend/src/services/callDocumentService.ts` — in `generateDetailedSummary`, the participant list sent to the summarizer LLM now annotates the participant whose `userId` matches `call.createdByUserId` (the "User who initiated the call") with `(call creator)`. Falls back to plain name if the creator isn't in the participant map.
2. `apps/backend/src/services/recordingSummaryTemplates.ts` — added a `CALL CREATOR` instruction block and updated the default Call Overview Participants line so the LLM preserves the `(call creator)` annotation and does not invent it for anyone else.

## Notes / template checklist
1. Problem: detailed summary Participants list did not indicate who created the call.
2. Identified: feature request in the detailed-summary panel.
3. Solution: annotate creator in the LLM participant input + prompt instruction to preserve it. See How.
4. Documentation: N/A
5. DB Alter: N/A (uses existing Call.createdByUserId)
6. Data fix: N/A
7. Env var changes: N/A
8. Testing: backend typecheck clean on touched files; annotation flows into {participants} for RECORDING_DETAILED_SUMMARY_PROMPT.
9. Services: backend (call summary generation).
10. Main PR link: N/A