### PR TITLE
feat: add from parameter to spacesEmails tool for email sorting

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -5005,6 +5005,7 @@ const spacesEmails: ToolDef = {
   description:
     "Get the full email thread for an Xyne Desk ticket. Returns all emails (inbound and outbound) " +
     "associated with a desk ticket's conversation — subject, from, to, cc, bcc, body, and timestamps. " +
+    "Use from=first for the oldest emails or from=last for the latest emails; results are rendered chronologically. " +
     "Use the conversationId from spaces-tickets results. Desk tickets have their email history here; " +
     "regular chat messages live in spaces-messages instead.",
   inputSchema: {
@@ -5021,6 +5022,12 @@ const spacesEmails: ToolDef = {
         default: 100,
         description: "Max emails to return (default 100)",
       },
+      from: {
+        type: "string",
+        enum: ["first", "last"],
+        default: "first",
+        description: "Fetch from the first/oldest or last/latest email (default first).",
+      },
       offset: {
         type: "number",
         minimum: 0,
@@ -5035,20 +5042,22 @@ const spacesEmails: ToolDef = {
     try {
       const conversationId = String(args["conversationId"]);
       const take = (args["limit"] as number | undefined) ?? 100;
+      const from = (args["from"] as "first" | "last" | undefined) ?? "first";
       const skip = (args["offset"] as number | undefined) ?? 0;
 
       const rows = (await interact({
         model: "email",
         operation: "findMany",
         where: { conversationId: { equals: conversationId } },
-        orderBy: [{ createdAt: "asc" }],
+        orderBy: [{ createdAt: from === "last" ? "desc" : "asc" }],
         take,
         skip,
       })) as EmailRow[];
 
       if (!rows || rows.length === 0) return ok(`No emails found for conversation ${conversationId}.`);
+      const chronologicalRows = from === "last" ? [...rows].reverse() : rows;
 
-      const lines = rows.map((e, idx) => {
+      const lines = chronologicalRows.map((e, idx) => {
         const parts = [`[${idx + 1}] ${e.type === "DEFAULT" ? "\u{1F4E5} Inbound" : "\u{1F4E4} Outbound"}`];
         parts.push(`  Subject: ${e.subject}`);
         parts.push(`  From: ${e.from}`);
@@ -5078,7 +5087,7 @@ const spacesEmails: ToolDef = {
       const citations: Citation[] = [];
       const channelId = rows.find((r) => r.channelId)?.channelId;
       const ticketXyneId = await resolveTicketByConversation(conversationId);
-      rows.forEach((e, idx) => {
+      chronologicalRows.forEach((e, idx) => {
         pushThreadCitation(citations, channelId, conversationId, idx + 1, "Desk email thread", {
           ...(ticketXyneId ? { xyneId: ticketXyneId } : {}),
           ...(e.id ? { mailId: e.id } : {}),

--- a/apps/xyne-claw/skills/spaces-tools-guide.md
+++ b/apps/xyne-claw/skills/spaces-tools-guide.md
@@ -533,8 +533,9 @@ Full email thread for an Xyne Desk ticket — subject, from, to, cc, bcc, body, 
 
 - **conversationId** (string, required) — From `spaces-tickets` results (desk ticket's conversationId).
 - **limit** (number, 1–100, default 20).
+- **from** (`first | last`, default `first`) — Start from the oldest or latest email.
 
-**Notes:** Sorted chronologically. Bodies are HTML — stripped to 500 chars in display. For full body or attachments, use `spaces-thread-attachments`.
+**Notes:** Sorted chronologically. With `from=last`, the latest `limit` emails are selected and then displayed oldest-to-newest. Bodies are HTML — stripped to 500 chars in display. For full body or attachments, use `spaces-thread-attachments`.
 
 ---
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
