### PR TITLE
fix: agent-scoped MCP connection health check

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -10,6 +10,7 @@ import { getWorkspaceIdForUser } from "../lib/spaces-db.js";
 import { prisma } from "../db.js";
 import { CONFIG } from "../config.js";
 import { encrypt, decrypt } from "../crypto.js";
+import { checkHealth } from "../health.js";
 import { fetchAndStoreSigningSecretFromSpacesApi } from "../lib/spaces-app-secret.js";
 import { extractCodexBearer } from "../lib/codex-creds.js";
 import { extractClaudeBearer } from "../lib/claude-creds.js";
@@ -3253,6 +3254,110 @@ router.delete(
       res.json({ success: true });
     } catch (err) {
       log.error("[agents] delete mcp connection error:", err);
+      res.status(500).json({ success: false, error: "Internal server error" });
+    }
+  },
+);
+
+// Health-check a single agent-pinned MCP instance. Mirrors the global
+// connection health route (routes/connections.ts) but loads credentials
+// from agentMcpConnection instead of userMcpConnection, so an agent owner
+// can see whether a pinned token (e.g. an expired Grafana token) is
+// actually reachable. The agent MCP tab previously showed a hardcoded
+// "connected" badge that never reflected reality.
+//
+// The first arg to checkHealth() is used purely as an MCP session-cache
+// key. We pass a synthetic `agent:<agentId>:<slug>` id (NEVER a real
+// userId) so probing an agent connection cannot evict or rebuild the
+// requesting user's own GLOBAL MCP session for the same server type.
+router.get(
+  "/:slug/mcp/connections/:mcpServerType/:instanceSlug/health",
+  requireAgentOwnerContributorOrAdmin,
+  async (req: Request<{ slug: string; mcpServerType: string; instanceSlug: string }>, res: Response) => {
+    try {
+      const agent = req.agentContext!.agent;
+      const { mcpServerType, instanceSlug } = req.params;
+      if (!isValidSlug(instanceSlug)) {
+        res.status(400).json({ success: false, error: "Invalid instance slug" });
+        return;
+      }
+      const server = await prisma.mcpServer.findUnique({ where: { type: mcpServerType } });
+      if (!server) {
+        res.status(404).json({ success: false, error: `Unknown mcpServerType: ${mcpServerType}` });
+        return;
+      }
+      const connection = await prisma.agentMcpConnection.findUnique({
+        where: { agentId_mcpServerId_slug: { agentId: agent.id, mcpServerId: server.id, slug: instanceSlug } },
+      });
+      if (!connection) {
+        res.status(404).json({ success: false, error: "Connection not found" });
+        return;
+      }
+
+      const decrypted = decrypt(connection.encryptedCreds, connection.iv, connection.authTag, CONFIG.encryptionKey);
+      const credentials = JSON.parse(decrypted) as Record<string, unknown>;
+
+      // Isolated session key - never a real userId (see note above).
+      const healthSessionId = `agent:${agent.id}:${instanceSlug}`;
+
+      // Google / Microsoft are OAuth-token connectors, not MCP adapters -
+      // check them directly, mirroring the global connection health route.
+      if (server.type === "google") {
+        const start = Date.now();
+        const token = (credentials as { accessToken?: string }).accessToken;
+        if (!token) {
+          res.json({ success: true, data: { healthy: false, message: "No access token stored", latencyMs: 0 } });
+          return;
+        }
+        try {
+          const gRes = await fetch("https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=" + encodeURIComponent(token));
+          const latencyMs = Date.now() - start;
+          if (gRes.ok) {
+            const info = (await gRes.json()) as { email?: string; expires_in?: number };
+            res.json({ success: true, data: { healthy: true, message: `Connected as ${info.email ?? "unknown"} (expires in ${info.expires_in ?? "?"}s)`, latencyMs } });
+          } else {
+            const refreshToken = (credentials as { refreshToken?: string }).refreshToken;
+            res.json({ success: true, data: refreshToken
+              ? { healthy: true, message: "Token expired but refresh token available - will auto-refresh on next use", latencyMs }
+              : { healthy: false, message: "Token expired and no refresh token", latencyMs } });
+          }
+        } catch (err) {
+          res.json({ success: true, data: { healthy: false, message: err instanceof Error ? err.message : "Health check failed", latencyMs: Date.now() - start } });
+        }
+        return;
+      }
+
+      if (server.type === "microsoft") {
+        const start = Date.now();
+        const token = (credentials as { accessToken?: string }).accessToken;
+        if (!token) {
+          res.json({ success: true, data: { healthy: false, message: "No access token stored", latencyMs: 0 } });
+          return;
+        }
+        try {
+          const msRes = await fetch("https://graph.microsoft.com/v1.0/me", { headers: { Authorization: `Bearer ${token}` } });
+          const latencyMs = Date.now() - start;
+          if (msRes.ok) {
+            const info = (await msRes.json()) as { displayName?: string; mail?: string };
+            res.json({ success: true, data: { healthy: true, message: `Connected as ${info.displayName ?? info.mail ?? "unknown"}`, latencyMs } });
+          } else if (msRes.status === 401) {
+            const refreshToken = (credentials as { refreshToken?: string }).refreshToken;
+            res.json({ success: true, data: refreshToken
+              ? { healthy: true, message: "Token expired but refresh token available - will auto-refresh on next use", latencyMs }
+              : { healthy: false, message: "Token expired and no refresh token", latencyMs } });
+          } else {
+            res.json({ success: true, data: { healthy: false, message: `Health check failed (HTTP ${msRes.status})`, latencyMs } });
+          }
+        } catch (err) {
+          res.json({ success: true, data: { healthy: false, message: err instanceof Error ? err.message : "Health check failed", latencyMs: Date.now() - start } });
+        }
+        return;
+      }
+
+      const result = await checkHealth(healthSessionId, server.type, server.name, credentials);
+      res.json({ success: true, data: result });
+    } catch (err) {
+      log.error("[agents] agent mcp health check error:", err);
       res.status(500).json({ success: false, error: "Internal server error" });
     }
   },

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -2569,6 +2569,25 @@ export async function removeAgentShare(slug: string, requesterId: string, target
   );
 }
 
+/**
+ * Health-check a single agent-pinned MCP instance. Hits the agent-scoped
+ * health route (mirrors checkConnectionHealth for global connections) so the
+ * agent MCP tab can show a real reachability status instead of a hardcoded
+ * "connected" badge.
+ */
+export async function checkAgentMcpConnectionHealth(
+  slug: string,
+  requesterId: string,
+  mcpServerType: string,
+  instanceSlug = "default",
+): Promise<HealthResult> {
+  const data = await request<{ success: boolean; data: HealthResult }>(
+    `${AUTH_API_URL}/api/v1/agents/${slug}/mcp/connections/${encodeURIComponent(mcpServerType)}/${encodeURIComponent(instanceSlug)}/health`,
+    { headers: { "x-user-id": requesterId } },
+  );
+  return data.data;
+}
+
 // ── Agent-scoped MCP connections ────────────────────────────────────
 //
 // Lists / upserts / deletes credentials pinned to a specific agent. The

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AgentMcpTabV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AgentMcpTabV3.tsx
@@ -7,10 +7,11 @@ import {
   getCredentialFields,
   listSubagents,
   forkSubagentForInstance,
+  checkAgentMcpConnectionHealth,
   type AgentMcpConnectionMeta,
   type SubagentDef,
 } from "../../../../lib/api";
-import type { McpServer, CredentialField } from "../../../../lib/types";
+import type { McpServer, CredentialField, HealthResult } from "../../../../lib/types";
 
 interface Props {
   agentSlug: string;
@@ -44,6 +45,13 @@ function canPinWithoutCreds(server: McpServer, fieldCount: number): boolean {
 interface EditingKey {
   serverType: string;
   slug: string | null;
+}
+
+/** On-demand health status for one agent-pinned MCP instance. */
+interface InstanceHealth {
+  status: "checking" | "healthy" | "unhealthy";
+  message?: string;
+  latencyMs?: number;
 }
 
 /**
@@ -85,6 +93,34 @@ export function AgentMcpTabV3({ agentSlug, userId, canEdit }: Props) {
   /** Fork modal state. Null when closed; otherwise carries which instance
    *  we're forking for + the user's source/name picks. */
   const [forkModal, setForkModal] = useState<ForkModalState | null>(null);
+  /** On-demand health per instance id. Never auto-run on mount — the operator
+   *  clicks "Check" so opening the tab does not spawn N MCP child processes. */
+  const [healthByInstance, setHealthByInstance] = useState<Record<string, InstanceHealth>>({});
+
+  const runHealthCheck = useCallback(async (inst: AgentMcpConnectionMeta) => {
+    setHealthByInstance((prev) => ({ ...prev, [inst.id]: { status: "checking" } }));
+    try {
+      const result: HealthResult = await checkAgentMcpConnectionHealth(
+        agentSlug,
+        userId,
+        inst.mcpServerType,
+        inst.slug,
+      );
+      setHealthByInstance((prev) => ({
+        ...prev,
+        [inst.id]: {
+          status: result.healthy ? "healthy" : "unhealthy",
+          message: result.message,
+          latencyMs: result.latencyMs,
+        },
+      }));
+    } catch (err) {
+      setHealthByInstance((prev) => ({
+        ...prev,
+        [inst.id]: { status: "unhealthy", message: err instanceof Error ? err.message : String(err) },
+      }));
+    }
+  }, [agentSlug, userId]);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -348,13 +384,34 @@ export function AgentMcpTabV3({ agentSlug, userId, canEdit }: Props) {
                             <div className="flex items-center gap-2">
                               <span className="text-sm font-medium text-xyne-fg-primary">{inst.displayName}</span>
                               <span className="rounded bg-xyne-surface-sunken px-1.5 py-0.5 font-mono text-[10px] text-xyne-fg-tertiary">{inst.slug}</span>
-                              <span className="rounded bg-xyne-success-bg px-1.5 py-0.5 text-[10px] uppercase text-xyne-success">connected</span>
+                              {(() => {
+                                const h = healthByInstance[inst.id];
+                                if (!h) {
+                                  return <span title="Health not checked yet - click Check" className="rounded bg-xyne-surface-sunken px-1.5 py-0.5 text-[10px] uppercase text-xyne-fg-tertiary">unknown</span>;
+                                }
+                                if (h.status === "checking") {
+                                  return <span className="rounded bg-xyne-surface-sunken px-1.5 py-0.5 text-[10px] uppercase text-xyne-fg-tertiary">checking</span>;
+                                }
+                                if (h.status === "healthy") {
+                                  return <span title={h.message} className="rounded bg-xyne-success-bg px-1.5 py-0.5 text-[10px] uppercase text-xyne-success">healthy</span>;
+                                }
+                                return <span title={h.message} className="rounded bg-xyne-error-bg px-1.5 py-0.5 text-[10px] uppercase text-xyne-error">unhealthy</span>;
+                              })()}
                             </div>
                             <p className="mt-1 text-[11px] text-xyne-fg-muted">
                               Tool prefix: <span className="font-mono text-xyne-fg-tertiary">{`${server.type}-${inst.slug}__`}</span>
                               {" · "}Pinned by user {inst.createdByUserId ?? "unknown"}
                               {" · "}last updated {new Date(inst.updatedAt).toLocaleString()}
                             </p>
+                            {(() => {
+                              const h = healthByInstance[inst.id];
+                              if (!h || !h.message || h.status === "checking") return null;
+                              return (
+                                <p className={`mt-1 text-[11px] ${h.status === "healthy" ? "text-xyne-success" : "text-xyne-error"}`}>
+                                  {h.message}{typeof h.latencyMs === "number" ? ` (${h.latencyMs}ms)` : ""}
+                                </p>
+                              );
+                            })()}
                             {/* Reverse-lookup: which subagents have THIS
                                 instance pinned via mcpInstanceMap. Lets the
                                 operator see at a glance the blast radius of
@@ -379,6 +436,14 @@ export function AgentMcpTabV3({ agentSlug, userId, canEdit }: Props) {
                           </div>
                           {canEdit && !isEditingThis && (
                             <div className="flex shrink-0 gap-2">
+                              <button
+                                onClick={() => void runHealthCheck(inst)}
+                                disabled={healthByInstance[inst.id]?.status === "checking"}
+                                title="Check whether this instance's pinned credentials are actually reachable"
+                                className="rounded border border-xyne-border-subtle px-2 py-1 text-xs text-xyne-fg-secondary hover:bg-xyne-surface-sunken disabled:cursor-not-allowed disabled:opacity-40"
+                              >
+                                {healthByInstance[inst.id]?.status === "checking" ? "Checking" : "Check"}
+                              </button>
                               <button
                                 onClick={() => openForkModal(inst)}
                                 disabled={forkableSubagents.length === 0}


### PR DESCRIPTION
## What
Adds a health check for agent-pinned MCP connections, mirroring the existing global connection health check.

Previously the agent MCP tab (`AgentMcpTabV3`) rendered a hardcoded `connected` badge for every pinned instance, so an expired token (e.g. an expired Grafana token) still showed as "connected". There was no way to verify an agent-pinned MCP instance's reachability.

## Changes
- **backend** (`apps/xyne-claw-auth/backend/src/routes/agents.ts`): new `GET /:slug/mcp/connections/:mcpServerType/:instanceSlug/health` behind `requireAgentOwnerContributorOrAdmin`. Loads the `agentMcpConnection`, decrypts credentials, and reuses `checkHealth()`. Google/Microsoft OAuth connectors are validated directly (token introspection), mirroring the global `routes/connections.ts` health route. Uses a synthetic session key `agent:<agentId>:<slug>` as the MCP session-cache key so probing an agent connection never evicts or rebuilds the requesting user's own **global** MCP session for the same server type.
- **frontend api** (`apps/xyne-claw-auth/frontend/src/lib/api.ts`): new `checkAgentMcpConnectionHealth(slug, requesterId, mcpServerType, instanceSlug)` client.
- **frontend ui** (`AgentMcpTabV3.tsx`): replaced the static `connected` badge with a real per-instance status (`unknown` / `checking` / `healthy` / `unhealthy`) plus an on-demand **Check** button and a health message line. Health is never auto-run on mount, so opening the tab does not spawn MCP child processes.

## Validation
- Frontend typecheck passes clean.
- Backend typecheck shows only the sandbox's pre-existing `@prisma/client` generation cascade (identical on the base branch); the new route block has zero attributable errors.

## Test plan
- Pin a Grafana MCP on an agent with a valid token, click Check → healthy (green).
- Expire/replace with a bad token, click Check → unhealthy (red) with the error message.
- Confirm a viewer (no owner/contributor/admin) receives 403.
- Confirm running the agent health check does not 401 the same user's global MCP session for that server type.