### PR TITLE
fix: XYNE-56311 links in cmdK

### DIFF
--- a/apps/backend/src/utils/urlUtils.ts
+++ b/apps/backend/src/utils/urlUtils.ts
@@ -1,5 +1,6 @@
 // backend/src/utils/urlUtils.ts
 import { config } from '@/config/env';
+import { NodeType, parse, type HTMLElement, type Node } from 'node-html-parser';
 
 /**
  * URL detection utilities
@@ -33,6 +34,154 @@ const EXTRA_MULTI_PART_TLDS = ["co\\.uk", "co\\.in", "com\\.au", "com\\.br", "co
 // Build the final TLD group for regex. Escape any dots already present.
 const ALL_TLDS = [...TOP_TLDS.map(t => t.replace(/\./g, "\\.")), ...EXTRA_MULTI_PART_TLDS];
 const TLD_GROUP = ALL_TLDS.join("|");
+
+export function canonicalizeMessageLink(candidate: string): string | null {
+  const trimmed = candidate.trim();
+  if (!trimmed) return null;
+
+  let absolute = trimmed;
+  try {
+    const direct = new URL(trimmed);
+    if (direct.protocol !== 'http:' && direct.protocol !== 'https:') return null;
+  } catch {
+    if (trimmed.startsWith('//')) {
+      absolute = `http:${trimmed}`;
+    } else {
+      return null;
+    }
+  }
+
+  try {
+    const parsed = new URL(absolute);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    if (!parsed.hostname) return null;
+
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+const RENDERED_AUTO_LINK_REGEX = /https?:\/\/[^\s<|]+[^<>|.,:;"')\]\s]/gi;
+const AUTO_LINK_EXCLUDED_TAGS = new Set(['a', 'code', 'pre', 'script', 'style']);
+
+function collectMessageLinks(node: Node, links: Set<string>): void {
+  if (node.nodeType === NodeType.TEXT_NODE) {
+    for (const match of node.text.matchAll(RENDERED_AUTO_LINK_REGEX)) {
+      const canonical = canonicalizeMessageLink(match[0]);
+      if (canonical) links.add(canonical);
+    }
+    return;
+  }
+
+  if (node.nodeType !== NodeType.ELEMENT_NODE) return;
+
+  const element = node as HTMLElement;
+  // node-html-parser represents the document root as an element without a tag name.
+  const tagName = (element.rawTagName || '').toLowerCase();
+  if (tagName === 'a') {
+    const href = element.getAttribute('href');
+    if (!href) return;
+    const canonical = canonicalizeMessageLink(href);
+    if (canonical) links.add(canonical);
+    return;
+  }
+
+  if (AUTO_LINK_EXCLUDED_TAGS.has(tagName)) return;
+  for (const child of element.childNodes) collectMessageLinks(child, links);
+}
+
+export function extractMessageLinks(content: string): string[] {
+  if (typeof content !== 'string' || !content) return [];
+
+  const links = new Set<string>();
+
+  try {
+    const root = parse(content);
+    collectMessageLinks(root, links);
+  } catch {
+    // Malformed imported HTML should not block message ingestion.
+  }
+
+  return [...links];
+}
+
+const FLOW_TEXT_LINK_REGEX =
+  /<(https?:[^|>]+)\|[^>]+>|<(https?:[^>\s]+)>|(https?:\/\/[^\s<>|]+[^\s<>|.,:;"')\]])/g;
+
+export function extractFlowTextLinks(text: string): string[] {
+  if (!text) return [];
+
+  const links = new Set<string>();
+  for (const match of text.matchAll(FLOW_TEXT_LINK_REGEX)) {
+    const candidate = match[1] ?? match[2] ?? match[3];
+    if (!candidate) continue;
+    const canonical = canonicalizeMessageLink(candidate);
+    if (canonical) links.add(canonical);
+  }
+
+  return [...links];
+}
+
+const FLOW_LINK_PROPS = ['href', 'url', 'detailsUrl'] as const;
+
+function collectFlowLinks(components: unknown[], links: Set<string>): void {
+  for (const comp of components) {
+    if (!comp || typeof comp !== 'object') continue;
+    const c = comp as Record<string, unknown>;
+
+    if (c['props'] && typeof c['props'] === 'object') {
+      const props = c['props'] as Record<string, unknown>;
+
+      for (const key of FLOW_LINK_PROPS) {
+        const value = props[key];
+        if (typeof value !== 'string' || !value.trim()) continue;
+        const canonical = canonicalizeMessageLink(value);
+        if (canonical) links.add(canonical);
+      }
+
+      const text = props['content'];
+      if (typeof text === 'string' && text) {
+        for (const link of extractFlowTextLinks(text)) links.add(link);
+      }
+    }
+
+    if (Array.isArray(c['children'])) {
+      collectFlowLinks(c['children'] as unknown[], links);
+    }
+  }
+}
+
+function extractFlowJsonLinks(content: string): string[] {
+  const attrMatch = content.match(/data-flow-json="([^"]+)"/);
+  if (!attrMatch?.[1]) return [];
+
+  try {
+    const json = attrMatch[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&#10;/g, '\n')
+      .replace(/&#13;/g, '\r');
+    const flow = JSON.parse(json) as { components?: unknown[] };
+
+    const links = new Set<string>();
+    if (Array.isArray(flow.components)) collectFlowLinks(flow.components, links);
+    return [...links];
+  } catch {
+    return [];
+  }
+}
+
+export function extractLinksFromContent(content: string): string[] {
+  if (typeof content !== 'string' || !content) return [];
+
+  try {
+    return [
+      ...new Set([...extractFlowJsonLinks(content), ...extractMessageLinks(content)]),
+    ];
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Remove HTML tags and replace them with spaces (so adjacent words don't glue together).

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -215,6 +215,8 @@ export interface VespaChatContainerDocument extends VespaDocument {
 export interface VespaChatMessageDocument extends Omit<VespaDocument, 'orgId' | 'workspaceId'> {
   text: string;
   chunks: string[];
+  links?: string[];
+  hasLinks: boolean;
   userId: string;
   username: string;
   userEmail: string;

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -32,6 +32,7 @@ import { FileProcessor } from '@/services/fileProcessor';
 import { transformUserToVespa } from '@/services/vespaTransformers';
 import { extractPlainTextFromHtml } from '@/utils/contentUtils';
 import { getFlowJsonContentForNotification } from '@/zero/side-effects/tables/messages-handler';
+import { extractLinksFromContent } from '@/utils/urlUtils';
 import vespaClient from '@/vespa/client';
 import { messageSignalService } from '@/services/personalization';
 import { logger } from '@/utils/logger';
@@ -450,6 +451,8 @@ export const mapMessage = async (
     getFlowJsonContentForNotification(args.content || '') ||
     extractPlainTextFromHtml(args.content || '') || '';
 
+  const messageLinks = extractLinksFromContent(args.content || '');
+
   const threadInfo = await mapAndUpdatePreviousMessagesMentions(args.messageId, args.conversationId);
 
   // Message acts, denormalized onto the doc so search can filter on them. Stored as a
@@ -505,6 +508,8 @@ export const mapMessage = async (
     docType: VespaDocType.MESSAGE,
     text: messageContent,
     chunks: chunkPlainText(messageContent),
+    links: messageLinks,
+    hasLinks: messageLinks.length > 0,
     username: sender?.name || '',
     userEmail: sender?.email || '',
     image: "",

--- a/vespa-core/vespa/common/schemas/chat_message.sd
+++ b/vespa-core/vespa/common/schemas/chat_message.sd
@@ -280,7 +280,6 @@ field text_fuzzy type string {
     summary channelMentions {}
     summary attachmentIds {}
     summary links {}
-    summary hasLinks {}
     summary channelName {}
     summary isPrivate {}
     summary channelId {}

--- a/vespa-core/vespa/common/schemas/chat_message.sd
+++ b/vespa-core/vespa/common/schemas/chat_message.sd
@@ -15,6 +15,18 @@ schema chat_message {
       index: enable-bm25
     }
 
+    field links type array<string> {
+      indexing: index | summary
+      match: text
+      stemming: none
+      index: enable-bm25
+    }
+
+    field hasLinks type bool {
+      indexing: attribute | summary
+      attribute: fast-search
+    }
+
     # Per-chunk body used for chunk-level embeddings, mirroring mail.sd.
     # `text` (above) is retained as the single display/summary/lexical field;
     # `chunks` holds the same body split into <=2000-char segments so long
@@ -267,6 +279,8 @@ field text_fuzzy type string {
     summary mentions {}
     summary channelMentions {}
     summary attachmentIds {}
+    summary links {}
+    summary hasLinks {}
     summary channelName {}
     summary isPrivate {}
     summary channelId {}
@@ -292,6 +306,8 @@ field text_fuzzy type string {
     summary messageType {}
     summary threadSenders {}
     summary attachmentIds {}
+    summary links {}
+    summary hasLinks {}
     # imported from channelRef
     summary channelId {}
     summary channelName {}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
