### PR TITLE
feat: add coverage-gated /understanding run mode to experiment loop

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260814120000_experiment_kind/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260814120000_experiment_kind/migration.sql
@@ -1,0 +1,3 @@
+-- Add kind column to experiment_runs so /understanding runs stay tagged across every epoch dispatch.
+-- Default "experiment" preserves existing rows and the classic proof-reward loop.
+ALTER TABLE "experiment_runs" ADD COLUMN "kind" TEXT NOT NULL DEFAULT 'experiment';

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1814,6 +1814,10 @@ model ExperimentRun {
   /// dispatch. NULL = the agent's normal provider resolution.
   provider          String?
   modelId           String?
+  /// "experiment" (default proof-reward loop) or "understanding" (coverage-gated:
+  /// end-experiment stays locked until the open-conjecture frontier is exhausted).
+  /// Persisted per-run so EVERY epoch dispatch forwards it, not just the first.
+  kind              String              @default("experiment")
   status            String              @default("running") /// running | finishing | done | aborted
   epoch             Int                 @default(1)
   deadlineAt        DateTime

--- a/apps/xyne-claw-auth/backend/src/lib/experiment.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/experiment.ts
@@ -12,7 +12,7 @@ const MAX_DURATION_MS = 8 * 60 * 60 * 1000;
 const DEFAULT_DURATION_MS = 60 * 60 * 1000;
 
 export type ExperimentCommand =
-  | { sub: "start"; durationMs: number; focus?: string; provider?: string; model?: string; invalidProvider?: string }
+  | { sub: "start"; durationMs: number; focus?: string; provider?: string; model?: string; invalidProvider?: string; kind?: "understanding" }
   | { sub: "status" }
   | { sub: "stop" }
   | { sub: "findings"; id?: string }
@@ -29,9 +29,20 @@ const LEADING_MENTIONS = /^(?:@[\w.\-]+(?:\s+[\w.\-]+)*\s*)+/;
 export function parseExperimentCommand(text: string | undefined | null): ExperimentCommand | null {
   if (!text) return null;
   const trimmed = text.trim().replace(LEADING_MENTIONS, "");
-  if (!trimmed.toLowerCase().startsWith("/experiment")) return null;
-  const rest = trimmed.slice("/experiment".length).trim();
-  if (!rest) return { sub: "start", durationMs: DEFAULT_DURATION_MS };
+  const lower = trimmed.toLowerCase();
+  // /understanding is /experiment's coverage-gated sibling: identical epoch loop
+  // and subcommands, but the run is tagged so end-experiment stays locked until
+  // the open-conjecture frontier is exhausted (the epoch runtime keys off the
+  // dispatch payload's `kind`). Everything below is shared parsing.
+  const commandWord = lower.startsWith("/understanding")
+    ? "/understanding"
+    : lower.startsWith("/experiment")
+      ? "/experiment"
+      : null;
+  if (!commandWord) return null;
+  const kind = commandWord === "/understanding" ? ("understanding" as const) : undefined;
+  const rest = trimmed.slice(commandWord.length).trim();
+  if (!rest) return { sub: "start", durationMs: DEFAULT_DURATION_MS, ...(kind ? { kind } : {}) };
   const [first, ...tail] = rest.split(/\s+/);
   const firstLower = first?.toLowerCase() ?? "";
   if (firstLower === "status") return { sub: "status" };
@@ -64,6 +75,7 @@ export function parseExperimentCommand(text: string | undefined | null): Experim
     ...(resolvedProvider ? { provider: resolvedProvider } : {}),
     ...(model ? { model } : {}),
     ...(invalidProvider !== undefined ? { invalidProvider } : {}),
+    ...(kind ? { kind } : {}),
   };
 }
 
@@ -344,6 +356,9 @@ async function dispatchExperimentRun(
       deadlineAt: run.deadlineAt.toISOString(),
       ...(run.focus ? { focus: run.focus } : {}),
       ...(opts.mode ? { mode: opts.mode } : {}),
+      // Understanding runs advertise their coverage-gated intent to the epoch
+      // runtime, which keeps end-experiment locked until the frontier empties.
+      ...(run.kind === "understanding" ? { kind: "understanding" as const } : {}),
     },
   };
 

--- a/apps/xyne-claw-auth/backend/src/repositories/experimentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/experimentRepository.ts
@@ -47,6 +47,7 @@ export const experimentRepository = {
     focus?: string | null;
     provider?: string | null;
     modelId?: string | null;
+    kind?: string | null;
     deadlineAt: Date;
   }) {
     return prisma.experimentRun.create({
@@ -59,6 +60,7 @@ export const experimentRepository = {
         focus: args.focus ?? null,
         provider: args.provider ?? null,
         modelId: args.modelId ?? null,
+        ...(args.kind ? { kind: args.kind } : {}),
         deadlineAt: args.deadlineAt,
       },
     });

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -1554,6 +1554,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
     if (experimentCommand.sub === "unknown") {
       await postExperimentReply([
         "/experiment <duration> [provider=…] [model=…] [focus…]",
+        "/understanding [duration cap] [focus…] — coverage-gated: runs until the code-path frontier is exhausted",
         "/experiment status",
         "/experiment list",
         "/experiment findings [id]",
@@ -1743,12 +1744,16 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       focus: experimentCommand.focus ?? null,
       provider: experimentCommand.provider ?? null,
       modelId: experimentCommand.model ?? null,
+      kind: experimentCommand.kind ?? null,
       deadlineAt: new Date(Date.now() + experimentCommand.durationMs),
     });
+    const isUnderstanding = experimentCommand.kind === "understanding";
     await postExperimentReply([
-      "**/experiment started**",
-      `Mode: time-boxed autonomous exploration`,
-      `Duration: ${formatDuration(experimentCommand.durationMs)}`,
+      isUnderstanding ? "**/understanding started**" : "**/experiment started**",
+      isUnderstanding
+        ? `Mode: coverage-gated understanding loop (ends when the code-path frontier is exhausted)`
+        : `Mode: time-boxed autonomous exploration`,
+      `${isUnderstanding ? "Safety cap" : "Duration"}: ${formatDuration(experimentCommand.durationMs)}`,
       ...(experimentCommand.provider ? [`Model: ${formatExperimentModel(experimentCommand.provider, experimentCommand.model)}`] : []),
       `Focus: ${experimentCommand.focus?.trim() || "(none)"}`,
       `Use \`/experiment status\` to inspect progress.`,

--- a/apps/xyne-claw/src/experiment.ts
+++ b/apps/xyne-claw/src/experiment.ts
@@ -12,6 +12,12 @@ export interface ExperimentContext {
    *  NOT end-experiment or the ledger write path — a checker must not be able
    *  to end the experiment or edit the work it is judging. */
   mode?: "review";
+  /** "understanding" = a coverage-gated run: the exit condition is an EXHAUSTED
+   *  code-path frontier (zero open conjectures) rather than an elapsed deadline.
+   *  Each unexplored path is recorded as an open conjecture; closing every one of
+   *  them (proved/refuted, with evidence) is the exit. The deadline still applies
+   *  as a hard safety cap so the loop stays bounded. */
+  kind?: "understanding";
 }
 
 type FindingStatus = "conjecture" | "proved" | "refuted";
@@ -356,7 +362,7 @@ export function buildExperimentTools(
     {
       name: "end-experiment",
       label: "End Experiment",
-      description: "Complete the experiment after the deadline. This is the ONLY exit. Before ending, ensure every proved finding's artifact has been delivered to the thread.",
+      description: "Complete the run. For a time-boxed experiment this unlocks only AFTER the deadline; for an understanding run it unlocks only once the code-path frontier is exhausted (zero open conjectures, at least one path closed). Before ending, ensure every finding's artifact has been delivered to the thread.",
       parameters: Type.Object({
         report: Type.String(),
       }, { additionalProperties: false }),
@@ -364,7 +370,31 @@ export function buildExperimentTools(
         const p = asRecord(params);
         const report = typeof p["report"] === "string" ? p["report"] : "";
         const deadline = deadlineMs(ctx);
-        if (Date.now() < deadline) {
+        const pastDeadline = Date.now() >= deadline;
+        if (ctx.kind === "understanding") {
+          // Coverage-gated exit: the run ends when the enumerated code-path
+          // frontier is EXHAUSTED (open conjectures -> 0), not when the clock
+          // runs out. The deadline is only a hard safety cap so the loop stays
+          // bounded even if the frontier never fully closes.
+          let open: number | undefined;
+          let closed = 0;
+          try {
+            const ledger = await readLedger(ctx);
+            open = ledger.counts.conjecture;
+            closed = ledger.counts.proved + ledger.counts.refuted;
+          } catch {
+            // Ledger unreachable: we cannot prove exhaustion, so only the
+            // deadline cap below can release the run.
+          }
+          const frontierExhausted = open === 0 && closed > 0;
+          if (!pastDeadline && !frontierExhausted) {
+            const openStr = open === undefined ? "unknown" : String(open);
+            return textResult(
+              `❌ Cannot end: the code-path frontier is not exhausted (epoch ${ctx.epoch}). Open paths: ${openStr}, closed: ${closed}. Enumerate every reachable path in scope as an open conjecture, then close each one (proved/refuted) with file:line evidence. Every new callee or branch you find is itself a new open path. Exit unlocks only when open reaches 0. Your report was NOT accepted.`,
+              { refused: true, open, closed },
+            );
+          }
+        } else if (!pastDeadline) {
           let open = "unknown";
           try {
             const ledger = await readLedger(ctx);

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -213,6 +213,7 @@ function normalizeExperimentContext(raw: unknown): ExperimentContext | undefined
     deadlineAt,
     ...(focus ? { focus } : {}),
     ...(obj["mode"] === "review" ? { mode: "review" as const } : {}),
+    ...(obj["kind"] === "understanding" ? { kind: "understanding" as const } : {}),
   };
 }
 
@@ -564,6 +565,9 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
       epoch?: number;
       deadlineAt?: string;
       focus?: string;
+      /** "understanding" = coverage-gated variant: exit on an exhausted
+       *  code-path frontier instead of the deadline. Set by claw-auth. */
+      kind?: "understanding";
     };
     /** True when this run is Turn 2 (auto) dispatched right after a plan was
      *  approved (or a trivial plan auto-continued). Used only to emit a
@@ -2711,6 +2715,8 @@ async function processTask(
       log(
         experiment.mode === "review"
           ? `Experiment CHECKER mode — injected review tools (verifying epoch ${experiment.epoch})`
+          : experiment.kind === "understanding"
+          ? `Understanding mode — injected experiment tools (epoch ${experiment.epoch}, coverage-gated exit)`
           : `Experiment mode — injected experiment tools (epoch ${experiment.epoch}, remaining ${experimentRemaining(experiment.deadlineAt)})`,
       );
     }
@@ -3460,6 +3466,8 @@ async function processTask(
     // fabricating results from a tool it never received.
     const experimentGuide = experiment?.mode === "review"
       ? `\n\n## Experiment checker\nYou are the CHECKER for a running experiment, not a participant. Do NOT hunt for new findings, do not start a hypothesis, and do not try to end the experiment — you have neither tool. Verify each finding you were given against the current code and the delivered proof, then call experiment-review once per finding. Your verdict is advisory; it never changes a finding's status. When unsure, say contradicts or unverifiable — a false confirm becomes a ticket a human has to disprove. Finish with ONE short line of verdict counts.`
+      : experiment?.kind === "understanding"
+      ? `\n\n## Understanding mode\nYou are in a coverage-gated understanding run (epoch ${experiment.epoch}; focus ${experiment.focus ?? "unspecified"}). Your job is to UNDERSTAND every reachable code path in scope, not to accumulate trivially-provable facts. The exit is exhaustion, not the clock: end-experiment unlocks only when the open-conjecture frontier reaches 0 (with at least one path closed). Loop: read the ledger -> if the frontier is empty, enumerate every entrypoint and branch in scope as an open conjecture (experiment-ledger action=record status=conjecture, one per path) -> pick ONE open path, trace it to real behavior, and ADD every new callee or branch you discover as a new open conjecture BEFORE you close the current one (proved/refuted) with file:line evidence and a description of what the code actually does and why. The frontier grows as you explore and shrinks only when a path is genuinely explained — never close a path with a shallow structural restatement. When open reaches 0 the scope is exhausted: deliver the artifacts and end.`
       : experiment
       ? `\n\n## Experiment mode\nYou are in a time-boxed experiment (epoch ${experiment.epoch}; deadline ${experiment.deadlineAt}; focus ${experiment.focus ?? "unspecified"}). You cannot finish early — end-experiment refuses before the deadline. Loop: read the ledger → declare a hypothesis (experiment-ledger action=hypothesis) → gather PROOF in the sandbox (failing test, benchmark delta, profile) → record the finding with its proof path. Never re-test refuted hypotheses. If your current lead dies, pick a different subsystem. Prose without a recorded finding is wasted time.`
       : "";


### PR DESCRIPTION
## What

Adds an `understanding` variant of the experiment loop whose exit condition is an **exhausted code-path frontier** (open conjectures → 0, with at least one path closed) instead of an elapsed **deadline**. The deadline is demoted to a hard safety cap so the loop stays bounded.

## Why

The time-boxed `/experiment` loop rewards *quantity of trivially falsifiable claims*. On a comprehension task (e.g. "explain the scope/use case of 48 Euler DB tables") this drifts into shallow structural inventories — a recent run produced 33 epochs / 30 proved / 0 open / 1 refuted, and the human feedback was "most results are basic." Popperian falsification is the wrong optimizer for a coverage/understanding task.

Understanding mode reuses the **existing findings ledger as a coverage frontier**: each unexplored code path is an open `conjecture`; closing it (proved/refuted with `file:line` evidence) shrinks the frontier; every newly discovered callee/branch grows it. `end-experiment` unlocks only when the frontier is exhausted — so the run ends when the scope is genuinely understood, not when the clock runs out.

## Changes (xyne-claw only)

- `apps/xyne-claw/src/experiment.ts`
  - `ExperimentContext.kind?: "understanding"`
  - `end-experiment`: coverage-gated exit for understanding runs — refuses while `open > 0` (or nothing closed yet), with the deadline retained only as a hard safety cap. Non-understanding (time-boxed) path is unchanged (deadline-only).
- `apps/xyne-claw/src/routes/run.ts`
  - `normalizeExperimentContext` parses `kind: "understanding"`
  - `/run` request-body type gains optional `kind`
  - tool-inject diagnostic log branch for understanding mode
  - new `## Understanding mode` prompt guide (coverage-gated loop: enumerate every entrypoint/branch as open conjectures, close each with `file:line` evidence, exit when open → 0)

## Follow-up required (NOT in this PR)

This change is **inert** until claw-auth dispatches `kind: "understanding"` on the `/run` request body. The `/experiment` → command parsing and slash-command dispatch live in **claw-auth** (separate service, not in this repo), which must be updated to:
1. Register the `/understanding` command.
2. Send `kind: "understanding"` in the experiment context on the `/run` call.

Until that wiring lands, existing `/experiment` behavior is completely unaffected.

## Validation

- `tsc --noEmit` clean for both edited files (the only tsc errors in the sandbox are pre-existing `src/gcs.ts` failures from `@google-cloud/storage` not being installed there — unrelated to this change).
- No behavior change for existing time-boxed experiments (branch is gated on `ctx.kind === "understanding"`).