### PR TITLE
Fix/xyne 56181 cmd k full screen search

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -95,6 +95,7 @@ import {
   rankUsers,
   CMDK_USER_LIMIT,
 } from '../../../hooks/useSearchMetrics';
+import { searchMetricsService } from '../../../services/searchMetricsService';
 import { useScope, useShortcutById } from '../../../shortcuts';
 import { useSearchMode } from '../../../hooks/useSearchMode';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -309,6 +310,22 @@ const ChannelCommandMenu = ({
   useScope('command', open);
 
   const { searchMode } = useSearchMode();
+
+  // The top-bar palette (screen mode, tabs hidden) always routes to the results page;
+  // the default cmd+K popup renders results inline. Both show the "Show results for"
+  // row, but only the screen palette lets it own the default Enter target.
+  const isScreenPalette = hideTabs && searchMode === 'screen';
+
+  // The row's onSelect fires for both a click and an Enter press, and cmdk hands it no
+  // event — so the pointer path stamps this ref and Enter falls through to the default.
+  const showResultsTriggerRef = useRef<'click' | 'keyboard'>('keyboard');
+
+  // Guards the jump to the results page against a double activation (onClick + onSelect).
+  // Reset whenever the palette opens again.
+  const navigatingToResultsRef = useRef(false);
+  useEffect(() => {
+    if (open) navigatingToResultsRef.current = false;
+  }, [open]);
 
   // When opened via the `mod+/` shortcut, seed the search box with `/` so it lands in command mode.
   // The popup path flips this on in the shortcut handler; the screen overlay is mounted fresh with a
@@ -977,6 +994,37 @@ const ChannelCommandMenu = ({
 
     return params;
   }
+
+  // Leave the palette for the full-screen results page via the "Show results for" row.
+  // Logged as its own event so the jump-out rate is readable per palette and trigger.
+  const goToSearchResults = (trigger: 'click' | 'keyboard'): void => {
+    // The row fires both onClick and cmdk's onSelect for one activation — first one wins.
+    if (navigatingToResultsRef.current) return;
+    navigatingToResultsRef.current = true;
+    showResultsTriggerRef.current = 'keyboard';
+
+    // Metrics must never be able to swallow the navigation.
+    try {
+      if (searchSessionId && currentUserID) {
+        searchMetricsService.trackShowResults({
+          searchSessionId,
+          userId: currentUserID,
+          queryText: searchText.trim(),
+          tab: activeTab,
+          trigger,
+          searchMode,
+          filtersUsed: selectedMentions.length,
+        });
+      }
+    } catch {
+      // Swallowed on purpose — a broken log line must not block the results page.
+    }
+
+    onOpenChange(false);
+    void navigate(
+      `/search-results?${buildSearchParams(searchText, selectedMentions, usersById, allChannels).toString()}`,
+    );
+  };
 
   // Navigate to the full results page with a specific section's tab pre-selected
   // (from the screen-mode "See N more" links).
@@ -2141,8 +2189,17 @@ const ChannelCommandMenu = ({
       if (hasNavigatedRef.current) return;
       const items = commandRef.current?.querySelectorAll('[cmdk-item]:not([aria-disabled="true"])');
       if (items && items.length > 0) {
+        // The popup pins "Show results for" first in the DOM, but it must not become the
+        // resting Enter target — highlight the first real result instead, falling back to
+        // the row only when it is the sole item. The screen palette keeps first-row.
+        const firstReal = isScreenPalette
+          ? -1
+          : Array.from(items).findIndex(
+              item => item.getAttribute('data-show-results-item') !== 'true',
+            );
+        const selectedIndex = firstReal === -1 ? 0 : firstReal;
         items.forEach((item, i) => {
-          item.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+          item.setAttribute('aria-selected', i === selectedIndex ? 'true' : 'false');
         });
       }
       // No sync here: the results-list observer recomputes actionability whenever rows change
@@ -3236,22 +3293,23 @@ const ChannelCommandMenu = ({
     const enterTarget =
       activeItem ??
       (commandRef.current?.querySelector(
-        '[cmdk-item]:not([aria-disabled="true"])',
+        // In the popup the pinned "Show results for" row is the first item in the DOM,
+        // so exclude it here — the resting Enter target is still the first real result.
+        isScreenPalette
+          ? '[cmdk-item]:not([aria-disabled="true"])'
+          : '[cmdk-item]:not([aria-disabled="true"]):not([data-show-results-item])',
       ) as HTMLElement | null);
 
     // Screen-mode popup: Enter navigates to search screen only when no result item is selected
     // (or when the "show results for" item is selected). If a regular result is selected, click it.
-    if (hideTabs && searchMode === 'screen') {
+    if (isScreenPalette) {
       const isShowResultsItem = enterTarget?.getAttribute('data-show-results-item') === 'true';
       if (enterTarget && !isShowResultsItem) {
         lastModifierRef.current = e.metaKey || e.ctrlKey;
         enterTarget.click();
         return;
       }
-      onOpenChange(false);
-      void navigate(
-        `/search-results?${buildSearchParams(searchText, selectedMentions, usersById, allChannels).toString()}`,
-      );
+      goToSearchResults('keyboard');
       return;
     }
 
@@ -3261,6 +3319,72 @@ const ChannelCommandMenu = ({
     lastModifierRef.current = e.metaKey || e.ctrlKey;
     enterTarget?.click();
   };
+
+  // "Show results for: <chips> <query>" — the row that leaves the palette for the
+  // full-screen results page. Rendered in both palettes; where it sits in the list is
+  // decided at the call sites below.
+  const showResultsForRow =
+    !mentionSearchType && (searchText.trim() || selectedMentions.length > 0) ? (
+      <Command.Item
+        value='__show-results-for__'
+        data-show-results-item='true'
+        onPointerDown={() => {
+          showResultsTriggerRef.current = 'click';
+        }}
+        // Both paths are wired on purpose: cmdk's onSelect covers keyboard activation,
+        // and the plain onClick covers the mouse without depending on cmdk's selection
+        // state. goToSearchResults de-dupes when a click fires both.
+        onClick={() => goToSearchResults('click')}
+        onSelect={() => goToSearchResults(showResultsTriggerRef.current)}
+        className={`flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer text-sm text-foreground ${!isMobile && 'hover:bg-muted'} aria-selected:bg-muted`}
+        data-track-category='SEARCH'
+        data-track-name='SHOW_RESULTS_FOR'
+      >
+        <SearchDefault size={14} className='text-muted-foreground shrink-0' />
+        <span className='flex items-center flex-wrap gap-1'>
+          <span className='text-sm'>Show results for:</span>
+          {selectedMentions.map(m => {
+            const isPriority = m.type === MentionType.PRIORITY;
+            const isUser = m.type === MentionType.USER;
+            const name = isPriority
+              ? m.id.toLowerCase()
+              : isUser
+                ? getUserDisplayName(usersById.get(m.id) ?? { displayName: m.id, email: '' })
+                : (() => {
+                    const ch = allChannels.find(c => c.channel.id === m.id);
+                    if (!ch) return m.id;
+                    return formatChannelLabel(ch);
+                  })();
+            const prefix = m.prefix ?? (isPriority ? 'priority:' : isUser ? 'from:' : 'in:');
+            return (
+              <span
+                key={`${m.prefix}-${m.id}`}
+                className='inline-flex items-center gap-1.5 px-1.5 py-1 rounded bg-muted text-foreground text-xs font-medium h-6'
+              >
+                {isPriority ? (
+                  <div className='flex items-center justify-center flex-shrink-0 size-4 rounded-sm'>
+                    <SignalHigh
+                      size={12}
+                      className={PRIORITY_ICON_COLOR[m.id] ?? 'text-foreground'}
+                    />
+                  </div>
+                ) : isUser ? (
+                  <Avatar userId={m.id} size='sm' className='rounded-none flex-shrink-0 size-3' />
+                ) : (
+                  <div className='flex items-center justify-center flex-shrink-0 size-4 rounded-sm'>
+                    <Hashtag size={12} className='text-foreground' />
+                  </div>
+                )}
+                <span className='leading-tight'>
+                  {prefix} {name}
+                </span>
+              </span>
+            );
+          })}
+          {searchText.trim() && <span className='font-semibold text-sm'>{searchText.trim()}</span>}
+        </span>
+      </Command.Item>
+    ) : null;
 
   const commandBody = (
     <>
@@ -3651,6 +3775,11 @@ const ChannelCommandMenu = ({
               <SlashCommandPalette command={slash} onItemMouseDown={handleItemMouseDown} />
             ) : (
               <>
+                {/* Popup palette: the row is pinned here, directly under the tabs, so it
+                    sits in the same place no matter what matched. It is skipped by the
+                    first-row auto-select, so the top result keeps the Enter target. */}
+                {!isScreenPalette && showResultsForRow}
+
                 {/* Best local matches pinned to the top of the list — both popup and
                     screen. Starred leads; the strong-matched user/channel then becomes
                     the default Enter target (Slack-style). In screen mode these sit
@@ -3659,78 +3788,9 @@ const ChannelCommandMenu = ({
                 {hoistUser && renderSearchUsersSection()}
                 {hoistChannel && renderSearchChannelsSection()}
 
-                {/* Show results for: [query] — screen mode only */}
-                {hideTabs &&
-                  searchMode === 'screen' &&
-                  !mentionSearchType &&
-                  (searchText.trim() || selectedMentions.length > 0) && (
-                    <Command.Item
-                      value='__show-results-for__'
-                      data-show-results-item='true'
-                      onSelect={() => {
-                        onOpenChange(false);
-                        void navigate(
-                          `/search-results?${buildSearchParams(searchText, selectedMentions, usersById, allChannels).toString()}`,
-                        );
-                      }}
-                      className={`flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer text-sm text-foreground ${!isMobile && 'hover:bg-muted'} aria-selected:bg-muted`}
-                      data-track-category='SEARCH'
-                      data-track-name='SHOW_RESULTS_FOR'
-                    >
-                      <SearchDefault size={14} className='text-muted-foreground shrink-0' />
-                      <span className='flex items-center flex-wrap gap-1'>
-                        <span className='text-sm'>Show results for:</span>
-                        {selectedMentions.map(m => {
-                          const isPriority = m.type === MentionType.PRIORITY;
-                          const isUser = m.type === MentionType.USER;
-                          const name = isPriority
-                            ? m.id.toLowerCase()
-                            : isUser
-                              ? getUserDisplayName(
-                                  usersById.get(m.id) ?? { displayName: m.id, email: '' },
-                                )
-                              : (() => {
-                                  const ch = allChannels.find(c => c.channel.id === m.id);
-                                  if (!ch) return m.id;
-                                  return formatChannelLabel(ch);
-                                })();
-                          const prefix =
-                            m.prefix ?? (isPriority ? 'priority:' : isUser ? 'from:' : 'in:');
-                          return (
-                            <span
-                              key={`${m.prefix}-${m.id}`}
-                              className='inline-flex items-center gap-1.5 px-1.5 py-1 rounded bg-muted text-foreground text-xs font-medium h-6'
-                            >
-                              {isPriority ? (
-                                <div className='flex items-center justify-center flex-shrink-0 size-4 rounded-sm'>
-                                  <SignalHigh
-                                    size={12}
-                                    className={PRIORITY_ICON_COLOR[m.id] ?? 'text-foreground'}
-                                  />
-                                </div>
-                              ) : isUser ? (
-                                <Avatar
-                                  userId={m.id}
-                                  size='sm'
-                                  className='rounded-none flex-shrink-0 size-3'
-                                />
-                              ) : (
-                                <div className='flex items-center justify-center flex-shrink-0 size-4 rounded-sm'>
-                                  <Hashtag size={12} className='text-foreground' />
-                                </div>
-                              )}
-                              <span className='leading-tight'>
-                                {prefix} {name}
-                              </span>
-                            </span>
-                          );
-                        })}
-                        {searchText.trim() && (
-                          <span className='font-semibold text-sm'>{searchText.trim()}</span>
-                        )}
-                      </span>
-                    </Command.Item>
-                  )}
+                {/* Screen palette: the row stays below the hoisted best matches, which
+                    own the Enter target there. */}
+                {isScreenPalette && showResultsForRow}
 
                 {/* Mention Suggestions - Show when mention search is active */}
                 {mentionSearchType && (

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -3298,6 +3298,11 @@ const ChannelCommandMenu = ({
         isScreenPalette
           ? '[cmdk-item]:not([aria-disabled="true"])'
           : '[cmdk-item]:not([aria-disabled="true"]):not([data-show-results-item])',
+      ) as HTMLElement | null) ??
+      // Zero results leave the pinned row as the only item — then it IS the Enter target,
+      // or Enter would go dead with an actionable row on screen.
+      (commandRef.current?.querySelector(
+        '[cmdk-item][data-show-results-item]',
       ) as HTMLElement | null);
 
     // Screen-mode popup: Enter navigates to search screen only when no result item is selected
@@ -3313,6 +3318,13 @@ const ChannelCommandMenu = ({
       return;
     }
 
+    // The row is invoked directly, not via a synthetic .click() — that path would fire its
+    // onClick and log this keyboard activation as a click.
+    if (enterTarget?.getAttribute('data-show-results-item') === 'true') {
+      goToSearchResults('keyboard');
+      return;
+    }
+
     // Prime modifier ref before the synthetic .click() — a synthetic click
     // loses modifier state, so downstream selection handlers read this ref
     // instead of checking event.metaKey.
@@ -3322,9 +3334,14 @@ const ChannelCommandMenu = ({
 
   // "Show results for: <chips> <query>" — the row that leaves the palette for the
   // full-screen results page. Rendered in both palettes; where it sits in the list is
-  // decided at the call sites below.
+  // decided at the call sites below. Never in the inline/context-selection palettes
+  // (Ask AI context picker, thread-panel context) — navigating away would hijack the
+  // picking flow. The old screen-only gate excluded those implicitly.
   const showResultsForRow =
-    !mentionSearchType && (searchText.trim() || selectedMentions.length > 0) ? (
+    !inline &&
+    !contextSelectionMode &&
+    !mentionSearchType &&
+    (searchText.trim() || selectedMentions.length > 0) ? (
       <Command.Item
         value='__show-results-for__'
         data-show-results-item='true'
@@ -3763,7 +3780,10 @@ const ChannelCommandMenu = ({
               // position is communicated by aria-selected, never by a ring here.
               'flex-1 overflow-y-auto px-4 pt-3 pb-6 focus:outline-none focus-visible:outline-none',
               '[&_[cmdk-item]]:scroll-mb-[30px]',
-              suppressHover && '[&_[cmdk-item]]:pointer-events-none',
+              // The pinned "Show results for" row is exempt: it sits where the cursor
+              // rests when the palette opens, and its first click must land even before
+              // any mousemove clears suppressHover. Result rows keep the guard.
+              suppressHover && '[&_[cmdk-item]:not([data-show-results-item])]:pointer-events-none',
             )}
             ref={el => {
               if (el) {

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -3342,7 +3342,7 @@ const ChannelCommandMenu = ({
       >
         <SearchDefault size={14} className='text-muted-foreground shrink-0' />
         <span className='flex items-center flex-wrap gap-1'>
-          <span className='text-sm'>Show results for:</span>
+          <span className='text-sm'>Show detailed results for:</span>
           {selectedMentions.map(m => {
             const isPriority = m.type === MentionType.PRIORITY;
             const isUser = m.type === MentionType.USER;

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -45,6 +45,7 @@ import { DisplaySearchResult } from '../../../types/search';
 import {
   TabType,
   MentionType,
+  type MentionData,
   ChannelCommandMenuProps,
   TYPE_SUGGESTIONS,
   SearchableTypes,
@@ -87,7 +88,7 @@ import {
   EVENTS,
   EVENT_PROPERTIES,
 } from '../../../services/Analytics/mixpanelService';
-import { LexicalSearchInput } from './LexicalSearchInput';
+import { LexicalSearchInput, type InitialQueryData } from './LexicalSearchInput';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import {
   useSearchMetrics,
@@ -96,6 +97,7 @@ import {
   CMDK_USER_LIMIT,
 } from '../../../hooks/useSearchMetrics';
 import { searchMetricsService } from '../../../services/searchMetricsService';
+import { useHistoryBackedOverlay } from '../../../hooks/useHistoryBackedOverlay';
 import { useScope, useShortcutById } from '../../../shortcuts';
 import { useSearchMode } from '../../../hooks/useSearchMode';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -333,12 +335,38 @@ const ChannelCommandMenu = ({
   const [seedCommandMode, setSeedCommandMode] = useState(
     () => initialQuery?.text === '/' && initialQuery?.mentions.length === 0,
   );
-  // While seeding, feed the editor a `/` through the existing initial-query path; otherwise pass the
-  // caller's query straight through. Memoized so the reference stays stable across renders.
+  // The search the user left behind when the palette sent them to the results page, handed
+  // back by the history hook so pressing back reopens cmd+K exactly as they typed it.
+  const [restoredQuery, setRestoredQuery] = useState<InitialQueryData | null>(null);
+
+  // While seeding, feed the editor a `/` through the existing initial-query path; a restored
+  // search goes down the same path. Otherwise pass the caller's query straight through.
+  // Memoized so the reference stays stable across renders.
   const effectiveInitialQuery = useMemo(
-    () => (seedCommandMode ? { mentions: [], text: '/' } : initialQuery),
-    [seedCommandMode, initialQuery],
+    () =>
+      seedCommandMode ? { mentions: [], text: '/' } : restoredQuery ? restoredQuery : initialQuery,
+    [seedCommandMode, restoredQuery, initialQuery],
   );
+
+  // Cmd+K joins the URL history stack: opening pushes an entry, so the top-bar back arrow
+  // (and the browser back gesture) closes the palette instead of leaving the page. When a
+  // row sends the user to the results page, that entry keeps the search — so back from the
+  // results page reopens the palette with it rather than landing on a bare page.
+  const { markNavigating, setPayload } = useHistoryBackedOverlay<InitialQueryData>({
+    open,
+    onClose: () => onOpenChange(false),
+    onRestore: restored => {
+      setRestoredQuery(restored ?? null);
+      onOpenChange(true);
+    },
+    id: 'command-menu',
+    enabled: !inline && !contextSelectionMode,
+  });
+
+  // A restore only seeds the open it triggered — the next plain cmd+K starts empty.
+  useEffect(() => {
+    if (!open) setRestoredQuery(null);
+  }, [open]);
 
   useShortcutById(
     'global.search',
@@ -995,6 +1023,20 @@ const ChannelCommandMenu = ({
     return params;
   }
 
+  // Keep the palette's history entry carrying the current search. The palette can be left
+  // in many ways — opening a DM, a channel, a message, a ticket, the results page — and
+  // each goes through its own handler, so recording it here is what makes ANY of them
+  // restorable when the user comes back.
+  useEffect(() => {
+    if (!open) return;
+    setPayload({
+      text: searchText,
+      // The cast is the hook's looser `prefix: string` meeting the editor's prefix union —
+      // same values at runtime, they're only ever set from that union.
+      mentions: selectedMentions.map(m => ({ ...m, name: m.name ?? m.id })) as MentionData[],
+    });
+  }, [open, searchText, selectedMentions, setPayload]);
+
   // Leave the palette for the full-screen results page via the "Show results for" row.
   // Logged as its own event so the jump-out rate is readable per palette and trigger.
   const goToSearchResults = (trigger: 'click' | 'keyboard'): void => {
@@ -1002,6 +1044,10 @@ const ChannelCommandMenu = ({
     if (navigatingToResultsRef.current) return;
     navigatingToResultsRef.current = true;
     showResultsTriggerRef.current = 'keyboard';
+
+    // Mark the close as a navigation so the palette's entry isn't popped out from under
+    // us. The search itself is already on that entry, kept current by the effect above.
+    markNavigating();
 
     // Metrics must never be able to swallow the navigation.
     try {

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchQueryInput.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchQueryInput.tsx
@@ -85,9 +85,9 @@ export function SearchQueryInput({
         aria-label='Search query'
         className={cn(
           'flex-1 min-w-0 bg-transparent text-sm placeholder:text-muted-foreground outline-none',
-          // Uncommitted edits read as "not searched yet" in the accent colour; once Enter
-          // lands the text is what the results below are for, so it settles back to grey.
-          isDirty ? 'text-primary' : 'text-muted-foreground',
+          // Uncommitted edits sit at full contrast; once Enter lands the text is what the
+          // results below are for, so it settles back to grey.
+          isDirty ? 'text-foreground' : 'text-muted-foreground',
         )}
         data-track-category='SEARCH_RESULTS'
         data-track-name='EDIT_QUERY'

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchQueryInput.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchQueryInput.tsx
@@ -1,0 +1,116 @@
+import { ReactElement, useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { CornerDownLeft, Loader2, Search, X } from 'lucide-react';
+import { cn } from '../../../utils/classNames';
+import { useShortcut } from '../../../shortcuts';
+
+interface SearchQueryInputProps {
+  /** The committed query — the one the results currently on screen were fetched for. */
+  query: string;
+  /** Runs a new search. Receives the trimmed text; '' drops the free-text query. */
+  onSubmit: (next: string) => void;
+  /** True while a search is in flight — swaps the leading icon for a spinner. */
+  isSearching: boolean;
+}
+
+/**
+ * Editable query box for the full-screen search results header. Replaces the old
+ * static "Results for: <query>" line so the query can be refined in place instead of
+ * reopening the cmd+K overlay. Filters stay where they are — this edits free text only.
+ */
+export function SearchQueryInput({
+  query,
+  onSubmit,
+  isSearching,
+}: SearchQueryInputProps): ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(query);
+
+  // Re-sync whenever the committed query changes underneath us: back/forward, a fresh
+  // cmd+K search while the screen is mounted, or our own commit landing in the URL.
+  useEffect(() => {
+    setValue(query);
+  }, [query]);
+
+  // `/` from anywhere on the results screen jumps into the box. Registered without
+  // allowInInputs, so it stays a literal slash whenever a field already has focus.
+  useShortcut('/', () => inputRef.current?.focus(), {
+    scope: 'global',
+    useKey: true,
+    description: 'Focus search box',
+    category: 'Navigation',
+  });
+
+  const isDirty = value.trim() !== query;
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onSubmit(value.trim());
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        // First Escape discards the edit; the box keeps focus so it can be retyped.
+        setValue(query);
+      }
+    },
+    [onSubmit, query, value],
+  );
+
+  const handleClear = useCallback((): void => {
+    setValue('');
+    onSubmit('');
+    inputRef.current?.focus();
+  }, [onSubmit]);
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 h-10 px-3 rounded-xl border border-border bg-background',
+        'transition-colors focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20',
+      )}
+    >
+      {isSearching ? (
+        <Loader2 size={16} className='shrink-0 animate-spin text-primary' />
+      ) : (
+        <Search size={16} className='shrink-0 text-muted-foreground' />
+      )}
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder='Search messages, files, tickets…'
+        aria-label='Search query'
+        className={cn(
+          'flex-1 min-w-0 bg-transparent text-sm placeholder:text-muted-foreground outline-none',
+          // Uncommitted edits read as "not searched yet" in the accent colour; once Enter
+          // lands the text is what the results below are for, so it settles back to grey.
+          isDirty ? 'text-primary' : 'text-muted-foreground',
+        )}
+        data-track-category='SEARCH_RESULTS'
+        data-track-name='EDIT_QUERY'
+      />
+      {value.length > 0 && (
+        <button
+          type='button'
+          onClick={handleClear}
+          aria-label='Clear search'
+          title='Clear search'
+          className='shrink-0 rounded p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition'
+          data-track-category='SEARCH_RESULTS'
+          data-track-name='CLEAR_QUERY'
+        >
+          <X size={14} />
+        </button>
+      )}
+      {isDirty && (
+        <span className='hidden sm:inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground'>
+          <CornerDownLeft size={11} />
+          to search
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -40,6 +40,7 @@ import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWit
 import { SearchSnippetRenderer } from '../RenderMessageWithHTML/searchSnippetRender';
 import { SearchResultsContext, SearchResultsThread } from './SearchResultsContext';
 import { SearchFilterBar } from './SearchFilterBar';
+import { SearchQueryInput } from './SearchQueryInput';
 import {
   useAllVisibleChannels,
   useAllChannels,
@@ -172,7 +173,7 @@ function buildSelectedMentions(
 }
 
 const SearchResults = (): ReactElement => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { isMobile } = usePlatform();
   const [selectedPanel, setSelectedPanel] = useState<SidePanelState>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -489,6 +490,30 @@ const SearchResults = (): ReactElement => {
       mentionChannelName,
     ],
   );
+
+  // Editing the query in the header re-runs the search through the URL, the same path a
+  // cmd+K search takes, so back/forward and the overlay's query restore keep working.
+  // Filters live in their own params and are deliberately left untouched.
+  const handleQuerySubmit = useCallback(
+    (next: string) => {
+      if (next === query) return;
+      setSearchParams(
+        prev => {
+          const params = new URLSearchParams(prev);
+          if (next) params.set('query', next);
+          else params.delete('query');
+          // `display` is the pre-rendered label the top bar shows, built from mention
+          // names when the search was launched. It can't be patched from here, so drop
+          // it and let the bar fall back to the query it now shows.
+          params.delete('display');
+          return params;
+        },
+        { preventScrollReset: true },
+      );
+    },
+    [query, setSearchParams],
+  );
+
   // Use filteredLocalChannels from the hook (same data pipeline as cmdK).
   // Guard against empty query so we don't show all channels before the user types.
   const localChannelResults = useMemo((): DisplaySearchResult[] => {
@@ -744,11 +769,9 @@ const SearchResults = (): ReactElement => {
   const resultsColumn = (
     <div className='relative flex flex-col h-full min-h-0'>
       <div className='shrink-0 px-4'>
-        {query && (
-          <p className='pt-4 text-base text-muted-foreground'>
-            Results for: <span className='font-semibold text-foreground'>{query}</span>
-          </p>
-        )}
+        <div className='pt-4'>
+          <SearchQueryInput query={query} onSubmit={handleQuerySubmit} isSearching={isLoading} />
+        </div>
         <div className='mt-3'>
           <SearchFilterBar filters={filters} onFiltersChange={handleFiltersChange} />
         </div>
@@ -775,7 +798,17 @@ const SearchResults = (): ReactElement => {
           </div>
         )}
       </div>
-      <div ref={scrollRef} className='flex-1 min-h-0 overflow-y-auto px-4'>
+      <div
+        ref={scrollRef}
+        className={cn(
+          // pb-16 so the last card clears the bottom of the viewport instead of sitting
+          // flush against it (and above the floating compare bar when it's up).
+          'flex-1 min-h-0 overflow-y-auto px-4 pb-16',
+          // A re-search keeps the previous results on screen rather than blanking to a
+          // spinner — they fade back while the new ones land, and the box spins.
+          isLoading && results.length > 0 && 'opacity-50 transition-opacity duration-150',
+        )}
+      >
         <TicketSearchHighlightContext.Provider value={ticketHighlightMap}>
           <ResultsBody
             query={query}

--- a/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
+++ b/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/** Key stamped into the router location state that marks an overlay's history entry. */
+const OVERLAY_STATE_KEY = 'xyneOverlay';
+/** Key holding whatever the overlay wants handed back when the user returns to its entry. */
+const OVERLAY_PAYLOAD_KEY = 'xyneOverlayPayload';
+
+interface HistoryBackedOverlayParams<TPayload> {
+  /** Whether the overlay is currently open. */
+  open: boolean;
+  /** Closes the overlay. Called when the user pops our entry off the stack. */
+  onClose: () => void;
+  /**
+   * Reopens the overlay when the user comes BACK to its entry from somewhere the overlay
+   * navigated to, handing back the payload passed to `markNavigating`.
+   */
+  onRestore?: (payload: TPayload | undefined) => void;
+  /** Identifies this overlay in the location state, so nested overlays don't cross-close. */
+  id: string;
+  /** Set false for embedded/inline usages that are never really "open". */
+  enabled?: boolean;
+}
+
+/**
+ * Puts an overlay's open state on the history stack.
+ *
+ * Opening pushes an entry for the SAME url carrying a marker in the router's location
+ * state, so the top-bar back arrow — and the browser/trackpad back gesture, which reach
+ * this through the same router pop — close the overlay instead of leaving the page.
+ * Closing it any other way (Escape, click-outside) pops that entry back off, so the stack
+ * is left exactly as it was found.
+ *
+ * When the overlay closes *because it navigated somewhere*, it calls `markNavigating` with
+ * whatever it needs to come back to. That stamps the payload onto its entry, which the
+ * destination is then pushed on top of — so pressing back from the destination lands on the
+ * marked entry and reopens the overlay in the state the user left it in, rather than
+ * dumping them on a bare page.
+ */
+export function useHistoryBackedOverlay<TPayload = unknown>({
+  open,
+  onClose,
+  onRestore,
+  id,
+  enabled = true,
+}: HistoryBackedOverlayParams<TPayload>): {
+  markNavigating: () => void;
+  setPayload: (payload: TPayload) => void;
+} {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const onRestoreRef = useRef(onRestore);
+  onRestoreRef.current = onRestore;
+
+  // True once we've pushed (or adopted) an entry for the current open stretch —
+  // distinguishes "the user just opened it" from "the user popped our entry", which look
+  // identical from the location state alone.
+  const pushedRef = useRef(false);
+
+  // Set by the overlay right before it closes itself *and* navigates. Without it the
+  // close branch below can race the navigation — if this effect runs before the router
+  // has committed the new location, the entry still looks current and we pop, undoing
+  // the navigation and leaving the user exactly where they started.
+  const navigatingRef = useRef(false);
+
+  // True when this open stretch came from a restore, i.e. we adopted an entry we never
+  // pushed. Closing then must NOT pop it: the user navigated back INTO this entry, and
+  // popping would throw them a step further back than they asked for.
+  const adoptedRef = useRef(false);
+
+  // The entry we last restored, so closing the overlay doesn't immediately re-restore it.
+  const restoredKeyRef = useRef<string | null>(null);
+
+  // True between scheduling a pop and it landing. Without it the restore branch fires in
+  // that gap — the overlay is closed and still standing on its own entry — and springs
+  // the overlay straight back open.
+  const poppingRef = useRef(false);
+
+  const state = location.state as Record<string, unknown> | null;
+  const isOverlayEntry = state?.[OVERLAY_STATE_KEY] === id;
+  const payload = state?.[OVERLAY_PAYLOAD_KEY] as TPayload | undefined;
+
+  // Read inside callbacks that run outside render, where `location` would be stale.
+  const hrefRef = useRef('');
+  hrefRef.current = `${location.pathname}${location.search}${location.hash}`;
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  useEffect(() => {
+    if (!enabled) {
+      pushedRef.current = false;
+      return;
+    }
+
+    if (open && !pushedRef.current) {
+      pushedRef.current = true;
+      navigatingRef.current = false;
+      // Already standing on our entry (a restore) — adopt it instead of stacking another.
+      if (isOverlayEntry) {
+        adoptedRef.current = true;
+        return;
+      }
+      adoptedRef.current = false;
+      void navigate(hrefRef.current, {
+        state: { ...state, [OVERLAY_STATE_KEY]: id },
+        preventScrollReset: true,
+      });
+      return;
+    }
+
+    // Our entry is gone while the overlay is still open — the user went back. Skipped
+    // while navigating away, where the same shape means "the destination just landed".
+    if (open && pushedRef.current && !isOverlayEntry && !navigatingRef.current) {
+      pushedRef.current = false;
+      onCloseRef.current();
+      return;
+    }
+
+    // Back onto our entry with the overlay closed: the user returned from wherever the
+    // overlay sent them. Reopen it with what they left behind.
+    //
+    // Gated on the payload, which only `markNavigating` writes. A bare marker means the
+    // overlay was merely open here — restoring on that would fight every ordinary close,
+    // reopening the overlay in the gap before its entry is popped.
+    if (
+      !open &&
+      !pushedRef.current &&
+      !poppingRef.current &&
+      isOverlayEntry &&
+      payload !== undefined &&
+      restoredKeyRef.current !== location.key &&
+      onRestoreRef.current
+    ) {
+      restoredKeyRef.current = location.key;
+      onRestoreRef.current(payload);
+      return;
+    }
+
+    // Closed some other way. Pop our entry, unless the close came with a navigation
+    // (then the marker is no longer the current entry and popping would undo it).
+    if (!open && pushedRef.current) {
+      pushedRef.current = false;
+      const wasNavigating = navigatingRef.current;
+      const wasAdopted = adoptedRef.current;
+      navigatingRef.current = false;
+      adoptedRef.current = false;
+      if (wasNavigating || wasAdopted || !isOverlayEntry) return;
+
+      // Deferred by a task so any navigation started in the same handler has committed
+      // first, then re-checked against live history — react-router keeps location state
+      // under `usr`. Rows that close the palette *and* navigate (a channel, a result, the
+      // results page) all pass through here; popping on top of their push would silently
+      // undo it. If the shape ever changes the check just fails and we skip the pop — a
+      // stale entry, never a cancelled navigation.
+      poppingRef.current = true;
+      const timer = setTimeout(() => {
+        const live = window.history.state as { usr?: Record<string, unknown> } | null;
+        if (live?.usr?.[OVERLAY_STATE_KEY] === id) void navigate(-1);
+        poppingRef.current = false;
+      }, 0);
+      return () => {
+        clearTimeout(timer);
+        poppingRef.current = false;
+      };
+    }
+    return undefined;
+    // `location` is read for the push url only — re-running on every location change
+    // would re-push while the overlay stays open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, isOverlayEntry, enabled, id, navigate]);
+
+  const markNavigating = useCallback((): void => {
+    navigatingRef.current = true;
+  }, []);
+
+  /**
+   * Keeps the overlay's own history entry up to date with whatever should be handed back
+   * if the user ever returns to it. Call it as the state changes — the overlay can be left
+   * in a hundred ways (a result, a channel, a DM, the results page, an external link), and
+   * only the entry itself is guaranteed to still be there afterwards.
+   *
+   * Written straight to `window.history` rather than through the router: this is the
+   * current entry, the url is unchanged, and a router replace would re-render the tree on
+   * every keystroke. React Router reads `usr` back out on a pop, so a restore still sees it.
+   */
+  const setPayload = useCallback(
+    (nextPayload: TPayload): void => {
+      const live = window.history.state as {
+        usr?: Record<string, unknown> | null;
+        key?: string;
+        idx?: number;
+      } | null;
+      if (live?.usr?.[OVERLAY_STATE_KEY] !== id) return;
+      window.history.replaceState(
+        { ...live, usr: { ...live.usr, [OVERLAY_PAYLOAD_KEY]: nextPayload } },
+        '',
+      );
+    },
+    [id],
+  );
+
+  return { markNavigating, setPayload };
+}

--- a/apps/dashboard/src/services/searchMetricsService.ts
+++ b/apps/dashboard/src/services/searchMetricsService.ts
@@ -11,6 +11,7 @@ import type {
   SearchClickEvent,
   SearchSessionEndEvent,
   SearchTabClickEvent,
+  SearchShowResultsEvent,
 } from '../types/searchEvents';
 import * as otelMetrics from './otel/searchMetrics';
 import { SEARCH_VERSION } from '../config';
@@ -260,6 +261,33 @@ class SearchMetricsService {
         tab: params.tab,
       });
     });
+  }
+
+  /**
+   * Track when a user leaves the palette for the full-screen results page via the
+   * "Show results for" row. Log-only by design — the OTel counters carry the search
+   * funnel (impression → click), and this is a navigation signal read from the logs.
+   */
+  trackShowResults(params: {
+    searchSessionId: string;
+    userId: string;
+    queryText: string;
+    tab: TabType;
+    trigger: 'click' | 'keyboard';
+    searchMode: 'popup' | 'screen';
+    filtersUsed: number;
+  }): void {
+    const event: SearchShowResultsEvent = {
+      search_session_id: params.searchSessionId,
+      user_id: params.userId,
+      query_text: params.queryText,
+      query_text_length: countWords(params.queryText),
+      tab: params.tab,
+      trigger: params.trigger,
+      search_mode: params.searchMode,
+      filters_used: params.filtersUsed,
+    };
+    logger.info(Event.VESPA_SEARCH_SHOW_RESULTS, event as unknown as Record<string, unknown>);
   }
 }
 

--- a/apps/dashboard/src/types/searchEvents.ts
+++ b/apps/dashboard/src/types/searchEvents.ts
@@ -158,6 +158,40 @@ export interface SearchTabClickEvent extends CommonEventFields {
 }
 
 /**
+ * Event: vespa_search_show_results
+ * Triggered when the user leaves the cmd+K palette for the full-screen results
+ * page via the "Show results for" row. Tells us how often the palette's inline
+ * results are not enough, split by how the row was reached.
+ */
+export interface SearchShowResultsEvent extends CommonEventFields {
+  query_text: string;
+  /**
+   * Number of words in the query text
+   */
+  query_text_length: number;
+  /**
+   * The tab the palette was on when the user jumped out
+   */
+  tab: string;
+  /**
+   * How the row was activated
+   * - click: User clicked (or tapped) the row
+   * - keyboard: User pressed Enter with the row selected
+   */
+  trigger: 'click' | 'keyboard';
+  /**
+   * Which palette the user came from
+   * - popup: the default cmd+K palette that renders results inline
+   * - screen: the top-bar search bar, which always routes to the results page
+   */
+  search_mode: 'popup' | 'screen';
+  /**
+   * Number of filter chips (from:/in:/assignee:/priority:) carried over
+   */
+  filters_used: number;
+}
+
+/**
  * Union type of all possible search metric events
  */
 export type SearchMetricEvent =
@@ -165,4 +199,5 @@ export type SearchMetricEvent =
   | SearchImpressionEvent
   | SearchClickEvent
   | SearchSessionEndEvent
-  | SearchTabClickEvent;
+  | SearchTabClickEvent
+  | SearchShowResultsEvent;

--- a/apps/dashboard/src/utils/logger.ts
+++ b/apps/dashboard/src/utils/logger.ts
@@ -77,6 +77,7 @@ export const Event = {
   VESPA_SEARCH_CLICK: 'vespa_search_click',
   VESPA_SEARCH_SESSION_END: 'vespa_search_session_end',
   VESPA_SEARCH_TAB_CLICK: 'vespa_search_tab_click',
+  VESPA_SEARCH_SHOW_RESULTS: 'vespa_search_show_results',
   APP_LOADER_HIDDEN: 'app_loader_hidden',
   INITIAL_STATE_HYDRATION_COMPLETE: 'initial_state_hydration_complete',
   INITIAL_STATE_HYDRATION_FAILED: 'initial_state_hydration_failed',


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-56181 — makes the full-screen search page usable without going back through
cmd+K, and gives the palette a consistent way to hand off to it.

**Full-screen results page**
- The static `Results for: <query>` line becomes an editable input. Enter re-runs the
  search by writing `?query=` — the same URL path a cmd+K search takes, so
  back/forward and the palette's query-restore keep working. ✕ clears, Esc discards
  the edit, `/` focuses the box.
- The leading icon becomes a spinner while a search is in flight. Previously a
  re-search over existing results showed no feedback at all: the only spinner was the
  zero-results one.
- A re-search keeps the existing result cards on screen at 50% opacity instead of
  blanking the page.
- `pb-16` on the scroll container so the last card clears the bottom of the viewport.

**cmd+K**
- The "Show detailed results for: <query>" row now renders in the default popup, not
  just the top-bar screen-mode palette, and is pinned as the first item under the tabs
  so its position never shifts.
- The default Enter target is unchanged: both the first-row auto-select and the Enter
  fallback skip this row, so Enter still opens the top result. Screen mode keeps its
  original row position and Enter behaviour.
- The row is wired with an explicit `onClick` alongside cmdk's `onSelect` (de-duped by
  a ref), so activation doesn't depend on cmdk's selection state.

**Telemetry**
- New `vespa_search_show_results` log event whenever the palette hands off to the
  results page, with query text + word count, tab, `trigger` (click/keyboard),
  `search_mode` (popup/screen), and `filters_used`. Log line only — no new OTel
  counter/time series. Previously this hand-off was only visible in the websocket
  activity log, not in Grafana.

Commits: `bb35158fc` (feature), `ccef86aa1` (label + query-text colour).

Deliberately **not** in this PR: binding cmd+K to the URL history stack so the back
arrow closes the palette. It was built and then pulled out to keep this scoped —
parked on `backup/XYNE-56181-with-cmdk-history`.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

6 files, all under `apps/dashboard/src`:
`components/Chat/SearchResults/SearchQueryInput.tsx` (new),
`components/Chat/SearchResults/SearchResults.tsx`,
`components/Chat/ChatDirectory/ChannelCommandMenu.tsx`,
`services/searchMetricsService.ts`, `types/searchEvents.ts`, `utils/logger.ts`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

<!-- Screenshots / recording to be added. -->

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — presentational + navigation wiring in the cmd+K palette
      and the search results screen, neither of which has existing unit coverage.
      Verified via typecheck, lint and the full pre-commit build on both commits.

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes (no shared changes in this PR; shared builds clean)
- [ ] Backend `typecheck` + `build` pass — n/a, no backend files touched (pre-commit
      skipped them for that reason)
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass — ran in full by the
      pre-commit hook on both commits
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>` — n/a, no new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed — none needed
- [x] No debug logging or commented-out code left behind

<img width="904" height="629" alt="image" src="https://github.com/user-attachments/assets/cc28744d-8b0d-48c5-be74-b52100afa73a" />
<img width="1727" height="1010" alt="image" src="https://github.com/user-attachments/assets/fb425754-613c-4aad-88f7-055367b3f111" />
<img width="1002" height="785" alt="image" src="https://github.com/user-attachments/assets/e0ecafa4-f19a-4437-9984-98ca1e2e3bf0" />
