### PR TITLE
feat: XYNE-56342 recording in thread

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -417,6 +417,32 @@ export class CallController {
           title: 'Untitled Notes',
         });
 
+        // Thread-linked recording: validate the conversation up front (fail
+        // fast with a 404 instead of creating a LiveKit room for nothing) and
+        // stamp channelId/conversationId onto the room metadata. The actual
+        // Call DB row — and the thread's single anchor message — are created
+        // together by noteTakerWebhookController on first participant_joined,
+        // so nothing is posted into the thread unless the recording actually
+        // starts (e.g. mic permission denied / room creation failure after
+        // this point never leaves a ghost message behind).
+        if (channelId && conversationId) {
+          stage = 'thread_conversation_lookup';
+          const conversation = await repositories.conversations.findByIdAndWorkspace(
+            conversationId,
+            req.user!.workspaceId!,
+          );
+          if (!conversation || conversation.channelId !== channelId) {
+            res.status(404).json({ success: false, error: 'Conversation not found' });
+            return;
+          }
+          stage = 'thread_channel_membership_check';
+          const isMember = await repositories.channelParticipants.isParticipant(channelId, userId);
+          if (!isMember) {
+            res.status(403).json({ success: false, error: 'Not a member of this channel' });
+            return;
+          }
+        }
+
         const roomLink = buildCallInviteUrl(callExternalId);
         const roomMetadata = JSON.stringify({
           callType: CallType.HEADLESS,
@@ -424,6 +450,7 @@ export class CallController {
           createdBy: userId,
           workspaceId: req.user!.workspaceId,
           notesCanvasId,
+          ...(channelId && conversationId ? { channelId, conversationId } : {}),
         });
 
         stage = 'livekit_room_creation';
@@ -459,6 +486,7 @@ export class CallController {
           roomLink,
           channelId: null,
           notesCanvasId,
+          ...(conversationId ? { conversationId } : {}),
         });
         return;
       }

--- a/apps/backend/src/controllers/noteTakerWebhookController.ts
+++ b/apps/backend/src/controllers/noteTakerWebhookController.ts
@@ -95,6 +95,18 @@ class NoteTakerWebhookController {
       typeof roomMetadata.createdBy === 'string' ? roomMetadata.createdBy : participant.identity;
     const notesCanvasId =
       typeof roomMetadata.notesCanvasId === 'string' ? roomMetadata.notesCanvasId : undefined;
+    // Present only when the recording was started from inside a thread (see
+    // callController's headless-initiate branch, which stamps these two onto
+    // the LiveKit room metadata synchronously). messageId is generated here,
+    // not in callController, so the anchor message is only ever posted once
+    // the recording has actually started (this webhook fires) — a mic
+    // permission denial or room-creation failure between initiate and here
+    // never leaves a ghost message in the thread.
+    const conversationId =
+      typeof roomMetadata.conversationId === 'string' ? roomMetadata.conversationId : undefined;
+    const threadChannelId =
+      typeof roomMetadata.channelId === 'string' ? roomMetadata.channelId : undefined;
+    const messageId = conversationId && threadChannelId ? uuidv4() : undefined;
 
     if (!workspaceId) {
       logger.error(`[NoteTaker Webhook] Missing workspaceId in room metadata for ${roomName}`);
@@ -162,6 +174,44 @@ class NoteTakerWebhookController {
     logger.info(`[NoteTaker Webhook] Created note taker call record for ${roomName}`, {
       callId: call.id,
     });
+
+    // Thread-linked recording: post the single anchor message into the thread
+    // now that the recording is actually live. Best-effort — a failure here
+    // must not block call creation or transcription (the recording still
+    // works, it just won't be anchored to a thread message).
+    if (conversationId && messageId && threadChannelId) {
+      try {
+        const posted = await noteTakerCallRepository.createThreadAnchorMessage({
+          callId: call.id,
+          conversationId,
+          channelId: threadChannelId,
+          messageId,
+          callExternalId: call.externalId,
+          createdBy,
+          workspaceId,
+          notesCanvasId,
+        });
+        if (!posted) {
+          logger.error('[NoteTaker Webhook] thread_anchor_message_conversation_mismatch', {
+            room: roomName,
+            conversationId,
+            channelId: threadChannelId,
+          });
+        }
+      } catch (messageError) {
+        logger.error('[NoteTaker Webhook] thread_anchor_message_failed', {
+          room: roomName,
+          conversationId,
+          error: messageError,
+        });
+      }
+    }
+
+    // Thread-linked recording: view access to the recording is granted to
+    // the thread's channel later, once the detailed summary canvas exists
+    // (recordingSharingService requires it) — see
+    // noteTakerTranscriptService.shareThreadRecordingIfLinked, called at the
+    // end of transcript/summary processing.
 
     // Auto-start an audio recording for the whole call — note-taker calls have
     // no manual "start recording" UI action, so this replaces that trigger.

--- a/apps/backend/src/database/repositories/noteTakerCallRepository.ts
+++ b/apps/backend/src/database/repositories/noteTakerCallRepository.ts
@@ -84,6 +84,7 @@ export class NoteTakerCallRepository {
           isHeadlessRecording: true,
           callId: call.externalId,
           operation: 'recording_ended',
+          createdBy: call.createdByUserId,
           ...(durationMs !== null ? { durationMs } : {}),
         },
       },
@@ -136,20 +137,8 @@ export class NoteTakerCallRepository {
   }
 
   /**
-   * Create the thread's single anchor message for a thread-linked recording,
-   * once the recording is actually live (called right after `createCall`
-   * succeeds). Validates the conversation still belongs to the given channel,
-   * inserts the SYSTEM message, and bumps the conversation's reply count the
-   * same way a normal reply into the thread would.
-   *
-   * Returns false (no throw) if the conversation/channel no longer match, if
-   * they don't belong to the call's own workspace, or if the call's creator
-   * is no longer a member of that channel — the caller treats that as a soft
-   * failure, since the recording itself still works even if it can't be
-   * anchored to a thread message. These checks are the authoritative gate
-   * (callController's own pre-check is only a fail-fast UX optimization —
-   * conversationId/channelId are client-supplied, so re-validating workspace
-   * + membership here matters even if that earlier check already passed).
+   * Create the thread's single anchor message for a thread-linked recording.
+   * Returns false (no throw) if the conversation/channel/membership checks fail.
    */
   async createThreadAnchorMessage(params: {
     callId: string;
@@ -179,61 +168,53 @@ export class NoteTakerCallRepository {
     });
 
     const now = new Date();
-    await this.db.message.create({
-      data: {
-        messageId,
-        conversationId,
-        workspaceId,
-        senderId: 'system',
-        content: `${initiator?.displayName || initiator?.name || 'Someone'} started recording notes`,
-        msgType: MessageType.SYSTEM,
-        showInChannel: false,
-        createdAt: now,
-        metadata: {
-          isRecordingMessage: true,
-          isHeadlessRecording: true,
-          callId: callExternalId,
-          callType: CallType.HEADLESS,
-          operation: 'recording_active',
-          notesCanvasId,
-        },
-      },
-    });
-
-    // Bumps conversation.replyCount (so the "N replies" pill in the channel
-    // view updates), touches lastActivityAt, and refreshes participants'
-    // lastReplyAt — the same bookkeeping any normal reply into this thread gets.
-    await repositories.conversations.incrementReplyCount(conversationId, now);
-
-    // Mirrors what a regular in-thread call does (callRepository sets
-    // conversation.callId while ACTIVE, clears it on end): lets the channel
-    // row's reply-count line detect "this thread has something live" via the
-    // same field the call flow already uses (hasActiveCallForConversation).
-    // isHeadlessRecording on conversation.metadata (merge-safe) is the extra
-    // bit that disambiguates "it's a recording, not a real call" — read
-    // directly off this already-subscribed conversation row, no separate
-    // per-thread-row query needed.
     const existingMetadata: Record<string, unknown> =
       conversation.metadata && typeof conversation.metadata === 'object' && !Array.isArray(conversation.metadata)
         ? (conversation.metadata as Record<string, unknown>)
         : {};
-    await this.db.conversation.update({
-      where: { conversationId },
-      data: {
-        callId: callExternalId,
-        metadata: { ...existingMetadata, isHeadlessRecording: true } as Prisma.InputJsonValue,
-      },
+
+    // Anchor message, conversation stamp, and call metadata must land atomically.
+    await this.db.$transaction(async (tx) => {
+      await tx.message.create({
+        data: {
+          messageId,
+          conversationId,
+          workspaceId,
+          senderId: 'system',
+          content: `${initiator?.displayName || initiator?.name || 'Someone'} started recording notes`,
+          msgType: MessageType.SYSTEM,
+          showInChannel: false,
+          createdAt: now,
+          metadata: {
+            isRecordingMessage: true,
+            isHeadlessRecording: true,
+            callId: callExternalId,
+            callType: CallType.HEADLESS,
+            operation: 'recording_active',
+            notesCanvasId,
+            createdBy,
+          },
+        },
+      });
+
+      // Marks the conversation as having a live recording attached.
+      await tx.conversation.update({
+        where: { conversationId },
+        data: {
+          callId: callExternalId,
+          metadata: { ...existingMetadata, isHeadlessRecording: true } as Prisma.InputJsonValue,
+        },
+      });
+
+      // Persist the thread linkage onto the Call row itself.
+      await tx.call.update({
+        where: { id: callId },
+        data: { metadata: { notesCanvasId, conversationId, messageId, channelId } as Prisma.InputJsonValue },
+      });
     });
 
-    // Only now — after every validation above passed — persist the thread
-    // linkage onto the Call row itself. shareThreadRecordingIfLinked and
-    // updateThreadMessageOnEnd both key off call.metadata.channelId /
-    // .conversationId, so this is the single point where a call becomes
-    // "thread-linked" from their point of view.
-    await this.db.call.update({
-      where: { id: callId },
-      data: { metadata: { notesCanvasId, conversationId, messageId, channelId } as Prisma.InputJsonValue },
-    });
+    // Bumps reply count only after the transaction above has committed.
+    await repositories.conversations.incrementReplyCount(conversationId, now);
 
     return true;
   }

--- a/apps/backend/src/database/repositories/noteTakerCallRepository.ts
+++ b/apps/backend/src/database/repositories/noteTakerCallRepository.ts
@@ -1,6 +1,7 @@
-import { type Call } from '@prisma/client';
-import { CallStatus, CallType } from '@xyne/shared';
+import { type Call, type Prisma } from '@prisma/client';
+import { CallStatus, CallType, MessageType } from '@xyne/shared';
 import { DatabaseClient } from '@/database/client';
+import { repositories } from './index';
 
 export interface CreateNoteTakerCallParams {
   callId: string;
@@ -10,6 +11,13 @@ export interface CreateNoteTakerCallParams {
   notesCanvasId: string;
   roomLink: string;
   now: Date;
+}
+
+interface NoteTakerCallMetadata {
+  notesCanvasId?: string;
+  conversationId?: string;
+  messageId?: string;
+  channelId?: string;
 }
 
 /**
@@ -28,6 +36,14 @@ export class NoteTakerCallRepository {
   async createCall(params: CreateNoteTakerCallParams): Promise<Call> {
     const { callId, roomName, workspaceId, createdBy, notesCanvasId, roomLink, now } = params;
 
+    // Thread-linkage (conversationId/messageId/channelId) is deliberately NOT
+    // stamped here — it's only added to metadata by createThreadAnchorMessage,
+    // and only once that method's workspace/channel/membership checks pass.
+    // Writing it here unconditionally would let a later-failed validation
+    // still leave metadata.channelId behind for shareThreadRecordingIfLinked /
+    // updateThreadMessageOnEnd to act on.
+    const metadata: NoteTakerCallMetadata = { notesCanvasId };
+
     return this.db.call.create({
       data: {
         id: callId,
@@ -37,16 +53,189 @@ export class NoteTakerCallRepository {
         callType: CallType.HEADLESS,
         status: CallStatus.ACTIVE,
         roomLink,
-        metadata: { notesCanvasId },
+        metadata: metadata as Prisma.InputJsonValue,
         startedAt: now,
         lastActivityAt: now,
       },
     });
   }
 
+  /**
+   * Update the thread's single anchor message once a thread-linked recording
+   * ends. No-op (returns false) for recordings that weren't started from a
+   * thread (no conversationId/messageId on call.metadata).
+   */
+  private async updateThreadMessageOnEnd(
+    tx: Prisma.TransactionClient,
+    call: Call,
+    endedAt: Date,
+  ): Promise<boolean> {
+    const metadata = (call.metadata as NoteTakerCallMetadata | null) ?? {};
+    if (!metadata.conversationId || !metadata.messageId) return false;
+
+    const durationMs = call.startedAt ? endedAt.getTime() - call.startedAt.getTime() : null;
+
+    await tx.message.update({
+      where: { messageId: metadata.messageId },
+      data: {
+        content: 'Recording ended',
+        metadata: {
+          isRecordingMessage: true,
+          isHeadlessRecording: true,
+          callId: call.externalId,
+          operation: 'recording_ended',
+          ...(durationMs !== null ? { durationMs } : {}),
+        },
+      },
+    });
+
+    // Clear conversation.callId so the channel row's live-recording indicator
+    // turns off immediately, and drop the isHeadlessRecording metadata flag
+    // stamped in createThreadAnchorMessage (merge-safe: only removes that key).
+    const conversation = await tx.conversation.findUnique({
+      where: { conversationId: metadata.conversationId },
+      select: { metadata: true },
+    });
+    const conversationMetadata: Record<string, unknown> =
+      conversation?.metadata && typeof conversation.metadata === 'object' && !Array.isArray(conversation.metadata)
+        ? { ...(conversation.metadata as Record<string, unknown>) }
+        : {};
+    delete conversationMetadata.isHeadlessRecording;
+
+    await tx.conversation.update({
+      where: { conversationId: metadata.conversationId },
+      data: { callId: null, metadata: conversationMetadata as Prisma.InputJsonValue },
+    });
+
+    return true;
+  }
+
   /** Update activity when the creator reconnects to an existing headless room. */
   async touchCallActivity(callId: string, now: Date): Promise<void> {
     await this.db.call.update({ where: { id: callId }, data: { lastActivityAt: now } });
+  }
+
+  /**
+   * Patches the thread's anchor message content with the AI-generated title
+   * once it's ready (called from noteTakerTranscriptService, well after the
+   * recording itself has ended and updateThreadMessageOnEnd already ran).
+   * Mirrors how a regular call's ended message shows its AI text directly as
+   * message.content — RecordingBubble reads this straight off the message,
+   * no separate live query on the Call row needed for the ended-state title.
+   * No-op for recordings that weren't started from a thread.
+   */
+  async updateThreadMessageTitle(callId: string, title: string): Promise<void> {
+    const call = await this.db.call.findUnique({ where: { id: callId }, select: { metadata: true } });
+    const metadata = (call?.metadata as NoteTakerCallMetadata | null) ?? {};
+    if (!metadata.messageId) return;
+
+    await this.db.message.update({
+      where: { messageId: metadata.messageId },
+      data: { content: title },
+    });
+  }
+
+  /**
+   * Create the thread's single anchor message for a thread-linked recording,
+   * once the recording is actually live (called right after `createCall`
+   * succeeds). Validates the conversation still belongs to the given channel,
+   * inserts the SYSTEM message, and bumps the conversation's reply count the
+   * same way a normal reply into the thread would.
+   *
+   * Returns false (no throw) if the conversation/channel no longer match, if
+   * they don't belong to the call's own workspace, or if the call's creator
+   * is no longer a member of that channel — the caller treats that as a soft
+   * failure, since the recording itself still works even if it can't be
+   * anchored to a thread message. These checks are the authoritative gate
+   * (callController's own pre-check is only a fail-fast UX optimization —
+   * conversationId/channelId are client-supplied, so re-validating workspace
+   * + membership here matters even if that earlier check already passed).
+   */
+  async createThreadAnchorMessage(params: {
+    callId: string;
+    conversationId: string;
+    channelId: string;
+    messageId: string;
+    callExternalId: string;
+    createdBy: string;
+    workspaceId: string;
+    notesCanvasId: string;
+  }): Promise<boolean> {
+    const { callId, conversationId, channelId, messageId, callExternalId, createdBy, workspaceId, notesCanvasId } =
+      params;
+
+    const conversation = await repositories.conversations.findByIdAndWorkspace(conversationId, workspaceId);
+    if (!conversation || conversation.channelId !== channelId) {
+      return false;
+    }
+    const isMember = await repositories.channelParticipants.isParticipant(channelId, createdBy);
+    if (!isMember) {
+      return false;
+    }
+
+    const initiator = await this.db.user.findUnique({
+      where: { id: createdBy },
+      select: { name: true, displayName: true },
+    });
+
+    const now = new Date();
+    await this.db.message.create({
+      data: {
+        messageId,
+        conversationId,
+        workspaceId,
+        senderId: 'system',
+        content: `${initiator?.displayName || initiator?.name || 'Someone'} started recording notes`,
+        msgType: MessageType.SYSTEM,
+        showInChannel: false,
+        createdAt: now,
+        metadata: {
+          isRecordingMessage: true,
+          isHeadlessRecording: true,
+          callId: callExternalId,
+          callType: CallType.HEADLESS,
+          operation: 'recording_active',
+          notesCanvasId,
+        },
+      },
+    });
+
+    // Bumps conversation.replyCount (so the "N replies" pill in the channel
+    // view updates), touches lastActivityAt, and refreshes participants'
+    // lastReplyAt — the same bookkeeping any normal reply into this thread gets.
+    await repositories.conversations.incrementReplyCount(conversationId, now);
+
+    // Mirrors what a regular in-thread call does (callRepository sets
+    // conversation.callId while ACTIVE, clears it on end): lets the channel
+    // row's reply-count line detect "this thread has something live" via the
+    // same field the call flow already uses (hasActiveCallForConversation).
+    // isHeadlessRecording on conversation.metadata (merge-safe) is the extra
+    // bit that disambiguates "it's a recording, not a real call" — read
+    // directly off this already-subscribed conversation row, no separate
+    // per-thread-row query needed.
+    const existingMetadata: Record<string, unknown> =
+      conversation.metadata && typeof conversation.metadata === 'object' && !Array.isArray(conversation.metadata)
+        ? (conversation.metadata as Record<string, unknown>)
+        : {};
+    await this.db.conversation.update({
+      where: { conversationId },
+      data: {
+        callId: callExternalId,
+        metadata: { ...existingMetadata, isHeadlessRecording: true } as Prisma.InputJsonValue,
+      },
+    });
+
+    // Only now — after every validation above passed — persist the thread
+    // linkage onto the Call row itself. shareThreadRecordingIfLinked and
+    // updateThreadMessageOnEnd both key off call.metadata.channelId /
+    // .conversationId, so this is the single point where a call becomes
+    // "thread-linked" from their point of view.
+    await this.db.call.update({
+      where: { id: callId },
+      data: { metadata: { notesCanvasId, conversationId, messageId, channelId } as Prisma.InputJsonValue },
+    });
+
+    return true;
   }
 
   /**
@@ -73,14 +262,17 @@ export class NoteTakerCallRepository {
         data: { status: CallStatus.ENDED, endedAt: leftAt },
       });
 
+      await this.updateThreadMessageOnEnd(tx, call, leftAt);
+
       return { shouldEndCall: true, call };
     });
   }
 
   /**
    * Authoritative room-closed fallback (mirrors callRepository.handleRoomFinished),
-   * simplified for note-taker: no SCHEDULED revert, no system message, no
-   * conversation.callId clearing (note-taker calls have no conversation).
+   * simplified for note-taker: no SCHEDULED revert, no system message.
+   * conversation.callId clearing for thread-linked recordings happens inside
+   * updateThreadMessageOnEnd (no-op for recordings with no conversation).
    */
   async handleRoomFinished(params: {
     callExternalId: string;
@@ -100,6 +292,8 @@ export class NoteTakerCallRepository {
         where: { id: call.id },
         data: { status: CallStatus.ENDED, endedAt },
       });
+
+      await this.updateThreadMessageOnEnd(tx, call, endedAt);
 
       return { shouldEndCall: true, call };
     });

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -1,5 +1,6 @@
 import { Prisma, type Call } from '@prisma/client';
 import { repositories } from '@/database/repositories';
+import { noteTakerCallRepository } from '@/database/repositories/noteTakerCallRepository';
 import { logger } from '@/utils/logger';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
@@ -10,7 +11,8 @@ import { findExistingDetailedSummaryCanvas } from '@/services/canvasService';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { tagService, TagServiceError } from '@/tags/service';
 import { tagRepository } from '@/database/repositories/tagRepository';
-import { TAG_FORMAT_REGEX, TagMethod } from '@xyne/shared';
+import { TAG_FORMAT_REGEX, TagMethod, EntityUserAccess } from '@xyne/shared';
+import { recordingSharingService } from '@/services/recordingSharingService';
 import {
   mergeRecordingSummaryMarkedItems,
   type RecordingSummaryMarkedItem,
@@ -155,6 +157,17 @@ class NoteTakerTranscriptService {
         ...(detailedSummary ? { markedItems: detailedSummary.markedItems } : {}),
       });
       await this.queueVespaIndexing(call);
+
+      // Thread-linked recording (started from inside a thread — see
+      // callController's headless-initiate branch): now that the detailed
+      // summary canvas exists, auto-share the recording to that thread's
+      // channel. Must wait until here — recordingSharingService requires both
+      // notesCanvasId AND detailedSummaryCanvasId to be on Call.metadata
+      // before it can sync canvas access, so calling it any earlier (e.g. at
+      // call-start) always fails with "Detailed summary canvas is not ready yet".
+      if (detailedSummary?.canvasId) {
+        await this.shareThreadRecordingIfLinked(call);
+      }
     } finally {
       await releaseLock(lockHandle);
     }
@@ -236,6 +249,41 @@ class NoteTakerTranscriptService {
         : null;
     const stored = metadata?.transcriptEntryCount;
     return typeof stored === 'number' ? stored : -1;
+  }
+
+  /**
+   * Grants the thread's channel VIEW access to this recording (same
+   * EntityAccess/NOTE_TAKER share the manual "share to channel" flow uses),
+   * so every thread/channel member can see the recording message card and
+   * open /recordings/:callId. No-op for recordings not started from a thread
+   * (no channelId on Call.metadata). Best-effort — a failure here must never
+   * block transcript/summary processing.
+   */
+  private async shareThreadRecordingIfLinked(call: Call): Promise<void> {
+    const metadata =
+      call.metadata && typeof call.metadata === 'object' && !Array.isArray(call.metadata)
+        ? (call.metadata as Record<string, unknown>)
+        : {};
+    const channelId = typeof metadata.channelId === 'string' ? metadata.channelId : undefined;
+    if (!channelId) return;
+
+    try {
+      await recordingSharingService.execute(
+        call.externalId,
+        { userId: call.createdByUserId, workspaceId: call.workspaceId },
+        {
+          action: 'grant',
+          targets: [{ type: 'channel', id: channelId }],
+          access: EntityUserAccess.VIEW,
+        },
+      );
+    } catch (error) {
+      logger.error(`[${call.externalId}] thread_channel_share_failed`, {
+        channelId,
+        error,
+        path: 'note_taker',
+      });
+    }
   }
 
   /**
@@ -403,6 +451,19 @@ class NoteTakerTranscriptService {
       try {
         await repositories.calls.update(call.id, { title });
         logger.info(`[${callId}] call_record_updated`, { fields_updated: 'title', path: 'note_taker' });
+        // Thread-linked recording: patch the anchor message's content with
+        // this title too (mirrors how a regular call's ended message shows its
+        // AI text as message.content) so RecordingBubble never needs its own
+        // live query on the Call row just to display the ended-state title.
+        // Best-effort — a failure here must not affect the saved Call.title.
+        try {
+          await noteTakerCallRepository.updateThreadMessageTitle(call.id, title);
+        } catch (messageError) {
+          logger.error(`[${callId}] thread_message_title_update_failed`, {
+            path: 'note_taker',
+            error: messageError,
+          });
+        }
         return true;
       } catch (error) {
         logger.error(`[${callId}] call_record_update_failed`, {

--- a/apps/dashboard/src/components/Call/ThreadRecordingButton/ThreadRecordingButton.tsx
+++ b/apps/dashboard/src/components/Call/ThreadRecordingButton/ThreadRecordingButton.tsx
@@ -1,0 +1,47 @@
+import { MicOn } from '@xyne/icons';
+import { Button } from '../../ui/Button';
+import Tooltip from '../../ui/Tooltip';
+
+interface ThreadRecordingButtonProps {
+  onStartRecording: () => void;
+  hasActiveRecording?: boolean;
+  testId?: string;
+  trackCategory?: string;
+  trackName?: string;
+  trackMetadata?: Record<string, unknown>;
+}
+
+/**
+ * "Take notes" button for thread/conversation headers — starts a headless
+ * (note-taker) recording anchored to this thread. Matches ThreadCallButton's
+ * sizing/placement (28px ghost, single icon) so the two sit naturally side by
+ * side in the conversation-header action row.
+ */
+export const ThreadRecordingButton = ({
+  onStartRecording,
+  hasActiveRecording = false,
+  testId = 'thread-start-recording-button',
+  trackCategory,
+  trackName,
+  trackMetadata,
+}: ThreadRecordingButtonProps) => {
+  return (
+    <Tooltip content={hasActiveRecording ? 'Recording already in progress' : 'Take notes'}>
+      <Button
+        variant='ghost'
+        size='sm'
+        onClick={onStartRecording}
+        disabled={hasActiveRecording}
+        className='h-7 w-7 rounded-lg text-muted-foreground hover:text-foreground'
+        data-testid={testId}
+        {...(trackCategory && { 'data-track-category': trackCategory })}
+        {...(trackName && { 'data-track-name': trackName })}
+        {...(trackMetadata && {
+          'data-track-metadata': JSON.stringify(trackMetadata),
+        })}
+      >
+        <MicOn size={16} />
+      </Button>
+    </Tooltip>
+  );
+};

--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -98,6 +98,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { DatePicker } from '../../ui/DatePicker/DatePicker';
 import { appsService, type AppShortcutWithApp } from '../../../services/Apps/appsService';
 import { ShortcutPickerModal } from '../../Apps/ShortcutPickerModal/ShortcutPickerModal';
+import { sendRecordingEvent, useRecordingStore } from '../../../hooks/useRecordingStore';
+import { getRecordingDefaultLayout } from '../../../hooks/useRecordingDefaultLayout';
 import { parseRecordingShareMessage } from '../../ui/MessageBubble/recordingShareMessage';
 
 export interface ThreadData {
@@ -472,6 +474,30 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
 
   const handleInitiateCall = (): void => {
     setShowParticipantsModal(true);
+  };
+
+  // Starts a headless ("take notes") recording anchored to this message's
+  // thread — directly via the recording store (no navigation), same as the
+  // ThreadPannel "Take notes" button. Only rendered for the thread's root
+  // message (see HoverActionsToolbar's messageId === initialMessageId gate).
+  const recordingStatus = useRecordingStore(ctx => ctx.status);
+  const handleStartRecordingFromMessage = (): void => {
+    const targetConversationId = conversation?.conversationId || message.conversationId;
+    if (!targetConversationId || !channelId) return;
+    if (recordingStatus !== 'idle' && recordingStatus !== 'error') {
+      toast.info('A recording is already in progress');
+      return;
+    }
+    sendRecordingEvent({ type: 'clearTranscripts' });
+    sendRecordingEvent({
+      type: 'startRecording',
+      defaultLayout: getRecordingDefaultLayout(),
+      conversationId: targetConversationId,
+      channelId,
+    });
+    toast.success('Recording started', {
+      description: 'Taking notes in the background \u2014 open Recordings anytime to view it live.',
+    });
   };
 
   const handleAddBookmark = (): void => {
@@ -1022,6 +1048,8 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
         !isMessageDeleted && {
           onInitiateCall: handleInitiateCall,
           isCallDisabled: hasActiveCallForConversation,
+          onStartRecording: handleStartRecordingFromMessage,
+          isRecordingDisabled: recordingStatus !== 'idle' && recordingStatus !== 'error',
         }),
       ...(conversation &&
         (!isSystemMessage || isTicketCreationMessage) &&
@@ -1347,6 +1375,8 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
                 !isMessageDeleted && {
                   onInitiateCall: handleInitiateCall,
                   isCallDisabled: hasActiveCallForConversation,
+                  onStartRecording: handleStartRecordingFromMessage,
+                  isRecordingDisabled: recordingStatus !== 'idle' && recordingStatus !== 'error',
                 })}
               {...(conversation &&
                 (!isSystemMessage || isTicketCreationMessage) &&

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   Copy,
   Headphones,
+  Mic,
   Pin,
   CornerUpLeft,
   SquareAsterisk,
@@ -86,6 +87,9 @@ export interface HoverActionsToolbarProps {
   onMarkAsUnread?: () => void;
   onInitiateCall?: () => void;
   isCallDisabled?: boolean;
+  /** Starts a headless ("take notes") recording anchored to this thread. */
+  onStartRecording?: () => void;
+  isRecordingDisabled?: boolean;
   isChannelArchived?: boolean;
   /** MESSAGE shortcuts for this channel — shown in the More Actions dropdown */
   messageShortcuts?: AppShortcutWithApp[];
@@ -140,6 +144,8 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
   onMarkAsUnread,
   onInitiateCall,
   isCallDisabled = false,
+  onStartRecording,
+  isRecordingDisabled = false,
   isChannelArchived = false,
   messageShortcuts,
   onRunShortcut,
@@ -312,6 +318,28 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
             data-track-metadata={JSON.stringify({ messageId })}
           >
             <Headphones className='w-4 h-4' />
+          </Button>
+        </Tooltip>
+      )}
+
+      {/* Start Recording (Take Notes) */}
+      {onStartRecording && messageId === initialMessageId && !isChannelArchived && (
+        <Tooltip
+          content={isRecordingDisabled ? 'Recording in progress' : 'Take notes'}
+          side='top'
+        >
+          <Button
+            variant='ghost'
+            className='size-7 text-muted-foreground'
+            onClick={onStartRecording}
+            disabled={isRecordingDisabled}
+            title={isRecordingDisabled ? 'Recording in progress' : 'Take notes'}
+            data-testid='hover-action-start-recording'
+            data-track-category='HOVER_ACTIONS_TOOLBAR'
+            data-track-name='START_RECORDING_FROM_MESSAGE'
+            data-track-metadata={JSON.stringify({ messageId })}
+          >
+            <Mic className='w-4 h-4' />
           </Button>
         </Tooltip>
       )}

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
@@ -324,10 +324,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
 
       {/* Start Recording (Take Notes) */}
       {onStartRecording && messageId === initialMessageId && !isChannelArchived && (
-        <Tooltip
-          content={isRecordingDisabled ? 'Recording in progress' : 'Take notes'}
-          side='top'
-        >
+        <Tooltip content={isRecordingDisabled ? 'Recording in progress' : 'Take notes'} side='top'>
           <Button
             variant='ghost'
             className='size-7 text-muted-foreground'

--- a/apps/dashboard/src/components/Chat/MessageActionsDrawer/MessageActionsDrawer.tsx
+++ b/apps/dashboard/src/components/Chat/MessageActionsDrawer/MessageActionsDrawer.tsx
@@ -13,6 +13,7 @@ import {
   Forward,
   Copy,
   Headphones,
+  Mic,
   ArrowLeft,
   Clock3,
 } from 'lucide-react';
@@ -59,6 +60,9 @@ export interface MessageActionsDrawerProps {
   onMarkAsUnread?: () => void;
   onInitiateCall?: () => void;
   isCallDisabled?: boolean;
+  /** Starts a headless ("take notes") recording anchored to this thread. */
+  onStartRecording?: () => void;
+  isRecordingDisabled?: boolean;
   isChannelArchived?: boolean;
   onCopyImage?: () => void;
 }
@@ -90,6 +94,8 @@ export const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
   onMarkAsUnread,
   onInitiateCall,
   isCallDisabled = false,
+  onStartRecording,
+  isRecordingDisabled = false,
   isChannelArchived = false,
   onCopyImage,
 }) => {
@@ -226,6 +232,16 @@ export const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
                       label={isCallDisabled ? 'Call already in progress' : 'Start Call'}
                       onClick={() => handleActionClick(onInitiateCall)}
                       disabled={isCallDisabled}
+                    />
+                  )}
+
+                  {/* Start Recording (Take Notes) */}
+                  {onStartRecording && messageId === initialMessageId && !isChannelArchived && (
+                    <ActionButton
+                      icon={<Mic className='w-5 h-5' />}
+                      label={isRecordingDisabled ? 'Recording in progress' : 'Take Notes'}
+                      onClick={() => handleActionClick(onStartRecording)}
+                      disabled={isRecordingDisabled}
                     />
                   )}
 

--- a/apps/dashboard/src/components/Chat/ReplyLayout/ReplyLayoutV2.tsx
+++ b/apps/dashboard/src/components/Chat/ReplyLayout/ReplyLayoutV2.tsx
@@ -34,6 +34,18 @@ const ReplyLayoutV2: React.FC<{
   const twinBadge = useTwinDraftBadge(replies?.conversation?.conversationId);
   const showTwinDraft = !isThreadOpen && !!twinBadge;
 
+  // A thread-linked "take notes" recording sets conversation.callId while
+  // ACTIVE (mirrors how a regular in-thread call does) and clears it when it
+  // ends — see noteTakerCallRepository. conversation.metadata.isHeadlessRecording
+  // is stamped/cleared alongside it, so both checks read directly off this
+  // already-subscribed conversation row — no separate per-thread-row query.
+  const activeCallId = replies?.conversation?.callId;
+  const conversationMetadata = replies?.conversation?.metadata as
+    | { isHeadlessRecording?: boolean }
+    | null
+    | undefined;
+  const isRecordingActive = !!activeCallId && conversationMetadata?.isHeadlessRecording === true;
+
   // For showInChannel messages, show "View newer replies" only if there are newer replies in the parent thread
   // parentReplyCount is the current reply count in the original thread
   // replies.replyCount is the reply count at the time this message was shown in channel
@@ -94,6 +106,16 @@ const ReplyLayoutV2: React.FC<{
           <span className='font-medium text-foreground'>
             {replies.replyCount} {replies.replyCount === 1 ? 'reply' : 'replies'}
             {inlineDraftCount > 0 && ` and ${draftWord(inlineDraftCount)}`}
+          </span>
+        )}
+
+        {isRecordingActive && (
+          <span className='flex items-center gap-1 shrink-0 font-medium text-status-success'>
+            <span className='relative flex size-1.5'>
+              <span className='animate-ping absolute inline-flex h-full w-full rounded-full bg-status-success opacity-75' />
+              <span className='relative inline-flex rounded-full size-1.5 bg-status-success' />
+            </span>
+            Recording
           </span>
         )}
 

--- a/apps/dashboard/src/components/Chat/ReplyLayout/ReplyLayoutV2.tsx
+++ b/apps/dashboard/src/components/Chat/ReplyLayout/ReplyLayoutV2.tsx
@@ -110,10 +110,10 @@ const ReplyLayoutV2: React.FC<{
         )}
 
         {isRecordingActive && (
-          <span className='flex items-center gap-1 shrink-0 font-medium text-status-success'>
+          <span className='flex items-center gap-1 shrink-0 font-medium text-status-failure'>
             <span className='relative flex size-1.5'>
-              <span className='animate-ping absolute inline-flex h-full w-full rounded-full bg-status-success opacity-75' />
-              <span className='relative inline-flex rounded-full size-1.5 bg-status-success' />
+              <span className='animate-ping absolute inline-flex h-full w-full rounded-full bg-status-failure opacity-75' />
+              <span className='relative inline-flex rounded-full size-1.5 bg-status-failure' />
             </span>
             Recording
           </span>

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -1070,7 +1070,9 @@ export const ThreadMessages = ({
                     {derivedConversationId && (
                       <ThreadRecordingButton
                         onStartRecording={handleStartRecordingFromThread}
-                        hasActiveRecording={recordingStatus !== 'idle' && recordingStatus !== 'error'}
+                        hasActiveRecording={
+                          recordingStatus !== 'idle' && recordingStatus !== 'error'
+                        }
                         trackCategory='THREAD_PANEL'
                         trackName='START_RECORDING_FROM_THREAD'
                         trackMetadata={{

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -95,6 +95,9 @@ import { useSelf, useUser } from '../../hooks/useUsers';
 import { CallParticipantsSelectionModal } from '../Call/CallParticipantsSelectionModal';
 import { ScheduleCallModal } from '../Call/ScheduleCallModal/ScheduleCallModal';
 import { ThreadCallButton } from '../Call/ThreadCallButton/ThreadCallButton';
+import { ThreadRecordingButton } from '../Call/ThreadRecordingButton/ThreadRecordingButton';
+import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
+import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { ConversationTabContext } from './ConversationTabContext';
 
 type TabType = 'thread' | 'details' | 'files' | 'rca';
@@ -371,6 +374,10 @@ export const ThreadMessages = ({
   };
   // Call participants modal state
   const [showParticipantsModal, setShowParticipantsModal] = useState(false);
+
+  // Global recording status — used to guard the thread "Take notes" button
+  // against starting a second recording while one is already in progress.
+  const recordingStatus = useRecordingStore(ctx => ctx.status);
 
   // Navigation for thread summary
   const navigate = useNavigate();
@@ -815,6 +822,29 @@ export const ThreadMessages = ({
     setShowParticipantsModal(true);
   };
 
+  // Starts a headless (note-taker) recording anchored to this thread: posts
+  // one anchor message into the thread now and connects the mic in the
+  // background via the recording store directly (no navigation) — the user
+  // stays in the thread and can open /recordings/:callId later from the
+  // message that appears, or from the sidebar, whenever they want.
+  const handleStartRecordingFromThread = (): void => {
+    if (!derivedConversationId || !derivedChannelId) return;
+    if (recordingStatus !== 'idle' && recordingStatus !== 'error') {
+      toast.info('A recording is already in progress');
+      return;
+    }
+    sendRecordingEvent({ type: 'clearTranscripts' });
+    sendRecordingEvent({
+      type: 'startRecording',
+      defaultLayout: getRecordingDefaultLayout(),
+      conversationId: derivedConversationId,
+      channelId: derivedChannelId,
+    });
+    toast.success('Recording started', {
+      description: 'Taking notes in the background \u2014 open Recordings anytime to view it live.',
+    });
+  };
+
   const handleTicketCreated = (): void => {
     toast.success('Success', {
       description: 'Ticket created successfully',
@@ -1036,6 +1066,19 @@ export const ThreadMessages = ({
                         }}
                       />
                     )}
+                    {/* Start Recording (Take Notes) Button */}
+                    {derivedConversationId && (
+                      <ThreadRecordingButton
+                        onStartRecording={handleStartRecordingFromThread}
+                        hasActiveRecording={recordingStatus !== 'idle' && recordingStatus !== 'error'}
+                        trackCategory='THREAD_PANEL'
+                        trackName='START_RECORDING_FROM_THREAD'
+                        trackMetadata={{
+                          channelId: channel?.id,
+                          conversationId: derivedConversationId,
+                        }}
+                      />
+                    )}
                   </div>
                 </Tabs.List>
               </div>
@@ -1206,6 +1249,16 @@ export const ThreadMessages = ({
                   hasActiveCall={hasActiveCallForConversation}
                   trackCategory='THREAD_PANEL'
                   trackName='INITIATE_CALL_FROM_THREAD'
+                  trackMetadata={{ channelId: channel?.id, conversationId: derivedConversationId }}
+                />
+              )}
+              {/* Start Recording (Take Notes) Button */}
+              {derivedConversationId && (
+                <ThreadRecordingButton
+                  onStartRecording={handleStartRecordingFromThread}
+                  hasActiveRecording={recordingStatus !== 'idle' && recordingStatus !== 'error'}
+                  trackCategory='THREAD_PANEL'
+                  trackName='START_RECORDING_FROM_THREAD'
                   trackMetadata={{ channelId: channel?.id, conversationId: derivedConversationId }}
                 />
               )}
@@ -1558,6 +1611,20 @@ export const ThreadMessages = ({
                       hasActiveCall={hasActiveCallForConversation}
                       trackCategory='THREAD_PANEL'
                       trackName='INITIATE_CALL_FROM_THREAD'
+                      trackMetadata={{
+                        channelId: channel?.id,
+                        conversationId: derivedConversationId,
+                      }}
+                    />
+                  )}
+
+                  {/* Start Recording (Take Notes) Button */}
+                  {derivedConversationId && !channel?.isArchived && (
+                    <ThreadRecordingButton
+                      onStartRecording={handleStartRecordingFromThread}
+                      hasActiveRecording={recordingStatus !== 'idle' && recordingStatus !== 'error'}
+                      trackCategory='THREAD_PANEL'
+                      trackName='START_RECORDING_FROM_THREAD'
                       trackMetadata={{
                         channelId: channel?.id,
                         conversationId: derivedConversationId,

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -878,7 +878,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
               >
                 <MicOn
                   size={16}
-                  color={isRecordingEnded ? 'hsl(var(--foreground) / 0.8)' : 'var(--status-success)'}
+                  color={
+                    isRecordingEnded ? 'hsl(var(--foreground) / 0.8)' : 'var(--status-success)'
+                  }
                 />
               </div>
             ) : showAvatar && sender?.userType === UserType.APP ? (

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -874,12 +874,12 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
               </div>
             ) : showAvatar && isRecordingMessage && !isForwardedMessage ? (
               <div
-                className={`w-8 h-8 rounded-md flex items-center justify-center self-center shrink-0 border ${isRecordingEnded ? 'bg-muted-foreground/10 border-border/25' : 'bg-status-success/15 border-status-success/30'}`}
+                className={`w-8 h-8 rounded-md flex items-center justify-center self-center shrink-0 border ${isRecordingEnded ? 'bg-muted-foreground/10 border-border/25' : 'bg-status-failure/15 border-status-failure/30'}`}
               >
                 <MicOn
                   size={16}
                   color={
-                    isRecordingEnded ? 'hsl(var(--foreground) / 0.8)' : 'var(--status-success)'
+                    isRecordingEnded ? 'hsl(var(--foreground) / 0.8)' : 'var(--status-failure)'
                   }
                 />
               </div>

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -62,6 +62,7 @@ import { NonParticipantActions } from './NonParticipantActions';
 import { PostedInLink } from './PostedInLink';
 import { MessageHeader } from './MessageHeader';
 import HuddleIcon from '../../icons/HuddleIcon';
+import { MicOn } from '@xyne/icons';
 import workflowBotAvatar from './workflowBotAvatar.png';
 import { downloadAttachment } from '../../Chat/MessageAttachment/utils';
 import { PendingIcon } from '../../../assets/icons/WorkflowIcons';
@@ -73,6 +74,7 @@ import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { StatusIndicator } from '../StatusIndicator';
 import DOMPurify from 'dompurify';
 import { CallBubble } from './CallBubble';
+import { RecordingBubble } from './RecordingBubble';
 import { getEmojiDisplayName, renderEmoji } from '../../../utils/customEmojiUtils';
 import { parseMarkdownWithTicketSuggestions } from '../../../utils/markdownTicketSuggestions';
 import { TicketSuggestions } from './TicketSuggestions';
@@ -595,6 +597,16 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   const ticketAttachments = isTicketCardMessage ? (conversation?.ticket?.attachments ?? []) : [];
   const isCallMessage = metadata?.isCallMessage === true;
   const isActiveCall = useIsCallActive(metadata?.callId);
+  // Anchor message for a headless recording started from a thread (see
+  // RecordingBubble) — deliberately independent of isCallMessage so it never
+  // picks up call-only behavior (transcript dimming, forwarding-as-call, PRD
+  // buttons, etc).
+  const isRecordingMessage = metadata?.['isRecordingMessage'] === true;
+  // Synchronous end-signal from the message's own metadata (stamped by
+  // noteTakerCallRepository.updateThreadMessageOnEnd) — mirrors isActiveCall's
+  // active/ended split for the avatar box below, without needing a live query
+  // at this level (RecordingBubble already does that for its own rendering).
+  const isRecordingEnded = metadata?.['operation'] === 'recording_ended';
   const hasTranscript = attachments.some(
     a =>
       a.mimetype === 'text/plain' ||
@@ -839,7 +851,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
         {/* ================== LEFT AVATAR ================== */}
         {!contentOnly && (
           <div
-            className={`w-8 h-full flex items-start justify-center ${showAvatar && !isWorkflowMessage ? 'pt-[4px]' : ''}`}
+            className={`w-8 h-full flex items-start justify-center ${showAvatar && !isWorkflowMessage && !isRecordingMessage ? 'pt-[4px]' : ''}`}
           >
             {message.isDeleted ? (
               <div className='w-8 h-8 rounded-md flex items-center justify-center bg-muted'>
@@ -858,6 +870,15 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
               >
                 <HuddleIcon
                   color={isActiveCall ? 'var(--status-success)' : 'hsl(var(--foreground) / 0.8)'}
+                />
+              </div>
+            ) : showAvatar && isRecordingMessage && !isForwardedMessage ? (
+              <div
+                className={`w-8 h-8 rounded-md flex items-center justify-center self-center shrink-0 border ${isRecordingEnded ? 'bg-muted-foreground/10 border-border/25' : 'bg-status-success/15 border-status-success/30'}`}
+              >
+                <MicOn
+                  size={16}
+                  color={isRecordingEnded ? 'hsl(var(--foreground) / 0.8)' : 'var(--status-success)'}
                 />
               </div>
             ) : showAvatar && sender?.userType === UserType.APP ? (
@@ -1031,6 +1052,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                       message.content ||
                       'A call happened'}
                 </h3>
+              ) : isRecordingMessage && !isForwardedMessage ? (
+                <h3 className='text-sm font-medium text-foreground'>Recording</h3>
               ) : isXyneBot ? (
                 <h3 className='text-sm font-medium text-foreground'>
                   {getUserDisplayName(sender) || 'AI Assistant'}
@@ -1162,7 +1185,17 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
             )}
 
           {/* ================== MESSAGE CONTENT ================== */}
-          {isCallMessage && metadata?.callId && !isForwardedMessage ? (
+          {isRecordingMessage && metadata?.callId && !isForwardedMessage ? (
+            <RecordingBubble
+              message={{
+                messageId: message.messageId,
+                content: message.content,
+                createdAt: message.createdAt,
+                metadata,
+              }}
+              callId={metadata.callId}
+            />
+          ) : isCallMessage && metadata?.callId && !isForwardedMessage ? (
             <CallBubble
               message={{
                 messageId: message.messageId,

--- a/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AudioLines } from 'lucide-react';
+import { useCallDuration } from '../../../hooks/useCalls';
+import { RecordingSharePill } from './RecordingSharePill';
+import { MessageMetadata } from './MessageBubble.utils';
+
+interface RecordingBubbleProps {
+  message: {
+    messageId: string;
+    content: string;
+    createdAt: number | Date;
+    metadata: MessageMetadata | null;
+  };
+  callId: string;
+}
+
+/**
+ * RecordingBubble — the single anchor message posted when a headless
+ * ("take notes") recording is started from inside a thread.
+ *
+ * Mirrors the CALL message mechanic (one message that live-anchors a
+ * pill/overlay while the thing is in progress, then settles into a normal
+ * card once it ends — see CallBubble/CallMessageOverlay) but with its own,
+ * distinct visuals: a recording has no join/participants concept, so it's
+ * a single always-clickable card rather than a header + overlay pair.
+ *
+ * Same trick CallBubble uses to avoid a per-message live query: everything
+ * needed to render is already on the message itself. The anchor message is
+ * only ever created once the recording is actually live (see
+ * noteTakerCallRepository.createThreadAnchorMessage), so its mere existence
+ * means "active"; `metadata.operation === 'recording_ended'` (stamped by
+ * updateThreadMessageOnEnd) flips it to "ended"; and the AI-generated title
+ * is patched directly onto message.content once ready (updateThreadMessageTitle)
+ * instead of living only on the Call row. No Zero query on `calls` needed.
+ */
+export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callId }) => {
+  const navigate = useNavigate();
+
+  const metadata = message.metadata;
+  const isEnded = metadata?.['operation'] === 'recording_ended';
+  const isActive = !isEnded;
+  const startedAt = message.createdAt ? Number(message.createdAt) : undefined;
+  const duration = useCallDuration(startedAt, isActive);
+
+  const goToRecording = (): void => {
+    void navigate(`/recordings/${callId}`);
+  };
+
+  if (isEnded) {
+    const durationMs = typeof metadata?.['durationMs'] === 'number' ? metadata['durationMs'] : null;
+    const title = message.content || 'Recording notes';
+
+    // Reuses the exact same pill used when a recording is manually shared to
+    // a channel (RecordingShareContent/RecordingSharePill) — keeps "a
+    // recording card in a message" looking identical everywhere instead of
+    // maintaining a second, slightly-different design here.
+    return <RecordingSharePill title={title} durationMs={durationMs} onOpen={goToRecording} />;
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={goToRecording}
+      className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-status-success/30 bg-status-success/5 hover:bg-status-success/10 transition-colors px-3 py-1.5 text-left'
+      data-testid='recording-active-card'
+      data-track-category='RECORDING'
+      data-track-name='OPEN_LIVE_RECORDING_FROM_THREAD'
+    >
+      <span className='flex size-5 shrink-0 items-center justify-center rounded-md border border-status-success/30 bg-status-success/15'>
+        <AudioLines size={12} strokeWidth={2.5} className='text-status-success' />
+      </span>
+      <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>
+        Recording notes
+        <span className='ml-1.5 font-normal text-xs text-muted-foreground'>
+          {duration ? `${duration} elapsed` : 'Just started'}
+        </span>
+      </span>
+      <span className='text-xs font-medium text-status-success shrink-0 rounded-full border border-status-success/30 px-2 py-0.5'>
+        View
+      </span>
+    </button>
+  );
+};

--- a/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AudioLines } from 'lucide-react';
+import { useAuth } from '../../../hooks/useAuth';
 import { useCallDuration } from '../../../hooks/useCalls';
 import { RecordingSharePill } from './RecordingSharePill';
 import { MessageMetadata } from './MessageBubble.utils';
@@ -36,14 +37,20 @@ interface RecordingBubbleProps {
  */
 export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callId }) => {
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   const metadata = message.metadata;
   const isEnded = metadata?.['operation'] === 'recording_ended';
   const isActive = !isEnded;
   const startedAt = message.createdAt ? Number(message.createdAt) : undefined;
   const duration = useCallDuration(startedAt, isActive);
+  // Only the recording's creator has view access (see callShareService.canView)
+  // until it's explicitly shared — other thread participants would just land
+  // on a not-found/access-denied screen, so don't offer them the click at all.
+  const canView = !!user?.id && metadata?.createdBy === user.id;
 
   const goToRecording = (): void => {
+    if (!canView) return;
     void navigate(`/recordings/${callId}`);
   };
 
@@ -55,14 +62,15 @@ export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callI
     // a channel (RecordingShareContent/RecordingSharePill) — keeps "a
     // recording card in a message" looking identical everywhere instead of
     // maintaining a second, slightly-different design here.
-    return <RecordingSharePill title={title} durationMs={durationMs} onOpen={goToRecording} />;
+    return <RecordingSharePill title={title} durationMs={durationMs} onOpen={canView ? goToRecording : undefined} />;
   }
 
   return (
     <button
       type='button'
       onClick={goToRecording}
-      className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-status-success/30 bg-status-success/5 hover:bg-status-success/10 transition-colors px-3 py-1.5 text-left'
+      disabled={!canView}
+      className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-status-success/30 bg-status-success/5 enabled:hover:bg-status-success/10 transition-colors px-3 py-1.5 text-left disabled:cursor-default'
       data-testid='recording-active-card'
       data-track-category='RECORDING'
       data-track-name='OPEN_LIVE_RECORDING_FROM_THREAD'
@@ -76,9 +84,15 @@ export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callI
           {duration ? `${duration} elapsed` : 'Just started'}
         </span>
       </span>
-      <span className='text-xs font-medium text-status-success shrink-0 rounded-full border border-status-success/30 px-2 py-0.5'>
-        View
+      <span className='relative flex size-2 shrink-0' aria-hidden='true'>
+        <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-status-success opacity-75' />
+        <span className='relative inline-flex size-2 rounded-full bg-status-success' />
       </span>
+      {canView && (
+        <span className='text-xs font-medium text-status-success shrink-0 rounded-full border border-status-success/30 px-2 py-0.5'>
+          View
+        </span>
+      )}
     </button>
   );
 };

--- a/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
@@ -76,13 +76,13 @@ export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callI
       type='button'
       onClick={goToRecording}
       disabled={!canView}
-      className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-status-success/30 bg-status-success/5 enabled:hover:bg-status-success/10 transition-colors px-3 py-1.5 text-left disabled:cursor-default'
+      className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-border bg-card enabled:hover:bg-muted/50 transition-colors px-3 py-1.5 text-left disabled:cursor-default'
       data-testid='recording-active-card'
       data-track-category='RECORDING'
       data-track-name='OPEN_LIVE_RECORDING_FROM_THREAD'
     >
-      <span className='flex size-5 shrink-0 items-center justify-center rounded-md border border-status-success/30 bg-status-success/15'>
-        <AudioLines size={12} strokeWidth={2.5} className='text-status-success' />
+      <span className='flex size-5 shrink-0 items-center justify-center rounded-md bg-muted'>
+        <AudioLines size={12} strokeWidth={2.5} className='text-muted-foreground' />
       </span>
       <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>
         Recording notes
@@ -91,11 +91,11 @@ export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callI
         </span>
       </span>
       <span className='relative flex size-2 shrink-0' aria-hidden='true'>
-        <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-status-success opacity-75' />
-        <span className='relative inline-flex size-2 rounded-full bg-status-success' />
+        <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-status-failure opacity-75' />
+        <span className='relative inline-flex size-2 rounded-full bg-status-failure' />
       </span>
       {canView && (
-        <span className='text-xs font-medium text-status-success shrink-0 rounded-full border border-status-success/30 px-2 py-0.5'>
+        <span className='text-xs font-medium text-foreground shrink-0 rounded-full border border-border px-2 py-0.5'>
           View
         </span>
       )}

--- a/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
@@ -62,7 +62,13 @@ export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callI
     // a channel (RecordingShareContent/RecordingSharePill) — keeps "a
     // recording card in a message" looking identical everywhere instead of
     // maintaining a second, slightly-different design here.
-    return <RecordingSharePill title={title} durationMs={durationMs} onOpen={canView ? goToRecording : undefined} />;
+    return (
+      <RecordingSharePill
+        title={title}
+        durationMs={durationMs}
+        onOpen={canView ? goToRecording : undefined}
+      />
+    );
   }
 
   return (

--- a/apps/dashboard/src/components/ui/MessageBubble/RecordingSharePill.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RecordingSharePill.tsx
@@ -6,7 +6,7 @@ import { formatElapsedTime } from '../../../utils/recordingUtils';
 interface RecordingSharePillProps {
   title: string;
   durationMs: number | null;
-  onOpen: () => void;
+  onOpen?: (() => void) | undefined;
 }
 
 export const RecordingSharePill: React.FC<RecordingSharePillProps> = ({
@@ -18,9 +18,10 @@ export const RecordingSharePill: React.FC<RecordingSharePillProps> = ({
     type='button'
     onClick={event => {
       event.stopPropagation();
-      onOpen();
+      onOpen?.();
     }}
-    className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-1.5 text-left shadow-sm'
+    disabled={!onOpen}
+    className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-1.5 text-left shadow-sm disabled:cursor-default'
     aria-label={`Open recording ${title}`}
     data-track-category='MESSAGE'
     data-track-name='OPEN_SHARED_RECORDING'
@@ -40,11 +41,13 @@ export const RecordingSharePill: React.FC<RecordingSharePillProps> = ({
       </span>
     )}
 
-    <ChevronRight
-      size={16}
-      strokeWidth={2.5}
-      className='shrink-0 text-muted-foreground transition-transform'
-      aria-hidden='true'
-    />
+    {onOpen && (
+      <ChevronRight
+        size={16}
+        strokeWidth={2.5}
+        className='shrink-0 text-muted-foreground transition-transform'
+        aria-hidden='true'
+      />
+    )}
   </button>
 );

--- a/apps/dashboard/src/hooks/useRecordingStore.ts
+++ b/apps/dashboard/src/hooks/useRecordingStore.ts
@@ -12,13 +12,15 @@ interface RecordingStoreSnapshot {
 }
 
 export type RecordingStoreEvent =
-  | { type: 'requestAutoStart' }
+  | { type: 'requestAutoStart'; conversationId?: string; channelId?: string }
   | { type: 'clearAutoStart' }
   | { type: 'requestStop' }
   | {
       type: 'startRecording';
       sttModel?: 'google' | 'azure' | 'deepgram';
       defaultLayout?: RecordingLayout;
+      conversationId?: string;
+      channelId?: string;
     }
   | {
       type: 'recordingStarted';

--- a/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
@@ -156,6 +156,8 @@ export default function RecordingsScreen(): ReactElement {
   const notesCanvasId = useRecordingStore(ctx => ctx.notesCanvasId);
   const pendingAutoStart = useRecordingStore(ctx => ctx.pendingAutoStart);
   const autoStartRequestedAt = useRecordingStore(ctx => ctx.autoStartRequestedAt);
+  const pendingConversationId = useRecordingStore(ctx => ctx.pendingConversationId);
+  const pendingChannelId = useRecordingStore(ctx => ctx.pendingChannelId);
   const pendingStop = useRecordingStore(ctx => ctx.pendingStop);
   const agentLeft = useRecordingStore(ctx => ctx.agentLeft);
   const room = useRecordingStore(ctx => ctx.room);
@@ -204,7 +206,13 @@ export default function RecordingsScreen(): ReactElement {
   const handleStartRecording = (): void => {
     const defaultLayout = getRecordingDefaultLayout();
     sendRecordingEvent({ type: 'clearTranscripts' });
-    sendRecordingEvent({ type: 'startRecording', sttModel, defaultLayout });
+    sendRecordingEvent({
+      type: 'startRecording',
+      sttModel,
+      defaultLayout,
+      ...(pendingConversationId && { conversationId: pendingConversationId }),
+      ...(pendingChannelId && { channelId: pendingChannelId }),
+    });
   };
 
   // Auto-start recording when triggered from the meeting popup, tray or shortcut

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -222,6 +222,7 @@ interface InitiateCallResponse {
   callId?: string;
   channelId: string | null;
   notesCanvasId: string;
+  conversationId?: string;
 }
 
 interface RecordingsResponse {
@@ -239,10 +240,15 @@ interface RecordingDetailResponse {
 class RecordingService {
   /**
    * Start a headless recording session
-   * Calls backend to initiate a HEADLESS call and returns LiveKit credentials
+   * Calls backend to initiate a HEADLESS call and returns LiveKit credentials.
+   * When `conversationId` + `channelId` are provided (recording started from a
+   * thread), the backend posts a single anchor message into that conversation
+   * that live-updates as the recording progresses and ends.
    */
   async startRecording(params?: {
     sttModel?: 'google' | 'azure' | 'deepgram';
+    conversationId?: string;
+    channelId?: string;
   }): Promise<RecordingSession> {
     const response: AxiosResponse<InitiateCallResponse> = await apiInstance.post(
       '/calls/initiate',
@@ -250,6 +256,8 @@ class RecordingService {
         isHeadless: true,
         callType: CallType.AUDIO,
         sttModel: params?.sttModel || 'google',
+        ...(params?.conversationId && { conversationId: params.conversationId }),
+        ...(params?.channelId && { channelId: params.channelId }),
       },
     );
 

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -72,6 +72,12 @@ export interface RecordingState {
   sttModel: SttModel;
   pendingAutoStart: boolean;
   autoStartRequestedAt: number | null;
+  /** conversationId/channelId of the thread that triggered `requestAutoStart`,
+   * consumed by RecordingsScreen's auto-start effect and forwarded to
+   * recordingService.startRecording so the backend can post/update the
+   * thread's anchor message. Cleared as soon as the recording actually starts. */
+  pendingConversationId: string | null;
+  pendingChannelId: string | null;
   pendingStop: boolean;
   /** Canvas created as part of starting a headless recording. */
   notesCanvasId: string | null;
@@ -102,6 +108,8 @@ const initialContext: RecordingState = {
   markedMoments: [],
   pendingAutoStart: false,
   autoStartRequestedAt: null,
+  pendingConversationId: null,
+  pendingChannelId: null,
   pendingStop: false,
   notesCanvasId: null,
   notesCanvasViewAccessId: null,
@@ -118,16 +126,23 @@ export const recordingStore = createStore({
   context: initialContext,
   on: {
     // Actions
-    requestAutoStart: (context): RecordingState => ({
+    requestAutoStart: (
+      context,
+      event: { conversationId?: string; channelId?: string } = {},
+    ): RecordingState => ({
       ...context,
       pendingAutoStart: true,
       autoStartRequestedAt: Date.now(),
+      pendingConversationId: event.conversationId ?? null,
+      pendingChannelId: event.channelId ?? null,
     }),
 
     clearAutoStart: (context): RecordingState => ({
       ...context,
       pendingAutoStart: false,
       autoStartRequestedAt: null,
+      pendingConversationId: null,
+      pendingChannelId: null,
     }),
 
     requestStop: (context): RecordingState => {
@@ -144,17 +159,28 @@ export const recordingStore = createStore({
 
     startRecording: (
       context,
-      event: { sttModel?: SttModel; defaultLayout?: RecordingLayout },
+      event: {
+        sttModel?: SttModel;
+        defaultLayout?: RecordingLayout;
+        conversationId?: string;
+        channelId?: string;
+      },
     ): RecordingState => {
       const sttModel = event.sttModel || context.sttModel;
       const defaultLayout = event.defaultLayout ?? 'transcript';
+      const conversationId = event.conversationId ?? context.pendingConversationId ?? undefined;
+      const threadChannelId = event.channelId ?? context.pendingChannelId ?? undefined;
 
       // Set starting status
       recordingStore.send({ type: 'setStatus', status: 'starting' });
 
       // Call API to start recording
       recordingService
-        .startRecording({ sttModel })
+        .startRecording({
+          sttModel,
+          ...(conversationId ? { conversationId } : {}),
+          ...(threadChannelId ? { channelId: threadChannelId } : {}),
+        })
         .then(async session => {
           // Create LiveKit room
           const room = new Room();
@@ -204,6 +230,8 @@ export const recordingStore = createStore({
         sttModel,
         error: null,
         pendingAutoStart: false,
+        pendingConversationId: null,
+        pendingChannelId: null,
         pendingStop: false,
         activeLayout: defaultLayout,
       };
@@ -455,6 +483,8 @@ export const recordingStore = createStore({
         markedMoments: [],
         pendingAutoStart: false,
         autoStartRequestedAt: null,
+        pendingConversationId: null,
+        pendingChannelId: null,
         pendingStop: false,
         notesCanvasId: null,
         notesCanvasViewAccessId: null,
@@ -520,6 +550,8 @@ export const recordingStore = createStore({
         markedMoments: [],
         pendingAutoStart: false,
         autoStartRequestedAt: null,
+        pendingConversationId: null,
+        pendingChannelId: null,
         pendingStop: false,
         notesCanvasId: null,
         notesCanvasViewAccessId: null,


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1dMfWz9kRInqoWJzPaz2wzQSGe2-m8FBY/view?usp=drive_link


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
