### PR TITLE
fix: XYNE-56134 decision and action items fix

### DIFF
--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -21,6 +21,7 @@ const NOTE_TAKER_LABEL_CATEGORY = 'topic';
 interface DetailedSummaryCanvasResult {
   canvasId: string;
   summaryTemplateId: string;
+  markedItems: MarkedItem[];
 }
 
 /**
@@ -65,8 +66,9 @@ function markedItemTimestamp(item: MarkedItem): number {
  *     the canvas is created/updated but never posted anywhere,
  *   - generates topical labels and stores them as generic Tag rows, with the
  *     resulting tag ids saved on Call.labels,
- *   - generates key decisions/action items (each anchored to a transcript
- *     timestamp) and stores them directly on Call.markedItems,
+ *   - generates key decisions/action items derived from the detailed summary
+ *     itself (each anchored to a transcript timestamp via the summary's own
+ *     citation segments) and stores them directly on Call.markedItems,
  *   - queues Vespa search indexing for the transcript.
  *
  * Dedup: the agent's transcript-ready webhook fires twice per call (initial +
@@ -145,11 +147,11 @@ class NoteTakerTranscriptService {
       // These workloads are independent once the transcript is available, so
       // start them together. generateDetailedSummaryCanvas preserves its own
       // ordered dependency chain: template selection -> prompt generation when
-      // needed -> detailed-summary streaming.
+      // needed -> detailed-summary streaming -> marked items (derived from the
+      // generated summary itself, see generateDetailedSummaryCanvas).
       const summaryPromise = this.generateAndSaveSummary(call, formattedTranscript);
       const detailedSummaryPromise = this.generateDetailedSummaryCanvas(call, formattedTranscript);
       const labelsPromise = this.generateAndSaveLabels(call, formattedTranscript);
-      const markedItemsPromise = this.generateMarkedItemsList(call, formattedTranscript);
 
       const saveLabelsPromise = labelsPromise.then(async (labelIds) => {
         if (labelIds.length === 0) return labelIds;
@@ -161,18 +163,11 @@ class NoteTakerTranscriptService {
         }
         return labelIds;
       });
-      const saveMarkedItemsPromise = markedItemsPromise.then(async (markedItems) => {
-        if (markedItems.length > 0) {
-          await this.finalizeCallUpdates(call, { markedItems });
-        }
-        return markedItems;
-      });
 
       const [, detailedSummary] = await Promise.all([
         summaryPromise,
         detailedSummaryPromise,
         saveLabelsPromise,
-        saveMarkedItemsPromise,
       ]);
       await this.finalizeCallUpdates(call, {
         metadata: {
@@ -180,6 +175,7 @@ class NoteTakerTranscriptService {
           detailedSummaryCanvasId: detailedSummary?.canvasId,
         },
         summaryTemplateId: detailedSummary?.summaryTemplateId,
+        markedItems: detailedSummary?.markedItems,
       });
       await this.queueVespaIndexing(call);
     } finally {
@@ -212,12 +208,13 @@ class NoteTakerTranscriptService {
       call.metadata && typeof call.metadata === 'object' && !Array.isArray(call.metadata)
         ? (call.metadata as Record<string, unknown>)
         : {};
-    await repositories.calls.update(call.id, {
+    await this.finalizeCallUpdates(call, {
       metadata: {
         ...currentMetadata,
         detailedSummaryCanvasId: detailedSummary.canvasId,
       },
       summaryTemplateId: detailedSummary.summaryTemplateId,
+      markedItems: detailedSummary.markedItems,
     });
 
     return {
@@ -528,7 +525,8 @@ class NoteTakerTranscriptService {
           return null;
         }
 
-        return { canvasId, summaryTemplateId: generated.template.id };
+        const markedItems = await this.generateMarkedItemsFromSummary(callId, generated.summary, citationCtx);
+        return { canvasId, summaryTemplateId: generated.template.id, markedItems };
       }
 
       const SYNC_INTERVAL_MS = 300;
@@ -703,7 +701,8 @@ class NoteTakerTranscriptService {
         return null;
       }
 
-      return { canvasId: newCanvasId, summaryTemplateId: generated.template.id };
+      const markedItems = await this.generateMarkedItemsFromSummary(callId, generated.summary, citationCtx);
+      return { canvasId: newCanvasId, summaryTemplateId: generated.template.id, markedItems };
     } catch (error) {
       logger.error(`[${callId}] detailed_summary_failed`, {
         stage: 'detailed_summary_generation',
@@ -796,19 +795,26 @@ class NoteTakerTranscriptService {
   }
 
   /**
-   * Generate key decisions/action items, each anchored to a transcript
-   * timestamp. Returns [] on any failure or when nothing qualifies.
+   * Generate key decisions/action items DERIVED FROM the just-generated
+   * detailed summary markdown (see transcriptService.generateMarkedItems),
+   * reusing the same segment map built for the canvas's `[clf-n]` citations
+   * to resolve each item's timestamp. Returns [] on any failure.
    */
-  private async generateMarkedItemsList(call: Call, formattedTranscript: string): Promise<MarkedItem[]> {
-    const callId = call.externalId;
-    return transcriptService.generateMarkedItems(formattedTranscript, callId).catch((err) => {
-      logger.error(`[${callId}] generate_marked_items_threw`, {
-        path: 'note_taker',
-        error: err,
-        stack: err instanceof Error ? err.stack : undefined,
+  private async generateMarkedItemsFromSummary(
+    callId: string,
+    summaryMarkdown: string,
+    citationCtx: CitationContext,
+  ): Promise<MarkedItem[]> {
+    return transcriptService
+      .generateMarkedItems(summaryMarkdown, citationCtx.segments, callId)
+      .catch((err) => {
+        logger.error(`[${callId}] generate_marked_items_threw`, {
+          path: 'note_taker',
+          error: err,
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+        return [] as MarkedItem[];
       });
-      return [] as MarkedItem[];
-    });
   }
 
   // Indexing only — not a message post. Uses the Call's own denormalized

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -242,19 +242,24 @@ TRANSCRIPT:
 {transcript}
 `;
 
-// Decisions/actions extraction. Transcript lines are prefixed with a "[MM:SS]"
-// (or "[HH:MM:SS]") timestamp relative to call start — the LLM is asked to
-// report that same timestamp back per item so it can be stored alongside the
-// text, instead of us trying to re-locate the sentence in the transcript.
+// Decisions/actions extraction — derived from the ALREADY-GENERATED detailed
+// call summary (not the raw transcript) so the decisions/action items are
+// guaranteed to match what the user sees in the detailed summary canvas,
+// instead of an independent LLM pass over the transcript producing different
+// wording/results. The summary's inline `[clf-N]` citation tokens (segment
+// numbers) are reused to recover the timestamp — the LLM only has to report
+// which token, if any, it copied the item from.
 const MARKED_ITEMS_PROMPT = `
-You are analyzing a call transcript (each line is prefixed with a "[MM:SS]" or "[HH:MM:SS]" timestamp relative to the start of the call) to extract key decisions made and action items assigned.
+You are analyzing an already-generated call summary (Markdown) to extract the key decisions and action items it documents.
 
 CRITICAL RULES:
 - Output ONLY valid JSON
-- Extract 0-15 items total across decisions and actions \u2014 only clear, concrete ones
-- For each item, use the exact "[MM:SS]" (or "[HH:MM:SS]") timestamp of the transcript line it is most closely associated with
+- Extract 0-15 items total across decisions and actions \u2014 only clear, concrete ones already stated in the summary (e.g. in sections like "Action Items", "Decisions Made", "Key Takeaways", "Consolidated Outcomes")
+- Do NOT introduce facts that are not in the summary \u2014 reuse its wording, only trimming for conciseness
 - "type" must be exactly "decision" or "action"
-- Keep "text" concise (one sentence)
+- Keep "text" concise (one sentence), WITHOUT any "[clf-N]" token in it
+- The summary may have one or more inline citation tokens like "[clf-12]" attached to an item \u2014 report the FIRST such number that appears on that item as "segment" (a number). If the item has no citation token, set "segment" to null
+- Do NOT invent segment numbers \u2014 only report numbers that literally appear as "[clf-N]" in the summary text
 - If nothing clear qualifies, return an empty array for "items"
 
 BRAND NAME CORRECTION:
@@ -263,15 +268,15 @@ BRAND NAME CORRECTION:
 JSON STRUCTURE (FOLLOW EXACTLY):
 {
   "items": [
-    { "type": "decision" | "action", "text": "[concise description]", "timestamp": "MM:SS" }
+    { "type": "decision" | "action", "text": "[concise description]", "segment": 12 | null }
   ]
 }
 
 Only output valid JSON.
 No explanations.
 
-TRANSCRIPT:
-{transcript}
+CALL SUMMARY:
+{summary}
 `;
 
 export interface TicketSuggestion {
@@ -1313,11 +1318,19 @@ Output ONLY the processed transcript, nothing else.`;
   }
 
   /**
-   * Generate key decisions/action items from the transcript, each anchored to
-   * the timestamp (in seconds from call start) of the transcript line it came
-   * from. Returns [] on any failure or when nothing qualifies.
+   * Generate key decisions/action items DERIVED FROM the already-generated
+   * detailed call summary (rather than a second, independent pass over the raw
+   * transcript), so the marked items always match what's shown in the detailed
+   * summary. `segments` is the same segment-number -> transcript-line map used
+   * to resolve the summary's inline "[clf-N]" citation tokens when rendering
+   * the canvas; it's reused here purely to recover each item's timestamp.
+   * Returns [] on any failure or when nothing qualifies.
    */
-  async generateMarkedItems(transcript: string, callId?: string): Promise<MarkedItem[]> {
+  async generateMarkedItems(
+    summaryMarkdown: string,
+    segments: Map<number, { timestamp: string }>,
+    callId?: string,
+  ): Promise<MarkedItem[]> {
     const logCallId = callId || 'unknown';
     const agent = await this.createAgent(logCallId);
     if (!agent) {
@@ -1325,7 +1338,7 @@ Output ONLY the processed transcript, nothing else.`;
       return [];
     }
 
-    const prompt = MARKED_ITEMS_PROMPT.replace('{transcript}', transcript);
+    const prompt = MARKED_ITEMS_PROMPT.replace('{summary}', summaryMarkdown);
 
     try {
       const result = await agent.execute({
@@ -1355,15 +1368,17 @@ Output ONLY the processed transcript, nothing else.`;
         .map((item: any) => {
           const text = typeof item?.text === 'string' ? item.text.trim() : '';
           if (!text) return null;
+          const segmentNumber = typeof item?.segment === 'number' ? item.segment : null;
+          const segment = segmentNumber !== null ? segments.get(segmentNumber) : undefined;
           return {
             type: item?.type === 'action' ? 'action' : 'decision',
             text,
-            timestampSeconds: this.parseTimestampToSeconds(item?.timestamp),
+            timestampSeconds: segment ? this.parseTimestampToSeconds(segment.timestamp) : 0,
           } satisfies MarkedItem;
         })
         .filter((item: MarkedItem | null): item is MarkedItem => item !== null);
 
-      logger.info(`Generated ${items.length} marked items`);
+      logger.info(`Generated ${items.length} marked items from detailed summary`);
       return items;
     } catch (error) {
       logger.error(`marked_items_generation_failed | error=${error instanceof Error ? error.message : JSON.stringify(error)}`, error);


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
