### PR TITLE
feat: extend apps user /info API to look up by email within workspace

### DIFF
--- a/apps/backend/src/apps/controllers/userController.ts
+++ b/apps/backend/src/apps/controllers/userController.ts
@@ -1,28 +1,66 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import { logger } from '@/utils/logger';
-import { getUserData } from '../core/userUtils';
+import { getUserData, getUserDataByEmail } from '../core/userUtils';
 
-const GetUserQuerySchema = z.object({
-  userId: z.string().min(1, 'User ID is required').trim(),
-});
+// Look up a user by EITHER userId OR email (exactly one is required).
+// - userId: resolves a user globally by primary key (existing behaviour).
+// - email: resolves a user by email. Because email is only unique per workspace,
+//   the lookup is scoped to the caller's authenticated workspace (see handler).
+//   An optional workspaceId may be supplied but, if present, must match the
+//   caller's own workspace — cross-workspace lookups are rejected.
+const GetUserQuerySchema = z
+  .object({
+    userId: z.string().trim().min(1).optional(),
+    email: z.string().trim().toLowerCase().email().optional(),
+    workspaceId: z.string().trim().min(1).optional(),
+  })
+  .refine((data) => Boolean(data.userId) !== Boolean(data.email), {
+    message: 'Provide exactly one of userId or email',
+  });
 
 export class UserController {
   getUserInfo = async (req: Request, res: Response): Promise<void> => {
     try {
       const queryResult = GetUserQuerySchema.safeParse(req.query);
-      
+
       if (!queryResult.success) {
-        res.status(400).json({ 
+        res.status(400).json({
           error: 'Validation error',
           code: 'VALIDATION_ERROR',
         });
         return;
       }
 
-      const { userId } = queryResult.data;
+      const { userId, email, workspaceId } = queryResult.data;
 
-      const userData = await getUserData(userId);
+      let userData;
+
+      if (userId) {
+        userData = await getUserData(userId);
+      } else {
+        // Email lookups are scoped to the caller's authenticated workspace so an
+        // app installed in one workspace cannot read another workspace's users.
+        const callerWorkspaceId = req.user?.workspaceId;
+        if (!callerWorkspaceId) {
+          res.status(401).json({
+            error: 'Unauthorized',
+            code: 'UNAUTHORIZED',
+          });
+          return;
+        }
+
+        // If a workspaceId is supplied, it must be the caller's own workspace.
+        if (workspaceId && workspaceId !== callerWorkspaceId) {
+          res.status(403).json({
+            error: 'Cannot access users outside your workspace',
+            code: 'FORBIDDEN',
+          });
+          return;
+        }
+
+        userData = await getUserDataByEmail(email!, callerWorkspaceId);
+      }
 
       res.status(200).json(userData);
     } catch (error) {

--- a/apps/backend/src/apps/core/userUtils.ts
+++ b/apps/backend/src/apps/core/userUtils.ts
@@ -1,35 +1,73 @@
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
 import { UserResponse } from '../types';
+import { User } from '@/types/database';
+
+/**
+ * Map a User row to the public UserResponse shape returned by the apps user API.
+ */
+function toUserResponse(user: User): UserResponse {
+  return {
+    userId: user.id,
+    name: user.name,
+    email: user.email,
+    picture: user.picture,
+    userType: user.userType,
+    status: user.status,
+    joined: user.createdAt,
+    statusEmoji: user.statusEmoji ?? null,
+    statusContent: user.statusContent ?? null,
+    statusExpiryAt: user.statusExpiryAt ?? null,
+  };
+}
 
 /**
  * Get user data by user ID
- * 
+ *
  * @param userId - User ID to fetch data for (required)
  * @returns User data with name, email, picture, userType, status, and joined date
  */
 export async function getUserData(userId: string): Promise<UserResponse> {
   try {
     const user = await repositories.users.findById(userId);
-    
+
     if (!user) {
       throw new Error('User not found');
     }
 
-    return {
-      userId: user.id,
-      name: user.name,
-      email: user.email,
-      picture: user.picture,
-      userType: user.userType,
-      status: user.status,
-      joined: user.createdAt,
-      statusEmoji: user.statusEmoji ?? null,
-      statusContent: user.statusContent ?? null,
-      statusExpiryAt: user.statusExpiryAt ?? null,
-    };
+    return toUserResponse(user);
   } catch (error) {
     logger.error('[USER-UTILS] Error fetching user data:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get user data by email, scoped to a single workspace.
+ *
+ * Email is only unique per workspace (@@unique([email, workspaceId])), so a
+ * workspaceId is required to resolve a user unambiguously. The caller must pass
+ * the workspace it is authorized for — never a client-supplied arbitrary
+ * workspace — to preserve tenant isolation. The lookup is case-insensitive.
+ *
+ * @param email - Email address to look up (required)
+ * @param workspaceId - Workspace to scope the lookup to (required)
+ * @returns User data with name, email, picture, userType, status, and joined date
+ */
+export async function getUserDataByEmail(
+  email: string,
+  workspaceId: string,
+): Promise<UserResponse> {
+  try {
+    const user = await repositories.users.findByEmailCaseInsensitive(email, workspaceId);
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    return toUserResponse(user);
+  } catch (error) {
+    logger.error('[USER-UTILS] Error fetching user data by email:', error);
     throw error;
   }
 }


### PR DESCRIPTION
## 1. Problem Description
The apps user info endpoint `GET /api/apps/user/info` only supported lookup by `userId`. Apps that only know a user's email (not their internal id) had no way to resolve that user. Requested: extend the same API to also fetch user info by email + workspace.

## 2. How the issue was identified
Feature request from the team — the existing endpoint (`userController.getUserInfo` → `getUserData(userId)`) accepted only `userId`.

## 3. Solution implemented in the PR
- `GET /api/apps/user/info` now accepts **either** `userId` **or** `email` (exactly one is required; Zod `.refine` enforces the XOR).
- New `getUserDataByEmail(email, workspaceId)` helper in `apps/backend/src/apps/core/userUtils.ts` (reuses the existing `usersRepository.findByEmailCaseInsensitive`; the User model has `@@unique([email, workspaceId])`).
- **Tenant isolation:** email is only unique per workspace, so the email lookup is scoped to the caller's **authenticated** workspace (`req.user.workspaceId`, populated by `authenticateApp`). An optional `workspaceId` query param may be passed but, if present, must equal the caller's own workspace — otherwise the request is rejected with `403 FORBIDDEN`. The caller can never read another workspace's users.
- No schema/DB change; no new repository method (existing `findByEmailCaseInsensitive` reused). Route guards unchanged (`authenticateApp` + `requirePermission('users:read')`).
- Backward compatible: existing `?userId=` callers are unaffected.

### Usage
- By id (unchanged): `GET /api/apps/user/info?userId=<id>`
- By email (new): `GET /api/apps/user/info?email=<email>` — resolved within the caller's workspace.
- Optional explicit workspace: `GET /api/apps/user/info?email=<email>&workspaceId=<callerWorkspaceId>` (must match caller's workspace).

### Note for reviewers
The pre-existing `userId` path resolves users **globally** by primary key with no workspace check — that behaviour is unchanged here. The new email path is deliberately workspace-scoped to avoid a cross-tenant PII leak. If a genuine cross-workspace lookup is ever required for a specific privileged app, that should be a separate, explicitly-authorized capability rather than a body/query-supplied `workspaceId`.

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
N/A — no schema change.

## 6. Data fix Details (if any)
N/A

## 7. Environment variable Changes (if any)
N/A

## 8. Testing
- `tsc --noEmit` on `apps/backend` passes clean.
- Manual: `?userId=` returns the same response as before; `?email=` resolves a user in the caller's workspace; unknown email → 404 NOT_FOUND; supplying a foreign `workspaceId` → 403 FORBIDDEN; supplying both or neither of userId/email → 400 VALIDATION_ERROR.

## 9. Services to which this change is to be deployed
backend

## 10. Main PR link (if raised against a release branch)
N/A — raised against `main`.