### PR TITLE
fix(zero): include conversationId (PK) in channelConversationsPaginat…

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -3570,7 +3570,12 @@ export const queries: AnyQueryRegistry = defineQueries({
       channelId: z.string(),
       isMember: z.boolean(),
       limit: z.number(),
-      start: z.object({ createdAt: z.number() }).nullable(),
+      // conversationId is the table's primary key and completes the (createdAt, conversationId)
+      // sort key. It MUST be included for a stable cursor: with createdAt alone, the SQLite
+      // source and the IVM comparator disagree about rows tied on createdAt, which can push an
+      // edit into an empty take window and throw "Bound should be set". Optional for backward
+      // compatibility with callers that don't have it (e.g. the read-cutoff cursor).
+      start: z.object({ createdAt: z.number(), conversationId: z.string().optional() }).nullable(),
       direction: z.literal('forward').or(z.literal('backward')),
     }),
     ({ ctx, args: { channelId, limit, start, direction } }) => {
@@ -3592,7 +3597,12 @@ export const queries: AnyQueryRegistry = defineQueries({
 
       // Apply cursor pagination if start is provided
       if (start) {
-        query = query.start({ createdAt: start.createdAt }, { inclusive: direction === 'forward' });
+        query = query.start(
+          start.conversationId != null
+            ? { createdAt: start.createdAt, conversationId: start.conversationId }
+            : { createdAt: start.createdAt },
+          { inclusive: direction === 'forward' },
+        );
       }
 
       // Apply limit

--- a/packages/shared/src/messages/useMessages.ts
+++ b/packages/shared/src/messages/useMessages.ts
@@ -204,7 +204,12 @@ function useChannelMessagesImpl(
     queries.channelConversationsPaginatedV3({
       channelId,
       isMember,
-      start: inViewAnchor ? { createdAt: inViewAnchor.createdAt } : null,
+      // Include conversationId (the PK) so the cursor is a complete (createdAt, conversationId)
+      // sort key. A createdAt-only cursor is ambiguous on ties and triggers the Zero
+      // "Bound should be set" crash on the backward (newer-than-anchor) subscription.
+      start: inViewAnchor
+        ? { createdAt: inViewAnchor.createdAt, conversationId: inViewAnchor.conversationId }
+        : null,
       direction: inViewAnchor ? inViewAnchor.direction : 'forward',
       limit: pageSize,
     }),

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3070,7 +3070,12 @@ export const queries = defineQueries({
       channelId: z.string(),
       isMember: z.boolean(),
       limit: z.number(),
-      start: z.object({ createdAt: z.number() }).nullable(),
+      // conversationId is the table's primary key and completes the (createdAt, conversationId)
+      // sort key. It MUST be included for a stable cursor: with createdAt alone, the SQLite
+      // source and the IVM comparator disagree about rows tied on createdAt, which can push an
+      // edit into an empty take window and throw "Bound should be set". Optional for backward
+      // compatibility with callers that don't have it (e.g. the read-cutoff cursor).
+      start: z.object({ createdAt: z.number(), conversationId: z.string().optional() }).nullable(),
       direction: z.literal('forward').or(z.literal('backward')),
     }),
     ({ ctx, args: { channelId, limit, start, direction } }) => {
@@ -3098,7 +3103,12 @@ export const queries = defineQueries({
 
       // Apply cursor pagination if start is provided
       if (start) {
-        query = query.start({ createdAt: start.createdAt }, { inclusive: direction === 'forward' });
+        query = query.start(
+          start.conversationId != null
+            ? { createdAt: start.createdAt, conversationId: start.conversationId }
+            : { createdAt: start.createdAt },
+          { inclusive: direction === 'forward' },
+        );
       }
 
       // Apply limit


### PR DESCRIPTION
The V3 pagination cursor carried only createdAt. Because the ordering is (createdAt, conversationId) with the PK auto-appended, a createdAt-only cursor is an ambiguous, partial sort key. On rows tied at the cursor's createdAt, the SQLite source (id > NULL -> false) excludes the tie while the IVM comparator (missing PK sorts first) includes it. That pushes an edit into an empty take window, tripping Take.#pushEditChange's assert(bound) and killing the view-syncer connection ('Bound should be set').

Add conversationId to the cursor (optional, backward compatible) in both the shared (client) and backend (server) query definitions, and pass it from useMessages' backward 'newer-than-anchor' subscription (inViewAnchor already carries it). This makes the cursor a complete sort key so the source and IVM agree on ties. The read-cutoff cursor keeps createdAt only (no conversationId available) but its window is not empty in practice.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
