### PR TITLE
fix: email sso routing back

### DIFF
--- a/apps/backend/src/integrations/routes/google-auth.ts
+++ b/apps/backend/src/integrations/routes/google-auth.ts
@@ -323,6 +323,7 @@ async function createGoogleRecordingEmailAuthUrl(
   userId: string,
   workspaceId: string,
   returnPath: string,
+  platform: ProviderPlatform,
   req: Request,
 ): Promise<string> {
   const user = await db.user.findFirst({
@@ -340,7 +341,7 @@ async function createGoogleRecordingEmailAuthUrl(
     workspaceId,
     expectedEmail: user.email.trim().toLowerCase(),
     returnPath,
-    platform: 'web',
+    platform,
     timestamp: Date.now(),
   });
 
@@ -583,6 +584,7 @@ router.post(
   authV2Middleware.authenticate,
   async (req: Request, res: Response): Promise<void> => {
     const returnPath = sanitizeReturnPath(req.body.returnPath);
+    const platform: ProviderPlatform = req.body.platform === 'electron' ? 'electron' : 'web';
     if (!returnPath) {
       res.status(400).json({ error: 'A valid return path is required' });
       return;
@@ -593,6 +595,7 @@ router.post(
         req.user!.id,
         req.user!.workspaceId,
         returnPath,
+        platform,
         req,
       );
       res.json({ authUrl });

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -141,6 +141,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
   const [showTranscriptPanel, setShowTranscriptPanel] = useState(false);
   const [showPostToChannelModal, setShowPostToChannelModal] = useState(false);
   const [showPostToEmailModal, setShowPostToEmailModal] = useState(false);
+  const [postToEmailNonce, setPostToEmailNonce] = useState(0);
   const [showGoogleDocPreviewModal, setShowGoogleDocPreviewModal] = useState(false);
   const [googleDocPreviewNonce, setGoogleDocPreviewNonce] = useState(0);
   const [isExportingGoogleDoc, setIsExportingGoogleDoc] = useState(false);
@@ -208,10 +209,14 @@ export default function RecordingDetailV2Screen(): ReactElement {
 
     if (connected) {
       toast.success('Google email connected');
+      // Remount so the compose context is refetched — in Electron the modal is still
+      // mounted from before the consent screen opened in the system browser.
+      setPostToEmailNonce(nonce => nonce + 1);
       setShowPostToEmailModal(true);
     }
     if (connectionError) {
       toast.error(connectionError);
+      setPostToEmailNonce(nonce => nonce + 1);
       setShowPostToEmailModal(true);
     }
 
@@ -1071,6 +1076,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
           testId='post-recording-to-email-dialog'
         >
           <PostRecordingToEmailModal
+            key={postToEmailNonce}
             recording={recording}
             onClose={() => setShowPostToEmailModal(false)}
           />

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToEmailModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToEmailModal.tsx
@@ -336,9 +336,22 @@ export const PostRecordingToEmailModal = ({
   const handleConnectGoogle = async (): Promise<void> => {
     setIsConnectingGoogle(true);
     try {
-      const returnPath = `${window.location.pathname}${window.location.search}`;
-      const authUrl = await recordingEmailService.connectGoogle(returnPath);
-      window.location.assign(authUrl);
+      const currentPath = `${window.location.pathname}${window.location.search}`;
+      const returnPath =
+        currentPath.startsWith('/') && !currentPath.startsWith('//') ? currentPath : '/recordings';
+      // In Electron the consent screen has to open in the system browser, and the backend
+      // needs to know so it can send the callback back through /launch (deep link) instead
+      // of leaving the user stranded on the web app.
+      const isElectron = typeof window.electronAPI?.openExternal === 'function';
+      const authUrl = await recordingEmailService.connectGoogle(
+        returnPath,
+        isElectron ? 'electron' : 'web',
+      );
+      if (isElectron) {
+        window.electronAPI?.openExternal(authUrl);
+      } else {
+        window.location.assign(authUrl);
+      }
     } catch (error) {
       const message =
         (error as { response?: { data?: { error?: string } } })?.response?.data?.error ||

--- a/apps/dashboard/src/services/Recording/recordingEmailService.ts
+++ b/apps/dashboard/src/services/Recording/recordingEmailService.ts
@@ -62,10 +62,10 @@ class RecordingEmailService {
     return response.data;
   }
 
-  async connectGoogle(returnPath: string): Promise<string> {
+  async connectGoogle(returnPath: string, platform: 'electron' | 'web' = 'web'): Promise<string> {
     const response = await apiInstance.post<GoogleRecordingEmailConnectionResponse>(
       '/integrations/google/connect/recording-email/init',
-      { returnPath },
+      { returnPath, platform },
     );
     return response.data.authUrl;
   }

--- a/apps/electron/src/services/deep-links.ts
+++ b/apps/electron/src/services/deep-links.ts
@@ -384,6 +384,7 @@ async function handleDeepLink(url: string): Promise<void> {
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.show();
+      mainWindow.focus();
       mainWindow.webContents.send('navigate-to', pathStr);
     }
   }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
