### PR TITLE
Fix/decision action in recording

### DIFF
--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -35,6 +35,11 @@ import {
   DEFAULT_RECORDING_SUMMARY_FIELDS,
   RECORDING_DETAILED_SUMMARY_PROMPT,
 } from './recordingSummaryTemplates';
+import {
+  extractMarkedItemsFromRecordingSummary,
+  stripRecordingSummaryMarkedItemAnnotations,
+  type RecordingSummaryMarkedItem,
+} from './recordingSummaryMarkedItems';
 import { summaryTemplateService } from './summaryTemplateService';
 
 // PRD Document structure
@@ -969,7 +974,12 @@ export class CallDocumentService {
     callId: string,
     templateId?: string,
     onDelta?: (accumulatedContent: string) => void | Promise<void>,
-  ): Promise<{ summary: string; template: SummaryTemplate } | null> {
+    citationSegments?: CitationContext['segments'],
+  ): Promise<{
+    summary: string;
+    template: SummaryTemplate;
+    markedItems: RecordingSummaryMarkedItem[];
+  } | null> {
     const call = await repositories.calls.findByExternalId(callId);
     if (!call?.workspaceId) return null;
 
@@ -1003,7 +1013,7 @@ export class CallDocumentService {
       return null;
     }
 
-    const summary = await this.generateDetailedSummary(
+    const rawSummary = await this.generateDetailedSummary(
       transcript,
       callId,
       template.autoTriggerPrompt ?? undefined,
@@ -1011,10 +1021,19 @@ export class CallDocumentService {
       template.systemPrompt,
       RECORDING_DETAILED_SUMMARY_PROMPT,
       DEFAULT_RECORDING_SUMMARY_FIELDS,
-      onDelta,
+      onDelta
+        ? accumulated => onDelta(stripRecordingSummaryMarkedItemAnnotations(accumulated))
+        : undefined,
     );
 
-    return summary ? { summary, template } : null;
+    if (!rawSummary) return null;
+
+    const markedItems = citationSegments
+      ? extractMarkedItemsFromRecordingSummary(rawSummary, citationSegments)
+      : [];
+    const summary = stripRecordingSummaryMarkedItemAnnotations(rawSummary);
+
+    return { summary, template, markedItems };
   }
 
   /**

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -4,13 +4,17 @@ import { logger } from '@/utils/logger';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
 import { acquireLock, releaseLock } from '@/utils/distributedLock';
-import { transcriptService, type TranscriptEntry, type MarkedItem } from '@/services/transcriptService';
+import { transcriptService, type TranscriptEntry } from '@/services/transcriptService';
 import { callDocumentService, numberTranscriptSegments, type CitationContext } from '@/services/callDocumentService';
 import { findExistingDetailedSummaryCanvas } from '@/services/canvasService';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { tagService, TagServiceError } from '@/tags/service';
 import { tagRepository } from '@/database/repositories/tagRepository';
 import { TAG_FORMAT_REGEX, TagMethod } from '@xyne/shared';
+import {
+  mergeRecordingSummaryMarkedItems,
+  type RecordingSummaryMarkedItem,
+} from '@/services/recordingSummaryMarkedItems';
 
 // Generic Tag framework sourceType/category for note-taker call labels. No
 // configKey is used, so tagService.createTag skips the "category must be
@@ -21,29 +25,7 @@ const NOTE_TAKER_LABEL_CATEGORY = 'topic';
 interface DetailedSummaryCanvasResult {
   canvasId: string;
   summaryTemplateId: string;
-}
-
-/**
- * Moments the user flagged during the recording, read back off a Call row.
- * They share Call.markedItems with the decisions/actions generated here, and the
- * type filter is what keeps re-runs idempotent: a second pass drops the previous
- * run's generated items and keeps only the user's.
- */
-function userMarkedMoments(markedItems: Call['markedItems']): MarkedItem[] {
-  if (!Array.isArray(markedItems)) return [];
-
-  return markedItems.filter(
-    (item): item is MarkedItem & Prisma.JsonObject =>
-      !!item &&
-      typeof item === 'object' &&
-      !Array.isArray(item) &&
-      (item as Record<string, unknown>).type === 'moment',
-  );
-}
-
-/** Marked items come from JSON, so the timestamp can be anything at runtime. */
-function markedItemTimestamp(item: MarkedItem): number {
-  return typeof item.timestampSeconds === 'number' ? item.timestampSeconds : 0;
+  markedItems: RecordingSummaryMarkedItem[];
 }
 
 /**
@@ -143,13 +125,11 @@ class NoteTakerTranscriptService {
       if (!formattedTranscript) return;
 
       // These workloads are independent once the transcript is available, so
-      // start them together. generateDetailedSummaryCanvas preserves its own
-      // ordered dependency chain: template selection -> prompt generation when
-      // needed -> detailed-summary streaming.
+      // start them together. The detailed-summary result is also the sole source
+      // for generated decisions/actions and their transcript timestamps.
       const summaryPromise = this.generateAndSaveSummary(call, formattedTranscript);
       const detailedSummaryPromise = this.generateDetailedSummaryCanvas(call, formattedTranscript);
       const labelsPromise = this.generateAndSaveLabels(call, formattedTranscript);
-      const markedItemsPromise = this.generateMarkedItemsList(call, formattedTranscript);
 
       const saveLabelsPromise = labelsPromise.then(async (labelIds) => {
         if (labelIds.length === 0) return labelIds;
@@ -161,18 +141,10 @@ class NoteTakerTranscriptService {
         }
         return labelIds;
       });
-      const saveMarkedItemsPromise = markedItemsPromise.then(async (markedItems) => {
-        if (markedItems.length > 0) {
-          await this.finalizeCallUpdates(call, { markedItems });
-        }
-        return markedItems;
-      });
-
       const [, detailedSummary] = await Promise.all([
         summaryPromise,
         detailedSummaryPromise,
         saveLabelsPromise,
-        saveMarkedItemsPromise,
       ]);
       await this.finalizeCallUpdates(call, {
         metadata: {
@@ -180,6 +152,7 @@ class NoteTakerTranscriptService {
           detailedSummaryCanvasId: detailedSummary?.canvasId,
         },
         summaryTemplateId: detailedSummary?.summaryTemplateId,
+        ...(detailedSummary ? { markedItems: detailedSummary.markedItems } : {}),
       });
       await this.queueVespaIndexing(call);
     } finally {
@@ -208,16 +181,24 @@ class NoteTakerTranscriptService {
     );
     if (!detailedSummary) return null;
 
+    const current = await repositories.calls.findByExternalId(call.externalId);
     const currentMetadata =
-      call.metadata && typeof call.metadata === 'object' && !Array.isArray(call.metadata)
-        ? (call.metadata as Record<string, unknown>)
-        : {};
+      current?.metadata && typeof current.metadata === 'object' && !Array.isArray(current.metadata)
+        ? (current.metadata as Record<string, unknown>)
+        : call.metadata && typeof call.metadata === 'object' && !Array.isArray(call.metadata)
+          ? (call.metadata as Record<string, unknown>)
+          : {};
+    const markedItems = mergeRecordingSummaryMarkedItems(
+      current?.markedItems ?? call.markedItems,
+      detailedSummary.markedItems,
+    ) as Prisma.InputJsonValue[];
     await repositories.calls.update(call.id, {
       metadata: {
         ...currentMetadata,
         detailedSummaryCanvasId: detailedSummary.canvasId,
       },
       summaryTemplateId: detailedSummary.summaryTemplateId,
+      markedItems,
     });
 
     return {
@@ -277,7 +258,7 @@ class NoteTakerTranscriptService {
     updates: {
       metadata?: Record<string, unknown>;
       labels?: string[];
-      markedItems?: MarkedItem[];
+      markedItems?: RecordingSummaryMarkedItem[];
       summaryTemplateId?: string | null;
     },
   ): Promise<void> {
@@ -301,14 +282,12 @@ class NoteTakerTranscriptService {
     if (updates.labels && updates.labels.length > 0) {
       data.labels = updates.labels;
     }
-    if (updates.markedItems && updates.markedItems.length > 0) {
-      
+    if (updates.markedItems !== undefined) {
       const current = await repositories.calls.findByExternalId(call.externalId);
-      const existingMoments = userMarkedMoments(current?.markedItems ?? call.markedItems);
-
-      const merged = [...existingMoments, ...updates.markedItems];
-      merged.sort((a, b) => markedItemTimestamp(a) - markedItemTimestamp(b));
-      data.markedItems = merged as unknown as Prisma.InputJsonValue[];
+      data.markedItems = mergeRecordingSummaryMarkedItems(
+        current?.markedItems ?? call.markedItems,
+        updates.markedItems,
+      ) as Prisma.InputJsonValue[];
     }
     if (updates.summaryTemplateId !== undefined) {
       data.summaryTemplateId = updates.summaryTemplateId;
@@ -490,6 +469,8 @@ class NoteTakerTranscriptService {
           numberedTranscript,
           callId,
           templateId,
+          undefined,
+          citationCtx.segments,
         );
         if (!generated) {
           logger.error(`[${callId}] detailed_summary_skipped`, {
@@ -528,7 +509,11 @@ class NoteTakerTranscriptService {
           return null;
         }
 
-        return { canvasId, summaryTemplateId: generated.template.id };
+        return {
+          canvasId,
+          summaryTemplateId: generated.template.id,
+          markedItems: generated.markedItems,
+        };
       }
 
       const SYNC_INTERVAL_MS = 300;
@@ -645,6 +630,7 @@ class NoteTakerTranscriptService {
             latestMarkdown = accumulated;
             await ensureStreamingCanvas(accumulated);
           },
+          citationCtx.segments,
         );
       } finally {
         writerActive = false;
@@ -703,7 +689,11 @@ class NoteTakerTranscriptService {
         return null;
       }
 
-      return { canvasId: newCanvasId, summaryTemplateId: generated.template.id };
+      return {
+        canvasId: newCanvasId,
+        summaryTemplateId: generated.template.id,
+        markedItems: generated.markedItems,
+      };
     } catch (error) {
       logger.error(`[${callId}] detailed_summary_failed`, {
         stage: 'detailed_summary_generation',
@@ -793,22 +783,6 @@ class NoteTakerTranscriptService {
       }
       throw error;
     }
-  }
-
-  /**
-   * Generate key decisions/action items, each anchored to a transcript
-   * timestamp. Returns [] on any failure or when nothing qualifies.
-   */
-  private async generateMarkedItemsList(call: Call, formattedTranscript: string): Promise<MarkedItem[]> {
-    const callId = call.externalId;
-    return transcriptService.generateMarkedItems(formattedTranscript, callId).catch((err) => {
-      logger.error(`[${callId}] generate_marked_items_threw`, {
-        path: 'note_taker',
-        error: err,
-        stack: err instanceof Error ? err.stack : undefined,
-      });
-      return [] as MarkedItem[];
-    });
   }
 
   // Indexing only — not a message post. Uses the Call's own denormalized

--- a/apps/backend/src/services/recordingSummaryMarkedItems.ts
+++ b/apps/backend/src/services/recordingSummaryMarkedItems.ts
@@ -1,0 +1,150 @@
+const MARKED_ITEM_ANNOTATIONS = {
+  action: '[xyne-action]',
+  decision: '[xyne-decision]',
+} as const;
+
+const MARKED_ITEM_LINE_RE = /^\s*[-*+]\s+\[xyne-(action|decision)\]\s+(.+?)\s*$/;
+const SUMMARY_HEADING_RE = /^\s*#{1,6}\s+(.+?)\s*$/;
+const SUMMARY_BULLET_RE = /^\s*[-*+]\s+(.+?)\s*$/;
+const CITATION_TOKEN_RE = /\[clf-(\d+)\]/g;
+const COMPLETE_ANNOTATION_RE = /\[xyne-(?:action|decision)\]\s*/g;
+const MAX_MARKED_ITEMS = 15;
+
+export interface RecordingSummaryMarkedItem {
+  type: 'decision' | 'action';
+  text: string;
+  timestampSeconds: number;
+}
+
+interface TimestampedSegment {
+  timestamp: string;
+}
+
+function isUserMarkedMoment(item: unknown): item is Record<string, unknown> {
+  return (
+    !!item &&
+    typeof item === 'object' &&
+    !Array.isArray(item) &&
+    (item as Record<string, unknown>).type === 'moment'
+  );
+}
+
+function markedItemTimestamp(item: unknown): number {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return 0;
+  const timestamp = (item as Record<string, unknown>).timestampSeconds;
+  return typeof timestamp === 'number' ? timestamp : 0;
+}
+
+function timestampToSeconds(timestamp: string): number | null {
+  const match = timestamp.trim().match(/^(?:(\d+):)?(\d{1,2}):(\d{2})$/);
+  if (!match) return null;
+
+  const hours = match[1] ? Number.parseInt(match[1], 10) : 0;
+  const minutes = Number.parseInt(match[2], 10);
+  const seconds = Number.parseInt(match[3], 10);
+  if (minutes > 59 || seconds > 59) return null;
+
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
+function removeCitationTokens(value: string): string {
+  return value
+    .replace(CITATION_TOKEN_RE, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+function markedItemTypeFromHeading(heading: string): RecordingSummaryMarkedItem['type'] | null {
+  const hasActionItems = /\baction\s+items?\b/i.test(heading);
+  const hasDecisions = /\bdecisions?\b/i.test(heading);
+  if (hasActionItems === hasDecisions) return null;
+  return hasActionItems ? 'action' : 'decision';
+}
+
+/**
+ * Remove the private LLM annotations before summary Markdown reaches the
+ * canvas. The partial-marker branch also handles an in-flight streaming delta
+ * that ends halfway through an annotation.
+ */
+export function stripRecordingSummaryMarkedItemAnnotations(markdown: string): string {
+  return markdown
+    .split('\n')
+    .map((line) => {
+      const withoutCompleteAnnotations = line.replace(COMPLETE_ANNOTATION_RE, '');
+      const bulletMatch = withoutCompleteAnnotations.match(/^(\s*[-*+]\s+)(.*)$/);
+      if (!bulletMatch) return withoutCompleteAnnotations;
+
+      const [, bulletPrefix, content] = bulletMatch;
+      const candidate = content.trimStart();
+      const isPartialAnnotation = Object.values(MARKED_ITEM_ANNOTATIONS).some(
+        annotation => candidate.length > 0 && annotation.startsWith(candidate),
+      );
+      return isPartialAnnotation ? bulletPrefix : withoutCompleteAnnotations;
+    })
+    .join('\n');
+}
+
+/**
+ * Build timeline items from the exact action/decision bullets produced by the
+ * detailed-summary call. The first valid citation on a bullet is resolved via
+ * the deterministic transcript segment map, so timestamps are never guessed.
+ */
+export function extractMarkedItemsFromRecordingSummary(
+  markdown: string,
+  segments: ReadonlyMap<number, TimestampedSegment>,
+): RecordingSummaryMarkedItem[] {
+  const items: RecordingSummaryMarkedItem[] = [];
+  let sectionType: RecordingSummaryMarkedItem['type'] | null = null;
+
+  for (const line of markdown.split('\n')) {
+    if (items.length >= MAX_MARKED_ITEMS) break;
+
+    const heading = line.match(SUMMARY_HEADING_RE);
+    if (heading) {
+      sectionType = markedItemTypeFromHeading(heading[1]);
+      continue;
+    }
+
+    const markedLine = line.match(MARKED_ITEM_LINE_RE);
+    const ordinaryBullet = sectionType ? line.match(SUMMARY_BULLET_RE) : null;
+    if (!markedLine && !ordinaryBullet) continue;
+
+    const type = markedLine?.[1] ?? sectionType;
+    const annotatedText = markedLine?.[2] ?? ordinaryBullet?.[1];
+    if (!type || !annotatedText) continue;
+    const citationMatches = annotatedText.matchAll(CITATION_TOKEN_RE);
+    let timestampSeconds: number | null = null;
+    for (const citationMatch of citationMatches) {
+      const segmentNumber = Number.parseInt(citationMatch[1], 10);
+      const segment = segments.get(segmentNumber);
+      if (!segment) continue;
+
+      timestampSeconds = timestampToSeconds(segment.timestamp);
+      if (timestampSeconds !== null) break;
+    }
+
+    const text = removeCitationTokens(annotatedText);
+    if (!text || timestampSeconds === null) continue;
+
+    items.push({
+      type: type === 'action' ? 'action' : 'decision',
+      text,
+      timestampSeconds,
+    });
+  }
+
+  return items;
+}
+
+/** Replace generated items while retaining moments explicitly marked by the user. */
+export function mergeRecordingSummaryMarkedItems(
+  existingMarkedItems: unknown,
+  generatedMarkedItems: RecordingSummaryMarkedItem[],
+): unknown[] {
+  const existingMoments = Array.isArray(existingMarkedItems)
+    ? existingMarkedItems.filter(isUserMarkedMoment)
+    : [];
+  const merged: unknown[] = [...existingMoments, ...generatedMarkedItems];
+  merged.sort((left, right) => markedItemTimestamp(left) - markedItemTimestamp(right));
+  return merged;
+}

--- a/apps/backend/src/services/recordingSummaryTemplates.ts
+++ b/apps/backend/src/services/recordingSummaryTemplates.ts
@@ -42,6 +42,16 @@ INSTRUCTIONS:
 - In Action Items: Use @ before FULL NAMES for participants in the call (e.g., @Mayank Bansal)
 - In Action Items: For people NOT in the participant list, write their name plainly with "(not in channel)" notation
 
+MARKED DECISIONS AND ACTIONS:
+- Prefix every concrete decision bullet with the exact private annotation \`[xyne-decision]\` immediately after the bullet marker.
+- Prefix every concrete action-item bullet with the exact private annotation \`[xyne-action]\` immediately after the bullet marker.
+- Every annotated bullet MUST end with at least one supporting transcript citation. The first citation must identify the moment most closely associated with that decision or action.
+- Never use these annotations for takeaways, discussion points, open questions, blockers, or other bullets.
+- The annotations are internal metadata and will be removed before the summary is displayed.
+- Examples:
+  - \`- [xyne-decision] The team approved the consolidated pipeline [clf-12]\`
+  - \`- [xyne-action] @Mayank Bansal will update the backend [clf-18]\`
+
 CITATIONS:
 - Each transcript line may start with a segment number such as "[12] [03:24] Alice: ...".
 - After a specific claim, decision, action item, number, date, name, or quote, append the supporting token [clf-N].

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -247,38 +247,6 @@ TRANSCRIPT:
 {transcript}
 `;
 
-// Decisions/actions extraction. Transcript lines are prefixed with a "[MM:SS]"
-// (or "[HH:MM:SS]") timestamp relative to call start — the LLM is asked to
-// report that same timestamp back per item so it can be stored alongside the
-// text, instead of us trying to re-locate the sentence in the transcript.
-const MARKED_ITEMS_PROMPT = `
-You are analyzing a call transcript (each line is prefixed with a "[MM:SS]" or "[HH:MM:SS]" timestamp relative to the start of the call) to extract key decisions made and action items assigned.
-
-CRITICAL RULES:
-- Output ONLY valid JSON
-- Extract 0-15 items total across decisions and actions \u2014 only clear, concrete ones
-- For each item, use the exact "[MM:SS]" (or "[HH:MM:SS]") timestamp of the transcript line it is most closely associated with
-- "type" must be exactly "decision" or "action"
-- Keep "text" concise (one sentence)
-- If nothing clear qualifies, return an empty array for "items"
-
-BRAND NAME CORRECTION:
-- The word "Xyne" (product name, pronounced "zine") is often misspelled by speech-to-text as "Zain", "Zine", "Xine", "Zyane", or "Zyne"
-
-JSON STRUCTURE (FOLLOW EXACTLY):
-{
-  "items": [
-    { "type": "decision" | "action", "text": "[concise description]", "timestamp": "MM:SS" }
-  ]
-}
-
-Only output valid JSON.
-No explanations.
-
-TRANSCRIPT:
-{transcript}
-`;
-
 export interface TicketSuggestion {
   id: string;
   title: string;
@@ -287,12 +255,6 @@ export interface TicketSuggestion {
   suggestedAssignee: string;
   status: 'pending' | 'created' | 'dismissed';
   createdTicketId?: string;
-}
-
-export interface MarkedItem {
-  type: 'decision' | 'action' | 'moment';
-  text: string;
-  timestampSeconds: number;
 }
 
 export class TranscriptService {
@@ -1313,76 +1275,6 @@ Output ONLY the processed transcript, nothing else.`;
       return labels;
     } catch (error) {
       logger.error(`call_labels_generation_failed | error=${error instanceof Error ? error.message : JSON.stringify(error)}`, error);
-      return [];
-    }
-  }
-
-  /** Parse a "MM:SS" or "HH:MM:SS" string (as emitted by formatTimestamp) back to seconds. */
-  private parseTimestampToSeconds(value: unknown): number {
-    if (typeof value !== 'string') return 0;
-    const match = value.trim().match(/^(?:(\d+):)?(\d{1,2}):(\d{2})$/);
-    if (!match) return 0;
-    const hours = match[1] ? parseInt(match[1], 10) : 0;
-    const minutes = parseInt(match[2], 10);
-    const seconds = parseInt(match[3], 10);
-    return hours * 3600 + minutes * 60 + seconds;
-  }
-
-  /**
-   * Generate key decisions/action items from the transcript, each anchored to
-   * the timestamp (in seconds from call start) of the transcript line it came
-   * from. Returns [] on any failure or when nothing qualifies.
-   */
-  async generateMarkedItems(transcript: string, callId?: string): Promise<MarkedItem[]> {
-    const logCallId = callId || 'unknown';
-    const agent = await this.createAgent(logCallId);
-    if (!agent) {
-      logger.warn('Agent creation failed. Skipping marked items generation.');
-      return [];
-    }
-
-    const prompt = MARKED_ITEMS_PROMPT.replace('{transcript}', transcript);
-
-    try {
-      const result = await agent.execute({
-        messages: [createUserMessage(prompt)],
-      });
-
-      const extracted = extractAgentContent(result);
-      if (!extracted.ok) {
-        logger.error(`marked_items_generation_failed | reason=${extracted.reason} | status=${extracted.status ?? result.status}`);
-        return [];
-      }
-
-      let jsonContent = extracted.content;
-      const codeBlockMatch = jsonContent.match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/);
-      if (codeBlockMatch) {
-        jsonContent = codeBlockMatch[1].trim();
-      }
-
-      const parsed = JSON.parse(jsonContent);
-      if (!Array.isArray(parsed.items)) {
-        logger.error(`marked_items_generation_failed | error=invalid_format, parsed=${JSON.stringify(parsed)}`);
-        return [];
-      }
-
-      const items: MarkedItem[] = parsed.items
-        .slice(0, 15)
-        .map((item: any) => {
-          const text = typeof item?.text === 'string' ? item.text.trim() : '';
-          if (!text) return null;
-          return {
-            type: item?.type === 'action' ? 'action' : 'decision',
-            text,
-            timestampSeconds: this.parseTimestampToSeconds(item?.timestamp),
-          } satisfies MarkedItem;
-        })
-        .filter((item: MarkedItem | null): item is MarkedItem => item !== null);
-
-      logger.info(`Generated ${items.length} marked items`);
-      return items;
-    } catch (error) {
-      logger.error(`marked_items_generation_failed | error=${error instanceof Error ? error.message : JSON.stringify(error)}`, error);
       return [];
     }
   }


### PR DESCRIPTION

<img width="3216" height="1484" alt="image" src="https://github.com/user-attachments/assets/14857fbb-5c9c-42f1-b00b-ecf14a28295f" />


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
