### PR TITLE
fix: XYNE-56134 decision and action items fix

### DIFF
--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -21,6 +21,7 @@ const NOTE_TAKER_LABEL_CATEGORY = 'topic';
 interface DetailedSummaryCanvasResult {
   canvasId: string;
   summaryTemplateId: string;
+  markedItems: MarkedItem[];
 }
 
 /**
@@ -46,6 +47,112 @@ function markedItemTimestamp(item: MarkedItem): number {
   return typeof item.timestampSeconds === 'number' ? item.timestampSeconds : 0;
 }
 
+/** Parse a "MM:SS" or "HH:MM:SS" citation timestamp (from CitationSegment.timestamp) to seconds. */
+function timestampStringToSeconds(value: string): number {
+  const match = value.trim().match(/^(?:(\d+):)?(\d{1,2}):(\d{2})$/);
+  if (!match) return 0;
+  const hours = match[1] ? parseInt(match[1], 10) : 0;
+  const minutes = parseInt(match[2], 10);
+  const seconds = parseInt(match[3], 10);
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
+const MAX_DERIVED_MARKED_ITEMS = 15;
+
+/**
+ * Derive decisions/action items directly from the already-generated detailed
+ * summary markdown instead of running a second, separate LLM pass over the raw
+ * transcript. The summary's "Action Items" and "Decisions Made" sections (or
+ * any custom-template section whose heading mentions "action item"/"decision")
+ * are scanned for table rows/bullets, each anchored to the transcript
+ * timestamp of its first `[clf-N]` citation \u2014 the SAME citation segments used
+ * to render citation chips in the canvas \u2014 so the two features can never
+ * disagree and no extra LLM call is needed.
+ *
+ * Rows/bullets with no `[clf-N]` citation are skipped: a marked item that
+ * can't be anchored to a transcript moment isn't useful here.
+ */
+function deriveMarkedItemsFromSummary(markdown: string, citationCtx: CitationContext): MarkedItem[] {
+  const items: MarkedItem[] = [];
+  let currentType: 'action' | 'decision' | null = null;
+  let tableRowIndex = 0;
+
+  const classifyLabel = (label: string): 'action' | 'decision' | null => {
+    if (/action item/i.test(label)) return 'action';
+    if (/decision/i.test(label)) return 'decision';
+    return null;
+  };
+
+  const resolveTimestampSeconds = (text: string): number | null => {
+    const match = text.match(/\[clf-(\d+)\]/);
+    if (!match) return null;
+    const segment = citationCtx.segments.get(parseInt(match[1], 10));
+    if (!segment) return null;
+    return timestampStringToSeconds(segment.timestamp);
+  };
+
+  const cleanText = (text: string): string =>
+    text
+      .replace(/\[clf-\d+\]/g, '')
+      .replace(/\*\*/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const headingMatch = line.match(/^#{1,6}\s*(.+)$/);
+    const boldLabelMatch = !headingMatch ? line.match(/^\*\*([^*]+)\*\*/) : null;
+    const labelText = headingMatch?.[1] ?? boldLabelMatch?.[1] ?? null;
+    if (labelText !== null) {
+      currentType = classifyLabel(labelText);
+      tableRowIndex = 0;
+      continue;
+    }
+
+    if (!currentType) continue;
+
+    if (line.startsWith('|')) {
+      const isSeparatorRow = /^\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|?$/.test(line);
+      if (isSeparatorRow) {
+        tableRowIndex += 1;
+        continue;
+      }
+      const isDataRow = tableRowIndex > 0;
+      tableRowIndex += 1;
+      if (!isDataRow) continue; // header row
+
+      const cells = line.split('|').map(c => c.trim()).filter(c => c.length > 0);
+      const contentCell = /^\d+$/.test(cells[0] ?? '') ? cells[1] : cells[0];
+      if (!contentCell) continue;
+
+      const timestampSeconds = resolveTimestampSeconds(contentCell);
+      if (timestampSeconds === null) continue;
+
+      const text = cleanText(contentCell);
+      if (!text) continue;
+
+      items.push({ type: currentType, text, timestampSeconds });
+      continue;
+    }
+
+    const bulletMatch = line.match(/^[-*]\s+(?:\[[ xX]\]\s+)?(.+)$/);
+    if (bulletMatch) {
+      const content = bulletMatch[1];
+      const timestampSeconds = resolveTimestampSeconds(content);
+      if (timestampSeconds === null) continue;
+
+      const text = cleanText(content);
+      if (!text) continue;
+
+      items.push({ type: currentType, text, timestampSeconds });
+    }
+  }
+
+  return items.slice(0, MAX_DERIVED_MARKED_ITEMS);
+}
+
 /**
  * NOTE_TAKER (HEADLESS / "Xyne Oats") call transcript pipeline.
  *
@@ -65,8 +172,10 @@ function markedItemTimestamp(item: MarkedItem): number {
  *     the canvas is created/updated but never posted anywhere,
  *   - generates topical labels and stores them as generic Tag rows, with the
  *     resulting tag ids saved on Call.labels,
- *   - generates key decisions/action items (each anchored to a transcript
- *     timestamp) and stores them directly on Call.markedItems,
+ *   - derives key decisions/action items (each anchored to a transcript
+ *     timestamp) from the detailed summary's own "Action Items"/"Decisions
+ *     Made" sections — no separate LLM call — and stores them directly on
+ *     Call.markedItems,
  *   - queues Vespa search indexing for the transcript.
  *
  * Dedup: the agent's transcript-ready webhook fires twice per call (initial +
@@ -145,11 +254,13 @@ class NoteTakerTranscriptService {
       // These workloads are independent once the transcript is available, so
       // start them together. generateDetailedSummaryCanvas preserves its own
       // ordered dependency chain: template selection -> prompt generation when
-      // needed -> detailed-summary streaming.
+      // needed -> detailed-summary streaming. Decisions/action items are no
+      // longer a separate LLM call: they're derived from that same detailed
+      // summary's markdown (see deriveMarkedItemsFromSummary), so they can
+      // never disagree with what the canvas shows.
       const summaryPromise = this.generateAndSaveSummary(call, formattedTranscript);
       const detailedSummaryPromise = this.generateDetailedSummaryCanvas(call, formattedTranscript);
       const labelsPromise = this.generateAndSaveLabels(call, formattedTranscript);
-      const markedItemsPromise = this.generateMarkedItemsList(call, formattedTranscript);
 
       const saveLabelsPromise = labelsPromise.then(async (labelIds) => {
         if (labelIds.length === 0) return labelIds;
@@ -161,18 +272,11 @@ class NoteTakerTranscriptService {
         }
         return labelIds;
       });
-      const saveMarkedItemsPromise = markedItemsPromise.then(async (markedItems) => {
-        if (markedItems.length > 0) {
-          await this.finalizeCallUpdates(call, { markedItems });
-        }
-        return markedItems;
-      });
 
       const [, detailedSummary] = await Promise.all([
         summaryPromise,
         detailedSummaryPromise,
         saveLabelsPromise,
-        saveMarkedItemsPromise,
       ]);
       await this.finalizeCallUpdates(call, {
         metadata: {
@@ -180,6 +284,7 @@ class NoteTakerTranscriptService {
           detailedSummaryCanvasId: detailedSummary?.canvasId,
         },
         summaryTemplateId: detailedSummary?.summaryTemplateId,
+        markedItems: detailedSummary?.markedItems,
       });
       await this.queueVespaIndexing(call);
     } finally {
@@ -208,16 +313,12 @@ class NoteTakerTranscriptService {
     );
     if (!detailedSummary) return null;
 
-    const currentMetadata =
-      call.metadata && typeof call.metadata === 'object' && !Array.isArray(call.metadata)
-        ? (call.metadata as Record<string, unknown>)
-        : {};
-    await repositories.calls.update(call.id, {
+    await this.finalizeCallUpdates(call, {
       metadata: {
-        ...currentMetadata,
         detailedSummaryCanvasId: detailedSummary.canvasId,
       },
       summaryTemplateId: detailedSummary.summaryTemplateId,
+      markedItems: detailedSummary.markedItems,
     });
 
     return {
@@ -528,7 +629,11 @@ class NoteTakerTranscriptService {
           return null;
         }
 
-        return { canvasId, summaryTemplateId: generated.template.id };
+        return {
+          canvasId,
+          summaryTemplateId: generated.template.id,
+          markedItems: deriveMarkedItemsFromSummary(generated.summary, citationCtx),
+        };
       }
 
       const SYNC_INTERVAL_MS = 300;
@@ -703,7 +808,11 @@ class NoteTakerTranscriptService {
         return null;
       }
 
-      return { canvasId: newCanvasId, summaryTemplateId: generated.template.id };
+      return {
+        canvasId: newCanvasId,
+        summaryTemplateId: generated.template.id,
+        markedItems: deriveMarkedItemsFromSummary(generated.summary, citationCtx),
+      };
     } catch (error) {
       logger.error(`[${callId}] detailed_summary_failed`, {
         stage: 'detailed_summary_generation',
@@ -793,22 +902,6 @@ class NoteTakerTranscriptService {
       }
       throw error;
     }
-  }
-
-  /**
-   * Generate key decisions/action items, each anchored to a transcript
-   * timestamp. Returns [] on any failure or when nothing qualifies.
-   */
-  private async generateMarkedItemsList(call: Call, formattedTranscript: string): Promise<MarkedItem[]> {
-    const callId = call.externalId;
-    return transcriptService.generateMarkedItems(formattedTranscript, callId).catch((err) => {
-      logger.error(`[${callId}] generate_marked_items_threw`, {
-        path: 'note_taker',
-        error: err,
-        stack: err instanceof Error ? err.stack : undefined,
-      });
-      return [] as MarkedItem[];
-    });
   }
 
   // Indexing only — not a message post. Uses the Call's own denormalized

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -242,38 +242,6 @@ TRANSCRIPT:
 {transcript}
 `;
 
-// Decisions/actions extraction. Transcript lines are prefixed with a "[MM:SS]"
-// (or "[HH:MM:SS]") timestamp relative to call start — the LLM is asked to
-// report that same timestamp back per item so it can be stored alongside the
-// text, instead of us trying to re-locate the sentence in the transcript.
-const MARKED_ITEMS_PROMPT = `
-You are analyzing a call transcript (each line is prefixed with a "[MM:SS]" or "[HH:MM:SS]" timestamp relative to the start of the call) to extract key decisions made and action items assigned.
-
-CRITICAL RULES:
-- Output ONLY valid JSON
-- Extract 0-15 items total across decisions and actions \u2014 only clear, concrete ones
-- For each item, use the exact "[MM:SS]" (or "[HH:MM:SS]") timestamp of the transcript line it is most closely associated with
-- "type" must be exactly "decision" or "action"
-- Keep "text" concise (one sentence)
-- If nothing clear qualifies, return an empty array for "items"
-
-BRAND NAME CORRECTION:
-- The word "Xyne" (product name, pronounced "zine") is often misspelled by speech-to-text as "Zain", "Zine", "Xine", "Zyane", or "Zyne"
-
-JSON STRUCTURE (FOLLOW EXACTLY):
-{
-  "items": [
-    { "type": "decision" | "action", "text": "[concise description]", "timestamp": "MM:SS" }
-  ]
-}
-
-Only output valid JSON.
-No explanations.
-
-TRANSCRIPT:
-{transcript}
-`;
-
 export interface TicketSuggestion {
   id: string;
   title: string;
@@ -1297,76 +1265,6 @@ Output ONLY the processed transcript, nothing else.`;
       return labels;
     } catch (error) {
       logger.error(`call_labels_generation_failed | error=${error instanceof Error ? error.message : JSON.stringify(error)}`, error);
-      return [];
-    }
-  }
-
-  /** Parse a "MM:SS" or "HH:MM:SS" string (as emitted by formatTimestamp) back to seconds. */
-  private parseTimestampToSeconds(value: unknown): number {
-    if (typeof value !== 'string') return 0;
-    const match = value.trim().match(/^(?:(\d+):)?(\d{1,2}):(\d{2})$/);
-    if (!match) return 0;
-    const hours = match[1] ? parseInt(match[1], 10) : 0;
-    const minutes = parseInt(match[2], 10);
-    const seconds = parseInt(match[3], 10);
-    return hours * 3600 + minutes * 60 + seconds;
-  }
-
-  /**
-   * Generate key decisions/action items from the transcript, each anchored to
-   * the timestamp (in seconds from call start) of the transcript line it came
-   * from. Returns [] on any failure or when nothing qualifies.
-   */
-  async generateMarkedItems(transcript: string, callId?: string): Promise<MarkedItem[]> {
-    const logCallId = callId || 'unknown';
-    const agent = await this.createAgent(logCallId);
-    if (!agent) {
-      logger.warn('Agent creation failed. Skipping marked items generation.');
-      return [];
-    }
-
-    const prompt = MARKED_ITEMS_PROMPT.replace('{transcript}', transcript);
-
-    try {
-      const result = await agent.execute({
-        messages: [createUserMessage(prompt)],
-      });
-
-      const extracted = extractAgentContent(result);
-      if (!extracted.ok) {
-        logger.error(`marked_items_generation_failed | reason=${extracted.reason} | status=${extracted.status ?? result.status}`);
-        return [];
-      }
-
-      let jsonContent = extracted.content;
-      const codeBlockMatch = jsonContent.match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/);
-      if (codeBlockMatch) {
-        jsonContent = codeBlockMatch[1].trim();
-      }
-
-      const parsed = JSON.parse(jsonContent);
-      if (!Array.isArray(parsed.items)) {
-        logger.error(`marked_items_generation_failed | error=invalid_format, parsed=${JSON.stringify(parsed)}`);
-        return [];
-      }
-
-      const items: MarkedItem[] = parsed.items
-        .slice(0, 15)
-        .map((item: any) => {
-          const text = typeof item?.text === 'string' ? item.text.trim() : '';
-          if (!text) return null;
-          return {
-            type: item?.type === 'action' ? 'action' : 'decision',
-            text,
-            timestampSeconds: this.parseTimestampToSeconds(item?.timestamp),
-          } satisfies MarkedItem;
-        })
-        .filter((item: MarkedItem | null): item is MarkedItem => item !== null);
-
-      logger.info(`Generated ${items.length} marked items`);
-      return items;
-    } catch (error) {
-      logger.error(`marked_items_generation_failed | error=${error instanceof Error ? error.message : JSON.stringify(error)}`, error);
       return [];
     }
   }


### PR DESCRIPTION

<img width="3106" height="1918" alt="image" src="https://github.com/user-attachments/assets/2e4cfa4a-33a5-4071-81df-4174567b8416" />


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
