### PR TITLE
feat: custom slash-command registry (MVP)

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260814130000_command_registry/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260814130000_command_registry/migration.sql
@@ -1,0 +1,26 @@
+-- Custom slash-command registry: a command is a saved, parameterized /goal loop.
+-- Uniqueness is per-org (orgId, slug) so two orgs may each define their own slug.
+CREATE TABLE "command_definitions" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "template" TEXT NOT NULL,
+    "provider" TEXT,
+    "model" TEXT,
+    "maxTurns" INTEGER,
+    "maxWallClockMs" INTEGER,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "command_definitions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "command_definitions_orgId_slug_key" ON "command_definitions"("orgId", "slug");
+CREATE INDEX "command_definitions_orgId_idx" ON "command_definitions"("orgId");
+
+-- Observability: which registered command (if any) started an active goal loop.
+-- Additive + nullable → existing rows and typed /goal loops are unaffected.
+ALTER TABLE "active_goals" ADD COLUMN "commandSlug" TEXT;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1783,6 +1783,7 @@ model ActiveGoal {
   turnCount      Int      @default(0) /// Turns completed so far
   maxTurns       Int      @default(5) /// Hard cap, enforced by relooper. Default 5: covers worker → audit → 1-2 fix cycles. Longer loops tend to burn LLM cost on judge-driven rabbit holes (e.g. judge falsely flagging missing attachments).
   maxWallClockMs Int? /// Optional wall-clock budget (ms) measured from createdAt; enforced by relooper alongside maxTurns. Null = no time cap (legacy/default). Second mandatory ceiling for user-configured loops.
+  commandSlug    String? /// Registered custom-command slug that started this loop, if any (observability). Null = a typed /goal.
   lastTurnResult String? /// Most recent worker output (≤ 4KB stored)
   lastReason     String? /// Last boss reason or terminal reason
   runPayload     Json /// Stashed first-turn /run inputs to replay
@@ -1801,6 +1802,30 @@ model ActiveGoal {
   @@index([status, updatedAt])
   @@index([orgId])
   @@map("active_goals")
+}
+
+/// Org-scoped custom slash command — a saved, parameterized /goal loop.
+/// Invoked as /<slug> <input>; the webhook renders `template` (with {input}
+/// substituted) into a goal condition and boots the same worker -> judge ->
+/// audit loop /goal uses. Budgets are clamped to the /goal caps at define time.
+model CommandDefinition {
+  id             String   @id @default(cuid())
+  orgId          String
+  slug           String /// Invoked as /<slug>; unique within an org
+  description    String?
+  template       String /// Goal-condition template; {input} is replaced by the user's invocation text
+  provider       String? /// Optional provider override (same allowlist as /goal)
+  model          String? /// Optional model override
+  maxTurns       Int? /// Optional turn ceiling (clamped to the /goal cap at define time)
+  maxWallClockMs Int? /// Optional wall-clock budget in ms (clamped to the /goal cap at define time)
+  enabled        Boolean  @default(true)
+  createdBy      String /// Spaces userId that defined it
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@unique([orgId, slug])
+  @@index([orgId])
+  @@map("command_definitions")
 }
 
 model ExperimentRun {

--- a/apps/xyne-claw-auth/backend/src/lib/commandRegistry.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/commandRegistry.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RESERVED_COMMAND_SLUGS,
+  renderCommandTemplate,
+  renderCommandToGoalStart,
+  validateCommandSlug,
+} from "./commandRegistry.js";
+import { extractCustomCommandInvocation, parseSlashCommand } from "./parseSlashCommand.js";
+
+describe("validateCommandSlug", () => {
+  it("accepts a normal slug and lowercases it", () => {
+    expect(validateCommandSlug("Triage")).toEqual({ ok: true, slug: "triage" });
+  });
+
+  it("rejects a reserved built-in verb", () => {
+    const res = validateCommandSlug("goal");
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects an over-short or malformed slug", () => {
+    expect(validateCommandSlug("x").ok).toBe(false);
+    expect(validateCommandSlug("1abc").ok).toBe(false);
+    expect(validateCommandSlug("has space").ok).toBe(false);
+  });
+
+  it("every reserved slug is itself rejected", () => {
+    for (const slug of RESERVED_COMMAND_SLUGS) {
+      expect(validateCommandSlug(slug).ok).toBe(false);
+    }
+  });
+});
+
+describe("renderCommandTemplate", () => {
+  it("substitutes {input}", () => {
+    expect(renderCommandTemplate("investigate {input} and report", "the 500s")).toBe(
+      "investigate the 500s and report",
+    );
+  });
+
+  it("replaces every {input} occurrence", () => {
+    expect(renderCommandTemplate("{input} — repeat: {input}", "x")).toBe("x — repeat: x");
+  });
+
+  it("appends input as a paragraph when there is no placeholder", () => {
+    expect(renderCommandTemplate("summarize the incident", "focus on auth")).toBe(
+      "summarize the incident\n\nfocus on auth",
+    );
+  });
+
+  it("leaves a placeholder-less template untouched when input is empty", () => {
+    expect(renderCommandTemplate("do the standing task", "")).toBe("do the standing task");
+  });
+});
+
+describe("renderCommandToGoalStart", () => {
+  it("maps a template + budgets + provider into a goalStart", () => {
+    const cmd = renderCommandToGoalStart(
+      {
+        slug: "triage",
+        template: "investigate {input} and post an RCA",
+        provider: "claude",
+        maxTurns: 8,
+        maxWallClockMs: 3_600_000,
+      },
+      "the webhook is 500ing",
+    );
+    expect(cmd).toEqual({
+      kind: "goalStart",
+      condition: "investigate the webhook is 500ing and post an RCA",
+      providerOverride: { provider: "claude" },
+      maxTurns: 8,
+      maxWallClockMs: 3_600_000,
+    });
+  });
+
+  it("promotes a bare model to a spaces-provider override (matches /goal)", () => {
+    const cmd = renderCommandToGoalStart(
+      { slug: "sum", template: "summarize {input}", model: "open-large" },
+      "the thread",
+    );
+    expect(cmd).toMatchObject({
+      kind: "goalStart",
+      condition: "summarize the thread",
+      providerOverride: { provider: "spaces", model: "open-large" },
+    });
+  });
+
+  it("omits provider/budgets when the definition has none", () => {
+    const cmd = renderCommandToGoalStart({ slug: "x", template: "do {input}" }, "it");
+    expect(cmd).toEqual({ kind: "goalStart", condition: "do it" });
+  });
+});
+
+describe("parseSlashCommand — /command management", () => {
+  it("parses /command list (and the bare/plural forms)", () => {
+    expect(parseSlashCommand("/command list")).toEqual({ kind: "commandList" });
+    expect(parseSlashCommand("/command")).toEqual({ kind: "commandList" });
+    expect(parseSlashCommand("/commands")).toEqual({ kind: "commandList" });
+  });
+
+  it("parses /command show and /command delete", () => {
+    expect(parseSlashCommand("/command show triage")).toEqual({ kind: "commandShow", slug: "triage" });
+    expect(parseSlashCommand("/command delete triage")).toEqual({ kind: "commandDelete", slug: "triage" });
+    expect(parseSlashCommand("/command rm triage")).toEqual({ kind: "commandDelete", slug: "triage" });
+  });
+
+  it("parses /command define with leading options then a template", () => {
+    const cmd = parseSlashCommand("/command define triage maxTurns=8 maxTime=1h model=open-large investigate {input}");
+    expect(cmd).toEqual({
+      kind: "commandDefine",
+      slug: "triage",
+      template: "investigate {input}",
+      providerOverride: { provider: "spaces", model: "open-large" },
+      maxTurns: 8,
+      maxWallClockMs: 3_600_000,
+    });
+  });
+
+  it("clamps define budgets to the /goal hard caps", () => {
+    const cmd = parseSlashCommand("/command define big maxTurns=999 maxTime=99h keep going {input}");
+    expect(cmd).toMatchObject({
+      kind: "commandDefine",
+      maxTurns: 20,
+      maxWallClockMs: 6 * 60 * 60 * 1000,
+    });
+  });
+
+  it("treats a malformed option as the start of the template (never silently coerced)", () => {
+    const cmd = parseSlashCommand("/command define t maxTurns=abc do the thing");
+    expect(cmd).toEqual({
+      kind: "commandDefine",
+      slug: "t",
+      template: "maxTurns=abc do the thing",
+    });
+  });
+
+  it("returns null for a define with no template", () => {
+    expect(parseSlashCommand("/command define onlyslug")).toBeNull();
+  });
+});
+
+describe("extractCustomCommandInvocation", () => {
+  it("extracts a custom slug and its input", () => {
+    expect(extractCustomCommandInvocation("/triage the payment webhook is 500ing")).toEqual({
+      slug: "triage",
+      input: "the payment webhook is 500ing",
+    });
+  });
+
+  it("extracts a bare custom slug with empty input", () => {
+    expect(extractCustomCommandInvocation("/triage")).toEqual({ slug: "triage", input: "" });
+  });
+
+  it("strips leading @mentions before the slug", () => {
+    expect(extractCustomCommandInvocation("@Xyne Doctor /triage look at logs")).toEqual({
+      slug: "triage",
+      input: "look at logs",
+    });
+  });
+
+  it("returns null for built-in verbs (never resolved against the registry)", () => {
+    expect(extractCustomCommandInvocation("/goal do a thing")).toBeNull();
+    expect(extractCustomCommandInvocation("/stop")).toBeNull();
+    expect(extractCustomCommandInvocation("/help")).toBeNull();
+  });
+
+  it("returns null for prose that merely contains a slash", () => {
+    expect(extractCustomCommandInvocation("please check the /api/foo route")).toBeNull();
+    expect(extractCustomCommandInvocation("run it and/or skip")).toBeNull();
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/commandRegistry.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/commandRegistry.ts
@@ -1,0 +1,131 @@
+/**
+ * Custom slash-command registry — pure helpers (no DB, no I/O).
+ *
+ * A custom command is a *saved, parameterized `/goal`*: an org-scoped template
+ * plus optional provider/model and budget ceilings. When a user types
+ * `/<slug> <input>`, the webhook renders the stored template into a goal
+ * condition and boots the SAME proven worker → judge → audit loop that `/goal`
+ * uses. This module owns the pure parts of that mapping so they can be unit
+ * tested without a Prisma client:
+ *
+ *   - RESERVED_COMMAND_SLUGS / validateCommandSlug  — which slugs a user may register.
+ *   - renderCommandTemplate                          — {input} substitution.
+ *   - renderCommandToGoalStart                       — stored definition → goalStart command.
+ *
+ * The pure parser (parseSlashCommand.ts) imports RESERVED_COMMAND_SLUGS so a
+ * registered slug can never shadow a built-in, and so `/<builtin>` is never
+ * mis-resolved as a custom command.
+ */
+
+import type { SlashCommand } from "./parseSlashCommand.js";
+
+/** A goalStart command (the only SlashCommand shape a custom command maps to). */
+type GoalStartCommand = Extract<SlashCommand, { kind: "goalStart" }>;
+
+/**
+ * Built-in verbs a custom command may NOT shadow. Two jobs:
+ *   1. validateCommandSlug rejects an attempt to `/command define` one of these.
+ *   2. extractCustomCommandInvocation (in parseSlashCommand.ts) skips these so a
+ *      built-in like `/stop` is never resolved against the registry.
+ * Keep in sync with the verbs handled in parseSlashCommand.ts / webhook.ts.
+ */
+export const RESERVED_COMMAND_SLUGS: ReadonlySet<string> = new Set([
+  "goal",
+  "goals",
+  "stop",
+  "help",
+  "clear",
+  "compact",
+  "queue",
+  "queues",
+  "fast",
+  "upgrade",
+  "experiment",
+  "experiments",
+  "command",
+  "commands",
+  "status",
+]);
+
+/** Slug charset: lowercase, starts with a letter, 2-32 chars, [a-z0-9_-]. */
+const SLUG_RE = /^[a-z][a-z0-9_-]{1,31}$/;
+
+export type SlugValidation =
+  | { ok: true; slug: string }
+  | { ok: false; reason: string };
+
+/**
+ * Validate a user-supplied command slug. Lowercases first, then enforces the
+ * charset and the reserved-word list. Returns a human-readable reason on
+ * failure so the webhook can post a helpful error.
+ */
+export function validateCommandSlug(raw: string): SlugValidation {
+  const slug = raw.trim().toLowerCase();
+  if (!slug) return { ok: false, reason: "slug is empty" };
+  if (!SLUG_RE.test(slug)) {
+    return {
+      ok: false,
+      reason:
+        "slug must be 2-32 chars, start with a letter, and contain only a-z, 0-9, - or _",
+    };
+  }
+  if (RESERVED_COMMAND_SLUGS.has(slug)) {
+    return { ok: false, reason: `\`/${slug}\` is a built-in command and can't be redefined` };
+  }
+  return { ok: true, slug };
+}
+
+/** The stored-definition fields renderCommandToGoalStart needs. */
+export interface StoredCommandDefinition {
+  slug: string;
+  template: string;
+  provider?: string | null;
+  model?: string | null;
+  maxTurns?: number | null;
+  maxWallClockMs?: number | null;
+}
+
+/** Placeholder a template uses to interpolate the user's invocation text. */
+const INPUT_PLACEHOLDER_RE = /\{input\}/g;
+
+/**
+ * Render a stored template with the user's invocation text. If the template
+ * contains `{input}` every occurrence is replaced; otherwise the input (when
+ * non-empty) is appended as an extra paragraph so a command with a fixed
+ * template still receives the user's arguments.
+ */
+export function renderCommandTemplate(template: string, input: string): string {
+  const trimmedInput = (input ?? "").trim();
+  if (template.includes("{input}")) {
+    return template.replace(INPUT_PLACEHOLDER_RE, trimmedInput).trim();
+  }
+  return (trimmedInput ? `${template}\n\n${trimmedInput}` : template).trim();
+}
+
+/**
+ * Map a stored command definition + invocation text to a `goalStart` command.
+ * The webhook feeds this through the exact same path a typed `/goal` takes, so
+ * budgets, provider override, persistence, and the audit loop are all reused.
+ *
+ * Budgets are already clamped to the hard caps at `/command define` time (see
+ * parseSlashCommand.ts); nothing here can exceed them because the only write
+ * path to a definition is the parser.
+ */
+export function renderCommandToGoalStart(
+  def: StoredCommandDefinition,
+  input: string,
+): GoalStartCommand {
+  const condition = renderCommandTemplate(def.template, input).slice(0, 2_000);
+  const providerOverride = def.provider
+    ? { provider: def.provider, ...(def.model ? { model: def.model } : {}) }
+    : def.model
+      ? { provider: "spaces", model: def.model }
+      : undefined;
+  return {
+    kind: "goalStart",
+    condition,
+    ...(providerOverride ? { providerOverride } : {}),
+    ...(def.maxTurns != null ? { maxTurns: def.maxTurns } : {}),
+    ...(def.maxWallClockMs != null ? { maxWallClockMs: def.maxWallClockMs } : {}),
+  };
+}

--- a/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.ts
@@ -13,6 +13,8 @@
  * as `/goal status`.
  */
 
+import { RESERVED_COMMAND_SLUGS } from "./commandRegistry.js";
+
 export type ProviderOverride = { provider: string; model?: string };
 
 export type SlashCommand =
@@ -34,7 +36,20 @@ export type SlashCommand =
   | { kind: "help" }
   // `/fast` / `/fast off` — thread-scoped fast-mode toggle. Start-anchored only.
   | { kind: "fastMode"; enabled: boolean }
-  | { kind: "fastModeUsage" };
+  | { kind: "fastModeUsage" }
+  // `/command` registry — define/list/show/delete org-scoped custom commands.
+  | { kind: "commandList" }
+  | { kind: "commandShow"; slug: string }
+  | { kind: "commandDelete"; slug: string }
+  | {
+      kind: "commandDefine";
+      slug: string;
+      template: string;
+      description?: string;
+      providerOverride?: ProviderOverride;
+      maxTurns?: number;
+      maxWallClockMs?: number;
+    };
 
 // Strip a sequence of leading `@<token>` mentions so /goal works even when
 // the message addresses an agent first (e.g. `@Xyne Doctor /goal count to 10`).
@@ -148,6 +163,13 @@ function parseFromSlash(trimmed: string): SlashCommand | null {
     return { kind: "compact", instructions: trimmed.slice("/compact ".length).trim().slice(0, 2_000) };
   }
 
+  if (lower === "/command" || lower === "/commands" || lower === "/command list") {
+    return { kind: "commandList" };
+  }
+  if (lower.startsWith("/command ")) {
+    return parseCommandMgmt(trimmed.slice("/command ".length));
+  }
+
   if (lower === "/stop" || lower === "/goal clear") {
     return { kind: "goalClear" };
   }
@@ -222,4 +244,116 @@ function parseGoalStart(raw: string): { condition: string; providerOverride?: Pr
     ...(maxTurns != null ? { maxTurns } : {}),
     ...(maxWallClockMs != null ? { maxWallClockMs } : {}),
   };
+}
+
+// ── /command registry parsing ──────────────────────────────────────────────
+// `/command list` · `/command show <slug>` · `/command delete <slug>` ·
+// `/command define <slug> [key=val …] <template…>`. Slug validity + reserved
+// checks are enforced downstream (validateCommandSlug) so the webhook can post a
+// helpful error; here we only extract structure.
+function parseCommandMgmt(rest: string): SlashCommand | null {
+  const trimmed = rest.trim();
+  const firstTok = /^(\S+)/.exec(trimmed);
+  const sub = (firstTok?.[1] ?? "").toLowerCase();
+  const afterSub = trimmed.slice(firstTok?.[1]?.length ?? 0).trim();
+
+  if (sub === "" || sub === "list" || sub === "ls") return { kind: "commandList" };
+  if (sub === "show" || sub === "get") {
+    const slug = (/^(\S+)/.exec(afterSub)?.[1] ?? "").toLowerCase();
+    return slug ? { kind: "commandShow", slug } : null;
+  }
+  if (sub === "delete" || sub === "remove" || sub === "rm") {
+    const slug = (/^(\S+)/.exec(afterSub)?.[1] ?? "").toLowerCase();
+    return slug ? { kind: "commandDelete", slug } : null;
+  }
+  if (sub === "define" || sub === "set" || sub === "add" || sub === "create") {
+    return parseCommandDefine(afterSub);
+  }
+  return null;
+}
+
+// `/command define <slug> [key=val …] <template…>`. Leading key=value tokens
+// (provider/model/maxTurns/maxTime/desc) are consumed as options; the first
+// non-option token begins the template, which keeps its original spacing from
+// there. Budgets are clamped to the same hard caps /goal uses, so a custom
+// command can never exceed the /goal ceilings.
+function parseCommandDefine(afterSub: string): SlashCommand | null {
+  let s = afterSub.trim();
+  const slugMatch = /^(\S+)\s*/.exec(s);
+  if (!slugMatch) return null;
+  const slug = (slugMatch[1] ?? "").toLowerCase();
+  s = s.slice(slugMatch[0].length);
+
+  let provider: string | undefined;
+  let model: string | undefined;
+  let maxTurns: number | undefined;
+  let maxWallClockMs: number | undefined;
+  let description: string | undefined;
+
+  for (;;) {
+    const m = /^(\S+?)=(\S*)\s*/.exec(s);
+    if (!m) break;
+    const key = (m[1] ?? "").toLowerCase();
+    const val = m[2] ?? "";
+    if (key === "provider") {
+      if (!GOAL_OVERRIDABLE_PROVIDERS.has(val.toLowerCase())) break;
+      provider = val.toLowerCase();
+    } else if (key === "model") {
+      if (!val) break;
+      model = val;
+    } else if (key === "maxturns" || key === "max_turns" || key === "turns") {
+      const n = Number.parseInt(val, 10);
+      if (!(Number.isInteger(n) && n > 0)) break;
+      maxTurns = Math.min(n, GOAL_MAX_TURNS_CAP);
+    } else if (
+      key === "maxtime" || key === "max_time" || key === "maxwallclock" ||
+      key === "timeout" || key === "deadline"
+    ) {
+      const ms = parseDurationMs(val);
+      if (ms == null) break;
+      maxWallClockMs = Math.min(ms, GOAL_MAX_WALL_CLOCK_MS_CAP);
+    } else if (key === "desc" || key === "description") {
+      description = val;
+    } else {
+      break;
+    }
+    s = s.slice(m[0].length);
+  }
+
+  const template = s.trim().slice(0, 2_000);
+  if (!slug || !template) return null;
+
+  const resolvedProvider = provider ?? (model ? "spaces" : undefined);
+  return {
+    kind: "commandDefine",
+    slug,
+    template,
+    ...(description ? { description } : {}),
+    ...(resolvedProvider
+      ? { providerOverride: { provider: resolvedProvider, ...(model ? { model } : {}) } }
+      : {}),
+    ...(maxTurns != null ? { maxTurns } : {}),
+    ...(maxWallClockMs != null ? { maxWallClockMs } : {}),
+  };
+}
+
+/**
+ * Extract a custom-command invocation `/<slug> <input>` from a raw message.
+ * Returns null unless the WHOLE message (after leading @mentions) is a single
+ * `/<slug>` token optionally followed by args, and the slug is not a built-in.
+ * The caller resolves <slug> against the org's registry; a miss falls through
+ * to normal processing. Start-anchored + reserved-slug filtered, so prose that
+ * merely contains a slash is never hijacked.
+ */
+export function extractCustomCommandInvocation(
+  input: string | undefined | null,
+): { slug: string; input: string } | null {
+  if (!input) return null;
+  const trimmed = input.trim().replace(LEADING_MENTIONS, "");
+  if (trimmed[0] !== "/") return null;
+  const m = /^\/([a-z][a-z0-9_-]{1,31})(?:\s+([\s\S]*))?$/iu.exec(trimmed);
+  if (!m) return null;
+  const slug = (m[1] ?? "").toLowerCase();
+  if (RESERVED_COMMAND_SLUGS.has(slug)) return null;
+  return { slug, input: (m[2] ?? "").trim() };
 }

--- a/apps/xyne-claw-auth/backend/src/repositories/activeGoalRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/activeGoalRepository.ts
@@ -31,6 +31,7 @@ export const activeGoalRepository = {
     condition: string;
     maxTurns?: number;
     maxWallClockMs?: number | null;
+    commandSlug?: string | null;
     runPayload: Prisma.InputJsonValue;
   }) {
     const max = args.maxTurns ?? Number(process.env["GOAL_MAX_TURNS_DEFAULT"] ?? 5);
@@ -43,6 +44,7 @@ export const activeGoalRepository = {
         condition: args.condition,
         maxTurns: max,
         maxWallClockMs,
+        commandSlug: args.commandSlug ?? null,
         runPayload: args.runPayload,
         orgId: args.orgId,
         status: "active",
@@ -63,6 +65,7 @@ export const activeGoalRepository = {
         condition: args.condition,
         maxTurns: max,
         maxWallClockMs,
+        commandSlug: args.commandSlug ?? null,
         runPayload: args.runPayload,
         status: "active",
       },

--- a/apps/xyne-claw-auth/backend/src/repositories/commandDefinitionRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/commandDefinitionRepository.ts
@@ -1,0 +1,61 @@
+/**
+ * Repository for the CommandDefinition table — org-scoped custom slash commands.
+ *
+ * A custom command is a saved, parameterized `/goal` (template + optional
+ * provider/model + budget ceilings). Uniqueness is (orgId, slug), so a slug is
+ * unique within an org but two orgs may each define their own `/triage`.
+ *
+ * Reads are on the message hot path: every unrecognized `/<slug>` triggers ONE
+ * indexed lookup by (orgId, slug). Writes happen only via `/command define`.
+ */
+import { prisma } from "../db.js";
+
+export const commandDefinitionRepository = {
+  /** Hot-path lookup: resolve a typed `/<slug>` for an org. */
+  findByOrgAndSlug(orgId: string, slug: string) {
+    return prisma.commandDefinition.findUnique({
+      where: { orgId_slug: { orgId, slug } },
+    });
+  },
+
+  /** List an org's custom commands (for `/command list`). */
+  listByOrg(orgId: string) {
+    return prisma.commandDefinition.findMany({
+      where: { orgId },
+      orderBy: { slug: "asc" },
+    });
+  },
+
+  /** Create or replace a definition (for `/command define`). */
+  upsert(args: {
+    orgId: string;
+    slug: string;
+    template: string;
+    description?: string | null;
+    provider?: string | null;
+    model?: string | null;
+    maxTurns?: number | null;
+    maxWallClockMs?: number | null;
+    createdBy: string;
+  }) {
+    const data = {
+      description: args.description ?? null,
+      template: args.template,
+      provider: args.provider ?? null,
+      model: args.model ?? null,
+      maxTurns: args.maxTurns ?? null,
+      maxWallClockMs: args.maxWallClockMs ?? null,
+      enabled: true,
+    };
+    return prisma.commandDefinition.upsert({
+      where: { orgId_slug: { orgId: args.orgId, slug: args.slug } },
+      update: data,
+      create: { orgId: args.orgId, slug: args.slug, createdBy: args.createdBy, ...data },
+    });
+  },
+
+  /** Delete a definition (for `/command delete`). Idempotent. */
+  remove(orgId: string, slug: string) {
+    return prisma.commandDefinition.deleteMany({ where: { orgId, slug } });
+  },
+};

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -33,7 +33,10 @@ import { buildSpacesMentionLookups, buildSpacesMentionLookupsDb } from "../lib/m
 import { mintSessionToken } from "../lib/session-tokens.js";
 import { verifySpacesSignature } from "../middleware/verify-spaces-signature.js";
 import { coerceAutomationForwardResult } from "../lib/automation-result.js";
-import { parseSlashCommand } from "../lib/parseSlashCommand.js";
+import { parseSlashCommand, extractCustomCommandInvocation, type SlashCommand } from "../lib/parseSlashCommand.js";
+import { renderCommandToGoalStart, validateCommandSlug } from "../lib/commandRegistry.js";
+import { commandDefinitionRepository } from "../repositories/commandDefinitionRepository.js";
+import { formatDurationMs } from "../services/loopBudget.js";
 import { buildExperimentProofBundle } from "../lib/experiment-bundle.js";
 import { resolveAuthForUser } from "../services/userMemoryFetcher.js";
 import { parseExperimentCommand, formatDuration, dispatchExperimentEpoch, dispatchExperimentChecker, EXPERIMENT_PROVIDERS, buildFindingsMarkdown, cancelRunSession } from "../lib/experiment.js";
@@ -1535,8 +1538,132 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
   // Without this, autoGoal turns "/stop" into "/goal … /stop" (a new goal),
   // making the thread impossible to stop.
   const rawSlash = parseSlashCommand(userText);
+
+  // ── /command registry management (define / list / show / delete) ─────────
+  // Org-scoped reads/writes that short-circuit before any run. Any workspace
+  // member may manage custom commands; budgets are hard-capped by the parser,
+  // so a definition can never exceed the /goal ceilings.
+  if (
+    rawSlash &&
+    (rawSlash.kind === "commandList" ||
+      rawSlash.kind === "commandShow" ||
+      rawSlash.kind === "commandDelete" ||
+      rawSlash.kind === "commandDefine") &&
+    agent.orgId
+  ) {
+    const cmd = rawSlash;
+    const orgId = agent.orgId;
+    const reply = (markdownText: string) =>
+      spacesAppFetch(
+        "/chat/postMessage",
+        {
+          channelId: payload.channelId,
+          conversationId: payload.conversationId,
+          markdownText,
+          userId: agent.spacesAppUserId,
+          metadata: { contentFormat: "markdown" },
+        },
+        agent.appToken,
+      ).catch((err) => {
+        log.warn("Failed to post /command reply", { error: err instanceof Error ? err.message : String(err) });
+      });
+    const budgetSuffix = (d: { maxTurns: number | null; maxWallClockMs: number | null }): string => {
+      const bits: string[] = [];
+      if (d.maxTurns != null) bits.push(`maxTurns=${d.maxTurns}`);
+      if (d.maxWallClockMs != null) bits.push(`maxTime=${formatDurationMs(d.maxWallClockMs)}`);
+      return bits.length ? ` \u00b7 ${bits.join(" ")}` : "";
+    };
+
+    if (cmd.kind === "commandList") {
+      const defs = await commandDefinitionRepository.listByOrg(orgId).catch(() => []);
+      if (defs.length === 0) {
+        await reply(
+          "No custom commands defined for this workspace yet.\n" +
+            "Create one: `/command define <slug> [maxTurns=8] [maxTime=1h] [model=open-large] <template with {input}>`",
+        );
+      } else {
+        const lines = defs.map((d: { slug: string; template: string; maxTurns: number | null; maxWallClockMs: number | null }) => {
+          const preview = d.template.length > 100 ? `${d.template.slice(0, 97)}\u2026` : d.template;
+          return `- \`/${d.slug}\`${budgetSuffix(d)} \u2014 ${preview}`;
+        });
+        await reply([`**Custom commands** (${defs.length})`, ...lines].join("\n"));
+      }
+    } else if (cmd.kind === "commandShow") {
+      const def = await commandDefinitionRepository.findByOrgAndSlug(orgId, cmd.slug).catch(() => null);
+      if (!def) {
+        await reply(`No custom command \`/${cmd.slug}\` in this workspace.`);
+      } else {
+        await reply(
+          [
+            `**/${def.slug}**${budgetSuffix(def)}`,
+            def.provider
+              ? `provider: ${def.provider}${def.model ? ` \u00b7 model: ${def.model}` : ""}`
+              : def.model
+                ? `model: ${def.model}`
+                : "",
+            "```",
+            def.template,
+            "```",
+          ]
+            .filter((l) => l !== "")
+            .join("\n"),
+        );
+      }
+    } else if (cmd.kind === "commandDelete") {
+      const res = await commandDefinitionRepository.remove(orgId, cmd.slug).catch(() => ({ count: 0 }));
+      await reply(res.count > 0 ? `Deleted \`/${cmd.slug}\`.` : `No custom command \`/${cmd.slug}\` to delete.`);
+    } else {
+      const valid = validateCommandSlug(cmd.slug);
+      if (!valid.ok) {
+        await reply(`Couldn't define that command: ${valid.reason}`);
+      } else {
+        try {
+          await commandDefinitionRepository.upsert({
+            orgId,
+            slug: valid.slug,
+            template: cmd.template,
+            description: cmd.description ?? null,
+            provider: cmd.providerOverride?.provider ?? null,
+            model: cmd.providerOverride?.model ?? null,
+            maxTurns: cmd.maxTurns ?? null,
+            maxWallClockMs: cmd.maxWallClockMs ?? null,
+            createdBy: payload.userId,
+          });
+          await reply(
+            `Defined \`/${valid.slug}\`${budgetSuffix({ maxTurns: cmd.maxTurns ?? null, maxWallClockMs: cmd.maxWallClockMs ?? null })}. ` +
+              `Anyone in the workspace can now run \`/${valid.slug}\` <input>.`,
+          );
+        } catch (err) {
+          log.warn("Failed to persist /command define", { error: err instanceof Error ? err.message : String(err) });
+          await reply(`Couldn't save \`/${valid.slug}\` \u2014 please try again.`);
+        }
+      }
+    }
+    return;
+  }
+
+  // ── custom command invocation: `/<slug> <input>` \u2192 a bounded /goal boot ──
+  // When the message isn't a built-in, it may be an org-registered custom
+  // command (a saved, parameterized /goal). Resolve it to a goalStart so it
+  // reuses the exact worker -> judge -> audit loop, budgets, and persistence.
+  let customCommandSlug: string | null = null;
+  let customBoot: SlashCommand | null = null;
+  if (!rawSlash && agent.orgId) {
+    const inv = extractCustomCommandInvocation(userText);
+    if (inv) {
+      const def = await commandDefinitionRepository
+        .findByOrgAndSlug(agent.orgId, inv.slug)
+        .catch(() => null);
+      if (def && def.enabled) {
+        customBoot = renderCommandToGoalStart(def, inv.input);
+        customCommandSlug = def.slug;
+      }
+    }
+  }
+
   const slash =
     rawSlash ??
+    customBoot ??
     (autoGoalEnabled && !immediateTaskCommand ? parseSlashCommand(`/goal ${userText}`) : null);
   const experimentCommand = parseExperimentCommand(userText);
 
@@ -1802,6 +1929,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         "**Slash commands**",
         "- `/goal <condition>` — work autonomously until the condition is met · options: `model=<name>` `provider=<name>` `maxTurns=<1-20>` `maxTime=<30m|2h>`",
         "- `/goal status` — show the active goal",
+        "- `/command define <slug> [maxTurns=…] [maxTime=…] [model=…] <template with {input}>` — save a custom command · `/command list` · `/command show <slug>` · `/command delete <slug>`",
         "- `/experiment <duration> [focus...]` — explore until the deadline · `/experiment status` · `/experiment stop`",
         "- `/stop` (or `/goal clear`) — stop the current run, drop queued messages, and clear any active goal",
         "- `/clear` — wipe this thread's context and start fresh",
@@ -3017,6 +3145,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
           condition: pendingGoalStart.condition,
           ...(pendingGoalStart.maxTurns != null ? { maxTurns: pendingGoalStart.maxTurns } : {}),
           ...(pendingGoalStart.maxWallClockMs != null ? { maxWallClockMs: pendingGoalStart.maxWallClockMs } : {}),
+          ...(customCommandSlug ? { commandSlug: customCommandSlug } : {}),
           // dispatchPayload is JSON-safe by construction (strings / arrays /
           // plain objects only); the cast satisfies Prisma's InputJsonValue
           // brand which doesn't accept Record<string, unknown> directly.

--- a/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
+++ b/apps/xyne-claw-auth/backend/src/services/goalRelooper.ts
@@ -191,6 +191,7 @@ export async function handleSlashCommandBeforeRun(args: {
       kind: "goalStatusReply",
       replyToUser:
         `**/goal status** — turn ${goal.turnCount}/${goal.maxTurns}` +
+        (goal.commandSlug ? ` · via /${goal.commandSlug}` : "") +
         (goal.maxWallClockMs != null ? ` · budget ${formatDurationMs(goal.maxWallClockMs)}` : "") +
         (goal.lastReason ? ` · last: ${goal.lastReason}` : "") +
         `\n_${condPreview}_`,
@@ -241,6 +242,7 @@ export async function persistGoalStart(args: {
   runPayload: Prisma.InputJsonValue;
   maxTurns?: number;
   maxWallClockMs?: number;
+  commandSlug?: string | null;
 }): Promise<void> {
   await activeGoalRepository.startOrReplace(args);
 }


### PR DESCRIPTION
## What
Lets workspace members define custom `/commands` without a developer in the loop. A custom command is a **saved, parameterized `/goal`**: an org-scoped template plus optional provider/model and budget ceilings. Typing `/<slug> <input>` renders the template into a goal condition and boots the **same** proven worker → judge → audit loop `/goal` already uses, persisting into `active_goals`. No new execution engine.

Solves Sahebjot / Reetam's ask for configurable `/commands`.

## How
- **`CommandDefinition`** Prisma model (unique per `orgId` + `slug`) + tracked migration `20260814130000_command_registry`. Additive nullable `active_goals.commandSlug` for run observability.
- **Parser stays pure**: `parseSlashCommand` gains only the `/command define|list|show|delete` verbs and a pure `extractCustomCommandInvocation` (start-anchored, reserved-slug filtered). The async org-scoped registry lookup happens in the webhook path, not the parser.
- **`commandRegistry.ts`** (pure): slug validation (lowercase, 2–32 chars, no builtin collision), `{input}` render, definition → `goalStart` mapping.
- **Budgets hard-capped**: per-command `maxTurns` / `maxTime` are clamped to the same `GOAL_MAX_TURNS_CAP` / `GOAL_MAX_WALL_CLOCK_MS_CAP` ceilings at define time — a custom command can never exceed the `/goal` limits.
- `/goal status` and `/help` surface the driving command.

## Scope / safety
- MVP: org-scoped + budget-capped; any workspace member may define (no approval flow yet — follow-up).
- Multi-node graph / FlowUI authoring is explicit follow-up, intentionally not in this PR.
- Stacked on `feature/claw-loop-budgets` (PR #601). Merge #601 first.

## Validation
- 22 new unit tests (46 passing across the touched suites: commandRegistry + parseSlashCommand + goalRelooper.budget).
- `tsc --noEmit` parity 578 == 578 (no net new type errors beyond the pre-existing offline-prisma degradation).