### PR TITLE
fix: optimize Y-Sweet routes and database cleanup logic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,9 @@ __tests__
 
 # Build outputs
 dist
+**/dist
 build
+**/*.tsbuildinfo
 .next
 out
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -574,8 +574,10 @@ export class App {
     // Memory routes (auth handled internally by dualAuthenticate middleware)
     this.app.use('/api/memory', memoryRoutes);
 
-    // Y-Sweet collaboration routes (auth required)
-    this.app.use('/api/ysweet', authMiddleware.authenticate, ysweetRoutes);
+    // Y-Sweet collaboration routes. Auth already runs for every /api request via
+    // the /api attachment mounts above; applying it here again cost two more DB
+    // round-trips per canvas open.
+    this.app.use('/api/ysweet', ysweetRoutes);
     // AI routes (auth required)
     this.app.use('/api/ai', authMiddleware.authenticate, aiRoutes);
 

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -695,7 +695,10 @@ export class CallController {
       logger.error(`[${callIdForLog}] call_initiation_failed`, { stage, error: error, stack: error instanceof Error ? error.stack : undefined });
       if (headlessNotesCanvasId) {
         try {
-          await db.canvas.deleteMany({ where: { id: headlessNotesCanvasId } });
+          await db.$transaction([
+            db.canvasParticipant.deleteMany({ where: { canvasId: headlessNotesCanvasId } }),
+            db.canvas.deleteMany({ where: { id: headlessNotesCanvasId } }),
+          ]);
         } catch (cleanupError) {
           logger.error(`[${callIdForLog}] headless_notes_canvas_cleanup_failed`, {
             canvasId: headlessNotesCanvasId,

--- a/apps/backend/src/controllers/ysweetController.ts
+++ b/apps/backend/src/controllers/ysweetController.ts
@@ -1,25 +1,11 @@
 import { Request, Response } from 'express';
-import type { ClientToken } from '@y-sweet/sdk';
 import { canvasAuthService } from '@/services/canvasAuthService';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 import { getTrustedOriginalHost } from '@/utils/publicUrls';
+import { ysweetGetOrCreateDocAndToken } from '@/utils/ysweetUtils';
 
 const TOKEN_VALID_SECONDS = 3600;
-
-async function ysweetPost<T>(docId: string, path: string, body: unknown): Promise<T> {
-  const base = config.ysweet.url.replace(/\/$/, '');
-  const url = `${base}/${path}?docId=${encodeURIComponent(docId)}&z=${Date.now().toString(36)}`;
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    throw new Error(`y-sweet ${path} responded ${res.status} ${res.statusText}`);
-  }
-  return (await res.json()) as T;
-}
 
 const isDevelopment = config.env === 'development' || config.isTestEnv;
 
@@ -208,15 +194,10 @@ export class YSweetController {
         ysweetUrl: config.ysweet.url,
       });
 
-      await ysweetPost(canonicalDocId, 'doc/new', { docId: canonicalDocId });
-      const clientToken = await ysweetPost<ClientToken>(
-        canonicalDocId,
-        `doc/${encodeURIComponent(canonicalDocId)}/auth`,
-        {
-          authorization,
-          validForSeconds: TOKEN_VALID_SECONDS,
-        }
-      );
+      const clientToken = await ysweetGetOrCreateDocAndToken(canonicalDocId, {
+        authorization,
+        validForSeconds: TOKEN_VALID_SECONDS,
+      });
 
       logger.debug('[YSweet] Received client token from y-sweet', {
         baseUrl: clientToken.baseUrl,

--- a/apps/backend/src/routes/ysweet.ts
+++ b/apps/backend/src/routes/ysweet.ts
@@ -1,10 +1,9 @@
 import { Router } from 'express';
 import { YSweetController } from '../controllers/ysweetController';
-import { authMiddleware } from '../middleware/auth';
 
 const router = Router();
 const ysweetController = new YSweetController();
 
-router.post('/auth', authMiddleware.authenticate, ysweetController.getClientToken.bind(ysweetController));
+router.post('/auth', ysweetController.getClientToken.bind(ysweetController));
 
 export default router;

--- a/apps/backend/src/services/canvasAuthService.ts
+++ b/apps/backend/src/services/canvasAuthService.ts
@@ -454,10 +454,15 @@ class CanvasAuthService {
             ...(folderId ? { folderId } : {}),
           },
         }),
-        db.canvasParticipant.create({
-          data: {
+        db.canvasParticipant.upsert({
+          where: { canvasId_userId: { canvasId, userId } },
+          create: {
             canvasId,
             userId,
+            workspaceId,
+            role: CanvasRole.OWNER,
+          },
+          update: {
             workspaceId,
             role: CanvasRole.OWNER,
           },

--- a/apps/backend/src/utils/ysweetUtils.ts
+++ b/apps/backend/src/utils/ysweetUtils.ts
@@ -4,7 +4,7 @@
  * Common utilities for Y-Sweet document operations.
  */
 
-import { DocConnection, DocumentManager } from '@y-sweet/sdk';
+import { DocumentManager, type ClientToken } from '@y-sweet/sdk';
 import * as Y from 'yjs';
 import { ServerBlockNoteEditor } from '@blocknote/server-util';
 import {
@@ -90,6 +90,88 @@ function overrideTokenUrls(
   logger.debug(`[YSweetUtils] URL override: "${originalBaseUrl}" -> "${clientToken.baseUrl}"`);
 }
 
+export class YSweetHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string,
+  ) {
+    super(`y-sweet ${path} responded ${status}`);
+    this.name = 'YSweetHttpError';
+  }
+}
+
+export interface YSweetAuthRequest {
+  authorization: 'full' | 'read-only';
+  validForSeconds?: number;
+}
+
+function withDocId(base: string, path: string, docId: string): string {
+  return `${base.replace(/\/$/, '')}/${path}?docId=${encodeURIComponent(docId)}&z=${Date.now().toString(36)}`;
+}
+
+async function ysweetRequest(url: string, path: string, init: RequestInit): Promise<Response> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new YSweetHttpError(res.status, path);
+  }
+  return res;
+}
+
+async function ysweetJson<T>(base: string, path: string, docId: string, body: unknown): Promise<T> {
+  const res = await ysweetRequest(withDocId(base, path, docId), path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return (await res.json()) as T;
+}
+
+/** POST /doc/new */
+export async function ysweetCreateDoc(docId: string): Promise<void> {
+  await ysweetJson(config.ysweet.url, 'doc/new', docId, { docId });
+}
+
+export function ysweetGetClientToken(docId: string, auth: YSweetAuthRequest): Promise<ClientToken> {
+  return ysweetJson<ClientToken>(config.ysweet.url, `doc/${encodeURIComponent(docId)}/auth`, docId, auth);
+}
+
+export async function ysweetGetOrCreateDocAndToken(
+  docId: string,
+  auth: YSweetAuthRequest,
+): Promise<ClientToken> {
+  try {
+    return await ysweetGetClientToken(docId, auth);
+  } catch (error) {
+    if (!(error instanceof YSweetHttpError) || error.status !== 404) {
+      throw error;
+    }
+    await ysweetCreateDoc(docId);
+    return ysweetGetClientToken(docId, auth);
+  }
+}
+
+function tokenHeaders(clientToken: ClientToken): Record<string, string> {
+  return clientToken.token ? { Authorization: `Bearer ${clientToken.token}` } : {};
+}
+
+export async function ysweetGetAsUpdate(clientToken: ClientToken): Promise<Uint8Array> {
+  const path = 'as-update';
+  const res = await ysweetRequest(withDocId(clientToken.baseUrl, path, clientToken.docId), path, {
+    method: 'GET',
+    headers: tokenHeaders(clientToken),
+  });
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function ysweetUpdateDoc(clientToken: ClientToken, update: Uint8Array): Promise<void> {
+  const path = 'update';
+  await ysweetRequest(withDocId(clientToken.baseUrl, path, clientToken.docId), path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream', ...tokenHeaders(clientToken) },
+    body: update,
+  });
+}
+
 /**
  * Initialize a Y-Sweet document with BlockNote content.
  * This ensures the collaborative editor has content when first opened.
@@ -109,11 +191,8 @@ export async function initializeYSweetDoc(
       return false;
     }
 
-    const manager = new DocumentManager(ysweetUrl);
-
-    // Step 1: Create the document first using getOrCreateDocAndToken
-    // This ensures the document exists before we try to update it
-    const clientToken = await manager.getOrCreateDocAndToken(canvasId, {
+    // Step 1: Make sure the document exists and get a write token for it
+    const clientToken = await ysweetGetOrCreateDocAndToken(canvasId, {
       authorization: 'full',
     });
     logger.debug(`[YSweetUtils] Created/retrieved Y-Sweet document for canvas ${canvasId}`);
@@ -129,8 +208,7 @@ export async function initializeYSweetDoc(
     overrideTokenUrls(clientToken, ysweetUrl, clientToken.baseUrl);
 
     // Step 5: Update the document with initial content
-    const connection = new DocConnection(clientToken);
-    await connection.updateDoc(update);
+    await ysweetUpdateDoc(clientToken, update);
 
     logger.info(`[YSweetUtils] Successfully initialized Y-Sweet document for canvas ${canvasId} with ${blocks.length} blocks`);
     return true;
@@ -164,24 +242,20 @@ export async function syncToYSweet(canvasId: string, blocks: BlockNoteBlock[]): 
       return false;
     }
 
-    const manager = new DocumentManager(ysweetUrl);
-
     // Get a client token with full authorization for write operations
-    const clientToken = await manager.getClientToken(canvasId, {
+    const clientToken = await ysweetGetClientToken(canvasId, {
       authorization: 'full',
     });
 
     // Override URLs before both read and write so backend uses the internal Y-Sweet service.
     overrideTokenUrls(clientToken, ysweetUrl, clientToken.baseUrl);
 
-    const connection = new DocConnection(clientToken);
-
     // Create a new Y.Doc to work with
     const ydoc = new Y.Doc();
 
     // Get the existing document state from Y-Sweet
     try {
-      const existingUpdate = await connection.getAsUpdate();
+      const existingUpdate = await ysweetGetAsUpdate(clientToken);
       if (existingUpdate && existingUpdate.length > 0) {
         // Apply existing state to our doc
         Y.applyUpdate(ydoc, existingUpdate);
@@ -209,8 +283,8 @@ export async function syncToYSweet(canvasId: string, blocks: BlockNoteBlock[]): 
     // Encode the state diff as an update
     const update = Y.encodeStateAsUpdate(ydoc);
 
-    // Push the update to Y-Sweet using DocConnection with full authorization
-    await connection.updateDoc(update);
+    // Push the update to Y-Sweet with full authorization
+    await ysweetUpdateDoc(clientToken, update);
 
     logger.info(`[YSweetUtils] Successfully synced content to Y-Sweet for canvas ${canvasId}`);
     return true;
@@ -236,19 +310,15 @@ export async function readFromYSweet(canvasId: string): Promise<BlockNoteBlock[]
       return [];
     }
 
-    const manager = new DocumentManager(ysweetUrl);
-
     // Get a client token with read-only authorization
-    const clientToken = await manager.getClientToken(canvasId, {
+    const clientToken = await ysweetGetClientToken(canvasId, {
       authorization: 'read-only',
     });
 
     // Override URLs to use direct Y-Sweet URL instead of proxy URL
     overrideTokenUrls(clientToken, ysweetUrl, clientToken.baseUrl);
 
-    // Use DocConnection to get the document state
-    const connection = new DocConnection(clientToken);
-    const existingUpdate = await connection.getAsUpdate();
+    const existingUpdate = await ysweetGetAsUpdate(clientToken);
 
     if (!existingUpdate || existingUpdate.length === 0) {
       logger.debug(`[YSweetUtils] No existing Y-Sweet state for canvas ${canvasId}`);


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
