### PR TITLE
feat: enforce configurable /goal wall-clock budget (maxTime=)

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260814120000_active_goal_wall_clock_budget/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260814120000_active_goal_wall_clock_budget/migration.sql
@@ -1,0 +1,5 @@
+-- Adds an optional wall-clock budget (milliseconds) to active goals.
+-- Nullable + no default: existing rows keep NULL (no time cap), so this is a
+-- backward-compatible additive change. Enforced by the relooper alongside
+-- maxTurns as the second mandatory ceiling for user-configured loops.
+ALTER TABLE "active_goals" ADD COLUMN "maxWallClockMs" INTEGER;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1782,6 +1782,7 @@ model ActiveGoal {
   status         String   @default("active") /// "active" | "done" | "cancelled" | "failed"
   turnCount      Int      @default(0) /// Turns completed so far
   maxTurns       Int      @default(5) /// Hard cap, enforced by relooper. Default 5: covers worker → audit → 1-2 fix cycles. Longer loops tend to burn LLM cost on judge-driven rabbit holes (e.g. judge falsely flagging missing attachments).
+  maxWallClockMs Int? /// Optional wall-clock budget (ms) measured from createdAt; enforced by relooper alongside maxTurns. Null = no time cap (legacy/default). Second mandatory ceiling for user-configured loops.
   lastTurnResult String? /// Most recent worker output (≤ 4KB stored)
   lastReason     String? /// Last boss reason or terminal reason
   runPayload     Json /// Stashed first-turn /run inputs to replay

--- a/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseSlashCommand } from "./parseSlashCommand.js";
+import { parseDurationMs, parseSlashCommand } from "./parseSlashCommand.js";
 
 describe("parseSlashCommand — /goal options", () => {
   it("parses a bare /goal as a condition with no overrides", () => {
@@ -72,5 +72,64 @@ describe("parseSlashCommand — /goal options", () => {
     expect(parseSlashCommand("/goal status")).toEqual({ kind: "goalStatus" });
     expect(parseSlashCommand("/stop")).toEqual({ kind: "goalClear" });
     expect(parseSlashCommand("/help")).toEqual({ kind: "help" });
+  });
+});
+
+describe("parseSlashCommand — /goal maxTime= (wall-clock budget)", () => {
+  it("parses maxTime=30m into milliseconds", () => {
+    const cmd = parseSlashCommand("/goal maxTime=30m keep iterating");
+    expect(cmd).toMatchObject({ kind: "goalStart", condition: "keep iterating", maxWallClockMs: 1_800_000 });
+  });
+
+  it("treats a bare number as MINUTES", () => {
+    expect(parseSlashCommand("/goal maxTime=30 x")).toMatchObject({ maxWallClockMs: 1_800_000 });
+  });
+
+  it("accepts h / s / ms units and max_time / timeout / deadline aliases", () => {
+    expect(parseSlashCommand("/goal maxTime=2h x")).toMatchObject({ maxWallClockMs: 7_200_000 });
+    expect(parseSlashCommand("/goal max_time=45s x")).toMatchObject({ maxWallClockMs: 45_000 });
+    expect(parseSlashCommand("/goal timeout=500ms x")).toMatchObject({ maxWallClockMs: 500 });
+    expect(parseSlashCommand("/goal deadline=10m x")).toMatchObject({ maxWallClockMs: 600_000 });
+  });
+
+  it("clamps above the 6h hard cap", () => {
+    const cmd = parseSlashCommand("/goal maxTime=99h run forever");
+    expect(cmd).toMatchObject({ maxWallClockMs: 6 * 60 * 60 * 1000 });
+  });
+
+  it("treats invalid maxTime as goal text", () => {
+    const cmd = parseSlashCommand("/goal maxTime=soon finish up");
+    expect(cmd).toMatchObject({ kind: "goalStart", condition: "maxTime=soon finish up" });
+    expect(cmd).not.toHaveProperty("maxWallClockMs");
+  });
+
+  it("combines maxTurns=, maxTime= and model= in one command", () => {
+    const cmd = parseSlashCommand("/goal model=open-large maxTurns=8 maxTime=1h tidy the backlog");
+    expect(cmd).toMatchObject({
+      kind: "goalStart",
+      condition: "tidy the backlog",
+      providerOverride: { provider: "spaces", model: "open-large" },
+      maxTurns: 8,
+      maxWallClockMs: 3_600_000,
+    });
+  });
+});
+
+describe("parseDurationMs", () => {
+  it("parses units", () => {
+    expect(parseDurationMs("500ms")).toBe(500);
+    expect(parseDurationMs("45s")).toBe(45_000);
+    expect(parseDurationMs("30m")).toBe(1_800_000);
+    expect(parseDurationMs("2h")).toBe(7_200_000);
+  });
+  it("defaults a bare number to minutes", () => {
+    expect(parseDurationMs("15")).toBe(900_000);
+  });
+  it("returns undefined for junk / non-positive", () => {
+    expect(parseDurationMs("abc")).toBeUndefined();
+    expect(parseDurationMs("0")).toBeUndefined();
+    expect(parseDurationMs("-5m")).toBeUndefined();
+    expect(parseDurationMs("")).toBeUndefined();
+    expect(parseDurationMs("10x")).toBeUndefined();
   });
 });

--- a/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.ts
@@ -16,7 +16,7 @@
 export type ProviderOverride = { provider: string; model?: string };
 
 export type SlashCommand =
-  | { kind: "goalStart"; condition: string; providerOverride?: ProviderOverride; maxTurns?: number }
+  | { kind: "goalStart"; condition: string; providerOverride?: ProviderOverride; maxTurns?: number; maxWallClockMs?: number }
   | { kind: "goalStatus" }
   | { kind: "goalClear" }
   // `/clear` — wipe this thread's agent session (forget prior context).
@@ -59,6 +59,26 @@ const GOAL_OVERRIDABLE_PROVIDERS = new Set(["spaces", "litellm", "claude", "code
 // applies. Anything above this cap is clamped down — a user-configured loop
 // must never be able to schedule unbounded, cost-bearing agent turns.
 const GOAL_MAX_TURNS_CAP = 20;
+// Hard ceiling for a user-supplied `/goal maxTime=…` wall-clock budget: 6h.
+// Absent → no time cap (only maxTurns applies). Like maxTurns, this bounds a
+// user-configured loop so it can never run unbounded, cost-bearing turns.
+const GOAL_MAX_WALL_CLOCK_MS_CAP = 6 * 60 * 60 * 1000;
+
+/**
+ * Parse a compact duration like `30m`, `2h`, `45s`, `500ms`, or a bare
+ * integer (interpreted as MINUTES) into milliseconds. Returns undefined for
+ * anything non-positive or malformed so the caller can preserve it as goal
+ * text rather than silently coercing junk.
+ */
+export function parseDurationMs(raw: string): number | undefined {
+  const m = /^(\d+)(ms|s|m|h)?$/iu.exec(raw.trim());
+  if (!m) return undefined;
+  const n = Number.parseInt(m[1] ?? "", 10);
+  if (!Number.isInteger(n) || n <= 0) return undefined;
+  const unit = (m[2] ?? "m").toLowerCase();
+  const mult = unit === "ms" ? 1 : unit === "s" ? 1000 : unit === "h" ? 3_600_000 : 60_000;
+  return n * mult;
+}
 
 export function parseSlashCommand(input: string | undefined | null): SlashCommand | null {
   if (!input) return null;
@@ -145,6 +165,7 @@ function parseFromSlash(trimmed: string): SlashCommand | null {
       condition: condition.slice(0, 2_000),
       ...(parsed.providerOverride ? { providerOverride: parsed.providerOverride } : {}),
       ...(parsed.maxTurns != null ? { maxTurns: parsed.maxTurns } : {}),
+      ...(parsed.maxWallClockMs != null ? { maxWallClockMs: parsed.maxWallClockMs } : {}),
     };
   }
   return null;
@@ -153,10 +174,11 @@ function parseFromSlash(trimmed: string): SlashCommand | null {
 /** Extract the same provider/model tokens as `/experiment` while leaving the
  * remaining text as the goal's exit condition. A model-only override uses the
  * Spaces provider, matching `/experiment`'s default. */
-function parseGoalStart(raw: string): { condition: string; providerOverride?: ProviderOverride; maxTurns?: number } {
+function parseGoalStart(raw: string): { condition: string; providerOverride?: ProviderOverride; maxTurns?: number; maxWallClockMs?: number } {
   let provider: string | undefined;
   let model: string | undefined;
   let maxTurns: number | undefined;
+  let maxWallClockMs: number | undefined;
   const conditionParts: string[] = [];
   for (const part of raw.trim().split(/\s+/)) {
     const match = /^([^=]+)=(.*)$/u.exec(part);
@@ -182,6 +204,14 @@ function parseGoalStart(raw: string): { condition: string; providerOverride?: Pr
       else conditionParts.push(part);
       continue;
     }
+    if (key === "maxtime" || key === "max_time" || key === "maxwallclock" || key === "timeout" || key === "deadline") {
+      const ms = parseDurationMs(match?.[2] ?? "");
+      // Valid positive duration only; clamp to the hard cap. Junk is kept as
+      // goal text rather than silently coerced — mirrors maxTurns handling.
+      if (ms != null) maxWallClockMs = Math.min(ms, GOAL_MAX_WALL_CLOCK_MS_CAP);
+      else conditionParts.push(part);
+      continue;
+    }
     conditionParts.push(part);
   }
   const condition = conditionParts.join(" ").replace(/^focus=/i, "").trim();
@@ -190,5 +220,6 @@ function parseGoalStart(raw: string): { condition: string; providerOverride?: Pr
     condition,
     ...(resolvedProvider ? { providerOverride: { provider: resolvedProvider, ...(model ? { model } : {}) } } : {}),
     ...(maxTurns != null ? { maxTurns } : {}),
+    ...(maxWallClockMs != null ? { maxWallClockMs } : {}),
   };
 }

--- a/apps/xyne-claw-auth/backend/src/repositories/activeGoalRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/activeGoalRepository.ts
@@ -30,9 +30,11 @@ export const activeGoalRepository = {
     orgId: string;
     condition: string;
     maxTurns?: number;
+    maxWallClockMs?: number | null;
     runPayload: Prisma.InputJsonValue;
   }) {
     const max = args.maxTurns ?? Number(process.env["GOAL_MAX_TURNS_DEFAULT"] ?? 5);
+    const maxWallClockMs = args.maxWallClockMs ?? null;
     return prisma.activeGoal.upsert({
       where: { conversationId: args.conversationId },
       update: {
@@ -40,6 +42,7 @@ export const activeGoalRepository = {
         agentSlug: args.agentSlug,
         condition: args.condition,
         maxTurns: max,
+        maxWallClockMs,
         runPayload: args.runPayload,
         orgId: args.orgId,
         status: "active",
@@ -59,6 +62,7 @@ export const activeGoalRepository = {
         orgId: args.orgId,
         condition: args.condition,
         maxTurns: max,
+        maxWallClockMs,
         runPayload: args.runPayload,
         status: "active",
       },

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -1800,7 +1800,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       conversationId: payload.conversationId,
       markdownText: [
         "**Slash commands**",
-        "- `/goal <condition>` — work autonomously until the condition is met · options: `model=<name>` `provider=<name>` `maxTurns=<1-20>`",
+        "- `/goal <condition>` — work autonomously until the condition is met · options: `model=<name>` `provider=<name>` `maxTurns=<1-20>` `maxTime=<30m|2h>`",
         "- `/goal status` — show the active goal",
         "- `/experiment <duration> [focus...]` — explore until the deadline · `/experiment status` · `/experiment stop`",
         "- `/stop` (or `/goal clear`) — stop the current run, drop queued messages, and clear any active goal",
@@ -1964,7 +1964,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       ? slash
       : null;
   const intercept = await handleSlashCommandBeforeRun({ command: goalCommand, conversationId: payload.conversationId });
-  let pendingGoalStart: { condition: string; providerOverride?: { provider: string; model?: string }; maxTurns?: number } | null = null;
+  let pendingGoalStart: { condition: string; providerOverride?: { provider: string; model?: string }; maxTurns?: number; maxWallClockMs?: number } | null = null;
   let task: string;
   if (intercept.kind === "goalStatusReply" || intercept.kind === "goalCleared") {
     await spacesAppFetch("/chat/postMessage", {
@@ -1989,6 +1989,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       condition: intercept.condition,
       ...(intercept.providerOverride ? { providerOverride: intercept.providerOverride } : {}),
       ...(intercept.maxTurns != null ? { maxTurns: intercept.maxTurns } : {}),
+      ...(intercept.maxWallClockMs != null ? { maxWallClockMs: intercept.maxWallClockMs } : {}),
     };
     task = intercept.firstTurnTask;
     // Show "Starting /goal…" on the ephemeral progress spinner (same surface as
@@ -3015,6 +3016,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
           orgId: agent.orgId,
           condition: pendingGoalStart.condition,
           ...(pendingGoalStart.maxTurns != null ? { maxTurns: pendingGoalStart.maxTurns } : {}),
+          ...(pendingGoalStart.maxWallClockMs != null ? { maxWallClockMs: pendingGoalStart.maxWallClockMs } : {}),
           // dispatchPayload is JSON-safe by construction (strings / arrays /
           // plain objects only); the cast satisfies Prisma's InputJsonValue
           // brand which doesn't accept Record<string, unknown> directly.

--- a/apps/xyne-claw-auth/backend/src/services/goalRelooper.budget.test.ts
+++ b/apps/xyne-claw-auth/backend/src/services/goalRelooper.budget.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDurationMs, isWallClockExceeded } from "./loopBudget.js";
+
+describe("isWallClockExceeded", () => {
+  const created = new Date("2026-08-14T10:00:00.000Z");
+  const createdMs = created.getTime();
+
+  it("is false before the budget elapses", () => {
+    expect(isWallClockExceeded(created, 30 * 60_000, createdMs + 29 * 60_000)).toBe(false);
+  });
+
+  it("is true exactly at the budget boundary (>=)", () => {
+    expect(isWallClockExceeded(created, 30 * 60_000, createdMs + 30 * 60_000)).toBe(true);
+  });
+
+  it("is true after the budget elapses", () => {
+    expect(isWallClockExceeded(created, 30 * 60_000, createdMs + 31 * 60_000)).toBe(true);
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("prefers the largest whole unit", () => {
+    expect(formatDurationMs(7_200_000)).toBe("2h");
+    expect(formatDurationMs(1_800_000)).toBe("30m");
+    expect(formatDurationMs(45_000)).toBe("45s");
+    expect(formatDurationMs(500)).toBe("500ms");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
+++ b/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
@@ -14,6 +14,7 @@
  */
 
 import { activeGoalRepository } from "../repositories/activeGoalRepository.js";
+import { formatDurationMs, isWallClockExceeded } from "./loopBudget.js";
 import { judgeGoalViaClaw } from "./goalJudgeClient.js";
 import type { Prisma } from "@prisma/client";
 
@@ -149,6 +150,7 @@ export type SlashIntercept =
       replyToUser: string;
       providerOverride?: { provider: string; model?: string };
       maxTurns?: number;
+      maxWallClockMs?: number;
     }
   | { kind: "goalStatusReply"; replyToUser: string }
   | { kind: "goalCleared"; replyToUser: string }
@@ -189,6 +191,7 @@ export async function handleSlashCommandBeforeRun(args: {
       kind: "goalStatusReply",
       replyToUser:
         `**/goal status** — turn ${goal.turnCount}/${goal.maxTurns}` +
+        (goal.maxWallClockMs != null ? ` · budget ${formatDurationMs(goal.maxWallClockMs)}` : "") +
         (goal.lastReason ? ` · last: ${goal.lastReason}` : "") +
         `\n_${condPreview}_`,
     };
@@ -218,6 +221,7 @@ export async function handleSlashCommandBeforeRun(args: {
     firstTurnTask: NEXT_TURN_TASK_TEMPLATE(command.condition),
     ...(command.providerOverride ? { providerOverride: command.providerOverride } : {}),
     ...(command.maxTurns != null ? { maxTurns: command.maxTurns } : {}),
+    ...(command.maxWallClockMs != null ? { maxWallClockMs: command.maxWallClockMs } : {}),
     // Don't echo the condition back — the user just typed it, the thread
     // already contains it. A short, fixed ack keeps the thread clean even
     // when the goal is multi-paragraph.
@@ -236,6 +240,7 @@ export async function persistGoalStart(args: {
   condition: string;
   runPayload: Prisma.InputJsonValue;
   maxTurns?: number;
+  maxWallClockMs?: number;
 }): Promise<void> {
   await activeGoalRepository.startOrReplace(args);
 }
@@ -293,6 +298,19 @@ export async function recordTurnAndDecide(args: {
       kind: "terminated",
       reason: `max_turns_reached:${updated.maxTurns}`,
       replyToUser: `**/goal stopped — turn limit (${updated.maxTurns}) reached.**`,
+    };
+  }
+
+  // Wall-clock budget — the second mandatory ceiling alongside maxTurns.
+  // Enforced BEFORE the judge so a long-running loop always halts even when
+  // turns remain. Null (legacy/unset goals) means no time cap.
+  if (updated.maxWallClockMs != null && isWallClockExceeded(updated.createdAt, updated.maxWallClockMs)) {
+    const label = formatDurationMs(updated.maxWallClockMs);
+    await activeGoalRepository.terminate(conversationId, "failed", `wall_clock_exceeded:${updated.maxWallClockMs}ms`);
+    return {
+      kind: "terminated",
+      reason: `wall_clock_exceeded:${updated.maxWallClockMs}ms`,
+      replyToUser: `**/goal stopped — time budget (${label}) reached.**`,
     };
   }
 

--- a/apps/xyne-claw-auth/backend/src/services/loopBudget.ts
+++ b/apps/xyne-claw-auth/backend/src/services/loopBudget.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure loop-budget helpers, deliberately free of any DB / Prisma import so the
+ * relooper's budget guards stay unit-testable without a generated client.
+ *
+ * A goal loop is bounded by two ceilings enforced in goalRelooper:
+ *   - maxTurns       — hard cap on completed turns (always present, default 5)
+ *   - maxWallClockMs — optional wall-clock budget measured from createdAt
+ * Both must halt the loop; this module owns the wall-clock arithmetic.
+ */
+
+/**
+ * True when the elapsed time since `createdAt` meets or exceeds
+ * `maxWallClockMs`. `now` is injectable for testing.
+ */
+export function isWallClockExceeded(
+  createdAt: Date,
+  maxWallClockMs: number,
+  now: number = Date.now(),
+): boolean {
+  return now - createdAt.getTime() >= maxWallClockMs;
+}
+
+/** Compact human label for a ms duration (e.g. 1_800_000 → "30m"). */
+export function formatDurationMs(ms: number): string {
+  if (ms % 3_600_000 === 0) return `${ms / 3_600_000}h`;
+  if (ms % 60_000 === 0) return `${ms / 60_000}m`;
+  if (ms % 1000 === 0) return `${ms / 1000}s`;
+  return `${ms}ms`;
+}


### PR DESCRIPTION
## Phase 2a — the second mandatory loop ceiling (wall-clock budget)

Stacks on #600 (which added `/goal maxTurns=`). This adds the **wall-clock budget** — the second hard ceiling the command framework needs so a user-configured loop can never run unbounded, cost-bearing agent turns.

Users can now run:
```
/goal <condition> maxTime=30m
/goal <condition> maxTime=2h maxTurns=8 model=open-large
```
`maxTime=` accepts `30m` / `2h` / `45s` / `500ms`, or a bare integer interpreted as **minutes**. Aliases: `max_time=`, `timeout=`, `deadline=`. Absent → no time cap (only `maxTurns` applies). Invalid values are preserved as goal text, never silently coerced (mirrors the existing `provider=`/`model=`/`maxTurns=` handling).

### What changed
- **`parseSlashCommand.ts`** — `parseDurationMs()` + `maxTime=`/`timeout=`/`deadline=` parsing, clamped to a 6h hard cap (`GOAL_MAX_WALL_CLOCK_MS_CAP`).
- **schema + migration** — additive **nullable** `active_goals.maxWallClockMs` (`ALTER TABLE ADD COLUMN`, null = no cap → backward compatible; existing rows untouched).
- **`activeGoalRepository.startOrReplace`** — persists the budget on start/replace.
- **`loopBudget.ts`** (new, DB-free) — pure `isWallClockExceeded()` + `formatDurationMs()`, so the guard is unit-testable without a generated Prisma client.
- **`goalRelooper.recordTurnAndDecide`** — enforces the wall-clock guard **before** the judge (so the loop halts even when turns remain); budget surfaced in `/goal status`.
- **`webhook.ts` + `/help`** — threads `maxWallClockMs` through `pendingGoalStart` → `persistGoalStart`; documents `maxTime=`.

### Safety
- Enforced at parse time (6h cap) AND at every turn (before the judge). A user-authored time budget can never become a cost DoS.
- Nullable column + null-guarded enforcement → zero behavior change for existing `/goal` loops.

### Validation
- **24 unit tests pass** (`parseSlashCommand.test.ts` parser/duration/clamp + new `goalRelooper.budget.test.ts` for the pure helpers).
- `tsc --noEmit` git-stash parity: **15 == 15** errors on the touched shared files with vs without this change → **0 new type errors** (pre-existing errors are the ungenerated Prisma client + legacy implicit-any, unrelated). New pure files add 0 errors.

Note: this is Phase 2a (safety substrate only). The Phase-2 controller generalization (`LoopSpec` + generic executor) and Phases 3–4 (command registry, FlowUI authoring) are follow-ups.