### PR TITLE
fix: XYNE-56275 flow board ui fixes

### DIFF
--- a/apps/dashboard/src/components/Board/FlowRun/FlowNodeSidePanel.tsx
+++ b/apps/dashboard/src/components/Board/FlowRun/FlowNodeSidePanel.tsx
@@ -4,15 +4,21 @@ import { toast } from 'sonner';
 import {
   CircleCheck,
   Archive,
-  ExternalLink,
   GitBranch,
-  MessageSquare,
+  Hash,
+  PanelRight,
   PauseCircle,
   Ticket as TicketIcon,
   X,
   XCircle,
 } from 'lucide-react';
-import { ActivityType, FLOW_STAGE_NAMES, TicketStatusV2, type FlowPlanNode } from '@xyne/shared';
+import {
+  ActivityType,
+  FLOW_STAGE_NAMES,
+  TicketStatusV2,
+  type FlowPlanNode,
+  type FormFields,
+} from '@xyne/shared';
 import { Button } from '../../ui/Button';
 import Tooltip from '../../ui/Tooltip';
 import { getStatusOption } from '../BoardStageConfigScreen/BoardStageConfigScreen.types';
@@ -21,19 +27,47 @@ import { StageFormInlinePanel } from '../../Tickets/StageFormInlinePanel/StageFo
 import { isFlowStepBacklogged, normalizeUserId, type FlowRunTicket } from './flowRun.utils';
 import { queries } from '../../../zero/queries';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
-import { useActiveUsers } from '../../../hooks/useUsers';
+import { useUsersById } from '../../../hooks/useUsers';
 import { useConfirmDialog } from '../../../hooks/useConfirmDialog';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 import UserAvatar, { AvatarSize } from '../../UserAvatar/UserAvatar';
+
+/** Activity payloads this panel reads; `field` is a plain string on the wire. */
+interface FlowActivityValue {
+  field?: string;
+  newValue?: string;
+  fieldName?: string;
+  isAutomation?: boolean;
+}
+
+// The status change and the form write are logged by two independent backend
+// handlers, so a normal Submit's timestamps can land in either order — only an
+// edit past this window is a real post-completion edit.
+const FLOW_FORM_EDIT_GRACE_MS = 10_000;
 
 const FlowStepCompletionInfo: React.FC<{
   ticketId: string;
   status?: TicketStatusV2;
   backlogged?: boolean;
   highlighted?: boolean;
-}> = ({ ticketId, status, backlogged = false, highlighted = false }) => {
+  /** Scopes the "Updated by" byline to this form's own fields. */
+  gateFormId?: string;
+}> = ({ ticketId, status, backlogged = false, highlighted = false, gateFormId = '' }) => {
   const [activities] = useCachedQuery(queries.ticketActivities({ ticketId }));
-  const users = useActiveUsers();
+  const [gateFormFields] = useCachedQuery(queries.getFormFieldsByFormId({ formId: gateFormId }), {
+    enabled: !!gateFormId,
+  });
+  // Includes deactivated users — a completion by a since-removed teammate must
+  // still carry their name, not "Someone".
+  const usersById = useUsersById();
+  const resolveActor = useCallback(
+    (updatedBy: string): { id: string; name: string } => {
+      const id = normalizeUserId(updatedBy) ?? updatedBy;
+      const user = usersById.get(id);
+      return { id, name: user ? getUserDisplayName(user) : 'Someone' };
+    },
+    [usersById],
+  );
   // Stage changes share STATUS activity type, so exclude their stageName rows.
   const activity = useMemo(
     () =>
@@ -53,10 +87,31 @@ const FlowStepCompletionInfo: React.FC<{
       }) ?? null,
     [activities, backlogged, status],
   );
+  // A gate-form value edited by a person after the step completed. The flow
+  // already moved on with the original answers; only the byline changes.
+  const lastEditActivity = useMemo(() => {
+    if (backlogged || status !== TicketStatusV2.COMPLETED || !activity || !gateFormId) return null;
+    const gateFieldNames = new Set(
+      ((gateFormFields ?? []) as Array<FormFields & { globalField?: { fieldName?: string } }>)
+        .map(row => row.globalField?.fieldName ?? row.fieldName)
+        .filter((fieldName): fieldName is string => !!fieldName),
+    );
+    if (gateFieldNames.size === 0) return null;
+    // Activities come back newest-first, so the first match is the latest edit.
+    return (
+      (activities ?? []).find(row => {
+        if (row.activityType !== ActivityType.METADATA) return false;
+        if (row.timestamp <= activity.timestamp + FLOW_FORM_EDIT_GRACE_MS) return false;
+        const value = row.value as FlowActivityValue | null;
+        // 'customField' covers ordinary fields, 'stageFormFile' file fields.
+        if (value?.field !== 'customField' && value?.field !== 'stageFormFile') return false;
+        // Automation writes are not a person revising the answer.
+        if (value.isAutomation) return false;
+        return !!value.fieldName && gateFieldNames.has(value.fieldName);
+      }) ?? null
+    );
+  }, [activities, activity, backlogged, status, gateFormId, gateFormFields]);
   if (!activity) return null;
-  const userId = normalizeUserId(activity.updatedBy) ?? activity.updatedBy;
-  const user = users?.find(candidate => candidate.id === userId) ?? null;
-  const name = user ? getUserDisplayName(user) : 'Someone';
   const verb = backlogged
     ? 'Moved to backlog'
     : status === TicketStatusV2.COMPLETED
@@ -72,21 +127,40 @@ const FlowStepCompletionInfo: React.FC<{
     : status === TicketStatusV2.COMPLETED
       ? 'border-emerald-500/15 bg-emerald-500/[0.05]'
       : 'border-red-500/15 bg-red-500/[0.05]';
-  const when = new Date(activity.timestamp).toLocaleDateString(undefined, {
-    dateStyle: 'medium',
-  });
+  const row = lastEditActivity
+    ? {
+        ...resolveActor(lastEditActivity.updatedBy),
+        verb: 'Updated',
+        verbColor: 'text-amber-600',
+        surfaceColor: 'border-amber-500/15 bg-amber-500/[0.05]',
+        when: new Date(lastEditActivity.timestamp).toLocaleString(undefined, {
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        }),
+        title:
+          'This form was edited after the step completed — the flow already moved on with the original answers.',
+      }
+    : {
+        ...resolveActor(activity.updatedBy),
+        verb,
+        verbColor,
+        surfaceColor,
+        when: new Date(activity.timestamp).toLocaleDateString(undefined, { dateStyle: 'medium' }),
+        title: undefined,
+      };
   return (
     <div
       className={`flex items-center gap-2 border-t ${
-        highlighted ? `${surfaceColor} px-3 py-2.5` : 'border-border/60 pt-2.5'
+        highlighted ? `${row.surfaceColor} px-3 py-2.5` : 'border-border/60 pt-2.5'
       }`}
+      {...(row.title && { title: row.title })}
     >
-      <UserAvatar userId={userId} showActiveStatus={false} size={AvatarSize.SM} />
+      <UserAvatar userId={row.id} showActiveStatus={false} size={AvatarSize.SM} />
       <p className='min-w-0 truncate text-[11px] text-muted-foreground'>
-        <span className={`font-semibold ${verbColor}`}>{verb} by</span>{' '}
-        <span className='font-medium text-foreground'>{name}</span>
+        <span className={`font-semibold ${row.verbColor}`}>{row.verb} by</span>{' '}
+        <span className='font-medium text-foreground'>{row.name}</span>
         <span className='mx-1 text-border'>·</span>
-        {when}
+        {row.when}
       </p>
     </div>
   );
@@ -102,12 +176,11 @@ export interface FlowNodeSelection {
 interface FlowNodeSidePanelProps {
   node: FlowNodeSelection;
   backlogSteps?: FlowNodeSelection[];
-  projectId: string;
-  boardId: string;
   /** True when a pause above this step (main ticket or a pass-over) locks it */
   locked: boolean;
   backlogBlockedReason?: string | undefined;
   onClose: () => void;
+  onShowDetails?: (ticket: FlowRunTicket) => void;
   onChangeStatus: (ticketId: string, statusV2: TicketStatusV2) => Promise<void>;
   onBacklog: (ticketId: string) => Promise<void>;
   onSelectBacklog?: (step: FlowNodeSelection) => void;
@@ -140,11 +213,10 @@ const ROOT_ACTIONS: Partial<Record<TicketStatusV2, Array<{ label: string; to: Ti
 export const FlowNodeSidePanel: React.FC<FlowNodeSidePanelProps> = ({
   node,
   backlogSteps = [],
-  projectId,
-  boardId,
   locked,
   backlogBlockedReason,
   onClose,
+  onShowDetails,
   onChangeStatus,
   onBacklog,
   onSelectBacklog,
@@ -240,33 +312,37 @@ export const FlowNodeSidePanel: React.FC<FlowNodeSidePanelProps> = ({
         </div>
         {ticket && (
           <div className='flex items-center gap-0.5'>
-            <Tooltip content='Open ticket' side='bottom' sideOffset={6}>
-              <button
-                type='button'
-                aria-label='Open ticket'
-                onClick={() => void navigate(`/projects/${projectId}/${boardId}/${ticket.id}`)}
-                data-track-category='flow_board'
-                data-track-name='open_node_ticket_header'
-                className='rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-              >
-                <ExternalLink size={14} />
-              </button>
-            </Tooltip>
-            {ticket.channelId && ticket.conversationId && (
-              <Tooltip content='Open chat' side='bottom' sideOffset={6}>
+            {/* The thread panel only renders its close button for a ticket
+                thread — without a conversation it would open with no way out. */}
+            {onShowDetails && ticket.conversationId && (
+              <Tooltip content='Show details' side='bottom' sideOffset={6}>
                 <button
                   type='button'
-                  aria-label='Open chat'
+                  aria-label='Show details'
+                  onClick={() => onShowDetails(ticket)}
+                  data-track-category='flow_board'
+                  data-track-name='show_node_details'
+                  className='rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                >
+                  <PanelRight size={14} />
+                </button>
+              </Tooltip>
+            )}
+            {ticket.channelId && ticket.conversationId && (
+              <Tooltip content='Go to channel' side='bottom' sideOffset={6}>
+                <button
+                  type='button'
+                  aria-label='Go to channel'
                   onClick={() =>
                     void navigate(
                       `/chat/dir/${ticket.channelId}/${ticket.conversationId}/${ticket.id}`,
                     )
                   }
                   data-track-category='flow_board'
-                  data-track-name='open_node_chat_header'
+                  data-track-name='go_to_node_channel'
                   className='rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
                 >
-                  <MessageSquare size={14} />
+                  <Hash size={14} />
                 </button>
               </Tooltip>
             )}
@@ -499,6 +575,7 @@ export const FlowNodeSidePanel: React.FC<FlowNodeSidePanelProps> = ({
                   highlighted
                   ticketId={ticket.id}
                   status={TicketStatusV2.COMPLETED}
+                  gateFormId={formId}
                 />
               </div>
             )}

--- a/apps/dashboard/src/components/Board/FlowRun/useFlowRunGraph.tsx
+++ b/apps/dashboard/src/components/Board/FlowRun/useFlowRunGraph.tsx
@@ -33,6 +33,9 @@ export interface FlowRunGraph {
   locked: Set<string>;
 }
 
+/** React Flow node id for a group's cover — consumers must not re-derive the prefix. */
+export const flowGroupCoverId = (groupId: string): string => `flow-group:${groupId}`;
+
 interface UseFlowRunGraphArgs {
   isFlowBoard: boolean;
   selectedFlowRunModel: FlowPlanModel | null;
@@ -109,7 +112,7 @@ export function useFlowRunGraph({
         )
         .map(group => group.id),
     );
-    const coverId = (groupId: string): string => `flow-group:${groupId}`;
+    const coverId = flowGroupCoverId;
     const displayId = (planId: string): string =>
       activeGroupIds.has(planId) ? coverId(planId) : planId;
     const runtimeParentIds = (parentIds: string[]): string[] =>

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -4452,6 +4452,24 @@ img.inline-emoji,
   pointer-events: none;
 }
 
+/* Flow run search: hits get an indigo ring, everything else fades back.
+   Classes are set on the React Flow node wrappers from KanbanBoardScreen. */
+.flow-run-view .react-flow__node.flow-search-hit {
+  outline: 3px solid rgb(99 102 241 / 0.65);
+  outline-offset: 3px;
+  border-radius: 12px;
+}
+
+.flow-run-view .react-flow__node.flow-search-miss {
+  opacity: 0.25;
+  filter: grayscale(0.6);
+  transition: opacity 150ms ease;
+}
+
+.flow-run-view--searching .react-flow__edge {
+  opacity: 0.35;
+}
+
 /* ----------------------------
    File viewer in-file search (Cmd+F)
    Marks are injected into highlight.js HTML as raw strings (see

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -36,6 +36,7 @@ import {
   FileText,
   Archive,
   ArrowLeft,
+  Search,
 } from 'lucide-react';
 import { CalendarView } from '../../components/Tickets/CalendarView';
 import TicketReportsScreen from '../../routes/TicketReportsScreen/TicketReportsScreen';
@@ -164,6 +165,11 @@ import {
 } from '../../components/Tickets/TicketActivity/TicketActivity';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import Tooltip from '../../components/ui/Tooltip';
+import { XyneAIStar } from '../../components/icons/xyne-ai';
+import ThreadMessages from '../../components/Chat/ThreadPannel';
+import { xyneAIActor, type ThreadInfo } from '../../machines/xyneAIMachine';
+import { useFlowRunPersistence } from './useFlowRunPersistence';
+import { flowGroupCoverId } from '../../components/Board/FlowRun/useFlowRunGraph';
 import Avatar from '../../components/ui/Avatar/Avatar';
 import {
   getPriorityIcon,
@@ -460,6 +466,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const [flowLegendOpen, setFlowLegendOpen] = useState(false);
   const [flowActivityOpen, setFlowActivityOpen] = useState(false);
   const [flowRunExporting, setFlowRunExporting] = useState<'excel' | 'pdf' | null>(null);
+  const [flowRunSearchQuery, setFlowRunSearchQuery] = useState('');
+  const [flowThreadTicket, setFlowThreadTicket] = useState<FlowRunTicket | null>(null);
   const [flowGroupBacklogPendingId, setFlowGroupBacklogPendingId] = useState<string | null>(null);
   const collapseInitRunRef = useRef<string | null>(null);
   // When mounted from the project route (AppRoot.tsx → :projectId / :projectId/:boardId),
@@ -634,6 +642,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   // Flow view: the open run lives in the URL so browser back returns to the
   // main-tickets grid and run links are shareable.
   const selectedGraphRootTicketId = layoutView === 'flow' ? searchParams.get('run') : null;
+  // The sessionStorage mirror is owned by useFlowRunPersistence; this setter
+  // only owns the URL.
   const setSelectedGraphRootTicketId = useCallback(
     (ticketId: string | null, opts?: { replace?: boolean }) => {
       setSearchParams(
@@ -1091,6 +1101,10 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     return flowPlan ? new FlowPlanModel(deserializeFlowPlan(flowPlan)) : null;
   }, [isFlowBoard, selectedBoardDetail]);
 
+  // On a fresh mount the filters machine is still 'idle', so isFlowBoard/
+  // filteredSingleBoardId read false/null for one effect pass — demoting the
+  // layout on that snapshot would tear down the flow view on every remount.
+  const filtersInitialized = state.matches('initialized');
   useEffect(() => {
     if (isFlowBoard && layoutView !== 'flow') {
       setSearchParams(
@@ -1104,6 +1118,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     } else if (
       !isFlowBoard &&
       layoutView === 'flow' &&
+      filtersInitialized &&
       // no single board selected (e.g. All Boards) — flow view is meaningless;
       // with a single board, wait for its detail to load before deciding
       (!filteredSingleBoardId || selectedBoardDetail)
@@ -1118,8 +1133,14 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         { replace: true },
       );
     }
-  }, [isFlowBoard, selectedBoardDetail, filteredSingleBoardId, layoutView, setSearchParams]);
-
+  }, [
+    filtersInitialized,
+    isFlowBoard,
+    selectedBoardDetail,
+    filteredSingleBoardId,
+    layoutView,
+    setSearchParams,
+  ]);
   const handleFlowStatusChange = useCallback(
     async (ticketId: string, statusV2: TicketStatusV2): Promise<void> => {
       const result = zero.mutate(
@@ -2099,11 +2120,23 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     return roots.map(ticket => toTicketNode(ticket, 0, new Set([ticket.id])));
   }, [graphSubTicketMappings, graphTickets]);
   useEffect(() => {
-    if (!selectedGraphRootTicketId || ticketsDetails.type !== 'complete') return;
-    if (!ticketGraphNodes.some(root => root.key === selectedGraphRootTicketId)) {
+    if (!selectedGraphRootTicketId || ticketsDetails.type !== 'complete' || !filtersInitialized) {
+      return;
+    }
+    // An empty node list is usually a reloading artifact (queries restart on
+    // remount), not proof the run is gone — clear only when other roots have
+    // loaded, or when the settled unfiltered project list lacks the run
+    // entirely (deleted run / bad shared link on an empty board).
+    if (
+      !ticketGraphNodes.some(root => root.key === selectedGraphRootTicketId) &&
+      (ticketGraphNodes.length > 0 ||
+        !(allProjectTickets ?? []).some(ticket => ticket.id === selectedGraphRootTicketId))
+    ) {
       setSelectedGraphRootTicketId(null, { replace: true });
     }
   }, [
+    allProjectTickets,
+    filtersInitialized,
     selectedGraphRootTicketId,
     setSelectedGraphRootTicketId,
     ticketGraphNodes,
@@ -2111,7 +2144,18 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   ]);
   useEffect(() => {
     if (!selectedGraphRootTicketId) setFlowSelection(null);
+    // Search and the thread panel are scoped to one run
+    setFlowRunSearchQuery('');
+    setFlowThreadTicket(null);
   }, [selectedGraphRootTicketId]);
+  // The two floating panels are mutually exclusive
+  useEffect(() => {
+    if (flowSelection) setFlowThreadTicket(null);
+  }, [flowSelection]);
+  const handleShowFlowTicketDetails = useCallback((ticket: FlowRunTicket): void => {
+    setFlowSelection(null);
+    setFlowThreadTicket(ticket);
+  }, []);
   const selectedFlowRunRootTicket = useMemo(() => {
     if (!selectedGraphRootTicketId) return null;
     return (
@@ -2209,13 +2253,62 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       ),
     [flowRunGraph],
   );
-  // Entering a run collapses every group by default
-  useEffect(() => {
-    if (!isFlowBoard || !selectedGraphRootTicketId || !selectedFlowRunModel) return;
-    if (collapseInitRunRef.current === selectedGraphRootTicketId) return;
-    collapseInitRunRef.current = selectedGraphRootTicketId;
-    setCollapsedFlowGroups(new Set(selectedFlowRunModel.groups.map(group => group.id)));
-  }, [isFlowBoard, selectedGraphRootTicketId, selectedFlowRunModel]);
+  // null = search inactive, so nothing is dimmed
+  const flowRunSearchMatches = useMemo((): Set<string> | null => {
+    const query = flowRunSearchQuery.trim().toLowerCase();
+    if (!query || !selectedGraphRootTicketId || !selectedFlowRunModel) return null;
+    const matchesQuery = (...values: Array<string | null | undefined>): boolean =>
+      values.some(value => value?.toLowerCase().includes(query));
+    const matches = new Set<string>();
+    if (
+      selectedFlowRunRootTicket &&
+      matchesQuery(selectedFlowRunRootTicket.xyneId, selectedFlowRunRootTicket.title)
+    ) {
+      matches.add(FLOW_VIRTUAL_ROOT_ID);
+    }
+    const runTickets = mapPlanToRunTickets(
+      graphTickets as unknown as FlowRunTicket[],
+      selectedGraphRootTicketId,
+    );
+    for (const planNode of selectedFlowRunModel.nodes) {
+      const ticket = runTickets.get(planNode.id);
+      // `||`: an empty ticket title must fall back to the plan node's title,
+      // which is what the card renders.
+      if (matchesQuery(ticket?.xyneId, ticket?.title || planNode.title)) {
+        matches.add(planNode.id);
+      }
+    }
+    return matches;
+  }, [
+    flowRunSearchQuery,
+    graphTickets,
+    selectedFlowRunModel,
+    selectedFlowRunRootTicket,
+    selectedGraphRootTicketId,
+  ]);
+  // A cover counts as a hit when any descendant step matches, so a match stays
+  // visible while its group is collapsed.
+  const flowRunSearchHitNodeIds = useMemo((): Set<string> | null => {
+    if (!flowRunSearchMatches) return null;
+    const hits = new Set(flowRunSearchMatches);
+    for (const group of selectedFlowRunModel?.groups ?? []) {
+      if (
+        selectedFlowRunModel
+          ?.descendantMembersOf(group.id)
+          .some(member => flowRunSearchMatches.has(member.id))
+      ) {
+        hits.add(flowGroupCoverId(group.id));
+      }
+    }
+    return hits;
+  }, [flowRunSearchMatches, selectedFlowRunModel]);
+  const searchedFlowRunNodes = useMemo(() => {
+    if (!flowRunSearchHitNodeIds) return flowRunGraph.nodes;
+    return flowRunGraph.nodes.map(graphNode => ({
+      ...graphNode,
+      className: flowRunSearchHitNodeIds.has(graphNode.id) ? 'flow-search-hit' : 'flow-search-miss',
+    }));
+  }, [flowRunGraph.nodes, flowRunSearchHitNodeIds]);
   const flowRunSummaries = useMemo<Map<string, FlowRunSummary>>(
     () =>
       isFlowBoard && flowModel
@@ -2242,15 +2335,46 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     });
   }, [allProjectTickets, flowModel, graphTickets, isFlowBoard, userNamesById]);
   const flowRunExportTitle = `${selectedBoardDetail?.name ?? 'Flow board'} — Ticket Tracker`;
+  const selectedRunExportRows = useMemo(() => {
+    if (!isFlowBoard || !flowModel || !selectedFlowRunRootTicket) return [];
+    return buildFlowRunExportRows({
+      currentModel: flowModel,
+      visibleTickets: [selectedFlowRunRootTicket],
+      allTickets: (allProjectTickets ?? graphTickets) as unknown as FlowRunTicket[],
+      userNamesById,
+    });
+  }, [
+    allProjectTickets,
+    flowModel,
+    graphTickets,
+    isFlowBoard,
+    selectedFlowRunRootTicket,
+    userNamesById,
+  ]);
+  const selectedRunExportTitle = selectedFlowRunRootTicket
+    ? `${selectedFlowRunRootTicket.xyneId} ${selectedFlowRunRootTicket.title} — Ticket Tracker`
+    : flowRunExportTitle;
+  const flowAskAIThreadInfo = useMemo((): ThreadInfo | null => {
+    if (!selectedFlowRunRootTicket?.conversationId) return null;
+    return {
+      conversationId: selectedFlowRunRootTicket.conversationId,
+      ...(selectedFlowRunRootTicket.channelId && {
+        channelId: selectedFlowRunRootTicket.channelId,
+      }),
+      previewText: `${selectedFlowRunRootTicket.xyneId} ${selectedFlowRunRootTicket.title}`,
+    };
+  }, [selectedFlowRunRootTicket]);
   const handleFlowRunExport = useCallback(
     async (format: 'excel' | 'pdf'): Promise<void> => {
-      if (flowRunExportRows.length === 0 || flowRunExporting) return;
+      const rows = selectedGraphRootTicketId ? selectedRunExportRows : flowRunExportRows;
+      const title = selectedGraphRootTicketId ? selectedRunExportTitle : flowRunExportTitle;
+      if (rows.length === 0 || flowRunExporting) return;
       setFlowRunExporting(format);
       try {
         if (format === 'excel') {
-          await downloadFlowRunsExcel(flowRunExportTitle, flowRunExportRows);
+          await downloadFlowRunsExcel(title, rows);
         } else {
-          await downloadFlowRunsPdf(flowRunExportTitle, flowRunExportRows);
+          await downloadFlowRunsPdf(title, rows);
         }
         toast.success(`${format === 'excel' ? 'Excel' : 'PDF'} downloaded`);
       } catch {
@@ -2259,7 +2383,39 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         setFlowRunExporting(null);
       }
     },
-    [flowRunExportRows, flowRunExportTitle, flowRunExporting],
+    [
+      flowRunExportRows,
+      flowRunExportTitle,
+      flowRunExporting,
+      selectedGraphRootTicketId,
+      selectedRunExportRows,
+      selectedRunExportTitle,
+    ],
+  );
+  // Shared by both flow headers — only the triggers differ per screen
+  const flowExportDropdownMenu = (
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
+        align='end'
+        sideOffset={6}
+        className='z-50 min-w-40 rounded-lg border border-border bg-background p-1 shadow-xl'
+      >
+        <DropdownMenu.Item
+          onSelect={() => void handleFlowRunExport('excel')}
+          className='flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-xs text-foreground outline-none data-[highlighted]:bg-muted'
+        >
+          <FileSpreadsheet className='h-4 w-4 text-emerald-600' />
+          Excel (.xlsx)
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onSelect={() => void handleFlowRunExport('pdf')}
+          className='flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-xs text-foreground outline-none data-[highlighted]:bg-muted'
+        >
+          <FileText className='h-4 w-4 text-red-500' />
+          PDF (.pdf)
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
   );
   // Auto-advance: jump to the next waiting step ONLY on a transition we
   // witnessed while the selection stayed put — a viewed step settling
@@ -2268,6 +2424,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   // it, or an already-finished step, leaves it exactly where the user put it.
   const flowRunInstanceRef = useRef<ReactFlowInstance | null>(null);
   const pendingFlowFocusRef = useRef<string | null>(null);
+  // The node the viewport is parked on, so a canvas resize restores that
+  // framing instead of a whole-graph fit. Cleared when the user pans/zooms.
+  const focusedFlowNodeRef = useRef<string | null>(null);
   // Animate the viewport only after React Flow has measured the destination.
   // A pending request stays armed when its containing group is still collapsed;
   // the graph-nodes effect below retries after expansion renders the member.
@@ -2279,6 +2438,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         if (!instance || pendingFlowFocusRef.current !== nodeId || !instance.getNode(nodeId))
           return;
         pendingFlowFocusRef.current = null;
+        focusedFlowNodeRef.current = nodeId;
         void instance.fitView({
           nodes: [{ id: nodeId }],
           maxZoom: 1,
@@ -2292,6 +2452,72 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     const pendingNodeId = pendingFlowFocusRef.current;
     if (pendingNodeId) focusFlowNode(pendingNodeId);
   }, [flowRunGraph.nodes, focusFlowNode]);
+  // React Flow only fits its content on mount — re-fit whenever the canvas
+  // changes width (side panels docking, divider drags, window resizes). A
+  // callback ref, not an effect: the canvas mounts only once board detail AND
+  // tickets resolve, and an effect can't reliably know when that happens.
+  const flowCanvasObserverRef = useRef<ResizeObserver | null>(null);
+  const flowResizeFrameRef = useRef(0);
+  const attachFlowCanvas = useCallback((node: HTMLDivElement | null): void => {
+    flowCanvasObserverRef.current?.disconnect();
+    flowCanvasObserverRef.current = null;
+    window.cancelAnimationFrame(flowResizeFrameRef.current);
+    if (!node) return;
+    let lastWidth = node.clientWidth;
+    const observer = new ResizeObserver(entries => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      if (Math.abs(width - lastWidth) < 1) return;
+      lastWidth = width;
+      window.cancelAnimationFrame(flowResizeFrameRef.current);
+      // Two frames: fitView reads dimensions stored by React Flow's own
+      // ResizeObserver, which haven't updated yet in ours.
+      flowResizeFrameRef.current = window.requestAnimationFrame(() => {
+        flowResizeFrameRef.current = window.requestAnimationFrame(() => {
+          const instance = flowRunInstanceRef.current;
+          if (!instance) return;
+          // Defer to a queued node focus only while it is resolvable — a
+          // request for a node that never rendered stays pending forever and
+          // must not block the fit.
+          const pendingNodeId = pendingFlowFocusRef.current;
+          if (pendingNodeId && instance.getNode(pendingNodeId)) return;
+          const focusedNodeId = focusedFlowNodeRef.current;
+          if (focusedNodeId && instance.getNode(focusedNodeId)) {
+            void instance.fitView({
+              nodes: [{ id: focusedNodeId }],
+              maxZoom: 1,
+              padding: 0.4,
+            });
+            return;
+          }
+          void instance.fitView({ padding: 0.25, maxZoom: 1 });
+        });
+      });
+    });
+    observer.observe(node);
+    flowCanvasObserverRef.current = observer;
+  }, []);
+  // Pan once per distinct first hit, so status updates or node clicks while a
+  // query is active don't yank the viewport.
+  const lastSearchFocusRef = useRef<string | null>(null);
+  // Keyed by run + node: plan node ids repeat across runs of the same plan.
+  const firstSearchHit = useMemo((): { key: string; nodeId: string } | null => {
+    if (!flowRunSearchHitNodeIds || flowRunSearchHitNodeIds.size === 0) return null;
+    const firstHit =
+      flowRunGraph.nodes.find(
+        node => node.type === 'flowTicketNode' && flowRunSearchHitNodeIds.has(node.id),
+      ) ?? flowRunGraph.nodes.find(node => flowRunSearchHitNodeIds.has(node.id));
+    if (!firstHit) return null;
+    return { key: `${selectedGraphRootTicketId ?? ''}:${firstHit.id}`, nodeId: firstHit.id };
+  }, [flowRunGraph.nodes, flowRunSearchHitNodeIds, selectedGraphRootTicketId]);
+  useEffect(() => {
+    if (!firstSearchHit) {
+      lastSearchFocusRef.current = null;
+      return;
+    }
+    if (lastSearchFocusRef.current === firstSearchHit.key) return;
+    lastSearchFocusRef.current = firstSearchHit.key;
+    focusFlowNode(firstSearchHit.nodeId);
+  }, [firstSearchHit, focusFlowNode]);
   const handleSelectFlowBacklog = useCallback(
     (step: FlowNodeSelection): void => {
       if (!step.planNode) return;
@@ -2456,13 +2682,49 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   // Re-arm on run close so reopening a run re-focuses its waiting step (the
   // ref otherwise remembers we already auto-selected and skips it).
   useEffect(() => {
-    if (!selectedGraphRootTicketId) autoSelectedRunRef.current = null;
+    if (!selectedGraphRootTicketId) {
+      autoSelectedRunRef.current = null;
+      collapseInitRunRef.current = null;
+    }
     // Run changed/closed — stale watching must not leak into the next run.
+    focusedFlowNodeRef.current = null;
     witnessedRootStatusRef.current = null;
     pendingRootAdvanceRef.current = false;
     witnessedActiveNodeRef.current = null;
     lastFlowSelectionKeyRef.current = null;
   }, [selectedGraphRootTicketId]);
+  // Must stay above the entry-default effects: a restore claims their
+  // once-per-run refs before they fire.
+  const { forgetRunUiState } = useFlowRunPersistence({
+    isFlowBoard,
+    layoutView,
+    filteredSingleBoardId,
+    selectedGraphRootTicketId,
+    setSelectedGraphRootTicketId,
+    selectedFlowRunModel,
+    flowTickets: graphTickets as unknown as FlowRunTicket[],
+    flowSelection,
+    setFlowSelection,
+    collapsedFlowGroups,
+    setCollapsedFlowGroups,
+    flowRunSearchQuery,
+    setFlowRunSearchQuery,
+    flowThreadTicket,
+    setFlowThreadTicket,
+    focusFlowNode,
+    collapseInitRunRef,
+    autoSelectedRunRef,
+  });
+  // Entering a run collapses every group by default. Must stay AFTER the
+  // persistence hook and gated on the same root ticket, so a restore claims
+  // collapseInitRunRef before this can.
+  useEffect(() => {
+    if (!isFlowBoard || !selectedGraphRootTicketId || !selectedFlowRunModel) return;
+    if (!selectedFlowRunRootTicket) return;
+    if (collapseInitRunRef.current === selectedGraphRootTicketId) return;
+    collapseInitRunRef.current = selectedGraphRootTicketId;
+    setCollapsedFlowGroups(new Set(selectedFlowRunModel.groups.map(group => group.id)));
+  }, [isFlowBoard, selectedGraphRootTicketId, selectedFlowRunModel, selectedFlowRunRootTicket]);
   useEffect(() => {
     if (!isFlowBoard || !selectedGraphRootTicketId || !selectedFlowRunModel) return;
     if (autoSelectedRunRef.current === selectedGraphRootTicketId) return;
@@ -3814,69 +4076,144 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       ) : layoutView === 'flow' ? (
         <div className='flex-1 overflow-hidden bg-background p-4'>
           <div className='relative flex h-full flex-col overflow-hidden rounded-lg border border-border bg-muted'>
-            <div className='flex items-center justify-between border-b border-border bg-background px-4 py-3'>
-              <div className='flex items-center gap-2'>
-                <GitBranch className='h-4 w-4 text-muted-foreground' />
-                <h2 className='text-sm font-semibold text-foreground'>
-                  {selectedGraphRootTicketId
-                    ? `${selectedFlowRunRootTicket?.title ?? 'Ticket'} run`
-                    : 'Main Tickets'}
-                </h2>
-                <span className='rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'>
-                  {selectedGraphRootTicketId
-                    ? `${flowRunGraph.nodes.length} nodes`
-                    : `${ticketGraphNodes.length} tickets`}
-                </span>
-                {selectedGraphRootTicketId && (
-                  <span className='rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'>
+            {selectedGraphRootTicketId ? (
+              <div className='flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-border bg-background px-4 py-2.5'>
+                <button
+                  type='button'
+                  onClick={() => {
+                    setSelectedGraphRootTicketId(null);
+                    setFlowSelection(null);
+                  }}
+                  aria-label='Back to main tickets'
+                  title='Back to main tickets'
+                  data-track-category='flow_board'
+                  data-track-name='back_to_main_tickets'
+                  className='flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-muted text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+                >
+                  <ArrowLeft className='h-[18px] w-[18px]' />
+                </button>
+                <div className='h-6 w-px shrink-0 bg-border' aria-hidden='true' />
+                <div className='flex min-w-0 flex-auto items-center gap-2.5'>
+                  <h2 className='truncate text-[15px] font-bold tracking-[-0.01em] text-foreground'>
+                    {selectedFlowRunRootTicket?.title ?? 'Ticket'} run
+                  </h2>
+                  <span className='shrink-0 whitespace-nowrap rounded-full bg-muted px-2.5 py-1 text-xs font-semibold text-muted-foreground'>
+                    {flowRunGraph.nodes.length} nodes
+                  </span>
+                  <span className='shrink-0 whitespace-nowrap rounded-full bg-muted px-2.5 py-1 text-xs font-semibold text-muted-foreground'>
                     {flowRunGraph.edges.length} edges
                   </span>
-                )}
+                </div>
+                <label className='relative block w-[clamp(150px,16vw,240px)] min-w-[150px] shrink'>
+                  <Search className='pointer-events-none absolute left-3 top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-muted-foreground/70' />
+                  <input
+                    type='search'
+                    value={flowRunSearchQuery}
+                    onChange={event => setFlowRunSearchQuery(event.target.value)}
+                    // Browsers clear a search input on Escape without always
+                    // firing change, leaving the graph dimmed by a stale query.
+                    onKeyDown={event => {
+                      if (event.key === 'Escape') setFlowRunSearchQuery('');
+                    }}
+                    placeholder='Search ticket ID or title'
+                    data-track-category='flow_board'
+                    data-track-name='search_flow_run'
+                    className='h-9 w-full rounded-[10px] border border-border bg-muted/40 pl-[34px] pr-3 text-sm text-foreground placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
+                  />
+                </label>
+                <Tooltip content='Ask AI' side='bottom'>
+                  <button
+                    type='button'
+                    onClick={() => {
+                      // Same path as the channel header: the app-level docked
+                      // Ask AI sidebar, seeded with this run's root ticket.
+                      xyneAIActor.send({
+                        type: 'OPEN',
+                        ...(selectedFlowRunRootTicket?.channelId && {
+                          channelId: selectedFlowRunRootTicket.channelId,
+                        }),
+                        // Passed even when null — the machine keeps the
+                        // previous thread context when the key is absent.
+                        threadInfo: flowAskAIThreadInfo,
+                        startFreshChat: true,
+                      });
+                    }}
+                    aria-label='Ask AI'
+                    data-track-category='flow_board'
+                    data-track-name='ask_ai_flow_run'
+                    className='flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                  >
+                    <XyneAIStar />
+                  </button>
+                </Tooltip>
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger asChild>
+                    <button
+                      type='button'
+                      disabled={flowRunExporting !== null || selectedRunExportRows.length === 0}
+                      aria-label='Download'
+                      title={flowRunExporting ? 'Downloading…' : 'Download'}
+                      data-track-category='flow_board'
+                      data-track-name='download_flow_run'
+                      className='flex h-9 shrink-0 items-center gap-1 rounded-[10px] border border-border bg-background pl-2.5 pr-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+                    >
+                      <Download className='h-[17px] w-[17px]' />
+                      <ChevronDownIcon className='h-3.5 w-3.5' />
+                    </button>
+                  </DropdownMenu.Trigger>
+                  {flowExportDropdownMenu}
+                </DropdownMenu.Root>
               </div>
-              <div className='flex items-center gap-2'>
-                {!selectedGraphRootTicketId && flowRunExportRows.length > 0 && (
-                  <DropdownMenu.Root>
-                    <DropdownMenu.Trigger asChild>
-                      <button
-                        type='button'
-                        disabled={flowRunExporting !== null}
-                        data-track-category='flow_board'
-                        data-track-name='download_flow_runs'
-                        className='flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
-                      >
-                        <Download className='h-3.5 w-3.5' />
-                        {flowRunExporting ? 'Downloading…' : 'Download'}
-                        <ChevronDownIcon className='h-3 w-3' />
-                      </button>
-                    </DropdownMenu.Trigger>
-                    <DropdownMenu.Portal>
-                      <DropdownMenu.Content
-                        align='end'
-                        sideOffset={6}
-                        className='z-50 min-w-40 rounded-lg border border-border bg-background p-1 shadow-xl'
-                      >
-                        <DropdownMenu.Item
-                          onSelect={() => void handleFlowRunExport('excel')}
-                          className='flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-xs text-foreground outline-none data-[highlighted]:bg-muted'
+            ) : (
+              <div className='flex items-center justify-between border-b border-border bg-background px-4 py-3'>
+                <div className='flex items-center gap-2'>
+                  <GitBranch className='h-4 w-4 text-muted-foreground' />
+                  <h2 className='text-sm font-semibold text-foreground'>Main Tickets</h2>
+                  <span className='rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'>
+                    {ticketGraphNodes.length} tickets
+                  </span>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <Tooltip content='Ask AI' side='bottom'>
+                    <button
+                      type='button'
+                      onClick={() => {
+                        // threadInfo cleared explicitly — the machine keeps the
+                        // previous value when the key is absent.
+                        xyneAIActor.send({
+                          type: 'OPEN',
+                          ...(channelId && { channelId }),
+                          threadInfo: null,
+                          startFreshChat: true,
+                        });
+                      }}
+                      aria-label='Ask AI'
+                      data-track-category='flow_board'
+                      data-track-name='ask_ai_flow_board'
+                      className='flex items-center justify-center rounded-md border border-border bg-background p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                    >
+                      <XyneAIStar />
+                    </button>
+                  </Tooltip>
+                  {flowRunExportRows.length > 0 && (
+                    <DropdownMenu.Root>
+                      <DropdownMenu.Trigger asChild>
+                        <button
+                          type='button'
+                          disabled={flowRunExporting !== null}
+                          data-track-category='flow_board'
+                          data-track-name='download_flow_runs'
+                          className='flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
                         >
-                          <FileSpreadsheet className='h-4 w-4 text-emerald-600' />
-                          Excel (.xlsx)
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item
-                          onSelect={() => void handleFlowRunExport('pdf')}
-                          className='flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-xs text-foreground outline-none data-[highlighted]:bg-muted'
-                        >
-                          <FileText className='h-4 w-4 text-red-500' />
-                          PDF (.pdf)
-                        </DropdownMenu.Item>
-                      </DropdownMenu.Content>
-                    </DropdownMenu.Portal>
-                  </DropdownMenu.Root>
-                )}
-                {!selectedGraphRootTicketId &&
-                  isFlowBoard &&
-                  filteredSingleBoardId &&
-                  flowProjectId && (
+                          <Download className='h-3.5 w-3.5' />
+                          {flowRunExporting ? 'Downloading…' : 'Download'}
+                          <ChevronDownIcon className='h-3 w-3' />
+                        </button>
+                      </DropdownMenu.Trigger>
+                      {flowExportDropdownMenu}
+                    </DropdownMenu.Root>
+                  )}
+                  {isFlowBoard && filteredSingleBoardId && flowProjectId && (
                     <button
                       type='button'
                       onClick={() =>
@@ -3892,24 +4229,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                       Edit board
                     </button>
                   )}
-                {selectedGraphRootTicketId && (
-                  <Button
-                    type='button'
-                    size='sm'
-                    data-track-category='flow_board'
-                    data-track-name='back_to_main_tickets'
-                    onClick={() => {
-                      setSelectedGraphRootTicketId(null);
-                      setFlowSelection(null);
-                    }}
-                    className='h-8 bg-foreground px-3 text-xs text-background shadow-sm hover:bg-foreground/85 hover:text-background'
-                  >
-                    <ArrowLeft className='size-3.5' />
-                    Back to main tickets
-                  </Button>
-                )}
+                </div>
               </div>
-            </div>
+            )}
             {ticketsDetails.type !== 'complete' ? (
               <div className='rounded-lg border border-border bg-muted p-4 text-sm text-muted-foreground'>
                 Loading tickets...
@@ -3941,7 +4263,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                           type='button'
                           data-track-category='flow_board'
                           data-track-name='open_flow_run'
-                          onClick={() => setSelectedGraphRootTicketId(root.key)}
+                          onClick={() => {
+                            // An explicit open from the grid starts fresh
+                            forgetRunUiState(root.key);
+                            setSelectedGraphRootTicketId(root.key);
+                          }}
                           className='flex h-full flex-col gap-2 rounded-xl border border-border bg-background p-4 text-left shadow-sm transition-all hover:-translate-y-px hover:border-[#6276be]/50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50'
                         >
                           <div className='flex items-center justify-between gap-2'>
@@ -4148,9 +4474,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                 )}
               </div>
             ) : isFlowBoard && flowModel ? (
-              <div className='relative min-h-0 flex-1'>
+              <div ref={attachFlowCanvas} className='relative min-h-0 flex-1'>
                 <ReactFlow
-                  nodes={flowRunGraph.nodes}
+                  nodes={searchedFlowRunNodes}
                   edges={flowRunGraph.edges}
                   nodeTypes={FLOW_NODE_TYPES}
                   fitView
@@ -4161,6 +4487,10 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                   nodesConnectable={false}
                   elementsSelectable
                   onPaneClick={() => setFlowSelection(null)}
+                  // Only user-driven moves carry an event — programmatic fits don't.
+                  onMoveStart={(event, _viewport) => {
+                    if (event) focusedFlowNodeRef.current = null;
+                  }}
                   onInit={instance => {
                     flowRunInstanceRef.current = instance;
                     // Entry focus may have been requested before the canvas
@@ -4169,7 +4499,10 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                     if (pending) focusFlowNode(pending);
                   }}
                   proOptions={{ hideAttribution: true }}
-                  className='flow-run-view'
+                  className={cn(
+                    'flow-run-view',
+                    flowRunSearchMatches && 'flow-run-view--searching',
+                  )}
                 >
                   <Background
                     variant={BackgroundVariant.Dots}
@@ -4388,13 +4721,28 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                     </div>
                   </Panel>
                 </ReactFlow>
+                {flowThreadTicket && (
+                  <div className='absolute bottom-4 right-4 top-4 z-20 flex w-[480px] max-w-[calc(100%-2rem)] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl'>
+                    <ThreadMessages
+                      ticketId={flowThreadTicket.id}
+                      {...(flowThreadTicket.channelId && {
+                        channelId: flowThreadTicket.channelId,
+                      })}
+                      {...(flowThreadTicket.conversationId && {
+                        conversationId: flowThreadTicket.conversationId,
+                      })}
+                      // A restore must not pull keyboard focus into the composer.
+                      skipInputAutoFocus
+                      onClose={() => setFlowThreadTicket(null)}
+                    />
+                  </div>
+                )}
                 {flowSelection && filteredSingleBoardId && flowProjectId && (
                   <div className='absolute bottom-4 right-4 top-4 z-10 flex items-start'>
                     <FlowNodeSidePanel
                       node={flowSelection}
                       backlogSteps={selectedFlowRunBacklogs}
-                      projectId={flowProjectId}
-                      boardId={filteredSingleBoardId}
+                      onShowDetails={handleShowFlowTicketDetails}
                       locked={
                         flowSelection.planNode
                           ? flowRunGraph.locked.has(flowSelection.planNode.id)

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useFlowRunPersistence.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useFlowRunPersistence.ts
@@ -1,0 +1,307 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from 'react';
+import type { FlowPlanModel } from '@xyne/shared';
+import type { FlowNodeSelection } from '../../components/Board/FlowRun/FlowNodeSidePanel';
+import {
+  isRunRoot,
+  mapPlanToRunTickets,
+  type FlowRunTicket,
+} from '../../components/Board/FlowRun/flowRun.utils';
+import { VIRTUAL_ROOT_ID as FLOW_VIRTUAL_ROOT_ID } from '../../components/Board/FlowPlanEditor/FlowPlanEditor.utils';
+
+interface StoredFlowUiState {
+  selection?: string | null;
+  collapsed?: unknown;
+  search?: unknown;
+  threadTicketId?: string | null;
+}
+
+const openRunKey = (boardId: string): string => `flow-open-run-${boardId}`;
+const runUiKey = (runId: string): string => `flow-ui-${runId}`;
+
+// sessionStorage throws in private-mode/quota situations; degrade to
+// "nothing remembered".
+const readStorage = (key: string): string | null => {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const writeStorage = (key: string, value: string): void => {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    /* storage unavailable */
+  }
+};
+
+const removeStorage = (key: string): void => {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    /* storage unavailable */
+  }
+};
+
+interface UseFlowRunPersistenceArgs {
+  isFlowBoard: boolean;
+  layoutView: string;
+  filteredSingleBoardId: string | null | undefined;
+  selectedGraphRootTicketId: string | null;
+  setSelectedGraphRootTicketId: (ticketId: string | null, opts?: { replace?: boolean }) => void;
+  selectedFlowRunModel: FlowPlanModel | null;
+  flowTickets: readonly FlowRunTicket[];
+  flowSelection: FlowNodeSelection | null;
+  setFlowSelection: Dispatch<SetStateAction<FlowNodeSelection | null>>;
+  collapsedFlowGroups: Set<string>;
+  setCollapsedFlowGroups: Dispatch<SetStateAction<Set<string>>>;
+  flowRunSearchQuery: string;
+  setFlowRunSearchQuery: Dispatch<SetStateAction<string>>;
+  flowThreadTicket: FlowRunTicket | null;
+  setFlowThreadTicket: Dispatch<SetStateAction<FlowRunTicket | null>>;
+  /** Re-frames the restored selection — a remount resets the viewport to
+   *  React Flow's whole-graph mount fit. */
+  focusFlowNode: (nodeId: string) => void;
+  /** Entry defaults' once-per-run guards — a restore claims them so "collapse
+   *  all" / "auto-open the waiting step" only apply on a run's first open. */
+  collapseInitRunRef: RefObject<string | null>;
+  autoSelectedRunRef: RefObject<string | null>;
+}
+
+interface UseFlowRunPersistenceResult {
+  /** Drops a run's remembered UI state and re-arms the entry defaults. Only
+   *  for EXPLICIT open paths (the main-tickets run card) — never restores. */
+  forgetRunUiState: (runId: string) => void;
+}
+
+/**
+ * Persists the flow screen's state to sessionStorage and restores it on
+ * revisits (URL params die with the URL) and remounts.
+ *
+ * Two stores, deliberately separate:
+ * - `flow-open-run-<boardId>` — WHICH run is open. The URL (`?run=`) stays the
+ *   primary carrier so browser back/forward work natively; this only covers
+ *   fresh visits, and is removed only on a deliberate exit (back button, or
+ *   browser Back seen as an in-place `?run=` removal). Automatic cleanups
+ *   leave it alone — the reopen path verifies the run still exists.
+ * - `flow-ui-<runId>` — HOW the run was left. sessionStorage, not
+ *   history.state: the latter is clobbered by every setSearchParams write and
+ *   empty on fresh visits.
+ */
+export function useFlowRunPersistence({
+  isFlowBoard,
+  layoutView,
+  filteredSingleBoardId,
+  selectedGraphRootTicketId,
+  setSelectedGraphRootTicketId,
+  selectedFlowRunModel,
+  flowTickets,
+  flowSelection,
+  setFlowSelection,
+  collapsedFlowGroups,
+  setCollapsedFlowGroups,
+  flowRunSearchQuery,
+  setFlowRunSearchQuery,
+  flowThreadTicket,
+  setFlowThreadTicket,
+  focusFlowNode,
+  collapseInitRunRef,
+  autoSelectedRunRef,
+}: UseFlowRunPersistenceArgs): UseFlowRunPersistenceResult {
+  // Ref, not state: must take effect within the flush it is set in.
+  const uiRunRestoredRef = useRef<string | null>(null);
+  // State, not ref: the save effect must only arm on a LATER render, or it
+  // would serialise pre-restore values over the stored ones in the same flush.
+  const [uiSaveArmedRunId, setUiSaveArmedRunId] = useState<string | null>(null);
+  // The board the open run belongs to — a close must remove that board's key
+  // even if the board filter changed in the same commit.
+  const openRunBoardIdRef = useRef<string | null>(null);
+  const previousRunIdRef = useRef<string | null>(null);
+  const runSeenThisMountRef = useRef(false);
+
+  const runExists = useCallback(
+    (runId: string): boolean =>
+      flowTickets.some(ticket => ticket.id === runId && isRunRoot(ticket)),
+    [flowTickets],
+  );
+
+  useEffect(() => {
+    uiRunRestoredRef.current = null;
+    setUiSaveArmedRunId(null);
+  }, [selectedGraphRootTicketId]);
+
+  // Only remember runs confirmed to belong to THIS board: switching the board
+  // filter while `?run=` survives in the URL would otherwise file the old
+  // board's run under the new board.
+  useEffect(() => {
+    if (!isFlowBoard || !filteredSingleBoardId || !selectedGraphRootTicketId) return;
+    if (!runExists(selectedGraphRootTicketId)) return;
+    openRunBoardIdRef.current = filteredSingleBoardId;
+    writeStorage(openRunKey(filteredSingleBoardId), selectedGraphRootTicketId);
+  }, [isFlowBoard, filteredSingleBoardId, selectedGraphRootTicketId, runExists]);
+
+  // A deliberate exit (back button / browser Back) drops `?run=` in place;
+  // only it forgets the memory. An automatic cleanup (run deleted or filtered
+  // out) is told apart by the run being gone from a LOADED ticket set — the
+  // cleanup effects never fire while tickets are loading, so an in-place drop
+  // with no tickets yet can only be the user leaving.
+  useEffect(() => {
+    const previousRunId = previousRunIdRef.current;
+    previousRunIdRef.current = selectedGraphRootTicketId;
+    if (selectedGraphRootTicketId) {
+      runSeenThisMountRef.current = true;
+      return;
+    }
+    if (!runSeenThisMountRef.current || !previousRunId) return;
+    if (flowTickets.length > 0 && !runExists(previousRunId)) return;
+    const boardId = openRunBoardIdRef.current ?? filteredSingleBoardId ?? null;
+    if (!boardId) return;
+    removeStorage(openRunKey(boardId));
+    openRunBoardIdRef.current = null;
+  }, [selectedGraphRootTicketId, flowTickets, runExists, filteredSingleBoardId]);
+
+  // Reopen the remembered run on a fresh visit ONLY — once any run was shown
+  // this mount, landing on the grid is a deliberate place to be (board-filter
+  // round-trips, browser Back), not something to auto-reenter from. Verified
+  // against the loaded tickets first — reopening a deleted or filtered-out run
+  // would strand the user on an empty canvas.
+  useEffect(() => {
+    if (!isFlowBoard || layoutView !== 'flow' || !filteredSingleBoardId) return;
+    if (selectedGraphRootTicketId || runSeenThisMountRef.current) return;
+    const stored = readStorage(openRunKey(filteredSingleBoardId));
+    if (!stored || !runExists(stored)) return;
+    setSelectedGraphRootTicketId(stored, { replace: true });
+  }, [
+    isFlowBoard,
+    layoutView,
+    filteredSingleBoardId,
+    selectedGraphRootTicketId,
+    setSelectedGraphRootTicketId,
+    runExists,
+  ]);
+
+  // Restore the run's UI state, claiming the entry defaults' once-per-run refs
+  // first — both default effects are declared after this hook's call site and
+  // wait for the same root ticket, so this always wins.
+  useEffect(() => {
+    if (!isFlowBoard || !selectedGraphRootTicketId || !selectedFlowRunModel) return;
+    if (uiRunRestoredRef.current === selectedGraphRootTicketId) return;
+    const rootTicket = flowTickets.find(ticket => ticket.id === selectedGraphRootTicketId) ?? null;
+    // Tickets not loaded yet — don't consume the once-per-run slot.
+    if (!rootTicket) return;
+    uiRunRestoredRef.current = selectedGraphRootTicketId;
+    // Armed in both paths — with nothing stored, the entry defaults become the
+    // state the next render persists.
+    setUiSaveArmedRunId(selectedGraphRootTicketId);
+
+    const raw = readStorage(runUiKey(selectedGraphRootTicketId));
+    let stored: StoredFlowUiState | null = null;
+    try {
+      stored = raw ? (JSON.parse(raw) as StoredFlowUiState) : null;
+    } catch {
+      stored = null;
+    }
+    if (!stored) return; // first open this session — entry defaults proceed
+    collapseInitRunRef.current = selectedGraphRootTicketId;
+    autoSelectedRunRef.current = selectedGraphRootTicketId;
+    const restoredCollapsed = new Set(
+      Array.isArray(stored.collapsed)
+        ? stored.collapsed.filter((id): id is string => typeof id === 'string')
+        : [],
+    );
+    setCollapsedFlowGroups(restoredCollapsed);
+    setFlowRunSearchQuery(typeof stored.search === 'string' ? stored.search : '');
+    const storedNode =
+      stored.selection && stored.selection !== FLOW_VIRTUAL_ROOT_ID
+        ? (selectedFlowRunModel.getNode(stored.selection) ?? null)
+        : null;
+    // A node hidden under the restored collapsed set never renders — selecting
+    // it would freeze the panel snapshot and leave the focus request armed
+    // until a later expand yanks the viewport.
+    const planNode =
+      storedNode?.groupId &&
+      selectedFlowRunModel
+        .groupAndAncestorIds(storedNode.groupId)
+        .some(groupId => restoredCollapsed.has(groupId))
+        ? null
+        : storedNode;
+    if (planNode) {
+      const ticketsByPlanNodeId = mapPlanToRunTickets(flowTickets, selectedGraphRootTicketId);
+      // skipped/skipReason refresh from the live graph via the sync effect
+      setFlowSelection({
+        planNode,
+        ticket: ticketsByPlanNodeId.get(planNode.id) ?? null,
+        skipped: false,
+      });
+      focusFlowNode(planNode.id);
+    } else if (stored.selection === FLOW_VIRTUAL_ROOT_ID) {
+      setFlowSelection({ planNode: null, ticket: rootTicket, skipped: false });
+      focusFlowNode(FLOW_VIRTUAL_ROOT_ID);
+    } else {
+      setFlowSelection(null);
+    }
+    // A selection wins over a stored thread panel — the two are exclusive, and
+    // restoring both would stack them for a render. conversationId mirrors the
+    // open path's gate: without one the panel has no close button.
+    const threadTicket =
+      !planNode && !stored.selection && stored.threadTicketId
+        ? (flowTickets.find(ticket => ticket.id === stored.threadTicketId) ?? null)
+        : null;
+    setFlowThreadTicket(threadTicket?.conversationId ? threadTicket : null);
+  }, [
+    isFlowBoard,
+    selectedGraphRootTicketId,
+    selectedFlowRunModel,
+    flowTickets,
+    setCollapsedFlowGroups,
+    setFlowRunSearchQuery,
+    setFlowThreadTicket,
+    setFlowSelection,
+    focusFlowNode,
+    collapseInitRunRef,
+    autoSelectedRunRef,
+  ]);
+
+  // Persist the run's UI state on every change once restoration has settled.
+  useEffect(() => {
+    const runId = selectedGraphRootTicketId;
+    if (!runId || uiSaveArmedRunId !== runId) return;
+    const uiState: StoredFlowUiState = {
+      selection: flowSelection ? (flowSelection.planNode?.id ?? FLOW_VIRTUAL_ROOT_ID) : null,
+      collapsed: [...collapsedFlowGroups],
+      search: flowRunSearchQuery,
+      threadTicketId: flowThreadTicket?.id ?? null,
+    };
+    writeStorage(runUiKey(runId), JSON.stringify(uiState));
+  }, [
+    collapsedFlowGroups,
+    flowRunSearchQuery,
+    flowSelection,
+    flowThreadTicket,
+    selectedGraphRootTicketId,
+    uiSaveArmedRunId,
+  ]);
+
+  const forgetRunUiState = useCallback(
+    (runId: string): void => {
+      removeStorage(runUiKey(runId));
+      // Clearing storage alone would leave the in-memory guards claimed, so a
+      // same-mount re-open would keep the previous visit's groups.
+      if (collapseInitRunRef.current === runId) collapseInitRunRef.current = null;
+      if (autoSelectedRunRef.current === runId) autoSelectedRunRef.current = null;
+      if (uiRunRestoredRef.current === runId) uiRunRestoredRef.current = null;
+    },
+    [collapseInitRunRef, autoSelectedRunRef],
+  );
+
+  return { forgetRunUiState };
+}


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
