### PR TITLE
fix: allow global skill owner to approve their own skill updates

### DIFF
--- a/packages/xyne-claw-shared/src/skill-diff/index.ts
+++ b/packages/xyne-claw-shared/src/skill-diff/index.ts
@@ -256,9 +256,9 @@ export interface ApproverResolution {
  * are required.
  *
  *   personal skill → the owner approves (DM goes to the owner).
- *   global skill   → an admin must approve. We route the DM to the recorded
- *                    owner/promoter as the notify target, but the resolve step
- *                    still enforces `callerIsAdmin`.
+ *   global skill   → the recorded owner/promoter OR any admin may approve. The
+ *                    DM is routed to the owner/promoter as the notify target,
+ *                    and the resolve step accepts that owner or a CLAW_ADMIN.
  */
 export function resolveSkillUpdateApprover(skill: SkillForAuthz): ApproverResolution {
   if (skill.scope === "global") {
@@ -294,8 +294,12 @@ export function authorizeSkillUpdateApproval(params: {
   baseContentHash: string;
 }): SkillApprovalAuthz {
   if (params.requiresAdmin) {
-    if (!params.callerIsAdmin) {
-      return { ok: false, code: 403, reason: "global skill changes can only be approved by an admin" };
+    // Global skills are org-wide, so an admin may always approve. We also allow
+    // the skill's own owner/promoter (the resolved approverUserId) to approve
+    // their own change — otherwise the update DM is routed to the owner but the
+    // owner can never act on it, deadlocking the proposal.
+    if (!params.callerIsAdmin && params.callerUserId !== params.approverUserId) {
+      return { ok: false, code: 403, reason: "global skill changes can only be approved by the skill owner or an admin" };
     }
   } else if (params.callerUserId !== params.approverUserId && !params.callerIsAdmin) {
     return { ok: false, code: 403, reason: "only the skill owner (or an admin) can approve this change" };

--- a/packages/xyne-claw-shared/src/skill-diff/skill-diff.test.ts
+++ b/packages/xyne-claw-shared/src/skill-diff/skill-diff.test.ts
@@ -138,8 +138,12 @@ describe("authorizeSkillUpdateApproval", () => {
   it("allows an admin to approve a personal skill", () => {
     expect(authorizeSkillUpdateApproval({ ...base, approverUserId: "u1", requiresAdmin: false, callerUserId: "admin", callerIsAdmin: true }).ok).toBe(true);
   });
-  it("rejects a non-admin on a global (admin-gated) skill even if they are the notify target", () => {
+  it("allows the owner/promoter to approve their own global skill (non-admin)", () => {
     const r = authorizeSkillUpdateApproval({ ...base, approverUserId: "u1", requiresAdmin: true, callerUserId: "u1", callerIsAdmin: false });
+    expect(r).toEqual({ ok: true });
+  });
+  it("rejects a non-owner non-admin on a global (admin-gated) skill (403)", () => {
+    const r = authorizeSkillUpdateApproval({ ...base, approverUserId: "u1", requiresAdmin: true, callerUserId: "attacker", callerIsAdmin: false });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe(403);
   });


### PR DESCRIPTION
## 1. Problem Description
When an agent proposes an update to a **global** skill, the approval DM is routed to the skill's recorded owner/promoter as the notify target. But `authorizeSkillUpdateApproval` required `callerIsAdmin` for global skills, so the owner received an "Approve" button that always returned 403 ("global skill changes can only be approved by an admin"). The interactive card was then consumed/replaced with the warning, and the proposal deadlocked — the owner could never apply the update. Reported by Rohan Gupta: agent skill-update requests appeared lost after he approved them.

## 2. How the issue was identified
Traced the skill-update approval flow on `feature/deploy-xyneclaw`: `resolveSkillUpdateApprover` sets the notify target to `ownerUserId ?? promotedBy` for global skills, while `authorizeSkillUpdateApproval` (in `packages/xyne-claw-shared/src/skill-diff/index.ts`) ignored `approverUserId` and only allowed admins — so the notify target and the authorized approver diverged.

## 3. Solution implemented
Widened the `requiresAdmin` branch of `authorizeSkillUpdateApproval` to also accept the resolved `approverUserId` (the owner/promoter), in addition to any CLAW_ADMIN. Admin behavior is unchanged; personal-skill behavior is unchanged. Updated the doc comment on `resolveSkillUpdateApprover` and the unit tests (owner-approves-global now allowed; a non-owner non-admin is still 403). The flow-action card's first gate already requires `callerUserId === approverUserId`, so no card-side change was needed.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A

## 8. Testing
`npx vitest run src/skill-diff/skill-diff.test.ts` in `packages/xyne-claw-shared` — 23 passed, including the new owner-approves-global-skill case.

## 9. Services to which this change is to be deployed
xyne-claw-auth (skill approval path), xyne-claw-shared package.

## 10. Main PR link (if against a release branch)
N/A — targets the feature/deploy-xyneclaw integration line.