### PR TITLE
fix: surface ticket/email attachments in spaces-thread-attachments

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -5137,7 +5137,8 @@ interface MessageAttachmentRow {
   size: number;
   createdAt: string;
   uploadedByUserId: string;
-  entityId: string; // messageId for CHAT entityType
+  entityId: string;          // messageId for CHAT; ticket/email id for TICKET/EMAIL
+  entityType?: string;       // CHAT, TICKET, EMAIL, ... (present when the query returns it)
   url?: string;
 }
 
@@ -5280,6 +5281,7 @@ const spacesThreadAttachments: ToolDef = {
     "List every non-deleted attachment in a Spaces conversation thread. " +
     "Pass the conversationId from your Session Metadata block. " +
     "Returns one line per attachment with id, filename, mimetype, size, uploader, posted time, and source messageId. " +
+    "Attachments on a linked ticket or email are NOT part of the chat thread (they are keyed by the ticket/email id, not the conversation), so pass that id as entityId to include them. " +
     "Use the returned id with spaces-fetch-attachment to download.",
   inputSchema: {
     type: "object",
@@ -5287,6 +5289,11 @@ const spacesThreadAttachments: ToolDef = {
       conversationId: {
         type: "string",
         description: "Thread/conversation id (from Session Metadata or spaces-messages results).",
+      },
+      entityId: {
+        type: "string",
+        description:
+          "Optional. A ticket or email id whose attachments should ALSO be listed. Ticket/email attachments are stored with conversationId unset (keyed by this id), so they never appear from conversationId alone — pass the ticket/email id here to surface them (e.g. an invoice attached to the email, or images on the ticket).",
       },
       limit: {
         type: "number",
@@ -5309,6 +5316,7 @@ const spacesThreadAttachments: ToolDef = {
     try {
       const conversationId = String(args["conversationId"] ?? "");
       if (!conversationId) return err("conversationId is required");
+      const entityId = String(args["entityId"] ?? "").trim();
       const limit = (args["limit"] as number | undefined) ?? 100;
       const offset = (args["offset"] as number | undefined) ?? 0;
 
@@ -5363,12 +5371,18 @@ const spacesThreadAttachments: ToolDef = {
         take: fetchCap,
       })) as MessageAttachmentRow[];
 
+      // Union the conversation's messageIds with an explicit ticket/email
+      // entityId (when supplied). TICKET/EMAIL attachments carry
+      // conversationId = NULL and entityId = <ticket/email id>, so the
+      // conversationId query above can never see them; adding the id to this
+      // entityId `in` filter is the only path that surfaces them.
+      const entityIds = entityId ? [...messageIds, entityId] : messageIds;
       const byEntity =
-        messageIds.length > 0
+        entityIds.length > 0
           ? ((await interact({
               model: "messageAttachment",
               operation: "findMany",
-              where: { entityId: { in: messageIds }, isDeleted: { equals: false } },
+              where: { entityId: { in: entityIds }, isDeleted: { equals: false } },
               orderBy: [{ createdAt: "asc" }],
               take: fetchCap,
             })) as MessageAttachmentRow[])
@@ -5397,13 +5411,17 @@ const spacesThreadAttachments: ToolDef = {
         // entityId here IS the messageId the attachment was posted on, so the
         // citation chip can deep-link straight to that message in the thread
         // panel instead of dropping the user at the top.
+        // Only CHAT attachments have entityId == a real messageId we can
+        // deep-link to. For TICKET/EMAIL rows entityId is the ticket/email id,
+        // so don't emit it as a messageId (that would be a broken link).
+        const isChatRow = !r.entityType || r.entityType === "CHAT";
         pushThreadCitation(
           citations,
           channelIdForChunk,
           conversationId,
           idx + 1,
           r.originalFilename,
-          r.entityId ? { messageId: r.entityId } : undefined,
+          isChatRow && r.entityId ? { messageId: r.entityId } : undefined,
         );
         return prefixChunk(
           idx + 1,


### PR DESCRIPTION
Cherry-pick of commit 03c5625 (PR #615 by @Rohan Gupta) onto feature/deploy-xyneclaw.

## What it changes
Ticket and email attachments are stored in message_attachments with conversationId = NULL and entityId = <ticket/email id>. The spaces-thread-attachments listing tool only queried by the conversation's messageIds and by conversationId, so those rows were structurally invisible — an agent could never obtain an id to pass to spaces-fetch-attachment.

This PR adds an optional entityId arg to spaces-thread-attachments: when supplied, it is folded into the existing entityId 'in' filter so a linked ticket/email's attachments are listed alongside the chat thread's. The citation deep-link is guarded so a non-CHAT entityId is not emitted as a messageId.

One file changed: apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts (+22/-4).

## Conflict resolution
The cherry-pick had 3 merge conflicts (formatting differences between main and deploy-xyneclaw). Resolved by taking the architect's logic while preserving the deploy-xyneclaw branch's expanded formatting style for the inputSchema properties.

## Validation
- TypeScript: 0 errors in the changed file (pre-existing errors in other files from Prisma client not being generated in the sandbox are unchanged).
- Backward compatible: entityId is optional; existing callers are unaffected.

Original PR: https://github.com/juspay/xyne-spaces/pull/615