### PR TITLE
fix: revamp authcontrollers

### DIFF
--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -244,6 +244,10 @@ export class AuthV2Controller {
     );
   }
 
+  private getGoogleAuthScopes(): string[] {
+    return ['openid', 'email', 'profile'];
+  }
+
   private detectPlatform(req: Request): 'web' | 'electron' | 'mobile' {
     const userAgent = req.headers['user-agent'] || '';
     const platform = req.headers['x-platform'] as string;
@@ -274,7 +278,7 @@ export class AuthV2Controller {
     const requestId = `LOGIN_${Date.now()}`;
 
     try {
-      logger.info(`[${requestId}] Initiating OAuth login`);
+      logger.info(`[${requestId}] Initiating Google OAuth login`);
 
       const platformQuery = req.query.platform as 'electron' | 'web' | 'mobile';
       const platform = platformQuery || this.detectPlatform(req);
@@ -291,7 +295,7 @@ export class AuthV2Controller {
       if (redirectToParam) {
         const allowedOrigins = (process.env.ALLOWED_REDIRECT_ORIGINS ?? '')
           .split(',')
-          .map((o) => o.trim())
+          .map(origin => origin.trim())
           .filter(Boolean);
         try {
           const origin = new URL(redirectToParam).origin;
@@ -299,7 +303,7 @@ export class AuthV2Controller {
           if (allowedOrigins.includes(origin) || origin === frontendOrigin) {
             validatedRedirectTo = redirectToParam;
           }
-        } catch (_e) {
+        } catch (_error) {
           // Ignore malformed redirect targets; only configured origins are allowed.
         }
       }
@@ -311,7 +315,7 @@ export class AuthV2Controller {
         platform,
         codeChallenge,
         validatedRedirectTo,
-        undefined,
+        'google',
         isNy,
         invitationId,
         enterpriseLogin,
@@ -325,7 +329,7 @@ export class AuthV2Controller {
 
       const authUrl = this.getGoogleClient(isNy).generateAuthUrl({
         access_type: 'offline',
-        scope: ['openid', 'email', 'profile'],
+        scope: this.getGoogleAuthScopes(),
         prompt: 'consent',
         redirect_uri: redirectUri,
         state,
@@ -333,7 +337,7 @@ export class AuthV2Controller {
         code_challenge_method: CodeChallengeMethod.S256,
       });
 
-      // sameSite=lax so the cookie survives Google's top-level callback redirect.
+      // The callback echoes this state back through the HttpOnly cookie.
       const isProduction = process.env.NODE_ENV === 'production';
       res.cookie('oauth_state', state, {
         httpOnly: true,
@@ -346,10 +350,10 @@ export class AuthV2Controller {
       logger.info(`[${requestId}] Redirecting to Google OAuth`);
       res.redirect(authUrl);
     } catch (error) {
-      logger.error(`[${requestId}] Error initiating login:`, error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      logger.error(`[${requestId}] Error initiating Google login: ${errorMessage}`);
 
       const frontendUrl = getFrontendUrl(req);
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       res.redirect(
         `${frontendUrl}?error=oauth_init_failed&message=${encodeURIComponent(errorMessage)}`
       );
@@ -378,16 +382,6 @@ export class AuthV2Controller {
         const frontendUrl = getFrontendUrl(req);
         res.redirect(
           `${frontendUrl}?error=missing_params&message=${encodeURIComponent('Missing authorization code or state')}`
-        );
-        return;
-      }
-
-      const isCodeUsed = await oauthStateServiceV2.isCodeUsed(code as string);
-      if (isCodeUsed) {
-        logger.error(`[${requestId}] Authorization code already used`);
-        const frontendUrl = getFrontendUrl(req);
-        res.redirect(
-          `${frontendUrl}?error=code_reused&message=${encodeURIComponent('Authorization code already used')}`
         );
         return;
       }
@@ -446,7 +440,15 @@ export class AuthV2Controller {
         return;
       }
 
-      await oauthStateServiceV2.markCodeAsUsed(code as string);
+      const codeClaimed = await oauthStateServiceV2.claimCode(code as string);
+      if (!codeClaimed) {
+        logger.error(`[${requestId}] Authorization code already used`);
+        const frontendUrl = getFrontendUrl(req);
+        res.redirect(
+          `${frontendUrl}?error=code_reused&message=${encodeURIComponent('Authorization code already used')}`
+        );
+        return;
+      }
 
       const redirectUri = this.getGoogleRedirectUri(req);
 
@@ -536,7 +538,9 @@ export class AuthV2Controller {
       // Prefer cookie (set by the browser invite redirect) but fall back to state (set by mobile/other flows).
       const pendingInvitationId = cookieInvitationId || stateInvitationId;
       
-      const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email);
+      const userExistsButRemoved = workspaces.length === 0
+        ? await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email)
+        : false;
 
       let domainConflict = null;
       let domainConflictError = null;
@@ -689,10 +693,10 @@ export class AuthV2Controller {
       res.redirect(`${frontendUrl}?${params.toString()}`);
       return;
     } catch (error) {
-      logger.error(`[${requestId}] Callback error:`, error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      logger.error(`[${requestId}] Google OAuth callback failed: ${errorMessage}`);
 
       const frontendUrl = getFrontendUrl(req);
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       res.redirect(
         `${frontendUrl}?error=callback_failed&message=${encodeURIComponent(errorMessage)}`
       );
@@ -807,16 +811,6 @@ export class AuthV2Controller {
         return;
       }
 
-      const isCodeUsed = await oauthStateServiceV2.isCodeUsed(code);
-      if (isCodeUsed) {
-        logger.error(`[${requestId}] Authorization code already used`);
-        res.status(409).json({
-          error: 'Code already used',
-          message: 'Authorization code has already been exchanged',
-        });
-        return;
-      }
-
       const stateData = await oauthStateServiceV2.validateState(state);
       if (!stateData) {
         logger.error(`[${requestId}] Invalid or expired state`);
@@ -846,7 +840,15 @@ export class AuthV2Controller {
         return;
       }
 
-      await oauthStateServiceV2.markCodeAsUsed(code);
+      const codeClaimed = await oauthStateServiceV2.claimCode(code);
+      if (!codeClaimed) {
+        logger.error(`[${requestId}] Authorization code already used`);
+        res.status(409).json({
+          error: 'Code already used',
+          message: 'Authorization code has already been exchanged',
+        });
+        return;
+      }
 
       const redirectUri = this.getGoogleRedirectUri(req);
 
@@ -922,7 +924,9 @@ export class AuthV2Controller {
         await this.userService.getWorkspacesByEmail(googleUserData.email),
         stateData.enterpriseLogin,
       );
-      const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email);
+      const userExistsButRemoved = workspaces.length === 0
+        ? await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email)
+        : false;
 
       const isProduction = process.env.NODE_ENV === 'production';
 
@@ -1120,13 +1124,6 @@ export class AuthV2Controller {
         return;
       }
 
-      const isCodeUsed = await oauthStateServiceV2.isCodeUsed(code as string);
-      if (isCodeUsed) {
-        logger.error(`[${requestId}] Authorization code already used`);
-        sendError('code_reused', 'Authorization code already used');
-        return;
-      }
-
       // Native does PKCE inside the Google SDK, so only the web branch verifies it server-side.
       let codeVerifier: string | undefined;
       if (!isMobileNative) {
@@ -1151,7 +1148,12 @@ export class AuthV2Controller {
         }
       }
 
-      await oauthStateServiceV2.markCodeAsUsed(code as string);
+      const codeClaimed = await oauthStateServiceV2.claimCode(code as string);
+      if (!codeClaimed) {
+        logger.error(`[${requestId}] Authorization code already used`);
+        sendError('code_reused', 'Authorization code already used');
+        return;
+      }
 
       // For mobile native apps using serverAuthCode, use empty string as redirect_uri
       // For web OAuth flow, use the backend callback URL
@@ -1223,7 +1225,9 @@ export class AuthV2Controller {
       }
 
       const workspaces = await this.userService.getWorkspacesByEmail(googleUserData.email);
-      const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email);
+      const userExistsButRemoved = workspaces.length === 0
+        ? await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email)
+        : false;
 
       const isProduction = process.env.NODE_ENV === 'production';
       const cookieOptions = {

--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -4,7 +4,6 @@ import jwt from 'jsonwebtoken';
 import { Request, Response } from 'express';
 import { UserSessionService } from '../services/userSessionService';
 import { UserService } from '../services/userService';
-import { jwtService } from '../services/jwtService';
 import {
   hashPassword,
   validatePasswordComplexity,
@@ -23,7 +22,6 @@ import {
 } from '@/services/organizationDomainService';
 import '../types/express';
 import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper';
-import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 
 interface ResetCodePayload {
@@ -73,12 +71,47 @@ export class EmailAuthController {
     res.clearCookie('xyne_last_workspace', { path: '/' });
   }
 
+  private async setPendingAuthCookie(
+    res: Response,
+    email: string,
+    name: string,
+  ): Promise<void> {
+    const pendingAuthJwtId = crypto.randomUUID();
+    await redisService.set(`pendingauth:jwtid:${pendingAuthJwtId}`, email, 10 * 60);
+
+    res.cookie(
+      'google_access_token',
+      jwt.sign(
+        {
+          email,
+          name,
+          providerUserId: `email-${email}`,
+          provider: AuthProvider.EMAIL,
+          // Email auth has no upstream OAuth refresh token. This opaque token
+          // lets the common loginWorkspace flow create a renewable session.
+          refreshToken: crypto.randomUUID(),
+          accessToken: null,
+          jwtId: pendingAuthJwtId,
+        },
+        process.env.JWT_SECRET!,
+        { expiresIn: '10m' },
+      ),
+      {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict' as const,
+        path: '/',
+        maxAge: 10 * 60 * 1000,
+      },
+    );
+  }
+
   /**
    * Login with email + password
    * POST /v2/auth/email/login
    *
-   * Verifies against orgMember.passwordHash. On success creates a session,
-   * issues JWT + cookies, and returns workspace info identical to OAuth flow.
+   * Verifies against orgMember.passwordHash. On success issues pending auth
+   * and returns workspace info; loginWorkspace creates the final session.
    */
   login = async (req: Request, res: Response): Promise<void> => {
     try {
@@ -237,42 +270,7 @@ export class EmailAuthController {
           // signal the frontend to complete the join for this workspace.
           const approvedJoinRequest = approvedJoinRequests[0];
           const userName = normalizedEmail.split('@')[0];
-          const pendingAuthJwtId = crypto.randomUUID();
-
-          await redisService.set(
-            `pendingauth:jwtid:${pendingAuthJwtId}`,
-            normalizedEmail,
-            10 * 60,
-          );
-
-          const isProduction = process.env.NODE_ENV === 'production';
-          const cookieBase = {
-            httpOnly: true,
-            secure: isProduction,
-            sameSite: 'strict' as const,
-            path: '/',
-          };
-
-          res.cookie(
-            'google_access_token',
-            jwt.sign(
-              {
-                email: normalizedEmail,
-                name: userName,
-                providerUserId: `email-${normalizedEmail}`,
-                provider: 'EMAIL',
-                refreshToken: null,
-                accessToken: null,
-                jwtId: pendingAuthJwtId,
-              },
-              process.env.JWT_SECRET!,
-              { expiresIn: '10m' },
-            ),
-            {
-              ...cookieBase,
-              maxAge: 10 * 60 * 1000,
-            },
-          );
+          await this.setPendingAuthCookie(res, normalizedEmail, userName);
 
           res.status(200).json({
             success: true,
@@ -293,42 +291,7 @@ export class EmailAuthController {
           });
           const workspaceMap = new Map(workspaces.map(w => [w.id, w.name]));
           const userName = normalizedEmail.split('@')[0];
-          const pendingAuthJwtId = crypto.randomUUID();
-
-          await redisService.set(
-            `pendingauth:jwtid:${pendingAuthJwtId}`,
-            normalizedEmail,
-            10 * 60,
-          );
-
-          const isProduction = process.env.NODE_ENV === 'production';
-          const cookieBase = {
-            httpOnly: true,
-            secure: isProduction,
-            sameSite: 'strict' as const,
-            path: '/',
-          };
-
-          res.cookie(
-            'google_access_token',
-            jwt.sign(
-              {
-                email: normalizedEmail,
-                name: userName,
-                providerUserId: `email-${normalizedEmail}`,
-                provider: 'EMAIL',
-                refreshToken: null,
-                accessToken: null,
-                jwtId: pendingAuthJwtId,
-              },
-              process.env.JWT_SECRET!,
-              { expiresIn: '10m' },
-            ),
-            {
-              ...cookieBase,
-              maxAge: 10 * 60 * 1000,
-            },
-          );
+          await this.setPendingAuthCookie(res, normalizedEmail, userName);
 
           res.status(200).json({
             success: true,
@@ -364,49 +327,11 @@ export class EmailAuthController {
         return;
       }
 
-      // Cookie base (used below for both invitation-pending and normal flows)
-      const isProduction = process.env.NODE_ENV === 'production';
-      const cookieBase = {
-        httpOnly: true,
-        secure: isProduction,
-        sameSite: 'strict' as const,
-        path: '/',
-      };
-
       if (pendingInvitation) {
         // Invited user hasn't accepted yet — set pending auth cookie (mirrors OAuth flow)
         // and return a signal so the frontend redirects to the invite page.
         const userName = normalizedEmail.split('@')[0];
-        const pendingAuthJwtId = crypto.randomUUID();
-
-        // Store the pending-auth token ID in Redis with 10-minute TTL.
-        // acceptInvitation will verify this entry exists before proceeding.
-        await redisService.set(
-          `pendingauth:jwtid:${pendingAuthJwtId}`,
-          normalizedEmail,
-          10 * 60, // 10 minutes
-        );
-
-        res.cookie(
-          'google_access_token',
-          jwt.sign(
-            {
-              email: normalizedEmail,
-              name: userName,
-              providerUserId: `email-${normalizedEmail}`,
-              provider: 'EMAIL',
-              refreshToken: null,
-              accessToken: null,
-              jwtId: pendingAuthJwtId,
-            },
-            process.env.JWT_SECRET!,
-            { expiresIn: '10m' },
-          ),
-          {
-            ...cookieBase,
-            maxAge: 10 * 60 * 1000, // 10 minutes pending auth window
-          },
-        );
+        await this.setPendingAuthCookie(res, normalizedEmail, userName);
 
         res.status(200).json({
           success: true,
@@ -420,80 +345,31 @@ export class EmailAuthController {
       }
 
       const workspaceUser = workspaceUsers[0];
-
-      // 5. Create session
-      const refreshToken = crypto.randomUUID();
-      const refreshTokenExpiry = new Date();
-      refreshTokenExpiry.setDate(refreshTokenExpiry.getDate() + 30);
-
-      const session = await this.userSessionService.createSession({
-        userId: workspaceUser.id,
-        refreshToken,
-        refreshTokenExpiry,
-        deviceInfo: JSON.stringify({
-          userAgent: req.headers['user-agent'],
-          timestamp: new Date().toISOString(),
-        }),
-        ipAddress: req.ip || req.connection.remoteAddress || undefined,
-      });
-
-      // 6. Generate JWT
-      const jwtToken = jwtService.generateToken({
-        sub: workspaceUser.id,
-        email: workspaceUser.email,
-        name: workspaceUser.name,
-        workspaceId: workspaceUser.workspaceId,
-        memberId: workspaceUser.orgMemberId,
-        providerUserId: `email-${workspaceUser.email}`,
-        provider: AuthProvider.EMAIL,
-      });
-
-      res.cookie('google_access_token', jwtToken, {
-        ...cookieBase,
-        maxAge: config.jwt.expirationSeconds * 1000,
-      });
-
-      res.cookie(`xyne_ws_${workspaceUser.workspaceId}_token`, jwtToken, {
-        ...cookieBase,
-        maxAge: config.jwt.expirationSeconds * 1000,
-      });
-
-      res.cookie('user_session_id', session.id, {
-        ...cookieBase,
-        maxAge: 30 * 24 * 60 * 60 * 1000,
-      });
-
-      res.cookie('xyne_last_workspace', workspaceUser.workspaceId, {
-        ...cookieBase,
-        maxAge: 30 * 24 * 60 * 60 * 1000,
-      });
-
-      // Build workspaces array for frontend auth machine
       const workspaces = workspaceUsers.map(u => ({
         id: u.workspaceId,
         name: u.workspace?.name || u.workspaceId,
         role: u.role,
       }));
 
-      // 8. Success response — shape matches what useAuth.signInWithEmail expects
+      // Defer workspace-scoped cookies and session creation to the common
+      // loginWorkspace endpoint, exactly like the OAuth callbacks.
+      await this.setPendingAuthCookie(
+        res,
+        normalizedEmail,
+        workspaceUser.name || normalizedEmail.split('@')[0],
+      );
+
       res.status(200).json({
         success: true,
-        user: {
-          id: workspaceUser.id,
-          email: workspaceUser.email,
-          name: workspaceUser.name,
-          workspaceId: workspaceUser.workspaceId,
-          role: workspaceUser.role,
-          orgRole: orgMember.role,
-          memberId: orgMember.memberId,
-          authProvider: AuthProvider.EMAIL,
-        },
         workspaces,
         pendingUserData: {
           email: workspaceUser.email,
           name: workspaceUser.name,
         },
         userExistsButRemoved: false,
+        ...(workspaces.length === 1
+          ? { autoLoginWorkspace: workspaces[0]!.id }
+          : {}),
       });
     } catch (error) {
       res.status(500).json({
@@ -1082,42 +958,7 @@ export class EmailAuthController {
 
       // Issue pending-auth cookie — same mechanism as OAuth callback.
       const userName = name || normalizedEmail.split('@')[0];
-      const pendingAuthJwtId = crypto.randomUUID();
-
-      await redisService.set(
-        `pendingauth:jwtid:${pendingAuthJwtId}`,
-        normalizedEmail,
-        10 * 60,
-      );
-
-      const isProduction = process.env.NODE_ENV === 'production';
-      const cookieBase = {
-        httpOnly: true,
-        secure: isProduction,
-        sameSite: 'strict' as const,
-        path: '/',
-      };
-
-      res.cookie(
-        'google_access_token',
-        jwt.sign(
-          {
-            email: normalizedEmail,
-            name: userName,
-            providerUserId: `email-${normalizedEmail}`,
-            provider: 'EMAIL',
-            refreshToken: null,
-            accessToken: null,
-            jwtId: pendingAuthJwtId,
-          },
-          process.env.JWT_SECRET!,
-          { expiresIn: '10m' },
-        ),
-        {
-          ...cookieBase,
-          maxAge: 10 * 60 * 1000,
-        },
-      );
+      await this.setPendingAuthCookie(res, normalizedEmail, userName);
 
       // Build response — mirrors OAuth callback structure.
       // If workspaceId was provided, return empty workspaces so the frontend
@@ -1167,6 +1008,9 @@ export class EmailAuthController {
         workspaces: workspaces.map(w => ({ id: w.id, name: w.name, role: w.role })),
         pendingUserData: { email: normalizedEmail, name: userName },
         userExistsButRemoved: false,
+        ...(workspaces.length === 1
+          ? { autoLoginWorkspace: workspaces[0]!.id }
+          : {}),
         ...(domainConflictError ? { domainConflictError } : {}),
         ...(enterpriseJoinOrgName ? { enterpriseJoinOrgName } : {}),
         ...(enterpriseJoinWorkspaces ? { enterpriseJoinWorkspaces } : {}),

--- a/apps/backend/src/controllers/microsoftAuthController.ts
+++ b/apps/backend/src/controllers/microsoftAuthController.ts
@@ -518,8 +518,66 @@ export class MicrosoftAuthController {
           }
         }
 
-        // Keep provider tokens in Redis. The short-lived cookie contains only
-        // normalized identity and the Redis lookup key consumed by loginWorkspace.
+        // Mobile (browser-based OAuth): create user/session and redirect to app deep link.
+        // Old mobile clients expect xyne-spaces://auth/microsoft/callback with token in URL.
+        // New mobile clients use POST /microsoft/exchange-mobile instead.
+        if (resolvedPlatform === 'mobile') {
+          const { user } = await this.userService.findOrCreateOAuthUser({
+            provider: AuthProvider.MICROSOFT,
+            providerUserId: microsoftUserData.providerUserId,
+            email: microsoftUserData.email,
+            name: microsoftUserData.name,
+            picture: microsoftUserData.picture,
+          }, workspaces[0]?.id ?? '');
+
+          await this.userService.ensureUserPresence(user.id, user.workspaceId);
+
+          const customToken = jwtService.generateToken({
+            sub: user.id,
+            email: user.email,
+            name: user.name,
+            picture: user.picture ?? undefined,
+            workspaceId: user.workspaceId ?? undefined,
+            memberId: user.orgMemberId ?? undefined,
+          });
+
+          if (refreshToken) {
+            try {
+              const refreshTokenExpiry = new Date();
+              refreshTokenExpiry.setDate(refreshTokenExpiry.getDate() + config.session.expiryDays);
+              await this.userSessionService.createSession({
+                userId: user.id,
+                refreshToken,
+                refreshTokenExpiry,
+                accessToken,
+                accessTokenExpiry,
+                deviceInfo: JSON.stringify({
+                  userAgent: req.headers['user-agent'],
+                  acceptLanguage: req.headers['accept-language'],
+                  timestamp: new Date().toISOString(),
+                }),
+                ipAddress: req.ip || req.socket.remoteAddress || undefined,
+              });
+            } catch (sessionError) {
+              logger.error(`[${requestId}] Error creating user session:`, sessionError);
+            }
+          }
+
+          const mobileParams = new URLSearchParams({
+            success: 'true',
+            token: customToken,
+            user_id: user.id,
+            email: user.email,
+            name: user.name,
+          });
+          const mobileRedirectUrl = `xyne-spaces://auth/microsoft/callback?${mobileParams.toString()}`;
+          logger.info(`[${requestId}] Redirecting to mobile app: xyne-spaces://auth/microsoft/callback`);
+          res.redirect(mobileRedirectUrl);
+          return;
+        }
+
+        // Web: set google_access_token cookie and redirect to frontend.
+        // loginWorkspace creates the session from this cookie.
         const tokenKey = await this.storePendingOAuthTokens(
           refreshToken,
           accessToken,

--- a/apps/backend/src/controllers/microsoftAuthController.ts
+++ b/apps/backend/src/controllers/microsoftAuthController.ts
@@ -25,8 +25,8 @@ import { randomUUID } from 'crypto';
 
 export class MicrosoftAuthController {
   private oauthClient: AuthorizationCode | undefined;
-  private userService: UserService | undefined;
-  private userSessionService: UserSessionService | undefined;
+  private userService: UserService;
+  private userSessionService: UserSessionService;
   private clientId: string | undefined;
   private tenantId: string = '';
   private msJwks!: ReturnType<typeof createRemoteJWKSet>;
@@ -50,6 +50,9 @@ export class MicrosoftAuthController {
   }
 
   constructor() {
+    this.userService = new UserService();
+    this.userSessionService = new UserSessionService();
+
     const clientId = process.env.MICROSOFT_CLIENT_ID;
     const clientSecret = process.env.MICROSOFT_CLIENT_SECRET;
     const tenantId = process.env.MICROSOFT_TENANT_ID || undefined;
@@ -88,8 +91,6 @@ export class MicrosoftAuthController {
 
     this.clientId = clientId;
     this.tenantId = tenantId ?? '';
-    this.userService = new UserService();
-    this.userSessionService = new UserSessionService();
     const jwksTenant = tenantId ?? 'common';
     this.msJwks = createRemoteJWKSet(
       new URL(`https://login.microsoftonline.com/${jwksTenant}/discovery/v2.0/keys`)
@@ -154,21 +155,49 @@ export class MicrosoftAuthController {
     return undefined;
   }
 
+  private detectPlatform(req: Request): 'web' | 'electron' | 'mobile' {
+    const userAgent = req.headers['user-agent'] || '';
+    const platform = req.headers['x-platform'] as string;
+
+    if (platform === 'electron' || userAgent.toLowerCase().includes('electron')) {
+      return 'electron';
+    }
+
+    if (platform === 'mobile' || userAgent.toLowerCase().includes('mobile')) {
+      return 'mobile';
+    }
+
+    return 'web';
+  }
+
+  private async verifyMicrosoftIdToken(idToken: string) {
+    const { payload } = await jwtVerify(idToken, this.msJwks, {
+      audience: this.clientId,
+      // issuer: `https://login.microsoftonline.com/${this.tenantId}/v2.0`, unpinned for multi-tenet
+    });
+    return payload as {
+      email?: string;
+      name?: string;
+      preferred_username?: string;
+      xms_edov?: boolean;
+      oid?: string;
+      sub?: string;
+      tid?: string;
+    };
+  }
+
   initiateLogin = async (req: Request, res: Response): Promise<void> => {
     const requestId = `MS_LOGIN_${Date.now()}`;
 
     try {
       if (this.oauthClient) {
-        // return an error that MS auth not setup
         logger.info(`[${requestId}] Initiating Microsoft OAuth login`);
 
-        const platformQuery = req.query.platform;
-        const platform: 'mobile' | 'electron' | 'web' =
-          platformQuery === 'mobile'
-            ? 'mobile'
-            : platformQuery === 'electron'
-              ? 'electron'
-              : 'web';
+        const platformQuery = req.query.platform as 'electron' | 'web' | 'mobile';
+        const platform = platformQuery || this.detectPlatform(req);
+        logger.info(`[${requestId}] Detected platform: ${platform}`);
+
+        const enterpriseLogin = req.query.enterpriseLogin === 'true';
 
         const codeVerifier = pkceServiceV2.generateCodeVerifier();
         const codeChallenge = pkceServiceV2.generateCodeChallenge(codeVerifier);
@@ -178,7 +207,7 @@ export class MicrosoftAuthController {
         if (redirectToParam) {
           const allowedOrigins = (process.env.ALLOWED_REDIRECT_ORIGINS ?? '')
             .split(',')
-            .map((origin) => origin.trim())
+            .map(origin => origin.trim())
             .filter(Boolean);
           try {
             const origin = new URL(redirectToParam).origin;
@@ -187,14 +216,12 @@ export class MicrosoftAuthController {
               validatedRedirectTo = redirectToParam;
             }
           } catch (_error) {
-            // Ignore malformed redirect targets; only configured/current frontend origins are allowed.
+            // Ignore malformed redirect targets; only configured origins are allowed.
           }
         }
 
         // Get invitationId from query (for invitation flow)
         const invitationId = req.query.invitationId as string | undefined;
-
-        const enterpriseLogin = req.query.enterpriseLogin === 'true';
 
         const state = await oauthStateServiceV2.generateState(
           platform,
@@ -208,18 +235,6 @@ export class MicrosoftAuthController {
 
         await pkceServiceV2.storeVerifier(state, codeVerifier);
 
-        // The callback echoes this state back via the HttpOnly cookie. sameSite=lax lets the
-        // cookie ride Microsoft's top-level callback redirect. Mirrors the Google flow; only
-        // the web callback verifies it.
-        const isProduction = process.env.NODE_ENV === 'production';
-        res.cookie('oauth_state', state, {
-          httpOnly: true,
-          secure: isProduction,
-          sameSite: 'lax' as const,
-          maxAge: 10 * 60 * 1000,
-          path: '/',
-        });
-
         const redirectUri = this.getMicrosoftRedirectUri(req);
 
         logger.info('[OAuth] Redirect URI:', redirectUri);
@@ -232,6 +247,16 @@ export class MicrosoftAuthController {
           code_challenge_method: 'S256',
           prompt: 'select_account',
         } as Record<string, string | string[]>);
+
+        // The callback echoes this state back through the HttpOnly cookie.
+        const isProduction = process.env.NODE_ENV === 'production';
+        res.cookie('oauth_state', state, {
+          httpOnly: true,
+          secure: isProduction,
+          sameSite: 'lax' as const,
+          maxAge: 10 * 60 * 1000,
+          path: '/',
+        });
 
         logger.info(`[${requestId}] Redirecting to Microsoft OAuth`);
         res.redirect(authorizationUri);
@@ -253,64 +278,47 @@ export class MicrosoftAuthController {
     }
   };
 
-  private async verifyMicrosoftIdToken(idToken: string) {
-    const { payload } = await jwtVerify(idToken, this.msJwks, {
-      audience: this.clientId,
-      // issuer: `https://login.microsoftonline.com/${this.tenantId}/v2.0`, unpinned for multi-tenet
-    });
-    return payload as {
-      email?: string;
-      name?: string;
-      preferred_username?: string;
-      xms_edov?: boolean;
-      oid?: string;
-      sub?: string;
-      tid?: string;
-    };
-  }
-
   handleCallback = async (req: Request, res: Response): Promise<void> => {
     const requestId = `MS_CALLBACK_${Date.now()}`;
     let resolvedPlatform: string = 'web';
-    let peekedState: Awaited<ReturnType<typeof oauthStateServiceV2.validateState>> = null;
+    let callbackState: Awaited<ReturnType<typeof oauthStateServiceV2.validateState>> = null;
 
     try {
-      if (this.oauthClient && this.userService && this.userSessionService) {
+      if (this.oauthClient) {
         const { code, state, error } = req.query;
 
         logger.info(`[${requestId}] Microsoft OAuth callback received`);
 
-        // Peek at state early to determine platform for error redirects
-        if (state) {
-          peekedState = await oauthStateServiceV2.validateState(state as string, false);
-          if (peekedState) {
-            resolvedPlatform = peekedState.platform;
-          }
-        }
-        logger.info(`[${requestId}] STATE_PEEK: platform=${peekedState?.platform || 'NULL'}, provider=${peekedState?.provider || 'NULL'}, invitationId=${peekedState?.invitationId || 'NULL'}, stateFound=${!!peekedState}`);
-
         if (error) {
           logger.error(`[${requestId}] Microsoft OAuth error: ${error}`);
-          if (state) await oauthStateServiceV2.deleteState(state as string);
+          const frontendUrl = getFrontendUrl(req);
           res.redirect(
-            this.getRedirectUrl(req, resolvedPlatform, {
-              error: 'oauth_error',
-              message: error as string,
-            })
+            `${frontendUrl}?error=oauth_error&message=${encodeURIComponent(error as string)}`
           );
           return;
         }
 
         if (!code || !state) {
           logger.error(`[${requestId}] Missing code or state`);
+          const frontendUrl = getFrontendUrl(req);
           res.redirect(
-            this.getRedirectUrl(req, resolvedPlatform, {
-              error: 'missing_params',
-              message: 'Missing authorization code or state',
-            })
+            `${frontendUrl}?error=missing_params&message=${encodeURIComponent('Missing authorization code or state')}`
           );
           return;
         }
+
+        const stateData = await oauthStateServiceV2.validateState(state as string, false);
+        if (!stateData || stateData.provider !== 'microsoft') {
+          logger.error(`[${requestId}] Invalid, expired, or mismatched OAuth state`);
+          const frontendUrl = getFrontendUrl(req);
+          res.redirect(
+            `${frontendUrl}?error=invalid_state&message=${encodeURIComponent('Invalid or expired state')}`
+          );
+          return;
+        }
+
+        callbackState = stateData;
+        resolvedPlatform = stateData.platform;
 
         // Electron: defer the MS code exchange to the desktop app.
         // Redirect the browser to the launch page, which triggers the unified
@@ -320,16 +328,16 @@ export class MicrosoftAuthController {
         // record and routes Microsoft states to the Microsoft exchange handler.
         // State and PKCE verifier must remain intact until that exchange.
         if (resolvedPlatform === 'electron') {
-          const frontendUrl = getFrontendUrl(req);
+          const frontendUrl = stateData.redirectTo ?? getFrontendUrl(req);
           const launchParams = new URLSearchParams({
             code: code as string,
             state: state as string,
           });
-          if (peekedState?.invitationId) {
-            launchParams.set('invitationId', peekedState.invitationId);
+          if (stateData.invitationId) {
+            launchParams.set('invitationId', stateData.invitationId);
           }
           const launchUrl = `${frontendUrl}/launch?${launchParams.toString()}`;
-          logger.info(`[${requestId}] ELECTRON_REDIRECT: invitationId_appended=${!!peekedState?.invitationId}, invitationId=${peekedState?.invitationId || 'NULL'}, launchUrl=${launchUrl}`);
+          logger.info(`[${requestId}] Redirecting to frontend launch page: ${launchUrl}`);
           res.redirect(launchUrl);
           return;
         }
@@ -366,6 +374,16 @@ export class MicrosoftAuthController {
               error: 'pkce_error',
               message: 'PKCE verification failed',
             })
+          );
+          return;
+        }
+
+        const codeClaimed = await oauthStateServiceV2.claimCode(code as string);
+        if (!codeClaimed) {
+          logger.error(`[${requestId}] Authorization code already used`);
+          const frontendUrl = getFrontendUrl(req);
+          res.redirect(
+            `${frontendUrl}?error=code_reused&message=${encodeURIComponent('Authorization code already used')}`
           );
           return;
         }
@@ -438,7 +456,7 @@ export class MicrosoftAuthController {
           authProvider: AuthProvider.MICROSOFT,
           providerUserId: microsoftUserData.providerUserId,
         });
-        
+
         // SECURITY: reject provider mismatch before issuing any pending-auth cookie
         // or touching workspace state. Account linking is intentionally NOT done here
         // (it enables account takeover). If an account already exists for this email
@@ -461,40 +479,71 @@ export class MicrosoftAuthController {
 
         const workspaces = this.getEnterpriseAwareWorkspaces(
           await this.userService.getWorkspacesByEmail(microsoftUserData.email),
-          peekedState?.enterpriseLogin,
+          stateData.enterpriseLogin,
         );
         logger.info(`[${requestId}] User has ${workspaces.length} workspace(s)`);
 
         const refreshToken = token.refresh_token as string | undefined;
         const isProduction = process.env.NODE_ENV === 'production';
-
-        // Keep Microsoft provider tokens in Redis; the cookie contains identity
-        // plus only the short-lived Redis lookup key.
         const cookieInvitationId = req.cookies?.pending_invitation_id as string | undefined;
-        const pendingInvitationId = cookieInvitationId || peekedState?.invitationId;
-        if (resolvedPlatform !== 'mobile' && pendingInvitationId) {
-          const tokenKey = await this.storePendingOAuthTokens(
-            refreshToken,
-            accessToken,
-            accessTokenExpiry,
-          );
-          res.cookie(
-            'google_access_token',
-            signMicrosoftInvitationPendingAuthToken(
-              microsoftUserData,
-              tokenKey,
-              process.env.JWT_SECRET!,
-            ),
-            {
-              httpOnly: true,
-              secure: isProduction,
-              sameSite: 'lax' as const,
-              path: '/',
-              maxAge: 10 * 60 * 1000,
-            },
-          );
+        const pendingInvitationId = cookieInvitationId || stateData.invitationId;
+        const userExistsButRemoved = workspaces.length === 0
+          ? await this.userService.userExistsButNoActiveWorkspaces(microsoftUserData.email)
+          : false;
 
-          const frontendUrl = peekedState?.redirectTo ?? getFrontendUrl(req);
+        let domainConflict = null;
+        let domainConflictError = null;
+        let publicEmailError = null;
+
+        if (workspaces.length === 0 && !userExistsButRemoved) {
+          if (stateData.enterpriseLogin) {
+            try {
+              await organizationDomainService.assertCanCreateOrgForEmail(microsoftUserData.email);
+            } catch (error) {
+              if (error instanceof PublicEmailDomainError) {
+                publicEmailError = error;
+              } else if (error instanceof OrganizationDomainConflictError) {
+                domainConflictError = error;
+              }
+            }
+          }
+
+          if (!domainConflictError && !publicEmailError) {
+            domainConflict = await organizationDomainService.findEnterpriseWorkspaceByEmailDomain(
+              microsoftUserData.email,
+            );
+            domainConflictError = domainConflict
+              ? new OrganizationDomainConflictError(domainConflict.domain, domainConflict)
+              : null;
+          }
+        }
+
+        // Keep provider tokens in Redis. The short-lived cookie contains only
+        // normalized identity and the Redis lookup key consumed by loginWorkspace.
+        const tokenKey = await this.storePendingOAuthTokens(
+          refreshToken,
+          accessToken,
+          accessTokenExpiry,
+        );
+        res.cookie(
+          'google_access_token',
+          signMicrosoftInvitationPendingAuthToken(
+            microsoftUserData,
+            tokenKey,
+            process.env.JWT_SECRET!,
+          ),
+          {
+            httpOnly: true,
+            secure: isProduction,
+            sameSite: 'strict' as const,
+            path: '/',
+            maxAge: 10 * 60 * 1000,
+          },
+        );
+
+        const frontendUrl = stateData.redirectTo ?? getFrontendUrl(req);
+
+        if (pendingInvitationId) {
           logger.info(
             `[${requestId}] Pending invitation ${pendingInvitationId} found — redirecting to invite page for ${microsoftUserData.email}`,
           );
@@ -508,204 +557,6 @@ export class MicrosoftAuthController {
           return;
         }
 
-        if (resolvedPlatform !== 'mobile' && workspaces.length === 0) {
-          const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(
-            microsoftUserData.email,
-          );
-
-
-          let domainConflict = null;
-          let domainConflictError = null;
-          let publicEmailError = null;
-
-          if (!userExistsButRemoved) {
-            if (peekedState?.enterpriseLogin) {
-              try {
-                await organizationDomainService.assertCanCreateOrgForEmail(microsoftUserData.email);
-              } catch (error) {
-                if (error instanceof PublicEmailDomainError) {
-                  publicEmailError = error;
-                } else if (error instanceof OrganizationDomainConflictError) {
-                  domainConflictError = error;
-                }
-              }
-            }
-
-            if (!domainConflictError && !publicEmailError) {
-              domainConflict = await organizationDomainService.findEnterpriseWorkspaceByEmailDomain(microsoftUserData.email);
-              domainConflictError = domainConflict
-                ? new OrganizationDomainConflictError(domainConflict.domain, domainConflict)
-                : null;
-            }
-          }
-
-          const tokenKey = await this.storePendingOAuthTokens(
-            refreshToken,
-            accessToken,
-            accessTokenExpiry,
-          );
-          res.cookie('google_access_token', jwt.sign({
-            providerUserId: microsoftUserData.providerUserId,
-            email: microsoftUserData.email,
-            name: microsoftUserData.name,
-            picture: microsoftUserData.picture,
-            provider: AuthProvider.MICROSOFT,
-            tokenKey,
-          }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
-            httpOnly: true,
-            secure: isProduction,
-            sameSite: 'lax' as const,
-            path: '/',
-            maxAge: 10 * 60 * 1000,
-          });
-
-          const frontendUrl = peekedState?.redirectTo ?? getFrontendUrl(req);
-          const params = new URLSearchParams({
-            success: 'true',
-            email: microsoftUserData.email,
-            name: microsoftUserData.name,
-            picture: microsoftUserData.picture || '',
-            workspaces: JSON.stringify([]),
-            userExistsButRemoved: String(userExistsButRemoved),
-          });
-          if (domainConflictError && domainConflict) {
-            params.set('domainConflictError', domainConflictError.message);
-            params.set('enterpriseJoinOrgName', domainConflict.name);
-            params.set('enterpriseJoinWorkspaces', JSON.stringify(domainConflict.workspaces));
-          }
-          if (publicEmailError) {
-            params.set('publicEmailDomainError', publicEmailError.message);
-          }
-
-          logger.info(
-            `[${requestId}] No workspace found for ${microsoftUserData.email}; redirecting with pending auth for org creation`,
-          );
-          res.redirect(`${frontendUrl}?${params.toString()}`);
-          return;
-        }
-
-        logger.info(`[${requestId}] Finding/creating user: ${microsoftUserData.email}`);
-        const { user, isNewUser } = await this.userService.findOrCreateOAuthUser({
-          provider: AuthProvider.MICROSOFT,
-          providerUserId: microsoftUserData.providerUserId,
-          email: microsoftUserData.email,
-          name: microsoftUserData.name,
-          picture: microsoftUserData.picture,
-        }, workspaces[0]?.id ?? '');
-
-        // Ensure user presence entry exists
-        await this.userService.ensureUserPresence(user.id, user.workspaceId);
-
-        logger.info(
-          `[${requestId}] User resolved: ${user.email} (ID: ${user.id}, isNew: ${isNewUser})`
-        );
-
-        // Generate custom JWT token
-        const customToken = jwtService.generateToken({
-          sub: user.id,
-          email: user.email,
-          name: user.name,
-          picture: user.picture ?? undefined,
-          workspaceId: user.workspaceId ?? undefined,
-          memberId: user.orgMemberId ?? undefined,
-        });
-
-        // Create user session
-        let sessionId = null;
-
-        if (refreshToken) {
-          try {
-            logger.info(`[${requestId}] Creating user session with refresh token`);
-
-            const refreshTokenExpiry = new Date();
-            refreshTokenExpiry.setDate(refreshTokenExpiry.getDate() + config.session.expiryDays);
-
-            const session = await this.userSessionService.createSession({
-              userId: user.id,
-              refreshToken: refreshToken,
-              refreshTokenExpiry,
-              accessToken: accessToken,
-              accessTokenExpiry,
-              deviceInfo: JSON.stringify({
-                userAgent: req.headers['user-agent'],
-                acceptLanguage: req.headers['accept-language'],
-                timestamp: new Date().toISOString(),
-              }),
-              ipAddress: req.ip || req.socket.remoteAddress || undefined,
-            });
-
-            sessionId = session.id;
-            logger.info(`[${requestId}] Session created`);
-          } catch (sessionError) {
-            logger.error(`[${requestId}] Error creating user session:`, sessionError);
-            // Continue without session creation - not critical for login
-          }
-        }
-
-        // Handle mobile platform: redirect to app deep link with token
-        if (resolvedPlatform === 'mobile') {
-          const mobileParams = new URLSearchParams({
-            success: 'true',
-            token: customToken,
-            user_id: user.id,
-            email: user.email,
-            name: user.name,
-          });
-
-          const mobileRedirectUrl = `xyne-spaces://auth/microsoft/callback?${mobileParams.toString()}`;
-          logger.info(`[${requestId}] Redirecting to mobile app: xyne-spaces://auth/microsoft/callback`);
-          res.redirect(mobileRedirectUrl);
-          return;
-        }
-
-        const userExistsButRemoved = workspaces.length === 0
-          ? await this.userService.userExistsButNoActiveWorkspaces(microsoftUserData.email)
-          : false;
-
-        const cookieOptions = {
-          httpOnly: true,
-          secure: isProduction,
-          sameSite: 'lax' as const,
-          path: '/',
-        };
-
-        // Keep provider identity in the signed cookie and provider tokens in Redis.
-        const tokenKey = await this.storePendingOAuthTokens(
-          refreshToken,
-          accessToken,
-          accessTokenExpiry,
-        );
-        res.cookie('google_access_token', jwt.sign({
-          providerUserId: microsoftUserData.providerUserId,
-          email: microsoftUserData.email,
-          name: microsoftUserData.name,
-          picture: microsoftUserData.picture,
-          provider: AuthProvider.MICROSOFT,
-          tokenKey,
-        }, process.env.JWT_SECRET!, { expiresIn: '10m' }), {
-          ...cookieOptions,
-          maxAge: 10 * 60 * 1000, // 10 minutes pending auth window
-        });
-
-        // Set session ID cookie
-        if (sessionId) {
-          res.cookie('user_session_id', sessionId, {
-            ...cookieOptions,
-            maxAge: config.session.expiryDays * 24 * 60 * 60 * 1000,
-          });
-        }
-
-        // Set new user cookie for onboarding
-        if (isNewUser) {
-          res.cookie('is_new_user', 'true', {
-            ...cookieOptions,
-            maxAge: 24 * 60 * 60 * 1000, // 24 hours
-          });
-        }
-
-        // Redirect to frontend with success
-        const frontendUrl = peekedState?.redirectTo ?? getFrontendUrl(req);
-
         const params = new URLSearchParams({
           success: 'true',
           email: microsoftUserData.email,
@@ -717,35 +568,40 @@ export class MicrosoftAuthController {
         if (workspaces.length === 1) {
           params.set('autoLoginWorkspace', workspaces[0]!.id);
         }
+        if (domainConflictError && domainConflict) {
+          params.set('domainConflictError', domainConflictError.message);
+          params.set('enterpriseJoinOrgName', domainConflict.name);
+          params.set('enterpriseJoinWorkspaces', JSON.stringify(domainConflict.workspaces));
+        }
+        if (publicEmailError) {
+          params.set('publicEmailDomainError', publicEmailError.message);
+        }
 
         res.redirect(`${frontendUrl}?${params.toString()}`);
+        return;
       } else {
         logger.error(`[${requestId}] Microsoft OAuth client not configured`);
+        const frontendUrl = getFrontendUrl(req);
         res.redirect(
-          this.getRedirectUrl(req, resolvedPlatform, {
-            error: 'microsoft_not_configured',
-            message: 'Microsoft SSO is not configured',
-          })
+          `${frontendUrl}?error=microsoft_not_configured&message=${encodeURIComponent('Microsoft SSO is not configured')}`
         );
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       logger.error(`[${requestId}] Microsoft OAuth callback failed: ${errorMessage}`);
 
-      if (resolvedPlatform !== 'mobile' && peekedState?.redirectTo) {
+      if (resolvedPlatform !== 'mobile' && callbackState?.redirectTo) {
         const params = new URLSearchParams({
           error: 'auth_failed',
           message: errorMessage,
         });
-        res.redirect(`${peekedState.redirectTo}?${params.toString()}`);
+        res.redirect(`${callbackState.redirectTo}?${params.toString()}`);
         return;
       }
 
+      const frontendUrl = getFrontendUrl(req);
       res.redirect(
-        this.getRedirectUrl(req, resolvedPlatform, {
-          error: 'auth_failed',
-          message: errorMessage,
-        })
+        `${frontendUrl}?error=callback_failed&message=${encodeURIComponent(errorMessage)}`
       );
     }
   };
@@ -764,7 +620,7 @@ export class MicrosoftAuthController {
     const requestId = `MS_EXCHANGE_ELECTRON_${Date.now()}`;
 
     try {
-      if (!this.oauthClient || !this.userService || !this.userSessionService) {
+      if (!this.oauthClient) {
         logger.error(`[${requestId}] Microsoft OAuth client not configured`);
         res.status(500).json({
           success: false,
@@ -786,17 +642,6 @@ export class MicrosoftAuthController {
           success: false,
           error: 'missing_params',
           message: 'code and state are required',
-        });
-        return;
-      }
-
-      const isCodeUsed = await oauthStateServiceV2.isCodeUsed(code);
-      if (isCodeUsed) {
-        logger.error(`[${requestId}] Authorization code already used`);
-        res.status(409).json({
-          success: false,
-          error: 'code_already_used',
-          message: 'Authorization code has already been exchanged',
         });
         return;
       }
@@ -838,7 +683,16 @@ export class MicrosoftAuthController {
         return;
       }
 
-      await oauthStateServiceV2.markCodeAsUsed(code);
+      const codeClaimed = await oauthStateServiceV2.claimCode(code);
+      if (!codeClaimed) {
+        logger.error(`[${requestId}] Authorization code already used`);
+        res.status(409).json({
+          success: false,
+          error: 'code_already_used',
+          message: 'Authorization code has already been exchanged',
+        });
+        return;
+      }
 
       const redirectUri = this.getMicrosoftRedirectUri(req);
 
@@ -916,7 +770,9 @@ export class MicrosoftAuthController {
         await this.userService.getWorkspacesByEmail(email),
         stateData.enterpriseLogin,
       );
-      const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(email);
+      const userExistsButRemoved = workspaces.length === 0
+        ? await this.userService.userExistsButNoActiveWorkspaces(email)
+        : false;
       logger.info(`[${requestId}] User has ${workspaces.length} workspace(s), userExistsButRemoved: ${userExistsButRemoved}`);
       logger.info(`[${requestId}] PROFILE: email=${email}, msId=${profile.id}, verifiedOid=${idTokenClaims.oid ?? 'NULL'}, workspaceCount=${workspaces.length}`);
 
@@ -1258,7 +1114,7 @@ export class MicrosoftAuthController {
     const requestId = `MS_EXCHANGE_MOBILE_${Date.now()}`;
 
     try {
-      if (!this.oauthClient || !this.userService || !this.userSessionService) {
+      if (!this.oauthClient) {
         logger.error(`[${requestId}] Microsoft OAuth client not configured`);
         res.status(500).json({
           success: false,
@@ -1278,6 +1134,17 @@ export class MicrosoftAuthController {
           success: false,
           error: 'missing_params',
           message: 'code, code_verifier, and redirect_uri are required',
+        });
+        return;
+      }
+
+      const codeClaimed = await oauthStateServiceV2.claimCode(code);
+      if (!codeClaimed) {
+        logger.error(`[${requestId}] Authorization code already used`);
+        res.status(409).json({
+          success: false,
+          error: 'code_already_used',
+          message: 'Authorization code has already been exchanged',
         });
         return;
       }

--- a/apps/backend/src/routes/authV2.ts
+++ b/apps/backend/src/routes/authV2.ts
@@ -25,11 +25,11 @@ router.get('/microsoft/login', microsoftAuthController.initiateLogin);
 
 router.get('/microsoft/callback', microsoftAuthController.handleCallback);
 
-router.post('/microsoft/exchange-mobile', microsoftAuthController.exchangeMobile);
-
 router.post('/exchange-electron', authV2Controller.exchangeElectronCode);
 
 router.post('/exchange-mobile', authV2Controller.exchangeMobileCode);
+
+router.post('/microsoft/exchange-mobile', microsoftAuthController.exchangeMobile);
 
 router.get('/refresh-session', authV2Controller.refreshSession);
 

--- a/apps/backend/src/services/oauthStateServiceV2.ts
+++ b/apps/backend/src/services/oauthStateServiceV2.ts
@@ -86,25 +86,25 @@ class OAuthStateService {
     logger.info(`OAuth state deleted: ${state}`);
   }
 
-  async markCodeAsUsed(code: string): Promise<void> {
+  async claimCode(code: string): Promise<boolean> {
     const { redisService } = await import('./redisService');
     const client = redisService.getClient();
 
-    await client.setex(
+    const result = await client.set(
       `${this.CODE_PREFIX}${code}`,
+      'used',
+      'EX',
       this.CODE_TTL,
-      'used'
+      'NX',
     );
 
-    logger.info(`OAuth code marked as used: ${code.substring(0, 10)}...`);
-  }
-
-  async isCodeUsed(code: string): Promise<boolean> {
-    const { redisService } = await import('./redisService');
-    const client = redisService.getClient();
-
-    const exists = await client.exists(`${this.CODE_PREFIX}${code}`);
-    return exists === 1;
+    const claimed = result === 'OK';
+    if (claimed) {
+      logger.info(`OAuth code claimed: ${code.substring(0, 10)}...`);
+    } else {
+      logger.warn(`OAuth code already claimed by another request: ${code.substring(0, 10)}...`);
+    }
+    return claimed;
   }
 }
 

--- a/apps/dashboard/src/machines/authMachine.ts
+++ b/apps/dashboard/src/machines/authMachine.ts
@@ -820,6 +820,21 @@ export const authMachine = createMachine(
               }),
             },
             {
+              guard: 'hasAutoLoginWorkspace',
+              target: 'loggingInToWorkspace',
+              actions: assign(({ context, event }) => {
+                const output = (event as XStateEvent).output;
+                return {
+                  ...context,
+                  workspaces: getWorkspaces(output),
+                  pendingUserData: output?.pendingUserData || null,
+                  selectedWorkspaceId: output?.autoLoginWorkspace || null,
+                  userExistsButRemoved: output?.userExistsButRemoved || false,
+                  error: null,
+                };
+              }),
+            },
+            {
               guard: 'hasLastActiveWorkspace',
               target: 'loggingInToWorkspace',
               actions: assign(({ context, event }) => {
@@ -906,6 +921,21 @@ export const authMachine = createMachine(
               }),
             },
             {
+              guard: 'hasAutoLoginWorkspace',
+              target: 'loggingInToWorkspace',
+              actions: assign(({ context, event }) => {
+                const output = (event as XStateEvent).output;
+                return {
+                  ...context,
+                  workspaces: getWorkspaces(output),
+                  pendingUserData: output?.pendingUserData || null,
+                  selectedWorkspaceId: output?.autoLoginWorkspace || null,
+                  userExistsButRemoved: output?.userExistsButRemoved || false,
+                  error: null,
+                };
+              }),
+            },
+            {
               guard: 'hasLastActiveWorkspace',
               target: 'loggingInToWorkspace',
               actions: assign(({ context, event }) => {
@@ -984,6 +1014,21 @@ export const authMachine = createMachine(
                   workspaces: getWorkspaces(output),
                   pendingUserData: output?.pendingUserData || null,
                   selectedWorkspaceId: localStorage.getItem(PENDING_WORKSPACE_ID_KEY),
+                  userExistsButRemoved: output?.userExistsButRemoved || false,
+                  error: null,
+                };
+              }),
+            },
+            {
+              guard: 'hasAutoLoginWorkspace',
+              target: 'loggingInToWorkspace',
+              actions: assign(({ context, event }) => {
+                const output = (event as XStateEvent).output;
+                return {
+                  ...context,
+                  workspaces: getWorkspaces(output),
+                  pendingUserData: output?.pendingUserData || null,
+                  selectedWorkspaceId: output?.autoLoginWorkspace || null,
                   userExistsButRemoved: output?.userExistsButRemoved || false,
                   error: null,
                 };


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
