### PR TITLE
feature: XYNE-17198 kb generation

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260812000000_kb_extraction/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260812000000_kb_extraction/migration.sql
@@ -1,0 +1,76 @@
+-- CreateTable
+CREATE TABLE "kb_projects" (
+    "projectId" TEXT NOT NULL,
+    "projectCode" TEXT NOT NULL,
+    "projectName" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "collectionId" TEXT NOT NULL,
+    "extractAgentSlug" TEXT,
+    "mergeAgentSlug" TEXT,
+    "reconcileAgentSlug" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "enabledBy" TEXT,
+    "enabledAt" TIMESTAMP(3),
+
+    CONSTRAINT "kb_projects_pkey" PRIMARY KEY ("projectId")
+);
+
+-- CreateTable
+CREATE TABLE "kb_channels" (
+    "channelId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "visibility" TEXT NOT NULL,
+    "scopeType" TEXT NOT NULL,
+    "included" BOOLEAN NOT NULL DEFAULT false,
+    "includedBy" TEXT,
+    "includedAt" TIMESTAMP(3),
+    "extractedThrough" TIMESTAMP(3),
+    "backfillFrom" TIMESTAMP(3),
+    "lastRunAt" TIMESTAMP(3),
+    "lastError" TEXT,
+
+    CONSTRAINT "kb_channels_pkey" PRIMARY KEY ("channelId")
+);
+
+-- CreateTable
+-- One row per job attempt across every stage of the pipeline. Deliberately has
+-- no foreign key to kb_channels: a cascade would erase a channel's history the
+-- moment it was removed from the KB, which is exactly when someone would go
+-- looking for it.
+CREATE TABLE "kb_runs" (
+    "id" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "projectCode" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "channelId" TEXT,
+    "windowFrom" TIMESTAMP(3),
+    "windowTo" TIMESTAMP(3),
+    "metrics" JSONB,
+    "summary" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'RUNNING',
+    "error" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" TIMESTAMP(3),
+
+    CONSTRAINT "kb_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "kb_projects_enabled_idx" ON "kb_projects"("enabled");
+
+-- CreateIndex
+CREATE INDEX "kb_channels_projectId_included_idx" ON "kb_channels"("projectId", "included");
+
+-- CreateIndex
+CREATE INDEX "kb_runs_projectCode_kind_startedAt_idx" ON "kb_runs"("projectCode", "kind", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "kb_runs_kind_status_idx" ON "kb_runs"("kind", "status");
+
+-- CreateIndex
+CREATE INDEX "kb_runs_channelId_startedAt_idx" ON "kb_runs"("channelId", "startedAt");
+
+-- AddForeignKey
+ALTER TABLE "kb_channels" ADD CONSTRAINT "kb_channels_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "kb_projects"("projectId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -2303,3 +2303,131 @@ model EntityExtractionRun {
   @@index([workspaceId, status])
   @@map("entity_extraction_runs")
 }
+
+/// People-KB extraction — which projects are opted in, and where their KB lives.
+///
+/// Turning a team's conversations into a shared knowledge base is a deliberate
+/// act, so it is recorded rather than inferred: no row means no extraction.
+/// `enabledBy` / `enabledAt` are the consent trail.
+model KbProject {
+  /// Spaces project id. Projects live in the Spaces DB, so this is the local
+  /// projection of one — the row that carries the flag.
+  projectId    String  @id
+  /// Short stable code (e.g. "XYNE"). Used as the KB path segment, so it must
+  /// not change: pages cannot be moved once written.
+  projectCode  String
+  projectName  String
+  workspaceId  String
+  /// Collection this project's KB pages are written into.
+  collectionId String
+
+  /// Which agent extracts findings for this project. Null falls back to the
+  /// KB_EXTRACT_AGENT_SLUG env default, so existing rows keep working.
+  extractAgentSlug String?
+  /// Which agent merges findings into pages. Null falls back to
+  /// KB_MERGE_AGENT_SLUG.
+  mergeAgentSlug   String?
+  /// Which agent reconciles the written pages. Null falls back to
+  /// KB_RECONCILE_AGENT_SLUG.
+  reconcileAgentSlug String?
+
+  enabled   Boolean   @default(false)
+  enabledBy String?
+  enabledAt DateTime?
+
+  channels KbChannel[]
+
+  @@index([enabled])
+  @@map("kb_projects")
+}
+
+/// One row per channel considered for extraction, carrying its progress.
+///
+/// Progress is a WATERMARK (`extractedThrough`) rather than a per-day record:
+/// backfill and nightly incremental then share one code path, a failed window
+/// simply is not advanced past, and "is this channel caught up?" is a column
+/// rather than something inferred from logs.
+model KbChannel {
+  channelId String @id
+  projectId String
+  project   KbProject @relation(fields: [projectId], references: [projectId], onDelete: Cascade)
+
+  /// Snapshot of the channel when it was added, so an operator can see what
+  /// they included without joining back to Spaces.
+  name       String
+  visibility String
+  scopeType  String
+
+  /// Private channels are excluded by default and opt in HERE. Nothing in the
+  /// stack can delete a KB page, so a wrongly-included private channel cannot
+  /// be retracted — which is why the default is off and the actor is recorded.
+  included   Boolean   @default(false)
+  includedBy String?
+  includedAt DateTime?
+
+  /// Everything up to this instant has been extracted. Advances only when a
+  /// window COMPLETES, including empty ones — otherwise a quiet channel would
+  /// rescan the same range forever.
+  extractedThrough DateTime?
+  /// How far back to walk. Null means "from when it was included".
+  backfillFrom     DateTime?
+
+  lastRunAt DateTime?
+  lastError String?
+
+  @@index([projectId, included])
+  @@map("kb_channels")
+}
+
+/// One row per job attempt across the whole People-KB pipeline.
+///
+/// Extraction, merge and reconcile are three stages of ONE pipeline, and the
+/// question actually asked of them is "what happened to XYNE last night?" —
+/// which three separate tables answer only by running three queries and
+/// interleaving the results by hand. They also carried the same eight columns
+/// each, so a fourth stage meant a fourth near-identical table.
+///
+/// Deliberately NOT related to KbChannel. The relation it replaced cascaded on
+/// delete, so removing a channel from the KB erased the record of everything
+/// ever extracted from it — exactly the history someone would go looking for
+/// afterwards. A run record outlives its subject.
+model KbRun {
+  id String @id @default(cuid())
+
+  /// EXTRACT | MERGE | RECONCILE
+  kind String
+
+  projectId   String
+  projectCode String
+
+  /// What this run covered, in its own stage's terms: a channel name, a
+  /// findings day, an entity path. Displayed as-is, and the merge RESUMES from
+  /// it — the days it has already completed are the days it will not redo.
+  subject String
+
+  /// Extraction only: which channel, and the window walked. Real columns rather
+  /// than metrics, because the watermark logic orders and compares them.
+  channelId  String?
+  windowFrom DateTime?
+  windowTo   DateTime?
+
+  /// Per-stage counters — threads/batches for extraction, findings/files for
+  /// the merge. Json because they are read by humans, never queried: a column
+  /// per stage is how three tables happened in the first place.
+  metrics Json?
+
+  /// The agent's closing report, where a stage produces one. Reconcile rewrites
+  /// pages, so what it changed cannot be reconstructed from anywhere else.
+  summary String? @db.Text
+
+  /// RUNNING | COMPLETED | FAILED | NOTHING_TO_MERGE
+  status     String    @default("RUNNING")
+  error      String?
+  startedAt  DateTime  @default(now())
+  finishedAt DateTime?
+
+  @@index([projectCode, kind, startedAt])
+  @@index([kind, status])
+  @@index([channelId, startedAt])
+  @@map("kb_runs")
+}

--- a/apps/xyne-claw-auth/backend/src/lib/kb-fs.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/kb-fs.ts
@@ -1,0 +1,469 @@
+/**
+ * A filesystem view over a Spaces KB collection.
+ *
+ * The collections API is id-addressed (`itemId`); an agent reasons in paths
+ * (`services/livekit/service.md`). This module is the only place that mapping
+ * exists, so everything above it can pretend the KB is a directory.
+ *
+ * Three facts about the API shape this file:
+ *
+ *  - **Folders auto-create on upload.** The upload endpoint walks the supplied
+ *    `filePath` and creates any missing folder, so a nested page materialises
+ *    in one call. There is no create-folder endpoint to call first.
+ *  - **Updating means a new version, never a re-upload.** Re-uploading mints a
+ *    fresh itemId, and itemIds are embedded in KB links; versioning keeps the
+ *    id and the history.
+ *  - **There is no usable server-side content search.** `/search` matches on
+ *    filename only, and the Vespa-backed search returns ranked *chunks* — no
+ *    line numbers, no completeness. Grep therefore runs locally over page text,
+ *    which is why the session loads bodies once up front.
+ *
+ * Everything is session-scoped and in memory. Nothing is written to disk, so a
+ * KB agent needs no working directory and no sandbox.
+ */
+
+import type { SpacesAuthContext } from "../mcp/servers/xyne-spaces-client.js";
+import { fetchAccessibleKb, type KbCollectionNode } from "./spaces-kb.js";
+import { getSpacesAuthForUser } from "./spaces-db.js";
+import { createLogger, createTraceId } from "../logger.js";
+
+const log = createLogger("kb-fs", createTraceId());
+
+/** Pages larger than this are almost certainly not hand-authored prose. */
+const MAX_PAGE_CHARS = 200_000;
+
+export interface KbGrepMatch {
+  path: string;
+  /** 1-indexed, so it reads like a real grep result. */
+  line: number;
+  text: string;
+}
+
+export interface KbWriteOutcome {
+  path: string;
+  status: "created" | "updated" | "unchanged";
+}
+
+export interface KbFsOptions {
+  /**
+   * Narrows the tree fetch to one scope. Root collections are channel-scoped,
+   * so passing these avoids expanding every collection the caller can see just
+   * to index one — worth setting whenever the caller knows the channel.
+   */
+  scopeType?: string;
+  scopeId?: string;
+}
+
+export class KbFs {
+  /** path -> itemId. The whole point of this class. */
+  private readonly items = new Map<string, string>();
+  /** path -> contents. Filled lazily; grep forces a full load. */
+  private readonly bodies = new Map<string, string>();
+  private loadedAll = false;
+  /** Kept so reload() can repeat open()'s tree fetch with the same scope. */
+  private userId = "";
+  private options: KbFsOptions = {};
+
+  private constructor(
+    private readonly collectionId: string,
+    private readonly auth: SpacesAuthContext,
+  ) {}
+
+  /**
+   * Builds the path index for one collection.
+   *
+   * Paths are relative to the collection root, so the root's own name is not
+   * part of them — `services/livekit/service.md`, not `Juspay Services/...`.
+   */
+  static async open(
+    collectionId: string,
+    userId: string,
+    options: KbFsOptions = {},
+  ): Promise<KbFs> {
+    // One resolution of the Spaces session, shared by the tree fetch below and
+    // by the raw upload/download calls that cannot go through spacesFetch.
+    const startedAt = Date.now();
+    const auth = await getSpacesAuthForUser(userId, "agent-chat");
+    if (!auth) {
+      throw new Error(`kb-fs: no active Spaces session for user ${userId}`);
+    }
+
+    const tree = await fetchAccessibleKb(userId, {
+      includeItems: true,
+      ...(options.scopeType ? { scopeType: options.scopeType } : {}),
+      ...(options.scopeId ? { scopeId: options.scopeId } : {}),
+    });
+    if (tree === null) {
+      throw new Error(`kb-fs: no active Spaces session for user ${userId}`);
+    }
+
+    const root = tree.find((c) => c.id === collectionId);
+    if (!root) {
+      throw new Error(
+        `kb-fs: collection ${collectionId} not accessible` +
+          (options.scopeId ? ` within scope ${options.scopeId}` : ""),
+      );
+    }
+
+    const fs = new KbFs(collectionId, auth);
+    fs.userId = userId;
+    fs.options = options;
+
+    const walk = (node: KbCollectionNode, prefix: string): void => {
+      for (const item of node.items ?? []) {
+        fs.items.set(prefix ? `${prefix}/${item.name}` : item.name, item.id);
+      }
+      for (const child of node.children ?? []) {
+        walk(child, prefix ? `${prefix}/${child.name}` : child.name);
+      }
+    };
+    walk(root, "");
+
+    log.info(
+      `[kb-fs] opened "${root.name}" (${collectionId}) for user=${userId}: ` +
+        `${fs.items.size} pages in ${Date.now() - startedAt}ms` +
+        (options.scopeId ? ` [scope ${options.scopeType ?? "?"}:${options.scopeId}]` : ""),
+    );
+    if (fs.items.size === 0) {
+      // Not an error — a fresh collection is empty — but it is the state in
+      // which an agent will create everything from scratch, so make it visible.
+      log.warn(`[kb-fs] collection ${collectionId} contains no pages`);
+    }
+    return fs;
+  }
+
+  /** Every known path, optionally filtered by prefix. Free — index only. */
+  list(prefix = ""): string[] {
+    const paths = [...this.items.keys()];
+    const filtered = prefix ? paths.filter((p) => p.startsWith(prefix)) : paths;
+    return filtered.sort();
+  }
+
+  exists(path: string): boolean {
+    return this.items.has(path);
+  }
+
+  /** Contents of one page, or null when the path is unknown. */
+  async read(path: string): Promise<string | null> {
+    const cached = this.bodies.get(path);
+    if (cached !== undefined) return cached;
+
+    const itemId = this.items.get(path);
+    if (!itemId) return null;
+
+    const text = await this.download(itemId);
+    if (text !== null) this.bodies.set(path, text);
+    return text;
+  }
+
+  /**
+   * Literal search across every page, with line numbers.
+   *
+   * Loads all bodies on first call. At the scale this KB operates
+   * (tens to low hundreds of pages) that is one pass of a few hundred KB, and
+   * it is the only way to get grep semantics: the server can offer ranked
+   * chunks, which have no line numbers and no completeness guarantee.
+   */
+  async grep(pattern: string | RegExp, pathPrefix = ""): Promise<KbGrepMatch[]> {
+    await this.loadAll();
+
+    const re =
+      typeof pattern === "string"
+        ? new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i")
+        : pattern;
+
+    const matches: KbGrepMatch[] = [];
+    for (const [path, body] of this.bodies) {
+      if (pathPrefix && !path.startsWith(pathPrefix)) continue;
+      const lines = body.split("\n");
+      for (let i = 0; i < lines.length; i += 1) {
+        const text = lines[i] ?? "";
+        if (re.test(text)) matches.push({ path, line: i + 1, text: text.trim() });
+      }
+    }
+    return matches;
+  }
+
+  /**
+   * Creates the page, or versions it when the content actually differs.
+   *
+   * The comparison is the point. Discovery re-runs are largely deterministic,
+   * so most pages come back identical; versioning them anyway buries the few
+   * real changes under dozens of no-op versions and makes the history — the
+   * only reason to version at all — unreadable.
+   */
+  async write(path: string, content: string): Promise<KbWriteOutcome> {
+    if (content.length > MAX_PAGE_CHARS) {
+      throw new Error(`kb-fs: ${path} exceeds ${MAX_PAGE_CHARS} chars`);
+    }
+
+    let itemId = this.items.get(path);
+
+    if (!itemId) {
+      // The index is a snapshot from open(). Another session — the next merge
+      // batch, a concurrent run — may have created this page since, and the
+      // upload endpoint does NOT version on name collision: it creates a second
+      // item and renames it "operations (1).md". That duplicate is permanent,
+      // because nothing in the stack can delete a page. So confirm against the
+      // live listing before creating.
+      await this.reload();
+      itemId = this.items.get(path);
+    }
+
+    if (!itemId) {
+      const newId = await this.uploadNew(path, content);
+      this.items.set(path, newId);
+      this.bodies.set(path, content);
+      return { path, status: "created" };
+    }
+
+    const current = await this.read(path);
+    if (current !== null && current.trim() === content.trim()) {
+      return { path, status: "unchanged" };
+    }
+
+    await this.uploadVersion(itemId, path, content);
+    this.bodies.set(path, content);
+
+    // Versioning creates a NEW collection_item row: `item.id` changes, only
+    // `fileId` carries across (see createItemVersion). The version endpoint
+    // returns just { success, versionNumber }, so the new id has to be looked
+    // up — otherwise a second write to the same page in one session would use
+    // the superseded id and 404. Links are unaffected: KB URLs key on fileId.
+    await this.refreshItemId(path);
+
+    return { path, status: "updated" };
+  }
+
+  /**
+   * Replaces `oldText` with `newText` in one page.
+   *
+   * Fails unless `oldText` occurs exactly once. That single constraint is what
+   * makes an agent's edits safe rather than hopeful: without it, changing one
+   * alias silently rewrites every line that resembles it.
+   */
+  async edit(path: string, oldText: string, newText: string): Promise<KbWriteOutcome> {
+    const body = await this.read(path);
+    if (body === null) throw new Error(`kb-fs: ${path} not found`);
+
+    const occurrences = body.split(oldText).length - 1;
+    if (occurrences === 0) throw new Error(`kb-fs: text not found in ${path}`);
+    if (occurrences > 1) {
+      throw new Error(`kb-fs: text is not unique in ${path} (${occurrences} occurrences)`);
+    }
+
+    return this.write(path, body.replace(oldText, newText));
+  }
+
+  // There is deliberately no delete. itemIds are embedded in saved KB links,
+  // and every other operation here is non-destructive; an obsolete page is
+  // rewritten as a redirect stub, keeping its id and its history.
+
+  // -------------------------------------------------------------------------
+
+  /**
+   * The one expensive operation here, so it is timed.
+   *
+   * Grep needs full text (the server can only offer ranked chunks, which have
+   * no line numbers), so the first grep pays for every page. If this line ever
+   * shows seconds rather than hundreds of milliseconds, the KB has outgrown
+   * read-everything and grep needs a narrowing step in front of it.
+   */
+  /**
+   * Re-reads the path→itemId index from the live collection.
+   *
+   * The index is a snapshot from open(); a page created by another session
+   * since then is invisible to it. Only used before creating a page, where a
+   * stale miss would produce a permanent duplicate.
+   */
+  private async reload(): Promise<void> {
+    const tree = await fetchAccessibleKb(this.userId, {
+      includeItems: true,
+      ...(this.options.scopeType ? { scopeType: this.options.scopeType } : {}),
+      ...(this.options.scopeId ? { scopeId: this.options.scopeId } : {}),
+    });
+    const root = tree?.find((c) => c.id === this.collectionId);
+    if (!root) return;
+
+    const before = this.items.size;
+    this.items.clear();
+    const walk = (node: KbCollectionNode, prefix: string): void => {
+      for (const item of node.items ?? []) {
+        this.items.set(prefix ? `${prefix}/${item.name}` : item.name, item.id);
+      }
+      for (const child of node.children ?? []) {
+        walk(child, prefix ? `${prefix}/${child.name}` : child.name);
+      }
+    };
+    walk(root, "");
+
+    if (this.items.size !== before) {
+      log.info(`[kb-fs] index reloaded: ${before} -> ${this.items.size} pages`);
+    }
+  }
+
+  private async loadAll(): Promise<void> {
+    if (this.loadedAll) return;
+
+    const startedAt = Date.now();
+    const alreadyCached = this.bodies.size;
+    for (const path of this.items.keys()) {
+      if (!this.bodies.has(path)) await this.read(path);
+    }
+    this.loadedAll = true;
+
+    const fetched = this.bodies.size - alreadyCached;
+    const totalChars = [...this.bodies.values()].reduce((sum, body) => sum + body.length, 0);
+    log.info(
+      `[kb-fs] loaded ${this.bodies.size} pages (${fetched} fetched, ${alreadyCached} cached), ` +
+        `${Math.round(totalChars / 1024)}KB in ${Date.now() - startedAt}ms`,
+    );
+
+    const unreadable = this.items.size - this.bodies.size;
+    if (unreadable > 0) {
+      // Grep silently under-reports by exactly this many pages.
+      log.warn(`[kb-fs] ${unreadable} of ${this.items.size} pages could not be read`);
+    }
+  }
+
+  /**
+   * Re-reads one path's itemId after it has been superseded by a new version.
+   *
+   * Costs one tree fetch. Only called on an actual content change, which is the
+   * rare case — an unchanged write returns before reaching here.
+   */
+  private async refreshItemId(path: string): Promise<void> {
+    try {
+      const res = await this.rawFetch("/api/collections/accessible?includeItems=1", {
+        method: "GET",
+      });
+      const body = (await res.json()) as { collections?: KbCollectionNode[] };
+      const root = (body.collections ?? []).find((c) => c.id === this.collectionId);
+      if (!root) return;
+
+      const find = (node: KbCollectionNode, prefix: string): string | undefined => {
+        for (const item of node.items ?? []) {
+          if ((prefix ? `${prefix}/${item.name}` : item.name) === path) return item.id;
+        }
+        for (const child of node.children ?? []) {
+          const hit = find(child, prefix ? `${prefix}/${child.name}` : child.name);
+          if (hit) return hit;
+        }
+        return undefined;
+      };
+
+      const fresh = find(root, "");
+      if (fresh) this.items.set(path, fresh);
+      else log.warn(`[kb-fs] ${path} vanished from the tree after versioning`);
+    } catch (err) {
+      // The write succeeded; only the cached id is stale. Log and continue —
+      // the next KbFs.open rebuilds it correctly.
+      log.warn(`[kb-fs] could not refresh itemId for ${path}: ${String(err)}`);
+    }
+  }
+
+  private async download(itemId: string): Promise<string | null> {
+    try {
+      const res = await this.rawFetch(`/api/collections/items/${itemId}/download`, {
+        method: "GET",
+      });
+      return await res.text();
+    } catch (err) {
+      log.warn(`[kb-fs] download ${itemId} failed: ${String(err)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Creates a page, materialising any missing folders on the way.
+   *
+   * Two details, both verified against the running backend rather than assumed:
+   *
+   *  - The folder chain comes from a `paths` field: a JSON ARRAY, one entry per
+   *    uploaded file, holding the DIRECTORY only. Sending the full path creates
+   *    a folder named after the file (`services/x/service.md/service.md`), and
+   *    sending `filePath` instead is ignored entirely, dropping the page into
+   *    the collection root.
+   *  - The response is `{ results: [{ fileName, itemId, status }] }` — not
+   *    `{ items: [{ id }] }`.
+   */
+  private async uploadNew(path: string, content: string): Promise<string> {
+    const form = new FormData();
+    form.append("files", new File([content], basename(path), { type: "text/markdown" }));
+    form.append("paths", JSON.stringify([dirname(path)]));
+
+    const res = await this.rawFetch(`/api/collections/${this.collectionId}/upload`, {
+      method: "POST",
+      body: form,
+    });
+
+    const data = (await res.json()) as {
+      results?: Array<{ itemId?: string; status?: string; error?: string }>;
+    };
+    const result = data.results?.[0];
+    if (!result?.itemId || result.status !== "success") {
+      throw new Error(
+        `kb-fs: upload of ${path} failed: ${result?.error ?? JSON.stringify(data).slice(0, 200)}`,
+      );
+    }
+    return result.itemId;
+  }
+
+  private async uploadVersion(itemId: string, path: string, content: string): Promise<void> {
+    const form = new FormData();
+    form.append("file", new File([content], basename(path), { type: "text/markdown" }));
+    await this.rawFetch(`/api/collections/items/${itemId}/versions`, {
+      method: "POST",
+      body: form,
+    });
+  }
+
+  /**
+   * spacesFetch cannot be used for these: it hardcodes
+   * `Content-Type: application/json`, and multipart needs the boundary set by
+   * the runtime, while download needs the raw body rather than parsed JSON.
+   */
+  private async rawFetch(path: string, init: RequestInit): Promise<Response> {
+    const { token, sessionId, workspaceId } = this.auth;
+    if (!token) throw new Error("kb-fs: Spaces auth token missing");
+
+    // Same resolution order spacesFetch uses, and the caller's baseUrl wins so
+    // a session pointed at another deployment stays pointed at it.
+    const baseUrl = (
+      this.auth.baseUrl ??
+      process.env["SPACES_BACKEND_URL"] ??
+      process.env["XYNE_SPACES_URL"] ??
+      ""
+    ).replace(/\/+$/, "");
+    if (!baseUrl) throw new Error("kb-fs: SPACES_BACKEND_URL not configured");
+
+    const cookies: string[] = [];
+    if (sessionId) cookies.push(`xyne_session=${sessionId}`, `user_session_id=${sessionId}`);
+    if (workspaceId) cookies.push(`xyne_last_workspace=${workspaceId}`);
+
+    const res = await fetch(new URL(path, `${baseUrl}/`).toString(), {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(sessionId ? { "x-session-id": sessionId } : {}),
+        ...(workspaceId ? { "x-workspace-id": workspaceId } : {}),
+        ...(cookies.length ? { Cookie: cookies.join("; ") } : {}),
+      },
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`kb-fs: ${init.method} ${path} -> ${res.status}: ${text.slice(0, 200)}`);
+    }
+    return res;
+  }
+}
+
+function basename(path: string): string {
+  return path.split("/").pop() ?? "page.md";
+}
+
+function dirname(path: string): string {
+  return path.split("/").slice(0, -1).join("/");
+}

--- a/apps/xyne-claw-auth/backend/src/lib/spaces-kb.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/spaces-kb.ts
@@ -153,3 +153,36 @@ export async function validateKbGrants(
   }
   return { accepted, rejected };
 }
+
+/**
+ * Attaches the agent's collection grants to the config sent to claw, but only
+ * for KB-curating agents (`kbAccess: "files"`).
+ *
+ * claw builds its KB target from `knowledgeBase` on the config it receives.
+ * Without this the grant never crosses the wire and claw logs "kbAccess=files
+ * but no knowledgeBase grant" — the agent silently falls back to filesystem
+ * tools pointed at an empty session workspace, which looks like the KB is empty
+ * rather than like a misconfiguration.
+ *
+ * Every dispatcher that calls claw's /run must go through this, or the tools
+ * differ depending on which entry point the user happened to hit.
+ */
+export async function attachKbGrantsToConfig(
+  config: Record<string, unknown> | undefined,
+  agentId: string,
+  // Structurally typed so both dispatchers can pass their own client without
+  // this module importing prisma and creating a cycle.
+  prisma: { agentCollection: { findMany: (args: any) => Promise<Array<{ collectionId: string }>> } },
+): Promise<Record<string, unknown> | undefined> {
+  if (config?.["kbAccess"] !== "files") return config;
+
+  const grants = await prisma.agentCollection.findMany({
+    where: { agentId },
+    select: { collectionId: true },
+  });
+
+  return {
+    ...config,
+    knowledgeBase: grants.map((g) => ({ collectionId: g.collectionId })),
+  };
+}

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -62,6 +62,7 @@ import { settingsRouter } from "./routes/settings.js";
 import { runsRouter } from "./routes/runs.js";
 import { metricsRouter } from "./routes/metrics.js";
 import { memoryRouter } from "./routes/memory.js";
+import { kbRouter } from "./routes/kb.js";
 import { digitalTwinRouter } from "./routes/digital-twin.js";
 import { controlCenterRouter } from "./routes/control-center.js";
 import { evalsRouter } from "./routes/evals/index.js";
@@ -93,6 +94,8 @@ import { bootstrapCustomTools } from "./bootstrap-tools.js";
 import { initMemoryCron } from "./services/memoryCronService.js";
 import { initSlackConfigTokenCron } from "./surfaces/slack/config-token-cron.js";
 import { initDigitalTwinDaily } from "./services/digitalTwinDaily.js";
+import { initKbExtractDaily } from "./services/kbExtractDaily.js";
+import { initKbMergeDaily } from "./services/kbMergeDaily.js";
 import {
   startBitbucketStatsBackgroundRefresh,
   stopBitbucketStatsBackgroundRefresh,
@@ -295,6 +298,8 @@ app.use(`${BASE}/metrics`, requireAuth, requireNoAccessToken, metricsRouter);
 // (not requireUserAuth) because /recall-hits is an S2S callback from xyne-claw.
 // The per-request memoization in require-auth.ts makes the second layer free.
 app.use(`${BASE}/memory`, requireAuth, requireNoAccessToken, memoryRouter);
+// KB filesystem for the curator agent. S2S only — xyne-claw holds no Spaces session.
+app.use(`${BASE}/kb`, requireAuth, kbRouter);
 app.use(`${BASE}/digital-twin`, requireUserAuth, digitalTwinRouter);
 app.use(`${BASE}/control-center`, requireAuth, requireNoAccessToken, controlCenterRouter);
 app.use(`${BASE}/research-agent`, requireAuth, requireNoAccessToken, researchAgentRouter);
@@ -351,6 +356,10 @@ listen(CONFIG.port, () => {
     initMemoryCron();
     initSlackConfigTokenCron();
     initDigitalTwinDaily();
+    // People-KB extraction. No-op unless ENABLE_KB_EXTRACT_DAILY=true.
+    initKbExtractDaily();
+    // Findings -> KB pages. No-op unless ENABLE_KB_MERGE_DAILY=true.
+    initKbMergeDaily();
     // Daily Brief: bounded worker (caps concurrent LLM runs) + leader-locked
     // enqueue cron (fans out opted-in users once/day). See services/dailyBrief*.
     initDailyBriefWorker();

--- a/apps/xyne-claw-auth/backend/src/queue/scheduled-jobs-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/scheduled-jobs-worker.ts
@@ -6,6 +6,7 @@ import { decrypt } from "../crypto.js";
 import { agentRunRepository, chatMessageRepository } from "../repositories/index.js";
 import { ensureUserExists } from "../lib/users-jit.js";
 import { resolveAgentProviderConfigs } from "../lib/agent-provider-config.js";
+import { attachKbGrantsToConfig } from "../lib/spaces-kb.js";
 import { resolveFastMode } from "../lib/fast-mode.js";
 import { registerRunRecovery, type RecoverySessionContext } from "./run-recovery-worker.js";
 import type { ScheduledJobData } from "./scheduled-jobs-queue.js";
@@ -84,6 +85,12 @@ async function processJob(job: Job<ScheduledJobData>): Promise<void> {
   const { providerConfigs, providerOrder, parent: providerParent } = agentRow
     ? await resolveAgentProviderConfigs(agentRow, { headlessBulk: true })
     : { providerConfigs: {}, providerOrder: [] as string[], parent: undefined as string | undefined };
+  // KB curators need their collection grants on the wire — see
+  // attachKbGrantsToConfig. Scheduled runs are the nightly merge's normal path,
+  // so omitting this here would leave cron-triggered runs on filesystem tools.
+  const scheduledAgentConfig = agentRow
+    ? await attachKbGrantsToConfig(agentRow.config as Record<string, unknown>, agentRow.id, prisma)
+    : undefined;
   const fastModeEnabled = await resolveFastMode(runConversationId, agentSlug, agentRow?.config);
 
   const progressUrl = `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`;
@@ -115,7 +122,7 @@ async function processJob(job: Job<ScheduledJobData>): Promise<void> {
     // (~19/hour in prod), mislabeling every scheduled run as "spaces" in the
     // Control Center. Mirrors how /agent-chat opts out (see run.ts).
     __persistedByCaller: true,
-    ...(agentRow?.config ? { agentConfig: agentRow.config as Record<string, unknown> } : {}),
+    ...(scheduledAgentConfig ? { agentConfig: scheduledAgentConfig } : {}),
     // Primary provider — the pod keys its model off `provider` (defaults to
     // "spaces"/kimi when unset). Without this, scheduled runs used the platform default
     // regardless of the agent's configured provider.

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -4,6 +4,7 @@ import multer from "multer";
 import { existsSync, readdirSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
+import { attachKbGrantsToConfig } from "../lib/spaces-kb.js";
 import { agentRepository, chatMessageRepository, userRepository, agentRunRepository, chatAttachmentRepository, userAgentConfigRepository, userProviderCredentialsRepository, userSubagentConfigRepository, agentProviderCredentialsRepository } from "../repositories/index.js";
 import { getValidClaudeBearer } from "../lib/claude-oauth-refresh.js";
 import { prisma } from "../db.js";
@@ -1404,7 +1405,10 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
           toolPermissions: {},
         }
       : runAgentConfig;
-    const fastModeEnabled = await resolveFastMode(conversationId, slug, effectiveAgentConfig);
+    // KB curators need their collection grants on the wire — see
+    // attachKbGrantsToConfig. No-op for every other agent.
+    const configWithKb = await attachKbGrantsToConfig(effectiveAgentConfig, agent.id, prisma);
+    const fastModeEnabled = await resolveFastMode(conversationId, slug, configWithKb);
 
     const forwardBody: Record<string, unknown> = {
       userId,
@@ -1443,7 +1447,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       // skillTriggers, promptInjections, custom-tool config values.
       // Without this, those features silently default to "off" on V2
       // dashboard chat (same bug existed for webhook + scheduled jobs).
-      ...(effectiveAgentConfig ? { agentConfig: effectiveAgentConfig } : {}),
+      ...(configWithKb ? { agentConfig: configWithKb } : {}),
       fastMode: fastModeEnabled,
     };
 

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -27,6 +27,25 @@ import { writeAuditLog } from "../lib/audit.js";
 import { buildAvailableToolsCatalog } from "./tools.js";
 import { validateAgentModelConfig } from "../lib/agent-config-validation.js";
 import { validateKbGrants } from "../lib/spaces-kb.js";
+
+/**
+ * Does this config ask for file-style KB access — the path-based read/ls/grep/
+ * write/edit tools?
+ *
+ * Retrieval agents read their knowledge base through Vespa and never need
+ * these; only a deliberately built curator does. It is gated rather than
+ * implied by holding a KB grant, and gated on admin because nothing in the
+ * stack can delete a KB page — a bad writer can only be papered over.
+ */
+function configMutatesKb(config: Record<string, unknown> | undefined): boolean {
+  return config?.["kbAccess"] === "files";
+}
+
+/** Drops the file-access key in place, leaving the rest of the config alone. */
+function stripKbFileAccess(config: Record<string, unknown> | undefined): void {
+  if (!config) return;
+  delete config["kbAccess"];
+}
 import { ORG_SCOPED_SLUGS } from "../lib/org-scoped-slugs.js";
 import { getAdminOrgScope, getOrgNameMap, withOrgLabel } from "../lib/admin-org-scope.js";
 
@@ -499,6 +518,13 @@ router.post("/", async (req: Request, res: Response) => {
     // the user's full KB.
     const effectiveKbScope: "COLLECTIONS" | "USER" = kbScope === "USER" ? "USER" : "COLLECTIONS";
 
+    // `kbAccess: "files"` swaps Vespa retrieval for the path-based tools, which
+    // can rewrite pages. Admin-only; non-admins keep the rest of their config.
+    const kbFileAccessDenied = !admin && configMutatesKb(normalizedConfig);
+    if (kbFileAccessDenied) {
+      stripKbFileAccess(normalizedConfig);
+    }
+
     const createOrgId = getOrgId(req);
     if (!createOrgId) {
       log.warn(`[agents/create] orgId is required requesterId=${requesterId ?? "none"} ownerUserId=${ownerUserId ?? "none"} slug=${slug.trim()} scope=${scope ?? "none"}`);
@@ -704,6 +730,14 @@ router.put("/:slug", async (req: Request<{ slug: string }>, res: Response) => {
     // OFF) a silent no-op, so disabled toggles snap back on. Any future
     // partial-PUT caller must spread the full existing config first.
     const normalizedConfig = await normalizeGatewayServicesInConfig(config);
+
+    // Same admin gate as create — otherwise a non-admin creates a plain agent
+    // and immediately edits KB write access onto it.
+    if (configMutatesKb(normalizedConfig)) {
+      const updaterId = getRequesterId(req);
+      const updaterIsAdmin = updaterId ? await isClawAdmin(updaterId) : false;
+      if (!updaterIsAdmin) stripKbFileAccess(normalizedConfig);
+    }
 
     const data: Prisma.AgentUpdateInput = {};
 

--- a/apps/xyne-claw-auth/backend/src/routes/kb.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/kb.ts
@@ -1,0 +1,639 @@
+/**
+ * Internal (S2S) KB filesystem routes.
+ *
+ * xyne-claw runs the agent and its tools but holds no Spaces session — that
+ * lives here, the same arrangement as memory/agent-file. Claw calls these with
+ * `x-s2s-key`; this router does the collection work through KbFs.
+ *
+ * A KbFs is opened per request rather than cached: the index costs one HTTP
+ * call, and a cached instance would silently go stale against edits made in the
+ * Spaces UI.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { requireAuth } from "../middleware/require-auth.js";
+import { KbFs } from "../lib/kb-fs.js";
+import { createLogger, createTraceId } from "../logger.js";
+import { requireClawAdmin, getRequesterId } from "../middleware/agent-acl.js";
+import { runKbExtraction } from "../services/kbExtractDaily.js";
+import { runKbMerge, runKbMergePending } from "../services/kbMergeDaily.js";
+import { runKbReconcile } from "../services/kbReconcile.js";
+import { prisma } from "../db.js";
+
+const logger = createLogger("kb-routes", createTraceId());
+export const kbRouter: Router = Router();
+
+// ---------------------------------------------------------------------------
+// Request parsing
+// ---------------------------------------------------------------------------
+
+/** A bad request from the caller. Distinguished from a downstream failure. */
+class BadRequest extends Error {}
+
+function requireString(source: Record<string, unknown>, key: string): string {
+  const value = source[key];
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) throw new BadRequest(`${key} is required`);
+  return trimmed;
+}
+
+function optionalString(source: Record<string, unknown>, key: string): string | undefined {
+  const value = source[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Rejects any attempt to walk out of the collection. */
+function requirePath(source: Record<string, unknown>): string {
+  const path = requireString(source, "path");
+  if (path.startsWith("/") || path.includes("..")) {
+    throw new BadRequest("path must be relative with no '..' segments");
+  }
+  return path;
+}
+
+/** Opens the collection named by the request. */
+async function openFs(source: Record<string, unknown>): Promise<KbFs> {
+  const collectionId = requireString(source, "collectionId");
+  const userId = requireString(source, "userId");
+  const scopeType = optionalString(source, "scopeType");
+  const scopeId = optionalString(source, "scopeId");
+
+  return KbFs.open(collectionId, userId, {
+    ...(scopeType ? { scopeType } : {}),
+    ...(scopeId ? { scopeId } : {}),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Handler wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps a handler so every route shares one error contract:
+ *
+ *   BadRequest              → 400, the caller can fix it
+ *   "not found"/"not unique" → 400, the AGENT can fix it by retrying differently
+ *   anything else            → 502, something downstream broke
+ *
+ * Without this each route grew its own try/catch and they drifted.
+ */
+function handle<T>(
+  name: string,
+  fn: (source: Record<string, unknown>) => Promise<T>,
+) {
+  return async (req: Request, res: Response): Promise<void> => {
+    const source = (req.method === "GET" ? req.query : req.body ?? {}) as Record<string, unknown>;
+    try {
+      res.json({ success: true, data: await fn(source) });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const callerError = err instanceof BadRequest || /not found|not unique/.test(message);
+      if (!callerError) logger.warn(`[kb] ${name} failed: ${message}`);
+      res.status(callerError ? 400 : 502).json({ success: false, error: message });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+/** GET /kb/list?userId=&collectionId=&prefix= */
+kbRouter.get(
+  "/list",
+  requireAuth,
+  handle("list", async (source) => {
+    const fs = await openFs(source);
+    return { paths: fs.list(optionalString(source, "prefix") ?? "") };
+  }),
+);
+
+/** GET /kb/read?userId=&collectionId=&path= */
+kbRouter.get(
+  "/read",
+  requireAuth,
+  handle("read", async (source) => {
+    const path = requirePath(source);
+    const fs = await openFs(source);
+    const content = await fs.read(path);
+    // A missing page is a normal answer, not an error: the agent probes for
+    // existence constantly and shouldn't have to tell 404 from failure.
+    return { path, found: content !== null, content };
+  }),
+);
+
+/** GET /kb/grep?userId=&collectionId=&pattern=&prefix= */
+kbRouter.get(
+  "/grep",
+  requireAuth,
+  handle("grep", async (source) => {
+    const pattern = requireString(source, "pattern");
+    const fs = await openFs(source);
+    return { matches: await fs.grep(pattern, optionalString(source, "prefix") ?? "") };
+  }),
+);
+
+/** POST /kb/write  { userId, collectionId, path, content } */
+kbRouter.post(
+  "/write",
+  requireAuth,
+  handle("write", async (source) => {
+    const path = requirePath(source);
+    const content = requireString(source, "content");
+    const fs = await openFs(source);
+    const outcome = await fs.write(path, content);
+    logger.info(`[kb] ${outcome.status} ${path}`);
+    return outcome;
+  }),
+);
+
+/** POST /kb/edit  { userId, collectionId, path, oldText, newText } */
+kbRouter.post(
+  "/edit",
+  requireAuth,
+  handle("edit", async (source) => {
+    const path = requirePath(source);
+    const oldText = requireString(source, "oldText");
+    // Empty newText is legitimate — it deletes the snippet.
+    const newText = typeof source["newText"] === "string" ? source["newText"] : "";
+    const fs = await openFs(source);
+    const outcome = await fs.edit(path, oldText, newText);
+    logger.info(`[kb] edited ${path}`);
+    return outcome;
+  }),
+);
+
+/**
+ * Admin trigger: build the KB for one project now, instead of waiting for the
+ * nightly. Admin-only, because it starts a run that costs real model spend and
+ * writes into a shared knowledge base.
+ *
+ * Returns immediately — extraction takes minutes per project, far longer than a
+ * request should hold. Each channel resumes from its own watermark, so this
+ * catches up whatever is outstanding rather than covering a caller-chosen day.
+ * Progress is visible in kb_runs (kind=EXTRACT); findings land in GCS.
+ */
+kbRouter.post("/extract/:projectCode", requireClawAdmin, async (req: Request, res: Response) => {
+  const projectCode = String(req.params["projectCode"] ?? "").toUpperCase();
+  if (!projectCode) {
+    res.status(400).json({ success: false, error: "projectCode required" });
+    return;
+  }
+
+  // A run is asynchronous and takes minutes. Without this, a second click walks
+  // from the same watermark and re-extracts the same windows — duplicated model
+  // spend for findings the merge will only dedupe away.
+  const active = await prisma.kbRun.findFirst({
+    where: {
+      kind: "EXTRACT",
+      projectCode,
+      status: "RUNNING",
+      // Anything older than an hour is an orphan from a killed process, not a
+      // live run — no single window takes that long.
+      startedAt: { gt: new Date(Date.now() - 60 * 60 * 1000) },
+    },
+    orderBy: { startedAt: "desc" },
+  });
+
+  if (active) {
+    const window = active.windowFrom?.toISOString().slice(0, 10) ?? "?";
+    res.status(409).json({
+      success: false,
+      error: `extraction already running for ${projectCode} (${active.subject}, window ${window}) — wait for it to finish`,
+    });
+    return;
+  }
+
+  void runKbExtraction(projectCode).catch((err) => {
+    logger.error(
+      `[kb-extract] on-demand run failed for ${projectCode}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+
+  res.status(202).json({ success: true, data: { projectCode, status: "started" } });
+});
+
+// ---------------------------------------------------------------------------
+// Admin: which projects and channels feed the KB
+// ---------------------------------------------------------------------------
+
+/** Everything the admin screen renders: opted-in projects and per-channel progress. */
+kbRouter.get("/projects", requireClawAdmin, async (_req: Request, res: Response) => {
+  const projects = await prisma.kbProject.findMany({
+    include: { channels: { orderBy: { name: "asc" } } },
+    orderBy: { projectCode: "asc" },
+  });
+
+  res.json({
+    success: true,
+    data: projects.map((project) => ({
+      projectId: project.projectId,
+      projectCode: project.projectCode,
+      projectName: project.projectName,
+      collectionId: project.collectionId,
+      extractAgentSlug: project.extractAgentSlug,
+      enabled: project.enabled,
+      enabledBy: project.enabledBy,
+      enabledAt: project.enabledAt,
+      channels: project.channels.map((channel) => ({
+        channelId: channel.channelId,
+        name: channel.name,
+        visibility: channel.visibility,
+        included: channel.included,
+        includedBy: channel.includedBy,
+        // Progress is the pair: where the walk starts, and how far it has got.
+        // `extractedThrough` alone cannot distinguish "nearly done" from
+        // "barely started" without knowing the origin.
+        backfillFrom: channel.backfillFrom,
+        includedAt: channel.includedAt,
+        extractedThrough: channel.extractedThrough,
+        lastRunAt: channel.lastRunAt,
+        lastError: channel.lastError,
+      })),
+    })),
+  });
+});
+
+/**
+ * Opt a project in, or change where its KB is written.
+ *
+ * Upsert rather than create: re-enabling a project that was turned off should
+ * keep its channels and their watermarks, so it resumes instead of re-extracting
+ * everything.
+ */
+kbRouter.post("/projects", requireClawAdmin, async (req: Request, res: Response) => {
+  const body = req.body as {
+    projectId?: string;
+    projectCode?: string;
+    projectName?: string;
+    workspaceId?: string;
+    collectionId?: string;
+    enabled?: boolean;
+    extractAgentSlug?: string;
+  };
+
+  if (!body.projectId || !body.projectCode || !body.workspaceId || !body.collectionId) {
+    res.status(400).json({
+      success: false,
+      error: "projectId, projectCode, workspaceId and collectionId are required",
+    });
+    return;
+  }
+
+  const enabled = body.enabled !== false;
+  const actor = getRequesterId(req);
+
+  const project = await prisma.kbProject.upsert({
+    where: { projectId: body.projectId },
+    create: {
+      projectId: body.projectId,
+      // Uppercased because this becomes the KB path segment, and a page cannot
+      // be moved once written — "XYNE" and "xyne" would be two permanent trees.
+      projectCode: body.projectCode.toUpperCase(),
+      projectName: body.projectName ?? body.projectCode,
+      workspaceId: body.workspaceId,
+      collectionId: body.collectionId,
+      enabled,
+      extractAgentSlug: body.extractAgentSlug?.trim() || null,
+      enabledBy: enabled ? actor ?? null : null,
+      enabledAt: enabled ? new Date() : null,
+    },
+    update: {
+      collectionId: body.collectionId,
+      extractAgentSlug: body.extractAgentSlug?.trim() || null,
+      enabled,
+      enabledBy: enabled ? actor ?? null : null,
+      enabledAt: enabled ? new Date() : null,
+    },
+  });
+
+  logger.info(`[kb-admin] project ${project.projectCode} enabled=${enabled} by=${actor ?? "?"}`);
+  res.json({ success: true, data: project });
+});
+
+/**
+ * Include or exclude one channel.
+ *
+ * Private channels are excluded by default and are opted in HERE, deliberately:
+ * nothing in the stack can delete a KB page, so a wrongly-included private
+ * channel cannot be retracted. `includedBy` records who accepted that.
+ *
+ * `backfillFrom` sets how far back to walk. Omit it and extraction starts from
+ * the moment of inclusion — the safe default, since backfilling a year of a
+ * channel costs real money.
+ */
+
+/**
+ * Oldest backfill we allow, in days.
+ *
+ * Enforced server-side rather than trusted to the caller: a typo'd year turns
+ * into thousands of windows, each an agent session with real cost, and the
+ * watermark means it would grind on across nights before anyone noticed.
+ */
+const MAX_BACKFILL_DAYS = 120;
+
+function clampBackfill(from: Date): { at: Date; clamped: boolean } {
+  const floor = new Date(Date.now() - MAX_BACKFILL_DAYS * 24 * 60 * 60 * 1000);
+  return from < floor ? { at: floor, clamped: true } : { at: from, clamped: false };
+}
+
+kbRouter.post("/channels", requireClawAdmin, async (req: Request, res: Response) => {
+  const body = req.body as {
+    channelId?: string;
+    projectId?: string;
+    name?: string;
+    visibility?: string;
+    scopeType?: string;
+    included?: boolean;
+    backfillFrom?: string;
+  };
+
+  if (!body.channelId || !body.projectId) {
+    res.status(400).json({ success: false, error: "channelId and projectId are required" });
+    return;
+  }
+
+  const project = await prisma.kbProject.findUnique({ where: { projectId: body.projectId } });
+  if (!project) {
+    res.status(400).json({ success: false, error: "project is not opted in — enable it first" });
+    return;
+  }
+
+  const included = body.included !== false;
+  const actor = getRequesterId(req);
+  const requested = body.backfillFrom ? new Date(body.backfillFrom) : undefined;
+  const clamp = requested ? clampBackfill(requested) : undefined;
+  const backfillFrom = clamp?.at;
+  if (clamp?.clamped) {
+    logger.warn(`[kb-admin] backfill for ${body.channelId} clamped to ${MAX_BACKFILL_DAYS} days`);
+  }
+
+  const channel = await prisma.kbChannel.upsert({
+    where: { channelId: body.channelId },
+    create: {
+      channelId: body.channelId,
+      projectId: body.projectId,
+      name: body.name ?? body.channelId,
+      visibility: body.visibility ?? "PUBLIC",
+      scopeType: body.scopeType ?? "DEFAULT",
+      included,
+      includedBy: included ? actor ?? null : null,
+      includedAt: included ? new Date() : null,
+      backfillFrom: backfillFrom ?? null,
+    },
+    update: {
+      included,
+      includedBy: included ? actor ?? null : null,
+      includedAt: included ? new Date() : null,
+      ...(backfillFrom ? { backfillFrom } : {}),
+    },
+  });
+
+  logger.info(
+    `[kb-admin] channel ${channel.name} (${channel.visibility}) included=${included} by=${actor ?? "?"}`,
+  );
+  res.json({ success: true, data: channel });
+});
+
+/**
+ * Extract one channel now.
+ *
+ * Project-wide extraction walks every included channel, which is the wrong
+ * granularity when only one is behind or you are testing a prompt change on a
+ * single channel.
+ */
+kbRouter.post("/channels/:channelId/extract", requireClawAdmin, async (req: Request, res: Response) => {
+  const channelId = String(req.params["channelId"] ?? "");
+  const channel = await prisma.kbChannel.findUnique({
+    where: { channelId },
+    include: { project: true },
+  });
+  if (!channel) {
+    res.status(404).json({ success: false, error: "channel not registered" });
+    return;
+  }
+
+  const active = await prisma.kbRun.findFirst({
+    where: {
+      kind: "EXTRACT",
+      channelId,
+      status: "RUNNING",
+      startedAt: { gt: new Date(Date.now() - 60 * 60 * 1000) },
+    },
+  });
+  if (active) {
+    res.status(409).json({
+      success: false,
+      error: `extraction already running for ${channel.name} (window ${active.windowFrom?.toISOString().slice(0, 10) ?? "?"})`,
+    });
+    return;
+  }
+
+  void runKbExtraction(channel.project.projectCode, channelId).catch((err) => {
+    logger.error(
+      `[kb-extract] on-demand channel run failed for ${channel.name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+
+  res.status(202).json({ success: true, data: { channel: channel.name, status: "started" } });
+});
+
+/**
+ * Recent runs across every stage of the pipeline.
+ *
+ * One endpoint rather than three, because the question is almost always "what
+ * happened to this project?" — and extract, merge and reconcile are stages of
+ * one chain. Narrow with ?kind= when you want a single stage.
+ */
+kbRouter.get("/runs", requireClawAdmin, async (req: Request, res: Response) => {
+  const limit = Math.min(Number(req.query["limit"] ?? 120), 400);
+  const kind = String(req.query["kind"] ?? "").toUpperCase();
+  const runs = await prisma.kbRun.findMany({
+    where: kind ? { kind } : {},
+    orderBy: { startedAt: "desc" },
+    take: limit,
+  });
+  res.json({ success: true, data: runs });
+});
+
+/**
+ * Stop extracting a project and forget its progress.
+ *
+ * Cascades to its channels and their run history. This does NOT delete the KB
+ * pages already written — nothing in the stack can. Removing a project stops
+ * new findings; the pages it produced stay in the collection.
+ *
+ * To pause instead, set enabled=false: that keeps the watermarks, so resuming
+ * picks up where it left off rather than re-extracting (and re-paying for)
+ * everything.
+ */
+kbRouter.delete("/projects/:projectId", requireClawAdmin, async (req: Request, res: Response) => {
+  const projectId = String(req.params["projectId"] ?? "");
+  const existing = await prisma.kbProject.findUnique({ where: { projectId } });
+  if (!existing) {
+    res.status(404).json({ success: false, error: "project not registered" });
+    return;
+  }
+
+  await prisma.kbProject.delete({ where: { projectId } });
+  logger.info(`[kb-admin] project ${existing.projectCode} removed by ${getRequesterId(req) ?? "?"}`);
+  res.json({ success: true, data: { projectCode: existing.projectCode } });
+});
+
+/**
+ * Remove a channel from extraction, discarding its watermark and run history.
+ *
+ * Un-ticking `included` is usually what you want: it stops extraction but keeps
+ * `extractedThrough`, so re-including resumes instead of re-reading months of
+ * history through the model again.
+ */
+kbRouter.delete("/channels/:channelId", requireClawAdmin, async (req: Request, res: Response) => {
+  const channelId = String(req.params["channelId"] ?? "");
+  const existing = await prisma.kbChannel.findUnique({ where: { channelId } });
+  if (!existing) {
+    res.status(404).json({ success: false, error: "channel not registered" });
+    return;
+  }
+
+  await prisma.kbChannel.delete({ where: { channelId } });
+  logger.info(`[kb-admin] channel ${existing.name} removed by ${getRequesterId(req) ?? "?"}`);
+  res.json({ success: true, data: { name: existing.name } });
+});
+
+/**
+ * Re-run extraction for a channel from a given date.
+ *
+ * Clears the watermark so the next run walks forward from `from` again. Setting
+ * `backfillFrom` alone does nothing: pendingWindows() reads
+ * `extractedThrough ?? backfillFrom`, so the watermark always wins until it is
+ * cleared — which is the whole point of this endpoint.
+ *
+ * Re-extracted findings are safe to merge: they carry the same idempotencyKey,
+ * so the merge treats them as confirmation rather than duplicates. The cost is
+ * model spend on ground already covered, so this is an explicit action rather
+ * than something a date change triggers silently.
+ */
+kbRouter.post("/channels/:channelId/backfill", requireClawAdmin, async (req: Request, res: Response) => {
+  const channelId = String(req.params["channelId"] ?? "");
+  const from = (req.body as { from?: string })?.from;
+  if (!from || Number.isNaN(Date.parse(from))) {
+    res.status(400).json({ success: false, error: "from (ISO date) is required" });
+    return;
+  }
+
+  const existing = await prisma.kbChannel.findUnique({ where: { channelId } });
+  if (!existing) {
+    res.status(404).json({ success: false, error: "channel not registered" });
+    return;
+  }
+
+  const { at: clampedFrom, clamped } = clampBackfill(new Date(from));
+  const channel = await prisma.kbChannel.update({
+    where: { channelId },
+    data: {
+      backfillFrom: clampedFrom,
+      extractedThrough: null,
+      lastError: null,
+    },
+  });
+
+  logger.info(
+    `[kb-admin] backfill queued for ${channel.name} from ${from} by ${getRequesterId(req) ?? "?"}`,
+  );
+  res.json({
+    success: true,
+    data: { name: channel.name, backfillFrom: channel.backfillFrom, clamped },
+  });
+});
+
+/**
+ * Admin trigger: merge a day's findings into KB pages now.
+ *
+ * Defaults to yesterday, the partition the nightly would have consumed.
+ * Returns immediately — a merge takes minutes per project. Progress lands in
+ * kb_runs, which the admin screen renders.
+ */
+kbRouter.post("/merge/:projectCode", requireClawAdmin, async (req: Request, res: Response) => {
+  const projectCode = String(req.params["projectCode"] ?? "").toUpperCase();
+  // A specific day when asked for; otherwise everything outstanding, oldest
+  // first — a backfill produces many days of findings and merging only one
+  // would leave the rest stranded in storage.
+  const dayParam = req.query["day"];
+  const day =
+    typeof dayParam === "string" && /^\d{4}-\d{2}-\d{2}$/.test(dayParam) ? dayParam : null;
+
+  const activeMerge = await prisma.kbRun.findFirst({
+    where: {
+      kind: "MERGE",
+      projectCode,
+      status: "RUNNING",
+      startedAt: { gt: new Date(Date.now() - 60 * 60 * 1000) },
+    },
+    orderBy: { startedAt: "desc" },
+  });
+
+  if (activeMerge) {
+    res.status(409).json({
+      success: false,
+      error: `merge already running for ${projectCode} (day ${activeMerge.subject}) — wait for it to finish`,
+    });
+    return;
+  }
+
+  const work = day ? runKbMerge(day, projectCode) : runKbMergePending(projectCode);
+  void work.catch((err) => {
+    logger.error(
+      `[kb-merge] on-demand run failed for ${projectCode}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+
+  res.status(202).json({
+    success: true,
+    data: { projectCode, day: day ?? "all pending", status: "started" },
+  });
+});
+
+/**
+ * Re-read the written KB and correct it.
+ *
+ * Manual only, and deliberately so: this rewrites pages the merge already wrote,
+ * and a fold cannot be undone.
+ */
+kbRouter.post("/reconcile/:projectCode", requireClawAdmin, async (req: Request, res: Response) => {
+  const projectCode = String(req.params["projectCode"] ?? "").toUpperCase();
+  if (!projectCode) {
+    res.status(400).json({ success: false, error: "projectCode required" });
+    return;
+  }
+
+  // Two reconciles at once would each rewrite pages from a view of the KB the
+  // other is already changing — the later write silently wins.
+  const active = await prisma.kbRun.findFirst({
+    where: {
+      kind: "RECONCILE",
+      projectCode,
+      status: "RUNNING",
+      startedAt: { gt: new Date(Date.now() - 60 * 60 * 1000) },
+    },
+    orderBy: { startedAt: "desc" },
+  });
+
+  if (active) {
+    res.status(409).json({
+      success: false,
+      error: `reconcile already running for ${projectCode} (${active.subject}) — wait for it to finish`,
+    });
+    return;
+  }
+
+  // ?entity=services/vespa narrows to one, for a targeted fix rather than a sweep.
+  const entity = typeof req.query["entity"] === "string" ? req.query["entity"].trim() : "";
+  void runKbReconcile(projectCode, entity || undefined).catch((err) => {
+    logger.error(
+      `[kb-reconcile] on-demand run failed for ${projectCode}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+
+  res.status(202).json({ success: true, data: { projectCode, status: "started" } });
+});
+

--- a/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
@@ -31,6 +31,7 @@ import {
 } from "./lib/branching.js";
 
 import { createLogger } from "../logger.js";
+import { attachKbGrantsToConfig } from "../lib/spaces-kb.js";
 const log = createLogger("run-stream");
 const SESSION_LOCKED_MESSAGE = "Still finishing your previous answer - try again in a few seconds.";
 
@@ -880,6 +881,15 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
         description: agentRow.description,
       },
     };
+
+    // KB curators need their collection grants on the wire — see
+    // attachKbGrantsToConfig. No-op for every other agent.
+    const configForClaw = (await attachKbGrantsToConfig(
+      enrichedAgentConfig,
+      agentRow.id,
+      prisma,
+    )) as Record<string, unknown>;
+
     const fastModeEnabled = await resolveFastMode(
       convId,
       slug,
@@ -913,7 +923,7 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
       researchContext,
       webSearchEnabled,
       deepResearchEnabled,
-      agentConfig: enrichedAgentConfig,
+      agentConfig: configForClaw,
       additionalInstructions,
       ...(generateFollowUpSuggestions === true ? { generateFollowUpSuggestions: true } : {}),
       __persistedByCaller: true,

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -423,28 +423,26 @@ async function resolveSpacesAuthFromRequest(
 async function resolveAgent(
   agentSlug: string | undefined,
   orgId: string | undefined,
-): Promise<
-  | {
-      id: string;
-      systemPrompt: string;
-      modelId?: string | undefined;
-      agentConfig: Record<string, unknown>;
-      config?: unknown;
-      orgId: string;
-      delegationTier: "standard" | "orchestrator";
-      spacesAppId?: string | null;
-      spacesAppToken?: string | null;
-      spacesAppUserId?: string | null;
-      skills?: {
-        slug: string;
-        name: string;
-        description: string;
-        content: string;
-        files?: Array<{ relativePath: string; content: string; contentType?: string | null }>;
-      }[];
-    }
-  | { error: string }
-> {
+  callerFindingScope?: unknown,
+): Promise<{
+  id: string;
+  systemPrompt: string;
+  modelId?: string | undefined;
+  agentConfig: Record<string, unknown>;
+  config?: unknown;
+  orgId: string;
+  delegationTier: "standard" | "orchestrator";
+  spacesAppId?: string | null;
+  spacesAppToken?: string | null;
+  spacesAppUserId?: string | null;
+  skills?: {
+    slug: string;
+    name: string;
+    description: string;
+    content: string;
+    files?: Array<{ relativePath: string; content: string; contentType?: string | null }>;
+  }[];
+} | { error: string }> {
   // Find by slug, or fall back to default agent. Include the skill's
   // sibling files (SkillFile rows) so directory-style skills get
   // materialized in the child workspace alongside SKILL.md.
@@ -501,7 +499,14 @@ async function resolveAgent(
     spacesAppId: agent.spacesAppId ?? null,
     spacesAppToken: agent.spacesAppToken ?? null,
     spacesAppUserId: agent.spacesAppUserId ?? null,
-    agentConfig: stripPlatformConfigKeys(agent.config as Record<string, unknown>),
+    // Caller-supplied runtime scope is merged in. `agentConfig` is otherwise
+    // rebuilt from the agent row, which would drop anything the dispatcher
+    // passed — findingScope tells the extractor which project it is reading
+    // for, and without it emit-finding is never built at all.
+    agentConfig: {
+      ...stripPlatformConfigKeys(agent.config as Record<string, unknown>),
+      ...(callerFindingScope ? { findingScope: callerFindingScope } : {}),
+    },
     config: agent.config,
     ...(skills.length > 0 ? { skills } : {}),
   };
@@ -909,7 +914,11 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
 
     // Resolve agent (only if explicitly requested). Org comes from auth/user DB,
     // never from request body.
-    const agent = await resolveAgent(agentSlug, runtimeOrgId);
+    const agent = await resolveAgent(
+      agentSlug,
+      runtimeOrgId,
+      (req.body as { agentConfig?: { findingScope?: unknown } } | undefined)?.agentConfig?.findingScope,
+    );
     if ("error" in agent) {
       res.status(400).json({ success: false, error: agent.error });
       return;

--- a/apps/xyne-claw-auth/backend/src/services/kbExtractDaily.ts
+++ b/apps/xyne-claw-auth/backend/src/services/kbExtractDaily.ts
@@ -1,0 +1,705 @@
+/**
+ * People-KB extraction — turns chat into findings, one channel window at a time.
+ *
+ * Self-scheduling via setTimeout, same pattern as digitalTwinDaily.ts. Fires at
+ * 1:30 AM IST (20:00 UTC), before the KB merge that consumes what this writes.
+ *
+ * Progress is a WATERMARK per channel (`KbChannel.extractedThrough`), not a
+ * per-night date. Three things fall out of that:
+ *
+ *   - Backfill and nightly incremental are the same code path. A channel added
+ *     today with a year of history just has further to walk.
+ *   - A failed window is retried, because the watermark is only advanced when
+ *     the window completes.
+ *   - "Is this channel caught up?" is a column rather than a log search.
+ *
+ * SELECTION IS CODE, NOT THE AGENT. Window size, row caps and batch sizes are
+ * enforced here, so a model that decides to be thorough cannot pull the corpus.
+ *
+ * Failures are non-fatal per channel and per batch: one channel's outage must
+ * not abandon the rest.
+ */
+import { prisma } from "../db.js";
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+import { acquireCronLeaderLock } from "../lib/cron-leader-lock.js";
+import { attachKbGrantsToConfig } from "../lib/spaces-kb.js";
+import { consumeClawStream } from "../lib/consume-claw-stream.js";
+
+const logger = createLogger("kb-extract");
+
+/** Fallback extractor when a project does not name its own. */
+const DEFAULT_AGENT_SLUG = process.env["KB_EXTRACT_AGENT_SLUG"] ?? "kb-extract";
+
+/** How much time one window covers. Keeps a long backfill interruptible. */
+const WINDOW_HOURS = 24;
+
+/** Windows per channel per run, so one far-behind channel cannot take a whole night. */
+const MAX_WINDOWS_PER_RUN = 7;
+
+/**
+ * Higher cap while a channel is still catching up (nothing extracted yet).
+ *
+ * The steady-state cap is there so one busy channel cannot monopolise a night,
+ * which is the wrong constraint for a first backfill — at 7 windows a night a
+ * year of history would take two months to ingest.
+ */
+const MAX_WINDOWS_BACKFILL = 60;
+
+/** Chars per batch — an approximation of tokens, as in userMemoryBatcher. */
+const BATCH_CHAR_BUDGET = 100_000;
+
+/** One pasted stack trace can be 100 KB; the head carries the signal. */
+const MSG_CHAR_CAP = 3_000;
+
+/** A long thread truncates rather than blowing a batch on its own. */
+const MAX_MSGS_PER_THREAD = 80;
+
+/** Hard ceiling per window, so a busy day cannot run away. */
+const MAX_MSGS_PER_WINDOW = 5_000;
+
+/** Acknowledgements ("ok", "thanks") are most of the volume and carry no signal. */
+const MIN_MSG_CHARS = 40;
+
+/** Tickets per channel. Only those matching a fetched thread are used. */
+const MAX_TICKETS_PER_CHANNEL = 800;
+
+/** A ticket description can be a whole design doc; the head carries the intent. */
+const TICKET_DESC_CAP = 1_500;
+
+/** How long one extraction session may run before it is treated as stuck. */
+const SESSION_WAIT_MS = Number(process.env["KB_EXTRACT_SESSION_WAIT_MS"] ?? 15 * 60 * 1000);
+
+/**
+ * Batches in flight at once.
+ *
+ * Unlike the merge, extraction batches are independent — each writes its own
+ * findings object and none reads the KB — so they need no ordering between
+ * them. Serialising them would make a 60-window backfill take days. The cap is
+ * here only so one channel cannot open a session per batch against the model
+ * provider all at once.
+ */
+const MAX_CONCURRENT_BATCHES = 4;
+
+/** Base for citation links. Wrong-but-present beats a synthesised id. */
+const SPACES_BASE_URL = (process.env["SPACES_PUBLIC_URL"] ?? "https://spaces.juspay.in").replace(/\/+$/, "");
+
+interface Message {
+  docId: string;
+  threadId: string;
+  userId: string;
+  username: string | undefined;
+  text: string;
+  /** Display string, e.g. "13/05/2026". Not sortable — see createdAtTimestamp. */
+  createdAt: string;
+  /** Epoch ms. The only orderable time field on chat_message. */
+  createdAtTimestamp: number;
+}
+
+/**
+ * A ticket attached to a thread.
+ *
+ * Threads and tickets are the same conversation seen from two sides: the thread
+ * carries the diagnosis, the ticket carries the resolution and who owned it.
+ * Extracting one without the other loses half of most findings.
+ */
+interface Ticket {
+  xyneId: string;
+  title: string;
+  description: string;
+  status: string;
+  stage: string;
+  assignedToName: string;
+  createdByName: string;
+  threadId: string;
+}
+
+interface Thread {
+  threadId: string;
+  messages: Message[];
+  ticket: Ticket | undefined;
+  chars: number;
+}
+
+interface Window {
+  from: Date;
+  to: Date;
+}
+
+interface ExtractTarget {
+  channelId: string;
+  channelName: string;
+  /** The user the KB listing is read as, for the known-entity vocabulary. */
+  userId: string;
+  /** Chosen per project, so one project can trial a different prompt. */
+  agentSlug: string;
+  project: { id: string; code: string; name: string };
+  workspaceId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Vespa
+// ---------------------------------------------------------------------------
+
+/** Vespa rejects any single request above this; larger reads must page. */
+const VESPA_PAGE_SIZE = 400;
+
+async function vespaPage(yql: string, hits: number, offset: number): Promise<Array<Record<string, unknown>>> {
+  const response = await fetch(`${CONFIG.vespaQueryEndpoint}/search/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ yql, hits, offset, timeout: "20s" }),
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`vespa query failed (${response.status}): ${await response.text()}`);
+  }
+
+  const body = (await response.json()) as {
+    root?: {
+      children?: Array<{ fields?: Record<string, unknown> }>;
+      errors?: Array<{ message?: string }>;
+    };
+  };
+  // Vespa answers 200 with an `errors` array for a rejected query, so a bad
+  // request would otherwise look like an empty result — indistinguishable from
+  // a quiet channel.
+  const failure = body.root?.errors?.[0]?.message;
+  if (failure) throw new Error(`vespa query rejected: ${failure}`);
+
+  return (body.root?.children ?? []).map((child) => child.fields ?? {});
+}
+
+/**
+ * Reads up to `limit` rows, paging around Vespa's per-request cap.
+ *
+ * Offset paging is NOT used: Vespa rejects offsets past ~1000, so a busy window
+ * would truncate silently. Instead the caller supplies a `__CURSOR__` token in
+ * the YQL, which is replaced with the highest createdAtTimestamp seen so far —
+ * unbounded, and stable because the query is ordered.
+ */
+async function vespaQuery(yql: string, limit: number, cursorFrom?: number): Promise<Array<Record<string, unknown>>> {
+  const cursored = yql.includes("__CURSOR__");
+  if (!cursored) return vespaPage(yql, Math.min(VESPA_PAGE_SIZE, limit), 0);
+
+  const rows: Array<Record<string, unknown>> = [];
+  let cursor = cursorFrom ?? 0;
+
+  while (rows.length < limit) {
+    const page = await vespaPage(
+      `${yql.replace("__CURSOR__", String(cursor))} order by createdAtTimestamp asc`,
+      VESPA_PAGE_SIZE,
+      0,
+    );
+    if (page.length === 0) break;
+    rows.push(...page);
+
+    const newest = Math.max(...page.map((r) => Number(r["createdAtTimestamp"] ?? 0)));
+    // No forward progress means every row shares a timestamp; stop rather than
+    // loop forever re-reading the same page.
+    if (newest <= cursor) break;
+    cursor = newest + 1;
+    if (page.length < VESPA_PAGE_SIZE) break;
+  }
+  return rows;
+}
+
+async function fetchMessages(channelId: string, window: Window): Promise<Message[]> {
+  const safeChannelId = channelId.replace(/"/g, "");
+  const yql =
+    `select docId, threadId, userId, username, text, createdAt, createdAtTimestamp from chat_message where ` +
+    `channelId contains "${safeChannelId}" and ` +
+    `createdAtTimestamp >= __CURSOR__ and ` +
+    `createdAtTimestamp < ${window.to.getTime()} and ` +
+    `deletedAt = 0`;
+
+  const rows = await vespaQuery(yql, MAX_MSGS_PER_WINDOW, window.from.getTime());
+
+  return rows
+    .map((row) => ({
+      docId: String(row["docId"] ?? ""),
+      threadId: String(row["threadId"] ?? row["docId"] ?? ""),
+      userId: String(row["userId"] ?? ""),
+      username: row["username"] ? String(row["username"]) : undefined,
+      text: String(row["text"] ?? "").slice(0, MSG_CHAR_CAP),
+      createdAt: String(row["createdAt"] ?? ""),
+      createdAtTimestamp: Number(row["createdAtTimestamp"] ?? 0),
+    }))
+    .filter((message) => message.text.trim().length >= MIN_MSG_CHARS);
+}
+
+/** Tickets raised in this channel, keyed by the thread they belong to. */
+async function fetchTickets(channelId: string): Promise<Map<string, Ticket>> {
+  const safeChannelId = channelId.replace(/"/g, "");
+  const yql =
+    `select xyneId, title, description, status, stage, threadId, assignedToName, createdByName ` +
+    `from ticket where channelId contains "${safeChannelId}"`;
+
+  const byThread = new Map<string, Ticket>();
+  try {
+    for (const row of await vespaQuery(yql, MAX_TICKETS_PER_CHANNEL)) {
+      const threadId = String(row["threadId"] ?? "");
+      if (!threadId) continue;
+      byThread.set(threadId, {
+        xyneId: String(row["xyneId"] ?? ""),
+        title: String(row["title"] ?? ""),
+        description: String(row["description"] ?? "").slice(0, TICKET_DESC_CAP),
+        status: String(row["status"] ?? ""),
+        stage: String(row["stage"] ?? ""),
+        assignedToName: String(row["assignedToName"] ?? ""),
+        createdByName: String(row["createdByName"] ?? ""),
+        threadId,
+      });
+    }
+  } catch (err) {
+    // Non-fatal: chat alone still yields findings, just poorer ones.
+    logger.warn("[kb-extract] ticket fetch failed; continuing with chat only", {
+      channelId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return byThread;
+}
+
+// ---------------------------------------------------------------------------
+// Grouping and batching
+// ---------------------------------------------------------------------------
+
+/**
+ * Groups messages into threads.
+ *
+ * The thread is the unit extraction works on. Per-message extraction was tried
+ * first and produced rosters of 133 people, because a message read on its own
+ * loses the context that gives it meaning.
+ */
+function groupThreads(messages: Message[], tickets: Map<string, Ticket>): Thread[] {
+  const byThread = new Map<string, Message[]>();
+
+  for (const message of messages) {
+    const existing = byThread.get(message.threadId) ?? [];
+    existing.push(message);
+    byThread.set(message.threadId, existing);
+  }
+
+  const threads: Thread[] = [];
+  for (const [threadId, threadMessages] of byThread) {
+    const ordered = threadMessages
+      // Sorted on the numeric field: `createdAt` is a display string like
+      // "13/05/2026", which sorts lexicographically and therefore wrongly.
+      .sort((a, b) => a.createdAtTimestamp - b.createdAtTimestamp)
+      .slice(0, MAX_MSGS_PER_THREAD);
+
+    threads.push({
+      threadId,
+      messages: ordered,
+      ticket: tickets.get(threadId),
+      chars: ordered.reduce((total, message) => total + message.text.length, 0),
+    });
+  }
+  return threads;
+}
+
+/** Packs threads until the next would overflow. A thread is never split. */
+function packBatches(threads: Thread[]): Thread[][] {
+  const batches: Thread[][] = [];
+  let current: Thread[] = [];
+  let chars = 0;
+
+  for (const thread of threads) {
+    const wouldOverflow = current.length > 0 && chars + thread.chars > BATCH_CHAR_BUDGET;
+    if (wouldOverflow) {
+      batches.push(current);
+      current = [];
+      chars = 0;
+    }
+    current.push(thread);
+    chars += thread.chars;
+  }
+
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+function renderBatch(threads: Thread[], channelId: string): string {
+  return threads
+    .map((thread) => {
+      const header = `### Thread ${thread.threadId}\n` +
+        // Real permalink, so citations in the KB are clickable. Synthesising one
+        // from an id produces links that look right and go nowhere.
+        `permalink: ${SPACES_BASE_URL}/c/${channelId}/t/${thread.threadId}\n`;
+
+      const ticket = thread.ticket
+        ? `[TICKET ${thread.ticket.xyneId}] status=${thread.ticket.status} stage=${thread.ticket.stage} ` +
+          `assignee=${thread.ticket.assignedToName} reporter=${thread.ticket.createdByName}\n` +
+          `permalink: ${SPACES_BASE_URL}/tickets/${thread.ticket.xyneId}\n` +
+          `  title: ${thread.ticket.title}\n  description: ${thread.ticket.description}\n`
+        : "";
+
+      const lines = thread.messages
+        .map((m) => `[${m.createdAt}] ${m.username ?? m.userId} (userId: ${m.userId}): ${m.text}`)
+        .join("\n");
+
+      return header + ticket + lines;
+    })
+    .join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Windows
+// ---------------------------------------------------------------------------
+
+/**
+ * The windows a channel still owes, oldest first.
+ *
+ * Starts at the watermark, or at `backfillFrom` when the channel has never run.
+ * Capped so one far-behind channel cannot consume a whole night.
+ */
+function pendingWindows(channel: {
+  extractedThrough: Date | null;
+  backfillFrom: Date | null;
+  includedAt: Date | null;
+}): Window[] {
+  const start = channel.extractedThrough ?? channel.backfillFrom ?? channel.includedAt ?? new Date();
+
+  // Still catching up gets the higher cap. The test is how far behind the
+  // watermark is, NOT whether one window has completed: after the first run a
+  // backfilling channel has a watermark like any other, and treating that as
+  // "caught up" would drop it to the steady-state cap with months still to go.
+  const daysBehind = (Date.now() - start.getTime()) / (24 * 60 * 60 * 1000);
+  const limit = daysBehind > MAX_WINDOWS_PER_RUN ? MAX_WINDOWS_BACKFILL : MAX_WINDOWS_PER_RUN;
+
+  const windows: Window[] = [];
+  const now = Date.now();
+  let cursor = start.getTime();
+
+  while (cursor < now && windows.length < limit) {
+    const to = Math.min(cursor + WINDOW_HOURS * 60 * 60 * 1000, now);
+    windows.push({ from: new Date(cursor), to: new Date(to) });
+    cursor = to;
+  }
+  return windows;
+}
+
+/**
+ * Entity names already in the KB for this project.
+ *
+ * Without it every batch is a blank slate and invents its own name for the same
+ * thing — one day's findings produced `vespa`, `vespa-search-metrics` and
+ * `askai` alongside an existing `ask-ai`. Naming is the one decision a batch
+ * cannot make correctly in isolation, so the vocabulary is supplied rather than
+ * left to the model.
+ */
+async function knownEntities(projectCode: string, userId: string): Promise<string[]> {
+  const project = await prisma.kbProject.findFirst({ where: { projectCode } });
+  if (!project || !userId) return [];
+
+  try {
+    const params = new URLSearchParams({ collectionId: project.collectionId, userId });
+    const res = await fetch(`${CONFIG.internalUrl}/claw/api/v1/kb/list?${params}`, {
+      headers: {
+        ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey, "x-user-id": userId } : {}),
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!res.ok) return [];
+
+    const body = (await res.json()) as { data?: { paths?: string[] } };
+    const names = new Set<string>();
+    for (const path of body.data?.paths ?? []) {
+      // projects/<CODE>/<root>/<entity>/<file>.md
+      const parts = path.split("/");
+      if (parts.length >= 4) names.add(parts[3]!);
+    }
+    return [...names].sort();
+  } catch {
+    // Non-fatal: extraction still works, it just names less consistently.
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Running
+// ---------------------------------------------------------------------------
+
+async function runBatch(
+  batch: Thread[],
+  target: ExtractTarget,
+  window: Window,
+  index: number,
+  total: number,
+  known: string[],
+): Promise<void> {
+  const agent = await prisma.agent.findFirst({ where: { slug: target.agentSlug } });
+  if (!agent) throw new Error(`agent ${target.agentSlug} not found`);
+
+  const agentConfig = await attachKbGrantsToConfig(
+    agent.config as Record<string, unknown>,
+    agent.id,
+    prisma,
+  );
+
+  const day = window.from.toISOString().slice(0, 10);
+
+  // Goes through claw-auth's own /internal/run, not claw directly: claw refuses
+  // a run without a sessionId and sessionToken, and minting those is claw-auth's
+  // job. Same path the scheduled-jobs worker uses.
+  //
+  // Consumed as SSE rather than fire-and-forget. Dispatch is not completion —
+  // /internal/run answers as soon as the session is minted and the agent then
+  // runs for minutes, so a batch whose agent died used to count as done and the
+  // watermark advanced past threads nothing had read. The stream closing is the
+  // completion signal, and it carries the terminal status with it.
+  const stream = await consumeClawStream({
+    url: `${CONFIG.internalUrl}/claw/api/v1/internal/run`,
+    s2sKey: CONFIG.xyneClawS2sKey,
+    // A hung agent must not hold the window open forever.
+    signal: AbortSignal.timeout(SESSION_WAIT_MS),
+    handlers: {
+      onError: (sessionId, error) => {
+        logger.error("[kb-extract] session error", { sessionId: sessionId ?? "?", error });
+      },
+    },
+    body: {
+      userId: agent.ownerUserId,
+      agentSlug: target.agentSlug,
+      systemPrompt: agent.systemPrompt,
+      task:
+        (known.length > 0
+          ? `KNOWN ENTITIES — reuse these exact names when a finding refers to one, ` +
+            `and only invent a name when it is genuinely something else:\n  ${known.join(", ")}\n\n`
+          : "") +
+        `Extract findings from these threads. Batch ${index + 1} of ${total}.\n` +
+        `Project: ${target.project.name} (code ${target.project.code}).\n` +
+        `Channel: ${target.channelName}.\n` +
+        `Call emit-finding once per observation. Emit nothing if a thread carries no signal.`,
+      context: renderBatch(batch, target.channelId),
+      // Distinct per batch, so each is its own session rather than resuming the
+      // previous batch's context.
+      // Unique per attempt — a deterministic id resumes the previous session,
+      // which then believes the window is already done and emits nothing.
+      conversationId: `kb-extract-${target.project.code}-${target.channelId}-${day}-${index}-${Date.now()}`,
+      agentConfig: {
+        ...(agentConfig ?? {}),
+        // Closed over by emit-finding, so the model cannot attribute a finding
+        // to another project or get the project code wrong.
+        findingScope: {
+          workspaceId: target.workspaceId,
+          project: target.project,
+          // The window's date, so findings are filed by when the conversation
+          // happened rather than when extraction ran. A backfill otherwise
+          // dumps months into one prefix and the merge cannot process it in
+          // order.
+          day,
+        },
+      },
+    },
+  });
+
+  // A stream that ends without a `done` frame means the run was lost, not that
+  // it succeeded quietly — the batch's findings never reached storage either way.
+  if (stream.result?.status !== "completed") {
+    throw new Error(
+      `extraction session ended as ${stream.result?.status ?? stream.errorReason ?? "no done frame"}`,
+    );
+  }
+}
+
+/**
+ * Extracts one window for one channel, recording the attempt either way.
+ *
+ * Returns true when the window completed, which is the caller's signal to
+ * advance the watermark. An empty window still completes — otherwise a quiet
+ * channel would rescan the same range every night forever.
+ */
+async function runWindow(target: ExtractTarget, window: Window): Promise<boolean> {
+  const run = await prisma.kbRun.create({
+    data: {
+      kind: "EXTRACT",
+      projectId: target.project.id,
+      projectCode: target.project.code,
+      subject: target.channelName,
+      channelId: target.channelId,
+      windowFrom: window.from,
+      windowTo: window.to,
+    },
+  });
+
+  try {
+    const [messages, tickets] = await Promise.all([
+      fetchMessages(target.channelId, window),
+      fetchTickets(target.channelId),
+    ]);
+    const threads = groupThreads(messages, tickets);
+    const batches = packBatches(threads);
+    // Fetched once per window: the vocabulary barely moves between batches, and
+    // a list call per batch would be pure overhead.
+    const known = await knownEntities(target.project.code, target.userId);
+
+    let failedBatches = 0;
+    // A few at a time, waiting for each group before starting the next. Every
+    // batch is awaited to completion, so the window's status reflects what the
+    // agents actually did rather than what was dispatched.
+    for (let start = 0; start < batches.length; start += MAX_CONCURRENT_BATCHES) {
+      const group = batches.slice(start, start + MAX_CONCURRENT_BATCHES);
+      const outcomes = await Promise.allSettled(
+        group.map((batch, offset) =>
+          runBatch(batch, target, window, start + offset, batches.length, known),
+        ),
+      );
+
+      outcomes.forEach((outcome, offset) => {
+        if (outcome.status === "fulfilled") return;
+        // Non-fatal: the remaining batches still carry findings worth having.
+        failedBatches += 1;
+        logger.error("[kb-extract] batch failed", {
+          channel: target.channelName,
+          batch: `${start + offset + 1}/${batches.length}`,
+          err: outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason),
+        });
+      });
+    }
+
+    const failed = failedBatches > 0;
+    await prisma.kbRun.update({
+      where: { id: run.id },
+      data: {
+        metrics: { threads: threads.length, batches: batches.length },
+        status: failed ? "FAILED" : "COMPLETED",
+        finishedAt: new Date(),
+        ...(failed ? { error: `${failedBatches} of ${batches.length} batches failed` } : {}),
+      },
+    });
+
+    // A partially failed window is not advanced past — those threads would
+    // otherwise never be looked at again.
+    return !failed;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await prisma.kbRun.update({
+      where: { id: run.id },
+      data: { status: "FAILED", error: message, finishedAt: new Date() },
+    });
+    logger.error("[kb-extract] window failed", { channel: target.channelName, err: message });
+    return false;
+  }
+}
+
+/**
+ * Walks every included channel forward to now.
+ *
+ * `onlyProjectCode` narrows to one project, which is how an admin triggers a KB
+ * on demand rather than waiting for the nightly.
+ */
+export async function runKbExtraction(
+  onlyProjectCode?: string,
+  onlyChannelId?: string,
+): Promise<void> {
+  const channels = await prisma.kbChannel.findMany({
+    where: {
+      included: true,
+      ...(onlyChannelId ? { channelId: onlyChannelId } : {}),
+      project: {
+        enabled: true,
+        ...(onlyProjectCode ? { projectCode: onlyProjectCode } : {}),
+      },
+    },
+    include: { project: true },
+  });
+
+  if (channels.length === 0) {
+    logger.info("[kb-extract] no included channels — nothing to do", {
+      ...(onlyProjectCode ? { requestedProject: onlyProjectCode } : {}),
+      ...(onlyChannelId ? { requestedChannel: onlyChannelId } : {}),
+    });
+    return;
+  }
+
+  logger.info("[kb-extract] starting", { channels: String(channels.length) });
+
+  for (const channel of channels) {
+    const target: ExtractTarget = {
+      channelId: channel.channelId,
+      channelName: channel.name,
+      project: {
+        id: channel.project.projectId,
+        code: channel.project.projectCode,
+        name: channel.project.projectName,
+      },
+      workspaceId: channel.project.workspaceId,
+      agentSlug: channel.project.extractAgentSlug ?? DEFAULT_AGENT_SLUG,
+      userId: channel.project.enabledBy ?? "",
+    };
+
+    const windows = pendingWindows(channel);
+    if (windows.length === 0) continue;
+
+    logger.info("[kb-extract] channel", {
+      channel: channel.name,
+      project: channel.project.projectCode,
+      windows: String(windows.length),
+      from: windows[0]!.from.toISOString(),
+    });
+
+    for (const window of windows) {
+      const completed = await runWindow(target, window);
+
+      if (!completed) {
+        // Stop at the first failure. Advancing past it would skip those threads
+        // permanently; the next run retries this same window.
+        await prisma.kbChannel.update({
+          where: { channelId: channel.channelId },
+          data: { lastRunAt: new Date(), lastError: "window failed — will retry" },
+        });
+        break;
+      }
+
+      await prisma.kbChannel.update({
+        where: { channelId: channel.channelId },
+        data: { extractedThrough: window.to, lastRunAt: new Date(), lastError: null },
+      });
+    }
+  }
+
+  logger.info("[kb-extract] finished");
+}
+
+// ---------------------------------------------------------------------------
+// Scheduling
+// ---------------------------------------------------------------------------
+
+function scheduleNextRun(): void {
+  const now = new Date();
+  // 1:30 AM IST = 20:00 UTC the previous calendar day.
+  const nextRun = new Date(now);
+  nextRun.setUTCHours(20, 0, 0, 0);
+  if (nextRun <= now) nextRun.setUTCDate(nextRun.getUTCDate() + 1);
+
+  logger.info("[kb-extract] next run scheduled", { nextRun: nextRun.toISOString() });
+
+  setTimeout(async () => {
+    try {
+      // Multi-replica guard: every pod arms this timer, only one wins the lock.
+      if (await acquireCronLeaderLock("kb-extract-daily")) {
+        await runKbExtraction();
+      } else {
+        logger.info("[kb-extract] skipped — another replica is running tonight's extraction");
+      }
+    } catch (err) {
+      logger.error("[kb-extract] unhandled error", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      scheduleNextRun();
+    }
+  }, nextRun.getTime() - now.getTime());
+}
+
+export function initKbExtractDaily(): void {
+  if (process.env["ENABLE_KB_EXTRACT_DAILY"] !== "true") {
+    logger.info("[kb-extract] disabled (set ENABLE_KB_EXTRACT_DAILY=true to enable)");
+    return;
+  }
+  logger.info("[kb-extract] initialising");
+  scheduleNextRun();
+}

--- a/apps/xyne-claw-auth/backend/src/services/kbMergeDaily.ts
+++ b/apps/xyne-claw-auth/backend/src/services/kbMergeDaily.ts
@@ -1,0 +1,482 @@
+/**
+ * People-KB merge — folds a day's findings into KB pages.
+ *
+ * Runs an hour after extraction (21:00 UTC / 2:30 AM IST) so it consumes a
+ * complete day rather than a partial one. Same self-scheduling pattern as
+ * kbExtractDaily and digitalTwinDaily.
+ *
+ * Reads people-kb/findings/dt=<day>/<CODE>/*.jsonl — one object per extraction
+ * session — and dispatches them to the project's merge agent.
+ *
+ * SEQUENTIAL BY DESIGN. Batches write to overlapping pages and KbFs has no
+ * compare-and-swap, so two concurrent merges would silently lose each other's
+ * edits. A nightly job can afford the wall-clock.
+ *
+ * Every attempt lands in kb_runs as kind=MERGE, with the day as its subject. The
+ * merge writes pages that cannot be deleted afterwards, so "what did this run
+ * consume, and did it finish?" has to be answerable later — and those rows are
+ * also how it RESUMES, since the days already completed are the days it skips.
+ */
+import { prisma } from "../db.js";
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+import { acquireCronLeaderLock } from "../lib/cron-leader-lock.js";
+import { attachKbGrantsToConfig } from "../lib/spaces-kb.js";
+import { consumeClawStream } from "../lib/consume-claw-stream.js";
+
+const logger = createLogger("kb-merge");
+
+/** Fallback when a project does not name its own merge agent. */
+const DEFAULT_MERGE_AGENT = process.env["KB_MERGE_AGENT_SLUG"] ?? "kb-merge";
+
+/**
+ * Findings characters per batch.
+ *
+ * Smaller than the extractor's budget: the merge must also survey the existing
+ * KB and write pages, so the model needs headroom the input would otherwise
+ * consume.
+ */
+const BATCH_CHAR_BUDGET = 60_000;
+
+/** How long one merge session may run before it is treated as stuck. */
+const SESSION_WAIT_MS = Number(process.env["KB_MERGE_SESSION_WAIT_MS"] ?? 15 * 60 * 1000);
+
+/** Object-storage prefix written by the extractor's emit-finding flush. */
+const FINDINGS_PREFIX = "people-kb/findings";
+
+interface FindingsObject {
+  name: string;
+  body: string;
+}
+
+// ---------------------------------------------------------------------------
+// Reading findings out of object storage
+// ---------------------------------------------------------------------------
+
+/**
+ * Lists and downloads the day's findings for one project.
+ *
+ * Goes through the JSON API rather than a storage SDK so the same code works
+ * against fake-gcs locally and real GCS in production — the emulator speaks the
+ * same endpoints, and claw already writes through an equivalent path.
+ */
+async function fetchFindings(projectCode: string, day: string): Promise<FindingsObject[]> {
+  const bucket = process.env["GCS_BUCKET_NAME"] ?? "xyne-claw-chat-attachments";
+  const host = storageHost();
+  const prefix = `${FINDINGS_PREFIX}/dt=${day}/${projectCode}/`;
+
+  const listUrl = `${host}/storage/v1/b/${bucket}/o?prefix=${encodeURIComponent(prefix)}`;
+  const listRes = await fetch(listUrl, { signal: AbortSignal.timeout(30_000) });
+  if (!listRes.ok) {
+    throw new Error(`findings list failed (${listRes.status}): ${await listRes.text()}`);
+  }
+
+  const listed = (await listRes.json()) as { items?: Array<{ name?: string }> };
+  const names = (listed.items ?? []).map((i) => i.name).filter((n): n is string => Boolean(n));
+
+  const objects: FindingsObject[] = [];
+  for (const name of names) {
+    const url = `${host}/storage/v1/b/${bucket}/o/${encodeURIComponent(name)}?alt=media`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+    if (!res.ok) {
+      // One unreadable object should not cost the whole night's merge.
+      logger.warn("[kb-merge] findings object unreadable; skipping", { name, status: String(res.status) });
+      continue;
+    }
+    objects.push({ name, body: await res.text() });
+  }
+  return objects;
+}
+
+/**
+ * Where object storage lives.
+ *
+ * FAKE_GCS_HOST points at the docker-compose emulator in dev; production talks
+ * to Google directly. Mirrors normalizeFakeGcsHost() in claw's config.
+ */
+function storageHost(): string {
+  const fake = process.env["FAKE_GCS_HOST"]?.trim();
+  if (fake && process.env["NODE_ENV"] !== "production") {
+    return fake.startsWith("http") ? fake : `http://${fake}`;
+  }
+  return "https://storage.googleapis.com";
+}
+
+
+/** Packs findings lines into batches the merge agent can hold. */
+function packBatches(objects: FindingsObject[]): string[] {
+  const lines = objects.flatMap((o) => o.body.split("\n").filter((l) => l.trim()));
+
+  const batches: string[] = [];
+  let current: string[] = [];
+  let chars = 0;
+
+  for (const line of lines) {
+    if (current.length > 0 && chars + line.length > BATCH_CHAR_BUDGET) {
+      batches.push(current.join("\n"));
+      current = [];
+      chars = 0;
+    }
+    current.push(line);
+    chars += line.length;
+  }
+  if (current.length > 0) batches.push(current.join("\n"));
+  return batches;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+async function runBatch(
+  runId: string,
+  findings: string,
+  project: { projectId: string; projectCode: string },
+  agentSlug: string,
+  day: string,
+  index: number,
+  total: number,
+): Promise<void> {
+  const agent = await prisma.agent.findFirst({ where: { slug: agentSlug } });
+  if (!agent) throw new Error(`agent ${agentSlug} not found`);
+
+  const agentConfig = await attachKbGrantsToConfig(
+    agent.config as Record<string, unknown>,
+    agent.id,
+    prisma,
+  );
+
+  // Through claw-auth's own /internal/run: claw refuses a run without a
+  // sessionId and sessionToken, and minting those is claw-auth's job.
+  //
+  // Consumed as SSE, so the call returns when the agent finishes rather than
+  // when the session is minted. Waiting is the whole point of the merge, not a
+  // nicety: without it every batch starts at once and the survey-first rule
+  // collapses — each session lists a KB the others have not written to yet, so
+  // they all independently invent folder names. That is what produced `vespa`
+  // alongside `vespa-core`, and five `xyne-spaces-*` variants. A batch must see
+  // what the previous one wrote.
+  const stream = await consumeClawStream({
+    url: `${CONFIG.internalUrl}/claw/api/v1/internal/run`,
+    s2sKey: CONFIG.xyneClawS2sKey,
+    // A stalled merge must not hold the whole night's sequence open.
+    signal: AbortSignal.timeout(SESSION_WAIT_MS),
+    handlers: {
+      onError: (sessionId, error) => {
+        logger.error("[kb-merge] session error", { sessionId: sessionId ?? "?", error });
+      },
+    },
+    body: {
+      userId: agent.ownerUserId,
+      agentSlug,
+      systemPrompt: agent.systemPrompt,
+      task: `Fold these findings into the KB. Batch ${index + 1} of ${total} for ${day}.`,
+      context: `## Findings (JSONL)\n\n${findings}`,
+      // Unique per ATTEMPT, not per day. A deterministic id resumes the prior
+      // session, and a resumed merge sees its own transcript saying the pages
+      // were already written — so a re-run after a wipe does nothing.
+      conversationId: `kb-merge-${project.projectCode}-${day}-${index}-${runId}`,
+      agentConfig,
+    },
+  });
+
+  // Anything short of a clean `done` stops this project's day. Carrying on is
+  // worse than giving up: a run that died halfway has written some pages and not
+  // others, and the next batch would survey that half-written KB and name things
+  // around what it found.
+  if (stream.result?.status !== "completed") {
+    throw new Error(
+      `merge session ended as ${stream.result?.status ?? stream.errorReason ?? "no done frame"}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+/**
+ * Fails unless the project's KB can actually be read.
+ *
+ * Listing alone is not enough — the listing is served from the collection index
+ * while page CONTENT comes from a separate download path, and it was exactly
+ * that download path (and every write) that broke while listing kept answering
+ * happily. So this reads a real page.
+ *
+ * Cheap: one list, one download, both of which the merge would do anyway.
+ */
+async function assertKbWritable(projectId: string): Promise<void> {
+  const project = await prisma.kbProject.findFirst({ where: { projectId } });
+  if (!project) throw new Error(`kb project ${projectId} not found`);
+
+  const userId = project.enabledBy;
+  if (!userId) throw new Error(`kb project ${project.projectCode} has no enabledBy — cannot reach the KB`);
+
+  const headers = {
+    ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey, "x-user-id": userId } : {}),
+  };
+  const params = new URLSearchParams({ collectionId: project.collectionId, userId });
+
+  const listRes = await fetch(`${CONFIG.internalUrl}/claw/api/v1/kb/list?${params}`, {
+    headers,
+    signal: AbortSignal.timeout(30_000),
+  });
+  const listed = (await listRes.json().catch(() => ({}))) as {
+    success?: boolean;
+    error?: string;
+    data?: { paths?: string[] };
+  };
+  if (!listRes.ok || !listed.success) {
+    throw new Error(`KB unreachable: list failed — ${listed.error ?? listRes.status}`);
+  }
+
+  // An empty KB is legitimate on the very first merge; there is simply nothing
+  // to read back, and the first write will surface any problem itself.
+  const first = (listed.data?.paths ?? []).find((p) => p.endsWith(".md"));
+  if (!first) return;
+
+  const readParams = new URLSearchParams({ collectionId: project.collectionId, userId, path: first });
+  const readRes = await fetch(`${CONFIG.internalUrl}/claw/api/v1/kb/read?${readParams}`, {
+    headers,
+    signal: AbortSignal.timeout(30_000),
+  });
+  const read = (await readRes.json().catch(() => ({}))) as { success?: boolean; error?: string };
+  if (!readRes.ok || !read.success) {
+    throw new Error(`KB unreachable: reading ${first} failed — ${read.error ?? readRes.status}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+/** Merges one day for one project, recording the attempt either way. */
+async function mergeProjectDay(
+  project: {
+    projectId: string;
+    projectCode: string;
+    mergeAgent: string;
+  },
+  day: string,
+): Promise<void> {
+  const run = await prisma.kbRun.create({
+    data: {
+      kind: "MERGE",
+      projectId: project.projectId,
+      projectCode: project.projectCode,
+      subject: day,
+    },
+  });
+
+  try {
+    // The KB has to be reachable BEFORE a model session is spent on it.
+    //
+    // Learned the hard way: with the Spaces DB behind its schema, every write
+    // 500'd, the agent politely reported that it could not save anything, the
+    // session ended cleanly — and this day was marked COMPLETED. The findings
+    // were consumed and the day would never be retried. A run that cannot write
+    // must fail loudly and early, not succeed quietly and late.
+    await assertKbWritable(project.projectId);
+
+    const objects = await fetchFindings(project.projectCode, day);
+    const batches = packBatches(objects);
+    const findingCount = objects.reduce(
+      (n, o) => n + o.body.split("\n").filter((l) => l.trim()).length,
+      0,
+    );
+
+    if (batches.length === 0) {
+      // A quiet day is a normal outcome, not a failure — but it is recorded so
+      // "nothing merged" can be told apart from "never ran".
+      await prisma.kbRun.update({
+        where: { id: run.id },
+        data: {
+          status: "NOTHING_TO_MERGE",
+          metrics: { findingsFiles: objects.length },
+          finishedAt: new Date(),
+        },
+      });
+      logger.info("[kb-merge] nothing to merge", { code: project.projectCode, day });
+      return;
+    }
+
+    let failed = 0;
+    for (const [index, batch] of batches.entries()) {
+      try {
+        await runBatch(run.id, batch, project, project.mergeAgent, day, index, batches.length);
+      } catch (err) {
+        failed += 1;
+        logger.error("[kb-merge] batch failed", {
+          code: project.projectCode,
+          batch: `${index + 1}/${batches.length}`,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    await prisma.kbRun.update({
+      where: { id: run.id },
+      data: {
+        metrics: {
+          findingsFiles: objects.length,
+          findings: findingCount,
+          batches: batches.length,
+        },
+        status: failed > 0 ? "FAILED" : "COMPLETED",
+        finishedAt: new Date(),
+        ...(failed > 0 ? { error: `${failed} of ${batches.length} batches failed` } : {}),
+      },
+    });
+
+    logger.info("[kb-merge] project done", {
+      code: project.projectCode,
+      day,
+      findings: String(findingCount),
+      batches: String(batches.length),
+      failed: String(failed),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await prisma.kbRun.update({
+      where: { id: run.id },
+      data: { status: "FAILED", error: message, finishedAt: new Date() },
+    });
+    logger.error("[kb-merge] project failed", { code: project.projectCode, day, err: message });
+  }
+}
+
+/**
+ * Merges every day that has findings and has not been merged, oldest first.
+ *
+ * Order matters. Findings are partitioned by when the conversation happened, so
+ * walking them chronologically means April's pages exist before May confirms
+ * them — which is what makes the first/last/seen freshness markers mean
+ * anything. Merging newest-first would set `first` from the wrong end.
+ */
+export async function runKbMergePending(onlyProjectCode?: string): Promise<void> {
+  const projects = await prisma.kbProject.findMany({
+    where: { enabled: true, ...(onlyProjectCode ? { projectCode: onlyProjectCode } : {}) },
+  });
+
+  for (const project of projects) {
+    const days = await pendingDays(project.projectCode);
+    if (days.length === 0) {
+      logger.info("[kb-merge] nothing pending", { code: project.projectCode });
+      continue;
+    }
+    logger.info("[kb-merge] pending days", {
+      code: project.projectCode,
+      days: String(days.length),
+      from: days[0]!,
+      to: days[days.length - 1]!,
+    });
+    for (const day of days) {
+      await runKbMerge(day, project.projectCode);
+    }
+  }
+}
+
+/**
+ * Days with findings that have not been merged yet, oldest first.
+ *
+ * Derived from what is in storage minus the days kb_runs already completed,
+ * so a partial backfill resumes rather than re-merging ground already covered.
+ */
+async function pendingDays(projectCode: string): Promise<string[]> {
+  const bucket = process.env["GCS_BUCKET_NAME"] ?? "xyne-claw-chat-attachments";
+  const url = `${storageHost()}/storage/v1/b/${bucket}/o?prefix=${encodeURIComponent(FINDINGS_PREFIX + "/dt=")}`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!res.ok) return [];
+
+  const listed = (await res.json()) as { items?: Array<{ name?: string }> };
+  const days = new Set<string>();
+  for (const item of listed.items ?? []) {
+    // people-kb/findings/dt=2026-04-14/XYNE/<session>.jsonl
+    const match = /\/dt=(\d{4}-\d{2}-\d{2})\/([^/]+)\//.exec(item.name ?? "");
+    if (match && match[2] === projectCode) days.add(match[1]!);
+  }
+
+  const merged = await prisma.kbRun.findMany({
+    where: { kind: "MERGE", projectCode, status: { in: ["COMPLETED", "NOTHING_TO_MERGE"] } },
+    select: { subject: true },
+  });
+  for (const m of merged) days.delete(m.subject);
+
+  return [...days].sort();
+}
+
+/**
+ * Merges a day across every enabled project.
+ *
+ * `onlyProjectCode` narrows to one, which is how an admin triggers a merge on
+ * demand instead of waiting for the nightly.
+ */
+export async function runKbMerge(day: string, onlyProjectCode?: string): Promise<void> {
+  const projects = await prisma.kbProject.findMany({
+    where: { enabled: true, ...(onlyProjectCode ? { projectCode: onlyProjectCode } : {}) },
+  });
+
+  if (projects.length === 0) {
+    logger.info("[kb-merge] no enabled projects — nothing to do", {
+      day,
+      ...(onlyProjectCode ? { requested: onlyProjectCode } : {}),
+    });
+    return;
+  }
+
+  logger.info("[kb-merge] starting", { day, projects: projects.map((p) => p.projectCode).join(",") });
+
+  for (const project of projects) {
+    await mergeProjectDay(
+      {
+        projectId: project.projectId,
+        projectCode: project.projectCode,
+        mergeAgent: project.mergeAgentSlug ?? DEFAULT_MERGE_AGENT,
+      },
+      day,
+    );
+  }
+
+  logger.info("[kb-merge] finished", { day });
+}
+
+// ---------------------------------------------------------------------------
+// Scheduling
+// ---------------------------------------------------------------------------
+
+function scheduleNextRun(): void {
+  const now = new Date();
+  // 2:30 AM IST = 21:00 UTC — an hour after extraction, so the day is complete.
+  const nextRun = new Date(now);
+  nextRun.setUTCHours(21, 0, 0, 0);
+  if (nextRun <= now) nextRun.setUTCDate(nextRun.getUTCDate() + 1);
+
+  logger.info("[kb-merge] next run scheduled", { nextRun: nextRun.toISOString() });
+
+  setTimeout(async () => {
+    try {
+      if (await acquireCronLeaderLock("kb-merge-daily")) {
+        // Everything outstanding, oldest first — so tonight's extraction is
+        // merged tonight, and a backfill catches up across nights.
+        await runKbMergePending();
+      } else {
+        logger.info("[kb-merge] skipped — another replica is running tonight's merge");
+      }
+    } catch (err) {
+      logger.error("[kb-merge] unhandled error", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      scheduleNextRun();
+    }
+  }, nextRun.getTime() - now.getTime());
+}
+
+export function initKbMergeDaily(): void {
+  if (process.env["ENABLE_KB_MERGE_DAILY"] !== "true") {
+    logger.info("[kb-merge] disabled (set ENABLE_KB_MERGE_DAILY=true to enable)");
+    return;
+  }
+  logger.info("[kb-merge] initialising");
+  scheduleNextRun();
+}

--- a/apps/xyne-claw-auth/backend/src/services/kbReconcile.ts
+++ b/apps/xyne-claw-auth/backend/src/services/kbReconcile.ts
@@ -1,0 +1,349 @@
+/**
+ * People-KB reconcile — reads the KB back and corrects it.
+ *
+ * The nightly merge writes from one day of findings, which is the right amount
+ * of evidence for a fact and far too little to judge a person. It names someone
+ * an authority off a single thread because a single thread is all it can see.
+ * This pass is what makes that acceptable: write eagerly, correct later.
+ *
+ * READS PAGES, NOT FINDINGS. The merge already put the evidence on the page —
+ * a permalink per claim, and first/last/seen markers saying how often something
+ * was confirmed. So the KB describes itself, and reconcile needs no second
+ * source. Its input is bounded by the size of the tree rather than by months of
+ * findings volume.
+ *
+ * What makes correction possible at all: pages cannot be DELETED (itemIds are
+ * embedded in saved links) but their content can be rewritten. That is the whole
+ * opening — a wrong verdict is fixable, a wrongly-created folder is not, which
+ * is why folding a duplicate means rewriting the loser into a redirect stub
+ * rather than removing it.
+ *
+ * ONE ENTITY PER SESSION, SEQUENTIAL. people/<person>.md is shared across
+ * entities, so concurrent sessions would overwrite each other there — KbFs has
+ * no compare-and-swap.
+ *
+ * Manual only. There is no cron: this rewrites pages wholesale, and a bad fold
+ * cannot be undone, so a human decides when it runs.
+ */
+import { prisma } from "../db.js";
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+import { attachKbGrantsToConfig } from "../lib/spaces-kb.js";
+import { consumeClawStream } from "../lib/consume-claw-stream.js";
+
+const logger = createLogger("kb-reconcile");
+
+/** Fallback when a project does not name its own reconcile agent. */
+const DEFAULT_RECONCILE_AGENT = process.env["KB_RECONCILE_AGENT_SLUG"] ?? "kb-reconcile";
+
+/** How long one entity's session may run before it is treated as stuck. */
+const SESSION_WAIT_MS = Number(process.env["KB_RECONCILE_SESSION_WAIT_MS"] ?? 15 * 60 * 1000);
+
+/** The KB roots an entity can live under. Anything else is not an entity folder. */
+const ENTITY_ROOTS = ["services", "surfaces", "tools"];
+
+/**
+ * Entities per run.
+ *
+ * Sessions are sequential and take minutes, so an unbounded pass over a real KB
+ * is hours: 213 entities measured locally would be about seven. A run has to
+ * finish while someone is still watching it, so it takes a slice and the next
+ * press continues.
+ */
+const MAX_ENTITIES_PER_RUN = Number(process.env["KB_RECONCILE_MAX_ENTITIES"] ?? 25);
+
+interface Entity {
+  root: string;
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Reading the tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Every entity folder in the project, from the KB listing.
+ *
+ * Same call knownEntities() makes in kbExtractDaily, read for a different
+ * purpose: there it is a naming vocabulary, here it is the work list. Paths are
+ * projects/<CODE>/<root>/<entity>/<file>.md, so the entity is segment 3.
+ *
+ * Derived from the tree rather than from findings on purpose — a duplicate
+ * folder may have no recent findings at all, and folding it is exactly what this
+ * pass exists for.
+ */
+async function listEntities(collectionId: string, userId: string): Promise<Entity[]> {
+  const params = new URLSearchParams({ collectionId, userId });
+  const res = await fetch(`${CONFIG.internalUrl}/claw/api/v1/kb/list?${params}`, {
+    headers: {
+      ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey, "x-user-id": userId } : {}),
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    throw new Error(`kb list failed (${res.status}): ${await res.text()}`);
+  }
+
+  const body = (await res.json()) as { data?: { paths?: string[] } };
+  const seen = new Map<string, Entity>();
+
+  for (const path of body.data?.paths ?? []) {
+    const parts = path.split("/");
+    // projects / <CODE> / <root> / <entity> [ / <file>.md ]
+    // Folder paths are listed alongside file paths, so four segments is enough —
+    // requiring the file would miss an entity whose folder came back on its own.
+    if (parts.length < 4) continue;
+    const root = parts[2]!;
+    const name = parts[3]!;
+    if (!ENTITY_ROOTS.includes(root)) continue;
+    seen.set(`${root}/${name}`, { root, name });
+  }
+
+  return [...seen.values()].sort((a, b) =>
+    a.root === b.root ? a.name.localeCompare(b.name) : a.root.localeCompare(b.root),
+  );
+}
+
+/**
+ * The slice to reconcile this run: least recently done first.
+ *
+ * Derived from kb_runs rather than a watermark column, because a position in an
+ * alphabetical list stops meaning anything the moment an entity is added ahead
+ * of it. Ordering by when each was last reconciled — never-reconciled first —
+ * round-robins the whole KB across successive runs and needs no new state.
+ */
+async function selectSlice(projectCode: string, entities: Entity[]): Promise<Entity[]> {
+  const previous = await prisma.kbRun.findMany({
+    where: { kind: "RECONCILE", projectCode, status: "COMPLETED" },
+    select: { subject: true, startedAt: true },
+    orderBy: { startedAt: "desc" },
+  });
+
+  const lastDone = new Map<string, number>();
+  for (const run of previous) {
+    // Ordered newest first, so the first sighting of a subject is its latest run.
+    if (!lastDone.has(run.subject)) lastDone.set(run.subject, run.startedAt.getTime());
+  }
+
+  return [...entities]
+    .sort((a, b) => {
+      const ka = lastDone.get(`${a.root}/${a.name}`) ?? 0;
+      const kb = lastDone.get(`${b.root}/${b.name}`) ?? 0;
+      return ka - kb;
+    })
+    .slice(0, MAX_ENTITIES_PER_RUN);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+interface ReconcileProject {
+  projectId: string;
+  projectCode: string;
+  agentSlug: string;
+}
+
+/** The instruction for one entity folder, including what it could be folded into. */
+function entityTask(project: ReconcileProject, entity: Entity, siblings: Entity[]): string {
+  // Judging whether this entity is a duplicate needs to know what else exists
+  // under the same root, and the agent would otherwise ls its way to the same
+  // answer.
+  const siblingNames = siblings
+    .filter((s) => s.root === entity.root && s.name !== entity.name)
+    .map((s) => s.name);
+
+  return (
+    `Reconcile projects/${project.projectCode}/${entity.root}/${entity.name}/.\n\n` +
+    `Read every page in that folder, and the person pages it references, then ` +
+    `correct them against the evidence recorded on them.\n\n` +
+    (siblingNames.length > 0
+      ? `Other entities under ${entity.root}/: ${siblingNames.join(", ")}\n` +
+        `If this entity is the same thing as one of those, or a component of one, ` +
+        `fold it into that one and leave this page as a redirect stub.\n\n`
+      : "") +
+    `Change nothing that the pages already support. A run that rewrites pages ` +
+    `without new reason to is worse than one that does nothing.`
+  );
+}
+
+/**
+ * The instruction for the project overview.
+ *
+ * Runs after every entity, so the tree it summarises is the corrected one — an
+ * overview written before a fold would name an entity that no longer exists.
+ */
+function overviewTask(project: ReconcileProject, entities: Entity[]): string {
+  const tree = entities.map((e) => `${e.root}/${e.name}`).join(", ");
+
+  return (
+    `Reconcile projects/${project.projectCode}/overview.md.\n\n` +
+    `The entities now in this KB: ${tree || "none yet"}\n\n` +
+    `Read the overview and check it against that list and against the entity pages ` +
+    `themselves. Remove anything naming an entity that no longer exists or was folded ` +
+    `away, and anything the pages no longer support. Keep it inside its budget — if ` +
+    `something belongs there and the page is full, drop the weaker line.\n\n` +
+    `Leave it alone if it is already right. This page is read first by everyone, so ` +
+    `churning it costs more than it gains.`
+  );
+}
+
+/** Runs one reconcile session, recording the attempt and what the agent reported. */
+async function reconcileOne(
+  project: ReconcileProject,
+  subject: string,
+  task: string,
+): Promise<boolean> {
+  const run = await prisma.kbRun.create({
+    data: {
+      kind: "RECONCILE",
+      projectId: project.projectId,
+      projectCode: project.projectCode,
+      subject,
+    },
+  });
+
+  try {
+    const agent = await prisma.agent.findFirst({ where: { slug: project.agentSlug } });
+    if (!agent) throw new Error(`agent ${project.agentSlug} not found`);
+
+    const agentConfig = await attachKbGrantsToConfig(
+      agent.config as Record<string, unknown>,
+      agent.id,
+      prisma,
+    );
+
+    // Report accumulates from the stream so the run row can say what changed,
+    // rather than only whether it finished.
+    let report = "";
+
+    const stream = await consumeClawStream({
+      url: `${CONFIG.internalUrl}/claw/api/v1/internal/run`,
+      s2sKey: CONFIG.xyneClawS2sKey,
+      signal: AbortSignal.timeout(SESSION_WAIT_MS),
+      handlers: {
+        onTextDelta: (_sessionId, delta) => {
+          report += delta;
+        },
+        onError: (sessionId, error) => {
+          logger.error("[kb-reconcile] session error", { sessionId: sessionId ?? "?", error });
+        },
+      },
+      body: {
+        userId: agent.ownerUserId,
+        agentSlug: project.agentSlug,
+        systemPrompt: agent.systemPrompt,
+        task,
+        // Unique per attempt. A deterministic id resumes the previous session,
+        // which then reads its own transcript saying the work is already done.
+        conversationId: `kb-reconcile-${project.projectCode}-${run.id}`,
+        agentConfig,
+      },
+    });
+
+    if (stream.result?.status !== "completed") {
+      throw new Error(
+        `reconcile session ended as ${stream.result?.status ?? stream.errorReason ?? "no done frame"}`,
+      );
+    }
+
+    await prisma.kbRun.update({
+      where: { id: run.id },
+      data: { status: "COMPLETED", summary: report.slice(0, 20_000), finishedAt: new Date() },
+    });
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await prisma.kbRun.update({
+      where: { id: run.id },
+      data: { status: "FAILED", error: message, finishedAt: new Date() },
+    });
+    logger.error("[kb-reconcile] session failed", {
+      code: project.projectCode,
+      subject,
+      err: message,
+    });
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Reconciles every entity in one project, one at a time.
+ *
+ * A failed entity does not stop the rest: the pages it left behind are no worse
+ * than before the run, and the remaining entities are still worth correcting.
+ */
+export async function runKbReconcile(projectCode: string, onlyEntity?: string): Promise<void> {
+  const project = await prisma.kbProject.findFirst({ where: { projectCode, enabled: true } });
+  if (!project) {
+    logger.info("[kb-reconcile] no enabled project", { code: projectCode });
+    return;
+  }
+
+  const userId = project.enabledBy ?? "";
+  if (!userId) {
+    logger.error("[kb-reconcile] project has no enabledBy — cannot read the KB", { code: projectCode });
+    return;
+  }
+
+  const entities = await listEntities(project.collectionId, userId);
+  if (entities.length === 0) {
+    logger.info("[kb-reconcile] no entities in the KB yet", { code: projectCode });
+    return;
+  }
+
+  const target: ReconcileProject = {
+    projectId: project.projectId,
+    projectCode: project.projectCode,
+    agentSlug: project.reconcileAgentSlug ?? DEFAULT_RECONCILE_AGENT,
+  };
+
+  const slice = onlyEntity
+    ? entities.filter((e) => `${e.root}/${e.name}` === onlyEntity)
+    : await selectSlice(projectCode, entities);
+
+  if (slice.length === 0) {
+    logger.warn("[kb-reconcile] nothing to do", { code: projectCode, requested: onlyEntity ?? "(slice)" });
+    return;
+  }
+
+  // Said out loud, because a capped run that reports success looks identical to
+  // one that covered everything.
+  logger.info("[kb-reconcile] starting", {
+    code: projectCode,
+    reconciling: String(slice.length),
+    ofTotal: String(entities.length),
+    ...(slice.length < entities.length
+      ? { deferred: `${entities.length - slice.length} entities left for the next run` }
+      : {}),
+  });
+
+  let failed = 0;
+  for (const entity of slice) {
+    const ok = await reconcileOne(
+      target,
+      `${entity.root}/${entity.name}`,
+      entityTask(target, entity, entities),
+    );
+    if (!ok) failed += 1;
+  }
+
+  // Last, deliberately. The overview summarises the tree, so it has to see the
+  // tree as the entity passes left it — written earlier it would describe folders
+  // that were folded away minutes later. Skipped for a single-entity run, which
+  // is a targeted fix rather than a sweep.
+  if (!onlyEntity && !(await reconcileOne(target, "overview.md", overviewTask(target, entities)))) {
+    failed += 1;
+  }
+
+  logger.info("[kb-reconcile] finished", {
+    code: projectCode,
+    reconciled: String(slice.length),
+    ofTotal: String(entities.length),
+    failed: String(failed),
+  });
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/AdminPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/AdminPageV3.tsx
@@ -30,6 +30,7 @@ import {
 import { PageLayout } from "./ui/PageLayout";
 import { PageHeader } from "./ui/PageHeader";
 import { Tabs, type TabItem } from "./ui/Tabs";
+import { KbExtractionTab } from "./admin/KbExtractionTab";
 import { Badge } from "./ui/Badge";
 import { Button } from "./ui/Button";
 import { TextField } from "./ui/TextField";
@@ -101,7 +102,8 @@ type TabKey =
   | "audit"
   | "usage"
   | "scheduled"
-  | "globalmcp";
+  | "globalmcp"
+  | "kb";
 
 interface Props {
   userId: string;
@@ -1106,6 +1108,7 @@ export function AdminPageV3({ userId }: Props) {
       { id: "usage", label: "Usage" },
       { id: "scheduled", label: scheduledTotal > 0 ? `Scheduled (${scheduledTotal})` : "Scheduled" },
       { id: "globalmcp", label: "Global MCP" },
+      { id: "kb", label: "Knowledge Base" },
     ],
     [requests.length, mcpRequests.length, workflowRequests.length, agents.length, admins.length, auditTotal, scheduledTotal],
   );
@@ -1350,6 +1353,8 @@ export function AdminPageV3({ userId }: Props) {
                     showOrgLabels={allOrgs}
                   />
                 )}
+
+                {tab === "kb" && <KbExtractionTab />}
 
                 {tab === "globalmcp" && (
                   <GlobalMcpTab

--- a/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
@@ -171,6 +171,10 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
   // Plan mode opt-in (agent.config.planMode). When on, non-twin thread mentions
   // propose a plan and wait for approval before multi-step work. Default false.
   const [draftPlanMode, setDraftPlanMode] = useState(false);
+  /* KB curation: swaps Vespa retrieval for path-based read/ls/grep/write/edit
+   * over the attached collection. Admin-only — the server strips `kbAccess`
+   * for non-admins, so the control is hidden rather than silently ignored. */
+  const [draftKbAccess, setDraftKbAccess] = useState(false);
   // Editable plan-mode primer (agent.config.planModePrompt) — how the agent scopes
   // a plan. Pre-filled with the default; only a CUSTOM value is persisted. Never
   // changes the propose→approve gate (enforced by the tool palette).
@@ -291,6 +295,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
         setDraftPostTodos((agentData.config as { postTodos?: boolean }).postTodos !== false);
         setDraftAutoGoal((agentData.config as { autoGoal?: boolean }).autoGoal === true);
         setDraftPlanMode((agentData.config as { planMode?: boolean }).planMode === true);
+        setDraftKbAccess((agentData.config as { kbAccess?: string }).kbAccess === "files");
         {
           const pmp = (agentData.config as { planModePrompt?: string }).planModePrompt;
           setDraftPlanModePrompt(typeof pmp === "string" && pmp.trim() ? pmp : DEFAULT_PLAN_MODE_PROMPT);
@@ -394,6 +399,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
     const basePostTodos = (agent.config as { postTodos?: boolean }).postTodos !== false;
     const baseAutoGoal = (agent.config as { autoGoal?: boolean }).autoGoal === true;
     const basePlanMode = (agent.config as { planMode?: boolean }).planMode === true;
+    const baseKbAccess = (agent.config as { kbAccess?: string }).kbAccess === "files";
     const basePlanModePromptRaw = (agent.config as { planModePrompt?: string }).planModePrompt;
     const basePlanModePrompt =
       typeof basePlanModePromptRaw === "string" && basePlanModePromptRaw.trim()
@@ -436,6 +442,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       draftPostTodos !== basePostTodos ||
       draftAutoGoal !== baseAutoGoal ||
       draftPlanMode !== basePlanMode ||
+      draftKbAccess !== baseKbAccess ||
       // Only counts as a change when plan mode is on (a prompt with no plan mode
       // is never persisted).
       (draftPlanMode && draftPlanModePrompt !== basePlanModePrompt) ||
@@ -450,7 +457,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       draftOutputRequireTools !== baseOutputRequireTools ||
       triggersChanged
     );
-  }, [agent, config, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers]);
+  }, [agent, config, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftKbAccess, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers]);
 
   /* ── handlers ──────────────────────────────────────────────────── */
 
@@ -559,6 +566,11 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       } else {
         delete nextConfig.autoGoal;
       }
+      if (draftKbAccess) {
+        nextConfig.kbAccess = "files";
+      } else {
+        delete nextConfig.kbAccess;
+      }
       if (draftPlanMode) {
         nextConfig.planMode = true;
         // Persist a CUSTOM plan-mode prompt only (empty or unchanged-from-default ⇒
@@ -658,7 +670,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
     } finally {
       setSavingConfig(false);
     }
-  }, [agent, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers, config, savingConfig, dirty, userId, showSnackbar]);
+  }, [agent, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftKbAccess, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers, config, savingConfig, dirty, userId, showSnackbar]);
 
   const persistToolsConfig = useCallback(async (nextTools: AgentToolSelection): Promise<Agent> => {
     if (!agent) throw new Error("Agent not loaded");
@@ -1020,6 +1032,9 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
             onDraftKbResourcesChange={setDraftKbResources}
             draftKbScope={draftKbScope}
             onDraftKbScopeChange={setDraftKbScope}
+            draftKbAccess={draftKbAccess}
+            onDraftKbAccessChange={setDraftKbAccess}
+            isAdmin={isAdmin}
             skillTriggers={skillTriggers}
             onSkillTriggersChange={setSkillTriggers}
             draftPromptInjection={draftPromptInjection}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/admin/KbExtractionTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/admin/KbExtractionTab.tsx
@@ -1,0 +1,751 @@
+/**
+ * Admin: which projects and channels feed the People-KB, and how far each has got.
+ *
+ * Two deliberate frictions, both because nothing in the stack can delete a KB
+ * page — a mistake here can only be papered over, never undone:
+ *
+ *   - Private channels are off by default and say so in the UI.
+ *   - Extraction is triggered explicitly, never on save.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { frontendConfig } from "../../../lib/config";
+
+const API = `${frontendConfig.clawApiBaseUrl}/api/v1/kb`;
+
+interface KbChannel {
+  channelId: string;
+  name: string;
+  visibility: string;
+  included: boolean;
+  includedBy: string | null;
+  /** null means this channel has never been extracted. */
+  backfillFrom: string | null;
+  includedAt: string | null;
+  extractedThrough: string | null;
+  lastRunAt: string | null;
+  lastError: string | null;
+}
+
+/**
+ * One row per job attempt, whatever the stage.
+ *
+ * Extract, merge and reconcile share this shape — `subject` is what the run
+ * covered in its own terms (a channel name, a findings day, an entity path) and
+ * `metrics` holds whatever counters that stage produces.
+ */
+interface KbRun {
+  id: string;
+  kind: "EXTRACT" | "MERGE" | "RECONCILE";
+  projectCode: string;
+  subject: string;
+  channelId: string | null;
+  windowFrom: string | null;
+  windowTo: string | null;
+  metrics: Record<string, number> | null;
+  summary: string | null;
+  status: string;
+  error: string | null;
+  startedAt: string;
+}
+
+interface KbProject {
+  projectId: string;
+  projectCode: string;
+  projectName: string;
+  collectionId: string;
+  extractAgentSlug: string | null;
+  enabled: boolean;
+  enabledBy: string | null;
+  enabledAt: string | null;
+  channels: KbChannel[];
+}
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API}${path}`, {
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+  const body = (await response.json()) as { success: boolean; data?: T; error?: string };
+  if (!response.ok || !body.success) throw new Error(body.error ?? `request failed (${response.status})`);
+  return body.data as T;
+}
+
+const day = (iso: string | null) => (iso ? iso.slice(0, 10) : null);
+
+/**
+ * How far a backfill has got, as "start -> position" plus days remaining.
+ *
+ * `extractedThrough` on its own cannot tell "nearly done" from "barely
+ * started" — that needs the origin the walk began from.
+ */
+function progress(channel: KbChannel): { label: string; remaining: number | null } {
+  const start = channel.backfillFrom ?? channel.includedAt;
+  if (!start) return { label: "—", remaining: null };
+  if (!channel.extractedThrough) return { label: `${day(start)} -> not started`, remaining: null };
+
+  const doneTo = new Date(channel.extractedThrough).getTime();
+  const remainingDays = Math.max(0, Math.ceil((Date.now() - doneTo) / 86_400_000));
+  return { label: `${day(start)} -> ${day(channel.extractedThrough)}`, remaining: remainingDays };
+}
+
+/** "2 hours ago" reads better than a timestamp when the question is "is it caught up?". */
+function relative(iso: string | null): string {
+  if (!iso) return "never";
+  const hours = (Date.now() - new Date(iso).getTime()) / 3_600_000;
+  if (hours < 1) return "just now";
+  if (hours < 24) return `${Math.floor(hours)}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+const inputClass =
+  "w-full rounded border border-xyne-border-subtle bg-xyne-surface px-2 py-1 text-[11px] text-xyne-fg-primary";
+
+function Field({ label, value, onChange, placeholder }: {
+  label: string; value: string; onChange: (v: string) => void; placeholder?: string;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[10px] uppercase tracking-wide text-xyne-fg-tertiary">{label}</span>
+      <input className={inputClass} value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </label>
+  );
+}
+
+export function KbExtractionTab() {
+  const [projects, setProjects] = useState<KbProject[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  /* Ids are typed in rather than picked: Spaces has no list-projects endpoint,
+     and an admin adding a project already has the id to hand. A picker can
+     replace this without changing anything below. */
+  const [allRuns, setAllRuns] = useState<KbRun[]>([]);
+  const [showRuns, setShowRuns] = useState(false);
+  const [showReconcile, setShowReconcile] = useState(false);
+  const [showAddProject, setShowAddProject] = useState(false);
+  const [newProject, setNewProject] = useState({
+    projectId: "", projectCode: "", projectName: "", workspaceId: "", collectionId: "",
+    extractAgentSlug: "",
+  });
+  const [addChannelTo, setAddChannelTo] = useState<string | null>(null);
+  const [newChannel, setNewChannel] = useState({
+    channelId: "", name: "", visibility: "PUBLIC", backfillFrom: "",
+  });
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [p, r] = await Promise.all([
+        api<KbProject[]>("/projects"),
+        // Non-fatal: the run history is diagnostic, not required to operate.
+        api<KbRun[]>("/runs?limit=150").catch(() => [] as KbRun[]),
+      ]);
+      setProjects(p);
+      setAllRuns(r);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  /* Runs are asynchronous and take minutes. The screen shows the state as of
+     the last load — deliberately not polled, since a background timer running
+     for the length of a backfill is a lot of load for numbers nobody is
+     watching. Refresh when you want to know.
+
+     Split by kind here rather than fetched per kind: one request answers "what
+     happened to this project?", which is the question actually being asked. */
+  const runs = allRuns.filter((r) => r.kind === "EXTRACT");
+  const mergeRuns = allRuns.filter((r) => r.kind === "MERGE");
+  const reconcileRuns = allRuns.filter((r) => r.kind === "RECONCILE");
+  const inFlight = allRuns.some((r) => r.status === "RUNNING");
+
+  const toggleChannel = async (project: KbProject, channel: KbChannel) => {
+    setBusy(channel.channelId);
+    try {
+      await api("/channels", {
+        method: "POST",
+        body: JSON.stringify({
+          channelId: channel.channelId,
+          projectId: project.projectId,
+          name: channel.name,
+          visibility: channel.visibility,
+          included: !channel.included,
+        }),
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const addProject = async () => {
+    setBusy("add-project");
+    try {
+      await api("/projects", { method: "POST", body: JSON.stringify({ ...newProject, enabled: true }) });
+      setShowAddProject(false);
+      setNewProject({ projectId: "", projectCode: "", projectName: "", workspaceId: "", collectionId: "", extractAgentSlug: "" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const addChannel = async (projectId: string) => {
+    setBusy("add-channel");
+    try {
+      await api("/channels", {
+        method: "POST",
+        body: JSON.stringify({
+          ...newChannel,
+          projectId,
+          scopeType: "DEFAULT",
+          included: true,
+          // Blank means "from now" — the safe default, since backfilling a
+          // channel's whole history costs real model spend.
+          ...(newChannel.backfillFrom ? { backfillFrom: new Date(newChannel.backfillFrom).toISOString() } : {}),
+        }),
+      });
+      setAddChannelTo(null);
+      setNewChannel({ channelId: "", name: "", visibility: "PUBLIC", backfillFrom: "" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const extractChannel = async (channel: KbChannel) => {
+    setBusy(channel.channelId);
+    try {
+      await api(`/channels/${channel.channelId}/extract`, { method: "POST" });
+      setError(null);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const backfillChannel = async (channel: KbChannel) => {
+    const from = window.prompt(
+      `Re-extract ${channel.name} from which date? (YYYY-MM-DD)\n\n` +
+        `This clears its progress and re-reads everything from that date, which costs ` +
+        `model spend on ground already covered. Findings dedupe on merge.`,
+      "2026-04-13",
+    );
+    if (!from) return;
+
+    setBusy(channel.channelId);
+    try {
+      await api(`/channels/${channel.channelId}/backfill`, {
+        method: "POST",
+        body: JSON.stringify({ from: new Date(from).toISOString() }),
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const removeChannel = async (channel: KbChannel) => {
+    if (!window.confirm(
+      `Remove ${channel.name} from extraction?\n\n` +
+        `Its progress and run history are discarded. Pages already written to the KB stay — ` +
+        `nothing can delete those. To pause instead, un-tick Included.`,
+    )) return;
+
+    setBusy(channel.channelId);
+    try {
+      await api(`/channels/${channel.channelId}`, { method: "DELETE" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const runMerge = async (project: KbProject) => {
+    setBusy(`merge-${project.projectId}`);
+    try {
+      await api(`/merge/${project.projectCode}`, { method: "POST" });
+      setError(null);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  /* Rewrites pages the merge already wrote, and a fold cannot be undone — so it
+     asks first. Everything else on this screen only adds. */
+  const runReconcile = async (project: KbProject) => {
+    const ok = window.confirm(
+      `Reconcile ${project.projectCode}?\n\n` +
+        `This re-reads every page in the KB and rewrites what the evidence does not ` +
+        `support — demoting people, removing uncorroborated claims, and folding ` +
+        `duplicate entities into redirect stubs.\n\nFolds cannot be undone.`,
+    );
+    if (!ok) return;
+
+    setBusy(`reconcile-${project.projectId}`);
+    try {
+      await api(`/reconcile/${project.projectCode}`, { method: "POST" });
+      setError(null);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const runExtraction = async (project: KbProject) => {
+    setBusy(project.projectId);
+    try {
+      await api(`/extract/${project.projectCode}`, { method: "POST" });
+      setError(null);
+      // Nothing to show yet — the run is asynchronous and takes minutes.
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) return <p className="text-[12px] text-xyne-fg-tertiary">Loading…</p>;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {inFlight && (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-500">
+          Working — {runs.filter((r) => r.status === "RUNNING").length} extraction and{" "}
+          {mergeRuns.filter((r) => r.status === "RUNNING").length} merge window(s) in progress.
+          Use Refresh to see progress.
+        </p>
+      )}
+
+      {error && (
+        <p className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-[12px] text-red-400">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button type="button" onClick={() => void load()} disabled={loading}
+                className="rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary hover:bg-xyne-surface disabled:opacity-50">
+          {loading ? "Refreshing…" : "Refresh"}
+        </button>
+      </div>
+
+      <div>
+        {!showAddProject ? (
+          <button type="button" onClick={() => setShowAddProject(true)}
+                  className="rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary hover:bg-xyne-surface">
+            + Add project
+          </button>
+        ) : (
+          <div className="rounded-lg border border-xyne-border-subtle bg-xyne-surface-muted p-4">
+            <h4 className="mb-3 text-[12px] font-medium text-xyne-fg-primary">Enable a project</h4>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Project ID" value={newProject.projectId} placeholder="cmsebr53j..."
+                     onChange={(v) => setNewProject((p) => ({ ...p, projectId: v }))} />
+              <Field label="Code" value={newProject.projectCode} placeholder="XYNE"
+                     onChange={(v) => setNewProject((p) => ({ ...p, projectCode: v }))} />
+              <Field label="Name" value={newProject.projectName} placeholder="Xyne-Space"
+                     onChange={(v) => setNewProject((p) => ({ ...p, projectName: v }))} />
+              <Field label="Workspace ID" value={newProject.workspaceId} placeholder="cmsebr50u..."
+                     onChange={(v) => setNewProject((p) => ({ ...p, workspaceId: v }))} />
+              <Field label="Collection ID (the KB)" value={newProject.collectionId} placeholder="col_..."
+                     onChange={(v) => setNewProject((p) => ({ ...p, collectionId: v }))} />
+              <Field label="Extractor agent (blank = kb-extract)" value={newProject.extractAgentSlug}
+                     placeholder="kb-extract"
+                     onChange={(v) => setNewProject((p) => ({ ...p, extractAgentSlug: v }))} />
+            </div>
+            <p className="mt-2 text-[10px] text-xyne-fg-tertiary">
+              The code becomes the KB path segment (projects/&lt;CODE&gt;/) and cannot be changed later —
+              pages cannot be renamed or moved.
+            </p>
+            <div className="mt-3 flex gap-2">
+              <button type="button" disabled={busy === "add-project" || !newProject.projectId || !newProject.projectCode || !newProject.workspaceId || !newProject.collectionId}
+                      onClick={() => void addProject()}
+                      className="rounded-md bg-xyne-accent px-3 py-1.5 text-[11px] text-white disabled:opacity-50">
+                {busy === "add-project" ? "Saving…" : "Enable"}
+              </button>
+              <button type="button" onClick={() => setShowAddProject(false)}
+                      className="rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {projects.length === 0 && (
+        <p className="text-[12px] text-xyne-fg-tertiary">
+          No projects opted in. A project must be enabled before any of its channels are extracted.
+        </p>
+      )}
+
+      {projects.map((project) => (
+        <section
+          key={project.projectId}
+          className="rounded-lg border border-xyne-border-subtle bg-xyne-surface-muted p-4"
+        >
+          <header className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-[13px] font-medium text-xyne-fg-primary">
+                {project.projectCode}
+                <span className="ml-2 font-normal text-xyne-fg-tertiary">{project.projectName}</span>
+              </h3>
+              <p className="mt-0.5 text-[11px] text-xyne-fg-tertiary">
+                KB → {project.collectionId} · agent: {project.extractAgentSlug ?? "kb-extract"}
+                {project.enabledBy && ` · enabled by ${project.enabledBy}`}
+              </p>
+            </div>
+
+            <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={busy === project.projectId || !project.enabled}
+              onClick={() => void runExtraction(project)}
+              className="rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary hover:bg-xyne-surface disabled:opacity-50"
+            >
+              {busy === project.projectId ? "Starting…" : "Extract now"}
+            </button>
+
+            <button
+              type="button"
+              disabled={busy === `merge-${project.projectId}` || !project.enabled}
+              onClick={() => void runMerge(project)}
+              className="rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary hover:bg-xyne-surface disabled:opacity-50"
+            >
+              {busy === `merge-${project.projectId}` ? "Starting…" : "Merge now"}
+            </button>
+
+            <button
+              type="button"
+              disabled={busy === `reconcile-${project.projectId}` || !project.enabled}
+              onClick={() => void runReconcile(project)}
+              className="rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary hover:bg-xyne-surface disabled:opacity-50"
+            >
+              {busy === `reconcile-${project.projectId}` ? "Starting…" : "Reconcile"}
+            </button>
+            </div>
+          </header>
+
+          <table className="mt-3 w-full text-[11px]">
+            <thead className="text-xyne-fg-tertiary">
+              <tr className="text-left">
+                <th className="pb-1 font-normal">Channel</th>
+                <th className="pb-1 font-normal">Progress</th>
+                <th className="pb-1 font-normal">Remaining</th>
+                <th className="pb-1 font-normal">Last run</th>
+                <th className="pb-1 font-normal">Included</th>
+                <th className="pb-1 font-normal"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {project.channels.map((channel) => (
+                <tr key={channel.channelId} className="border-t border-xyne-border-subtle/50">
+                  <td className="py-1.5 text-xyne-fg-secondary">
+                    {channel.name}
+                    {channel.visibility !== "PUBLIC" && (
+                      <span className="ml-1.5 rounded bg-amber-500/15 px-1 text-[10px] text-amber-500">
+                        private
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-1.5 font-mono text-[10px] text-xyne-fg-tertiary">
+                    {progress(channel).label}
+                  </td>
+                  <td className="py-1.5 text-xyne-fg-tertiary">
+                    {(() => {
+                      const r = progress(channel).remaining;
+                      if (r === null) return "—";
+                      // Under a day means the walk has reached now; the nightly
+                      // keeps it there.
+                      return r <= 1 ? <span className="text-green-500">caught up</span> : `${r}d behind`;
+                    })()}
+                  </td>
+                  <td className="py-1.5 text-xyne-fg-tertiary">
+                    {channel.lastError ? (
+                      <span className="text-red-400" title={channel.lastError}>
+                        failed
+                      </span>
+                    ) : (
+                      relative(channel.lastRunAt)
+                    )}
+                  </td>
+                  <td className="py-1.5">
+                    <input
+                      type="checkbox"
+                      checked={channel.included}
+                      disabled={busy === channel.channelId}
+                      onChange={() => void toggleChannel(project, channel)}
+                    />
+                  </td>
+                  <td className="py-1.5 text-right">
+                    <button type="button" disabled={busy === channel.channelId || !channel.included}
+                            onClick={() => void extractChannel(channel)}
+                            className="mr-2 text-xyne-fg-secondary hover:text-xyne-fg-primary disabled:opacity-50">
+                      extract
+                    </button>
+                    <button type="button" disabled={busy === channel.channelId}
+                            onClick={() => void backfillChannel(channel)}
+                            className="mr-2 text-xyne-fg-tertiary hover:text-xyne-fg-secondary disabled:opacity-50">
+                      backfill
+                    </button>
+                    <button type="button" disabled={busy === channel.channelId}
+                            onClick={() => void removeChannel(channel)}
+                            className="text-xyne-fg-tertiary hover:text-red-400 disabled:opacity-50">
+                      remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {project.channels.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="py-2 text-xyne-fg-tertiary">
+                    No channels registered for this project yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+
+          {addChannelTo === project.projectId ? (
+            <div className="mt-3 rounded border border-xyne-border-subtle p-3">
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Channel ID" value={newChannel.channelId} placeholder="cmi39e2jj..."
+                       onChange={(v) => setNewChannel((c) => ({ ...c, channelId: v }))} />
+                <Field label="Name" value={newChannel.name} placeholder="platform-dev"
+                       onChange={(v) => setNewChannel((c) => ({ ...c, name: v }))} />
+                <label className="flex flex-col gap-1">
+                  <span className="text-[10px] uppercase tracking-wide text-xyne-fg-tertiary">Visibility</span>
+                  <select className={inputClass} value={newChannel.visibility}
+                          onChange={(e) => setNewChannel((c) => ({ ...c, visibility: e.target.value }))}>
+                    <option value="PUBLIC">PUBLIC</option>
+                    <option value="PRIVATE">PRIVATE</option>
+                  </select>
+                </label>
+                <Field label="Backfill from (blank = from now)" value={newChannel.backfillFrom}
+                       placeholder="2026-04-13"
+                       onChange={(v) => setNewChannel((c) => ({ ...c, backfillFrom: v }))} />
+              </div>
+              <div className="mt-3 flex gap-2">
+                <button type="button" disabled={busy === "add-channel" || !newChannel.channelId}
+                        onClick={() => void addChannel(project.projectId)}
+                        className="rounded-md bg-xyne-accent px-3 py-1.5 text-[11px] text-white disabled:opacity-50">
+                  {busy === "add-channel" ? "Saving…" : "Include channel"}
+                </button>
+                <button type="button" onClick={() => setAddChannelTo(null)}
+                        className="rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary">
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button type="button" onClick={() => setAddChannelTo(project.projectId)}
+                    className="mt-3 rounded-md border border-xyne-border-subtle px-3 py-1.5 text-[11px] text-xyne-fg-secondary hover:bg-xyne-surface">
+              + Add channel
+            </button>
+          )}
+
+          <p className="mt-2 text-[10px] text-xyne-fg-tertiary">
+            Private channels are excluded by default. Including one copies its content into a
+            knowledge base with a wider audience, and KB pages cannot be deleted afterwards.
+          </p>
+        </section>
+      ))}
+
+      {/* Merge history. Findings are worthless until merged, so "extracted but
+          never merged" is the failure this panel exists to make visible. */}
+      <div className="rounded-lg border border-xyne-border-subtle bg-xyne-surface-muted p-4">
+        <h4 className="text-[12px] font-medium text-xyne-fg-primary">
+          Recent merges ({mergeRuns.length})
+          {mergeRuns.some((r) => r.status === "FAILED") && (
+            <span className="ml-2 text-[11px] font-normal text-red-400">
+              {mergeRuns.filter((r) => r.status === "FAILED").length} failed
+            </span>
+          )}
+        </h4>
+
+        {mergeRuns.length === 0 ? (
+          <p className="mt-2 text-[11px] text-xyne-fg-tertiary">
+            No merges yet. Extraction writes findings to storage; nothing reaches the KB
+            until a merge runs.
+          </p>
+        ) : (
+          <table className="mt-3 w-full text-[11px]">
+            <thead className="text-xyne-fg-tertiary">
+              <tr className="text-left">
+                <th className="pb-1 font-normal">Project</th>
+                <th className="pb-1 font-normal">Day</th>
+                <th className="pb-1 font-normal">Findings</th>
+                <th className="pb-1 font-normal">Batches</th>
+                <th className="pb-1 font-normal">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mergeRuns.map((run) => (
+                <tr key={run.id} className="border-t border-xyne-border-subtle/50">
+                  <td className="py-1.5 text-xyne-fg-secondary">{run.projectCode}</td>
+                  <td className="py-1.5 font-mono text-[10px] text-xyne-fg-tertiary">{run.subject}</td>
+                  <td className="py-1.5 text-xyne-fg-tertiary">
+                    {run.metrics?.findings ?? 0}{" "}
+                    <span className="opacity-60">({run.metrics?.findingsFiles ?? 0} files)</span>
+                  </td>
+                  <td className="py-1.5 text-xyne-fg-tertiary">{run.metrics?.batches ?? 0}</td>
+                  <td className="py-1.5">
+                    {run.status === "FAILED" ? (
+                      <span className="text-red-400" title={run.error ?? ""}>
+                        failed — {(run.error ?? "").slice(0, 50)}
+                      </span>
+                    ) : run.status === "NOTHING_TO_MERGE" ? (
+                      <span className="text-xyne-fg-tertiary">no findings that day</span>
+                    ) : run.status === "RUNNING" ? (
+                      <span className="text-amber-500">running</span>
+                    ) : (
+                      <span className="text-green-500">merged</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Reconcile history. This is the only pass that REWRITES pages, so what it
+          changed is the one thing here that cannot be reconstructed afterwards —
+          the summary is the record. */}
+      <div className="rounded-lg border border-xyne-border-subtle bg-xyne-surface-muted p-4">
+        <button type="button" onClick={() => setShowReconcile((v) => !v)}
+                className="text-[12px] font-medium text-xyne-fg-primary">
+          {showReconcile ? "▾" : "▸"} Recent reconciles ({reconcileRuns.length})
+          {reconcileRuns.some((r) => r.status === "FAILED") && (
+            <span className="ml-2 text-[11px] font-normal text-red-400">
+              {reconcileRuns.filter((r) => r.status === "FAILED").length} failed
+            </span>
+          )}
+        </button>
+
+        {showReconcile && (
+          reconcileRuns.length === 0 ? (
+            <p className="mt-3 text-[11px] text-xyne-fg-tertiary">
+              Never run. The merge writes from one day at a time and cannot tell an
+              authority from someone who answered once — reconcile re-reads the pages and
+              corrects them.
+            </p>
+          ) : (
+            <ul className="mt-3 space-y-2">
+              {reconcileRuns.map((run) => (
+                <li key={run.id} className="border-t border-xyne-border-subtle/50 pt-2">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-[11px] text-xyne-fg-secondary">{run.projectCode}</span>
+                    <span className="font-mono text-[10px] text-xyne-fg-tertiary">
+                      {run.subject}
+                    </span>
+                    {run.status === "FAILED" ? (
+                      <span className="text-[11px] text-red-400" title={run.error ?? ""}>
+                        failed — {(run.error ?? "").slice(0, 60)}
+                      </span>
+                    ) : run.status === "RUNNING" ? (
+                      <span className="text-[11px] text-amber-500">running</span>
+                    ) : (
+                      <span className="text-[11px] text-green-500">done</span>
+                    )}
+                  </div>
+                  {run.summary && (
+                    <p className="mt-1 whitespace-pre-wrap text-[10px] leading-relaxed text-xyne-fg-tertiary">
+                      {run.summary.slice(0, 1200)}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )
+        )}
+      </div>
+
+      {/* Per-window history. The channel table shows the latest state; this is
+          where you see WHICH window failed and how often. */}
+      <div className="rounded-lg border border-xyne-border-subtle bg-xyne-surface-muted p-4">
+        <button type="button" onClick={() => setShowRuns((v) => !v)}
+                className="text-[12px] font-medium text-xyne-fg-primary">
+          {showRuns ? "▾" : "▸"} Recent extraction runs ({runs.length})
+          {runs.some((r) => r.status === "FAILED") && (
+            <span className="ml-2 text-[11px] font-normal text-red-400">
+              {runs.filter((r) => r.status === "FAILED").length} failed
+            </span>
+          )}
+        </button>
+
+        {showRuns && (
+          runs.length === 0 ? (
+            <p className="mt-3 text-[11px] text-xyne-fg-tertiary">
+              No runs yet. They appear here once a channel has been extracted.
+            </p>
+          ) : (
+            <table className="mt-3 w-full text-[11px]">
+              <thead className="text-xyne-fg-tertiary">
+                <tr className="text-left">
+                  <th className="pb-1 font-normal">Channel</th>
+                  <th className="pb-1 font-normal">Window</th>
+                  <th className="pb-1 font-normal">Threads</th>
+                  <th className="pb-1 font-normal">Batches</th>
+                  <th className="pb-1 font-normal">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((run) => (
+                  <tr key={run.id} className="border-t border-xyne-border-subtle/50">
+                    <td className="py-1.5 text-xyne-fg-secondary">{run.subject}</td>
+                    <td className="py-1.5 font-mono text-[10px] text-xyne-fg-tertiary">
+                      {day(run.windowFrom) ?? "—"}
+                    </td>
+                    <td className="py-1.5 text-xyne-fg-tertiary">{run.metrics?.threads ?? 0}</td>
+                    <td className="py-1.5 text-xyne-fg-tertiary">{run.metrics?.batches ?? 0}</td>
+                    <td className="py-1.5">
+                      {run.status === "FAILED" ? (
+                        <span className="text-red-400" title={run.error ?? ""}>
+                          failed — {(run.error ?? "").slice(0, 60)}
+                        </span>
+                      ) : run.status === "RUNNING" ? (
+                        <span className="text-amber-500">running</span>
+                      ) : (
+                        <span className="text-xyne-fg-tertiary">
+                          {(run.metrics?.threads ?? 0) === 0 ? "empty window" : "done"}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailLeftColumn.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailLeftColumn.tsx
@@ -1483,6 +1483,10 @@ interface Props {
   //                "USER"        = inherit caller's full KB; picker hidden.
   draftKbScope: "COLLECTIONS" | "USER";
   onDraftKbScopeChange: (next: "COLLECTIONS" | "USER") => void;
+  /** KB curation toggle (config.kbAccess === "files"). Admin-gated. */
+  draftKbAccess: boolean;
+  onDraftKbAccessChange: (next: boolean) => void;
+  isAdmin: boolean;
 
   // Triggers
   skillTriggers: Array<{
@@ -1698,6 +1702,9 @@ export function AgentDetailLeftColumn({
   onDraftKbResourcesChange,
   draftKbScope,
   onDraftKbScopeChange,
+  draftKbAccess,
+  onDraftKbAccessChange,
+  isAdmin,
   skillTriggers,
   onSkillTriggersChange,
   draftPromptInjection,
@@ -2364,6 +2371,29 @@ export function AgentDetailLeftColumn({
                   ? "No KB grants — the agent will not be able to read documents."
                   : `${draftKbResources.length} grant${draftKbResources.length === 1 ? "" : "s"} attached`}
               </p>
+
+              {/* KB curation. Admin-only because the server strips `kbAccess`
+                  for non-admins — showing it to everyone would look like it
+                  saved and silently do nothing. */}
+              {isAdmin && (
+                <label className="mt-3 flex cursor-pointer items-start gap-2">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={draftKbAccess}
+                    disabled={!canEdit}
+                    onChange={(e) => canEdit && onDraftKbAccessChange(e.target.checked)}
+                  />
+                  <span className="text-[11px] text-xyne-fg-secondary">
+                    Let this agent edit the knowledge base
+                    <span className="block text-xyne-fg-tertiary">
+                      Replaces search with file-style access — list, read, grep, write and
+                      edit pages by path. For curator agents that maintain the KB; leave off
+                      for agents that only answer questions from it. Pages cannot be deleted.
+                    </span>
+                  </span>
+                </label>
+              )}
             </>
           )}
         </Section>

--- a/apps/xyne-claw-auth/frontend/src/v3/components/dialogs/CreateAgentModal.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/dialogs/CreateAgentModal.tsx
@@ -49,6 +49,7 @@ import { TextField } from "../ui/TextField";
 import { Button } from "../ui/Button";
 import { ToolboxPicker } from "../ToolboxPicker";
 import { KnowledgeBasePicker, type KbSelection } from "../KnowledgeBasePicker";
+import { useAdminStatus } from "../../hooks/useAdminStatus";
 
 interface Props {
   userId: string;
@@ -92,6 +93,8 @@ interface State {
   /** KB scope mode. USER hides the picker and tells the server to ignore
    *  any grants — the agent inherits the running user's spaces access. */
   selectedKbScope: "COLLECTIONS" | "USER";
+  /** config.kbAccess === "files" — file-style KB curation. Admin-only. */
+  kbFileAccess: boolean;
   researchAgentProducts: ResearchAgentOption[]; researchAgentRepositories: ResearchAgentOption[];
   researchAgentProductId: string; researchAgentRepositoryId: string; researchAgentOptionsLoading: boolean;
   /** AI-suggested starter toolkit. Auto-fetched once step 2 opens with a
@@ -121,6 +124,7 @@ const INIT: State = {
   availableSkills: [], skillsLoading: false, selectedSkillIds: [],
   selectedKbResources: [],
   selectedKbScope: "COLLECTIONS",
+  kbFileAccess: false,
   researchAgentProducts: [], researchAgentRepositories: [],
   researchAgentProductId: "", researchAgentRepositoryId: "", researchAgentOptionsLoading: false,
   suggestion: null, suggestionLoading: false, suggestionApplied: false,
@@ -266,6 +270,7 @@ function riskDotCls(
 
 export function CreateAgentModal({ userId, onClose, onCreated }: Props) {
   const [w, setW] = useState<State>(INIT);
+  const { isAdmin } = useAdminStatus();
   // Pinned detail = last clicked tool. Hovered detail = transient on hover/focus.
   const [pinnedDetail, setPinnedDetail] = useState<IntegrationToolEntry | null>(null);
   const [hoveredDetail, setHoveredDetail] = useState<IntegrationToolEntry | null>(null);
@@ -497,11 +502,13 @@ export function CreateAgentModal({ userId, onClose, onCreated }: Props) {
       const hasSkills = w.selectedSkillIds.length > 0;
       const trimmedRepoUrl = w.repoUrl.trim();
       const hasRepoUrl = trimmedRepoUrl.length > 0;
+      const hasKbFileAccess = w.kbFileAccess && !isUserScopedKb && w.selectedKbResources.length > 0;
       const hasResearchAgentConfig = w.custom.includes("query-codebase") || w.custom.includes("review-pull-request") || w.researchAgentProductId || w.researchAgentRepositoryId;
-      if (hasTools || hasSkills || hasResearchAgentConfig || hasRepoUrl) {
+      if (hasTools || hasSkills || hasResearchAgentConfig || hasRepoUrl || hasKbFileAccess) {
         const { updateAgent } = await import("../../../lib/api");
         const config: Record<string, unknown> = {};
         if (hasTools) config["tools"] = { subagents: w.subagents, direct: w.direct, custom: w.custom, gateway: w.gateway };
+        if (hasKbFileAccess) config["kbAccess"] = "files";
         if (hasResearchAgentConfig) {
           config["product_id"] = w.researchAgentProductId || null;
           config["repository_id"] = w.researchAgentRepositoryId || null;
@@ -995,6 +1002,29 @@ export function CreateAgentModal({ userId, onClose, onCreated }: Props) {
                       ? "No KB resources attached — the agent will not be able to read documents."
                       : `${w.selectedKbResources.length} grant${w.selectedKbResources.length === 1 ? "" : "s"} attached`}
                   </p>
+
+                  {/* KB curation. Only offered once a collection is attached —
+                      file access with nothing to act on is a no-op the server
+                      would warn about. Non-admins have `kbAccess` stripped on
+                      save, so the control stays hidden for them. */}
+                  {isAdmin && w.selectedKbResources.length > 0 && (
+                    <label className="flex cursor-pointer items-start gap-2 pt-1">
+                      <input
+                        type="checkbox"
+                        className="mt-0.5"
+                        checked={w.kbFileAccess}
+                        onChange={(e) => setW((p) => ({ ...p, kbFileAccess: e.target.checked }))}
+                      />
+                      <span className="text-[11px] text-xyne-fg-secondary">
+                        Let this agent edit the knowledge base
+                        <span className="block text-xyne-fg-tertiary">
+                          Replaces search with file-style access — list, read, grep, write and
+                          edit pages by path. For curator agents that maintain the KB; leave off
+                          for agents that only answer questions from it. Pages cannot be deleted.
+                        </span>
+                      </span>
+                    </label>
+                  )}
                 </>
               )}
             </div>

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -14,6 +14,7 @@ import { buildTwinDeliverMandate } from "./twin-deliver.js";
 import { installMidTurnCompaction, forceCompaction } from "./mid-turn-compaction.js";
 import { promoteIfOversized } from "./tool-output.js";
 import { createScopedToolMap } from "./scoped-tools.js";
+import { createKbToolMap, type KbTarget } from "./kb-tools.js";
 import { metric } from "./metrics.js";
 import { compactionExtension } from "./compaction-extension.js";
 import { takeCitations, takeDebug } from "./citations.js";
@@ -1282,6 +1283,17 @@ export interface RunTaskOptions {
   userName?: string | undefined;
   userEmail?: string | undefined;
   customTools?: ToolDefinition[] | undefined;
+  /**
+   * When set, read/ls/grep/write/edit operate on this KB collection instead of the
+   * session working directory. The agent sees the same tool names it always
+   * does; only the backing store differs.
+   * Comes from the agent's own `knowledgeBase[]` grant, so the collection is
+   * decided by configuration and the model cannot reach past it. Set only for
+   * agents whose row asks for file-style KB access (`kbAccess: "files"`) —
+   * retrieval agents read the same collection through Vespa and must not get these tools.
+   */
+  kbTarget?: KbTarget | undefined;
+  
   systemPromptOverride?: string | undefined;
   cwd?: string | undefined;
   /** Session key — `${userId}_${rawConversationId}_${agentSlug}` (see progressMeta). */
@@ -1752,7 +1764,30 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   // tool registry (agent-session.js:1844-1847 — customTools win on name
   // collision at execution time). The names stay in the allowlist below so they
   // remain active.
-  const scopedFileTools = Object.values(createScopedToolMap(workingDir, fileToolReadRoots));
+  //
+  // KB SESSIONS: when kbTarget is set, these names are backed by a Spaces KB
+  // collection instead of the filesystem (see kb-tools.ts). Two deliberate
+  // differences from the filesystem set:
+  //
+  //   - `find` is NOT provided. Leaving it in the allowlist without a KB
+  //     implementation would let pi's UNSCOPED built-in through, and it walks
+  //     the pod's real disk — the exact hole the comment above describes.
+  //   - `edit` IS provided, because exact-snippet replacement on a page is the
+  //     curator's main operation. It must appear in the allowlist below or pi
+  //     silently drops it.
+  //
+  // Set only for KB-curating agents. Agents that merely answer from a KB use
+  // Vespa retrieval and never reach here, so this map always includes write.
+  const kbTools = opts.kbTarget ? createKbToolMap(opts.kbTarget) : null;
+  const scopedFileTools = Object.values(
+    kbTools ?? createScopedToolMap(workingDir, fileToolReadRoots),
+  );
+  if (kbTools) {
+    log.info(
+      `[agent] KB-scoped session: [${Object.keys(kbTools).join(", ")}] -> collection ` +
+        `${opts.kbTarget?.collectionId} (filesystem tools disabled, find withheld)`,
+    );
+  }
   //
   // "bash" is EXCLUDED from the allowlist (and we never register a scoped bash)
   // — preserves the pre-migration security model. Pi would otherwise enable it.
@@ -1765,7 +1800,14 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   // include every customTool name. We enumerate them right before building
   // the options.
   // (Ref: pi-coding-agent/dist/core/sdk.js:157 — `allowedToolNames = options.tools`)
-  const builtinAllow = ["read", "write", "grep", "find", "ls"];
+  // A KB session swaps `find` (no KB equivalent — see above) for `edit`.
+  // Anything absent from this list is dropped silently by pi, so the two sets
+  // must match exactly what was registered above.
+  // Derived from what was actually built, so the allowlist cannot drift from
+  // the registered set — a read-only KB session lists no write/edit at all.
+  const builtinAllow = kbTools
+    ? Object.keys(kbTools)
+    : ["read", "write", "grep", "find", "ls"];
   const customToolNames = (customTools ?? []).map((t) => t.name);
   // Proof that the mandatory twin_deliver tool is actually in the pi payload
   // (allowlist + registered customTools) — logged for the Twin mention flow so a

--- a/apps/xyne-claw/src/finding-tools.ts
+++ b/apps/xyne-claw/src/finding-tools.ts
@@ -1,0 +1,243 @@
+/**
+ * emit-finding — the extractor agent's only way to record what it learned.
+ *
+ * The agent reads a batch of threads and calls this once per observation. The
+ * tool validates against the shared schema and buffers; the caller flushes the
+ * batch to GCS when the session ends.
+ *
+ * Validation lives HERE rather than downstream because the eventual consumer is
+ * the merge agent's prompt, which never complains — a malformed finding would
+ * be silently misread rather than rejected. Failing at the tool boundary gives
+ * the model the reason and a chance to correct itself, which is the only point
+ * in the pipeline where correction is still possible.
+ *
+ * The agent never sees GCS: no bucket, no path, no credentials. It emits
+ * observations; where they land is the caller's business.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import {
+  FINDINGS_SCHEMA_VERSION,
+  DEFAULT_FINDING_VOCABULARY,
+  buildIdempotencyKey,
+  validateFinding,
+  type Finding,
+  type FindingMode,
+  type FindingVocabulary,
+} from "xyne-claw-shared";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("finding-tools");
+
+/** Context the caller knows and the model must not invent. */
+export interface FindingScope {
+  workspaceId: string;
+  project: { id: string; code: string; name: string };
+  producer: { sessionId: string; agentSlug: string; model: string };
+}
+
+/** Collects a session's findings so the caller can flush them in one write. */
+export class FindingCollector {
+  private readonly findings: Finding[] = [];
+  private readonly seen = new Set<string>();
+  private rejected = 0;
+  private duplicates = 0;
+
+  constructor(
+    private readonly scope: FindingScope,
+    private readonly vocabulary: FindingVocabulary = DEFAULT_FINDING_VOCABULARY,
+  ) {}
+
+  add(finding: Finding): { ok: true } | { ok: false; reason: string } {
+    const result = validateFinding(finding, this.vocabulary);
+    if (!result.ok) {
+      this.rejected += 1;
+      return { ok: false, reason: result.reason };
+    }
+    // Within-session dedupe. The merge dedupes too, but catching it here keeps
+    // the GCS object honest about how much was actually observed.
+    if (this.seen.has(finding.idempotencyKey)) {
+      this.duplicates += 1;
+      return { ok: false, reason: `duplicate of an observation already recorded this session` };
+    }
+    this.seen.add(finding.idempotencyKey);
+    this.findings.push(result.finding);
+    return { ok: true };
+  }
+
+  /** JSONL body, or null when nothing survived. */
+  toJsonl(): string | null {
+    if (this.findings.length === 0) return null;
+    return this.findings.map((f) => JSON.stringify(f)).join("\n") + "\n";
+  }
+
+  stats(): { emitted: number; rejected: number; duplicates: number } {
+    return { emitted: this.findings.length, rejected: this.rejected, duplicates: this.duplicates };
+  }
+
+  get scopeRef(): FindingScope {
+    return this.scope;
+  }
+
+  get vocabularyRef(): FindingVocabulary {
+    return this.vocabulary;
+  }
+}
+
+function str(params: unknown, key: string): string {
+  const value = (params as Record<string, unknown> | undefined)?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function num(params: unknown, key: string): number | undefined {
+  const value = (params as Record<string, unknown> | undefined)?.[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+/**
+ * Builds the tool. Scope is closed over, so project, workspace and producer
+ * come from the caller — the model cannot attribute a finding to another
+ * project, and cannot get the project code wrong.
+ *
+ * The vocabulary comes from the caller too, so the taxonomy can be retuned from
+ * the agent row without shipping a new package.
+ */
+export function createEmitFindingTool(collector: FindingCollector): ToolDefinition {
+  const scope = collector.scopeRef;
+  const vocabulary = collector.vocabularyRef;
+
+  return {
+    name: "emit-finding",
+    label: "Emit Finding",
+    description: [
+      "Record one observation about who knows what, or one fact worth keeping.",
+      "",
+      "Call once per distinct observation. An observation needs either a `claim`",
+      "(a fact that stands on its own) or a `person` (someone who demonstrated",
+      "knowledge) — ideally both.",
+      "",
+      "RECORD WHAT YOU SAW, NEVER WHAT IT MEANS. Every `mode` must be something you",
+      "can point at in the quote. If you are concluding rather than observing, you",
+      "have the wrong mode. Do not decide who owns something — that is worked out",
+      "later, from how often a signal repeats across different threads.",
+      "",
+      "`entityName` must be lowercase and hyphenated (e.g. 'vespa', 'euler-api-txns').",
+      "Check existing KB pages first and reuse the name already in use there rather",
+      "than inventing a variant — 'postgres' and 'postgresql' become two permanent",
+      "pages that split the knowledge.",
+      "",
+      "`quote` must be verbatim from the source. It is what makes the claim",
+      "auditable, so never paraphrase it.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        entityName: { type: "string", description: "Lowercase, hyphenated. e.g. 'vespa'." },
+        entityKind: {
+          type: "string",
+          enum: [...vocabulary.entityKinds],
+          description: "SERVICE for deployables and infrastructure; TOOL for things you operate with.",
+        },
+        claim: {
+          type: "string",
+          description: "The fact, standing alone. Omit only when the observation is purely about a person.",
+        },
+        userId: { type: "string", description: "Spaces user id of the person, verbatim from the batch." },
+        displayName: { type: "string", description: "The person's name as shown." },
+        mode: {
+          type: "string",
+          enum: [...vocabulary.modes],
+          description: [
+            "What the quote SHOWS this person doing. Not your read of their standing.",
+            "DEFERRED_TO — someone ELSE pointed at them: 'ask X', 'X would know'.",
+            "RESOLVED — their message ended the thread, or they closed the ticket.",
+            "CORRECTED — they overrode someone else's answer.",
+            "ANSWERED — they gave a substantive answer.",
+            "CLAIMED_OWNERSHIP — they said so themselves: 'I own this', 'I'll take it'.",
+            "REVIEWED — they are the ticket's reviewer.",
+            "ASKED — they asked about it. Record this; it is evidence they are NOT",
+            "the expert here, and leaving it out is how a bystander gets mistaken",
+            "for an authority.",
+          ].join(" "),
+        },
+        quote: { type: "string", description: "Verbatim evidence from the source." },
+        ref: { type: "string", description: "Message id or ticket field the quote came from." },
+        confidence: { type: "number", description: "0-1. Below 0.5 will not be recorded as expertise." },
+        sourceType: { type: "string", enum: ["CHAT_THREAD", "TICKET"] },
+        sourceKey: { type: "string", description: "threadId for chat, ticket key for a ticket." },
+        permalink: { type: "string", description: "Deep link to the thread or ticket." },
+        occurredAt: { type: "string", description: "ISO time the conversation happened, NOT now." },
+      },
+      required: ["entityName", "entityKind", "quote", "confidence", "sourceType", "sourceKey", "permalink", "occurredAt"],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const entityName = str(params, "entityName");
+      const userId = str(params, "userId");
+      const mode = str(params, "mode") as FindingMode | "";
+      const sourceKey = str(params, "sourceKey");
+      const confidence = num(params, "confidence");
+
+      const finding: Finding = {
+        schemaVersion: FINDINGS_SCHEMA_VERSION,
+        // Derived from the observation, not random: a re-run of the same batch
+        // produces the same ids, so a retried session does not duplicate.
+        observationId: `obs_${sourceKey}_${entityName}_${userId || "none"}_${mode || "none"}`,
+        emittedAt: new Date().toISOString(),
+        workspaceId: scope.workspaceId,
+        producer: scope.producer,
+        source: {
+          type: str(params, "sourceType") === "TICKET" ? "TICKET" : "CHAT_THREAD",
+          project: scope.project,
+          permalink: str(params, "permalink"),
+          occurredAt: str(params, "occurredAt"),
+          ...(str(params, "sourceType") === "TICKET"
+            ? { ticketKey: sourceKey }
+            : { threadId: sourceKey }),
+        },
+        entity: {
+          // Not defaulted. A guessed kind routes the finding to a KB folder that
+          // cannot be moved afterwards, so a missing one is rejected instead.
+          kind: str(params, "entityKind") as Finding["entity"]["kind"],
+          name: entityName.toLowerCase(),
+        },
+        ...(str(params, "claim") ? { claim: str(params, "claim") } : {}),
+        ...(userId
+          ? { person: { userId, displayName: str(params, "displayName") || userId } }
+          : {}),
+        ...(mode ? { mode: mode as FindingMode } : {}),
+        evidence: {
+          // NOT trimmed — a verbatim quote keeps its whitespace.
+          quote: ((params as Record<string, unknown>)?.["quote"] as string) ?? "",
+          ...(str(params, "ref") ? { ref: str(params, "ref") } : {}),
+        },
+        confidence: confidence ?? 0,
+        idempotencyKey: buildIdempotencyKey({
+          sourceKey,
+          ...(userId ? { userId } : {}),
+          entityName: entityName.toLowerCase(),
+          ...(mode ? { mode: mode as FindingMode } : {}),
+        }),
+      };
+
+      const result = collector.add(finding);
+      if (!result.ok) {
+        log.warn(`[emit-finding] rejected ${entityName}: ${result.reason}`);
+        return {
+          content: [{ type: "text" as const, text: `Not recorded — ${result.reason}. Fix and call again.` }],
+          details: { error: true },
+        };
+      }
+
+      log.info(
+        `[emit-finding] ${scope.project.code} ${entityName} ` +
+          `${mode || "claim"} ${userId ? `by ${userId}` : ""} conf=${confidence}`,
+      );
+      return {
+        content: [{ type: "text" as const, text: `Recorded: ${entityName} (${mode || "claim"})` }],
+        details: { entityName, mode },
+      };
+    },
+  };
+}

--- a/apps/xyne-claw/src/gcs.ts
+++ b/apps/xyne-claw/src/gcs.ts
@@ -47,6 +47,10 @@ const DEBUG_RUN_PREFIX = "claw-debug-runs";
 // for the 2026-06-11 "completed sessions re-executed on restart" incident.
 // Source of truth for "did this finish?", independent of the lossy callback.
 const RESULT_MARKER_PREFIX = "claw-results";
+// People-KB findings, date-partitioned so the nightly merge reads one prefix.
+// Sharded by session because many extractor runs write concurrently — a shared
+// object would have them overwrite each other.
+const FINDINGS_PREFIX = "people-kb/findings";
 
 const GCS_TIMEOUT_MS = 15_000;
 
@@ -173,6 +177,44 @@ export async function gcsUploadSessionFromDisk(
     }
     noteIfCredsError(err);
     log.warn(`[gcs] direct upload failed for ${conversationId}:`, err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/**
+ * Write one extraction session's findings.
+ *
+ * Partitioned by the date of the CONVERSATION, not of the run: a backfill spans
+ * months, and filing it under the run date would collapse it into one prefix and
+ * leave the merge unable to process days in order.
+ *
+ * Returns false rather than throwing — the caller logs the loss and the window
+ * is retried, which is better than failing a session that has already done the
+ * expensive part.
+ */
+export async function gcsUploadFindings(
+  day: string,
+  projectCode: string,
+  sessionId: string,
+  jsonl: string,
+): Promise<boolean> {
+  const client = getStorage();
+  if (!client) return false;
+  const objectPath = `${FINDINGS_PREFIX}/dt=${day}/${projectCode}/${sessionId}.jsonl`;
+  try {
+    await client
+      .bucket(BUCKET)
+      .file(objectPath)
+      .save(Buffer.from(jsonl, "utf8"), {
+        resumable: false,
+        timeout: GCS_TIMEOUT_MS,
+        contentType: "application/x-ndjson",
+      });
+    log.info(`[gcs] findings written to ${objectPath}`);
+    return true;
+  } catch (err) {
+    noteIfCredsError(err);
+    log.error(`[gcs] findings upload FAILED for ${objectPath}:`, err instanceof Error ? err.message : String(err));
     return false;
   }
 }

--- a/apps/xyne-claw/src/kb-tools.ts
+++ b/apps/xyne-claw/src/kb-tools.ts
@@ -1,0 +1,505 @@
+/**
+ * KB filesystem tools — the coding-agent file tools, backed by a Spaces KB
+ * collection instead of disk.
+ *
+ * Returned as a MAP keyed by pi's built-in tool names (read/ls/grep/write/edit),
+ * so they take the place of the built-ins under the same names. The model is a
+ * coding agent and already knows these tools; it simply finds markdown pages
+ * where it expected files. Same substitution `scoped-tools.ts` performs for the
+ * sandbox filesystem.
+ *
+ * Scope is closed over at construction — collection and user are arguments to
+ * `createKbToolMap`, never tool parameters — so the model cannot widen its own
+ * reach. That mirrors `createWriteTool(root)` being confined to the working
+ * directory, and here it is the SOLE enforcement.
+ *
+ * There is deliberately no delete tool: itemIds are embedded in saved KB links,
+ * so an obsolete page is rewritten as a redirect stub rather than removed.
+ *
+ * Everything runs over HTTP through claw-auth, which holds the Spaces session,
+ * so a KB agent needs no working directory and no sandbox.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { SERVER } from "./config.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("kb-tools");
+
+/** Cap so one oversized page cannot swamp the model's context. */
+const MAX_READ_CHARS = 60_000;
+
+/** A broad grep can match hundreds of lines; the head is the useful part. */
+const MAX_GREP_MATCHES = 100;
+
+/**
+ * Which KB these tools act on. Named KbTarget, not KbTarget, because claw-auth
+ * already uses `kbScope` for something different — the "COLLECTIONS" | "USER"
+ * mode on an agent row.
+ */
+export interface KbTarget {
+  collectionId: string;
+  userId: string;
+  scopeType?: string;
+  scopeId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Calling claw-auth
+// ---------------------------------------------------------------------------
+
+function s2sHeaders(userId: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    ...(SERVER.s2sKey ? { "x-s2s-key": SERVER.s2sKey, "x-user-id": userId } : {}),
+  };
+}
+
+function kbUrl(endpoint: string): string {
+  return `${SERVER.authServiceUrl.replace(/\/+$/, "")}/claw/api/v1/kb/${endpoint}`;
+}
+
+/** Scope travels on every call. The model never supplies it. */
+function scopeFields(scope: KbTarget): Record<string, string> {
+  return {
+    userId: scope.userId,
+    collectionId: scope.collectionId,
+    ...(scope.scopeType ? { scopeType: scope.scopeType } : {}),
+    ...(scope.scopeId ? { scopeId: scope.scopeId } : {}),
+  };
+}
+
+/**
+ * Every KB route answers `{ success, data }` or `{ success: false, error }`.
+ * Failures throw so each tool can catch once and hand the message to the model.
+ */
+async function readEnvelope<T>(response: Response, endpoint: string): Promise<T> {
+  const body = (await response.json().catch(() => ({}))) as {
+    success?: boolean;
+    data?: T;
+    error?: string;
+  };
+  if (!response.ok || !body.success) {
+    throw new Error(body.error ?? `kb ${endpoint} failed (${response.status})`);
+  }
+  return body.data as T;
+}
+
+async function kbGet<T>(
+  endpoint: string,
+  scope: KbTarget,
+  params: Record<string, string>,
+): Promise<T> {
+  const query = new URLSearchParams({ ...scopeFields(scope), ...params });
+  const response = await fetch(`${kbUrl(endpoint)}?${query}`, {
+    method: "GET",
+    headers: s2sHeaders(scope.userId),
+    signal: AbortSignal.timeout(60_000),
+  });
+  return readEnvelope<T>(response, endpoint);
+}
+
+async function kbPost<T>(
+  endpoint: string,
+  scope: KbTarget,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(kbUrl(endpoint), {
+    method: "POST",
+    headers: s2sHeaders(scope.userId),
+    body: JSON.stringify({ ...scopeFields(scope), ...payload }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  return readEnvelope<T>(response, endpoint);
+}
+
+// ---------------------------------------------------------------------------
+// Reading what the model passed
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+/**
+ * One line per tool call, with its outcome and duration.
+ *
+ * An agent session IS its sequence of tool calls, so these lines are how you
+ * reconstruct what it did — which pages it looked at, what it searched for and
+ * whether it found anything, what it changed. Contents are never logged: pages
+ * are large and may be sensitive, and the path plus the outcome is what makes
+ * a run reproducible.
+ */
+function logCall(tool: string, summary: string, startedAt: number): void {
+  log.info(`[kb ${tool}] ${summary} (${Date.now() - startedAt}ms)`);
+}
+
+function logFailure(tool: string, subject: string, err: unknown, startedAt: number): string {
+  const message = err instanceof Error ? err.message : String(err);
+  log.warn(`[kb ${tool}] ${subject} FAILED after ${Date.now() - startedAt}ms: ${message}`);
+  return message;
+}
+
+/** A model-supplied string, trimmed. For paths and patterns. */
+function param(params: unknown, key: string): string {
+  const value = (params as Record<string, unknown> | undefined)?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * A model-supplied string with whitespace intact. For page content and edit
+ * snippets: trimming an `oldText` would break the exact-match guarantee that
+ * makes `edit` safe.
+ */
+function exactParam(params: unknown, key: string): string {
+  const value = (params as Record<string, unknown> | undefined)?.[key];
+  return typeof value === "string" ? value : "";
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+function createReadPageTool(scope: KbTarget): ToolDefinition {
+  return {
+    name: "read",
+    label: "Read KB Page",
+    description: [
+      "Read a knowledge-base page by its exact path, e.g. 'services/livekit/service.md'.",
+      "Paths are relative to the collection root. Use `ls` first if you do not know the path.",
+      "Returns the page's full markdown, including frontmatter.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        path: {
+          type: "string",
+          description: "Page path, e.g. 'services/livekit/service.md'.",
+        },
+      },
+      required: ["path"],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const path = param(params, "path");
+      if (!path) {
+        return { content: [{ type: "text" as const, text: "Error: path is required." }], details: {} };
+      }
+
+      const startedAt = Date.now();
+      try {
+        const page = await kbGet<{ found: boolean; content: string | null }>("read", scope, { path });
+
+        if (!page.found || page.content === null) {
+          logCall("read", `${path} -> NOT FOUND`, startedAt);
+          return { content: [{ type: "text" as const, text: `Not found: ${path}` }], details: {} };
+        }
+
+        const truncated = page.content.length > MAX_READ_CHARS;
+        logCall(
+          "read",
+          `${path} -> ${page.content.length} chars${truncated ? " (truncated)" : ""}`,
+          startedAt,
+        );
+
+        const text = truncated
+          ? `${page.content.slice(0, MAX_READ_CHARS)}\n\n[truncated at ${MAX_READ_CHARS} chars]`
+          : page.content;
+
+        return { content: [{ type: "text" as const, text }], details: { path } };
+      } catch (err) {
+        const message = logFailure("read", path, err, startedAt);
+        return {
+          content: [{ type: "text" as const, text: `Read failed: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  };
+}
+
+function createListPagesTool(scope: KbTarget): ToolDefinition {
+  return {
+    name: "ls",
+    label: "List KB Pages",
+    description: [
+      "List knowledge-base page paths, optionally under a prefix (e.g. 'services/').",
+      "Cheap and complete — it lists every page, so prefer it over guessing whether a page exists.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        path: {
+          type: "string",
+          description: "Optional prefix filter, e.g. 'services/'. Omit to list everything.",
+        },
+      },
+      required: [],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const prefix = param(params, "path");
+
+      const startedAt = Date.now();
+      try {
+        const result = await kbGet<{ paths: string[] }>(
+          "list",
+          scope,
+          prefix ? { prefix } : {},
+        );
+
+        logCall("ls", `${prefix || "(all)"} -> ${result.paths.length} paths`, startedAt);
+
+        if (result.paths.length === 0) {
+          const text = prefix ? `No pages under ${prefix}` : "The KB is empty.";
+          return { content: [{ type: "text" as const, text }], details: {} };
+        }
+
+        const text = `${result.paths.length} pages:\n${result.paths.join("\n")}`;
+        return { content: [{ type: "text" as const, text }], details: { count: result.paths.length } };
+      } catch (err) {
+        const message = logFailure("ls", prefix || "(all)", err, startedAt);
+        return {
+          content: [{ type: "text" as const, text: `List failed: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  };
+}
+
+function createGrepPagesTool(scope: KbTarget): ToolDefinition {
+  return {
+    name: "grep",
+    label: "Search KB Pages",
+    description: [
+      "Search page contents for a literal string or regex. Returns path:line matches.",
+      "Exact and complete — every page is read rather than ranked, so no match means the text is genuinely absent.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        pattern: {
+          type: "string",
+          description: "Literal text or regular expression to find.",
+        },
+        path: {
+          type: "string",
+          description: "Optional prefix to restrict the search, e.g. 'services/'.",
+        },
+      },
+      required: ["pattern"],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const pattern = param(params, "pattern");
+      if (!pattern) {
+        return {
+          content: [{ type: "text" as const, text: "Error: pattern is required." }],
+          details: {},
+        };
+      }
+
+      const prefix = param(params, "path");
+
+      const startedAt = Date.now();
+      try {
+        const result = await kbGet<{
+          matches: Array<{ path: string; line: number; text: string }>;
+        }>("grep", scope, { pattern, ...(prefix ? { prefix } : {}) });
+
+        if (result.matches.length === 0) {
+          // Worth a warn, not an info: an empty grep is usually the step before
+          // the agent decides nothing covers this and writes a new page. If a
+          // duplicate shows up later, this line is where the trail starts.
+          log.warn(
+            `[kb grep] "${pattern}"${prefix ? ` under ${prefix}` : ""} -> NO MATCHES ` +
+              `(${Date.now() - startedAt}ms)`,
+          );
+          return {
+            content: [{ type: "text" as const, text: `No matches for ${pattern}` }],
+            details: {},
+          };
+        }
+
+        logCall(
+          "grep",
+          `"${pattern}"${prefix ? ` under ${prefix}` : ""} -> ${result.matches.length} matches ` +
+            `in ${new Set(result.matches.map((m) => m.path)).size} pages`,
+          startedAt,
+        );
+
+        const shown = result.matches.slice(0, MAX_GREP_MATCHES);
+        const hidden = result.matches.length - shown.length;
+        const lines = shown.map((match) => `${match.path}:${match.line}: ${match.text}`);
+        const text = lines.join("\n") + (hidden > 0 ? `\n[+${hidden} more matches]` : "");
+
+        return { content: [{ type: "text" as const, text }], details: { count: result.matches.length } };
+      } catch (err) {
+        const message = logFailure("grep", `"${pattern}"`, err, startedAt);
+        return {
+          content: [{ type: "text" as const, text: `Grep failed: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  };
+}
+
+function createWritePageTool(scope: KbTarget): ToolDefinition {
+  return {
+    name: "write",
+    label: "Write KB Page",
+    description: [
+      "Create a knowledge-base page, or replace an existing one at that path.",
+      "Folders are created automatically from the path — no need to make them first.",
+      "If the content is identical to what is already there, nothing is written and no version is created.",
+      "Prefer `edit` for a small change; use `write` for a new page or a full rewrite.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        path: {
+          type: "string",
+          description: "Page path, e.g. 'services/livekit/service.md'.",
+        },
+        content: {
+          type: "string",
+          description: "Full markdown content of the page, including frontmatter.",
+        },
+      },
+      required: ["path", "content"],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const path = param(params, "path");
+      const content = exactParam(params, "content");
+      if (!path || !content) {
+        return {
+          content: [{ type: "text" as const, text: "Error: path and content are required." }],
+          details: {},
+        };
+      }
+
+      const startedAt = Date.now();
+      try {
+        const outcome = await kbPost<{ path: string; status: string }>("write", scope, {
+          path,
+          content,
+        });
+        // created / updated / unchanged. A run that is mostly "unchanged" is
+        // healthy; a run that is mostly "created" means paths are not matching
+        // existing pages and duplicates are accumulating.
+        logCall("write", `${path} -> ${outcome.status} (${content.length} chars)`, startedAt);
+        return {
+          content: [{ type: "text" as const, text: `${outcome.status}: ${outcome.path}` }],
+          details: { path: outcome.path, status: outcome.status },
+        };
+      } catch (err) {
+        const message = logFailure("write", path, err, startedAt);
+        return {
+          content: [{ type: "text" as const, text: `Write failed: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  };
+}
+
+function createEditPageTool(scope: KbTarget): ToolDefinition {
+  return {
+    name: "edit",
+    label: "Edit KB Page",
+    description: [
+      "Replace an exact snippet in an existing page.",
+      "`oldText` must appear EXACTLY ONCE — include enough surrounding context to make it unique.",
+      "Fails without changing anything if the text is missing or appears more than once.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        path: {
+          type: "string",
+          description: "Page path to edit.",
+        },
+        oldText: {
+          type: "string",
+          description: "Exact text to replace. Must appear exactly once in the page.",
+        },
+        newText: {
+          type: "string",
+          description: "Replacement text. An empty string deletes the snippet.",
+        },
+      },
+      required: ["path", "oldText", "newText"],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      const path = param(params, "path");
+      const oldText = exactParam(params, "oldText");
+      const newText = exactParam(params, "newText");
+      if (!path || !oldText) {
+        return {
+          content: [{ type: "text" as const, text: "Error: path and oldText are required." }],
+          details: {},
+        };
+      }
+
+      const startedAt = Date.now();
+      try {
+        const outcome = await kbPost<{ path: string; status: string }>("edit", scope, {
+          path,
+          oldText,
+          newText,
+        });
+        logCall(
+          "edit",
+          `${path} -> ${outcome.status} (${oldText.length} -> ${newText.length} chars)`,
+          startedAt,
+        );
+        return {
+          content: [{ type: "text" as const, text: `${outcome.status}: ${outcome.path}` }],
+          details: { path: outcome.path, status: outcome.status },
+        };
+      } catch (err) {
+        // "not found" and "not unique (3 occurrences)" are actionable: the model
+        // widens its snippet and retries. Surface them verbatim — and log them,
+        // because repeated "not unique" on one path means the page has grown
+        // boilerplate the agent cannot address precisely.
+        const message = logFailure("edit", path, err, startedAt);
+        return {
+          content: [{ type: "text" as const, text: `Edit failed: ${message}` }],
+          details: { error: true },
+        };
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Keyed by pi's built-in tool names, so these replace the filesystem versions.
+ *
+ * These exist for curating a KB, which means writing to it — an agent that only
+ * needs to read one uses Vespa retrieval instead and never gets this map.
+ */
+export function createKbToolMap(target: KbTarget): Record<string, ToolDefinition> {
+  const tools: Record<string, ToolDefinition> = {
+    read: createReadPageTool(target),
+    ls: createListPagesTool(target),
+    grep: createGrepPagesTool(target),
+    write: createWritePageTool(target),
+    edit: createEditPageTool(target),
+  };
+  log.info(
+    `[kb-tools] collection=${target.collectionId} tools=[${Object.keys(tools).join(", ")}]`,
+  );
+  return tools;
+}
+
+/** Array form, for registration paths that take a tool list. */
+export function createKbTools(target: KbTarget): ToolDefinition[] {
+  return Object.values(createKbToolMap(target));
+}

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -105,6 +105,10 @@ import {
   type SetupStep,
 } from "xyne-claw-shared";
 import { SERVER, PATHS, LITELLM, isAllowedCallbackUrl } from "../config.js";
+import type { KbTarget } from "../kb-tools.js";
+import { FindingCollector, createEmitFindingTool, type FindingScope } from "../finding-tools.js";
+import { DEFAULT_FINDING_VOCABULARY, type FindingVocabulary } from "xyne-claw-shared";
+import { gcsUploadFindings } from "../gcs.js";
 import { judgeChainContinuation } from "../chain-judge.js";
 import { isDigitalTwinAgent, listSubsystemTaxonomy, fetchAgentPromptFiles } from "../memory.js";
 import { buildMemorySearchTool } from "../memory-search.js";
@@ -182,6 +186,99 @@ function providerToolRequestCap(provider: string | undefined): number {
   const raw = (envKey ? process.env[envKey] : undefined) ?? process.env["XYNE_TOOL_REQUEST_CAP"] ?? "128";
   const parsed = Number(raw);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 128;
+}
+
+/**
+ * File-style KB access, resolved from the agent row's `kbAccess: "files"`.
+ *
+ * Agents that merely *read* a knowledge base do it through Vespa retrieval —
+ * ranked chunks, which is what answering a question needs. The path-based
+ * tools here exist for the opposite job: curating the KB, which means writing.
+ * So there is one flag, not a permission ladder. Absent (every agent today)
+ * means no KB tools at all and Vespa search as before.
+ */
+function resolveKbAccess(
+  agentConfig: Record<string, unknown> | undefined,
+  userId: string,
+): KbTarget | null {
+  if (agentConfig?.["kbAccess"] !== "files") return null;
+
+  const grants = agentConfig?.["knowledgeBase"];
+  const first = Array.isArray(grants) ? (grants[0] as Record<string, unknown> | undefined) : undefined;
+  const collectionId = typeof first?.["collectionId"] === "string" ? first["collectionId"] : undefined;
+  if (!collectionId) {
+    clog.warn(`[agent] kbAccess=files but no knowledgeBase grant; KB tools not attached`);
+    return null;
+  }
+
+  const scopeType = typeof first?.["scopeType"] === "string" ? first["scopeType"] : undefined;
+  const scopeId = typeof first?.["scopeId"] === "string" ? first["scopeId"] : undefined;
+
+  return {
+    collectionId,
+    userId,
+    // Uppercased because the collections API compares scopeType exactly, and a
+    // lower-case value fails as "not accessible" — which reads like a
+    // permissions problem rather than the typo it is.
+    ...(scopeType ? { scopeType: scopeType.toUpperCase() } : {}),
+    ...(scopeId ? { scopeId } : {}),
+  };
+}
+
+/**
+ * Extraction scope, from the orchestrator (kbExtractDaily) rather than the model.
+ *
+ * Present only for the extractor agent. Closing project and workspace over the
+ * tool is what stops a finding being attributed to the wrong project — the
+ * model supplies observations, never the scope they belong to.
+ */
+function resolveFindingScope(
+  agentConfig: Record<string, unknown> | undefined,
+  model: string,
+  sessionId: string,
+  agentSlug: string | undefined,
+): (FindingScope & { day?: string }) | null {
+  const raw = agentConfig?.["findingScope"] as
+    | {
+        workspaceId?: string;
+        project?: { id?: string; code?: string; name?: string };
+        /** Date of the CONVERSATION this batch covers, not of the run. */
+        day?: string;
+      }
+    | undefined;
+  if (!raw?.workspaceId || !raw.project?.id || !raw.project.code) return null;
+
+  return {
+    workspaceId: raw.workspaceId,
+    project: { id: raw.project.id, code: raw.project.code, name: raw.project.name ?? raw.project.code },
+    producer: { sessionId, agentSlug: agentSlug ?? "unknown", model },
+    ...(raw.day ? { day: raw.day } : {}),
+  };
+}
+
+/**
+ * The kinds and modes emit-finding will accept, from the agent row.
+ *
+ * Lets the taxonomy be retuned where the prompt already lives, instead of
+ * costing a shared-package bump and a redeploy of both services. Falls back to
+ * the built-in set, so an agent that says nothing behaves as before. A partial
+ * override is honoured per field — replacing the modes should not silently
+ * reset the entity kinds.
+ */
+function resolveFindingVocabulary(agentConfig: Record<string, unknown> | undefined): FindingVocabulary {
+  const raw = agentConfig?.["findingVocabulary"] as
+    | { entityKinds?: unknown; modes?: unknown }
+    | undefined;
+
+  const strings = (value: unknown): string[] | undefined =>
+    Array.isArray(value) && value.every((v) => typeof v === "string" && v.trim())
+      ? (value as string[])
+      : undefined;
+
+  return {
+    entityKinds: strings(raw?.entityKinds) ?? DEFAULT_FINDING_VOCABULARY.entityKinds,
+    modes: strings(raw?.modes) ?? DEFAULT_FINDING_VOCABULARY.modes,
+  };
 }
 
 function configFastModeEnabled(agentConfig: Record<string, unknown> | undefined): boolean {
@@ -2762,6 +2859,29 @@ async function processTask(
     // outputFormat is set it wins over verifyResponses and is skipped in
     // copilot mode.
     const modelSettings = parseModelSettings(agentConfig);
+    const kbAccess = resolveKbAccess(agentConfig, userId);
+    const findingScope = resolveFindingScope(
+      agentConfig,
+      modelSettings?.model ?? "unknown",
+      sessionId,
+      agentSlug,
+    );
+    const findingVocabulary = resolveFindingVocabulary(agentConfig);
+    const findingCollector = findingScope
+      ? new FindingCollector(findingScope, findingVocabulary)
+      : null;
+    if (findingCollector) {
+      clog.info(
+        `[agent] extraction session: project=${findingScope!.project.code} ` +
+          `modes=${findingVocabulary.modes.join("|")}`,
+      );
+    }
+    if (kbAccess) {
+      clog.info(
+        `[agent] KB file access: collection=${kbAccess.collectionId} ` +
+          `agent=${agentSlug ?? "unknown"}`,
+      );
+    }
     if (modelSettings) {
       log(`Per-agent modelSettings: ${JSON.stringify(modelSettings)}`);
     }
@@ -3581,7 +3701,14 @@ async function processTask(
         automationRun: isReadOnlyJob,
         userName,
         userEmail,
-        customTools: tools,
+        // emit-finding exists only for extraction sessions; every other agent
+        // gets the palette unchanged.
+        customTools: findingCollector
+          ? [...(tools ?? []), createEmitFindingTool(findingCollector)]
+          : tools,
+        ...(kbAccess
+          ? { kbTarget: kbAccess }
+          : {}),
         systemPromptOverride: effectiveSystemPrompt,
         cwd: workspaceDir,
         conversationId: sessionKey,
@@ -3710,6 +3837,34 @@ async function processTask(
           log(`Quota fallback succeeded on ${provider}.`),
       },
     });
+    // Flush findings before anything else can fail. The session's whole value is
+    // in these observations; losing them to a later error would mean re-running
+    // the extraction to get them back.
+    if (findingCollector) {
+      const stats = findingCollector.stats();
+      const jsonl = findingCollector.toJsonl();
+      if (jsonl) {
+        // Partition by when the conversation happened, not when extraction ran.
+        // A backfill spans months; filing it all under the run date collapses
+        // that into one pile and the merge loses chronological order — which
+        // makes the first/last freshness markers meaningless.
+        const day = findingScope?.day ?? new Date().toISOString().slice(0, 10);
+        const written = await gcsUploadFindings(
+          day,
+          findingCollector.scopeRef.project.code,
+          sessionId,
+          jsonl,
+        );
+        clog.info(
+          `[agent] findings ${written ? "written" : "LOST — upload failed"}: ` +
+            `emitted=${stats.emitted} rejected=${stats.rejected} duplicates=${stats.duplicates} ` +
+            `project=${findingCollector.scopeRef.project.code}`,
+        );
+      } else {
+        clog.info(`[agent] no findings emitted (rejected=${stats.rejected})`);
+      }
+    }
+
     const result = fbResult;
 
     const resultAttachments = [...getAttachments(), ...(mcpGetAttachments?.() ?? [])];

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -9,6 +9,14 @@ export type { Citation, CitationIconKey } from "./types/citation.js";
 export { citationIconUrl, citationIconKey, iconUrlForKey, toolIconKey, CITATION_ICONS } from "./types/citation.js";
 export type { TwinDelivery, TwinDeliveryAction, TwinReplyDestination, TwinDestinationCandidate } from "./types/twin-delivery.js";
 export { isTwinDelivery } from "./types/twin-delivery.js";
+export type {
+  Finding, FindingMode, FindingEntityKind, FindingProject, FindingSource,
+  FindingPerson, FindingEntity, FindingEvidence, FindingVocabulary,
+} from "./types/findings.js";
+export {
+  FINDINGS_SCHEMA_VERSION, DEFAULT_FINDING_VOCABULARY,
+  validateFinding, buildIdempotencyKey, parseFindingsJsonl,
+} from "./types/findings.js";
 export {
   normalizeSkillContent,
   hashSkillContent,

--- a/packages/xyne-claw-shared/src/types/findings.ts
+++ b/packages/xyne-claw-shared/src/types/findings.ts
@@ -1,0 +1,325 @@
+/**
+ * People-KB findings — the contract between extraction and merge.
+ *
+ * The extractor agent emits these through `emit-finding` (apps/xyne-claw), which
+ * validates each one and flushes the batch to object storage. The merge job
+ * (apps/xyne-claw-auth/services/kbMergeDaily) reads them back and hands them to
+ * the merge agent, which turns them into KB pages.
+ *
+ * The far consumer is a PROMPT, which never complains: rename a field and the
+ * agent silently does something plausible instead of failing. Nothing else in
+ * the stack has that property, so the shape lives here — both sides import it
+ * and break at compile time — and `validateFinding` rejects malformed
+ * observations at the tool boundary, the last point where the model can still
+ * be told to fix them.
+ *
+ * Serialised as JSONL, one self-contained observation per line. Object storage
+ * has no append, so each extraction session writes its OWN object under
+ * people-kb/findings/dt=<conversation date>/<CODE>/<sessionId>.jsonl. Sessions
+ * run concurrently, so no line may depend on another, and a truncated final
+ * line costs one observation rather than the file.
+ *
+ * Partitioned by when the CONVERSATION happened, not when extraction ran: a
+ * backfill spans months, and filing it under the run date would collapse it
+ * into one prefix, leaving the merge unable to process days in order.
+ */
+
+/**
+ * Bump when a field changes meaning.
+ *
+ * Checked by validateFinding when a finding is emitted, so a mismatch fails
+ * loudly at write time. Nothing re-validates on the read side — findings in
+ * storage are trusted, which is why the write-side check has to be strict.
+ *
+ * 2: modes became observations. See FindingMode.
+ */
+export const FINDINGS_SCHEMA_VERSION = 2;
+
+/**
+ * How a person relates to an entity — what was OBSERVED, never what it means.
+ *
+ * Every value has to be pointable-at in the quote. "Is this in the text?" has an
+ * answer; "does this person own vespa?" does not. The previous set asked for the
+ * second kind: OWNS was a verdict nobody states out loud, so it landed on
+ * whoever sounded most confident — which is exactly the assertive passer-by we
+ * were trying to tell apart from the actual owner. Nothing could catch it either,
+ * because there was no quote to check it against.
+ *
+ * OWNS is now a CONCLUSION, drawn by reconcile once a signal has repeated across
+ * distinct threads. It is never emitted.
+ *
+ * Roughly by weight:
+ *   DEFERRED_TO        someone else named them — third-party, so the strongest
+ *   RESOLVED           their message ended it / they closed the ticket
+ *   CORRECTED          they overrode someone else's answer
+ *   ANSWERED           gave a substantive answer
+ *   CLAIMED_OWNERSHIP  said it themselves — self-reported, needs corroboration
+ *   REVIEWED           ticket reviewer role, structural rather than conversational
+ *   ASKED              asked about it — evidence AGAINST expertise
+ *
+ * DEFERRED_TO vs CLAIMED_OWNERSHIP is the pair that matters: the org pointing at
+ * someone, versus someone pointing at themselves. Both used to collapse into OWNS.
+ */
+export type FindingMode =
+  | "DEFERRED_TO"
+  | "RESOLVED"
+  | "CORRECTED"
+  | "ANSWERED"
+  | "CLAIMED_OWNERSHIP"
+  | "REVIEWED"
+  | "ASKED";
+
+/**
+ * Routed to a KB root by the merge: SERVICE -> services/, SURFACE -> surfaces/,
+ * TOOL -> tools/.
+ *
+ * PRACTICE is gone: the practices/ folder was dropped because nothing in the
+ * findings reliably produced one, which left those findings with no home at all.
+ */
+export type FindingEntityKind = "SERVICE" | "SURFACE" | "TOOL";
+
+/**
+ * The value sets a finding is checked against.
+ *
+ * Supplied per-run rather than fixed here, because these are the taxonomy — the
+ * part worth experimenting with. Pinning them in a shipped package meant a new
+ * mode cost a package bump and a redeploy of both services, while the prompt
+ * beside it was a DB column editable from the UI. Now both live on the agent row.
+ *
+ * Only the vocabulary is configurable. Everything else validateFinding checks is
+ * structural — it is what makes findings joinable, and not a matter of opinion.
+ */
+export interface FindingVocabulary {
+  entityKinds: readonly string[];
+  modes: readonly string[];
+}
+
+export const DEFAULT_FINDING_VOCABULARY: FindingVocabulary = {
+  entityKinds: ["SERVICE", "SURFACE", "TOOL"],
+  modes: [
+    "DEFERRED_TO",
+    "RESOLVED",
+    "CORRECTED",
+    "ANSWERED",
+    "CLAIMED_OWNERSHIP",
+    "REVIEWED",
+    "ASKED",
+  ],
+};
+
+/**
+ * The project a finding belongs to.
+ *
+ * Supplied by the extraction pipeline via `findingScope`, closed over by
+ * emit-finding — the model never chooses it. A batch is dispatched for one
+ * channel of one project, so the project is known before the model sees a
+ * single message.
+ *
+ * All three identifiers travel together because they do different jobs — `code`
+ * paths the KB folder (stable, readable, and unmovable once written), `id`
+ * resolves back to the live record, `name` is what a human reads.
+ */
+export interface FindingProject {
+  id: string;
+  /** Short stable code, e.g. "XYNE". Unique per workspace; used as the KB path segment. */
+  code: string;
+  name: string;
+}
+
+export interface FindingSource {
+  type: "CHAT_THREAD" | "TICKET";
+  project: FindingProject;
+  /** Deep link to the thread or ticket. Every claim in the KB cites this. */
+  permalink: string;
+  /** When the conversation happened — NOT when it was extracted. Backfills would otherwise all look fresh. */
+  occurredAt: string;
+
+  // CHAT_THREAD
+  scopeType?: string;
+  scopeId?: string;
+  threadId?: string;
+  messageIds?: string[];
+
+  // TICKET
+  ticketKey?: string;
+  ticketState?: string;
+  boardId?: string;
+  /** The person's relationship to the ticket, e.g. ASSIGNEE / REVIEWER. */
+  role?: string;
+}
+
+export interface FindingPerson {
+  userId: string;
+  displayName: string;
+  email?: string;
+}
+
+export interface FindingEntity {
+  kind: FindingEntityKind;
+  /** Lowercase, hyphenated, singular — this becomes a KB folder name. */
+  name: string;
+}
+
+export interface FindingEvidence {
+  /** Verbatim quote. What makes a KB claim auditable rather than an assertion. */
+  quote: string;
+  /** Message id or ticket field the quote came from. */
+  ref?: string;
+}
+
+export interface Finding {
+  schemaVersion: number;
+  observationId: string;
+  /** When extraction ran. Distinct from `source.occurredAt`. */
+  emittedAt: string;
+  workspaceId: string;
+
+  producer: {
+    sessionId: string;
+    agentSlug: string;
+    model: string;
+  };
+
+  source: FindingSource;
+  entity: FindingEntity;
+
+  /**
+   * What was learned, standing on its own.
+   *
+   * Optional person: some of the most valuable facts have no clear owner
+   * ("job.discard() kills retries" is true regardless of who noticed). Forcing
+   * every fact through a person would drop those entirely.
+   */
+  claim?: string;
+  person?: FindingPerson;
+  /** What was observed, not what it means. Standing is reconcile's call. */
+  mode?: FindingMode;
+
+  evidence: FindingEvidence;
+  /** 0–1. The merge skips anything below 0.5 as too weak to record as expertise. */
+  confidence: number;
+
+  /**
+   * `<threadId|ticketKey>:<userId>:<entity>:<mode>` — stable across re-runs, so
+   * re-extracting a window produces the same keys. That is what makes a backfill
+   * or a retried window safe.
+   *
+   * A repeat is CONFIRMATION, not noise: the merge bumps the claim's `last` and
+   * `seen` markers rather than discarding it, which is how a fact is known to
+   * still be current.
+   */
+  idempotencyKey: string;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Validates one parsed JSONL line.
+ *
+ * `vocabulary` supplies the accepted kinds and modes; everything else checked
+ * here is structural and fixed. Returns the reason on failure rather than
+ * throwing: a malformed observation should be logged and skipped, never fail the
+ * batch around it.
+ */
+export function validateFinding(
+  value: unknown,
+  vocabulary: FindingVocabulary = DEFAULT_FINDING_VOCABULARY,
+): { ok: true; finding: Finding } | { ok: false; reason: string } {
+  const f = value as Partial<Finding> | null;
+  if (!f || typeof f !== "object") return { ok: false, reason: "not an object" };
+
+  if (f.schemaVersion !== FINDINGS_SCHEMA_VERSION) {
+    return { ok: false, reason: `unsupported schemaVersion ${String(f.schemaVersion)}` };
+  }
+  if (!isNonEmptyString(f.observationId)) return { ok: false, reason: "observationId missing" };
+  if (!isNonEmptyString(f.idempotencyKey)) return { ok: false, reason: "idempotencyKey missing" };
+
+  const source = f.source;
+  if (!source || typeof source !== "object") return { ok: false, reason: "source missing" };
+  if (!isNonEmptyString(source.permalink)) return { ok: false, reason: "source.permalink missing" };
+  if (!isNonEmptyString(source.occurredAt)) return { ok: false, reason: "source.occurredAt missing" };
+
+  // The KB path segment. An invented or empty code strands a whole night's
+  // findings in an orphan tree that cannot be moved afterwards.
+  if (!source.project || !isNonEmptyString(source.project.code)) {
+    return { ok: false, reason: "source.project.code missing" };
+  }
+  if (!isNonEmptyString(source.project.id)) return { ok: false, reason: "source.project.id missing" };
+
+  const entity = f.entity;
+  if (!entity || !isNonEmptyString(entity.name)) return { ok: false, reason: "entity.name missing" };
+  if (!vocabulary.entityKinds.includes(entity.kind as string)) {
+    return {
+      ok: false,
+      reason: `unknown entity.kind ${String(entity.kind)} — expected one of ${vocabulary.entityKinds.join(", ")}`,
+    };
+  }
+  if (entity.name !== entity.name.toLowerCase()) {
+    return { ok: false, reason: `entity.name must be lowercase: ${entity.name}` };
+  }
+
+  if (!f.evidence || !isNonEmptyString(f.evidence.quote)) {
+    return { ok: false, reason: "evidence.quote missing" };
+  }
+  if (typeof f.confidence !== "number" || f.confidence < 0 || f.confidence > 1) {
+    return { ok: false, reason: `confidence out of range: ${String(f.confidence)}` };
+  }
+
+  // A person without an id cannot be resolved back to a user record, and
+  // display names collide — so half a person is worse than none.
+  if (f.person && !isNonEmptyString(f.person.userId)) {
+    return { ok: false, reason: "person.userId missing" };
+  }
+  if (f.mode !== undefined && !vocabulary.modes.includes(f.mode)) {
+    return {
+      ok: false,
+      reason: `unknown mode ${String(f.mode)} — expected one of ${vocabulary.modes.join(", ")}`,
+    };
+  }
+  // A finding needs to say something: either a fact, or who relates to what.
+  if (!isNonEmptyString(f.claim) && !f.person) {
+    return { ok: false, reason: "needs either a claim or a person" };
+  }
+
+  return { ok: true, finding: f as Finding };
+}
+
+/** Builds the dedupe key. One definition, so writer and reader cannot disagree. */
+export function buildIdempotencyKey(parts: {
+  sourceKey: string;
+  userId?: string;
+  entityName: string;
+  mode?: FindingMode;
+}): string {
+  return [parts.sourceKey, parts.userId ?? "-", parts.entityName, parts.mode ?? "-"].join(":");
+}
+
+/** Parses a JSONL body, returning valid findings and the reason each reject failed. */
+export function parseFindingsJsonl(
+  body: string,
+  vocabulary: FindingVocabulary = DEFAULT_FINDING_VOCABULARY,
+): {
+  findings: Finding[];
+  rejected: Array<{ line: number; reason: string }>;
+} {
+  const findings: Finding[] = [];
+  const rejected: Array<{ line: number; reason: string }> = [];
+
+  body.split("\n").forEach((line, index) => {
+    if (!line.trim()) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      rejected.push({ line: index + 1, reason: "invalid JSON" });
+      return;
+    }
+    const result = validateFinding(parsed, vocabulary);
+    if (result.ok) findings.push(result.finding);
+    else rejected.push({ line: index + 1, reason: result.reason });
+  });
+
+  return { findings, rejected };
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
