### PR TITLE
fix: XYNE-56131 DM pen button opens same compose UI as CMD+N

### DIFF
--- a/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
@@ -328,7 +328,12 @@ const DmsPage = (): ReactElement => {
   }, [directMessages]);
 
   const handleAddDirectMessage = (): void => {
-    setShowAddDmForm(true);
+    // Keep parity with CMD+N and the sidebar "New Message" button: on desktop,
+    // route to the full-page compose panel (/chat/search?mode=dm -> ComposeDmPanel)
+    // instead of the AddDmForm modal. Mobile keeps the modal, matching ChatDirectory.
+    if (isMobile) {
+      setShowAddDmForm(true);
+    } else void navigate('/chat/search?mode=dm', { replace: true });
   };
 
   const handleAddDmSubmit = (data: CreateDmFormData): void => {

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
@@ -328,9 +328,6 @@ const DmsPage = (): ReactElement => {
   }, [directMessages]);
 
   const handleAddDirectMessage = (): void => {
-    // Keep parity with CMD+N and the sidebar "New Message" button: on desktop,
-    // route to the full-page compose panel (/chat/search?mode=dm -> ComposeDmPanel)
-    // instead of the AddDmForm modal. Mobile keeps the modal, matching ChatDirectory.
     if (isMobile) {
       setShowAddDmForm(true);
     } else void navigate('/chat/search?mode=dm', { replace: true });


### PR DESCRIPTION
## What
The "Create new message" pen button in the Direct Messages screen (`DmsPage.tsx`) opened the compact `AddDmForm` modal on all platforms, while **CMD+N** and the sidebar **New Message** button route to `/chat/search?mode=dm` which renders the full-page `ComposeDmPanel`. Same action → two different UIs on desktop.

## Fix
Mirror the platform-aware handler already used in `ChatDirectory.tsx`: on desktop, navigate to the full-page compose panel; on mobile, keep the `AddDmForm` modal.

```ts
const handleAddDirectMessage = (): void => {
  if (isMobile) {
    setShowAddDmForm(true);
  } else void navigate('/chat/search?mode=dm', { replace: true });
};
```

`navigate` and `isMobile` were already in scope; no new imports. Both the mobile and desktop pen buttons already call `handleAddDirectMessage`, so this single handler change covers both. The `AddDmForm` modal is unchanged and remains the mobile compose UI.

## Files
- `apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx`

## Validation
- Desktop: DM pen button now opens the same `/chat/search?mode=dm` compose panel as CMD+N and the sidebar New Message button.
- Mobile: DM pen button still opens the `AddDmForm` modal (unchanged), matching `ChatDirectory` mobile behavior.
- CMD+N and the sidebar New Message button unchanged.
- ESLint clean on the changed file; no new TypeScript errors introduced.

Ticket: XYNE-56131