### PR TITLE
fix: round Xyne AI main panel corners to match chat

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIShell.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIShell.tsx
@@ -73,7 +73,10 @@ export function AIShell({
       </Separator>
 
       <Panel id='ai-main' minSize='30%'>
-        <div ref={mainRef} className='bg-background relative flex h-full min-w-0 flex-1 flex-col'>
+        <div
+          ref={mainRef}
+          className='bg-background relative flex h-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl'
+        >
           {children}
         </div>
       </Panel>


### PR DESCRIPTION
## What

The Xyne AI content panel rendered flush and square against the window edge, while the chat screen and the rest of the app present their main content as a rounded card.

Adds `overflow-hidden rounded-2xl` to the `ai-main` container in `AIShell.tsx`. `rounded-2xl` matches `ChatScreen.tsx:174`; `overflow-hidden` is what makes the radius actually clip descendants, since several AI screens paint their own opaque surface over the shell.

## Scope

Every `/ai` route renders through `AIShell`, so one line covers all of them:

- landing / chat view, library, knowledge, admin, organization
- agent, subagent, skill and MCP detail + create + edit screens
- daily brief
- the `AISectionLayout` routes: digital-twin, metrics, settings

## Notes

- The 12 inner `<main>` elements needed no change — they are transparent `overflow-hidden` wrappers on `main`, so the shell's clip is sufficient.
- Prettier passes. The change is a className string only.
- Worth an eyeball while running: `bg-background` on the shell against the body may make the corner notches low-contrast in the classic theme, and the midnight theme is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)