### PR TITLE
fix: XYNE-62347 optimize Zero IVM — scalar channel-access ACL fast-paths + stagesByProject flip

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -3194,10 +3194,16 @@ export const queries: AnyQueryRegistry = defineQueries({
     z.object({ projectId: z.string(), boardType: z.nativeEnum(BoardType).optional() }),
     ({ args: { projectId, boardType } }) => {
       return zql.stages
-        .whereExists('board', (b) => {
-          const scoped = b.where('projectId', projectId);
-          return boardType ? scoped.where('boardType', boardType) : scoped;
-        })
+        .whereExists(
+          'board',
+          (b) => {
+            const scoped = b.where('projectId', projectId);
+            return boardType ? scoped.where('boardType', boardType) : scoped;
+          },
+          // boards-per-project is the selective side; without the flip the
+          // pipeline walks every stage in the workspace probing boards
+          { flip: true },
+        )
         .orderBy('boardId', 'asc')
         .orderBy('sequenceNumber', 'asc');
     },

--- a/packages/shared/src/zero/acl/core/channel-access.ts
+++ b/packages/shared/src/zero/acl/core/channel-access.ts
@@ -1,0 +1,59 @@
+import { ChannelVisibility } from '../../schema';
+import type { Context } from '../../schema';
+import type { SelectArgs } from './types';
+
+export const SCALAR = { scalar: true } as const;
+
+export function channelAccessArgs(args?: SelectArgs): {
+  channelId: string | undefined;
+  isMember: boolean | undefined;
+} {
+  return {
+    channelId: args?.channelId as string | undefined,
+    isMember: args?.isMember as boolean | undefined,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function channelAccessWhere(ctx: Context): (helpers: any) => any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ({ or, cmp, exists }: any) =>
+    or(
+      cmp('visibility', '=', ChannelVisibility.PUBLIC),
+      exists('participants', (p: any) => p.where('userId', ctx.userID)),
+    );
+}
+
+export function scalarChannelBody(
+  ctx: Context,
+  channelId: string,
+  isMember: boolean | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): (ch: any) => any {
+  if (isMember === true) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (ch: any) =>
+      ch
+        .where('id', channelId)
+        .where('workspaceId', '=', ctx.workspaceId)
+        .whereExists(
+          'participants',
+          (p: any) => p.where('userId', ctx.userID).where('channelId', channelId),
+          SCALAR,
+        );
+  }
+  if (isMember === false) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (ch: any) =>
+      ch
+        .where('id', channelId)
+        .where('workspaceId', '=', ctx.workspaceId)
+        .where('visibility', ChannelVisibility.PUBLIC);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (ch: any) =>
+    ch
+      .where('id', channelId)
+      .where('workspaceId', '=', ctx.workspaceId)
+      .where(channelAccessWhere(ctx));
+}

--- a/packages/shared/src/zero/acl/tables/calls-acl.ts
+++ b/packages/shared/src/zero/acl/tables/calls-acl.ts
@@ -2,6 +2,8 @@ import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
 import { CallType, CallVisibility, EntityUserAccess, ShareableEntityType } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class CallsACL extends BaseQueryACL<'calls'> {
@@ -9,7 +11,7 @@ export class CallsACL extends BaseQueryACL<'calls'> {
     super(ctx, 'calls');
   }
 
-  canSelect<TReturn>(query: Query<'calls', Schema, TReturn>): Query<'calls', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'calls', Schema, TReturn>, args?: SelectArgs): Query<'calls', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.where(({ or, and, cmp, exists }) =>
         or(
@@ -42,6 +44,41 @@ export class CallsACL extends BaseQueryACL<'calls'> {
               .where(guestChannelAccessWhere(this.ctx)),
           ),
         ),
+      );
+    }
+
+    // Optimization only: when the caller subscribes with a concrete channelId, the
+    // channel-membership branch below is a correlated single-row lookup, so mark it
+    // scalar. All access rules are identical to the generic path (main's logic).
+    const { channelId } = channelAccessArgs(args);
+    if (channelId) {
+      return query.where(({ or, and, cmp, exists }) =>
+        or(
+          cmp('createdByUserId', this.ctx.userID),
+          and(
+            cmp('callType', CallType.HEADLESS),
+            exists('shares', share =>
+              share
+                .where('workspaceId', this.ctx.workspaceId)
+                .where('shareableEntityType', ShareableEntityType.NOTE_TAKER)
+                .where('entityUserAccess', '!=', EntityUserAccess.REVOKED)
+                .where(({ or: shareOr, cmp: shareCmp, exists: shareExists }) =>
+                  shareOr(
+                    shareCmp('userId', this.ctx.userID),
+                    shareExists('userGroupMemberships', m => m.where('userId', this.ctx.userID)),
+                    shareExists('channelMembers', m => m.where('userId', this.ctx.userID)),
+                  ),
+                ),
+            ),
+          ),
+          and(
+            cmp('workspaceId', this.ctx.workspaceId),
+            cmp('callType', CallType.HEADLESS),
+            cmp('visibility', CallVisibility.PUBLIC),
+          ),
+          exists('participants', (p) => p.where('userId', this.ctx.userID)),
+          exists('channel', scalarChannelBody(this.ctx, channelId, true), SCALAR),
+        )
       );
     }
 

--- a/packages/shared/src/zero/acl/tables/canvas-folders-acl.ts
+++ b/packages/shared/src/zero/acl/tables/canvas-folders-acl.ts
@@ -1,6 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, scalarChannelBody } from '../core/channel-access';
 import { guestCanvasAccessWhere, guestChannelAccessWhere, guestProjectAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class CanvasFoldersACL extends BaseQueryACL<'canvas_folders'> {
@@ -8,7 +10,7 @@ export class CanvasFoldersACL extends BaseQueryACL<'canvas_folders'> {
     super(ctx, 'canvas_folders');
   }
 
-  canSelect<TReturn>(query: Query<'canvas_folders', Schema, TReturn>): Query<'canvas_folders', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'canvas_folders', Schema, TReturn>, args?: SelectArgs): Query<'canvas_folders', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query
         .where('workspaceId', '=', this.ctx.workspaceId)
@@ -27,6 +29,26 @@ export class CanvasFoldersACL extends BaseQueryACL<'canvas_folders'> {
     // - channel folders (channelId set) require membership of that channel,
     // - project folders (channelId null, projectId set) require membership of a project channel,
     // - personal folders (both null) are limited to the creator.
+    const { channelId } = channelAccessArgs(args);
+    if (channelId) {
+      return query
+        .where('workspaceId', '=', this.ctx.workspaceId)
+        .where(({ or, and, cmp, exists }) =>
+          or(
+            cmp('createdBy', this.ctx.userID),
+            exists('channel', scalarChannelBody(this.ctx, channelId, true), SCALAR),
+            and(
+              cmp('channelId', 'IS', null),
+              exists('project', (pr) =>
+                pr.whereExists('channels', (ch) =>
+                  ch.whereExists('participants', (p) => p.where('userId', this.ctx.userID)),
+                ),
+              ),
+            ),
+          ),
+        );
+    }
+
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
       .where(({ or, and, cmp, exists }) =>

--- a/packages/shared/src/zero/acl/tables/channel-participants-acl.ts
+++ b/packages/shared/src/zero/acl/tables/channel-participants-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class ChannelParticipantsACL extends BaseQueryACL<'channel_participants'> {
@@ -9,12 +10,22 @@ export class ChannelParticipantsACL extends BaseQueryACL<'channel_participants'>
     super(ctx, 'channel_participants');
   }
 
-  canSelect<TReturn>(query: Query<'channel_participants', Schema, TReturn>): Query<'channel_participants', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'channel_participants', Schema, TReturn>, args?: SelectArgs): Query<'channel_participants', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.whereExists('channel', (ch) =>
         ch
           .where('workspaceId', '=', this.ctx.workspaceId)
           .where(guestChannelAccessWhere(this.ctx)),
+      );
+    }
+
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.where(({ or, cmp, exists }) =>
+        or(
+          cmp('userId', this.ctx.userID),
+          exists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR),
+        ),
       );
     }
 
@@ -24,12 +35,7 @@ export class ChannelParticipantsACL extends BaseQueryACL<'channel_participants'>
         exists('channel', (ch) =>
           ch
             .where('workspaceId', '=', this.ctx.workspaceId)
-            .where(({ or, cmp, exists }) =>
-              or(
-                cmp('visibility', '=', ChannelVisibility.PUBLIC),
-                exists('participants', (p) => p.where('userId', this.ctx.userID))
-              )
-            )
+            .where(channelAccessWhere(this.ctx))
         )
       )
     );

--- a/packages/shared/src/zero/acl/tables/channel-recaps-acl.ts
+++ b/packages/shared/src/zero/acl/tables/channel-recaps-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class ChannelRecapsACL extends BaseQueryACL<'channel_recaps'> {
@@ -9,7 +10,7 @@ export class ChannelRecapsACL extends BaseQueryACL<'channel_recaps'> {
     super(ctx, 'channel_recaps');
   }
 
-  canSelect<TReturn>(query: Query<'channel_recaps', Schema, TReturn>): Query<'channel_recaps', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'channel_recaps', Schema, TReturn>, args?: SelectArgs): Query<'channel_recaps', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.where(({ or, cmp, and, exists }) =>
         or(
@@ -28,6 +29,19 @@ export class ChannelRecapsACL extends BaseQueryACL<'channel_recaps'> {
 
     // Base recaps (userId IS NULL): accessible to channel participants or public channels in the workspace
     // Custom recaps (userId = userID): only accessible to the specific user who owns them
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.where(({ or, cmp, and, exists }) =>
+        or(
+          and(
+            cmp('userId', 'IS', null),
+            exists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+          ),
+          cmp('userId', '=', this.ctx.userID)
+        )
+      );
+    }
+
     return query.where(({ or, cmp, and, exists }) =>
       or(
         and(
@@ -35,12 +49,7 @@ export class ChannelRecapsACL extends BaseQueryACL<'channel_recaps'> {
           exists('channel', (ch) =>
             ch
               .where('workspaceId', '=', this.ctx.workspaceId)
-              .where(({ or: or2, cmp: cmp2, exists: exists2 }) =>
-                or2(
-                  cmp2('visibility', '=', ChannelVisibility.PUBLIC),
-                  exists2('participants', (p) => p.where('userId', this.ctx.userID))
-                )
-              )
+              .where(channelAccessWhere(this.ctx))
           )
         ),
         cmp('userId', '=', this.ctx.userID)

--- a/packages/shared/src/zero/acl/tables/channel-stats-acl.ts
+++ b/packages/shared/src/zero/acl/tables/channel-stats-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class ChannelStatsACL extends BaseQueryACL<'channel_stats'> {
@@ -9,7 +10,7 @@ export class ChannelStatsACL extends BaseQueryACL<'channel_stats'> {
     super(ctx, 'channel_stats');
   }
 
-  canSelect<TReturn>(query: Query<'channel_stats', Schema, TReturn>): Query<'channel_stats', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'channel_stats', Schema, TReturn>, args?: SelectArgs): Query<'channel_stats', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.whereExists('channel', (ch) =>
         ch
@@ -18,13 +19,13 @@ export class ChannelStatsACL extends BaseQueryACL<'channel_stats'> {
       );
     }
 
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
+    }
+
     return query.whereExists('channel', (ch) =>
-      ch.where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', '=', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID))
-        )
-      )
+      ch.where(channelAccessWhere(this.ctx))
     );
   }
 }

--- a/packages/shared/src/zero/acl/tables/channels-acl.ts
+++ b/packages/shared/src/zero/acl/tables/channels-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility, WorkspaceRole } from '../../schema';
+import { WorkspaceRole } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import { channelAccessWhere } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 export class ChannelsACL extends BaseQueryACL<'channels'> {
   constructor(ctx: Context) {
@@ -21,11 +22,6 @@ export class ChannelsACL extends BaseQueryACL<'channels'> {
 
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
-      .where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', '=', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID))
-        )
-      );
+      .where(channelAccessWhere(this.ctx));
   }
 }

--- a/packages/shared/src/zero/acl/tables/conversation-label-mappings-acl.ts
+++ b/packages/shared/src/zero/acl/tables/conversation-label-mappings-acl.ts
@@ -1,8 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 
 // A label-on-conversation mapping is shared within the channel (the desk label views
 // show all applied labels, not just the caller's). It's readable when the user can see
@@ -17,32 +17,14 @@ export class ConversationLabelMappingsACL extends BaseQueryACL<'conversation_lab
     query: Query<'conversation_label_mappings', Schema, TReturn>,
     args?: SelectArgs,
   ): Query<'conversation_label_mappings', Schema, TReturn> {
-    const channelId = args?.channelId as string | undefined;
-
-    if (args?.isMember && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
-    }
-
-    if (args?.isMember === false && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.where('id', channelId).where('visibility', ChannelVisibility.PUBLIC),
-        { scalar: true }
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
     return query
       .whereExists('channel', (ch) =>
-        ch.where(({ or, cmp, exists }) =>
-          or(
-            cmp('visibility', ChannelVisibility.PUBLIC),
-            exists('participants', (p) => p.where('userId', this.ctx.userID)),
-          ),
-        ),
+        ch.where(channelAccessWhere(this.ctx)),
       );
   }
 }

--- a/packages/shared/src/zero/acl/tables/conversation-labels-acl.ts
+++ b/packages/shared/src/zero/acl/tables/conversation-labels-acl.ts
@@ -1,8 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 
 // Labels are a shared, channel-wide palette (the app fetches ALL labels for a channel,
 // e.g. conversationLabelsByChannelId). A user may read a label when they can see its
@@ -17,32 +17,14 @@ export class ConversationLabelsACL extends BaseQueryACL<'conversation_labels'> {
     query: Query<'conversation_labels', Schema, TReturn>,
     args?: SelectArgs,
   ): Query<'conversation_labels', Schema, TReturn> {
-    const channelId = args?.channelId as string | undefined;
-
-    if (args?.isMember && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
-    }
-
-    if (args?.isMember === false && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.where('id', channelId).where('visibility', ChannelVisibility.PUBLIC),
-        { scalar: true }
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
     return query
       .whereExists('channel', (ch) =>
-        ch.where(({ or, cmp, exists }) =>
-          or(
-            cmp('visibility', ChannelVisibility.PUBLIC),
-            exists('participants', (p) => p.where('userId', this.ctx.userID)),
-          ),
-        ),
+        ch.where(channelAccessWhere(this.ctx)),
       );
   }
 }

--- a/packages/shared/src/zero/acl/tables/conversation-participants-acl.ts
+++ b/packages/shared/src/zero/acl/tables/conversation-participants-acl.ts
@@ -1,6 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class ConversationParticipantsACL extends BaseQueryACL<'conversation_participants'> {
@@ -10,6 +12,7 @@ export class ConversationParticipantsACL extends BaseQueryACL<'conversation_part
 
   canSelect<TReturn>(
     query: Query<'conversation_participants', Schema, TReturn>,
+    args?: SelectArgs,
   ): Query<'conversation_participants', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.where(({ or, exists }) =>
@@ -21,6 +24,20 @@ export class ConversationParticipantsACL extends BaseQueryACL<'conversation_part
             conversation.whereExists('channel', (ch) =>
               ch.where('workspaceId', '=', this.ctx.workspaceId).where(guestChannelAccessWhere(this.ctx)),
             ),
+          ),
+        ),
+      );
+    }
+
+    const { channelId } = channelAccessArgs(args);
+    if (channelId) {
+      return query.where(({ or, exists }) =>
+        or(
+          exists('channel', scalarChannelBody(this.ctx, channelId, true), SCALAR),
+          exists('conversation', (conversation) =>
+            conversation
+              .where('channelId', channelId)
+              .whereExists('channel', scalarChannelBody(this.ctx, channelId, true), SCALAR),
           ),
         ),
       );

--- a/packages/shared/src/zero/acl/tables/conversations-acl.ts
+++ b/packages/shared/src/zero/acl/tables/conversations-acl.ts
@@ -3,6 +3,7 @@ import type { Schema, Context } from '../../schema';
 import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class ConversationsACL extends BaseQueryACL<'conversations'> {
@@ -19,37 +20,15 @@ export class ConversationsACL extends BaseQueryACL<'conversations'> {
       );
     }
 
-    const channelId = args?.channelId as string | undefined;
-
-    // When the caller knows the user is a member (pre-checked against channel_user_status),
-    // use a scalar EXISTS on channel_participants which resolves once at hydration time
-    // instead of the expensive OR(PUBLIC, EXISTS(participants)) evaluated per-row during push.
-    if (args?.isMember && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
-    }
-
-    if (args?.isMember === false && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.where("id", channelId).where('visibility', ChannelVisibility.PUBLIC),
-        {scalar: true}
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
     return query.whereExists('channel', (ch) =>
       ch
         .where('workspaceId', '=', this.ctx.workspaceId)
-        .where(({ or, cmp, exists }) =>
-          or(
-            cmp('visibility', ChannelVisibility.PUBLIC),
-            exists('participants', (p) => p.where('userId', this.ctx.userID))
-          )
-        )
+        .where(channelAccessWhere(this.ctx))
     );
-    
   }
 }

--- a/packages/shared/src/zero/acl/tables/delayed-messages-acl.ts
+++ b/packages/shared/src/zero/acl/tables/delayed-messages-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class DelayedMessagesACL extends BaseQueryACL<'delayed_messages'> {
@@ -11,6 +12,7 @@ export class DelayedMessagesACL extends BaseQueryACL<'delayed_messages'> {
 
   canSelect<TReturn>(
     query: Query<'delayed_messages', Schema, TReturn>,
+    args?: SelectArgs,
   ): Query<'delayed_messages', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query
@@ -22,17 +24,19 @@ export class DelayedMessagesACL extends BaseQueryACL<'delayed_messages'> {
         );
     }
 
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query
+        .where('senderId', this.ctx.userID)
+        .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
+    }
+
     return query
       .where('senderId', this.ctx.userID)
       .whereExists('channel', (ch) =>
         ch
           .where('workspaceId', '=', this.ctx.workspaceId)
-          .where(({ or, cmp, exists }) =>
-            or(
-              cmp('visibility', '=', ChannelVisibility.PUBLIC),
-              exists('participants', (p) => p.where('userId', this.ctx.userID)),
-            ),
-          ),
+          .where(channelAccessWhere(this.ctx)),
       );
   }
 }

--- a/packages/shared/src/zero/acl/tables/email-channel-preferences-acl.ts
+++ b/packages/shared/src/zero/acl/tables/email-channel-preferences-acl.ts
@@ -1,8 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { denyGuestSelect, isGuestContext } from '../core/guest-acl-utils';
 
 export class EmailChannelPreferencesACL extends BaseQueryACL<'email_channel_preferences'> {
@@ -15,34 +15,13 @@ export class EmailChannelPreferencesACL extends BaseQueryACL<'email_channel_pref
       return denyGuestSelect(query, 'channelId');
     }
 
-    const channelId = args?.channelId as string | undefined;
-
-    // When the caller knows the user is a member (pre-checked against channel_user_status),
-    // use a scalar EXISTS on channel_participants which resolves once at hydration time
-    // instead of the expensive OR(PUBLIC, EXISTS(participants)) evaluated per-row during push.
-    if (args?.isMember && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
-    }
-
-    if (args?.isMember === false && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.where("id", channelId).where('visibility', ChannelVisibility.PUBLIC),
-        { scalar: true }
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
     return query.whereExists('channel', (ch) =>
-      ch.where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID))
-        )
-      )
+      ch.where(channelAccessWhere(this.ctx))
     );
   }
 }

--- a/packages/shared/src/zero/acl/tables/email-drafts-acl.ts
+++ b/packages/shared/src/zero/acl/tables/email-drafts-acl.ts
@@ -1,8 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class EmailDraftsACL extends BaseQueryACL<'email_drafts'> {
@@ -23,8 +23,6 @@ export class EmailDraftsACL extends BaseQueryACL<'email_drafts'> {
         );
     }
 
-    const channelId = args?.channelId as string | undefined;
-
     // A user can read either their own draft (userId = me) or the shared
     // AI-seeded draft (userId IS NULL). The hook prefers the personal draft
     // when present and falls back to the AI one. Channel-membership gating
@@ -33,29 +31,13 @@ export class EmailDraftsACL extends BaseQueryACL<'email_drafts'> {
       or(cmp('userId', '=', this.ctx.userID), cmp('userId', 'IS', null)),
     );
 
-    if (args?.isMember && channelId) {
-      return ownDrafts.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
-    }
-
-    if (args?.isMember === false && channelId) {
-      return ownDrafts.whereExists('channel', (ch) =>
-        ch.where("id", channelId).where('visibility', ChannelVisibility.PUBLIC),
-        { scalar: true }
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return ownDrafts.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
     return ownDrafts.whereExists('channel', (ch) =>
-      ch.where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID))
-        )
-      )
+      ch.where(channelAccessWhere(this.ctx))
     );
   }
 }

--- a/packages/shared/src/zero/acl/tables/emails-acl.ts
+++ b/packages/shared/src/zero/acl/tables/emails-acl.ts
@@ -1,8 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class EmailsACL extends BaseQueryACL<'emails'> {
@@ -19,34 +19,13 @@ export class EmailsACL extends BaseQueryACL<'emails'> {
       );
     }
 
-    const channelId = args?.channelId as string | undefined;
-
-    // When the caller knows the user is a member (pre-checked against channel_user_status),
-    // use a scalar EXISTS on channel_participants which resolves once at hydration time
-    // instead of the expensive OR(PUBLIC, EXISTS(participants)) evaluated per-row during push.
-    if (args?.isMember && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
-    }
-
-    if (args?.isMember === false && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.where("id", channelId).where('visibility', ChannelVisibility.PUBLIC),
-        { scalar: true }
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
     return query.whereExists('channel', (ch) =>
-      ch.where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID))
-        )
-      )
+      ch.where(channelAccessWhere(this.ctx))
     );
   }
 }

--- a/packages/shared/src/zero/acl/tables/links-acl.ts
+++ b/packages/shared/src/zero/acl/tables/links-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class LinksACL extends BaseQueryACL<'links'> {
@@ -19,7 +20,7 @@ export class LinksACL extends BaseQueryACL<'links'> {
    * no-op for members. Keeping it on the table means the boundary holds for any
    * future query rather than depending on each caller to repeat it.
    */
-  canSelect<TReturn>(query: Query<'links', Schema, TReturn>): Query<'links', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'links', Schema, TReturn>, args?: SelectArgs): Query<'links', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query
         .where('workspaceId', '=', this.ctx.workspaceId)
@@ -30,15 +31,17 @@ export class LinksACL extends BaseQueryACL<'links'> {
         );
     }
 
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query
+        .where('workspaceId', '=', this.ctx.workspaceId)
+        .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
+    }
+
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
       .whereExists('channel', (ch) =>
-        ch.where(({ or, cmp, exists }) =>
-          or(
-            cmp('visibility', ChannelVisibility.PUBLIC),
-            exists('participants', (p) => p.where('userId', this.ctx.userID)),
-          ),
-        ),
+        ch.where(channelAccessWhere(this.ctx)),
       );
   }
 }

--- a/packages/shared/src/zero/acl/tables/message-attachments-acl.ts
+++ b/packages/shared/src/zero/acl/tables/message-attachments-acl.ts
@@ -2,6 +2,8 @@ import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
 import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class MessageAttachmentsACL extends BaseQueryACL<'message_attachments'> {
@@ -9,7 +11,7 @@ export class MessageAttachmentsACL extends BaseQueryACL<'message_attachments'> {
     super(ctx, 'message_attachments');
   }
 
-  canSelect<TReturn>(query: Query<'message_attachments', Schema, TReturn>): Query<'message_attachments', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'message_attachments', Schema, TReturn>, args?: SelectArgs): Query<'message_attachments', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query
         .where('workspaceId', '=', this.ctx.workspaceId)
@@ -22,6 +24,22 @@ export class MessageAttachmentsACL extends BaseQueryACL<'message_attachments'> {
                   .where('workspaceId', '=', this.ctx.workspaceId)
                   .where(guestChannelAccessWhere(this.ctx)),
               ),
+            ),
+          ),
+        );
+    }
+
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query
+        .where('workspaceId', '=', this.ctx.workspaceId)
+        .where(({ or, cmp, exists }) =>
+          or(
+            cmp('createdBy', '=', this.ctx.userID),
+            exists('conversation', (c) =>
+              c
+                .where('channelId', channelId)
+                .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR),
             ),
           ),
         );

--- a/packages/shared/src/zero/acl/tables/messages-acl.ts
+++ b/packages/shared/src/zero/acl/tables/messages-acl.ts
@@ -2,6 +2,8 @@ import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
 import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class MessagesACL extends BaseQueryACL<'messages'> {
@@ -9,7 +11,7 @@ export class MessagesACL extends BaseQueryACL<'messages'> {
     super(ctx, 'messages');
   }
 
-  canSelect<TReturn>(query: Query<'messages', Schema, TReturn>): Query<'messages', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'messages', Schema, TReturn>, args?: SelectArgs): Query<'messages', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query
         .where(({ or, cmp }) =>
@@ -27,24 +29,43 @@ export class MessagesACL extends BaseQueryACL<'messages'> {
         );
     }
 
-    return query
-      .where(({or, cmp}) => {
-        return or(
-          cmp("visibleTo", "IS" ,null),
-          cmp("visibleTo", this.ctx.userID)
-        )
-      })
-      .whereExists('conversation', (c) =>
-        c.whereExists('channel', (ch) =>
-          ch
-            .where('workspaceId', '=', this.ctx.workspaceId)
-            .where(({ or, cmp, exists }) =>
-              or(
-                cmp('visibility', '=', ChannelVisibility.PUBLIC),
-                exists('participants', (p) => p.where('userId', this.ctx.userID))
-              )
-            )
-        )
+    const withVisibleTo = query.where(({ or, cmp }) => {
+      return or(
+        cmp('visibleTo', 'IS', null),
+        cmp('visibleTo', this.ctx.userID)
       );
+    });
+
+    const { channelId, isMember } = channelAccessArgs(args);
+    const conversationId = args?.conversationId as string | undefined;
+
+    if (channelId) {
+      return withVisibleTo.whereExists('conversation', (c) =>
+        c
+          .where('channelId', channelId)
+          .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+      );
+    }
+
+    if (conversationId) {
+      return withVisibleTo.whereExists('conversation', (c) =>
+        c
+          .where('conversationId', conversationId)
+          .whereExists('channel', (ch) =>
+            ch
+              .where('workspaceId', '=', this.ctx.workspaceId)
+              .where(channelAccessWhere(this.ctx))
+          ),
+        SCALAR
+      );
+    }
+
+    return withVisibleTo.whereExists('conversation', (c) =>
+      c.whereExists('channel', (ch) =>
+        ch
+          .where('workspaceId', '=', this.ctx.workspaceId)
+          .where(channelAccessWhere(this.ctx))
+      )
+    );
   }
 }

--- a/packages/shared/src/zero/acl/tables/reaction-counts-acl.ts
+++ b/packages/shared/src/zero/acl/tables/reaction-counts-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class ReactionCountsACL extends BaseQueryACL<'reaction_counts'> {
@@ -9,7 +10,7 @@ export class ReactionCountsACL extends BaseQueryACL<'reaction_counts'> {
     super(ctx, 'reaction_counts');
   }
 
-  canSelect<TReturn>(query: Query<'reaction_counts', Schema, TReturn>): Query<'reaction_counts', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'reaction_counts', Schema, TReturn>, args?: SelectArgs): Query<'reaction_counts', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.whereExists('message', (messageQ) =>
         messageQ.whereExists('conversation', (cq) =>
@@ -22,17 +23,23 @@ export class ReactionCountsACL extends BaseQueryACL<'reaction_counts'> {
       );
     }
 
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('message', (messageQ) =>
+        messageQ.whereExists('conversation', (cq) =>
+          cq
+            .where('channelId', channelId)
+            .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+        )
+      );
+    }
+
     return query.whereExists('message', (messageQ) =>
       messageQ.whereExists('conversation', (cq) =>
         cq.whereExists('channel', (chQ) =>
           chQ
             .where('workspaceId', '=', this.ctx.workspaceId)
-            .where(({ or, exists, cmp }) =>
-              or(
-                cmp('visibility', ChannelVisibility.PUBLIC),
-                exists('participants', (p) => p.where('userId', this.ctx.userID))
-              )
-            )
+            .where(channelAccessWhere(this.ctx))
         )
       )
     );

--- a/packages/shared/src/zero/acl/tables/reactions-acl.ts
+++ b/packages/shared/src/zero/acl/tables/reactions-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class ReactionsACL extends BaseQueryACL<'reactions'> {
@@ -9,7 +10,7 @@ export class ReactionsACL extends BaseQueryACL<'reactions'> {
     super(ctx, 'reactions');
   }
 
-  canSelect<TReturn>(query: Query<'reactions', Schema, TReturn>): Query<'reactions', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'reactions', Schema, TReturn>, args?: SelectArgs): Query<'reactions', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.whereExists('message', (m) =>
         m.whereExists('conversation', (c) =>
@@ -22,17 +23,23 @@ export class ReactionsACL extends BaseQueryACL<'reactions'> {
       );
     }
 
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('message', (m) =>
+        m.whereExists('conversation', (c) =>
+          c
+            .where('channelId', channelId)
+            .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+        )
+      );
+    }
+
     return query.whereExists('message', (m) =>
       m.whereExists('conversation', (c) =>
         c.whereExists('channel', (ch) =>
           ch
             .where('workspaceId', '=', this.ctx.workspaceId)
-            .where(({ or, cmp, exists }) =>
-              or(
-                cmp('visibility', '=', ChannelVisibility.PUBLIC),
-                exists('participants', (p) => p.where('userId', this.ctx.userID))
-              )
-            )
+            .where(channelAccessWhere(this.ctx))
         )
       )
     );

--- a/packages/shared/src/zero/acl/tables/recaps-acl.ts
+++ b/packages/shared/src/zero/acl/tables/recaps-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class RecapsACL extends BaseQueryACL<'recaps'> {
@@ -9,7 +10,7 @@ export class RecapsACL extends BaseQueryACL<'recaps'> {
     super(ctx, 'recaps');
   }
 
-  canSelect<TReturn>(query: Query<'recaps', Schema, TReturn>): Query<'recaps', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'recaps', Schema, TReturn>, args?: SelectArgs): Query<'recaps', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.where(({ or, cmp, exists, and }) =>
         or(
@@ -29,6 +30,19 @@ export class RecapsACL extends BaseQueryACL<'recaps'> {
     // Base recaps (userId IS NULL): only visible when their channel is in the caller's
     // workspace AND the channel is PUBLIC or the caller is a participant.
     // Custom recaps (userId = userID): only visible to the owning user.
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.where(({ or, cmp, and, exists }) =>
+        or(
+          and(
+            cmp('userId', 'IS', null),
+            exists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+          ),
+          cmp('userId', '=', this.ctx.userID)
+        )
+      );
+    }
+
     return query.where(({ or, cmp, and, exists }) =>
       or(
         and(
@@ -36,12 +50,7 @@ export class RecapsACL extends BaseQueryACL<'recaps'> {
           exists('channel', (ch) =>
             ch
               .where('workspaceId', '=', this.ctx.workspaceId)
-              .where(({ or: or2, cmp: cmp2, exists: exists2 }) =>
-                or2(
-                  cmp2('visibility', '=', ChannelVisibility.PUBLIC),
-                  exists2('participants', (p) => p.where('userId', this.ctx.userID))
-                )
-              )
+              .where(channelAccessWhere(this.ctx))
           )
         ),
         cmp('userId', '=', this.ctx.userID)

--- a/packages/shared/src/zero/acl/tables/sub-tickets-acl.ts
+++ b/packages/shared/src/zero/acl/tables/sub-tickets-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import {type Schema, type Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestChannelAccessWhere, guestTicketAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class SubTicketsACL extends BaseQueryACL<'sub_tickets'> {
@@ -9,7 +10,7 @@ export class SubTicketsACL extends BaseQueryACL<'sub_tickets'> {
     super(ctx, 'sub_tickets');
   }
 
-  canSelect<TReturn>(query: Query<'sub_tickets', Schema, TReturn>): Query<'sub_tickets', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'sub_tickets', Schema, TReturn>, args?: SelectArgs): Query<'sub_tickets', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query
         .where('workspaceId', '=', this.ctx.workspaceId)
@@ -29,6 +30,22 @@ export class SubTicketsACL extends BaseQueryACL<'sub_tickets'> {
     // mapped to a parent ticket (mappedTicketId is null — a valid state) OR the caller can
     // access the mapped ticket's channel (PUBLIC, or a participant). Without the null branch,
     // unmapped sub-tickets would be hidden from everyone.
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query
+        .where('workspaceId', '=', this.ctx.workspaceId)
+        .where(({ or, cmp, exists }) =>
+          or(
+            cmp('mappedTicketId', 'IS', null),
+            exists('mappedTicket', (t) =>
+              t
+                .where('channelId', channelId)
+                .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+            )
+          )
+        );
+    }
+
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
       .where(({ or, cmp, exists }) =>
@@ -36,12 +53,7 @@ export class SubTicketsACL extends BaseQueryACL<'sub_tickets'> {
           cmp('mappedTicketId', 'IS', null),
           exists('mappedTicket', (t) =>
             t.whereExists('channel', (ch) =>
-              ch.where(({ or: o, cmp: c, exists: e }) =>
-                o(
-                  c('visibility', ChannelVisibility.PUBLIC),
-                  e('participants', (p) => p.where('userId', this.ctx.userID))
-                )
-              )
+              ch.where(channelAccessWhere(this.ctx))
             )
           )
         )

--- a/packages/shared/src/zero/acl/tables/ticket-activities-acl.ts
+++ b/packages/shared/src/zero/acl/tables/ticket-activities-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import { type Schema, type Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestTicketAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class TicketActivitiesACL extends BaseQueryACL<'ticket_activities'> {
@@ -9,7 +10,7 @@ export class TicketActivitiesACL extends BaseQueryACL<'ticket_activities'> {
     super(ctx, 'ticket_activities');
   }
 
-  canSelect<TReturn>(query: Query<'ticket_activities', Schema, TReturn>): Query<'ticket_activities', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'ticket_activities', Schema, TReturn>, args?: SelectArgs): Query<'ticket_activities', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.whereExists('ticket', (t) =>
         t
@@ -18,16 +19,21 @@ export class TicketActivitiesACL extends BaseQueryACL<'ticket_activities'> {
       );
     }
 
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('ticket', (t) =>
+        t
+          .where('workspaceId', '=', this.ctx.workspaceId)
+          .where('channelId', channelId)
+          .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+      );
+    }
+
     return query.whereExists('ticket', (t) =>
       t
         .where('workspaceId', '=', this.ctx.workspaceId)
         .whereExists('channel', (ch) =>
-          ch.where(({ or, cmp, exists }) =>
-            or(
-              cmp('visibility', ChannelVisibility.PUBLIC),
-              exists('participants', (p) => p.where('userId', this.ctx.userID))
-            )
-          )
+          ch.where(channelAccessWhere(this.ctx))
         )
     );
   }

--- a/packages/shared/src/zero/acl/tables/ticket-tags-acl.ts
+++ b/packages/shared/src/zero/acl/tables/ticket-tags-acl.ts
@@ -1,7 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import {type Schema, type Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
+import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestTicketAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class TicketTagsACL extends BaseQueryACL<'ticket_tags'> {
@@ -9,7 +10,7 @@ export class TicketTagsACL extends BaseQueryACL<'ticket_tags'> {
     super(ctx, 'ticket_tags');
   }
 
-  canSelect<TReturn>(query: Query<'ticket_tags', Schema, TReturn>): Query<'ticket_tags', Schema, TReturn> {
+  canSelect<TReturn>(query: Query<'ticket_tags', Schema, TReturn>, args?: SelectArgs): Query<'ticket_tags', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.whereExists('ticket', (t) =>
         t
@@ -18,16 +19,21 @@ export class TicketTagsACL extends BaseQueryACL<'ticket_tags'> {
       );
     }
 
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('ticket', (t) =>
+        t
+          .where('workspaceId', '=', this.ctx.workspaceId)
+          .where('channelId', channelId)
+          .whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR)
+      );
+    }
+
     return query.whereExists('ticket', (t) =>
       t
         .where('workspaceId', '=', this.ctx.workspaceId)
         .whereExists('channel', (ch) =>
-          ch.where(({ or, cmp, exists }) =>
-            or(
-              cmp('visibility', ChannelVisibility.PUBLIC),
-              exists('participants', (p) => p.where('userId', this.ctx.userID))
-            )
-          )
+          ch.where(channelAccessWhere(this.ctx))
         )
     );
   }

--- a/packages/shared/src/zero/acl/tables/ticket-user-mailbox-acl.ts
+++ b/packages/shared/src/zero/acl/tables/ticket-user-mailbox-acl.ts
@@ -1,8 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 
 // A mailbox overlay row is private to its owner (userId). A user may read it only when
 // it's theirs AND they can see the underlying channel: either it's a public channel or
@@ -16,32 +16,15 @@ export class TicketUserMailboxACL extends BaseQueryACL<'ticket_user_mailbox'> {
     query: Query<'ticket_user_mailbox', Schema, TReturn>,
     args?: SelectArgs,
   ): Query<'ticket_user_mailbox', Schema, TReturn> {
-    const scoped = query.where('userId', this.ctx.userID);
-    const channelId = args?.channelId as string | undefined;
+    const owned = query.where('userId', this.ctx.userID);
 
-    if (args?.isMember && channelId) {
-      return scoped.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return owned.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
-    if (args?.isMember === false && channelId) {
-      return scoped.whereExists('channel', (ch) =>
-        ch.where('id', channelId).where('visibility', ChannelVisibility.PUBLIC),
-        { scalar: true }
-      );
-    }
-
-    return scoped.whereExists('channel', (ch) =>
-      ch.where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID)),
-        ),
-      ),
+    return owned.whereExists('channel', (ch) =>
+      ch.where(channelAccessWhere(this.ctx)),
     );
   }
 }

--- a/packages/shared/src/zero/acl/tables/tickets-acl.ts
+++ b/packages/shared/src/zero/acl/tables/tickets-acl.ts
@@ -1,8 +1,8 @@
 import type { Query } from '@rocicorp/zero';
 import type { Schema, Context } from '../../schema';
-import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
+import { SCALAR, channelAccessArgs, channelAccessWhere, scalarChannelBody } from '../core/channel-access';
 import { guestTicketAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
 export class TicketsACL extends BaseQueryACL<'tickets'> {
@@ -17,38 +17,15 @@ export class TicketsACL extends BaseQueryACL<'tickets'> {
         .where(guestTicketAccessWhere(this.ctx));
     }
 
-    const channelId = args?.channelId as string | undefined;
-
-    // When the caller knows the user is a member (pre-checked against channel_user_status),
-    // use a scalar EXISTS on channel_participants which resolves once at hydration time
-    // instead of the expensive OR(PUBLIC, EXISTS(participants)) evaluated per-row during push.
-
     query = query.where('workspaceId', '=', this.ctx.workspaceId);
 
-    if (args?.isMember && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.whereExists('participants', (p) =>
-          p.where('userId', this.ctx.userID).where('channelId', channelId),
-          { scalar: true }
-        ),
-      );
-    }
-
-    if (args?.isMember === false && channelId) {
-      return query.whereExists('channel', (ch) =>
-        ch.where("id", channelId).where('visibility', ChannelVisibility.PUBLIC),
-        { scalar: true }
-      );
+    const { channelId, isMember } = channelAccessArgs(args);
+    if (channelId) {
+      return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
     return query.whereExists('channel', (ch) =>
-      ch.where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID))
-        )
-      )
+      ch.where(channelAccessWhere(this.ctx))
     );
-  
   }
 }

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2820,10 +2820,16 @@ export const queries = defineQueries({
     }),
     ({ args: { projectId, boardType } }) => {
       return zql.stages
-        .whereExists('board', b => {
+        .whereExists(
+        'board',
+        b => {
           const scoped = b.where('projectId', projectId);
           return boardType ? scoped.where('boardType', boardType) : scoped;
-        })
+        },
+        // boards-per-project is the selective side; without the flip the
+        // pipeline walks every stage in the workspace probing boards
+        { flip: true },
+      )
         .orderBy('boardId', 'asc')
         .orderBy('sequenceNumber', 'asc');
     },


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
