### PR TITLE
feat: extract platform-agnostic Ask AI stream core into @xyne/shared

### DIFF
--- a/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
+++ b/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
@@ -1,7 +1,19 @@
 /**
  * Web Worker for XyneAI Streaming
  * Runs API calls on a separate thread to avoid blocking the main UI thread
+ *
+ * The wire-body serialization and SSE framing now live in the platform-agnostic
+ * Ask AI stream core (`@xyne/shared/askAI`) so the dashboard (web) and the native
+ * mobile app share ONE serializer + parser and can't drift. This worker keeps the
+ * web-specific transport concerns: `fetch`, cookie credentials, the read loop,
+ * abort handling, and the worker<->main postMessage protocol.
  */
+
+import {
+  buildAskAIRequestBody,
+  createAskAISSEParser,
+  type AskAIRequestInput,
+} from '@xyne/shared/askAI';
 
 // Worker message types
 export interface WorkerStartStreamMessage {
@@ -9,59 +21,8 @@ export interface WorkerStartStreamMessage {
   payload: {
     streamId: string;
     url: string;
-    requestBody: {
-      query: string;
-      displayQuery?: string;
-      channelIds: string[];
-      collectionIds?: string[];
-      fileIds?: string[];
-      canvasIds?: string[];
-      ticketIds?: string[];
-      callIds?: string[];
-      attachedContext?: Array<{
-        type: 'channel' | 'ticket' | 'canvas' | 'call' | 'activity';
-        id: string;
-        title: string;
-        threadId?: string;
-        eventName?: string;
-        eventCategory?: string;
-        timestamp?: string;
-        metadata?: Record<string, unknown>;
-        relatedData?: Record<string, unknown>;
-      }>;
-      conversationId: string;
-      sessionId: string;
-      webSearchEnabled: boolean;
-      deepResearchEnabled?: boolean;
-      createCanvasEnabled?: boolean;
-      /** Single search + single answer pass instead of the full agentic tool
-       *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
-      instant?: boolean;
-      researchContext?: { type: string; id?: string; name: string } | null;
-      canvasId?: string;
-      messageAttachmentIds?: string[];
-      attachments?: Array<{
-        data: string;
-        mimeType: string;
-        filename: string;
-      }>;
-      parentMessageId?: string;
-      isRegenerate?: boolean;
-      // Branching: edit-user signals that the new user message is a sibling
-      // of `editedUserMessageId` under `parentAssistantMessageId` (the
-      // assistant parent the original lived under). claw-auth uses these to
-      // clone the PI session BEFORE the original user msg so the LLM session
-      // doesn't include the old turn as context.
-      isEditUserMessage?: boolean;
-      editedUserMessageId?: string;
-      parentAssistantMessageId?: string;
-      draftMode?: boolean;
-      version?: 'v1' | 'v2';
-      disableTools?: boolean;
-      agentSlug?: string;
-      /** Per-run model pin from the composer's model picker. */
-      model?: string;
-    };
+    // The camelCase Ask AI request shape is defined once in the shared core.
+    requestBody: AskAIRequestInput;
   };
 }
 
@@ -112,7 +73,7 @@ const activeStreams = new Map<string, AbortController>();
 async function executeStream(
   streamId: string,
   url: string,
-  requestBody: WorkerStartStreamMessage['payload']['requestBody'],
+  requestBody: AskAIRequestInput,
 ): Promise<void> {
   const abortController = new AbortController();
   activeStreams.set(streamId, abortController);
@@ -127,68 +88,8 @@ async function executeStream(
         Accept: 'text/event-stream',
       },
       credentials: 'include',
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      body: JSON.stringify({
-        query: requestBody.query,
-        ...(requestBody.displayQuery && { display_query: requestBody.displayQuery }),
-        /* eslint-disable @typescript-eslint/naming-convention */
-        channel_ids: requestBody.channelIds,
-        ...(requestBody.collectionIds &&
-          requestBody.collectionIds.length > 0 && { collection_ids: requestBody.collectionIds }),
-        ...(requestBody.fileIds &&
-          requestBody.fileIds.length > 0 && { file_ids: requestBody.fileIds }),
-        ...(requestBody.canvasIds &&
-          requestBody.canvasIds.length > 0 && { canvas_ids: requestBody.canvasIds }),
-        ...(requestBody.ticketIds &&
-          requestBody.ticketIds.length > 0 && { ticket_ids: requestBody.ticketIds }),
-        ...(requestBody.callIds &&
-          requestBody.callIds.length > 0 && { call_ids: requestBody.callIds }),
-        ...(requestBody.attachedContext &&
-          requestBody.attachedContext.length > 0 && {
-            attached_context: requestBody.attachedContext,
-          }),
-        conversation_id: requestBody.conversationId,
-        session_id: requestBody.sessionId,
-        web_search_enabled: requestBody.webSearchEnabled,
-        deep_research_enabled: requestBody.deepResearchEnabled ?? false,
-        create_canvas_enabled: requestBody.createCanvasEnabled ?? false,
-        instant: requestBody.instant ?? false,
-        research_context: requestBody.researchContext ?? null,
-        ...(requestBody.canvasId && {
-          canvas_id: requestBody.canvasId,
-        }),
-        ...(requestBody.messageAttachmentIds &&
-          requestBody.messageAttachmentIds.length > 0 && {
-            message_attachment_ids: requestBody.messageAttachmentIds,
-          }),
-        ...(requestBody.attachments &&
-          requestBody.attachments.length > 0 && {
-            attachments: requestBody.attachments.map(a => ({
-              data: a.data,
-              mime_type: a.mimeType,
-              filename: a.filename,
-            })),
-          }),
-        ...(requestBody.parentMessageId && {
-          parent_message_id: requestBody.parentMessageId,
-        }),
-        ...(requestBody.isRegenerate && { is_regenerate: requestBody.isRegenerate }),
-        ...(requestBody.isEditUserMessage && {
-          is_edit_user_message: requestBody.isEditUserMessage,
-        }),
-        ...(requestBody.editedUserMessageId && {
-          edited_user_message_id: requestBody.editedUserMessageId,
-        }),
-        ...(requestBody.parentAssistantMessageId && {
-          parent_assistant_message_id: requestBody.parentAssistantMessageId,
-        }),
-        ...(requestBody.draftMode && { draft_mode: true }),
-        ...(requestBody.version && { version: requestBody.version }),
-        ...(requestBody.disableTools && { disable_tools: true }),
-        ...(requestBody.agentSlug && { agentSlug: requestBody.agentSlug }),
-        ...(requestBody.model && { model: requestBody.model }),
-        /* eslint-enable @typescript-eslint/naming-convention */
-      }),
+      // Serialization is shared with native via @xyne/shared/askAI.
+      body: JSON.stringify(buildAskAIRequestBody(requestBody)),
       signal: abortController.signal,
     });
 
@@ -202,7 +103,8 @@ async function executeStream(
       throw new Error('No response body');
     }
 
-    let buffer = '';
+    // SSE framing/JSON/heartbeat handling is shared with native.
+    const parser = createAskAISSEParser();
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
     while (true) {
@@ -215,35 +117,21 @@ async function executeStream(
       if (done) break;
 
       const chunk = decoder.decode(value, { stream: true });
-      buffer += chunk;
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || '';
+      const events = parser.push(chunk, err => {
+        // eslint-disable-next-line no-console
+        console.error('[XyneAIWorker] Failed to parse SSE event:', err);
+      });
 
-      for (const line of lines) {
-        if (line.startsWith('data: ')) {
-          try {
-            const parsed: unknown = JSON.parse(line.slice(6));
-            if (typeof parsed !== 'object' || parsed === null) continue;
-
-            const data = parsed as Record<string, unknown>;
-
-            // Ignore heartbeat pings sent to keep the connection alive
-            if (data['type'] === 'ping') continue;
-
-            // Send chunk to main thread
-            const message: WorkerStreamChunkMessage = {
-              type: 'STREAM_CHUNK',
-              payload: {
-                streamId,
-                data,
-              },
-            };
-            self.postMessage(message);
-          } catch (err) {
-            // eslint-disable-next-line no-console
-            console.error('[XyneAIWorker] Failed to parse SSE event:', err);
-          }
-        }
+      for (const data of events) {
+        // Send chunk to main thread
+        const message: WorkerStreamChunkMessage = {
+          type: 'STREAM_CHUNK',
+          payload: {
+            streamId,
+            data: data as Record<string, unknown>,
+          },
+        };
+        self.postMessage(message);
       }
     }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./askAI": {
+      "types": "./dist/askAI/index.d.ts",
+      "import": "./dist/askAI/index.js",
+      "default": "./dist/askAI/index.js"
+    },
     "./zero": {
       "types": "./dist/zero/index.d.ts",
       "import": "./dist/zero/index.js",

--- a/packages/shared/src/askAI/index.ts
+++ b/packages/shared/src/askAI/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Ask AI stream core — platform-agnostic barrel.
+ *
+ * The shared, transport-free heart of the "Ask AI" streaming chat, consumed by
+ * BOTH the dashboard (web) and the native mobile app. Import it via the
+ * dedicated subpath, e.g. `import { buildAskAIRequestBody } from '@xyne/shared/askAI'`.
+ *
+ * What lives here (pure, no fetch / no globals / no React):
+ *  - types.ts       — request input, SSE + live event unions, transport/store seams
+ *  - requestBody.ts — camelCase input -> snake_case wire body
+ *  - sse.ts         — incremental SSE frame parser
+ *
+ * What stays per-platform (behind the seams): the actual streaming transport
+ * (web worker+fetch+cookies vs native mTLS+Bearer), persistence (IndexedDB vs
+ * MMKV/SQLite), rAF/UI batching, and applying events to platform message state.
+ */
+
+export * from "./types";
+export * from "./requestBody";
+export * from "./sse";

--- a/packages/shared/src/askAI/requestBody.ts
+++ b/packages/shared/src/askAI/requestBody.ts
@@ -1,0 +1,90 @@
+/**
+ * Platform-agnostic Ask AI request-body builder.
+ *
+ * Maps the camelCase {@link AskAIRequestInput} to the exact snake_case JSON body
+ * the backend (`POST /api/xyne-ai`) expects. This was previously inlined inside
+ * the dashboard Web Worker; it is pure (no `fetch`, no globals) so both web and
+ * native can share ONE serializer and never drift.
+ *
+ * IMPORTANT: this is a faithful, field-for-field port of the worker's original
+ * inline serialization — same conditional-inclusion rules, same defaults, same
+ * key names (including the deliberately camelCase `agentSlug`, and the always-
+ * present `research_context`/`instant`/`*_enabled` keys). Do not "clean up" the
+ * conditionals without checking the backend contract; empty-array omission and
+ * `?? false`/`?? null` defaults are load-bearing.
+ */
+
+import type { AskAIRequestInput } from "./types";
+
+/**
+ * Serialize an {@link AskAIRequestInput} into the wire body for the Ask AI
+ * streaming endpoint. Returns a plain object; the caller is responsible for
+ * `JSON.stringify` and transport.
+ */
+export function buildAskAIRequestBody(
+  input: AskAIRequestInput,
+): Record<string, unknown> {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  return {
+    query: input.query,
+    ...(input.displayQuery && { display_query: input.displayQuery }),
+    channel_ids: input.channelIds,
+    ...(input.collectionIds &&
+      input.collectionIds.length > 0 && {
+        collection_ids: input.collectionIds,
+      }),
+    ...(input.fileIds &&
+      input.fileIds.length > 0 && { file_ids: input.fileIds }),
+    ...(input.canvasIds &&
+      input.canvasIds.length > 0 && { canvas_ids: input.canvasIds }),
+    ...(input.ticketIds &&
+      input.ticketIds.length > 0 && { ticket_ids: input.ticketIds }),
+    ...(input.callIds &&
+      input.callIds.length > 0 && { call_ids: input.callIds }),
+    ...(input.attachedContext &&
+      input.attachedContext.length > 0 && {
+        attached_context: input.attachedContext,
+      }),
+    conversation_id: input.conversationId,
+    session_id: input.sessionId,
+    web_search_enabled: input.webSearchEnabled,
+    deep_research_enabled: input.deepResearchEnabled ?? false,
+    create_canvas_enabled: input.createCanvasEnabled ?? false,
+    instant: input.instant ?? false,
+    research_context: input.researchContext ?? null,
+    ...(input.canvasId && {
+      canvas_id: input.canvasId,
+    }),
+    ...(input.messageAttachmentIds &&
+      input.messageAttachmentIds.length > 0 && {
+        message_attachment_ids: input.messageAttachmentIds,
+      }),
+    ...(input.attachments &&
+      input.attachments.length > 0 && {
+        attachments: input.attachments.map((a) => ({
+          data: a.data,
+          mime_type: a.mimeType,
+          filename: a.filename,
+        })),
+      }),
+    ...(input.parentMessageId && {
+      parent_message_id: input.parentMessageId,
+    }),
+    ...(input.isRegenerate && { is_regenerate: input.isRegenerate }),
+    ...(input.isEditUserMessage && {
+      is_edit_user_message: input.isEditUserMessage,
+    }),
+    ...(input.editedUserMessageId && {
+      edited_user_message_id: input.editedUserMessageId,
+    }),
+    ...(input.parentAssistantMessageId && {
+      parent_assistant_message_id: input.parentAssistantMessageId,
+    }),
+    ...(input.draftMode && { draft_mode: true }),
+    ...(input.version && { version: input.version }),
+    ...(input.disableTools && { disable_tools: true }),
+    ...(input.agentSlug && { agentSlug: input.agentSlug }),
+    ...(input.model && { model: input.model }),
+  };
+  /* eslint-enable @typescript-eslint/naming-convention */
+}

--- a/packages/shared/src/askAI/sse.ts
+++ b/packages/shared/src/askAI/sse.ts
@@ -1,0 +1,85 @@
+/**
+ * Platform-agnostic SSE frame parser for the Ask AI stream.
+ *
+ * Turns raw decoded text chunks (as they arrive off the wire) into decoded,
+ * non-ping {@link AskAIStreamEvent}s. This is a faithful port of the dashboard
+ * Web Worker's inline parsing loop, extracted so web and native share ONE
+ * framing/JSON/heartbeat implementation.
+ *
+ * Behaviour (must stay identical across platforms):
+ *  - Chunks are accumulated into an internal buffer; the buffer is split on
+ *    "\n" and the trailing (possibly partial) segment is retained for the next
+ *    push. So a `data:` line split across two network chunks is handled.
+ *  - Only lines beginning with the exact prefix "data: " are considered; the
+ *    JSON is `line.slice(6)`.
+ *  - Non-object / null JSON is skipped.
+ *  - `type: "ping"` heartbeat frames are dropped.
+ *  - Malformed JSON does NOT throw; it is reported via the optional `onError`
+ *    callback (the dashboard passes a console.error to preserve its old log).
+ *
+ * This module is pure: no `fetch`, no `TextDecoder`, no globals. The caller owns
+ * byte decoding (`TextDecoder`) and the read loop, and feeds decoded strings in.
+ */
+
+import type { AskAIStreamEvent } from "./types";
+
+/** The exact SSE field prefix the Ask AI stream uses. */
+export const ASK_AI_SSE_DATA_PREFIX = "data: ";
+
+/** A stateful, incremental SSE parser. Create one per stream. */
+export interface AskAISSEParser {
+  /**
+   * Feed one decoded text chunk. Returns the decoded, non-ping events found in
+   * completed lines within this (and any buffered previous) chunk.
+   *
+   * @param chunk   Decoded text off the wire.
+   * @param onError Optional; called once per malformed `data:` line with the
+   *                thrown error and the offending line. Never throws.
+   */
+  push(
+    chunk: string,
+    onError?: (err: unknown, line: string) => void,
+  ): AskAIStreamEvent[];
+}
+
+/**
+ * Create an incremental Ask AI SSE parser. Hold one instance for the lifetime of
+ * a single stream and call {@link AskAISSEParser.push} for every decoded chunk.
+ */
+export function createAskAISSEParser(): AskAISSEParser {
+  let buffer = "";
+
+  return {
+    push(
+      chunk: string,
+      onError?: (err: unknown, line: string) => void,
+    ): AskAIStreamEvent[] {
+      buffer += chunk;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      const events: AskAIStreamEvent[] = [];
+
+      for (const line of lines) {
+        if (!line.startsWith(ASK_AI_SSE_DATA_PREFIX)) continue;
+        try {
+          const parsed: unknown = JSON.parse(
+            line.slice(ASK_AI_SSE_DATA_PREFIX.length),
+          );
+          if (typeof parsed !== "object" || parsed === null) continue;
+
+          const data = parsed as AskAIStreamEvent;
+
+          // Ignore heartbeat pings sent to keep the connection alive.
+          if (data.type === "ping") continue;
+
+          events.push(data);
+        } catch (err) {
+          onError?.(err, line);
+        }
+      }
+
+      return events;
+    },
+  };
+}

--- a/packages/shared/src/askAI/types.ts
+++ b/packages/shared/src/askAI/types.ts
@@ -1,0 +1,243 @@
+/**
+ * Platform-agnostic Ask AI stream core — TYPES.
+ *
+ * This is the shared contract for the "Ask AI" (Xyne AI / Claw-agent) streaming
+ * chat. It is deliberately transport- and platform-free so it can be consumed
+ * by BOTH the dashboard (web: Web Worker + fetch + cookies + IndexedDB) and the
+ * native mobile app (RN: native mTLS stream + Bearer + MMKV/SQLite).
+ *
+ * Nothing in this module touches `fetch`, `window`, `self`, IndexedDB, or React.
+ * Keep it that way — the transport and persistence live behind the
+ * {@link StreamTransport} / {@link StreamStore} interfaces defined below and are
+ * implemented per platform.
+ *
+ * The camelCase request shape here is the single source of truth for the wire
+ * body; {@link buildAskAIRequestBody} maps it to the snake_case payload the
+ * backend (`POST /api/xyne-ai`) expects.
+ */
+
+// ============================================================================
+// Request input (camelCase) — the platform-agnostic Ask AI request
+// ============================================================================
+
+/** A single attached-context item the composer can pin to a request. */
+export interface AskAIAttachedContextItem {
+  type: "channel" | "ticket" | "canvas" | "call" | "activity";
+  id: string;
+  title: string;
+  threadId?: string;
+  eventName?: string;
+  eventCategory?: string;
+  timestamp?: string;
+  metadata?: Record<string, unknown>;
+  relatedData?: Record<string, unknown>;
+}
+
+/** A binary attachment uploaded inline with the request (base64 data). */
+export interface AskAIAttachmentInput {
+  data: string;
+  mimeType: string;
+  filename: string;
+}
+
+/** Research-agent context selection (product/repository). */
+export interface AskAIResearchContextInput {
+  type: string;
+  id?: string;
+  name: string;
+}
+
+/**
+ * Platform-agnostic Ask AI request. Mirrors, field-for-field, the payload the
+ * dashboard Web Worker used to build inline. Serialize it with
+ * {@link buildAskAIRequestBody} before sending.
+ */
+export interface AskAIRequestInput {
+  query: string;
+  displayQuery?: string;
+  channelIds: string[];
+  collectionIds?: string[];
+  fileIds?: string[];
+  canvasIds?: string[];
+  ticketIds?: string[];
+  callIds?: string[];
+  attachedContext?: AskAIAttachedContextItem[];
+  conversationId: string;
+  sessionId: string;
+  webSearchEnabled: boolean;
+  deepResearchEnabled?: boolean;
+  createCanvasEnabled?: boolean;
+  /**
+   * Single search + single answer pass instead of the full agentic tool loop —
+   * see xyne-claw-auth's run-stream.ts POST / instant branch.
+   */
+  instant?: boolean;
+  researchContext?: AskAIResearchContextInput | null;
+  canvasId?: string;
+  messageAttachmentIds?: string[];
+  attachments?: AskAIAttachmentInput[];
+  parentMessageId?: string;
+  isRegenerate?: boolean;
+  /**
+   * Branching: edit-user signals that the new user message is a sibling of
+   * `editedUserMessageId` under `parentAssistantMessageId` (the assistant parent
+   * the original lived under). claw-auth uses these to clone the PI session
+   * BEFORE the original user msg so the LLM session doesn't include the old turn.
+   */
+  isEditUserMessage?: boolean;
+  editedUserMessageId?: string;
+  parentAssistantMessageId?: string;
+  draftMode?: boolean;
+  version?: "v1" | "v2";
+  disableTools?: boolean;
+  agentSlug?: string;
+  /** Per-run model pin from the composer's model picker. */
+  model?: string;
+}
+
+// ============================================================================
+// SSE stream events (the live answer stream)
+// ============================================================================
+
+/**
+ * The discriminated `type` values the Ask AI SSE stream emits on the main
+ * (answer) channel. `ping` frames are heartbeats and are dropped by the parser.
+ */
+export type AskAIStreamEventType =
+  | "start"
+  | "delta"
+  | "content"
+  | "tool_input"
+  | "tool_output"
+  | "reasoning_delta"
+  | "tool_invocation"
+  | "debug_event"
+  | "debug_artifacts_ready"
+  | "complete"
+  | "done"
+  | "error"
+  | "agent_update"
+  | "genius_start"
+  | "ping";
+
+/**
+ * A single decoded SSE frame. The payload is intentionally open (`unknown` per
+ * key): the backend adds fields over time and the platform reducers read them
+ * defensively. The named payload interfaces below document the important shapes;
+ * they are NOT enforced on the raw event so new fields never break parsing.
+ */
+export interface AskAIStreamEvent {
+  // Widened with `(string & {})` so unknown/future event types still type-check
+  // while keeping editor autocomplete for the known ones.
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  type: AskAIStreamEventType | (string & {});
+  [key: string]: unknown;
+}
+
+/**
+ * Tool-invocation payload carried on `tool_invocation` events (under the
+ * `toolInvocation` key). Documents the shape the reducers dedupe by
+ * `toolCallId`. Kept here so mobile can reuse it without re-deriving it.
+ */
+export interface AskAIToolInvocationPayload {
+  toolName: string;
+  toolCallId?: string;
+  args: Record<string, unknown>;
+  result?: string;
+  status: "running" | "completed" | "error";
+  durationMs: number;
+  isError?: boolean;
+  subagentName?: string;
+  parentToolCallId?: string;
+  citations?: Array<{
+    label?: string;
+    kind: "thread" | "canvas" | "ticket" | "external";
+    channelId?: string;
+    conversationId?: string;
+    channelName?: string;
+    channelType?: string;
+    canvasId?: string;
+    ticketId?: string;
+    url?: string;
+  }>;
+  /** Background (run_in_background) subagent lifecycle. */
+  background?: boolean;
+  backgroundState?: "running" | "completed" | "error";
+  backgroundTaskId?: string;
+}
+
+// ============================================================================
+// Live re-attach events (resuming an answer that kept running while away)
+// ============================================================================
+
+/**
+ * The `type` values emitted by the `/v2/.../live` re-attach channel, used to
+ * rebuild an in-flight answer after the client reconnects (e.g. the mobile app
+ * returns from background). Distinct vocabulary from the main SSE stream.
+ */
+export type AskAILiveEventType =
+  | "snapshot"
+  | "delta"
+  | "reasoning"
+  | "invocation"
+  | "label"
+  | "done"
+  | "live-disabled";
+
+/** A single decoded live re-attach frame. Same open-payload rule as SSE. */
+export interface AskAILiveEvent {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  type: AskAILiveEventType | (string & {});
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Transport seam (per-platform: web worker+fetch+cookies vs native mTLS+Bearer)
+// ============================================================================
+
+/** Callbacks a {@link StreamTransport} invokes as an answer streams in. */
+export interface AskAIStreamHandlers {
+  /** One decoded, non-ping SSE event. */
+  onChunk: (event: AskAIStreamEvent) => void;
+  /** The stream closed successfully. */
+  onComplete: () => void;
+  /** The stream failed; `error` is a human-readable message. */
+  onError: (error: string) => void;
+}
+
+/** Parameters to open a stream. */
+export interface AskAIStreamStartParams {
+  streamId: string;
+  url: string;
+  input: AskAIRequestInput;
+}
+
+/**
+ * The platform-specific streaming transport. The dashboard implements this with
+ * a Web Worker (`fetch` + `ReadableStream` + cookies); mobile will implement it
+ * with the native mTLS stream module (Bearer auth). The shared core never calls
+ * `fetch` directly — it only speaks this interface.
+ */
+export interface StreamTransport {
+  start(params: AskAIStreamStartParams, handlers: AskAIStreamHandlers): void;
+  abort(streamId: string): void;
+}
+
+// ============================================================================
+// Persistence seam (per-platform: IndexedDB vs MMKV/SQLite)
+// ============================================================================
+
+/**
+ * Abstract persistence for in-flight/finished streams so an answer survives
+ * navigation, reload, or app backgrounding. The dashboard implements this over
+ * IndexedDB; mobile will implement it over MMKV / expo-sqlite. Records and
+ * chunks are left generic so each platform keeps its own concrete shapes.
+ */
+export interface StreamStore<TRecord = unknown, TChunk = unknown> {
+  save(record: TRecord): Promise<void> | void;
+  appendChunk(streamId: string, chunk: TChunk): Promise<void> | void;
+  updateStatus(streamId: string, status: string): Promise<void> | void;
+  get(streamId: string): Promise<TRecord | null> | TRecord | null;
+  remove(streamId: string): Promise<void> | void;
+  list(): Promise<TRecord[]> | TRecord[];
+}

--- a/packages/shared/test/askAI.test.mjs
+++ b/packages/shared/test/askAI.test.mjs
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Imports the BUILT output on purpose: this is exactly the module consumers
+// (dashboard worker today, native transport tomorrow) resolve via the
+// `@xyne/shared/askAI` subpath. Run via `pnpm --filter @xyne/shared test`.
+import { buildAskAIRequestBody } from "../dist/askAI/requestBody.js";
+import { createAskAISSEParser } from "../dist/askAI/sse.js";
+
+/**
+ * Ask AI stream core — behaviour lock.
+ *
+ * `buildAskAIRequestBody` and `createAskAISSEParser` were extracted verbatim
+ * from the dashboard Web Worker (apps/dashboard/src/services/XyneAI/
+ * xyneAIStream.worker.ts). These tests pin the exact wire contract so the
+ * extraction is provably zero-behaviour-change and so a future edit that alters
+ * the serialization or SSE framing fails here instead of silently in prod.
+ */
+
+// ---------------------------------------------------------------------------
+// buildAskAIRequestBody
+// ---------------------------------------------------------------------------
+
+test("buildAskAIRequestBody: minimal request emits required snake_case keys and defaults", () => {
+  const body = buildAskAIRequestBody({
+    query: "hello",
+    channelIds: ["c1", "c2"],
+    conversationId: "conv-1",
+    sessionId: "sess-1",
+    webSearchEnabled: true,
+  });
+
+  assert.deepEqual(body, {
+    query: "hello",
+    channel_ids: ["c1", "c2"],
+    conversation_id: "conv-1",
+    session_id: "sess-1",
+    web_search_enabled: true,
+    // always-present defaults (load-bearing — backend reads them unconditionally)
+    deep_research_enabled: false,
+    create_canvas_enabled: false,
+    instant: false,
+    research_context: null,
+  });
+});
+
+test("buildAskAIRequestBody: empty arrays are omitted, not sent as []", () => {
+  const body = buildAskAIRequestBody({
+    query: "q",
+    channelIds: [],
+    collectionIds: [],
+    fileIds: [],
+    canvasIds: [],
+    ticketIds: [],
+    callIds: [],
+    attachedContext: [],
+    messageAttachmentIds: [],
+    attachments: [],
+    conversationId: "conv",
+    sessionId: "sess",
+    webSearchEnabled: false,
+  });
+
+  // channel_ids is always present (even empty); every other array key is omitted.
+  assert.deepEqual(body.channel_ids, []);
+  for (const k of [
+    "collection_ids",
+    "file_ids",
+    "canvas_ids",
+    "ticket_ids",
+    "call_ids",
+    "attached_context",
+    "message_attachment_ids",
+    "attachments",
+  ]) {
+    assert.ok(!(k in body), `${k} should be omitted for empty array`);
+  }
+});
+
+test("buildAskAIRequestBody: full request maps every field to the correct wire key", () => {
+  const body = buildAskAIRequestBody({
+    query: "q",
+    displayQuery: "shown",
+    channelIds: ["c"],
+    collectionIds: ["col"],
+    fileIds: ["f"],
+    canvasIds: ["cv"],
+    ticketIds: ["t"],
+    callIds: ["call"],
+    attachedContext: [{ type: "ticket", id: "T-1", title: "Bug" }],
+    conversationId: "conv",
+    sessionId: "sess",
+    webSearchEnabled: true,
+    deepResearchEnabled: true,
+    createCanvasEnabled: true,
+    instant: true,
+    researchContext: { type: "product", id: "p1", name: "Prod" },
+    canvasId: "canvas-1",
+    messageAttachmentIds: ["ma1"],
+    attachments: [{ data: "BASE64", mimeType: "image/png", filename: "a.png" }],
+    parentMessageId: "pm",
+    isRegenerate: true,
+    isEditUserMessage: true,
+    editedUserMessageId: "eum",
+    parentAssistantMessageId: "pam",
+    draftMode: true,
+    version: "v2",
+    disableTools: true,
+    agentSlug: "ticket-triage",
+    model: "claude-sonnet-5",
+  });
+
+  assert.equal(body.display_query, "shown");
+  assert.deepEqual(body.collection_ids, ["col"]);
+  assert.deepEqual(body.file_ids, ["f"]);
+  assert.deepEqual(body.canvas_ids, ["cv"]);
+  assert.deepEqual(body.ticket_ids, ["t"]);
+  assert.deepEqual(body.call_ids, ["call"]);
+  assert.deepEqual(body.attached_context, [
+    { type: "ticket", id: "T-1", title: "Bug" },
+  ]);
+  assert.equal(body.deep_research_enabled, true);
+  assert.equal(body.create_canvas_enabled, true);
+  assert.equal(body.instant, true);
+  assert.deepEqual(body.research_context, {
+    type: "product",
+    id: "p1",
+    name: "Prod",
+  });
+  assert.equal(body.canvas_id, "canvas-1");
+  assert.deepEqual(body.message_attachment_ids, ["ma1"]);
+  // attachments are re-keyed camel -> snake (mimeType -> mime_type)
+  assert.deepEqual(body.attachments, [
+    { data: "BASE64", mime_type: "image/png", filename: "a.png" },
+  ]);
+  assert.equal(body.parent_message_id, "pm");
+  assert.equal(body.is_regenerate, true);
+  assert.equal(body.is_edit_user_message, true);
+  assert.equal(body.edited_user_message_id, "eum");
+  assert.equal(body.parent_assistant_message_id, "pam");
+  assert.equal(body.draft_mode, true);
+  assert.equal(body.version, "v2");
+  assert.equal(body.disable_tools, true);
+  // agentSlug stays camelCase on the wire — deliberate, matches the original worker.
+  assert.equal(body.agentSlug, "ticket-triage");
+  assert.equal(body.model, "claude-sonnet-5");
+});
+
+test("buildAskAIRequestBody: falsy booleans omit their keys (draft_mode/disable_tools only sent when true)", () => {
+  const body = buildAskAIRequestBody({
+    query: "q",
+    channelIds: ["c"],
+    conversationId: "conv",
+    sessionId: "sess",
+    webSearchEnabled: false,
+    draftMode: false,
+    disableTools: false,
+    isRegenerate: false,
+  });
+  assert.ok(!("draft_mode" in body));
+  assert.ok(!("disable_tools" in body));
+  assert.ok(!("is_regenerate" in body));
+  // but the unconditional flags are still present
+  assert.equal(body.web_search_enabled, false);
+  assert.equal(body.instant, false);
+});
+
+// ---------------------------------------------------------------------------
+// createAskAISSEParser
+// ---------------------------------------------------------------------------
+
+test("SSE parser: parses complete data lines and drops ping heartbeats", () => {
+  const parser = createAskAISSEParser();
+  const events = parser.push(
+    'data: {"type":"start","sessionId":"s1"}\n' +
+      'data: {"type":"ping"}\n' +
+      'data: {"type":"delta","content":"Hel"}\n',
+  );
+  assert.deepEqual(events, [
+    { type: "start", sessionId: "s1" },
+    { type: "delta", content: "Hel" },
+  ]);
+});
+
+test("SSE parser: buffers a frame split across two chunks", () => {
+  const parser = createAskAISSEParser();
+  const first = parser.push('data: {"type":"delta","con');
+  assert.deepEqual(first, [], "incomplete line yields nothing yet");
+  const second = parser.push('tent":"lo"}\n');
+  assert.deepEqual(second, [{ type: "delta", content: "lo" }]);
+});
+
+test("SSE parser: ignores non-data lines and non-object JSON", () => {
+  const parser = createAskAISSEParser();
+  const events = parser.push(
+    "event: message\n" + "data: 42\n" + "data: null\n" + ": comment\n",
+  );
+  assert.deepEqual(events, []);
+});
+
+test("SSE parser: malformed JSON is reported to onError and does not throw", () => {
+  const parser = createAskAISSEParser();
+  const seen = [];
+  const events = parser.push(
+    "data: {not json}\n" + 'data: {"type":"done"}\n',
+    (err, line) => {
+      seen.push(line);
+    },
+  );
+  assert.deepEqual(events, [{ type: "done" }]);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0], "data: {not json}");
+});


### PR DESCRIPTION
## Summary
Phase 0 foundation for porting the dashboard "Ask AI" streaming chat to a fully native `apps/mobile` React Native surface. This PR extracts the **pure, transport-free heart** of the Ask AI stream into a new shared subpath so web and native share **one** serializer + SSE parser and cannot drift. **Zero behaviour change** on the dashboard.

## What's new — `@xyne/shared/askAI` (`packages/shared/src/askAI`)
- **`types.ts`** — `AskAIRequestInput` (camelCase request shape, single source of truth), the SSE event union (`start`/`delta`/`content`/`tool_input`/`tool_output`/`reasoning_delta`/`tool_invocation`/`debug_event`/`debug_artifacts_ready`/`complete`/`done`/`error`/`agent_update`/`genius_start`/`ping`), the live re-attach event union, and the `StreamTransport` / `StreamStore` seams (implemented per platform: web = worker+fetch+cookies+IndexedDB; native = mTLS+Bearer+MMKV/SQLite).
- **`requestBody.ts`** — `buildAskAIRequestBody`: camelCase input → snake_case wire body. A faithful, field-for-field port of the worker's inline serialization (same empty-array omission, same `?? false`/`?? null` defaults, same deliberately-camelCase `agentSlug` on the wire).
- **`sse.ts`** — `createAskAISSEParser`: incremental SSE framing / JSON decode / `ping` heartbeat drop, buffering frames split across chunks. Pure — no `fetch`, no `TextDecoder`, no globals; the caller owns byte decoding and the read loop.

## Dashboard rewire
`apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts` now imports `buildAskAIRequestBody` + `createAskAISSEParser` from `@xyne/shared/askAI` and drops its inline copies. The worker keeps all web-specific transport (fetch, cookie credentials, read loop, abort, `postMessage`). The worker's `requestBody` type is now the shared `AskAIRequestInput` (structurally identical — removes the duplicated type).

## Validation
- `pnpm --filter @xyne/shared build` — clean
- New behaviour-lock tests `packages/shared/test/askAI.test.mjs` — **8/8 pass** (pin the exact wire body + SSE framing so the extraction is provably zero-behaviour-change)
- `apps/dashboard` `tsc --noEmit` — clean
- worker `eslint` + `prettier --check` — clean

## Notes
- No XYNE ticket key was available at authoring time — happy to rename the branch / retitle to the team's `feature/ + XYNE-NNNNN` convention if one is assigned.
- This is Phase 0 step 1 (the pure, verifiable core). Remaining Phase 0 work — the stateful event-reducer normalization, the sessions REST client behind a shared HttpClient, and relocating the error map — is staged as follow-ups because each needs runtime validation of the full authenticated Ask AI flow.
