### PR TITLE
fix: allow global skill owner to upload their own skill files

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/skills.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/skills.ts
@@ -14,6 +14,7 @@ import {
   type SkillDiff,
   resolveSkillUpdateApprover,
   authorizeSkillUpdateApproval,
+  authorizeSkillFileUpdate,
   buildSkillUpdateApprovalFlow,
 } from "xyne-claw-shared";
 
@@ -394,16 +395,15 @@ router.put("/:slug/files", async (req: Request<{ slug: string }>, res: Response)
       res.status(404).json({ success: false, error: "Skill not found" });
       return;
     }
-    // ACL: owner of a personal skill, OR admin (for any skill).
-    const admin = await isClawAdmin(requesterId);
-    if (!admin) {
-      if (skill.scope !== "personal" || skill.ownerUserId !== requesterId) {
-        res.status(403).json({
-          success: false,
-          error: "Only the skill owner or a CLAW_ADMIN can update files",
-        });
-        return;
-      }
+    // ACL: the skill's own owner (personal OR global), OR a CLAW_ADMIN.
+    const authz = authorizeSkillFileUpdate({
+      ownerUserId: skill.ownerUserId,
+      callerUserId: requesterId,
+      callerIsAdmin: await isClawAdmin(requesterId),
+    });
+    if (!authz.ok) {
+      res.status(authz.code).json({ success: false, error: authz.reason });
+      return;
     }
 
     const body = req.body as { files?: Array<{ relativePath?: string; content?: string; contentType?: string }> };

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -17,8 +17,9 @@ export {
   formatSkillDiffForCard,
   resolveSkillUpdateApprover,
   authorizeSkillUpdateApproval,
+  authorizeSkillFileUpdate,
 } from "./skill-diff/index.js";
-export type { SkillDiff, SkillForAuthz, ApproverResolution, SkillApprovalAuthz } from "./skill-diff/index.js";
+export type { SkillDiff, SkillForAuthz, ApproverResolution, SkillApprovalAuthz, SkillFileUpdateAuthz } from "./skill-diff/index.js";
 export { createSkillTool, updateSkillTool } from "./tools/skill-management/index.js";
 export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption } from "./flow/builder.js";

--- a/packages/xyne-claw-shared/src/skill-diff/index.ts
+++ b/packages/xyne-claw-shared/src/skill-diff/index.ts
@@ -309,3 +309,33 @@ export function authorizeSkillUpdateApproval(params: {
   }
   return { ok: true };
 }
+
+export type SkillFileUpdateAuthz = { ok: true } | { ok: false; code: 403; reason: string };
+
+/**
+ * Authorize a DIRECT file upload/replace on a skill — the dashboard "Edit"
+ * upload that hits `PUT /:slug/files`.
+ *
+ * Trust model mirrors {@link authorizeSkillUpdateApproval}:
+ *   • a CLAW_ADMIN may edit any skill's files;
+ *   • the skill's recorded owner may edit their OWN skill's files, whether the
+ *     skill is `personal` OR `global`.
+ *
+ * A global skill's owner can already self-approve an `update-skill` proposal
+ * (see authorizeSkillUpdateApproval), so gating the equivalent direct edit on
+ * `scope === "personal"` locked owners out of their own global skill for no
+ * added safety. A skill with no `ownerUserId` has no owner, so only an admin
+ * qualifies.
+ */
+export function authorizeSkillFileUpdate(params: {
+  ownerUserId: string | null;
+  callerUserId: string;
+  callerIsAdmin: boolean;
+}): SkillFileUpdateAuthz {
+  if (params.callerIsAdmin) return { ok: true };
+  const isOwner = !!params.ownerUserId && params.ownerUserId === params.callerUserId;
+  if (!isOwner) {
+    return { ok: false, code: 403, reason: "Only the skill owner or a CLAW_ADMIN can update files" };
+  }
+  return { ok: true };
+}

--- a/packages/xyne-claw-shared/src/skill-diff/skill-diff.test.ts
+++ b/packages/xyne-claw-shared/src/skill-diff/skill-diff.test.ts
@@ -7,6 +7,7 @@ import {
   formatSkillDiffForCard,
   resolveSkillUpdateApprover,
   authorizeSkillUpdateApproval,
+  authorizeSkillFileUpdate,
 } from "./index.js";
 
 describe("normalizeSkillContent", () => {
@@ -154,5 +155,31 @@ describe("authorizeSkillUpdateApproval", () => {
     const r = authorizeSkillUpdateApproval({ approverUserId: "u1", requiresAdmin: false, callerUserId: "u1", callerIsAdmin: false, currentContentHash: "NEW", baseContentHash: "OLD" });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe(409);
+  });
+});
+
+
+describe("authorizeSkillFileUpdate", () => {
+  it("allows the owner to edit their own PERSONAL skill's files (non-admin)", () => {
+    expect(authorizeSkillFileUpdate({ ownerUserId: "u1", callerUserId: "u1", callerIsAdmin: false })).toEqual({ ok: true });
+  });
+  it("allows the owner to edit their own GLOBAL skill's files (non-admin) — the bug this fixes", () => {
+    // scope is irrelevant to the file-edit ACL: ownership is what matters.
+    expect(authorizeSkillFileUpdate({ ownerUserId: "u1", callerUserId: "u1", callerIsAdmin: false })).toEqual({ ok: true });
+  });
+  it("allows a CLAW_ADMIN to edit any skill's files, even a skill they do not own", () => {
+    expect(authorizeSkillFileUpdate({ ownerUserId: "u1", callerUserId: "admin", callerIsAdmin: true })).toEqual({ ok: true });
+  });
+  it("rejects a non-owner non-admin caller (403)", () => {
+    const r = authorizeSkillFileUpdate({ ownerUserId: "u1", callerUserId: "attacker", callerIsAdmin: false });
+    expect(r).toEqual({ ok: false, code: 403, reason: expect.any(String) });
+  });
+  it("rejects a non-admin when the skill has no owner (403)", () => {
+    const r = authorizeSkillFileUpdate({ ownerUserId: null, callerUserId: "u1", callerIsAdmin: false });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe(403);
+  });
+  it("allows an admin even when the skill has no owner", () => {
+    expect(authorizeSkillFileUpdate({ ownerUserId: null, callerUserId: "admin", callerIsAdmin: true })).toEqual({ ok: true });
   });
 });


### PR DESCRIPTION
## Problem
The skill "Edit" upload in the dashboard hits `PUT /:slug/files` (apps/xyne-claw-auth/backend/src/routes/skills.ts). Its ACL allowed a non-admin only when `skill.scope === "personal" && skill.ownerUserId === requesterId`. Owners of **global** skills were therefore rejected with `403 "Only the skill owner or a CLAW_ADMIN can update files"` even though they own the skill (reported for `rca-html-report-generation`, a `global` skill).

## Why it's safe / consistent
This mirrors the update-skill approval path. Commit e7cc1af (#579) already established that a **global** skill's recorded owner/promoter may self-approve their own update proposal (`authorizeSkillUpdateApproval`). Gating the equivalent *direct* file edit on `scope === "personal"` added no safety — it only locked owners out of their own global skill.

## Change
- New pure helper `authorizeSkillFileUpdate` in `packages/xyne-claw-shared` (mirrors `authorizeSkillUpdateApproval`): a `CLAW_ADMIN` may edit any skill; the recorded owner may edit their **own** skill regardless of scope; a skill with no `ownerUserId` is admin-only.
- Exported from the package barrel.
- `PUT /:slug/files` now delegates to the helper.
- 6 new unit tests in `skill-diff.test.ts` (owner personal, owner global, admin, non-owner 403, no-owner 403, admin-no-owner). Full suite: 29 passed.

## Validation
- `vitest run src/skill-diff/skill-diff.test.ts` → 29 passed.
- Typecheck: no new errors from the change (pre-existing baseline errors are from the ungenerated Prisma client in CI sandbox only).