### PR TITLE
fix: digital twin fixes with admin control

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -457,11 +457,11 @@ model UserMemoryCandidate {
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  /// Cluster label. One of: "style" | "expertise" | "projects" |
+  /// Cluster label. One of: "style" | "triage" | "expertise" | "projects" |
   /// "relationships" | "preferences" | "decisions" | "context" | "docs"
   subsystem String
 
-  /// The memory text the curator emitted, ≤ 1500 chars.
+  /// The memory text the curator emitted.
   text       String
   /// If the user edited before approving, the edited version goes here; the
   /// curator's original stays in `text` for audit.

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -28,6 +28,7 @@ import { knowledgeBaseRouter } from "./routes/knowledge-base.js";
 import subagentsRouter from "./routes/subagents.js";
 import sandboxRouter from "./routes/sandbox.js";
 import { adminRouter } from "./routes/admin.js";
+import { adminDigitalTwinRouter } from "./routes/admin-digital-twin.js";
 import { organizationsRouter } from "./routes/organizations.js";
 // TEMPORARY — delete after backfill of agents.signingSecret is complete.
 import { adminBackfillSigningSecretsRouter } from "./routes/admin-backfill-signing-secrets.js";
@@ -200,6 +201,7 @@ app.use(`${BASE}/knowledge-base`, requireAuth, requireNoAccessToken, knowledgeBa
 app.use(`${BASE}/subagents`, requireAuth, requireNoAccessToken, subagentsRouter);
 app.use(`${BASE}/sandbox`, requireAuth, requireNoAccessToken, sandboxRouter);
 app.use(`${BASE}/organizations`, requireAuth, requireNoAccessToken, organizationsRouter);
+app.use(`${BASE}/admin/digital-twin`, requireAuth, requireNoAccessToken, requireClawAdmin, adminDigitalTwinRouter);
 app.use(`${BASE}/admin`, requireAuth, requireNoAccessToken, adminRouter);
 // TEMPORARY — delete this mount + the import above + the file after backfill.
 app.use(`${BASE}/admin`, requireAuth, requireNoAccessToken, adminBackfillSigningSecretsRouter);

--- a/apps/xyne-claw-auth/backend/src/routes/admin-digital-twin.test.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/admin-digital-twin.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+
+const mocks = vi.hoisted(() => ({
+  userFindMany: vi.fn(),
+  userCount: vi.fn(),
+  organizationFindMany: vi.fn(),
+  enable: vi.fn(),
+  disable: vi.fn(),
+  backfill: vi.fn(),
+}));
+
+vi.mock("../db.js", () => ({
+  prisma: {
+    user: { findMany: mocks.userFindMany, count: mocks.userCount },
+    organization: { findMany: mocks.organizationFindMany },
+  },
+}));
+
+vi.mock("../middleware/agent-acl.js", () => ({
+  requireClawAdmin: (req: Request, res: Response, next: NextFunction) => {
+    if (req.headers["x-test-role"] !== "claw-admin") {
+      res.status(403).json({ success: false, error: "CLAW_ADMIN required" });
+      return;
+    }
+    next();
+  },
+  getRequesterId: (req: Request) => req.headers["x-user-id"] as string | undefined,
+}));
+
+vi.mock("../services/adminDigitalTwinControl.js", () => ({
+  AdminDigitalTwinControlError: class AdminDigitalTwinControlError extends Error {},
+  adminEnableDigitalTwin: mocks.enable,
+  adminDisableDigitalTwin: mocks.disable,
+  adminStartDigitalTwinBackfill: mocks.backfill,
+  summarizeAdminBackfill: () => ({ status: "not_started" }),
+}));
+
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import { adminDigitalTwinRouter } from "./admin-digital-twin.js";
+
+describe("admin Digital Twin router security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.userFindMany.mockResolvedValue([]);
+    mocks.userCount.mockResolvedValue(0);
+    mocks.organizationFindMany.mockResolvedValue([]);
+    mocks.enable.mockResolvedValue({ enabledAt: new Date("2026-08-15T00:00:00.000Z"), backfillJobIds: [] });
+    mocks.disable.mockResolvedValue({ cancelledJobs: 0 });
+  });
+
+  type RouterLayer = {
+    route?: { path: string; stack: Array<{ handle: (req: Request, res: Response, next: NextFunction) => unknown }> };
+    handle: (req: Request, res: Response, next: NextFunction) => unknown;
+  };
+
+  const layers = (adminDigitalTwinRouter as unknown as { stack: RouterLayer[] }).stack;
+
+  function responseProbe(): { response: Response; status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+    const status = vi.fn();
+    const json = vi.fn();
+    const response = { status, json } as unknown as Response;
+    status.mockReturnValue(response);
+    json.mockReturnValue(response);
+    return { response, status, json };
+  }
+
+  it("places the CLAW_ADMIN guard before every list and mutation route", () => {
+    expect(layers[0]?.route).toBeUndefined();
+    expect(layers.slice(1).every((layer) => Boolean(layer.route))).toBe(true);
+
+    const { response, status } = responseProbe();
+    const next = vi.fn();
+    layers[0]!.handle(
+      { headers: {} } as Request,
+      response,
+      next,
+    );
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+    expect(mocks.userFindMany).not.toHaveBeenCalled();
+    expect(mocks.disable).not.toHaveBeenCalled();
+  });
+
+  it("the disable endpoint ignores unrelated user fields and passes only the path user id", async () => {
+    const layer = layers.find((candidate) => candidate.route?.path === "/users/:userId/disable");
+    const handler = layer?.route?.stack.at(-1)?.handle;
+    expect(handler).toBeTypeOf("function");
+    const { response, status, json } = responseProbe();
+    await handler!(
+      {
+        params: { userId: "user-1" },
+        headers: { "x-test-role": "claw-admin", "x-user-id": "admin-1" },
+        body: { name: "Changed name", email: "changed@example.com", role: "CLAW_ADMIN" },
+      } as unknown as Request,
+      response,
+      vi.fn(),
+    );
+
+    expect(status).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({ success: true, data: { disabled: true, cancelledJobs: 0 } });
+    expect(mocks.disable).toHaveBeenCalledOnce();
+    expect(mocks.disable).toHaveBeenCalledWith("user-1");
+    expect(mocks.enable).not.toHaveBeenCalled();
+    expect(mocks.backfill).not.toHaveBeenCalled();
+  });
+
+  it("the enable endpoint accepts only the backfill window from its request body", async () => {
+    const layer = layers.find((candidate) => candidate.route?.path === "/users/:userId/enable");
+    const handler = layer?.route?.stack.at(-1)?.handle;
+    const { response, status } = responseProbe();
+    await handler!(
+      {
+        params: { userId: "user-2" },
+        headers: { "x-test-role": "claw-admin", "x-user-id": "admin-1" },
+        body: {
+          backfill: null,
+          name: "Changed name",
+          email: "changed@example.com",
+          digitalTwinMemoryApprovalMode: "auto",
+        },
+      } as unknown as Request,
+      response,
+      vi.fn(),
+    );
+
+    expect(status).not.toHaveBeenCalled();
+    expect(mocks.enable).toHaveBeenCalledOnce();
+    expect(mocks.enable).toHaveBeenCalledWith({ userId: "user-2", backfill: null });
+  });
+
+  it("returns a paginated, read-only projection instead of full user records", async () => {
+    mocks.userFindMany.mockResolvedValue([{
+      id: "user-1",
+      name: "Ada",
+      email: "ada@example.com",
+      orgId: "org-1",
+      digitalTwinEnabled: true,
+      digitalTwinEnabledAt: new Date("2026-08-15T00:00:00.000Z"),
+      digitalTwinBackfillState: { secretRawState: "must not leak" },
+      org: { name: "Engineering" },
+    }]);
+    mocks.userCount
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(0);
+    mocks.organizationFindMany.mockResolvedValue([{ id: "org-1", name: "Engineering" }]);
+
+    const layer = layers.find((candidate) => candidate.route?.path === "/users");
+    const handler = layer?.route?.stack.at(-1)?.handle;
+    const { response, json } = responseProbe();
+    await handler!(
+      {
+        query: { limit: "25", offset: "25", status: "enabled", search: "Ada", sort: "name_asc" },
+        headers: { "x-test-role": "claw-admin" },
+      } as unknown as Request,
+      response,
+      vi.fn(),
+    );
+
+    expect(mocks.userFindMany).toHaveBeenCalledWith(expect.objectContaining({ skip: 25, take: 25 }));
+    const payload = json.mock.calls[0]?.[0] as { data: { rows: Array<Record<string, unknown>>; total: number } };
+    expect(payload.data.total).toBe(1);
+    expect(payload.data.rows[0]).toEqual({
+      id: "user-1",
+      name: "Ada",
+      email: "ada@example.com",
+      orgId: "org-1",
+      orgName: "Engineering",
+      enabled: true,
+      enabledAt: new Date("2026-08-15T00:00:00.000Z"),
+      backfill: { status: "not_started" },
+    });
+    expect(payload.data.rows[0]).not.toHaveProperty("digitalTwinBackfillState");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/admin-digital-twin.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/admin-digital-twin.ts
@@ -1,0 +1,195 @@
+import { Prisma } from "@prisma/client";
+import { Router, type Request, type Response } from "express";
+import { prisma } from "../db.js";
+import { requireClawAdmin, getRequesterId } from "../middleware/agent-acl.js";
+import { createLogger } from "../logger.js";
+import {
+  AdminDigitalTwinControlError,
+  adminDisableDigitalTwin,
+  adminEnableDigitalTwin,
+  adminStartDigitalTwinBackfill,
+  summarizeAdminBackfill,
+  type AdminBackfillWindowInput,
+} from "../services/adminDigitalTwinControl.js";
+
+const log = createLogger("admin-digital-twin");
+const router = Router();
+
+// Defense in depth: main.ts also mounts this router behind verified session
+// auth and the access-token barrier. Keeping the role guard here ensures the
+// router remains admin-only if it is ever mounted elsewhere or tested directly.
+router.use(requireClawAdmin);
+
+function parseLimit(raw: unknown): number {
+  const value = Number(raw ?? 25);
+  return [10, 25, 50, 100].includes(value) ? value : 25;
+}
+
+function sendControlError(res: Response, error: unknown): void {
+  if (error instanceof AdminDigitalTwinControlError) {
+    res.status(error.status).json({ success: false, error: error.message, code: error.code });
+    return;
+  }
+  log.error("Admin Digital Twin control failed", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  res.status(500).json({ success: false, error: "Internal server error" });
+}
+
+function parseBackfill(raw: unknown, required: boolean): AdminBackfillWindowInput | null | undefined {
+  if (raw == null) {
+    if (required) throw new AdminDigitalTwinControlError("backfill is required", 400, "INVALID_BACKFILL_WINDOW");
+    return raw as null | undefined;
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new AdminDigitalTwinControlError("backfill must be an object or null", 400, "INVALID_BACKFILL_WINDOW");
+  }
+  const value = raw as Record<string, unknown>;
+  if (typeof value["from"] !== "string" || (value["to"] != null && typeof value["to"] !== "string")) {
+    throw new AdminDigitalTwinControlError("backfill requires string from/to dates", 400, "INVALID_BACKFILL_WINDOW");
+  }
+  return { from: value["from"], ...(typeof value["to"] === "string" ? { to: value["to"] } : {}) };
+}
+
+router.get("/users", async (req: Request, res: Response) => {
+  try {
+    const limit = parseLimit(req.query["limit"]);
+    const offset = Math.min(1_000_000, Math.max(0, Math.floor(Number(req.query["offset"] ?? 0) || 0)));
+    const search = String(req.query["search"] ?? "").trim().slice(0, 200);
+    const status = String(req.query["status"] ?? "all");
+    const orgId = String(req.query["orgId"] ?? "").trim();
+    const sort = String(req.query["sort"] ?? "name_asc");
+    if (!["all", "enabled", "disabled"].includes(status)) {
+      res.status(400).json({ success: false, error: "status must be all, enabled, or disabled" });
+      return;
+    }
+
+    const baseWhere: Prisma.UserWhereInput = {
+      ...(orgId ? { orgId } : {}),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: "insensitive" } },
+              { email: { contains: search, mode: "insensitive" } },
+              { id: { contains: search, mode: "insensitive" } },
+            ],
+          }
+        : {}),
+    };
+    const where: Prisma.UserWhereInput = {
+      ...baseWhere,
+      ...(status === "enabled"
+        ? { digitalTwinEnabled: true }
+        : status === "disabled"
+          ? { digitalTwinEnabled: false }
+          : {}),
+    };
+    const orderBy: Prisma.UserOrderByWithRelationInput[] =
+      sort === "name_desc"
+        ? [{ name: "desc" }, { id: "asc" }]
+        : sort === "email_asc"
+          ? [{ email: "asc" }, { id: "asc" }]
+          : sort === "recently_enabled"
+            ? [{ digitalTwinEnabledAt: { sort: "desc", nulls: "last" } }, { name: "asc" }]
+            : [{ name: "asc" }, { id: "asc" }];
+
+    const [rows, total, enabled, disabled, organizations] = await Promise.all([
+      prisma.user.findMany({
+        where,
+        orderBy,
+        skip: offset,
+        take: limit,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          orgId: true,
+          digitalTwinEnabled: true,
+          digitalTwinEnabledAt: true,
+          digitalTwinBackfillState: true,
+          org: { select: { name: true } },
+        },
+      }),
+      prisma.user.count({ where }),
+      prisma.user.count({ where: { ...baseWhere, digitalTwinEnabled: true } }),
+      prisma.user.count({ where: { ...baseWhere, digitalTwinEnabled: false } }),
+      prisma.organization.findMany({
+        orderBy: { name: "asc" },
+        select: { id: true, name: true },
+      }),
+    ]);
+
+    res.json({
+      success: true,
+      data: {
+        rows: rows.map((row) => ({
+          id: row.id,
+          name: row.name,
+          email: row.email,
+          orgId: row.orgId,
+          orgName: row.org.name,
+          enabled: row.digitalTwinEnabled,
+          enabledAt: row.digitalTwinEnabledAt,
+          backfill: summarizeAdminBackfill(row.digitalTwinBackfillState),
+        })),
+        total,
+        limit,
+        offset,
+        summary: { enabled, disabled, total: enabled + disabled },
+        organizations,
+      },
+    });
+  } catch (error) {
+    sendControlError(res, error);
+  }
+});
+
+router.post("/users/:userId/enable", async (req: Request<{ userId: string }>, res: Response) => {
+  try {
+    const backfill = parseBackfill((req.body as { backfill?: unknown } | undefined)?.backfill, false);
+    const result = await adminEnableDigitalTwin({
+      userId: req.params.userId,
+      ...(backfill !== undefined ? { backfill } : {}),
+    });
+    log.info("CLAW_ADMIN enabled Digital Twin for user", {
+      actorUserId: getRequesterId(req),
+      targetUserId: req.params.userId,
+      backfillStarted: result.backfillJobIds.length > 0,
+    });
+    res.json({ success: true, data: { enabled: true, ...result } });
+  } catch (error) {
+    sendControlError(res, error);
+  }
+});
+
+router.post("/users/:userId/disable", async (req: Request<{ userId: string }>, res: Response) => {
+  try {
+    const result = await adminDisableDigitalTwin(req.params.userId);
+    log.info("CLAW_ADMIN disabled Digital Twin for user", {
+      actorUserId: getRequesterId(req),
+      targetUserId: req.params.userId,
+      cancelledJobs: result.cancelledJobs,
+    });
+    res.json({ success: true, data: { disabled: true, ...result } });
+  } catch (error) {
+    sendControlError(res, error);
+  }
+});
+
+router.post("/users/:userId/backfill", async (req: Request<{ userId: string }>, res: Response) => {
+  try {
+    const backfill = parseBackfill((req.body as { backfill?: unknown } | undefined)?.backfill, true)!;
+    const result = await adminStartDigitalTwinBackfill({ userId: req.params.userId, backfill });
+    log.info("CLAW_ADMIN started Digital Twin backfill for user", {
+      actorUserId: getRequesterId(req),
+      targetUserId: req.params.userId,
+      from: backfill.from,
+      to: backfill.to,
+    });
+    res.json({ success: true, data: result });
+  } catch (error) {
+    sendControlError(res, error);
+  }
+});
+
+export { router as adminDigitalTwinRouter };

--- a/apps/xyne-claw-auth/backend/src/routes/digital-twin.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/digital-twin.ts
@@ -712,6 +712,9 @@ digitalTwinRouter.post("/memories/delete", requireUserAuth, async (req, res) => 
         const page = await memory.listMemories(TWIN_BANK_ID, { tags: [userTag], limit: 1000 });
         const targets = page.memories
           .filter((m) => (m.tags ?? []).includes(userTag))
+          // Observations are derived and cannot be invalidated directly.
+          // Removing their raw sources makes Hindsight reconcile them.
+          .filter((m) => m.factType?.toLowerCase() !== "observation")
           .filter((m) => {
             const t = Date.parse(m.createdAt ?? "");
             return Number.isFinite(t) && t >= fromMs && t <= toMs;
@@ -995,7 +998,7 @@ digitalTwinRouter.post("/clusters/:subsystem/approve", requireUserAuth, async (r
       let retained = 0;
       let failed = 0;
       for (const c of candidates) {
-        const content = (c.editedText ?? c.text).slice(0, 1500);
+        const content = c.editedText ?? c.text;
         const tags = [
           `user:${userId}`,
           `subsystem:${subsystem}`,
@@ -1071,12 +1074,12 @@ digitalTwinRouter.patch("/candidates/:id", requireUserAuth, async (req, res) => 
 
     const updates: Record<string, unknown> = {};
     if (typeof body.editedText === "string") {
-      updates["editedText"] = body.editedText.slice(0, 1500);
+      updates["editedText"] = body.editedText;
     }
 
     let hindsightMemoryId: string | null = candidate.hindsightMemoryId ?? null;
     if (body.status === "approved" && candidate.status === "pending") {
-      const content = (typeof body.editedText === "string" ? body.editedText : candidate.text).slice(0, 1500);
+      const content = typeof body.editedText === "string" ? body.editedText : candidate.text;
       const tags = [
         `user:${userId}`,
         `subsystem:${candidate.subsystem}`,

--- a/apps/xyne-claw-auth/backend/src/routes/memory.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/memory.ts
@@ -883,6 +883,7 @@ memoryRouter.get("/banks/:agentSlug/stats", requireUserAuth, async (req, res) =>
           content: m?.content ?? "(deleted from provider — recall history retained)",
           scope: isShared ? "shared" : ownerTag ? "user" : null,
           category: categoryTag ? categoryTag.slice(4) : (m?.factType ?? null),
+          factType: m?.factType ?? null,
           status: m ? "approved" : "rejected",
           createdAt: m?.createdAt ?? null,
         };
@@ -960,6 +961,7 @@ memoryRouter.get("/banks/:agentSlug/stats", requireUserAuth, async (req, res) =>
         content: m?.content ?? "(deleted from provider — recall history retained)",
         scope: isShared ? "shared" : ownerTag ? "user" : null,
         category: categoryTag ? categoryTag.slice(4) : (m?.factType ?? null),
+        factType: m?.factType ?? null,
         status: m ? "approved" : "rejected",
         createdAt: m?.createdAt ?? null,
       };
@@ -1359,6 +1361,20 @@ memoryRouter.delete("/banks/:agentSlug/memories/:hindsightMemoryId", requireUser
     res.json({ success: true });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("HINDSIGHT_DERIVED_OBSERVATION")) {
+      logger.info("[memory] Direct delete refused for derived observation", {
+        agentSlug: req.params["agentSlug"],
+        hindsightMemoryId: req.params["hindsightMemoryId"],
+        by: getRequesterId(req),
+      });
+      res.status(409).json({
+        success: false,
+        code: "HINDSIGHT_DERIVED_OBSERVATION",
+        error:
+          "This is a derived Hindsight observation and cannot be deleted directly. Delete its supporting world or experience memories; Hindsight will then recompute or remove the observation automatically.",
+      });
+      return;
+    }
     logger.error("[memory] DELETE /banks/:agentSlug/memories/:hindsightMemoryId failed", { err: msg });
     // Hindsight too old to support per-memory invalidate (405). Not a bug in this
     // service — return an actionable 503 so the UI shows a real reason instead of

--- a/apps/xyne-claw-auth/backend/src/services/adminDigitalTwinControl.test.ts
+++ b/apps/xyne-claw-auth/backend/src/services/adminDigitalTwinControl.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  userCount: vi.fn(),
+  userFindUnique: vi.fn(),
+  userUpdate: vi.fn(),
+  cancelBackfill: vi.fn(),
+  enqueueBackfill: vi.fn(),
+  ensureTwinBank: vi.fn(),
+  ensureDefaultFiles: vi.fn(),
+}));
+
+vi.mock("../db.js", () => ({
+  prisma: {
+    user: {
+      count: mocks.userCount,
+      findUnique: mocks.userFindUnique,
+      update: mocks.userUpdate,
+    },
+  },
+}));
+
+vi.mock("./userMemoryCuratorClient.js", () => ({ ensureTwinBank: mocks.ensureTwinBank }));
+vi.mock("./agentMemoryFiles.js", () => ({
+  TWIN_AGENT_SLUG: "digital-twin",
+  ensureDefaultFiles: mocks.ensureDefaultFiles,
+}));
+vi.mock("../queue/digital-twin-backfill-queue.js", () => ({
+  cancelDigitalTwinBackfill: mocks.cancelBackfill,
+  enqueueDigitalTwinBackfill: mocks.enqueueBackfill,
+}));
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import {
+  AdminDigitalTwinControlError,
+  adminDisableDigitalTwin,
+  adminEnableDigitalTwin,
+  buildAdminBackfillState,
+  parseAdminBackfillWindow,
+  summarizeAdminBackfill,
+} from "./adminDigitalTwinControl.js";
+
+describe("admin Digital Twin lifecycle controls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.userCount.mockResolvedValue(1);
+    mocks.userUpdate.mockResolvedValue({});
+    mocks.cancelBackfill.mockResolvedValue(0);
+    mocks.enqueueBackfill.mockImplementation(async ({ source }: { source: string }) => `job-${source}`);
+    mocks.ensureTwinBank.mockResolvedValue(undefined);
+    mocks.ensureDefaultFiles.mockResolvedValue(undefined);
+  });
+
+  it("builds the same three-source chronological backfill state used by the user pipeline", () => {
+    const now = new Date("2026-08-15T10:00:00.000Z");
+    const window = parseAdminBackfillWindow(
+      { from: "2026-05-15T10:00:00.000Z", to: "2026-08-15T10:00:00.000Z" },
+      now,
+    );
+    const state = buildAdminBackfillState(window, now);
+
+    expect(Object.keys(state)).toEqual(["messages", "calls", "canvases"]);
+    for (const source of Object.values(state)) {
+      expect(source).toMatchObject({
+        from: "2026-05-15T10:00:00.000Z",
+        to: "2026-08-15T10:00:00.000Z",
+        cursor: "2026-05-15T10:00:00.000Z",
+        complete: false,
+        progress: { windowsDone: 0, recordsSeen: 0, candidatesMade: 0 },
+      });
+    }
+  });
+
+  it("rejects invalid and over-24-month backfill windows", () => {
+    expect(() => parseAdminBackfillWindow({ from: "not-a-date" })).toThrow(AdminDigitalTwinControlError);
+    expect(() => parseAdminBackfillWindow({
+      from: "2024-01-01T00:00:00.000Z",
+      to: "2026-08-15T00:00:00.000Z",
+    })).toThrow("24 months or fewer");
+  });
+
+  it("accepts an exact 24-calendar-month preset", () => {
+    expect(parseAdminBackfillWindow({
+      from: "2024-08-15T00:00:00.000Z",
+      to: "2026-08-15T00:00:00.000Z",
+    })).toMatchObject({
+      from: new Date("2024-08-15T00:00:00.000Z"),
+      to: new Date("2026-08-15T00:00:00.000Z"),
+    });
+  });
+
+  it("disable mutates only Digital Twin enable/backfill columns and never deletes user data", async () => {
+    mocks.cancelBackfill.mockResolvedValue(3);
+
+    await expect(adminDisableDigitalTwin("user-1")).resolves.toEqual({ cancelledJobs: 3 });
+    expect(mocks.userUpdate).toHaveBeenCalledOnce();
+    const update = mocks.userUpdate.mock.calls[0]?.[0] as { where: unknown; data: Record<string, unknown> };
+    expect(update.where).toEqual({ id: "user-1" });
+    expect(Object.keys(update.data).sort()).toEqual(["digitalTwinBackfillState", "digitalTwinEnabled"]);
+    expect(update.data.digitalTwinEnabled).toBe(false);
+  });
+
+  it("enable only writes Digital Twin lifecycle columns and queues all selected sources", async () => {
+    await expect(adminEnableDigitalTwin({
+      userId: "user-1",
+      backfill: {
+        from: "2026-05-15T00:00:00.000Z",
+        to: "2026-08-15T00:00:00.000Z",
+      },
+    })).resolves.toMatchObject({
+      backfillJobIds: ["job-messages", "job-calls", "job-canvases"],
+    });
+
+    const update = mocks.userUpdate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(Object.keys(update.data).sort()).toEqual([
+      "digitalTwinBackfillState",
+      "digitalTwinEnabled",
+      "digitalTwinEnabledAt",
+    ]);
+    expect(mocks.ensureDefaultFiles).toHaveBeenCalledWith("digital-twin", "user-1");
+    expect(mocks.enqueueBackfill).toHaveBeenCalledTimes(3);
+  });
+
+  it("summarizes list-row progress without exposing the raw state", () => {
+    const summary = summarizeAdminBackfill({
+      messages: { complete: true, from: "2026-01-01", to: "2026-02-01", progress: { windowsDone: 1, windowsTotal: 1, recordsSeen: 10, candidatesMade: 2 } },
+      calls: { complete: false, from: "2026-01-01", to: "2026-02-01", progress: { windowsDone: 0, windowsTotal: 1, recordsSeen: 3, candidatesMade: 1 } },
+      canvases: { complete: false, pausedAt: "2026-02-01", from: "2026-01-01", to: "2026-02-01", progress: { windowsDone: 0, windowsTotal: 1 } },
+    });
+    expect(summary).toMatchObject({ status: "running", progressPct: 33, recordsSeen: 13, candidatesMade: 3 });
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/services/adminDigitalTwinControl.ts
+++ b/apps/xyne-claw-auth/backend/src/services/adminDigitalTwinControl.ts
@@ -1,0 +1,236 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../db.js";
+import { createLogger } from "../logger.js";
+import { ensureTwinBank } from "./userMemoryCuratorClient.js";
+import { ensureDefaultFiles, TWIN_AGENT_SLUG } from "./agentMemoryFiles.js";
+import {
+  cancelDigitalTwinBackfill,
+  enqueueDigitalTwinBackfill,
+  type BackfillSource,
+} from "../queue/digital-twin-backfill-queue.js";
+import {
+  BACKFILL_SOURCE_KEYS,
+  type BackfillState,
+  type BackfillEntryShape,
+} from "./backfillStatus.js";
+
+const log = createLogger("admin-digital-twin-control");
+const MAX_BACKFILL_MONTHS = 24;
+
+export interface AdminBackfillWindowInput {
+  from: string;
+  to?: string;
+}
+
+export interface ParsedAdminBackfillWindow {
+  from: Date;
+  to: Date;
+}
+
+export class AdminDigitalTwinControlError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = "AdminDigitalTwinControlError";
+  }
+}
+
+export function parseAdminBackfillWindow(
+  input: AdminBackfillWindowInput,
+  now = new Date(),
+): ParsedAdminBackfillWindow {
+  if (!input || typeof input.from !== "string" || !input.from.trim()) {
+    throw new AdminDigitalTwinControlError("backfill.from is required", 400, "INVALID_BACKFILL_WINDOW");
+  }
+  if (input.to != null && typeof input.to !== "string") {
+    throw new AdminDigitalTwinControlError("backfill.to must be an ISO date", 400, "INVALID_BACKFILL_WINDOW");
+  }
+
+  const from = new Date(input.from);
+  const to = input.to ? new Date(input.to) : now;
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from > to) {
+    throw new AdminDigitalTwinControlError("Invalid backfill date range", 400, "INVALID_BACKFILL_WINDOW");
+  }
+  const earliestAllowed = new Date(to);
+  earliestAllowed.setUTCMonth(earliestAllowed.getUTCMonth() - MAX_BACKFILL_MONTHS);
+  if (from < earliestAllowed) {
+    throw new AdminDigitalTwinControlError(
+      `Backfill must span ${MAX_BACKFILL_MONTHS} months or fewer`,
+      400,
+      "INVALID_BACKFILL_WINDOW",
+    );
+  }
+  return { from, to };
+}
+
+export function buildAdminBackfillState(
+  window: ParsedAdminBackfillWindow,
+  now = new Date(),
+): BackfillState {
+  const spanMs = window.to.getTime() - window.from.getTime();
+  const windowsTotal = Math.max(1, Math.ceil(spanMs / (30 * 24 * 60 * 60 * 1000)));
+  const nowIso = now.toISOString();
+  const state: BackfillState = {};
+  for (const source of BACKFILL_SOURCE_KEYS) {
+    state[source] = {
+      from: window.from.toISOString(),
+      to: window.to.toISOString(),
+      cursor: window.from.toISOString(),
+      complete: false,
+      progress: {
+        windowsTotal,
+        windowsDone: 0,
+        recordsSeen: 0,
+        candidatesMade: 0,
+        currentWindow: null,
+        lastError: null,
+        startedAt: nowIso,
+        updatedAt: nowIso,
+      },
+    };
+  }
+  return state;
+}
+
+export interface AdminBackfillSummary {
+  status: "not_started" | "running" | "paused" | "complete" | "error";
+  from: string | null;
+  to: string | null;
+  progressPct: number | null;
+  recordsSeen: number;
+  candidatesMade: number;
+  lastError: string | null;
+}
+
+export function summarizeAdminBackfill(raw: unknown): AdminBackfillSummary {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      status: "not_started",
+      from: null,
+      to: null,
+      progressPct: null,
+      recordsSeen: 0,
+      candidatesMade: 0,
+      lastError: null,
+    };
+  }
+  const entries = BACKFILL_SOURCE_KEYS
+    .map((source) => (raw as BackfillState)[source])
+    .filter((entry): entry is BackfillEntryShape => Boolean(entry));
+  if (entries.length === 0) return summarizeAdminBackfill(null);
+
+  const incomplete = entries.filter((entry) => entry.complete !== true);
+  const allPaused = incomplete.length > 0 && incomplete.every((entry) => Boolean(entry.pausedAt));
+  const lastError = entries
+    .map((entry) => entry.progress?.lastError?.message ?? null)
+    .find((message): message is string => Boolean(message)) ?? null;
+  const windowsDone = entries.reduce((sum, entry) => sum + (entry.progress?.windowsDone ?? 0), 0);
+  const windowsTotal = entries.reduce((sum, entry) => sum + (entry.progress?.windowsTotal ?? 0), 0);
+
+  return {
+    status: lastError ? "error" : incomplete.length === 0 ? "complete" : allPaused ? "paused" : "running",
+    from: entries.map((entry) => entry.from).filter((value): value is string => Boolean(value)).sort()[0] ?? null,
+    to: entries.map((entry) => entry.to).filter((value): value is string => Boolean(value)).sort().at(-1) ?? null,
+    progressPct: windowsTotal > 0 ? Math.min(100, Math.round((windowsDone * 100) / windowsTotal)) : null,
+    recordsSeen: entries.reduce((sum, entry) => sum + (entry.progress?.recordsSeen ?? 0), 0),
+    candidatesMade: entries.reduce((sum, entry) => sum + (entry.progress?.candidatesMade ?? 0), 0),
+    lastError,
+  };
+}
+
+async function requireTargetUser(userId: string): Promise<void> {
+  const exists = await prisma.user.count({ where: { id: userId } });
+  if (exists === 0) {
+    throw new AdminDigitalTwinControlError("User not found", 404, "USER_NOT_FOUND");
+  }
+}
+
+async function enqueueBackfillForAllSources(
+  userId: string,
+  window: ParsedAdminBackfillWindow,
+): Promise<string[]> {
+  const jobIds: string[] = [];
+  for (const source of BACKFILL_SOURCE_KEYS as readonly BackfillSource[]) {
+    jobIds.push(await enqueueDigitalTwinBackfill({ userId, source, ...window }));
+  }
+  return jobIds;
+}
+
+export async function adminEnableDigitalTwin(input: {
+  userId: string;
+  backfill?: AdminBackfillWindowInput | null;
+}): Promise<{ enabledAt: Date; backfillJobIds: string[] }> {
+  await requireTargetUser(input.userId);
+  const now = new Date();
+  const window = input.backfill ? parseAdminBackfillWindow(input.backfill, now) : null;
+  const state = window ? buildAdminBackfillState(window, now) : null;
+
+  await cancelDigitalTwinBackfill(input.userId);
+  await prisma.user.update({
+    where: { id: input.userId },
+    data: {
+      digitalTwinEnabled: true,
+      digitalTwinEnabledAt: now,
+      digitalTwinBackfillState: state
+        ? (state as unknown as Prisma.InputJsonValue)
+        : (Prisma.JsonNull as unknown as Prisma.NullableJsonNullValueInput),
+    },
+  });
+
+  await ensureTwinBank();
+  await ensureDefaultFiles(TWIN_AGENT_SLUG, input.userId).catch((error) => {
+    log.warn("Failed to seed default Digital Twin files during admin enable", {
+      userId: input.userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  return {
+    enabledAt: now,
+    backfillJobIds: window ? await enqueueBackfillForAllSources(input.userId, window) : [],
+  };
+}
+
+export async function adminDisableDigitalTwin(userId: string): Promise<{ cancelledJobs: number }> {
+  await requireTargetUser(userId);
+  const cancelledJobs = await cancelDigitalTwinBackfill(userId);
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      digitalTwinEnabled: false,
+      digitalTwinBackfillState: Prisma.JsonNull as unknown as Prisma.NullableJsonNullValueInput,
+    },
+  });
+  return { cancelledJobs };
+}
+
+export async function adminStartDigitalTwinBackfill(input: {
+  userId: string;
+  backfill: AdminBackfillWindowInput;
+}): Promise<{ backfillJobIds: string[] }> {
+  const user = await prisma.user.findUnique({
+    where: { id: input.userId },
+    select: { digitalTwinEnabled: true },
+  });
+  if (!user) throw new AdminDigitalTwinControlError("User not found", 404, "USER_NOT_FOUND");
+  if (!user.digitalTwinEnabled) {
+    throw new AdminDigitalTwinControlError(
+      "Enable Digital Twin before starting a backfill",
+      409,
+      "DIGITAL_TWIN_DISABLED",
+    );
+  }
+
+  const window = parseAdminBackfillWindow(input.backfill);
+  const state = buildAdminBackfillState(window);
+  await cancelDigitalTwinBackfill(input.userId);
+  await prisma.user.update({
+    where: { id: input.userId },
+    data: { digitalTwinBackfillState: state as unknown as Prisma.InputJsonValue },
+  });
+  await ensureTwinBank();
+  return { backfillJobIds: await enqueueBackfillForAllSources(input.userId, window) };
+}

--- a/apps/xyne-claw-auth/backend/src/services/agentMemoryFiles.ts
+++ b/apps/xyne-claw-auth/backend/src/services/agentMemoryFiles.ts
@@ -72,8 +72,8 @@ export const DEFAULT_TWIN_FILES: readonly DefaultFileSpec[] = [
     name: "soul.md",
     loadInPrompt: true,
     sortOrder: 0,
-    description: "Your core persona — how you sound and who you are. Always speak as this.",
-    subsystems: ["style", "context"],
+    description: "Your core persona — how you sound, who you are, and when you engage. Always follow this.",
+    subsystems: ["style", "context", "triage"],
     seed: [
       "# Soul",
       "",
@@ -84,6 +84,9 @@ export const DEFAULT_TWIN_FILES: readonly DefaultFileSpec[] = [
       "",
       "## Identity",
       "_(role, team, how you show up)_",
+      "",
+      "## Engagement",
+      "_(when you respond, when you stay silent, and which conversations you prioritize — from approved triage memories)_",
     ].join("\n"),
   },
   {

--- a/apps/xyne-claw-auth/backend/src/services/contextAssembler.ts
+++ b/apps/xyne-claw-auth/backend/src/services/contextAssembler.ts
@@ -23,8 +23,8 @@
  * rendered unit is prefixed to tell the curator to extract facts about the user
  * only. Nothing co-participant is stored verbatim as the user's memory.
  *
- * Flag-gated: only runs when TWIN_CONTEXT_ASSEMBLER=1 (else the legacy flat
- * `fetchUserMessages` path is used), so the two can be A/B'd safely.
+ * Enabled by default. Set TWIN_CONTEXT_ASSEMBLER=0/false/off/no to use the
+ * legacy flat `fetchUserMessages` path for rollback or comparison.
  */
 
 import type { UserMemoryChannelType, UserMemoryRecord, UserMemoryThreadContext } from "xyne-claw-shared";
@@ -119,8 +119,8 @@ const MENTION_ACTIONS = ["mentioned_user", "group_mention"];
 
 // ─── Flag ────────────────────────────────────────────────────────────────
 export function isContextAssemblerEnabled(): boolean {
-  const v = process.env["TWIN_CONTEXT_ASSEMBLER"];
-  return v === "1" || v === "true";
+  const value = process.env["TWIN_CONTEXT_ASSEMBLER"]?.trim().toLowerCase();
+  return !value || !["0", "false", "off", "no"].includes(value);
 }
 
 // ─── Loose Spaces row shapes (flat scalar rows from /api/query/claw) ───────

--- a/apps/xyne-claw-auth/backend/src/services/digitalTwinPipelineEvents.ts
+++ b/apps/xyne-claw-auth/backend/src/services/digitalTwinPipelineEvents.ts
@@ -42,6 +42,20 @@ export interface SynthFileResult {
   action: "updated" | "skipped" | "error";
   chars?: number;
   error?: string;
+  model?: string;
+  durationMs?: number;
+  systemPrompt?: string;
+  userPrompt?: string;
+  rawOutput?: string;
+  promptChars?: number;
+  factsAvailable?: number;
+  factsDropped?: number;
+  factsClipped?: number;
+  factInputChars?: number;
+  factInputBudgetChars?: number;
+  contextLimited?: boolean;
+  finishReason?: string;
+  usage?: { promptTokens?: number; completionTokens?: number };
 }
 
 /** Stored in DigitalTwinPipelineEvent.trace for runType="synthesize" runs, so
@@ -205,17 +219,21 @@ export async function finishSynthesisEvent(
 ): Promise<void> {
   try {
     const updated = result.files.filter((f) => f.action === "updated");
+    const errored = result.files.filter((f) => f.action === "error");
     const factsTotal = result.files.reduce((s, f) => s + f.factsUsed, 0);
+    const synthesisError = result.error ?? (errored.length > 0
+      ? `${errored.length} persona file${errored.length === 1 ? "" : "s"} failed to compile`
+      : null);
     await (prisma.digitalTwinPipelineEvent.update as any)({
       where: { id },
       data: {
-        status: result.error ? "error" : updated.length > 0 ? "ok" : "empty",
+        status: synthesisError ? "error" : updated.length > 0 ? "ok" : "empty",
         recordCount: factsTotal,
         emittedCount: result.files.length,
         keptCount: updated.length,
         candidatesCreated: updated.length,
         durationMs: result.durationMs,
-        error: result.error ?? null,
+        error: synthesisError,
         trace: { kind: "synthesize", trigger, files: result.files } satisfies SynthTrace,
       },
     });

--- a/apps/xyne-claw-auth/backend/src/services/twinSoulSynthesizer.ts
+++ b/apps/xyne-claw-auth/backend/src/services/twinSoulSynthesizer.ts
@@ -71,7 +71,25 @@ interface SynthReq {
   preserveEdits?: boolean;
 }
 
-async function synthesizeViaClaw(req: SynthReq): Promise<{ content: string | null; error?: string }> {
+interface SynthCallTrace {
+  model: string;
+  durationMs: number;
+  systemPrompt: string;
+  userPrompt: string;
+  rawOutput: string;
+  promptChars: number;
+  factsAvailable: number;
+  factsUsed: number;
+  factsDropped: number;
+  factsClipped: number;
+  factInputChars: number;
+  factInputBudgetChars: number;
+  contextLimited: boolean;
+  finishReason?: string;
+  usage?: { promptTokens?: number; completionTokens?: number };
+}
+
+async function synthesizeViaClaw(req: SynthReq): Promise<{ content: string | null; error?: string; trace?: SynthCallTrace }> {
   if (!CONFIG.xyneClawS2sKey) return { content: null, error: "no-s2s-key" };
   const url = `${CONFIG.xyneClawUrl.replace(/\/$/, "")}/internal/user-memory/synthesize-file`;
   try {
@@ -82,8 +100,12 @@ async function synthesizeViaClaw(req: SynthReq): Promise<{ content: string | nul
       signal: AbortSignal.timeout(SYNTH_TIMEOUT_MS),
     });
     if (!res.ok) return { content: null, error: `http-${res.status}` };
-    const data = (await res.json()) as { content?: string | null; error?: string };
-    return { content: data.content ?? null, ...(data.error ? { error: data.error } : {}) };
+    const data = (await res.json()) as { content?: string | null; error?: string; trace?: SynthCallTrace };
+    return {
+      content: data.content ?? null,
+      ...(data.error ? { error: data.error } : {}),
+      ...(data.trace ? { trace: data.trace } : {}),
+    };
   } catch (err) {
     return { content: null, error: err instanceof Error ? err.message : String(err) };
   }
@@ -118,7 +140,7 @@ export async function synthesizeSoulFilesForUser(
     }
     const current = await getFile(TWIN_AGENT_SLUG, userId, spec.name);
     const userEdited = current?.updatedBy === "user";
-    const { content, error } = await synthesizeViaClaw({
+    const { content, error, trace } = await synthesizeViaClaw({
       fileName: spec.name,
       description: spec.description,
       facts,
@@ -130,7 +152,8 @@ export async function synthesizeSoulFilesForUser(
       skipped.push(spec.name);
       fileResults.push({
         name: spec.name,
-        factsUsed: facts.length,
+        ...(trace ?? {}),
+        factsUsed: trace?.factsUsed ?? facts.length,
         action: error ? "error" : "skipped",
         ...(error ? { error } : {}),
       });
@@ -150,7 +173,13 @@ export async function synthesizeSoulFilesForUser(
       sortOrder: spec.sortOrder,
     });
     updated.push(spec.name);
-    fileResults.push({ name: spec.name, factsUsed: facts.length, action: "updated", chars: content.length });
+    fileResults.push({
+      name: spec.name,
+      ...(trace ?? {}),
+      factsUsed: trace?.factsUsed ?? facts.length,
+      action: "updated",
+      chars: content.length,
+    });
   }
 
   if (eventId) {

--- a/apps/xyne-claw-auth/backend/src/services/userMemoryBatcher.test.ts
+++ b/apps/xyne-claw-auth/backend/src/services/userMemoryBatcher.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import type { UserMemoryRecord } from "xyne-claw-shared";
+import { BATCH_TOKEN_BUDGET, packRecordsIntoBatches } from "./userMemoryBatcher.js";
+
+function records(count: number, chars = 1): UserMemoryRecord[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `message-${i}`,
+    type: "message" as const,
+    ts: "2026-08-14T00:00:00.000Z",
+    text: "x".repeat(chars),
+  }));
+}
+
+describe("packRecordsIntoBatches", () => {
+  test("packs up to 200 short records into one curator call", () => {
+    const batches = packRecordsIntoBatches(records(200));
+    expect(batches.map((batch) => batch.length)).toEqual([200]);
+  });
+
+  test("starts a new batch after the 200-record backstop", () => {
+    const batches = packRecordsIntoBatches(records(201));
+    expect(batches.map((batch) => batch.length)).toEqual([200, 1]);
+  });
+
+  test("the 80k-token text budget wins before the record backstop", () => {
+    const batches = packRecordsIntoBatches(records(200, 2_000));
+    const maxChars = BATCH_TOKEN_BUDGET * 4;
+    expect(batches.length).toBe(2);
+    expect(batches.flat()).toHaveLength(200);
+    for (const batch of batches) {
+      expect(batch.reduce((sum, record) => sum + record.text.length, 0)).toBeLessThanOrEqual(maxChars);
+    }
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/services/userMemoryBatcher.ts
+++ b/apps/xyne-claw-auth/backend/src/services/userMemoryBatcher.ts
@@ -12,7 +12,7 @@
  *   1. Token budget — accumulate records until the next one would push the batch
  *      past BATCH_TOKEN_BUDGET.
  *   2. Record backstop — never exceed MAX_RECORDS_PER_BATCH (matches the claw
- *      curator's own 50-record cap, so it never silently truncates a batch).
+ *      curator's own 200-record cap, so it never silently truncates a batch).
  *
  * Oversized single units (a rare 80-message thread all at the char cap, or a
  * huge canvas) are SUB-CHUNKED into `id#pN` pieces that each fit the budget, so
@@ -33,9 +33,10 @@ const CHARS_PER_TOKEN = 4;
  *  existing memories are added. */
 export const BATCH_TOKEN_BUDGET = 80_000;
 const BATCH_CHAR_BUDGET = BATCH_TOKEN_BUDGET * CHARS_PER_TOKEN; // 320_000
-/** Matches MAX_RECORDS_PER_BATCH in claw's user-memory-curator (never let a
- *  batch exceed what the curator will actually process). */
-const MAX_RECORDS_PER_BATCH = 50;
+/** Matches MAX_RECORDS_PER_BATCH in claw's user-memory-curator. Small records
+ * can now fill the 80k-token budget instead of being cut off at 50; large
+ * records still split earlier on BATCH_CHAR_BUDGET. */
+const MAX_RECORDS_PER_BATCH = 200;
 
 /** Marker prefixing every sub-chunk id: `<baseId>#p<n>`. Base record ids
  *  (message/conversation ids, `twin-reply:*`) never contain "#", so this is a
@@ -85,7 +86,7 @@ function subChunk(r: UserMemoryRecord): UserMemoryRecord[] {
   }));
 }
 
-/** Pack records into curator batches by token budget (+ 50-record backstop),
+/** Pack records into curator batches by token budget (+ 200-record backstop),
  *  sub-chunking any single oversized unit first. Every batch is non-empty and
  *  fits the budget (a lone sub-chunk that equals the budget is its own batch). */
 export function packRecordsIntoBatches(records: UserMemoryRecord[]): UserMemoryRecord[][] {

--- a/apps/xyne-claw-auth/backend/src/services/userMemoryCuratorClient.ts
+++ b/apps/xyne-claw-auth/backend/src/services/userMemoryCuratorClient.ts
@@ -430,7 +430,7 @@ export async function curateAndPersistBatch(args: {
   for (const row of writable) {
     if (autoApproveEnabled && row.signalScore >= minScore) {
       try {
-        const content = row.text.slice(0, 1500);
+        const content = row.text;
         const tags = [
           `user:${userId}`,
           `subsystem:${row.subsystem}`,

--- a/apps/xyne-claw-auth/frontend/src/components/DigitalTwinSection.tsx
+++ b/apps/xyne-claw-auth/frontend/src/components/DigitalTwinSection.tsx
@@ -603,7 +603,6 @@ function ClusterDetail({ userId, subsystem, onBack }: { userId: string; subsyste
                         <textarea
                           value={editText}
                           onChange={(e) => setEditText(e.target.value)}
-                          maxLength={1500}
                           className="h-24 w-full rounded border border-zinc-700 bg-zinc-900 p-2 text-sm text-zinc-100"
                         />
                       )}

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -6,7 +6,11 @@ const BACKEND_URL = frontendConfig.spacesAuthBaseUrl;
 const AUTH_API_URL = frontendConfig.clawApiBaseUrl;
 
 export class ApiError extends Error {
-  constructor(public readonly status: number, message: string) {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly code?: string,
+  ) {
     super(message);
     this.name = "ApiError";
   }
@@ -95,8 +99,8 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as { error?: string };
-    throw new ApiError(res.status, body.error ?? `Request failed: ${res.status}`);
+    const body = await res.json().catch(() => ({})) as { error?: string; code?: string };
+    throw new ApiError(res.status, body.error ?? `Request failed: ${res.status}`, body.code);
   }
 
   return res.json() as Promise<T>;
@@ -1690,6 +1694,120 @@ export interface AdminRole {
   grantedBy: string | null;
   createdAt: string;
   user: { id: string; name: string; email: string; orgId?: string; orgName?: string | null };
+}
+
+export type AdminDigitalTwinBackfillStatus =
+  | "not_started"
+  | "running"
+  | "paused"
+  | "complete"
+  | "error";
+
+export interface AdminDigitalTwinUser {
+  id: string;
+  name: string;
+  email: string;
+  orgId: string;
+  orgName: string;
+  enabled: boolean;
+  enabledAt: string | null;
+  backfill: {
+    status: AdminDigitalTwinBackfillStatus;
+    from: string | null;
+    to: string | null;
+    progressPct: number | null;
+    recordsSeen: number;
+    candidatesMade: number;
+    lastError: string | null;
+  };
+}
+
+export interface AdminDigitalTwinUsersPage {
+  rows: AdminDigitalTwinUser[];
+  total: number;
+  limit: number;
+  offset: number;
+  summary: { enabled: number; disabled: number; total: number };
+  organizations: Array<{ id: string; name: string }>;
+}
+
+export interface AdminDigitalTwinUsersQuery {
+  search?: string;
+  status?: "all" | "enabled" | "disabled";
+  orgId?: string;
+  sort?: "name_asc" | "name_desc" | "email_asc" | "recently_enabled";
+  limit?: 10 | 25 | 50 | 100;
+  offset?: number;
+}
+
+export interface AdminDigitalTwinBackfillWindow {
+  from: string;
+  to: string;
+}
+
+export async function listAdminDigitalTwinUsers(
+  userId: string,
+  query: AdminDigitalTwinUsersQuery = {},
+): Promise<AdminDigitalTwinUsersPage> {
+  const params = new URLSearchParams();
+  if (query.search) params.set("search", query.search);
+  if (query.status) params.set("status", query.status);
+  if (query.orgId) params.set("orgId", query.orgId);
+  if (query.sort) params.set("sort", query.sort);
+  if (query.limit) params.set("limit", String(query.limit));
+  if (query.offset != null) params.set("offset", String(query.offset));
+  const data = await request<{ success: boolean; data: AdminDigitalTwinUsersPage }>(
+    `${AUTH_API_URL}/api/v1/admin/digital-twin/users?${params.toString()}`,
+    { headers: { "x-user-id": userId } },
+  );
+  return data.data;
+}
+
+export async function adminEnableDigitalTwinForUser(
+  userId: string,
+  targetUserId: string,
+  backfill: AdminDigitalTwinBackfillWindow | null,
+): Promise<{ enabled: true; enabledAt: string; backfillJobIds: string[] }> {
+  const data = await request<{
+    success: boolean;
+    data: { enabled: true; enabledAt: string; backfillJobIds: string[] };
+  }>(`${AUTH_API_URL}/api/v1/admin/digital-twin/users/${encodeURIComponent(targetUserId)}/enable`, {
+    method: "POST",
+    headers: { "x-user-id": userId },
+    body: JSON.stringify({ backfill }),
+  });
+  return data.data;
+}
+
+export async function adminDisableDigitalTwinForUser(
+  userId: string,
+  targetUserId: string,
+): Promise<{ disabled: true; cancelledJobs: number }> {
+  const data = await request<{
+    success: boolean;
+    data: { disabled: true; cancelledJobs: number };
+  }>(`${AUTH_API_URL}/api/v1/admin/digital-twin/users/${encodeURIComponent(targetUserId)}/disable`, {
+    method: "POST",
+    headers: { "x-user-id": userId },
+    body: JSON.stringify({}),
+  });
+  return data.data;
+}
+
+export async function adminStartDigitalTwinBackfillForUser(
+  userId: string,
+  targetUserId: string,
+  backfill: AdminDigitalTwinBackfillWindow,
+): Promise<{ backfillJobIds: string[] }> {
+  const data = await request<{ success: boolean; data: { backfillJobIds: string[] } }>(
+    `${AUTH_API_URL}/api/v1/admin/digital-twin/users/${encodeURIComponent(targetUserId)}/backfill`,
+    {
+      method: "POST",
+      headers: { "x-user-id": userId },
+      body: JSON.stringify({ backfill }),
+    },
+  );
+  return data.data;
 }
 
 export interface AuditLogEntry {
@@ -4311,7 +4429,7 @@ export interface CuratorEmittedCandidate {
   signalScore?: number;
   groundedOnIds?: string[];
   verdict: "kept" | "dropped";
-  dropReason?: "empty-or-too-long" | "bad-subsystem" | "low-signal" | "ungrounded" | "malformed";
+  dropReason?: "empty" | "empty-or-too-long" | "bad-subsystem" | "low-signal" | "ungrounded" | "malformed";
 }
 
 /** Full trace of one curator LLM call. Mirrors UserMemoryCuratorTrace in
@@ -4348,6 +4466,20 @@ export interface SynthFileResult {
   action: "updated" | "skipped" | "error";
   chars?: number;
   error?: string;
+  model?: string;
+  durationMs?: number;
+  systemPrompt?: string;
+  userPrompt?: string;
+  rawOutput?: string;
+  promptChars?: number;
+  factsAvailable?: number;
+  factsDropped?: number;
+  factsClipped?: number;
+  factInputChars?: number;
+  factInputBudgetChars?: number;
+  contextLimited?: boolean;
+  finishReason?: string;
+  usage?: { promptTokens?: number; completionTokens?: number };
 }
 
 /** Trace stored on a synthesize pipeline event (instead of a CuratorTrace). */
@@ -4782,6 +4914,9 @@ export interface MemoryBankMemory {
   id: string;
   hindsightMemoryId: string;
   category: string | null;
+  /** Hindsight storage type. Observations are derived and cannot be curated
+   *  directly; delete their supporting world/experience facts instead. */
+  factType?: string | null;
   content: string;
   curatorReasoning: string | null;
   curatorConfidence: number | null;
@@ -4809,6 +4944,7 @@ export interface MemoryBankStats {
     lastRecalledAt: string | null;
     content: string;
     category: string | null;
+    factType?: string | null;
     status: string | null;
     createdAt: string | null;
   }>;
@@ -4869,7 +5005,14 @@ export async function deleteDigitalTwinMemory(userId: string, hindsightMemoryId:
     `${MEMORY_BASE}/banks/digital-twin/memories/${encodeURIComponent(hindsightMemoryId)}?userTag=${encodeURIComponent(`user:${userId}`)}`,
     { method: "DELETE", credentials: "include" },
   );
-  if (!res.ok) throw new Error(`Failed to delete memory: ${res.status}`);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string; code?: string };
+    throw new ApiError(
+      res.status,
+      body.error ?? `Failed to delete memory: ${res.status}`,
+      body.code,
+    );
+  }
 }
 
 

--- a/apps/xyne-claw-auth/frontend/src/v3/AppV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/AppV3.tsx
@@ -35,6 +35,7 @@ import { SearchEvalsPageV3 } from "./components/SearchEvalsPageV3";
 import { EntityTypesPageV3 } from "./components/EntityTypesPageV3";
 import { ErrorPipelinePageV3 } from "./components/ErrorPipelinePageV3";
 import { CliLoginPageV3 } from "./components/CliLoginPageV3";
+import { DigitalTwinUserControlsPageV3 } from "./components/DigitalTwinUserControlsPageV3";
 import { ChatProvider } from "./hooks/useChat";
 
 
@@ -194,6 +195,18 @@ export function AppV3() {
                 <OrganizationsPageV3 userId={userId} />
               </div>
             } />
+            <Route
+              path="/v3/configurations/digital-twin"
+              element={
+                isAdmin ? (
+                  <div className="flex flex-1 flex-col overflow-hidden rounded-xl bg-xyne-surface shadow-sm">
+                    <DigitalTwinUserControlsPageV3 userId={userId} />
+                  </div>
+                ) : isAdminLoading ? null : (
+                  <Navigate to="/v3/home" replace />
+                )
+              }
+            />
             <Route path="/v3/metrics" element={
               <div className="flex flex-1 flex-col overflow-hidden rounded-xl bg-xyne-surface shadow-sm">
                 <MetricsPageV3 userId={userId} />

--- a/apps/xyne-claw-auth/frontend/src/v3/ShellV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/ShellV3.tsx
@@ -134,6 +134,7 @@ const SIDEBAR_GROUPS: SidebarGroupConfig[] = [
     items: [
       { label: "Organization", path: "/v3/organizations", icon: BuildingsIcon },
       { label: "Settings", path: "/v3/settings", icon: GearSixIcon },
+      { label: "Digital Twin Users", path: "/v3/configurations/digital-twin", icon: BrainIcon },
     ],
   },
 ];
@@ -308,7 +309,9 @@ export function ShellV3({ children, isAdmin = false, hasSearchEvalAccess = false
         ...g,
         items: g.items.filter((i) => {
           if (i.path === "/v3/search-evals") return hasSearchEvalAccess;
-          return i.path !== "/v3/evals" && i.path !== "/v3/entity-types";
+          return i.path !== "/v3/evals"
+            && i.path !== "/v3/entity-types"
+            && i.path !== "/v3/configurations/digital-twin";
         }),
       }))
   ).filter((g) => g.items.length > 0);

--- a/apps/xyne-claw-auth/frontend/src/v3/components/DigitalTwinUserControlsPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/DigitalTwinUserControlsPageV3.tsx
@@ -1,0 +1,469 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  BrainIcon,
+  MagnifyingGlassIcon,
+  SpinnerGapIcon,
+  ArrowClockwiseIcon,
+  DatabaseIcon,
+} from "@phosphor-icons/react";
+import {
+  adminDisableDigitalTwinForUser,
+  adminEnableDigitalTwinForUser,
+  adminStartDigitalTwinBackfillForUser,
+  listAdminDigitalTwinUsers,
+  type AdminDigitalTwinBackfillWindow,
+  type AdminDigitalTwinUser,
+  type AdminDigitalTwinUsersPage,
+} from "../../lib/api";
+import { PageLayout } from "./ui/PageLayout";
+import { PageHeader } from "./ui/PageHeader";
+import { Button } from "./ui/Button";
+import { Badge } from "./ui/Badge";
+import { Switch } from "./ui/Switch";
+import { TextField } from "./ui/TextField";
+import { SelectField } from "./ui/SelectField";
+import { Dialog } from "./ui/Dialog";
+import { ConfirmDialog } from "./ui/ConfirmDialog";
+import { useSnackbar } from "./ui/Snackbar";
+
+type StatusFilter = "all" | "enabled" | "disabled";
+type SortOption = "name_asc" | "name_desc" | "email_asc" | "recently_enabled";
+type PageSize = 10 | 25 | 50 | 100;
+type BackfillPreset = "none" | "1" | "3" | "6" | "12" | "24" | "custom";
+
+const EMPTY_PAGE: AdminDigitalTwinUsersPage = {
+  rows: [],
+  total: 0,
+  limit: 25,
+  offset: 0,
+  summary: { enabled: 0, disabled: 0, total: 0 },
+  organizations: [],
+};
+
+function dateInputValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function presetWindow(preset: BackfillPreset, customFrom: string, customTo: string): AdminDigitalTwinBackfillWindow | null {
+  if (preset === "none") return null;
+  if (preset === "custom") {
+    if (!customFrom || !customTo) throw new Error("Choose both custom backfill dates");
+    const from = new Date(`${customFrom}T00:00:00`);
+    const to = new Date(`${customTo}T23:59:59.999`);
+    if (from > to) throw new Error("Backfill start date must be before the end date");
+    const earliestAllowed = new Date(to);
+    earliestAllowed.setMonth(earliestAllowed.getMonth() - 24);
+    if (from < earliestAllowed) throw new Error("Backfill range cannot exceed 24 months");
+    return { from: from.toISOString(), to: to.toISOString() };
+  }
+  const to = new Date();
+  const from = new Date(to);
+  from.setMonth(from.getMonth() - Number(preset));
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+function backfillBadge(user: AdminDigitalTwinUser): { label: string; variant: "neutral" | "success" | "warning" | "error" | "info" } {
+  const status = user.backfill.status;
+  if (status === "running") return { label: `Running${user.backfill.progressPct != null ? ` · ${user.backfill.progressPct}%` : ""}`, variant: "info" };
+  if (status === "paused") return { label: "Paused", variant: "warning" };
+  if (status === "complete") return { label: "Complete", variant: "success" };
+  if (status === "error") return { label: "Error", variant: "error" };
+  return { label: "Not started", variant: "neutral" };
+}
+
+export function DigitalTwinUserControlsPageV3({ userId }: { userId: string }) {
+  const { show: showSnackbar } = useSnackbar();
+  const [page, setPage] = useState(EMPTY_PAGE);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [orgId, setOrgId] = useState("");
+  const [sort, setSort] = useState<SortOption>("name_asc");
+  const [pageSize, setPageSize] = useState<PageSize>(25);
+  const [offset, setOffset] = useState(0);
+  const [disableTarget, setDisableTarget] = useState<AdminDigitalTwinUser | null>(null);
+  const [lifecycleAction, setLifecycleAction] = useState<{
+    kind: "enable" | "backfill";
+    user: AdminDigitalTwinUser;
+  } | null>(null);
+  const [backfillPreset, setBackfillPreset] = useState<BackfillPreset>("none");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState(dateInputValue(new Date()));
+  const [actionError, setActionError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setOffset(0);
+      setSearch(searchInput.trim());
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchInput]);
+
+  const load = useCallback(async (quiet = false) => {
+    quiet ? setRefreshing(true) : setLoading(true);
+    try {
+      setPage(await listAdminDigitalTwinUsers(userId, {
+        search: search || undefined,
+        status,
+        orgId: orgId || undefined,
+        sort,
+        limit: pageSize,
+        offset,
+      }));
+    } catch (error) {
+      showSnackbar({
+        variant: "error",
+        title: error instanceof Error ? error.message : "Failed to load Digital Twin users",
+      });
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [userId, search, status, orgId, sort, pageSize, offset, showSnackbar]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const organizationOptions = useMemo(
+    () => [{ value: "", label: "All organizations" }, ...page.organizations.map((org) => ({ value: org.id, label: org.name }))],
+    [page.organizations],
+  );
+
+  const openLifecycle = (kind: "enable" | "backfill", user: AdminDigitalTwinUser) => {
+    setLifecycleAction({ kind, user });
+    setBackfillPreset(kind === "enable" ? "none" : "3");
+    setCustomFrom("");
+    setCustomTo(dateInputValue(new Date()));
+    setActionError("");
+  };
+
+  const runLifecycleAction = async () => {
+    if (!lifecycleAction) return;
+    setActionError("");
+    setSaving(true);
+    try {
+      const window = presetWindow(backfillPreset, customFrom, customTo);
+      if (lifecycleAction.kind === "enable") {
+        await adminEnableDigitalTwinForUser(userId, lifecycleAction.user.id, window);
+        showSnackbar({
+          variant: "success",
+          title: `${lifecycleAction.user.name}'s Digital Twin enabled${window ? " and backfill started" : ""}`,
+        });
+      } else {
+        if (!window) throw new Error("Choose a backfill window");
+        await adminStartDigitalTwinBackfillForUser(userId, lifecycleAction.user.id, window);
+        showSnackbar({ variant: "success", title: `Backfill started for ${lifecycleAction.user.name}` });
+      }
+      setLifecycleAction(null);
+      await load(true);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Action failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmDisable = async () => {
+    if (!disableTarget) return;
+    const target = disableTarget;
+    setSaving(true);
+    try {
+      await adminDisableDigitalTwinForUser(userId, target.id);
+      showSnackbar({ variant: "success", title: `${target.name}'s Digital Twin disabled` });
+      setDisableTarget(null);
+      await load(true);
+    } catch (error) {
+      showSnackbar({
+        variant: "error",
+        title: error instanceof Error ? error.message : "Failed to disable Digital Twin",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(page.total / pageSize));
+  const currentPage = Math.floor(offset / pageSize) + 1;
+
+  return (
+    <>
+    <PageLayout
+      header={
+        <PageHeader
+          title="Digital Twin user controls"
+          description="CLAW_ADMIN-only controls for user opt-in and memory backfills."
+          icon={<BrainIcon size={22} className="text-xyne-brand" />}
+          actions={
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={refreshing}
+              leadingIcon={<ArrowClockwiseIcon size={14} className={refreshing ? "animate-spin" : ""} />}
+              onClick={() => void load(true)}
+            >
+              Refresh
+            </Button>
+          }
+        />
+      }
+      body={
+        <div data-id="digital-twin-user-controls" className="space-y-4 p-4">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <SummaryCard label="All users" value={page.summary.total} />
+            <SummaryCard label="Twin enabled" value={page.summary.enabled} tone="success" />
+            <SummaryCard label="Twin disabled" value={page.summary.disabled} tone="muted" />
+          </div>
+
+          <div className="rounded-xl border border-xyne-border bg-xyne-surface p-3">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="min-w-[240px] flex-1">
+                <TextField
+                  label="Search users"
+                  placeholder="Name, email, or user ID"
+                  value={searchInput}
+                  onChange={(event) => setSearchInput(event.target.value)}
+                />
+              </div>
+              <SelectField
+                label="Twin status"
+                className="w-[170px]"
+                value={status}
+                options={[
+                  { value: "all", label: "All statuses" },
+                  { value: "enabled", label: "Enabled" },
+                  { value: "disabled", label: "Disabled" },
+                ]}
+                onValueChange={(value) => { setOffset(0); setStatus((value ?? "all") as StatusFilter); }}
+              />
+              <SelectField
+                label="Organization"
+                className="w-[210px]"
+                value={orgId}
+                options={organizationOptions}
+                onValueChange={(value) => { setOffset(0); setOrgId(value ?? ""); }}
+              />
+              <SelectField
+                label="Sort"
+                className="w-[180px]"
+                value={sort}
+                options={[
+                  { value: "name_asc", label: "Name A–Z" },
+                  { value: "name_desc", label: "Name Z–A" },
+                  { value: "email_asc", label: "Email A–Z" },
+                  { value: "recently_enabled", label: "Recently enabled" },
+                ]}
+                onValueChange={(value) => { setOffset(0); setSort((value ?? "name_asc") as SortOption); }}
+              />
+              <SelectField
+                label="Rows"
+                className="w-[105px]"
+                value={String(pageSize)}
+                options={[10, 25, 50, 100].map((value) => ({ value: String(value), label: String(value) }))}
+                onValueChange={(value) => { setOffset(0); setPageSize(Number(value ?? 25) as PageSize); }}
+              />
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-xyne-border bg-xyne-surface">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-16 text-[13px] text-xyne-fg-muted">
+                <SpinnerGapIcon size={16} className="animate-spin" /> Loading users…
+              </div>
+            ) : page.rows.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 py-16 text-center">
+                <MagnifyingGlassIcon size={22} className="text-xyne-fg-tertiary" />
+                <p className="text-[13px] text-xyne-fg-muted">No users match these filters.</p>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-[960px] w-full text-left text-[13px]">
+                  <thead>
+                    <tr className="border-b border-xyne-border bg-xyne-surface-subtle text-[11px] uppercase tracking-wide text-xyne-fg-tertiary">
+                      <th className="px-4 py-3 font-medium">User</th>
+                      <th className="px-4 py-3 font-medium">Organization</th>
+                      <th className="px-4 py-3 font-medium">Digital Twin</th>
+                      <th className="px-4 py-3 font-medium">Last enabled</th>
+                      <th className="px-4 py-3 font-medium">Backfill</th>
+                      <th className="px-4 py-3 text-right font-medium">Controls</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {page.rows.map((user) => {
+                      const backfill = backfillBadge(user);
+                      return (
+                        <tr key={user.id} className="border-b border-xyne-border-subtle last:border-b-0 hover:bg-xyne-surface-subtle/40">
+                          <td className="px-4 py-3">
+                            <div className="font-medium text-xyne-fg-primary">{user.name}</div>
+                            <div className="text-[11px] text-xyne-fg-muted">{user.email}</div>
+                            <div className="max-w-[220px] truncate font-mono text-[10px] text-xyne-fg-tertiary" title={user.id}>{user.id}</div>
+                          </td>
+                          <td className="px-4 py-3 text-xyne-fg-secondary">{user.orgName}</td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <Switch
+                                checked={user.enabled}
+                                disabled={saving}
+                                ariaLabel={`${user.enabled ? "Disable" : "Enable"} Digital Twin for ${user.name}`}
+                                onChange={(enabled) => enabled ? openLifecycle("enable", user) : setDisableTarget(user)}
+                              />
+                              <Badge as="span" size="sm" variant={user.enabled ? "success" : "neutral"} label={user.enabled ? "Enabled" : "Disabled"} />
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-[11px] text-xyne-fg-muted">
+                            {user.enabledAt ? new Date(user.enabledAt).toLocaleString() : "—"}
+                          </td>
+                          <td className="px-4 py-3">
+                            <Badge as="span" size="sm" variant={backfill.variant} label={backfill.label} />
+                            {user.backfill.from && user.backfill.to && (
+                              <div className="mt-1 text-[10px] text-xyne-fg-tertiary">
+                                {new Date(user.backfill.from).toLocaleDateString()} – {new Date(user.backfill.to).toLocaleDateString()}
+                              </div>
+                            )}
+                            {user.backfill.lastError && (
+                              <div className="mt-1 max-w-[240px] truncate text-[10px] text-xyne-error-fg" title={user.backfill.lastError}>{user.backfill.lastError}</div>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex justify-end gap-2">
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                disabled={!user.enabled || saving}
+                                leadingIcon={<DatabaseIcon size={13} />}
+                                onClick={() => openLifecycle("backfill", user)}
+                              >
+                                Start backfill
+                              </Button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] text-xyne-fg-muted">
+            <div>
+              {page.total === 0 ? "0 users" : `${offset + 1}–${Math.min(offset + pageSize, page.total)} of ${page.total} users`}
+              <span className="ml-2">· Page {currentPage} of {totalPages}</span>
+            </div>
+            <div className="flex gap-2">
+              <Button size="sm" variant="secondary" disabled={offset === 0 || loading} onClick={() => setOffset(Math.max(0, offset - pageSize))}>Previous</Button>
+              <Button size="sm" variant="secondary" disabled={offset + pageSize >= page.total || loading} onClick={() => setOffset(offset + pageSize)}>Next</Button>
+            </div>
+          </div>
+
+          <p className="rounded-lg border border-xyne-border-subtle bg-xyne-surface-subtle px-3 py-2 text-[11px] text-xyne-fg-muted">
+            This page exposes no controls for user identity, organization membership, roles, memories,
+            persona content, or other user settings. Enabling may seed missing default persona files as part of normal Digital Twin setup.
+          </p>
+        </div>
+      }
+      footer={null}
+    />
+
+    <Dialog
+      open={lifecycleAction != null}
+      onOpenChange={(open) => { if (!open && !saving) setLifecycleAction(null); }}
+      title={lifecycleAction?.kind === "backfill" ? "Start Digital Twin backfill" : "Enable Digital Twin"}
+      description={
+        lifecycleAction
+          ? `${lifecycleAction.user.name} (${lifecycleAction.user.email})`
+          : undefined
+      }
+      maxWidth={520}
+      footer={
+        <>
+          <Button variant="secondary" disabled={saving} onClick={() => setLifecycleAction(null)}>Cancel</Button>
+          <Button variant="primary" disabled={saving} onClick={() => void runLifecycleAction()}>
+            {saving
+              ? "Saving…"
+              : lifecycleAction?.kind === "backfill"
+                ? "Start backfill"
+                : backfillPreset === "none"
+                  ? "Enable"
+                  : "Enable and start backfill"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-[12px] text-xyne-fg-secondary">
+          {lifecycleAction?.kind === "backfill"
+            ? "Choose how much existing Spaces history to process. A new backfill replaces any current backfill progress for this user."
+            : "Enabling allows the user's Twin to reply to mentions and includes them in daily memory curation and persona updates."}
+        </p>
+        <SelectField
+          label="Backfill window"
+          value={backfillPreset}
+          options={[
+            ...(lifecycleAction?.kind === "enable" ? [{ value: "none", label: "Do not start a backfill" }] : []),
+            { value: "1", label: "Last 1 month" },
+            { value: "3", label: "Last 3 months" },
+            { value: "6", label: "Last 6 months" },
+            { value: "12", label: "Last 12 months" },
+            { value: "24", label: "Last 24 months" },
+            { value: "custom", label: "Custom date range" },
+          ]}
+          onValueChange={(value) => { setBackfillPreset((value ?? "none") as BackfillPreset); setActionError(""); }}
+        />
+        {backfillPreset === "custom" && (
+          <div className="grid grid-cols-2 gap-3">
+            <TextField
+              label="From"
+              type="date"
+              value={customFrom}
+              max={customTo || dateInputValue(new Date())}
+              onChange={(event) => setCustomFrom(event.target.value)}
+            />
+            <TextField
+              label="To"
+              type="date"
+              value={customTo}
+              min={customFrom || undefined}
+              max={dateInputValue(new Date())}
+              onChange={(event) => setCustomTo(event.target.value)}
+            />
+          </div>
+        )}
+        {actionError && (
+          <div className="rounded-lg border border-xyne-error-border bg-xyne-error-bg px-3 py-2 text-[11px] text-xyne-error-fg">
+            {actionError}
+          </div>
+        )}
+      </div>
+    </Dialog>
+
+    <ConfirmDialog
+      open={disableTarget != null}
+      onOpenChange={(open) => { if (!open && !saving) setDisableTarget(null); }}
+      title="Disable Digital Twin"
+      description={
+        disableTarget
+          ? `Disable Digital Twin for ${disableTarget.name}? Auto replies, daily curation, and persona updates will stop, and active backfill jobs will be cancelled. Existing memories and persona files will be preserved.`
+          : ""
+      }
+      confirmLabel="Disable Digital Twin"
+      danger
+      onConfirm={() => void confirmDisable()}
+    />
+    </>
+  );
+}
+
+function SummaryCard({ label, value, tone = "default" }: { label: string; value: number; tone?: "default" | "success" | "muted" }) {
+  return (
+    <div className="rounded-xl border border-xyne-border bg-xyne-surface px-4 py-3">
+      <p className="text-[11px] text-xyne-fg-muted">{label}</p>
+      <p className={`mt-1 text-2xl font-semibold ${tone === "success" ? "text-xyne-success-fg" : tone === "muted" ? "text-xyne-fg-secondary" : "text-xyne-fg-primary"}`}>{value}</p>
+    </div>
+  );
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/digital-twin/DigitalTwinMemoriesTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/digital-twin/DigitalTwinMemoriesTab.tsx
@@ -16,6 +16,7 @@ import {
   InfoIcon,
 } from "@phosphor-icons/react";
 import {
+  ApiError,
   listDigitalTwinMemories,
   deleteDigitalTwinMemory,
   getDigitalTwinStats,
@@ -125,6 +126,23 @@ function fmtRelative(iso: string | null): string {
  */
 function cleanMemoryText(s: string): string {
   return s.replace(/\s*\|\s*(Involving|When|Where|Who|Related|Context)\s*:.*$/i, "").trim();
+}
+
+function memoryDeleteNotice(error: unknown): { title: string; description?: string } {
+  if (error instanceof ApiError && error.code === "HINDSIGHT_DERIVED_OBSERVATION") {
+    return {
+      title: "Derived observation cannot be deleted directly",
+      description: error.message,
+    };
+  }
+  return {
+    title: "Failed to delete memory",
+    ...(error instanceof Error ? { description: error.message } : {}),
+  };
+}
+
+function isObservationType(factType?: string | null): boolean {
+  return factType?.toLowerCase() === "observation";
 }
 
 /** The curator subsystem label of a memory, from its `subsystem:<x>` tag. */
@@ -550,16 +568,19 @@ function AllSubtab({
   const timelineLabel = new Date(timeCutoff ?? tMax).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 
   const handleDelete = useCallback(
-    async (hindsightMemoryId: string) => {
-      if (!window.confirm("Delete this memory? This removes it from Hindsight and marks all related review rows as rejected. Recall-hit history is retained.")) {
+    async (hindsightMemoryId: string, factType?: string | null) => {
+      // Let the backend return its explicit derived-observation signal so the
+      // user sees why this type cannot be deleted. Raw facts still get the
+      // destructive-action confirmation.
+      if (!isObservationType(factType) && !window.confirm("Delete this memory? This removes it from Hindsight and marks all related review rows as rejected. Recall-hit history is retained.")) {
         return;
       }
       try {
         await deleteDigitalTwinMemory(userId, hindsightMemoryId);
         onRemove(hindsightMemoryId);
         showSnackbar({ variant: "success", title: "Memory deleted" });
-      } catch {
-        showSnackbar({ variant: "error", title: "Failed to delete memory" });
+      } catch (error) {
+        showSnackbar({ variant: "error", ...memoryDeleteNotice(error), duration: 8_000 });
       }
     },
     [userId, onRemove, showSnackbar],
@@ -827,7 +848,7 @@ function MemoryCard({
   onViewReasoning,
 }: {
   memory: MemoryBankMemory;
-  onDelete: (id: string) => void;
+  onDelete: (id: string, factType?: string | null) => void;
   userId?: string;
   onViewReasoning?: (pipelineEventId: string) => void;
 }) {
@@ -835,6 +856,7 @@ function MemoryCard({
   const [showReasoning, setShowReasoning] = useState(false);
   const cleanText = cleanMemoryText(memory.content);
   const sub = subsystemOf(memory);
+  const isObservation = isObservationType(memory.factType);
   const isLong = cleanText.length > MEMORY_TRUNCATE_AT;
   const visibleText =
     expanded || !isLong
@@ -904,6 +926,13 @@ function MemoryCard({
                 <svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.4"><path d="M2.5 8h11M9 3.5 13.5 8 9 12.5" /></svg>
                 reasoning
               </button>
+            ) : isObservation ? (
+              <span
+                title="Derived by Hindsight from supporting world/experience facts; it has no single curator trace."
+                className="inline-flex items-center rounded-md border border-dashed border-xyne-warning-border px-[8px] py-[3px] font-mono text-[10.5px] text-xyne-warning-fg"
+              >
+                derived
+              </span>
             ) : (
               <span
                 title="No pipeline trace — this memory predates the reasoning link."
@@ -914,9 +943,9 @@ function MemoryCard({
             )
           )}
           <button
-            onClick={() => onDelete(memory.hindsightMemoryId)}
+            onClick={() => onDelete(memory.hindsightMemoryId, memory.factType)}
             className="text-xyne-fg-tertiary hover:text-xyne-error-fg"
-            title="Delete memory"
+            title={isObservation ? "Why can't I delete this derived observation?" : "Delete memory"}
           >
             <TrashIcon size={14} />
           </button>
@@ -947,8 +976,9 @@ function HotSubtab({ userId }: { userId: string }) {
   }, [userId, range, showSnackbar]);
 
   const handleDelete = useCallback(
-    async (hindsightMemoryId: string) => {
+    async (hindsightMemoryId: string, factType?: string | null) => {
       if (
+        !isObservationType(factType) &&
         !window.confirm(
           "Delete this memory? This removes it from Hindsight and marks related review rows as rejected. Recall-hit history is retained.",
         )
@@ -960,8 +990,8 @@ function HotSubtab({ userId }: { userId: string }) {
         // Optimistic — Hot is re-fetched on range change or manual refresh
         setDeletedIds((prev) => new Set(prev).add(hindsightMemoryId));
         showSnackbar({ variant: "success", title: "Memory deleted" });
-      } catch {
-        showSnackbar({ variant: "error", title: "Failed to delete memory" });
+      } catch (error) {
+        showSnackbar({ variant: "error", ...memoryDeleteNotice(error), duration: 8_000 });
       }
     },
     [userId, showSnackbar],
@@ -1041,9 +1071,9 @@ function HotSubtab({ userId }: { userId: string }) {
               </div>
               {!isRejected && (
                 <button
-                  onClick={() => handleDelete(m.hindsightMemoryId)}
+                  onClick={() => handleDelete(m.hindsightMemoryId, m.factType)}
                   className="shrink-0 text-xyne-fg-tertiary hover:text-xyne-error-fg"
-                  title="Delete memory"
+                  title={isObservationType(m.factType) ? "Why can't I delete this derived observation?" : "Delete memory"}
                   aria-label="Delete memory"
                 >
                   <TrashIcon size={14} />

--- a/apps/xyne-claw-auth/frontend/src/v3/components/digital-twin/DigitalTwinPipelinePageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/digital-twin/DigitalTwinPipelinePageV3.tsx
@@ -48,7 +48,7 @@ interface Props {
   initialEventId?: string | null;
 }
 
-type RunTypeFilter = "" | "backfill" | "daily" | "upload" | "twin-approval" | "gate";
+type RunTypeFilter = "" | "backfill" | "daily" | "upload" | "twin-approval" | "synthesize" | "gate";
 type StatusFilter = "" | "ok" | "empty" | "error" | "running" | "retry";
 
 const RUN_TYPE_OPTIONS: { label: string; value: RunTypeFilter }[] = [
@@ -57,6 +57,7 @@ const RUN_TYPE_OPTIONS: { label: string; value: RunTypeFilter }[] = [
   { label: "Daily",     value: "daily" },
   { label: "Upload",    value: "upload" },
   { label: "Twin reply", value: "twin-approval" },
+  { label: "Persona rebuild", value: "synthesize" },
   { label: "Respond gate", value: "gate" },
 ];
 
@@ -78,6 +79,7 @@ const RUN_TYPE_META: Record<string, { label: string; icon: React.ReactNode }> = 
 };
 
 const DROP_REASON_LABELS: Record<string, string> = {
+  "empty":             "empty",
   "empty-or-too-long": "empty / too long",
   "bad-subsystem":     "invalid subsystem",
   "low-signal":        "score < 0.7",
@@ -656,21 +658,77 @@ function GateDetail({ detail, trace }: { detail: PipelineEventDetail; trace: Gat
 }
 
 function SynthFileRow({ f }: { f: SynthFileResult }) {
+  const [open, setOpen] = useState(false);
   const tone =
     f.action === "updated"
       ? "text-xyne-success-fg"
       : f.action === "error"
       ? "text-xyne-error-fg"
       : "text-xyne-fg-muted";
+  const hasExchange = !!(f.systemPrompt || f.userPrompt || f.rawOutput);
+  const available = f.factsAvailable ?? f.factsUsed;
+  const tokens = f.usage
+    ? `${f.usage.promptTokens ?? "?"} in / ${f.usage.completionTokens ?? "?"} out`
+    : "—";
   return (
-    <div className="flex items-center gap-[10px] bg-xyne-surface px-[12px] py-[8px]">
-      <span className="font-mono text-[12px] text-xyne-fg-primary">{f.name}</span>
-      <span className="text-[11px] text-xyne-fg-tertiary">
-        {f.factsUsed} fact{f.factsUsed === 1 ? "" : "s"}
-        {f.chars ? ` · ${f.chars.toLocaleString()} chars` : ""}
-        {f.error ? ` · ${f.error}` : ""}
-      </span>
-      <span className={`ml-auto text-[10px] font-semibold uppercase tracking-[0.04em] ${tone}`}>{f.action}</span>
+    <div className="bg-xyne-surface">
+      <button
+        type="button"
+        onClick={() => hasExchange && setOpen((v) => !v)}
+        className={`flex w-full items-center gap-[8px] px-[12px] py-[8px] text-left ${hasExchange ? "cursor-pointer hover:bg-xyne-surface-sunken" : "cursor-default"}`}
+      >
+        {hasExchange
+          ? open ? <CaretDownIcon size={11} className="text-xyne-fg-muted" /> : <CaretRightIcon size={11} className="text-xyne-fg-muted" />
+          : <span className="w-[11px]" />}
+        <span className="font-mono text-[12px] text-xyne-fg-primary">{f.name}</span>
+        <span className="text-[11px] text-xyne-fg-tertiary">
+          {f.factsUsed}{available !== f.factsUsed ? ` of ${available}` : ""} fact{available === 1 ? "" : "s"}
+          {f.chars ? ` · ${f.chars.toLocaleString()} chars` : ""}
+          {f.error ? ` · ${f.error}` : ""}
+        </span>
+        {f.contextLimited && (
+          <span
+            className="flex items-center gap-[3px] text-[10px] font-medium text-xyne-warning-fg"
+            title={`Input capped: ${f.factsDropped ?? available - f.factsUsed} memories omitted${f.factsClipped ? `, ${f.factsClipped} clipped` : ""}.`}
+          >
+            <WarningIcon size={10} /> context limited
+          </span>
+        )}
+        <span className={`ml-auto text-[10px] font-semibold uppercase tracking-[0.04em] ${tone}`}>{f.action}</span>
+      </button>
+      {open && hasExchange && (
+        <div className="flex flex-col gap-[8px] border-t border-xyne-border-subtle bg-xyne-surface-subtle px-[12px] py-[10px]">
+          <div className="grid grid-cols-2 gap-x-[16px] gap-y-[6px] sm:grid-cols-4">
+            {[
+              ["Model", f.model ?? "—"],
+              ["LLM duration", fmtDuration(f.durationMs ?? 0)],
+              ["Prompt", f.promptChars != null ? `${f.promptChars.toLocaleString()} chars` : "—"],
+              ["Tokens", tokens],
+              ["Facts", `${f.factsUsed} used / ${available} available`],
+              ["Fact budget", f.factInputBudgetChars != null ? `${(f.factInputChars ?? 0).toLocaleString()} / ${f.factInputBudgetChars.toLocaleString()} chars` : "—"],
+              ["Finish reason", f.finishReason ?? "—"],
+              ["Output", f.chars != null ? `${f.chars.toLocaleString()} chars stored` : "—"],
+            ].map(([k, v]) => (
+              <div key={k} className="min-w-0">
+                <p className="text-[10px] uppercase tracking-[0.06em] text-xyne-fg-muted">{k}</p>
+                <p className="truncate text-[12px] text-xyne-fg-primary" title={v}>{v}</p>
+              </div>
+            ))}
+          </div>
+          {f.contextLimited && (
+            <div className="rounded-lg border border-xyne-warning-border bg-xyne-warning-bg px-[10px] py-[8px] text-[11px] text-xyne-warning-fg">
+              The input guard included {f.factsUsed} of {available} memories and omitted {f.factsDropped ?? available - f.factsUsed}
+              {f.factsClipped ? `; ${f.factsClipped} oversized memories were clipped by the previous per-memory limit` : ""}. The exact text sent is visible in the user prompt below.
+            </div>
+          )}
+          <div className="flex items-center gap-[6px] pt-[2px] text-[11px] font-semibold uppercase tracking-[0.06em] text-xyne-fg-muted">
+            <SparkleIcon size={12} className="text-xyne-brand" weight="fill" /> LLM exchange
+          </div>
+          {f.systemPrompt && <CodeBlock label="System prompt" text={f.systemPrompt} icon={<ScrollIcon size={11} />} />}
+          {f.userPrompt && <CodeBlock label="User prompt" text={f.userPrompt} icon={<ChatTextIcon size={11} />} />}
+          {f.rawOutput && <CodeBlock label="LLM output" text={f.rawOutput} icon={<CodeIcon size={11} />} defaultOpen />}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/xyne-claw-auth/frontend/src/v3/components/ui/Switch.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/ui/Switch.tsx
@@ -2,14 +2,16 @@ interface SwitchProps {
   checked: boolean;
   onChange: (v: boolean) => void;
   disabled?: boolean;
+  ariaLabel?: string;
 }
 
-export function Switch({ checked, onChange, disabled }: SwitchProps) {
+export function Switch({ checked, onChange, disabled, ariaLabel }: SwitchProps) {
   return (
     <button
       data-id="agent-switch"
       role="switch"
       aria-checked={checked}
+      aria-label={ariaLabel}
       disabled={disabled}
       onClick={(e) => { e.stopPropagation(); onChange(!checked); }}
       className={`relative inline-flex h-5 w-8 shrink-0 cursor-pointer items-center rounded-full border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-xyne-border-focus focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${

--- a/apps/xyne-claw/src/routes/user-memory.ts
+++ b/apps/xyne-claw/src/routes/user-memory.ts
@@ -104,7 +104,12 @@ userMemoryRouter.post("/internal/user-memory/synthesize-file", validateS2SKey, a
       ...(typeof body.currentContent === "string" ? { currentContent: body.currentContent } : {}),
       ...(body.preserveEdits === true ? { preserveEdits: true } : {}),
     });
-    res.json({ success: !!result.content, content: result.content, ...(result.error ? { error: result.error } : {}) });
+    res.json({
+      success: !!result.content,
+      content: result.content,
+      ...(result.error ? { error: result.error } : {}),
+      ...(result.trace ? { trace: result.trace } : {}),
+    });
   } catch (err) {
     log.error(`[user-memory-route] synthesize-file failed: ${err instanceof Error ? err.message : String(err)}`);
     res.status(500).json({ success: false, error: err instanceof Error ? err.message : "Internal error" });

--- a/apps/xyne-claw/src/twin-soul-synthesizer.ts
+++ b/apps/xyne-claw/src/twin-soul-synthesizer.ts
@@ -20,8 +20,19 @@ const LITELLM_URL = (process.env["LITELLM_URL"] ?? "https://grid.ai.example.com"
 const LITELLM_API_KEY = process.env["LITELLM_API_KEY"] ?? "";
 const SYNTH_MODEL = process.env["LITELLM_MODEL"] ?? "claude-haiku-4-5-20251001";
 const SYNTH_TIMEOUT_MS = Number(process.env["TWIN_SYNTH_TIMEOUT_MS"] ?? 120_000);
-/** Cap facts fed in so a heavy user doesn't blow the synth prompt. */
-const MAX_FACTS = 200;
+/** Match the claw-auth fetch ceiling. The character budget below remains the
+ * primary context safeguard; this count cap only bounds pathological sets of
+ * tiny facts. */
+const MAX_FACTS = 500;
+/** A count cap alone is not a context-window safeguard because individual facts
+ *  have no fixed size. Keep the fact portion at 200k chars (roughly 40-50k
+ *  English tokens), leaving substantial room in the configured 200k-token
+ *  models for the system prompt, a hand-edited file, and model output.
+ *  Operators can lower this for a smaller synthesis model. */
+const MAX_FACT_INPUT_CHARS = Math.max(
+  4_000,
+  Math.min(200_000, Number(process.env["TWIN_SYNTH_MAX_FACT_INPUT_CHARS"] ?? 200_000) || 200_000),
+);
 
 export interface SynthesizeFileRequest {
   fileName: string;
@@ -39,11 +50,63 @@ export interface SynthesizeFileRequest {
 export interface SynthesizeFileResult {
   content: string | null;
   error?: string;
+  trace?: SynthesizeFileTrace;
+}
+
+/** Full per-file LLM exchange returned to claw-auth for pipeline observability. */
+export interface SynthesizeFileTrace {
+  model: string;
+  durationMs: number;
+  systemPrompt: string;
+  userPrompt: string;
+  rawOutput: string;
+  promptChars: number;
+  factsAvailable: number;
+  factsUsed: number;
+  factsDropped: number;
+  factsClipped: number;
+  factInputChars: number;
+  factInputBudgetChars: number;
+  contextLimited: boolean;
+  finishReason?: string;
+  usage?: { promptTokens?: number; completionTokens?: number };
+}
+
+function selectFactsForPrompt(input: string[]): {
+  facts: string[];
+  available: number;
+  dropped: number;
+  clipped: number;
+  chars: number;
+} {
+  const normalized = (input ?? []).map((f) => (f ?? "").trim()).filter(Boolean);
+  const selected: string[] = [];
+  let chars = 0;
+
+  for (const fact of normalized) {
+    if (selected.length >= MAX_FACTS) break;
+    // Include the markdown bullet prefix + separating newline in the budget.
+    const cost = fact.length + 3;
+    if (chars + cost > MAX_FACT_INPUT_CHARS) continue;
+    selected.push(fact);
+    chars += cost;
+  }
+
+  return {
+    facts: selected,
+    available: normalized.length,
+    dropped: normalized.length - selected.length,
+    // Retained for trace compatibility. Facts are no longer clipped
+    // individually; the aggregate prompt budget remains the context guard.
+    clipped: 0,
+    chars,
+  };
 }
 
 export async function synthesizeMemoryFile(req: SynthesizeFileRequest): Promise<SynthesizeFileResult> {
-  if (!LITELLM_API_KEY) return { content: null, error: "no-api-key" };
-  const facts = (req.facts ?? []).map((f) => (f ?? "").trim()).filter(Boolean).slice(0, MAX_FACTS);
+  const startedAt = Date.now();
+  const selected = selectFactsForPrompt(req.facts ?? []);
+  const facts = selected.facts;
   if (facts.length === 0) return { content: null, error: "no-facts" };
 
   const maxChars = Math.max(200, Math.min(20_000, req.maxChars || 10_000));
@@ -75,6 +138,30 @@ export async function synthesizeMemoryFile(req: SynthesizeFileRequest): Promise<
     );
   }
   userLines.push("", `Write ${req.fileName} now.`);
+  const userPrompt = userLines.join("\n");
+  const baseTrace: SynthesizeFileTrace = {
+    model: SYNTH_MODEL,
+    durationMs: 0,
+    systemPrompt: system,
+    userPrompt,
+    rawOutput: "",
+    promptChars: system.length + userPrompt.length,
+    factsAvailable: selected.available,
+    factsUsed: facts.length,
+    factsDropped: selected.dropped,
+    factsClipped: selected.clipped,
+    factInputChars: selected.chars,
+    factInputBudgetChars: MAX_FACT_INPUT_CHARS,
+    contextLimited: selected.dropped > 0 || selected.clipped > 0,
+  };
+
+  if (!LITELLM_API_KEY) {
+    return {
+      content: null,
+      error: "no-api-key",
+      trace: { ...baseTrace, durationMs: Date.now() - startedAt },
+    };
+  }
 
   try {
     const res = await fetchLiteLLMWithRetry(
@@ -86,9 +173,12 @@ export async function synthesizeMemoryFile(req: SynthesizeFileRequest): Promise<
           model: SYNTH_MODEL,
           messages: [
             { role: "system", content: system },
-            { role: "user", content: userLines.join("\n") },
+            { role: "user", content: userPrompt },
           ],
           temperature: 0.3,
+          // The file is character-capped below; this token cap prevents a
+          // disobedient model from consuming the rest of its context on output.
+          max_tokens: Math.max(256, Math.min(8_192, Math.ceil(maxChars / 3))),
         }),
       },
       { timeoutMs: SYNTH_TIMEOUT_MS, label: `twin-soul-synth:${req.fileName}` },
@@ -96,16 +186,44 @@ export async function synthesizeMemoryFile(req: SynthesizeFileRequest): Promise<
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       log.warn(`[twin-soul-synth] LiteLLM ${res.status} file=${req.fileName}: ${body.slice(0, 200)}`);
-      return { content: null, error: `llm-http-${res.status}` };
+      return {
+        content: null,
+        error: `llm-http-${res.status}`,
+        trace: { ...baseTrace, durationMs: Date.now() - startedAt, rawOutput: body.slice(0, 20_000) },
+      };
     }
-    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string | null } }> };
-    let content = (data.choices?.[0]?.message?.content ?? "").trim();
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string | null }; finish_reason?: string | null }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const rawOutput = data.choices?.[0]?.message?.content ?? "";
+    let content = rawOutput.trim();
+    const trace: SynthesizeFileTrace = {
+      ...baseTrace,
+      durationMs: Date.now() - startedAt,
+      rawOutput,
+      ...(data.choices?.[0]?.finish_reason
+        ? { finishReason: data.choices[0].finish_reason }
+        : {}),
+      ...(data.usage
+        ? {
+            usage: {
+              ...(typeof data.usage.prompt_tokens === "number" ? { promptTokens: data.usage.prompt_tokens } : {}),
+              ...(typeof data.usage.completion_tokens === "number" ? { completionTokens: data.usage.completion_tokens } : {}),
+            },
+          }
+        : {}),
+    };
     // Strip accidental code fences.
     content = content.replace(/^```(?:markdown|md)?\s*/i, "").replace(/\s*```$/i, "").trim();
-    if (!content) return { content: null, error: "empty" };
-    return { content: content.slice(0, maxChars) };
+    if (!content) return { content: null, error: "empty", trace };
+    return { content: content.slice(0, maxChars), trace };
   } catch (err) {
     log.warn(`[twin-soul-synth] failed file=${req.fileName}: ${err instanceof Error ? err.message : String(err)}`);
-    return { content: null, error: err instanceof Error ? err.message : String(err) };
+    return {
+      content: null,
+      error: err instanceof Error ? err.message : String(err),
+      trace: { ...baseTrace, durationMs: Date.now() - startedAt },
+    };
   }
 }

--- a/apps/xyne-claw/src/user-memory-curator.ts
+++ b/apps/xyne-claw/src/user-memory-curator.ts
@@ -54,8 +54,10 @@ const CURATOR_TIMEOUT_MS = Number(process.env["USER_MEMORY_CURATOR_TIMEOUT_MS"] 
 // base+step (12m), attempt 3 = base+2·step (14m).
 const CURATOR_TIMEOUT_STEP_MS = Number(process.env["USER_MEMORY_CURATOR_TIMEOUT_STEP_MS"] ?? 120_000);
 
-/** Hard cap per batch — over this the prompt blows past Haiku's window. */
-const MAX_RECORDS_PER_BATCH = 50;
+/** Record-count backstop. The auth-side packer first enforces the ~80k-token
+ * record-text budget, so this mainly lets batches of short messages use the
+ * available context instead of stopping at the old 50-record ceiling. */
+const MAX_RECORDS_PER_BATCH = 200;
 const MAX_TEXT_CHARS_PER_RECORD = 1_500;
 /** Assembled conversation units (type="conversation") carry a whole thread and
  *  legitimately need far more room than a single message. This is now a
@@ -67,11 +69,10 @@ const MAX_TEXT_CHARS_PER_RECORD = 1_500;
  *  truncates a unit the packer already sized — the earlier 5k value re-clipped
  *  the very messages the 3k-per-message change was meant to preserve. */
 const MAX_CONVERSATION_CHARS = 320_000;
-/** Raised from 12 → 20: the enriched prompt scans a broad facet checklist
- *  (voice, response patterns, per-person tone, expertise, …) and a rich batch
- *  legitimately surfaces more distinct grounded facts than the old bland pass.
- *  The ≥0.7 signal bar + "merge near-duplicates" rule keep quantity honest. */
-const MAX_CANDIDATES_PER_BATCH = 20;
+/** A 200-record batch can contain many independent, grounded signals. Keep a
+ * high output ceiling so combining short records does not reduce recall; the
+ * ≥0.7 signal bar and "merge near-duplicates" rule still control quality. */
+const MAX_CANDIDATES_PER_BATCH = 100;
 
 const EMIT_CANDIDATES_TOOL = {
   type: "function" as const,
@@ -92,7 +93,7 @@ const EMIT_CANDIDATES_TOOL = {
               text: {
                 type: "string",
                 description:
-                  "Single concrete fact about the user, ≤ 1500 chars, written in third person ('the user…' or 'the user prefers…'). One fact per candidate. No generic statements; ground each in the records. For style/voice facts, embed a short real example or trigger in quotes (e.g. acks with 'on it', never 'I will get to it') — a voice fact with no example is too vague to use.",
+                  "Single concrete fact about the user, written in third person ('the user…' or 'the user prefers…'). Keep it concise but complete. One fact per candidate. No generic statements; ground each in the records. For style/voice facts, embed a short real example or trigger in quotes (e.g. acks with 'on it', never 'I will get to it') — a voice fact with no example is too vague to use.",
               },
               subsystem: {
                 type: "string",
@@ -234,7 +235,7 @@ GOOD: "Decided on 2026-05-22 to ship the workspaceId fix to /channel/openDm imme
 2. **Ground every fact** in record IDs from the input. If you can't cite ≥1 record, do not emit.
 3. **At least one specific entity OR one concrete, exampled communication pattern is required.** Skip vague ones even if they feel true.
 4. **Be comprehensive, not repetitive.** Cover every facet the batch evidences, but MERGE near-duplicate observations into the single most specific phrasing — don't emit five variations of "writes short replies".
-5. **Calibrate volume to signal density.** A rich batch may yield 12-20 candidates; a batch of routine one-word messages may yield 0-2. Never manufacture to hit a count.
+5. **Calibrate volume to signal density.** A rich 200-record batch may yield dozens of candidates (up to 100); a batch of routine one-word messages may yield 0-2. Never manufacture to hit a count.
 6. **Subsystem selection is constrained** to the eight fixed labels in the tool schema. Never invent one.
 7. **Third person + present tense.** "The user prefers X", "the user acks with …". Past tense only for dated decisions.
 8. **For style/voice facts, embed a short REAL example or trigger** (3-8 words, quoted) — "'on it', never 'I will get to it'". A voice fact without an example is usually too vague to use.
@@ -516,7 +517,12 @@ async function runDistillAttempt(
   const out: UserMemoryCandidatePayload[] = [];
   const emitted: UserMemoryCuratorEmittedCandidate[] = [];
 
-  for (const c of parsed.candidates) {
+  if (parsed.candidates.length > MAX_CANDIDATES_PER_BATCH) {
+    log.warn(
+      `[user-memory-curator] candidate output truncated ${parsed.candidates.length} → ${MAX_CANDIDATES_PER_BATCH} userId=${userId}`,
+    );
+  }
+  for (const c of parsed.candidates.slice(0, MAX_CANDIDATES_PER_BATCH)) {
     // malformed = the entry isn't an object; we can't report its fields.
     if (!c || typeof c !== "object") {
       emitted.push({ text: "", verdict: "dropped", dropReason: "malformed" });
@@ -538,8 +544,8 @@ async function runDistillAttempt(
       groundedOnIds,
     };
 
-    if (!text || text.length > 1_500) {
-      emitted.push({ ...base, dropReason: "empty-or-too-long" });
+    if (!text) {
+      emitted.push({ ...base, dropReason: "empty" });
       continue;
     }
     if (typeof subsystem !== "string" || !subsystemSet.has(subsystem as UserMemorySubsystem)) {

--- a/apps/xyne-claw/test/twin-soul-synthesizer-trace.test.ts
+++ b/apps/xyne-claw/test/twin-soul-synthesizer-trace.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("@xyne/litellm-client", () => ({
+  fetchLiteLLMWithRetry: fetchMock,
+}));
+
+function okResponse(content: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 123, completion_tokens: 9 },
+    }),
+    text: async () => "",
+  };
+}
+
+beforeEach(() => {
+  process.env["LITELLM_API_KEY"] = "test-key";
+  delete process.env["TWIN_SYNTH_MAX_FACT_INPUT_CHARS"];
+  fetchMock.mockReset();
+});
+
+test("captures the exact per-file LLM exchange and usage", async () => {
+  fetchMock.mockResolvedValue(okResponse("# Soul\n\nYou reply briefly."));
+  const { synthesizeMemoryFile } = await import("../src/twin-soul-synthesizer.js");
+
+  const result = await synthesizeMemoryFile({
+    fileName: "soul.md",
+    description: "Core persona",
+    facts: ["The user replies briefly."],
+    maxChars: 10_000,
+  });
+
+  expect(result.content).toBe("# Soul\n\nYou reply briefly.");
+  expect(result.trace).toMatchObject({
+    rawOutput: "# Soul\n\nYou reply briefly.",
+    factsAvailable: 1,
+    factsUsed: 1,
+    factsDropped: 0,
+    factInputBudgetChars: 200_000,
+    contextLimited: false,
+    finishReason: "stop",
+    usage: { promptTokens: 123, completionTokens: 9 },
+  });
+  expect(result.trace?.systemPrompt).toContain("You compile ONE persona file");
+  expect(result.trace?.userPrompt).toContain("Approved facts about the user:");
+  expect(result.trace?.userPrompt).toContain("The user replies briefly.");
+
+  const [, init] = fetchMock.mock.calls[0] as [string, { body: string }];
+  const sent = JSON.parse(init.body) as { messages: Array<{ role: string; content: string }>; max_tokens: number };
+  expect(sent.messages).toEqual([
+    { role: "system", content: result.trace?.systemPrompt },
+    { role: "user", content: result.trace?.userPrompt },
+  ]);
+  expect(sent.max_tokens).toBeGreaterThan(0);
+});
+
+test("caps large memory sets and reports what was omitted", async () => {
+  fetchMock.mockResolvedValue(okResponse("# Soul"));
+  const { synthesizeMemoryFile } = await import("../src/twin-soul-synthesizer.js");
+  const facts = Array.from({ length: 200 }, (_, i) => `fact-${i} ${"x".repeat(1_490)}`);
+
+  const result = await synthesizeMemoryFile({
+    fileName: "soul.md",
+    description: "Core persona",
+    facts,
+    maxChars: 10_000,
+  });
+
+  expect(result.trace?.factsAvailable).toBe(200);
+  expect(result.trace?.factsUsed).toBeLessThan(200);
+  expect(result.trace?.factsDropped).toBe(200 - (result.trace?.factsUsed ?? 0));
+  expect(result.trace?.factInputChars).toBeLessThanOrEqual(200_000);
+  expect(result.trace?.factInputBudgetChars).toBe(200_000);
+  expect(result.trace?.contextLimited).toBe(true);
+});
+
+test("passes an individual fact longer than 1,500 characters without clipping", async () => {
+  fetchMock.mockResolvedValue(okResponse("# Soul"));
+  const { synthesizeMemoryFile } = await import("../src/twin-soul-synthesizer.js");
+  const longFact = `The user documented ${"x".repeat(2_000)}`;
+
+  const result = await synthesizeMemoryFile({
+    fileName: "soul.md",
+    description: "Core persona",
+    facts: [longFact],
+    maxChars: 10_000,
+  });
+
+  expect(result.trace?.factsUsed).toBe(1);
+  expect(result.trace?.factsClipped).toBe(0);
+  expect(result.trace?.userPrompt).toContain(longFact);
+  expect(result.trace?.contextLimited).toBe(false);
+});

--- a/apps/xyne-claw/test/user-memory-curator-trace.test.ts
+++ b/apps/xyne-claw/test/user-memory-curator-trace.test.ts
@@ -101,14 +101,14 @@ test("kept + dropped verdicts with correct dropReasons and 1:1 kept↔candidates
   expect(trace.rawResponse).toContain("owns the curator pipeline");
 });
 
-test("empty-or-too-long and malformed drop reasons", async () => {
+test("empty and malformed candidates are dropped while long candidates are kept", async () => {
   const longText = "x".repeat(1_600);
   fetchMock.mockResolvedValue(
     okResponse(
       JSON.stringify({
         candidates: [
           { text: "   ", subsystem: "style", signalScore: 0.9, groundedOnIds: ["r1"] }, // empty
-          { text: longText, subsystem: "style", signalScore: 0.9, groundedOnIds: ["r1"] }, // too long
+          { text: longText, subsystem: "style", signalScore: 0.9, groundedOnIds: ["r1"] }, // long but valid
           "not-an-object", // malformed
         ],
       }),
@@ -116,10 +116,11 @@ test("empty-or-too-long and malformed drop reasons", async () => {
   );
 
   const { candidates, trace } = await run([rec("r1")]);
-  expect(candidates).toHaveLength(0);
+  expect(candidates).toHaveLength(1);
+  expect(candidates[0]?.text).toBe(longText);
   expect(trace.emitted).toHaveLength(3);
-  expect(trace.emitted[0]).toMatchObject({ verdict: "dropped", dropReason: "empty-or-too-long" });
-  expect(trace.emitted[1]).toMatchObject({ verdict: "dropped", dropReason: "empty-or-too-long" });
+  expect(trace.emitted[0]).toMatchObject({ verdict: "dropped", dropReason: "empty" });
+  expect(trace.emitted[1]).toMatchObject({ verdict: "kept", text: longText });
   expect(trace.emitted[2]).toMatchObject({ verdict: "dropped", dropReason: "malformed" });
 });
 
@@ -153,4 +154,43 @@ test("candidates return value is unchanged vs the kept emitted entries", async (
   // matching what the returned candidate carries.
   expect(kept[0]!.groundedOnIds).toEqual(candidates[0]!.groundedOnIds);
   expect(candidates[0]!.groundedOnIds).toEqual(["r1"]);
+});
+
+test("accepts a 200-record batch without truncating the grounding set", async () => {
+  fetchMock.mockResolvedValue(
+    okResponse(
+      JSON.stringify({
+        candidates: [
+          {
+            text: "The user follows a recurring acknowledgement pattern",
+            subsystem: "style",
+            signalScore: 0.9,
+            groundedOnIds: ["r199"],
+          },
+        ],
+      }),
+    ),
+  );
+
+  const records = Array.from({ length: 200 }, (_, i) => rec(`r${i}`, `message ${i}`));
+  const { candidates } = await run(records);
+
+  expect(candidates).toHaveLength(1);
+  expect(candidates[0]!.groundedOnIds).toEqual(["r199"]);
+});
+
+test("accepts up to 100 candidates and hard-caps excess model output", async () => {
+  const emitted = Array.from({ length: 101 }, (_, i) => ({
+    text: `Concrete grounded fact ${i}`,
+    subsystem: "projects",
+    signalScore: 0.9,
+    groundedOnIds: ["r1"],
+  }));
+  fetchMock.mockResolvedValue(okResponse(JSON.stringify({ candidates: emitted })));
+
+  const { candidates, trace } = await run([rec("r1")]);
+
+  expect(candidates).toHaveLength(100);
+  expect(trace.emitted).toHaveLength(100);
+  expect(candidates.at(-1)?.text).toBe("Concrete grounded fact 99");
 });

--- a/packages/xyne-claw-shared/src/memory/providers/hindsight-delete.test.ts
+++ b/packages/xyne-claw-shared/src/memory/providers/hindsight-delete.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { HindsightProvider } from "./hindsight.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("marks Hindsight's observation curation rejection with a stable error code", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 400,
+    text: async () =>
+      JSON.stringify({
+        detail:
+          "Memory 'obs-1' is a observation; only world/experience facts can be curated. Observations are derived and regenerate from their sources.",
+      }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  const provider = new HindsightProvider({ url: "http://hindsight.test" });
+
+  await expect(provider.deleteMemory("digital-twin", "obs-1")).rejects.toThrow(
+    "HINDSIGHT_DERIVED_OBSERVATION",
+  );
+});
+
+test("delete-by-tag retires raw facts and skips direct observation invalidation", async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [
+          { id: "obs-1", fact_type: "observation", tags: ["user:u1"] },
+          { id: "world-1", fact_type: "world", tags: ["user:u1"] },
+          { id: "other-user", fact_type: "experience", tags: ["user:u2"] },
+        ],
+      }),
+    })
+    .mockResolvedValueOnce({ ok: true, status: 200 });
+  vi.stubGlobal("fetch", fetchMock);
+  const provider = new HindsightProvider({ url: "http://hindsight.test" });
+
+  await expect(provider.deleteByTag("digital-twin", "user:u1")).resolves.toBe(1);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(fetchMock.mock.calls[1]?.[0]).toContain("/memories/world-1");
+  expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ method: "PATCH" });
+});

--- a/packages/xyne-claw-shared/src/memory/providers/hindsight.ts
+++ b/packages/xyne-claw-shared/src/memory/providers/hindsight.ts
@@ -417,6 +417,18 @@ export class HindsightProvider implements MemoryProvider {
     });
     if (!res.ok && res.status !== 404) {
       const txt = await res.text().catch(() => "");
+      // Observations are derived from world/experience facts and Hindsight
+      // deliberately refuses direct curation. Give callers a stable marker so
+      // they can return an actionable response instead of an opaque 500.
+      if (
+        res.status === 400 &&
+        (/\bis an observation\b/i.test(txt) || /only world\/experience facts can be curated/i.test(txt))
+      ) {
+        throw new Error(
+          "HINDSIGHT_DERIVED_OBSERVATION: derived observations cannot be deleted directly; " +
+            "invalidate their supporting world/experience facts instead",
+        );
+      }
       // 405 = this Hindsight deployment predates reversible curation (the PATCH
       // /memories/{id} invalidate endpoint, added upstream 2026-06-10 / PR #1976).
       // There is NO other per-memory delete/invalidate endpoint, so this can only
@@ -435,32 +447,28 @@ export class HindsightProvider implements MemoryProvider {
   }
 
   /**
-   * Hard-delete every memory in the bank carrying `tag`. Hindsight's list
-   * endpoint can't filter by tag, so we page the RAW list here (where we can
-   * see `items.length` vs the page size to know when to stop — something the
-   * listMemories abstraction can't expose), collect matching ids, then DELETE
-   * each. Best-effort per id; returns the count actually deleted.
+   * Soft-retire every raw world/experience memory carrying `tag`. Derived
+   * observations are reconciled asynchronously by Hindsight. Its list endpoint
+   * cannot filter by tag, so the shared sweep filters locally.
    */
   async deleteByTag(bankId: string, tag: string): Promise<number> {
     return this.sweepDelete(bankId, tag);
   }
 
   /**
-   * Hard-delete EVERY memory in the bank ("clear all memories" reset). The
-   * bank row and its config overrides survive — only memories go. Callers own
-   * the authorization; pair with a re-seed (backfill) when the user wants a
-   * fresh start rather than an empty brain.
+   * Soft-retire every raw world/experience memory in the bank. The bank row
+   * and its config overrides survive; derived observations are reconciled
+   * asynchronously by Hindsight. Callers own the authorization.
    */
   async clearAll(bankId: string): Promise<number> {
     return this.sweepDelete(bankId);
   }
 
   /**
-   * Shared sweep: page the RAW list (where `items.length` vs page size tells
-   * us when to stop — the listMemories abstraction can't expose that), collect
-   * ids (optionally only those carrying `tag` — Hindsight's list endpoint
-   * can't filter by tag server-side), then DELETE each. Best-effort per id;
-   * returns the count actually deleted.
+   * Shared sweep: page the RAW list, collect raw fact ids (optionally only
+   * those carrying `tag`), then invalidate each. Observations are deliberately
+   * skipped because Hindsight rebuilds them from the remaining valid sources.
+   * Best-effort per id; returns the count actually retired.
    */
   private async sweepDelete(bankId: string, tag?: string): Promise<number> {
     if (!this.enabled) return 0;
@@ -480,6 +488,11 @@ export class HindsightProvider implements MemoryProvider {
       for (const it of items) {
         const tags = (it["tags"] as string[] | undefined) ?? [];
         const id = String(it["id"] ?? "");
+        const factType = String(it["fact_type"] ?? it["type"] ?? "").toLowerCase();
+        // Observations cannot be invalidated directly. Invalidating the raw
+        // world/experience sources below makes Hindsight recompute (or remove)
+        // their derived observations asynchronously.
+        if (factType === "observation") continue;
         if (id && (!tag || tags.includes(tag))) ids.push(id);
       }
       if (items.length < PAGE) break; // last page

--- a/packages/xyne-claw-shared/src/memory/user-memory-types.ts
+++ b/packages/xyne-claw-shared/src/memory/user-memory-types.ts
@@ -131,7 +131,7 @@ export const USER_MEMORY_SUBSYSTEMS: readonly UserMemorySubsystem[] = [
  * signalScore + the IDs it grounded on.
  */
 export interface UserMemoryCandidatePayload {
-  /** ≤ 1500 chars. Written in third person ("the user…") for clarity. */
+  /** Written in third person ("the user…") for clarity. */
   text: string;
   subsystem: UserMemorySubsystem;
   /** 0-1, where 1 = strongly evidenced across multiple records, 0 = single
@@ -170,12 +170,14 @@ export interface UserMemoryCuratorEmittedCandidate {
   groundedOnIds?: string[];
   verdict: "kept" | "dropped";
   /** Why the server-side filter dropped it (verdict="dropped" only).
-   *  empty-or-too-long: blank text or >1500 chars.
+   *  empty: blank text.
+   *  empty-or-too-long: legacy value from traces created before the per-candidate
+   *  length limit was removed.
    *  bad-subsystem: not one of the eight fixed labels.
    *  low-signal: signalScore < 0.7.
    *  ungrounded: no groundedOnIds matching an input record.
    *  malformed: not an object / unparseable entry. */
-  dropReason?: "empty-or-too-long" | "bad-subsystem" | "low-signal" | "ungrounded" | "malformed";
+  dropReason?: "empty" | "empty-or-too-long" | "bad-subsystem" | "low-signal" | "ungrounded" | "malformed";
 }
 
 /**


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
