### PR TITLE
Fix/xyne 56181 cmd k back navigation

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -352,7 +352,7 @@ const ChannelCommandMenu = ({
   // (and the browser back gesture) closes the palette instead of leaving the page. When a
   // row sends the user to the results page, that entry keeps the search — so back from the
   // results page reopens the palette with it rather than landing on a bare page.
-  const { markNavigating } = useHistoryBackedOverlay<InitialQueryData>({
+  const { markNavigating, setPayload } = useHistoryBackedOverlay<InitialQueryData>({
     open,
     onClose: () => onOpenChange(false),
     onRestore: restored => {
@@ -1023,6 +1023,20 @@ const ChannelCommandMenu = ({
     return params;
   }
 
+  // Keep the palette's history entry carrying the current search. The palette can be left
+  // in many ways — opening a DM, a channel, a message, a ticket, the results page — and
+  // each goes through its own handler, so recording it here is what makes ANY of them
+  // restorable when the user comes back.
+  useEffect(() => {
+    if (!open) return;
+    setPayload({
+      text: searchText,
+      // The cast is the hook's looser `prefix: string` meeting the editor's prefix union —
+      // same values at runtime, they're only ever set from that union.
+      mentions: selectedMentions.map(m => ({ ...m, name: m.name ?? m.id })) as MentionData[],
+    });
+  }, [open, searchText, selectedMentions, setPayload]);
+
   // Leave the palette for the full-screen results page via the "Show results for" row.
   // Logged as its own event so the jump-out rate is readable per palette and trigger.
   const goToSearchResults = (trigger: 'click' | 'keyboard'): void => {
@@ -1031,17 +1045,9 @@ const ChannelCommandMenu = ({
     navigatingToResultsRef.current = true;
     showResultsTriggerRef.current = 'keyboard';
 
-    // Hand the history hook the search we're leaving with. It stamps this onto the
-    // palette's entry, so back from the results page reopens cmd+K with it — and it also
-    // marks the close as a navigation, so the entry isn't popped out from under us.
-    markNavigating({
-      text: searchText,
-      // Plain-object copies: history state has to survive structured cloning. Chips carry
-      // a display name; fall back to the id so a nameless one still restores.
-      // The cast is the hook's looser `prefix: string` meeting the editor's prefix union —
-      // same values at runtime, they're only ever set from that union.
-      mentions: selectedMentions.map(m => ({ ...m, name: m.name ?? m.id })) as MentionData[],
-    });
+    // Mark the close as a navigation so the palette's entry isn't popped out from under
+    // us. The search itself is already on that entry, kept current by the effect above.
+    markNavigating();
 
     // Metrics must never be able to swallow the navigation.
     try {

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -96,6 +96,7 @@ import {
   CMDK_USER_LIMIT,
 } from '../../../hooks/useSearchMetrics';
 import { searchMetricsService } from '../../../services/searchMetricsService';
+import { useHistoryBackedOverlay } from '../../../hooks/useHistoryBackedOverlay';
 import { useScope, useShortcutById } from '../../../shortcuts';
 import { useSearchMode } from '../../../hooks/useSearchMode';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -339,6 +340,16 @@ const ChannelCommandMenu = ({
     () => (seedCommandMode ? { mentions: [], text: '/' } : initialQuery),
     [seedCommandMode, initialQuery],
   );
+
+  // Cmd+K joins the URL history stack: opening pushes an entry, so the top-bar back
+  // arrow (and the browser back gesture) closes the palette instead of leaving the page.
+  // Closing it any other way pops that entry straight back off.
+  const { markNavigating } = useHistoryBackedOverlay({
+    open,
+    onClose: () => onOpenChange(false),
+    id: 'command-menu',
+    enabled: !inline && !contextSelectionMode,
+  });
 
   useShortcutById(
     'global.search',
@@ -1002,6 +1013,10 @@ const ChannelCommandMenu = ({
     if (navigatingToResultsRef.current) return;
     navigatingToResultsRef.current = true;
     showResultsTriggerRef.current = 'keyboard';
+
+    // Tell the history hook this close comes with a navigation, so it doesn't pop the
+    // palette's entry and land the user back where they started.
+    markNavigating();
 
     // Metrics must never be able to swallow the navigation.
     try {

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -45,6 +45,7 @@ import { DisplaySearchResult } from '../../../types/search';
 import {
   TabType,
   MentionType,
+  type MentionData,
   ChannelCommandMenuProps,
   TYPE_SUGGESTIONS,
   SearchableTypes,
@@ -87,7 +88,7 @@ import {
   EVENTS,
   EVENT_PROPERTIES,
 } from '../../../services/Analytics/mixpanelService';
-import { LexicalSearchInput } from './LexicalSearchInput';
+import { LexicalSearchInput, type InitialQueryData } from './LexicalSearchInput';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import {
   useSearchMetrics,
@@ -334,22 +335,38 @@ const ChannelCommandMenu = ({
   const [seedCommandMode, setSeedCommandMode] = useState(
     () => initialQuery?.text === '/' && initialQuery?.mentions.length === 0,
   );
-  // While seeding, feed the editor a `/` through the existing initial-query path; otherwise pass the
-  // caller's query straight through. Memoized so the reference stays stable across renders.
+  // The search the user left behind when the palette sent them to the results page, handed
+  // back by the history hook so pressing back reopens cmd+K exactly as they typed it.
+  const [restoredQuery, setRestoredQuery] = useState<InitialQueryData | null>(null);
+
+  // While seeding, feed the editor a `/` through the existing initial-query path; a restored
+  // search goes down the same path. Otherwise pass the caller's query straight through.
+  // Memoized so the reference stays stable across renders.
   const effectiveInitialQuery = useMemo(
-    () => (seedCommandMode ? { mentions: [], text: '/' } : initialQuery),
-    [seedCommandMode, initialQuery],
+    () =>
+      seedCommandMode ? { mentions: [], text: '/' } : restoredQuery ? restoredQuery : initialQuery,
+    [seedCommandMode, restoredQuery, initialQuery],
   );
 
-  // Cmd+K joins the URL history stack: opening pushes an entry, so the top-bar back
-  // arrow (and the browser back gesture) closes the palette instead of leaving the page.
-  // Closing it any other way pops that entry straight back off.
-  const { markNavigating } = useHistoryBackedOverlay({
+  // Cmd+K joins the URL history stack: opening pushes an entry, so the top-bar back arrow
+  // (and the browser back gesture) closes the palette instead of leaving the page. When a
+  // row sends the user to the results page, that entry keeps the search — so back from the
+  // results page reopens the palette with it rather than landing on a bare page.
+  const { markNavigating } = useHistoryBackedOverlay<InitialQueryData>({
     open,
     onClose: () => onOpenChange(false),
+    onRestore: restored => {
+      setRestoredQuery(restored ?? null);
+      onOpenChange(true);
+    },
     id: 'command-menu',
     enabled: !inline && !contextSelectionMode,
   });
+
+  // A restore only seeds the open it triggered — the next plain cmd+K starts empty.
+  useEffect(() => {
+    if (!open) setRestoredQuery(null);
+  }, [open]);
 
   useShortcutById(
     'global.search',
@@ -1014,9 +1031,17 @@ const ChannelCommandMenu = ({
     navigatingToResultsRef.current = true;
     showResultsTriggerRef.current = 'keyboard';
 
-    // Tell the history hook this close comes with a navigation, so it doesn't pop the
-    // palette's entry and land the user back where they started.
-    markNavigating();
+    // Hand the history hook the search we're leaving with. It stamps this onto the
+    // palette's entry, so back from the results page reopens cmd+K with it — and it also
+    // marks the close as a navigation, so the entry isn't popped out from under us.
+    markNavigating({
+      text: searchText,
+      // Plain-object copies: history state has to survive structured cloning. Chips carry
+      // a display name; fall back to the id so a nameless one still restores.
+      // The cast is the hook's looser `prefix: string` meeting the editor's prefix union —
+      // same values at runtime, they're only ever set from that union.
+      mentions: selectedMentions.map(m => ({ ...m, name: m.name ?? m.id })) as MentionData[],
+    });
 
     // Metrics must never be able to swallow the navigation.
     try {

--- a/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
+++ b/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
@@ -3,12 +3,19 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 /** Key stamped into the router location state that marks an overlay's history entry. */
 const OVERLAY_STATE_KEY = 'xyneOverlay';
+/** Key holding whatever the overlay wants handed back when the user returns to its entry. */
+const OVERLAY_PAYLOAD_KEY = 'xyneOverlayPayload';
 
-interface HistoryBackedOverlayParams {
+interface HistoryBackedOverlayParams<TPayload> {
   /** Whether the overlay is currently open. */
   open: boolean;
   /** Closes the overlay. Called when the user pops our entry off the stack. */
   onClose: () => void;
+  /**
+   * Reopens the overlay when the user comes BACK to its entry from somewhere the overlay
+   * navigated to, handing back the payload passed to `markNavigating`.
+   */
+  onRestore?: (payload: TPayload | undefined) => void;
   /** Identifies this overlay in the location state, so nested overlays don't cross-close. */
   id: string;
   /** Set false for embedded/inline usages that are never really "open". */
@@ -21,28 +28,33 @@ interface HistoryBackedOverlayParams {
  * Opening pushes an entry for the SAME url carrying a marker in the router's location
  * state, so the top-bar back arrow — and the browser/trackpad back gesture, which reach
  * this through the same router pop — close the overlay instead of leaving the page.
- * Closing it any other way (Escape, click-outside, picking a row) pops that entry back
- * off, so the stack is left exactly as it was found.
+ * Closing it any other way (Escape, click-outside) pops that entry back off, so the stack
+ * is left exactly as it was found.
  *
- * The one case we deliberately leave alone is closing *because* the overlay navigated
- * somewhere: the entry is then already buried under the destination, and popping would
- * undo the navigation. That leaves one same-url entry behind, so backing out of the
- * destination lands on the origin page (overlay closed) and takes one more back to leave.
+ * When the overlay closes *because it navigated somewhere*, it calls `markNavigating` with
+ * whatever it needs to come back to. That stamps the payload onto its entry, which the
+ * destination is then pushed on top of — so pressing back from the destination lands on the
+ * marked entry and reopens the overlay in the state the user left it in, rather than
+ * dumping them on a bare page.
  */
-export function useHistoryBackedOverlay({
+export function useHistoryBackedOverlay<TPayload = unknown>({
   open,
   onClose,
+  onRestore,
   id,
   enabled = true,
-}: HistoryBackedOverlayParams): { markNavigating: () => void } {
+}: HistoryBackedOverlayParams<TPayload>): { markNavigating: (payload?: TPayload) => void } {
   const location = useLocation();
   const navigate = useNavigate();
 
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const onRestoreRef = useRef(onRestore);
+  onRestoreRef.current = onRestore;
 
-  // True once we've pushed for the current open stretch — distinguishes "the user just
-  // opened it" from "the user popped our entry", which look identical from the state alone.
+  // True once we've pushed (or adopted) an entry for the current open stretch —
+  // distinguishes "the user just opened it" from "the user popped our entry", which look
+  // identical from the location state alone.
   const pushedRef = useRef(false);
 
   // Set by the overlay right before it closes itself *and* navigates. Without it the
@@ -51,8 +63,23 @@ export function useHistoryBackedOverlay({
   // the navigation and leaving the user exactly where they started.
   const navigatingRef = useRef(false);
 
-  const isOverlayEntry =
-    (location.state as Record<string, unknown> | null)?.[OVERLAY_STATE_KEY] === id;
+  // True when this open stretch came from a restore, i.e. we adopted an entry we never
+  // pushed. Closing then must NOT pop it: the user navigated back INTO this entry, and
+  // popping would throw them a step further back than they asked for.
+  const adoptedRef = useRef(false);
+
+  // The entry we last restored, so closing the overlay doesn't immediately re-restore it.
+  const restoredKeyRef = useRef<string | null>(null);
+
+  const state = location.state as Record<string, unknown> | null;
+  const isOverlayEntry = state?.[OVERLAY_STATE_KEY] === id;
+  const payload = state?.[OVERLAY_PAYLOAD_KEY] as TPayload | undefined;
+
+  // Read inside callbacks that run outside render, where `location` would be stale.
+  const hrefRef = useRef('');
+  hrefRef.current = `${location.pathname}${location.search}${location.hash}`;
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   useEffect(() => {
     if (!enabled) {
@@ -63,8 +90,14 @@ export function useHistoryBackedOverlay({
     if (open && !pushedRef.current) {
       pushedRef.current = true;
       navigatingRef.current = false;
-      void navigate(`${location.pathname}${location.search}${location.hash}`, {
-        state: { ...(location.state as Record<string, unknown> | null), [OVERLAY_STATE_KEY]: id },
+      // Already standing on our entry (a restore) — adopt it instead of stacking another.
+      if (isOverlayEntry) {
+        adoptedRef.current = true;
+        return;
+      }
+      adoptedRef.current = false;
+      void navigate(hrefRef.current, {
+        state: { ...state, [OVERLAY_STATE_KEY]: id },
         preventScrollReset: true,
       });
       return;
@@ -78,20 +111,41 @@ export function useHistoryBackedOverlay({
       return;
     }
 
+    // Back onto our entry with the overlay closed: the user returned from wherever the
+    // overlay sent them. Reopen it with what they left behind.
+    //
+    // Gated on the payload, which only `markNavigating` writes. A bare marker means the
+    // overlay was merely open here — restoring on that would fight every ordinary close,
+    // reopening the overlay in the gap before its entry is popped.
+    if (
+      !open &&
+      !pushedRef.current &&
+      isOverlayEntry &&
+      payload !== undefined &&
+      restoredKeyRef.current !== location.key &&
+      onRestoreRef.current
+    ) {
+      restoredKeyRef.current = location.key;
+      onRestoreRef.current(payload);
+      return;
+    }
+
     // Closed some other way. Pop our entry, unless the close came with a navigation
     // (then the marker is no longer the current entry and popping would undo it).
     if (!open && pushedRef.current) {
       pushedRef.current = false;
       const wasNavigating = navigatingRef.current;
+      const wasAdopted = adoptedRef.current;
       navigatingRef.current = false;
-      if (wasNavigating || !isOverlayEntry) return;
+      adoptedRef.current = false;
+      if (wasNavigating || wasAdopted || !isOverlayEntry) return;
 
       // Deferred by a task so any navigation started in the same handler has committed
       // first, then re-checked against live history — react-router keeps location state
-      // under `usr`. Rows that close the palette *and* navigate (opening a channel, a
-      // result, the results page) all pass through here; popping on top of their push
-      // would silently undo it. If the shape ever changes the check just fails and we
-      // skip the pop — a stale entry, never a cancelled navigation.
+      // under `usr`. Rows that close the palette *and* navigate (a channel, a result, the
+      // results page) all pass through here; popping on top of their push would silently
+      // undo it. If the shape ever changes the check just fails and we skip the pop — a
+      // stale entry, never a cancelled navigation.
       const timer = setTimeout(() => {
         const live = window.history.state as { usr?: Record<string, unknown> } | null;
         if (live?.usr?.[OVERLAY_STATE_KEY] === id) void navigate(-1);
@@ -104,9 +158,24 @@ export function useHistoryBackedOverlay({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, isOverlayEntry, enabled, id, navigate]);
 
-  const markNavigating = useCallback((): void => {
-    navigatingRef.current = true;
-  }, []);
+  const markNavigating = useCallback(
+    (nextPayload?: TPayload): void => {
+      navigatingRef.current = true;
+      if (nextPayload === undefined) return;
+      // Stamp the payload onto the entry we're about to bury, so returning to it can
+      // restore the overlay. Replace (not push) — this IS our entry.
+      void navigate(hrefRef.current, {
+        replace: true,
+        state: {
+          ...stateRef.current,
+          [OVERLAY_STATE_KEY]: id,
+          [OVERLAY_PAYLOAD_KEY]: nextPayload,
+        },
+        preventScrollReset: true,
+      });
+    },
+    [navigate, id],
+  );
 
   return { markNavigating };
 }

--- a/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
+++ b/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
@@ -43,7 +43,10 @@ export function useHistoryBackedOverlay<TPayload = unknown>({
   onRestore,
   id,
   enabled = true,
-}: HistoryBackedOverlayParams<TPayload>): { markNavigating: (payload?: TPayload) => void } {
+}: HistoryBackedOverlayParams<TPayload>): {
+  markNavigating: () => void;
+  setPayload: (payload: TPayload) => void;
+} {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -70,6 +73,11 @@ export function useHistoryBackedOverlay<TPayload = unknown>({
 
   // The entry we last restored, so closing the overlay doesn't immediately re-restore it.
   const restoredKeyRef = useRef<string | null>(null);
+
+  // True between scheduling a pop and it landing. Without it the restore branch fires in
+  // that gap — the overlay is closed and still standing on its own entry — and springs
+  // the overlay straight back open.
+  const poppingRef = useRef(false);
 
   const state = location.state as Record<string, unknown> | null;
   const isOverlayEntry = state?.[OVERLAY_STATE_KEY] === id;
@@ -120,6 +128,7 @@ export function useHistoryBackedOverlay<TPayload = unknown>({
     if (
       !open &&
       !pushedRef.current &&
+      !poppingRef.current &&
       isOverlayEntry &&
       payload !== undefined &&
       restoredKeyRef.current !== location.key &&
@@ -146,11 +155,16 @@ export function useHistoryBackedOverlay<TPayload = unknown>({
       // results page) all pass through here; popping on top of their push would silently
       // undo it. If the shape ever changes the check just fails and we skip the pop — a
       // stale entry, never a cancelled navigation.
+      poppingRef.current = true;
       const timer = setTimeout(() => {
         const live = window.history.state as { usr?: Record<string, unknown> } | null;
         if (live?.usr?.[OVERLAY_STATE_KEY] === id) void navigate(-1);
+        poppingRef.current = false;
       }, 0);
-      return () => clearTimeout(timer);
+      return () => {
+        clearTimeout(timer);
+        poppingRef.current = false;
+      };
     }
     return undefined;
     // `location` is read for the push url only — re-running on every location change
@@ -158,24 +172,35 @@ export function useHistoryBackedOverlay<TPayload = unknown>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, isOverlayEntry, enabled, id, navigate]);
 
-  const markNavigating = useCallback(
-    (nextPayload?: TPayload): void => {
-      navigatingRef.current = true;
-      if (nextPayload === undefined) return;
-      // Stamp the payload onto the entry we're about to bury, so returning to it can
-      // restore the overlay. Replace (not push) — this IS our entry.
-      void navigate(hrefRef.current, {
-        replace: true,
-        state: {
-          ...stateRef.current,
-          [OVERLAY_STATE_KEY]: id,
-          [OVERLAY_PAYLOAD_KEY]: nextPayload,
-        },
-        preventScrollReset: true,
-      });
+  const markNavigating = useCallback((): void => {
+    navigatingRef.current = true;
+  }, []);
+
+  /**
+   * Keeps the overlay's own history entry up to date with whatever should be handed back
+   * if the user ever returns to it. Call it as the state changes — the overlay can be left
+   * in a hundred ways (a result, a channel, a DM, the results page, an external link), and
+   * only the entry itself is guaranteed to still be there afterwards.
+   *
+   * Written straight to `window.history` rather than through the router: this is the
+   * current entry, the url is unchanged, and a router replace would re-render the tree on
+   * every keystroke. React Router reads `usr` back out on a pop, so a restore still sees it.
+   */
+  const setPayload = useCallback(
+    (nextPayload: TPayload): void => {
+      const live = window.history.state as {
+        usr?: Record<string, unknown> | null;
+        key?: string;
+        idx?: number;
+      } | null;
+      if (live?.usr?.[OVERLAY_STATE_KEY] !== id) return;
+      window.history.replaceState(
+        { ...live, usr: { ...live.usr, [OVERLAY_PAYLOAD_KEY]: nextPayload } },
+        '',
+      );
     },
-    [navigate, id],
+    [id],
   );
 
-  return { markNavigating };
+  return { markNavigating, setPayload };
 }

--- a/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
+++ b/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/** Key stamped into the router location state that marks an overlay's history entry. */
+const OVERLAY_STATE_KEY = 'xyneOverlay';
+
+interface HistoryBackedOverlayParams {
+  /** Whether the overlay is currently open. */
+  open: boolean;
+  /** Closes the overlay. Called when the user pops our entry off the stack. */
+  onClose: () => void;
+  /** Identifies this overlay in the location state, so nested overlays don't cross-close. */
+  id: string;
+  /** Set false for embedded/inline usages that are never really "open". */
+  enabled?: boolean;
+}
+
+/**
+ * Puts an overlay's open state on the history stack.
+ *
+ * Opening pushes an entry for the SAME url carrying a marker in the router's location
+ * state, so the top-bar back arrow — and the browser/trackpad back gesture, which reach
+ * this through the same router pop — close the overlay instead of leaving the page.
+ * Closing it any other way (Escape, click-outside, picking a row) pops that entry back
+ * off, so the stack is left exactly as it was found.
+ *
+ * The one case we deliberately leave alone is closing *because* the overlay navigated
+ * somewhere: the entry is then already buried under the destination, and popping would
+ * undo the navigation. That leaves one same-url entry behind, so backing out of the
+ * destination lands on the origin page (overlay closed) and takes one more back to leave.
+ */
+export function useHistoryBackedOverlay({
+  open,
+  onClose,
+  id,
+  enabled = true,
+}: HistoryBackedOverlayParams): { markNavigating: () => void } {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // True once we've pushed for the current open stretch — distinguishes "the user just
+  // opened it" from "the user popped our entry", which look identical from the state alone.
+  const pushedRef = useRef(false);
+
+  // Set by the overlay right before it closes itself *and* navigates. Without it the
+  // close branch below can race the navigation — if this effect runs before the router
+  // has committed the new location, the entry still looks current and we pop, undoing
+  // the navigation and leaving the user exactly where they started.
+  const navigatingRef = useRef(false);
+
+  const isOverlayEntry =
+    (location.state as Record<string, unknown> | null)?.[OVERLAY_STATE_KEY] === id;
+
+  useEffect(() => {
+    if (!enabled) {
+      pushedRef.current = false;
+      return;
+    }
+
+    if (open && !pushedRef.current) {
+      pushedRef.current = true;
+      navigatingRef.current = false;
+      void navigate(`${location.pathname}${location.search}${location.hash}`, {
+        state: { ...(location.state as Record<string, unknown> | null), [OVERLAY_STATE_KEY]: id },
+        preventScrollReset: true,
+      });
+      return;
+    }
+
+    // Our entry is gone while the overlay is still open — the user went back. Skipped
+    // while navigating away, where the same shape means "the destination just landed".
+    if (open && pushedRef.current && !isOverlayEntry && !navigatingRef.current) {
+      pushedRef.current = false;
+      onCloseRef.current();
+      return;
+    }
+
+    // Closed some other way. Pop our entry, unless the close came with a navigation
+    // (then the marker is no longer the current entry and popping would undo it).
+    if (!open && pushedRef.current) {
+      pushedRef.current = false;
+      const wasNavigating = navigatingRef.current;
+      navigatingRef.current = false;
+      if (wasNavigating || !isOverlayEntry) return;
+
+      // Deferred by a task so any navigation started in the same handler has committed
+      // first, then re-checked against live history — react-router keeps location state
+      // under `usr`. Rows that close the palette *and* navigate (opening a channel, a
+      // result, the results page) all pass through here; popping on top of their push
+      // would silently undo it. If the shape ever changes the check just fails and we
+      // skip the pop — a stale entry, never a cancelled navigation.
+      const timer = setTimeout(() => {
+        const live = window.history.state as { usr?: Record<string, unknown> } | null;
+        if (live?.usr?.[OVERLAY_STATE_KEY] === id) void navigate(-1);
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+    // `location` is read for the push url only — re-running on every location change
+    // would re-push while the overlay stays open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, isOverlayEntry, enabled, id, navigate]);
+
+  const markNavigating = useCallback((): void => {
+    navigatingRef.current = true;
+  }, []);
+
+  return { markNavigating };
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-56181 — cmd+K now takes part in the URL history stack, so going back returns you
to your search instead of throwing it away.

Today the palette is invisible to history. Open cmd+K, search, open a result, then hit
back: you land on the previous page with the search gone, and have to retype it.

**Opening cmd+K pushes a history entry** for the same url, marked in the router's
location state. So:

- **Back closes the palette** instead of leaving the page — the top-bar arrow, the
  browser gesture and `Cmd+[` all reach this through the same router pop.
- **Escape / click-outside pops that entry back off**, leaving the stack exactly as it
  was found. No phantom entry to click through later.
- **Back from wherever the palette sent you reopens it, with your search still in it** —
  text and filter chips both, seeded through the same initial-query path `mod+/` uses.

The search is recorded onto the palette's entry *as it is typed*, not at the point of
navigation. That matters: the palette can be left a dozen ways — a message, a DM, a
channel, a ticket, the results page — each through its own handler. Recording it in one
place is what makes all of them restorable. That write goes straight to `window.history`
rather than through the router, since it is the current entry at an unchanged url and a
router replace would re-render the tree on every keystroke; React Router reads `usr` back
out on a pop, so a restore still sees it.

Base: stacked on `fix/XYNE-56181-cmd-k-full-screen-search`. Against `main` this branch
also carries that PR's five commits — retarget to that branch to review these three alone:
`ab8d2a129`, `f19be0317`, `29592fbd9`.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

`src/hooks/useHistoryBackedOverlay.ts` (new) and
`src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx`.

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Manually, against local dev, in both search modes (`xyne:search-mode` = `popup` and
`screen`), checking `history.state` at each step rather than eyeballing it:

| Step | Expected | Result |
|---|---|---|
| Open cmd+K | entry pushed, url unchanged | idx 0→1, state marked, url same |
| Press back | palette closes, page untouched | palette closed, idx→0, same url |
| Open, then Escape | entry popped, no residue | idx→0, marker gone |
| Type `release` | entry carries the search | payload `{text: "release"}` |
| Enter — opens a DM result | navigates, entry buried | idx→2, palette closed |
| Back from that DM | **cmd+K reopens with `release`** | palette open, editor `release` |
| Row → results page → back | cmd+K reopens with the search | palette open, search restored |
| Escape on a restored palette | closes, stays put | palette closed, idx unchanged |

### Automated

- [ ] Backend unit tests
- [ ] Claw tests
- [ ] End-to-end suite
- [ ] Added / updated tests for this change
- [x] Not covered by tests — history/overlay interaction across real browser back
      navigation; there is no existing harness for it in this repo. Verified manually
      per the table above.

### Manual

**Users**
- [x] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Surface & data**
- [x] Web browser
- [ ] Electron desktop — worth a pass, history behaves differently there
- [ ] Narrow viewport, dark + light theme
- [x] Empty state (palette opened with no query — no entry payload, back just closes)
- [ ] Large / realistic data volume
- [ ] Error paths

---

## Notes for the reviewer

- **The results page has no in-app back arrow** — its top bar drops the nav cluster. From
  there it has to be browser back, `Cmd+[`, or a swipe. From a channel or DM the top-bar
  arrow works.
- **Escape on a restored palette deliberately does not pop.** You navigated back *into*
  that entry, so popping would throw you a step further back than you asked for.
- **Restoring is gated on the recorded search.** A bare marker only means "the palette was
  open here"; reopening on those fought every ordinary close, springing the palette back
  up in the gap before its entry was popped.
- **Not fixed here:** clicking a palette row does nothing until the mouse moves. The
  palette's `suppressHover` guard puts `pointer-events: none` on every cmdk row until a
  mousemove, so a click from a resting cursor is swallowed. Pre-existing, affects every
  row, and confirmed present without any of this change — worth its own ticket.

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass — n/a, no backend files touched
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass — run in full by the
      pre-commit hook on every commit
- [x] Formatting clean in the packages I touched
- [x] New deps — n/a, none added
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [ ] Docs / guidelines updated where behaviour changed — none needed
- [x] No debug logging or commented-out code left behind