### PR TITLE
fix: flow json ui fallback

### DIFF
--- a/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
@@ -266,8 +266,17 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
     if (!isVisible(component)) return null;
     const Component = NodeRegistry.get(component.type);
     if (!Component) {
+      // A component type added after this build was shipped — an older tab or
+      // desktop window mid-rollout, or any client after a release is rolled
+      // back. Render the children so the message degrades to its text content
+      // instead of silently vanishing; the wrapper's own presentation is the
+      // only thing lost.
       console.warn(`[FlowRenderer] Unknown component type: ${component.type}`);
-      return null;
+      return (
+        <React.Fragment key={component.id}>
+          {component.children?.map(renderComponent)}
+        </React.Fragment>
+      );
     }
     return (
       <Component key={component.id} node={component}>

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -648,41 +648,80 @@ export type AgentDraftProps = Extract<AgentProps, { variant: 'draft' }>;
 export type AgentDraftPhase = AgentDraftProps['phase'];
 export type AgentProfileProps = Extract<AgentProps, { variant: 'profile' }>;
 
+// ============================================================================
+// UNKNOWN COMPONENT (forward compatibility)
+// ============================================================================
+
+const knownComponentUnion = z.discriminatedUnion('type', [
+  textComponentSchema,
+  headingComponentSchema,
+  inputComponentSchema,
+  textareaComponentSchema,
+  dropdownComponentSchema,
+  selectComponentSchema,
+  multiselectComponentSchema,
+  dateComponentSchema,
+  buttonComponentSchema,
+  dividerComponentSchema,
+  imageComponentSchema,
+  linkComponentSchema,
+  tableComponentSchema,
+  planComponentSchema,
+  prComponentSchema,
+  prApprovalComponentSchema,
+  callScheduleComponentSchema,
+  agentComponentSchema,
+  // Container types — inline here so they can reference flowComponentSchema
+  baseComponentSchema.extend({
+    type: z.literal('row'),
+    children: z.array(z.lazy(() => flowComponentSchema)).optional(),
+  }),
+  baseComponentSchema.extend({
+    type: z.literal('column'),
+    children: z.array(z.lazy(() => flowComponentSchema)).optional(),
+  }),
+  baseComponentSchema.extend({
+    type: z.literal('card'),
+    children: z.array(z.lazy(() => flowComponentSchema)).optional(),
+  }),
+]);
+
+/** Derived from the union itself, so it can never drift as types are added. */
+const KNOWN_COMPONENT_TYPES: ReadonlySet<string> = new Set(
+  knownComponentUnion.options.map(option => option.shape.type.value),
+);
+
+/**
+ * Accepts a component type this build doesn't recognise, keeping its props and
+ * children intact.
+ *
+ * Flow messages are persisted, so a client can be asked to render a component
+ * type added after it was built — an older tab or desktop window mid-rollout,
+ * or any client after a release carrying a new type is rolled back. Without
+ * this branch one unknown `type` fails the whole `flowDefinitionSchema` and
+ * FlowRenderer replaces the entire message with "Invalid flow definition", so a
+ * single new component type breaks every message containing it, permanently,
+ * for everyone not yet updated.
+ *
+ * Validating unknown types loosely lets FlowRenderer fall back to rendering
+ * their children, degrading the message to its text content instead of an
+ * error. Types this build *does* know are excluded here, so a malformed known
+ * component still fails validation rather than slipping through this branch.
+ */
+export const unknownComponentSchema = baseComponentSchema.extend({
+  type: z
+    .string()
+    .min(1)
+    .refine(type => !KNOWN_COMPONENT_TYPES.has(type), {
+      message: 'Known component types must satisfy their own schema',
+    }),
+  children: z.array(z.lazy(() => flowComponentSchema)).optional(),
+});
+
 // Recursive container schemas need z.lazy
 export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
-  z.discriminatedUnion('type', [
-    textComponentSchema,
-    headingComponentSchema,
-    inputComponentSchema,
-    textareaComponentSchema,
-    dropdownComponentSchema,
-    selectComponentSchema,
-    multiselectComponentSchema,
-    dateComponentSchema,
-    buttonComponentSchema,
-    dividerComponentSchema,
-    imageComponentSchema,
-    linkComponentSchema,
-    tableComponentSchema,
-    planComponentSchema,
-    prComponentSchema,
-    prApprovalComponentSchema,
-    callScheduleComponentSchema,
-    agentComponentSchema,
-    // Container types — inline here so they can reference flowComponentSchema
-    baseComponentSchema.extend({
-      type: z.literal('row'),
-      children: z.array(z.lazy(() => flowComponentSchema)).optional(),
-    }),
-    baseComponentSchema.extend({
-      type: z.literal('column'),
-      children: z.array(z.lazy(() => flowComponentSchema)).optional(),
-    }),
-    baseComponentSchema.extend({
-      type: z.literal('card'),
-      children: z.array(z.lazy(() => flowComponentSchema)).optional(),
-    }),
-  ]),
+  // Unknown last: only reached when no known type matched.
+  z.union([knownComponentUnion, unknownComponentSchema]),
 );
 
 // ============================================================================


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
