### PR TITLE
feat: add 'Most recent' sort to Threads inbox (Part B)

### DIFF
--- a/apps/backend/src/controllers/conversationController.ts
+++ b/apps/backend/src/controllers/conversationController.ts
@@ -129,6 +129,7 @@ export class ConversationController {
       .object({
         limit: z.coerce.number().int().min(1).max(50).default(10),
         cursor: z.string().min(1).max(2048).optional(),
+        sort: z.enum(['sections', 'recent']).default('sections'),
       })
       .safeParse(req.query);
 
@@ -150,7 +151,8 @@ export class ConversationController {
     try {
       const page = await this.conversationParticipantRepository.findUserThreadsPage(
         queryResult.data.limit,
-        cursor
+        cursor,
+        queryResult.data.sort
       );
 
       res.json({

--- a/apps/backend/src/database/repositories/conversationParticipantRepository.ts
+++ b/apps/backend/src/database/repositories/conversationParticipantRepository.ts
@@ -2,7 +2,7 @@ import { BaseRepository } from './base';
 import { ConversationParticipant, Prisma } from '@prisma/client';
 import { ConversationParticipation } from '@xyne/shared';
 import { QueryOptions } from '@/types/database';
-import { ThreadListCursor, ThreadListSection } from '@/utils/threadListCursor';
+import { ThreadListCursor, ThreadListSection, ThreadListSort } from '@/utils/threadListCursor';
 import { ACLFactory } from '@/database/acl';
 import { getContextOrNull } from '@/database/tenant/context';
 
@@ -216,12 +216,25 @@ export class ConversationParticipantRepository extends BaseRepository<
    */
   async findUserThreadsPage(
     limit: number,
-    cursor: ThreadListCursor | null
+    cursor: ThreadListCursor | null,
+    sort: ThreadListSort = 'sections'
   ): Promise<ThreadListPage> {
     let pageRows: ThreadListSectionRow[];
     let hasMore: boolean;
 
-    if (cursor?.section === 'read') {
+    // 'recent' mode: a single flat list ordered by lastReplyAt desc, with no
+    // read/unread divider and WITHOUT mutating read-state.
+    if (sort === 'recent' || cursor?.section === 'recent') {
+      const recentRows = await this.findUserThreadSection(
+        'recent',
+        limit + 1,
+        cursor?.participantId
+      );
+      hasMore = recentRows.length > limit;
+      pageRows = recentRows
+        .slice(0, limit)
+        .map((row) => ({ row, section: 'recent' as const }));
+    } else if (cursor?.section === 'read') {
       const readRows = await this.findUserThreadSection(
         'read',
         limit + 1,
@@ -282,7 +295,9 @@ export class ConversationParticipantRepository extends BaseRepository<
     const userId = tenantContext.userId;
     const lastReplyAtField = this.db.conversationParticipant.fields.lastReplyAt;
     const sectionWhere: Prisma.ConversationParticipantWhereInput =
-      section === 'unread'
+      section === 'recent'
+        ? {}
+        : section === 'unread'
         ? {
             OR: [
               { lastReadAt: null },

--- a/apps/backend/src/utils/threadListCursor.ts
+++ b/apps/backend/src/utils/threadListCursor.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
-export type ThreadListSection = 'unread' | 'read';
+export type ThreadListSection = 'unread' | 'read' | 'recent';
+
+// Sort mode for the threads inbox.
+// - 'sections' (default): unread threads first, then read threads (existing behavior).
+// - 'recent': a single flat list ordered by lastReplyAt desc, without a read/unread
+//   divider and WITHOUT mutating read-state.
+export type ThreadListSort = 'sections' | 'recent';
 
 export interface ThreadListCursor {
   section: ThreadListSection;
@@ -10,7 +16,7 @@ export interface ThreadListCursor {
 const encodedThreadListCursorSchema = z
   .object({
     version: z.literal(1),
-    section: z.enum(['unread', 'read']),
+    section: z.enum(['unread', 'read', 'recent']),
     participantId: z.string().min(1).max(256),
   })
   .strict();

--- a/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
+++ b/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
@@ -18,7 +18,7 @@ import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import ChatLock from '../../icons/ChatLock';
 import { useNavigate, useParams, Outlet } from 'react-router-dom';
 import { usePlatform } from '../../../hooks/usePlatform';
-import { conversationService, ThreadListEntry } from '../../../services/Chat/conversationService';
+import { conversationService, ThreadListEntry, ThreadListSort } from '../../../services/Chat/conversationService';
 import { useUnreadThreadConversationIds } from '../../../hooks/useUnreadThreadsCount';
 import { TwinDraftIndicator } from '../TwinReplyDraft/TwinDraftIndicator';
 
@@ -125,6 +125,7 @@ const UserThreads = (): ReactElement => {
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [sortMode, setSortMode] = useState<ThreadListSort>('sections');
   const hasConversations = allConversations.length > 0;
   const seenConversationIdsRef = useRef(new Set<string>());
   const nextCursorRef = useRef<string | null>(null);
@@ -164,6 +165,7 @@ const UserThreads = (): ReactElement => {
             pageCursor,
             PAGE_SIZE,
             abortController.signal,
+            sortMode,
           );
           if (generationRef.current !== generation || abortController.signal.aborted) return;
 
@@ -199,7 +201,7 @@ const UserThreads = (): ReactElement => {
         }
       }
     },
-    [user?.id],
+    [user?.id, sortMode],
   );
 
   useEffect(() => {
@@ -243,7 +245,8 @@ const UserThreads = (): ReactElement => {
       thread =>
         thread.sectionAtLoad === 'read' && unreadThreadConversationIds.has(thread.conversationId),
     );
-    const shouldShowDivider = hasUnreadAtLoadThread && !hasReadAtLoadThreadTurnedUnread;
+    const shouldShowDivider =
+      sortMode === 'sections' && hasUnreadAtLoadThread && !hasReadAtLoadThreadTurnedUnread;
 
     for (const thread of allConversations) {
       if (thread.sectionAtLoad === 'read' && shouldShowDivider && !addedReadDivider) {
@@ -254,7 +257,7 @@ const UserThreads = (): ReactElement => {
     }
 
     return items;
-  }, [allConversations, unreadThreadConversationIds]);
+  }, [allConversations, unreadThreadConversationIds, sortMode]);
 
   // Memoize the itemContent callback
   const itemContent = useCallback(
@@ -301,6 +304,39 @@ const UserThreads = (): ReactElement => {
           showThreadPanel ? (isMobile ? 'hidden' : 'w-1/2 border-r border-border') : 'w-full'
         }`}
       >
+        <div className='flex items-center justify-between px-4 pb-3'>
+          <span className='text-sm font-semibold text-foreground'>Threads</span>
+          <div className='inline-flex items-center rounded-md border border-border p-0.5 text-sm'>
+            <button
+              type='button'
+              onClick={(): void => setSortMode('sections')}
+              className={`rounded px-2.5 py-1 transition-colors ${
+                sortMode === 'sections'
+                  ? 'bg-muted font-medium text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              aria-pressed={sortMode === 'sections'}
+              data-track-category='USER_THREADS'
+              data-track-name='SORT_UNREAD_FIRST'
+            >
+              Unread first
+            </button>
+            <button
+              type='button'
+              onClick={(): void => setSortMode('recent')}
+              className={`rounded px-2.5 py-1 transition-colors ${
+                sortMode === 'recent'
+                  ? 'bg-muted font-medium text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              aria-pressed={sortMode === 'recent'}
+              data-track-category='USER_THREADS'
+              data-track-name='SORT_MOST_RECENT'
+            >
+              Most recent
+            </button>
+          </div>
+        </div>
         <div className='flex-1'>
           {isInitialLoading && !hasConversations ? (
             <div className='flex h-full items-center justify-center'>

--- a/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
+++ b/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
@@ -27,6 +27,38 @@ import { useUnreadThreadConversationIds } from '../../../hooks/useUnreadThreadsC
 import { TwinDraftIndicator } from '../TwinReplyDraft/TwinDraftIndicator';
 
 const PAGE_SIZE = 10;
+const THREAD_LIST_SORT_STORAGE_PREFIX = 'xyne:user-threads-sort';
+
+interface ThreadListSortSelection {
+  userId: string;
+  sortMode: ThreadListSort;
+}
+
+const threadListSortStorageKey = (userId: string): string =>
+  `${THREAD_LIST_SORT_STORAGE_PREFIX}:${userId}`;
+
+const readStoredThreadListSort = (userId: string | undefined): ThreadListSort => {
+  if (!userId || typeof window === 'undefined') return 'sections';
+
+  try {
+    const storedSortMode = window.localStorage.getItem(threadListSortStorageKey(userId));
+    return storedSortMode === 'sections' || storedSortMode === 'recent'
+      ? storedSortMode
+      : 'sections';
+  } catch {
+    return 'sections';
+  }
+};
+
+const persistThreadListSort = (userId: string, sortMode: ThreadListSort): void => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(threadListSortStorageKey(userId), sortMode);
+  } catch {
+    // localStorage unavailable/full — keep the selection for this session.
+  }
+};
 
 // Optimize ThreadRow with memo to prevent unnecessary re-renders of existing rows
 // during scrolling or when new data loads at the bottom.
@@ -129,7 +161,11 @@ const UserThreads = (): ReactElement => {
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [sortMode, setSortMode] = useState<ThreadListSort>('sections');
+  const userId = user?.id;
+  const persistedSortMode = useMemo(() => readStoredThreadListSort(userId), [userId]);
+  const [sortSelection, setSortSelection] = useState<ThreadListSortSelection | null>(null);
+  const sortMode =
+    sortSelection && sortSelection.userId === userId ? sortSelection.sortMode : persistedSortMode;
   const hasConversations = allConversations.length > 0;
   const seenConversationIdsRef = useRef(new Set<string>());
   const nextCursorRef = useRef<string | null>(null);
@@ -137,6 +173,16 @@ const UserThreads = (): ReactElement => {
   const isLoadingRef = useRef(false);
   const generationRef = useRef(0);
   const requestAbortRef = useRef<AbortController | null>(null);
+
+  const handleSortModeChange = useCallback(
+    (nextSortMode: ThreadListSort): void => {
+      if (!userId) return;
+
+      setSortSelection({ userId, sortMode: nextSortMode });
+      persistThreadListSort(userId, nextSortMode);
+    },
+    [userId],
+  );
 
   const loadNextUniquePage = useCallback(
     async (startCursor: string | null, generation: number, initialLoad: boolean): Promise<void> => {
@@ -316,7 +362,7 @@ const UserThreads = (): ReactElement => {
           <div className='inline-flex items-center rounded-md border border-border p-0.5 text-sm'>
             <button
               type='button'
-              onClick={(): void => setSortMode('sections')}
+              onClick={(): void => handleSortModeChange('sections')}
               className={`rounded px-2.5 py-1 transition-colors ${
                 sortMode === 'sections'
                   ? 'bg-muted font-medium text-foreground'
@@ -330,7 +376,7 @@ const UserThreads = (): ReactElement => {
             </button>
             <button
               type='button'
-              onClick={(): void => setSortMode('recent')}
+              onClick={(): void => handleSortModeChange('recent')}
               className={`rounded px-2.5 py-1 transition-colors ${
                 sortMode === 'recent'
                   ? 'bg-muted font-medium text-foreground'

--- a/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
+++ b/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
@@ -18,7 +18,11 @@ import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import ChatLock from '../../icons/ChatLock';
 import { useNavigate, useParams, Outlet } from 'react-router-dom';
 import { usePlatform } from '../../../hooks/usePlatform';
-import { conversationService, ThreadListEntry, ThreadListSort } from '../../../services/Chat/conversationService';
+import {
+  conversationService,
+  ThreadListEntry,
+  ThreadListSort,
+} from '../../../services/Chat/conversationService';
 import { useUnreadThreadConversationIds } from '../../../hooks/useUnreadThreadsCount';
 import { TwinDraftIndicator } from '../TwinReplyDraft/TwinDraftIndicator';
 
@@ -298,14 +302,17 @@ const UserThreads = (): ReactElement => {
   );
 
   return (
-    <div className='flex h-full w-full bg-background'>
+    <div className='flex h-full w-full bg-background pt-14 [@media(min-width:500px)]:pt-0'>
       <div
-        className={`pt-8 h-full flex flex-col bg-background ${
+        className={`flex flex-col bg-background ${
           showThreadPanel ? (isMobile ? 'hidden' : 'w-1/2 border-r border-border') : 'w-full'
         }`}
       >
-        <div className='flex items-center justify-between px-4 pb-3'>
-          <span className='text-sm font-semibold text-foreground'>Threads</span>
+        <div className='relative z-30 shrink-0 px-6 py-4 border-b border-border/50 bg-background flex items-center justify-between'>
+          <div className='flex items-center gap-2 text-foreground'>
+            <MessageCircle className='w-5 h-5 text-primary' />
+            <h1 className='text-lg font-semibold tracking-tight'>Threads</h1>
+          </div>
           <div className='inline-flex items-center rounded-md border border-border p-0.5 text-sm'>
             <button
               type='button'

--- a/apps/dashboard/src/services/Chat/conversationService.ts
+++ b/apps/dashboard/src/services/Chat/conversationService.ts
@@ -93,7 +93,13 @@ export interface MarkTicketSuggestionAsCreatedResponse {
   conversationId: string;
 }
 
-export type ThreadListSection = 'unread' | 'read';
+export type ThreadListSection = 'unread' | 'read' | 'recent';
+
+// Threads inbox sort mode.
+// - 'sections' (default): unread threads first, then read threads.
+// - 'recent': flat list ordered by lastReplyAt desc, no read/unread divider,
+//   without marking threads as read.
+export type ThreadListSort = 'sections' | 'recent';
 
 export interface ThreadListEntry {
   conversationId: string;
@@ -149,11 +155,13 @@ export class ConversationService {
     cursor: string | null,
     limit: number,
     signal?: AbortSignal,
+    sort: ThreadListSort = 'sections',
   ): Promise<ThreadListResponse> {
     const response = await apiInstance.get<ThreadListResponse>('/conversations/threads', {
       params: {
         limit,
         ...(cursor ? { cursor } : {}),
+        ...(sort !== 'sections' ? { sort } : {}),
       },
       ...(signal ? { signal } : {}),
     });


### PR DESCRIPTION


https://github.com/user-attachments/assets/08311024-dc74-4cf3-8600-d14d11fbc326


## What
Adds an additive `sort=recent` option to the Threads inbox that orders threads by `lastReplyAt` descending as a single flat list (no read/unread divider) **without** marking threads as read. The default remains the sectioned "Unread first" view, so behavior is fully backward-compatible.

## Why
Users reported old May/June threads surfacing as "new/unread" in the Threads section. Rather than a "mark all as read" button (which causes a large write burst + Zero replication spike, especially for older threads), this lets a user re-order their inbox purely by recency on demand — zero writes, zero Zero-replication impact, no migration.

## Changes
**Backend**
- `apps/backend/src/utils/threadListCursor.ts` — new `ThreadListSort` type + `'recent'` section (cursor encoding + zod schema).
- `apps/backend/src/database/repositories/conversationParticipantRepository.ts` — `findUserThreadsPage(…, sort)` dispatches to a flat `lastReplyAt desc` path; `findUserThreadSection` `'recent'` case uses `sectionWhere = {}` (no read-state filter).
- `apps/backend/src/controllers/conversationController.ts` — `getUserThreads` accepts `sort: z.enum(['sections','recent']).default('sections')` and passes it through.

**Dashboard**
- `apps/dashboard/src/services/Chat/conversationService.ts` — `ThreadListSort` type + `sort` param on `getUserThreads`.
- `apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx` — "Unread first / Most recent" segmented toggle; `sortMode` resets pagination on switch; read/unread divider gated to sections mode; per-row unread markers preserved in flat mode.

## Compatibility & validation
- Additive only; `sort` defaults to `sections` on both client and server.
- `tsc --noEmit` clean on backend and dashboard.
- Verified in a local dashboard: default groups unread-first; "Most recent" surfaces an already-read newest-reply thread at the top with read/unread interleaved by recency, and cursor pagination has no dupes/gaps.