### PR TITLE
fix: skip custom emoji shortcode substitution inside code spans

### DIFF
--- a/apps/backend/src/utils/customEmojiUtils.test.ts
+++ b/apps/backend/src/utils/customEmojiUtils.test.ts
@@ -1,0 +1,57 @@
+import { replaceCustomEmojiShortcodesWithImg } from './customEmojiUtils';
+
+// The repo returns whatever emoji names it "knows". We register `aws` and
+// `tada` as existing custom emojis for the whole suite.
+const KNOWN_EMOJIS: Record<string, { id: string; name: string }> = {
+  aws: { id: 'cmqjxqfo100aq103oqxexk1os', name: 'aws' },
+  tada: { id: 'emoji_tada_1', name: 'tada' },
+};
+
+jest.mock('@/database/repositories/customEmojiRepository', () => ({
+  CustomEmojiRepository: class {
+    async findManyByNames(names: string[]): Promise<Array<{ id: string; name: string }>> {
+      return names.map((n) => KNOWN_EMOJIS[n]).filter(Boolean);
+    }
+  },
+}));
+
+const IMG = (name: string): string => {
+  const { id } = KNOWN_EMOJIS[name];
+  return `<img src="/api/emojis/${id}/stream" alt=":${name}:" title="${name}" data-emoji="true" data-emoji-id="${id}" class="inline-emoji">`;
+};
+
+describe('replaceCustomEmojiShortcodesWithImg', () => {
+  it('replaces a real shortcode in normal prose', async () => {
+    expect(await replaceCustomEmojiShortcodesWithImg('ship it :tada:')).toBe(`ship it ${IMG('tada')}`);
+  });
+
+  it('does NOT corrupt an ARN inside an inline code span (the reported bug)', async () => {
+    const input = '`arn:aws:kms:ap-south-1:297984596149:key/6655bd8c`';
+    // The :aws: inside the code span must be left untouched.
+    expect(await replaceCustomEmojiShortcodesWithImg(input)).toBe(input);
+  });
+
+  it('does NOT corrupt an ARN inside a fenced code block', async () => {
+    const input = '```\narn:aws:kms:ap-south-1:297984596149:key/abc\n```';
+    expect(await replaceCustomEmojiShortcodesWithImg(input)).toBe(input);
+  });
+
+  it('does NOT substitute inside HTML <code> spans', async () => {
+    const input = '<code>arn:aws:s3:::my-bucket</code>';
+    expect(await replaceCustomEmojiShortcodesWithImg(input)).toBe(input);
+  });
+
+  it('replaces prose shortcodes but preserves code in the same message', async () => {
+    const input = 'deploy done :tada: — key is `arn:aws:kms:ap-south-1:1:key/x`';
+    const expected = `deploy done ${IMG('tada')} — key is \`arn:aws:kms:ap-south-1:1:key/x\``;
+    expect(await replaceCustomEmojiShortcodesWithImg(input)).toBe(expected);
+  });
+
+  it('leaves unknown shortcodes untouched', async () => {
+    expect(await replaceCustomEmojiShortcodesWithImg('hi :nonexistent:')).toBe('hi :nonexistent:');
+  });
+
+  it('returns empty/falsy content unchanged', async () => {
+    expect(await replaceCustomEmojiShortcodesWithImg('')).toBe('');
+  });
+});

--- a/apps/backend/src/utils/customEmojiUtils.ts
+++ b/apps/backend/src/utils/customEmojiUtils.ts
@@ -3,6 +3,27 @@ import { CustomEmojiRepository } from '@/database/repositories/customEmojiReposi
 const SHORTCODE_REGEX = /:([a-zA-Z0-9_+-]{1,50}):/g;
 
 /**
+ * Regions where a `:shortcode:` must NEVER be treated as an emoji, because the
+ * text is meant to be literal:
+ *   - fenced markdown code blocks   ```...```
+ *   - inline markdown code spans    `...`
+ *   - HTML <pre>...</pre> blocks
+ *   - HTML <code>...</code> spans
+ *
+ * Substituting inside these corrupts literal content — e.g. an ARN written as
+ * `arn:aws:kms:...` would get its `:aws:` swapped for an <img> tag. On markdown
+ * clients the injected tag then renders as raw HTML text inside the code span
+ * (see the emoji-inside-ARN rendering bug), so we protect these regions here at
+ * the single write point instead of relying on each client to cope.
+ *
+ * The single capturing group is deliberate: String.prototype.split with one
+ * capturing group interleaves the array as [text, code, text, code, ...], so
+ * even indices are substitutable text and odd indices are protected code.
+ */
+const CODE_SPAN_REGEX =
+  /(```[\s\S]*?```|`[^`\r\n]*`|<pre\b[^>]*>[\s\S]*?<\/pre>|<code\b[^>]*>[\s\S]*?<\/code>)/gi;
+
+/**
  * Build emoji img tag with relative path.
  * Full URL is constructed at render time by the client based on current environment.
  */
@@ -16,14 +37,22 @@ function buildEmojiImgTag(name: string, emoji: { id: string }): string {
 /**
  * Replace custom emoji shortcodes (e.g. :test:) with inline <img> tags
  * if the emoji exists in DB (`customEmoji` table).
+ *
+ * Shortcodes inside code spans / code blocks are left untouched so that literal
+ * content such as ARNs (`arn:aws:kms:...`) is never corrupted.
  */
 export async function replaceCustomEmojiShortcodesWithImg(content: string): Promise<string> {
   if (!content) return content;
 
+  // Split into alternating [text, code, text, code, ...] segments. Only the
+  // even-indexed text segments are candidates for shortcode substitution.
+  const segments = content.split(CODE_SPAN_REGEX);
+
   const names = Array.from(
     new Set(
-      Array.from(content.matchAll(SHORTCODE_REGEX))
-        .map((m) => m[1])
+      segments
+        .filter((_, i) => i % 2 === 0)
+        .flatMap((segment) => Array.from(segment.matchAll(SHORTCODE_REGEX)).map((m) => m[1]))
         .filter(Boolean),
     ),
   );
@@ -37,8 +66,14 @@ export async function replaceCustomEmojiShortcodesWithImg(content: string): Prom
 
   const emojiByName = new Map(emojis.map((e) => [e.name, e]));
 
-  return content.replace(SHORTCODE_REGEX, (full, name: string) => {
-    const emoji = emojiByName.get(name);
-    return emoji ? buildEmojiImgTag(name, emoji) : full;
-  });
+  return segments
+    .map((segment, i) => {
+      // Odd indices are protected code segments — keep them verbatim.
+      if (i % 2 === 1) return segment;
+      return segment.replace(SHORTCODE_REGEX, (full, name: string) => {
+        const emoji = emojiByName.get(name);
+        return emoji ? buildEmojiImgTag(name, emoji) : full;
+      });
+    })
+    .join('');
 }


### PR DESCRIPTION
## 1. Problem Description
Custom emoji shortcodes render as raw HTML on the desktop app when a shortcode name collides with text inside a code span. Concretely, AWS ARNs such as `arn:aws:kms:ap-south-1:...` written in inline code get their `:aws:` segment replaced by an `<img class="inline-emoji">` tag (a workspace has a custom emoji named `aws`). On desktop the markdown renderer treats code-span content as literal text (correct per CommonMark), so it prints the raw `<img ...>` tag instead of an emoji. Lenient mobile renderers show the image, so it "works on phone but breaks on desktop".

## 2. If this is a bug fix or an enhancement, how did you identify the issue?
Traced the message write path: `conversationService.replaceEmojisInContent` → `replaceCustomEmojiShortcodesWithImg` (`apps/backend/src/utils/customEmojiUtils.ts`) ran a global `/:[a-zA-Z0-9_+-]{1,50}:/g` regex over the entire message body with no awareness of code spans, so `:aws:` inside an ARN in backticks was substituted. Desktop uses react-markdown (`MessageBubble.tsx` → `MarkdownMessageRenderer`) which renders inline-code content literally, exposing the injected tag as text.

## 3. Explain the solution implemented in the PR
Make `replaceCustomEmojiShortcodesWithImg` code-span aware. Split the content on fenced code blocks (```` ``` ````), inline code (`` ` ``), and HTML `<pre>`/`<code>` regions using a single-capture-group regex (so `String.split` interleaves as [text, code, text, code, ...]), collect candidate names only from the non-code segments, and substitute only in those segments — code segments are preserved verbatim. Genuine shortcodes in normal prose still become emojis.

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
N/A. Note: already-stored messages keep the corrupted bytes; a one-off backfill could repair history if desired, but is out of scope for this fix.

## 6. Data fix Details (if any)
N/A

## 7. Environment variable Changes (if any)
N/A

## 8. Testing
- Added `apps/backend/src/utils/customEmojiUtils.test.ts` (jest) — 7/7 passing. Covers: ARN inside inline code preserved, ARN inside fenced block preserved, HTML `<code>` preserved, mixed prose+code (prose shortcode replaced, code preserved), real shortcode in prose still replaced, unknown shortcode untouched, empty input.
- Proof-of-test video (rendered through the real `marked` inline-code path, mirroring the desktop renderer) shared in the Spaces thread: BEFORE shows the raw `<img>` tag printed inside the pink code span (the reported bug); AFTER shows the ARN untouched while the standalone `:aws:` in prose still renders as the emoji.

## 9. Services to which this change is to be deployed
Spaces backend.

## 10. Main PR link (if this PR is raised against a release branch)
N/A — raised against `main`.