### PR TITLE
fix: surface ticket/email attachments in spaces-thread-attachments

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -4039,7 +4039,8 @@ interface MessageAttachmentRow {
   size: number;
   createdAt: string;
   uploadedByUserId: string;
-  entityId: string;          // messageId for CHAT entityType
+  entityId: string;          // messageId for CHAT; ticket/email id for TICKET/EMAIL
+  entityType?: string;       // CHAT, TICKET, EMAIL, ... (present when the query returns it)
   url?: string;
 }
 
@@ -4049,11 +4050,13 @@ const spacesThreadAttachments: ToolDef = {
     "List every non-deleted attachment in a Spaces conversation thread. " +
     "Pass the conversationId from your Session Metadata block. " +
     "Returns one line per attachment with id, filename, mimetype, size, uploader, posted time, and source messageId. " +
+    "Attachments on a linked ticket or email are NOT part of the chat thread (they are keyed by the ticket/email id, not the conversation), so pass that id as entityId to include them. " +
     "Use the returned id with spaces-fetch-attachment to download.",
   inputSchema: {
     type: "object",
     properties: {
       conversationId: { type: "string", description: "Thread/conversation id (from Session Metadata or spaces-messages results)." },
+      entityId: { type: "string", description: "Optional. A ticket or email id whose attachments should ALSO be listed. Ticket/email attachments are stored with conversationId unset (keyed by this id), so they never appear from conversationId alone — pass the ticket/email id here to surface them (e.g. an invoice attached to the email, or images on the ticket)." },
       limit: { type: "number", minimum: 1, maximum: 200, default: 100, description: "Max attachments to return (default 100, max 200)." },
       offset: { type: "number", minimum: 0, default: 0, description: "Pagination offset (default 0). Call again with a higher offset to page through a thread with many attachments." },
     },
@@ -4063,6 +4066,7 @@ const spacesThreadAttachments: ToolDef = {
     try {
       const conversationId = String(args["conversationId"] ?? "");
       if (!conversationId) return err("conversationId is required");
+      const entityId = String(args["entityId"] ?? "").trim();
       const limit = (args["limit"] as number | undefined) ?? 100;
       const offset = (args["offset"] as number | undefined) ?? 0;
 
@@ -4117,11 +4121,17 @@ const spacesThreadAttachments: ToolDef = {
         take: fetchCap,
       })) as MessageAttachmentRow[];
 
-      const byEntity = messageIds.length > 0
+      // Union the conversation's messageIds with an explicit ticket/email
+      // entityId (when supplied). TICKET/EMAIL attachments carry
+      // conversationId = NULL and entityId = <ticket/email id>, so the
+      // conversationId query above can never see them; adding the id to this
+      // entityId `in` filter is the only path that surfaces them.
+      const entityIds = entityId ? [...messageIds, entityId] : messageIds;
+      const byEntity = entityIds.length > 0
         ? ((await interact({
             model: "messageAttachment",
             operation: "findMany",
-            where: { entityId: { in: messageIds }, isDeleted: { equals: false } },
+            where: { entityId: { in: entityIds }, isDeleted: { equals: false } },
             orderBy: [{ createdAt: "asc" }],
             take: fetchCap,
           })) as MessageAttachmentRow[])
@@ -4151,13 +4161,17 @@ const spacesThreadAttachments: ToolDef = {
         // entityId here IS the messageId the attachment was posted on, so the
         // citation chip can deep-link straight to that message in the thread
         // panel instead of dropping the user at the top.
+        // Only CHAT attachments have entityId == a real messageId we can
+        // deep-link to. For TICKET/EMAIL rows entityId is the ticket/email id,
+        // so don't emit it as a messageId (that would be a broken link).
+        const isChatRow = !r.entityType || r.entityType === "CHAT";
         pushThreadCitation(
           citations,
           channelIdForChunk,
           conversationId,
           idx + 1,
           r.originalFilename,
-          r.entityId ? { messageId: r.entityId } : undefined,
+          isChatRow && r.entityId ? { messageId: r.entityId } : undefined,
         );
         return prefixChunk(
           idx + 1,


### PR DESCRIPTION
## 1. Problem Description
The Claw `spaces-thread-attachments` tool could not list attachments that live on a **ticket or email** rather than on a chat message. In `#credit-mail-support`, an RCA agent repeatedly failed to read screenshots/invoices because it could never obtain an attachment id to pass to `spaces-fetch-attachment`.

Root cause: `MessageAttachment` is one unified table keyed by `entityType` + `entityId`, and `conversationId` is **nullable and only set for chat attachments**. TICKET/EMAIL attachments have `conversationId = NULL` and `entityId = <ticket/email id>`. The listing tool only queried (a) attachments whose `entityId` is a messageId of the conversation, and (b) attachments whose `conversationId` equals the thread — so ticket/email rows were structurally invisible.

`spaces-fetch-attachment` already downloads any attachment id via `GET /api/attachments/:id/download` (it looks up the row by id only), so the gap was solely in the listing tool.

## 2. If this is a bug fix or an enhancement, how did you identify the issue?
Traced the attachment-read failures reported by the RCA agent in `#credit-mail-support` to the tool code and the `MessageAttachment` schema (`apps/backend/prisma/schema.prisma`). Confirmed via full git history that the "signed-url 404" the agent narrated was a confabulation — that endpoint has never existed; the tool has only ever used `/download`. The real gap is coverage of non-chat (ticket/email) attachments in the listing tool.

## 3. Explain the solution implemented in the PR
Added an optional `entityId` argument to `spaces-thread-attachments`. When supplied, the ticket/email id is folded into the existing `entityId { in: [...] }` filter so its attachments are listed alongside the chat thread's. Also guarded the citation deep-link so a non-CHAT `entityId` (a ticket/email id) is not emitted as a `messageId` (which would produce a broken link). Backward compatible — `entityId` is optional and existing callers are unaffected. One file changed: `apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts`.

## 4. Documentation (link to docs created/updated for this change)
N/A

## 5. DB Alter Details (if any)
N/A — no schema change.

## 6. Data fix Details (if any)
N/A

## 7. Environment variable Changes (if any)
N/A

## 8. Testing (how it was tested; screenshots/links)
Typechecked the affected package (`tsc --noEmit`): zero errors in the changed file, and total error count identical with vs without the change (pre-existing environmental noise only). The two `interact()` queries already use `entityId { in: [...] }` and `isDeleted` filters, so no new pythonQuery validator surface is introduced (still no `OR` of condition objects). Functional validation to do on a deploy: call `spaces-thread-attachments` with a `#credit-mail-support` ticket/email id and confirm its attachments now list, then `spaces-fetch-attachment` on the returned id.

## 9. Services to which this change is to be deployed
xyne-claw-auth (MCP tools server).

## 10. Main PR link (if this PR is raised against a release branch)
N/A — raised against main.