### PR TITLE
feat: subagent follow-up via session_id resume

### DIFF
--- a/apps/xyne-claw/src/subagent-followup.ts
+++ b/apps/xyne-claw/src/subagent-followup.ts
@@ -1,0 +1,58 @@
+/**
+ * subagent-followup.ts — primitives for the parent→subagent follow-up feature.
+ *
+ * A subagent flagged `supportsFollowUp` persists its child pi session under
+ * sessions/{conversationId}/subagents/{name}/{handle}/ and returns the `handle`
+ * to the parent as `session_id`. A later call passing that `session_id` RESUMES
+ * the same child session (full prior context) instead of spawning a fresh one.
+ *
+ * This module holds the two pieces that must be correct in isolation and are
+ * therefore unit-tested without the heavy subagent-tools module graph:
+ *   1. handle validation — the value becomes a filesystem path segment, so it
+ *      must be strictly validated to prevent traversal/injection.
+ *   2. a per-handle async lock — two concurrent resumes of the same child
+ *      session would interleave appends to one JSONL and corrupt it.
+ */
+
+/**
+ * A follow-up handle is a single, safe path segment. We mint them as
+ * crypto.randomUUID(), so the accepted alphabet is intentionally narrow:
+ * letters, digits, `_` and `-`, length 1–128. This rejects path separators,
+ * `.`/`..` traversal, whitespace, and empty strings.
+ */
+export const SAFE_FOLLOWUP_HANDLE_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** True only for a string that is safe to use as a session-dir path segment. */
+export function isValidFollowUpHandle(value: unknown): value is string {
+  return typeof value === "string" && SAFE_FOLLOWUP_HANDLE_RE.test(value);
+}
+
+// Serializes concurrent follow-up resumes on the SAME persisted child session
+// directory. In-process is sufficient because a conversation is pinned to one
+// pod per turn (the conversation lock already serializes across turns); the only
+// contention is parallel same-handle resumes within a single parent turn.
+const followUpHandleLocks = new Map<string, Promise<void>>();
+
+/**
+ * Acquire the lock for `key` (the absolute child session dir). Resolves once any
+ * prior holder released. Returns a release function — call it exactly once
+ * (in a finally). Callers awaiting the same key are served in FIFO order.
+ */
+export async function acquireFollowUpLock(key: string): Promise<() => void> {
+  const prev = followUpHandleLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // The tail of the chain is `next`: the following waiter awaits it.
+  followUpHandleLocks.set(key, next);
+  await prev.catch(() => {});
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    release();
+    // Best-effort cleanup: only drop the entry if no newer waiter replaced it.
+    if (followUpHandleLocks.get(key) === next) followUpHandleLocks.delete(key);
+  };
+}

--- a/apps/xyne-claw/src/subagent-tools.ts
+++ b/apps/xyne-claw/src/subagent-tools.ts
@@ -22,6 +22,7 @@ import { workspacePath } from "./workspace.js";
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
 import { AGENT, LITELLM, SERVER } from "./config.js";
 import { ensureSessionDebugDir, sessionDir } from "./session-store.js";
+import { acquireFollowUpLock, isValidFollowUpHandle } from "./subagent-followup.js";
 import { SUBAGENT_DEFINITIONS, findSubagentDefinitionForServer, getSandboxSession, probeSession, REPO_CONFIGS, buildSandboxStoreKey, type SubagentDefinition, type SetupStep } from "xyne-claw-shared";
 import type { McpToolGroup } from "./mcp.js";
 import { resolveModel, applyCopilotProxyIfNeeded, capCustomToolOutput, pushDebugProgress, pushInvocation, type CopilotConfig, type ClaudeConfig, type CodexConfig, type DebugEventRecord, type ProgressDest, type ToolInvocation } from "./agent.js";
@@ -517,9 +518,34 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
             ),
           }
         : {}),
+      // Follow-up handle. Only exposed when this subagent opts in via
+      // def.supportsFollowUp. When the parent passes the `session_id` a PRIOR
+      // call of THIS subagent returned, the follow-up question runs INSIDE that
+      // same child session (full prior context) instead of a fresh one.
+      ...(def.supportsFollowUp
+        ? {
+            session_id: Type.Optional(
+              Type.String({
+                description:
+                  "Optional. To ask THIS subagent a follow-up WITH the full context of a previous call, pass the `session_id` that the previous call of THIS SAME subagent returned. Omit to start a fresh session. Never pass a session_id that a DIFFERENT subagent returned.",
+              }),
+            ),
+          }
+        : {}),
     }),
     async execute(_toolCallId: string, params: unknown) {
       const question = (params as Record<string, string>)[def.paramName] ?? "";
+      // Optional follow-up handle: resume the SAME child session (full prior
+      // context) instead of a fresh one. Only honoured when the def opts in,
+      // and only after the handle passes a strict single-path-segment check so
+      // it can never be used for path traversal.
+      const rawFollowUpId = def.supportsFollowUp
+        ? (params as Record<string, unknown>)["session_id"]
+        : undefined;
+      const followUpId = isValidFollowUpHandle(rawFollowUpId) ? rawFollowUpId : undefined;
+      if (typeof rawFollowUpId === "string" && rawFollowUpId.length > 0 && !followUpId) {
+        log.warn(`[${def.name}] Ignoring malformed session_id handle — starting a fresh session`);
+      }
       const execStartedAt = Date.now();
       log.info(`[${def.name}] Subagent start t=${execStartedAt} call=${_toolCallId.slice(0,8)}: ${question.slice(0, 100)}`);
 
@@ -574,7 +600,10 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
       // entirely. Skipped when there is no parentSessionId — without a
       // bounded scope we'd risk cross-run pollution.
       const parentSid = progressCtx?.parentSessionId;
-      if (parentSid) {
+      // Follow-ups are stateful and must NEVER dedupe against a prior fresh call
+      // (or against each other) — bypass the memo cache when a session_id is in
+      // play so each resume actually runs against the evolving child session.
+      if (parentSid && !followUpId) {
         const subMap = subagentResultCache.get(parentSid) ?? new Map<string, CachedEntry>();
         if (!subagentResultCache.has(parentSid)) subagentResultCache.set(parentSid, subMap);
         const key = subagentCacheKey(def.name, question);
@@ -602,6 +631,9 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
       // can clear the timer on early failures without leaking the interval.
       let stickyLabel: string | null = null;
       let sessionRef: unknown = null;
+      // Declared before the try so the finally can release it. Guards concurrent
+      // follow-up resumes that share one persisted child session directory.
+      let releaseFollowUpLock: (() => void) | null = null;
       let toolBudget: ToolBudgetTracker | null = null;
       // Hoisted so the finally can clean it up regardless of success/error.
       let childSkillScope: string | null = null;
@@ -778,6 +810,47 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
 
         const parentSessionId = progressCtx?.parentSessionId;
         const childWorkingDir = parentSessionId ? workspacePath(parentSessionId) : process.cwd();
+
+        // ── Follow-up session persistence. When this subagent supports
+        // follow-ups AND we have a conversation to scope under, the child
+        // session is PERSISTED in its own per-handle directory beneath the
+        // parent conversation's session dir. That directory is picked up by the
+        // existing recursive session archiver (session-store walk), so a
+        // resumed follow-up survives across turns/pods for free — no new GCS
+        // pipeline. Without a conversationId (nested/anon runs) or when the def
+        // opts out, fall back to the original in-memory session (no resume).
+        const followUpConversationId = progressCtx?.parentMeta?.conversationId;
+        const followUpEnabled = !!(def.supportsFollowUp && followUpConversationId);
+        let followUpHandle: string | null = null;
+        let followUpResumed = false;
+        let childSessionManager: SessionManager;
+        if (followUpEnabled) {
+          followUpHandle = followUpId ?? crypto.randomUUID();
+          // Root strictly under THIS conversation's session dir + this def's
+          // name. A handle minted by another conversation or subagent simply
+          // won't exist here, so continueRecent starts a fresh session rather
+          // than reading a foreign one — structural cross-tenant isolation.
+          const childSessionRoot = join(
+            sessionDir(followUpConversationId!),
+            "subagents",
+            def.name,
+            followUpHandle,
+          );
+          const { mkdir } = await import("node:fs/promises");
+          await mkdir(childSessionRoot, { recursive: true });
+          // Serialize any concurrent resume of the same handle before we open it.
+          releaseFollowUpLock = await acquireFollowUpLock(childSessionRoot);
+          if (followUpId) {
+            childSessionManager = SessionManager.continueRecent(childWorkingDir, childSessionRoot);
+            followUpResumed = true;
+            log.info(`[${def.name}] Resuming follow-up session handle=${followUpHandle}`);
+          } else {
+            childSessionManager = SessionManager.create(childWorkingDir, childSessionRoot);
+            log.info(`[${def.name}] Created persistent follow-up session handle=${followUpHandle}`);
+          }
+        } else {
+          childSessionManager = SessionManager.inMemory();
+        }
         // Same allowlist-must-include-customTools subtlety as agent.ts —
         // pi v0.75 treats `tools` as a global allowlist that filters
         // customTools too. Listing only the 5 built-ins would silently
@@ -799,7 +872,7 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
           // a subagent's read/grep could walk the whole container.
           tools: ["read", "write", "grep", "find", "ls", ...subagentCustomNames],
           cwd: childWorkingDir,
-          sessionManager: SessionManager.inMemory(),
+          sessionManager: childSessionManager,
           authStorage,
           modelRegistry,
           // cwd-scoped file tools (override pi's unscoped read/write/grep/find/
@@ -1082,8 +1155,12 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         let systemPrompt = `${preamble}${def.systemPrompt}`;
 
         const childPrompt = `${systemPrompt}\n\n## Question\n${question}`;
+        // On a RESUMED follow-up the child session already holds the system
+        // prompt + all prior turns; re-injecting the preamble/systemPrompt would
+        // bloat context and re-anchor the model. Send ONLY the new question.
+        const promptText = followUpResumed ? `## Follow-up\n${question}` : childPrompt;
         pushDebugEvent("session_prompt", {
-          prompt: childPrompt,
+          prompt: promptText,
           messages: snapshotMessages(),
         });
         turnStartedAt = Date.now();
@@ -1112,7 +1189,7 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         };
         subagentAbortSignal?.addEventListener("abort", onParentAbort, { once: true });
         try {
-          await session.prompt(childPrompt);
+          await session.prompt(promptText);
 
           const sq = session as unknown as { _agentEventQueue?: Promise<void> };
           if (sq._agentEventQueue) await sq._agentEventQueue;
@@ -1226,7 +1303,15 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
             log.warn(`[${def.name}] Failed to write child debug artifact: ${err instanceof Error ? err.message : String(err)}`);
           }
         }
-        return { content: [{ type: "text" as const, text }], details: {} };
+        if (followUpEnabled && followUpHandle) {
+          text += `\n\n---\n_Follow-up:_ to ask THIS \`${def.name}\` subagent another question WITH the full context of this run, call \`${def.name}\` again passing \`session_id: "${followUpHandle}"\`. Omit it to start fresh.`;
+        }
+        return {
+          content: [{ type: "text" as const, text }],
+          details: followUpEnabled && followUpHandle
+            ? { session_id: followUpHandle, resumed: followUpResumed }
+            : {},
+        };
       } catch (err) {
         if (stickyTimer) clearInterval(stickyTimer);
         stopStreamRateTimer();
@@ -1266,6 +1351,7 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         // already disposed it (dispose() is idempotent), but the catch path
         // didn't, leaking the session's listeners/extension context on every
         // failed subagent. Best-effort.
+        try { releaseFollowUpLock?.(); } catch { /* ignore */ }
         try { (sessionRef as { dispose?: () => void } | null)?.dispose?.(); } catch { /* ignore */ }
         if (toolBudget) {
           metric.observe("tool_calls_per_run", toolBudget.calls, {

--- a/apps/xyne-claw/test/subagent-followup.test.ts
+++ b/apps/xyne-claw/test/subagent-followup.test.ts
@@ -1,0 +1,153 @@
+/**
+ * subagent-followup.test.ts
+ *
+ * Covers the two safety-critical primitives behind parent→subagent follow-ups
+ * (handle validation + the per-handle resume lock), plus a config invariant
+ * asserting `supportsFollowUp` is only enabled on read/research subagents and
+ * never on stateful/action ones.
+ */
+import { describe, it, expect } from "vitest";
+import { SUBAGENT_DEFINITIONS } from "xyne-claw-shared";
+import {
+  isValidFollowUpHandle,
+  acquireFollowUpLock,
+  SAFE_FOLLOWUP_HANDLE_RE,
+} from "../src/subagent-followup.js";
+
+describe("isValidFollowUpHandle", () => {
+  it("accepts a crypto.randomUUID() handle", () => {
+    // Real shape the code mints.
+    const uuid = "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed";
+    expect(isValidFollowUpHandle(uuid)).toBe(true);
+    expect(SAFE_FOLLOWUP_HANDLE_RE.test(uuid)).toBe(true);
+  });
+
+  it("accepts plain alphanumerics with _ and -", () => {
+    expect(isValidFollowUpHandle("abc_DEF-123")).toBe(true);
+  });
+
+  it.each([
+    ["empty string", ""],
+    ["path traversal", "../etc/passwd"],
+    ["parent ref", ".."],
+    ["single dot", "."],
+    ["contains slash", "a/b"],
+    ["contains backslash", "a\\b"],
+    ["contains dot", "a.b"],
+    ["whitespace", "a b"],
+    ["null byte", "a\u0000b"],
+    ["newline", "a\nb"],
+  ])("rejects %s", (_label, value) => {
+    expect(isValidFollowUpHandle(value)).toBe(false);
+  });
+
+  it("rejects an over-length handle (>128 chars)", () => {
+    expect(isValidFollowUpHandle("a".repeat(129))).toBe(false);
+    expect(isValidFollowUpHandle("a".repeat(128))).toBe(true);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isValidFollowUpHandle(undefined)).toBe(false);
+    expect(isValidFollowUpHandle(null)).toBe(false);
+    expect(isValidFollowUpHandle(123)).toBe(false);
+    expect(isValidFollowUpHandle({})).toBe(false);
+  });
+});
+
+describe("acquireFollowUpLock", () => {
+  it("serializes concurrent acquisitions of the SAME key (no overlap)", async () => {
+    const key = "/sessions/conv1/subagents/spaces/handle-A";
+    const events: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+
+    async function critical(id: string) {
+      const release = await acquireFollowUpLock(key);
+      try {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        events.push(`enter:${id}`);
+        await new Promise((r) => setTimeout(r, 15));
+        events.push(`exit:${id}`);
+        active -= 1;
+      } finally {
+        release();
+      }
+    }
+
+    await Promise.all([critical("1"), critical("2"), critical("3")]);
+
+    // Never two holders at once.
+    expect(maxActive).toBe(1);
+    // Strict enter/exit interleaving proves mutual exclusion.
+    expect(events).toEqual([
+      "enter:1", "exit:1",
+      "enter:2", "exit:2",
+      "enter:3", "exit:3",
+    ]);
+  });
+
+  it("allows different keys to run concurrently", async () => {
+    let active = 0;
+    let maxActive = 0;
+    async function critical(key: string) {
+      const release = await acquireFollowUpLock(key);
+      try {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 15));
+        active -= 1;
+      } finally {
+        release();
+      }
+    }
+    await Promise.all([
+      critical("/sessions/conv1/subagents/spaces/handle-X"),
+      critical("/sessions/conv1/subagents/github/handle-Y"),
+    ]);
+    // Distinct keys are independent → they overlap.
+    expect(maxActive).toBe(2);
+  });
+
+  it("is idempotent on double-release and lets a later waiter proceed", async () => {
+    const key = "/sessions/conv2/subagents/grafana/handle-Z";
+    const release1 = await acquireFollowUpLock(key);
+    release1();
+    release1(); // second call is a no-op, must not throw or corrupt the chain
+
+    // A fresh acquisition on the same key still works.
+    const release2 = await acquireFollowUpLock(key);
+    expect(typeof release2).toBe("function");
+    release2();
+  });
+});
+
+describe("SUBAGENT_DEFINITIONS supportsFollowUp invariant", () => {
+  // Read/research subagents where a scoped drill-down on the same evidence is
+  // the natural next step — these are the ones we intentionally opted in.
+  const EXPECTED_FOLLOWUP = new Set([
+    "spaces",
+    "bitbucket",
+    "github",
+    "grafana",
+    "deepwiki",
+    "context7",
+  ]);
+
+  // Stateful / action / delegation subagents where resuming an old child
+  // session must NOT be silently offered. Guards against accidental enablement.
+  const MUST_NOT_FOLLOWUP = ["juspay-dashboard", "artifacts", "slack", "asana"];
+
+  it("enables supportsFollowUp on exactly the intended research subagents", () => {
+    const enabled = SUBAGENT_DEFINITIONS.filter((d) => d.supportsFollowUp).map((d) => d.name).sort();
+    expect(enabled).toEqual([...EXPECTED_FOLLOWUP].sort());
+  });
+
+  it("does not enable follow-up on stateful/action subagents", () => {
+    for (const name of MUST_NOT_FOLLOWUP) {
+      const def = SUBAGENT_DEFINITIONS.find((d) => d.name === name);
+      if (!def) continue; // tolerate catalog drift; only assert when present
+      expect(def.supportsFollowUp ?? false).toBe(false);
+    }
+  });
+});

--- a/packages/xyne-claw-shared/src/tools/subagents/definitions.ts
+++ b/packages/xyne-claw-shared/src/tools/subagents/definitions.ts
@@ -45,12 +45,22 @@ export interface SubagentDefinition {
    *  tool sweep. Used for hard retrieval where the first sweep often misses.
    *  Omit/false to keep the default single-sweep guidance. */
   allowRequery?: boolean;
+  /** When true, the PARENT agent may send a FOLLOW-UP question to the SAME
+   *  child session (via the `session_id` this tool returns) instead of spawning
+   *  a fresh subagent that has lost all prior context. The child session is then
+   *  PERSISTED under sessions/{conversationId}/subagents/{name}/{handle}/ so it
+   *  can be resumed, and it rides the existing recursive GCS session archive for
+   *  free. Only enable for read/research subagents where a scoped drill-down on
+   *  the same evidence is the natural next step. Omit/false → always fresh, and
+   *  no session_id parameter is exposed to the parent. */
+  supportsFollowUp?: boolean;
 }
 
 export const SUBAGENT_DEFINITIONS: SubagentDefinition[] = [
   // ── Spaces ──────────────────────────────────────────────────────
   {
     name: "spaces",
+    supportsFollowUp: true,
     progressLabels: [
       "🔍 Searching Spaces...",
       "📬 Scanning messages and channels...",
@@ -126,6 +136,7 @@ HARD RULES:
   // ── Bitbucket ───────────────────────────────────────────────────
   {
     name: "bitbucket",
+    supportsFollowUp: true,
     progressLabels: [
       "🔀 Checking Bitbucket...",
       "🌿 Looking up branches and PRs...",
@@ -153,6 +164,7 @@ Return structured findings with relevant identifiers (PR IDs, branch names, comm
   // ── GitHub ──────────────────────────────────────────────────────
   {
     name: "github",
+    supportsFollowUp: true,
     progressLabels: [
       "🐙 Checking GitHub...",
       "🌿 Looking up branches and PRs...",
@@ -206,6 +218,7 @@ Return structured findings (lists of {repo, number, title, state, url} when surf
   // ── Grafana ─────────────────────────────────────────────────────
   {
     name: "grafana",
+    supportsFollowUp: true,
     progressLabels: [
       "📊 Querying Grafana...",
       "📈 Pulling metrics and time ranges...",
@@ -233,6 +246,7 @@ Return structured findings with error counts, metric values, patterns, and time 
   // ── DeepWiki ────────────────────────────────────────────────────
   {
     name: "deepwiki",
+    supportsFollowUp: true,
     progressLabels: [
       "📚 Researching docs...",
       "🧠 Reading the wiki index...",
@@ -265,6 +279,7 @@ Return a concise answer grounded in the actual docs. Cite specific pages when re
   // ── Context7 ────────────────────────────────────────────────────
   {
     name: "context7",
+    supportsFollowUp: true,
     progressLabels: [
       "📖 Fetching library docs...",
       "📦 Resolving the library id...",


### PR DESCRIPTION
## What
Lets the PARENT agent send a follow-up question to the SAME research subagent session — via a `session_id` the subagent returns — instead of spawning a fresh subagent that has lost all prior context.

## Why
Today every subagent call is a cold start: the parent must re-explain context on each drill-down, wasting tokens and losing continuity. This adds an opt-in, resumable child session for read/research subagents.

## How
- New opt-in field `SubagentDefinition.supportsFollowUp`. Enabled on the read/research subagents: `spaces`, `bitbucket`, `github`, `grafana`, `deepwiki`, `context7`. All other (stateful/action) subagents are unaffected.
- An optional `session_id` tool param is exposed **only** on opted-in subagents.
  - Absent → generate a random UUID handle and `SessionManager.create` a persistent child session.
  - Present (and valid) → `SessionManager.continueRecent` to RESUME the same child session with full prior context.
  - No `conversationId` (nested/anon runs) → falls back to `SessionManager.inMemory()` (no resume), unchanged behavior.
- Child sessions are persisted under `sessions/{conversationId}/subagents/{name}/{handle}/`, so they ride the existing recursive GCS session archiver — no new storage pipeline.
- On resume, only the raw follow-up question is sent (the system prompt already lives in persisted history); the memoization cache is bypassed for stateful follow-ups.
- The handle is returned to the parent as `details.session_id` plus a short follow-up hint appended to the tool text.

## Security / safety
- `session_id` is validated as a strict single path segment (`^[A-Za-z0-9_-]{1,128}$`) before it ever touches the filesystem — no traversal, no separators. Malformed handles are ignored (fresh session) with a warning.
- Handles are plain UUIDs and the path is namespaced by `{conversationId}/{name}`, so a handle minted by another conversation or a different subagent simply won't resolve → it starts fresh instead of leaking cross-context history. Structural cross-tenant isolation.
- A per-handle in-process async lock serializes concurrent resumes of the same child session dir to prevent interleaved JSONL appends.

## Tests
- New `apps/xyne-claw/test/subagent-followup.test.ts` (19 tests): handle validation (accepts UUIDs; rejects traversal/separators/empty/over-length/non-strings), the resume lock (mutual exclusion on same key, concurrency across different keys, idempotent double-release), and a config invariant asserting follow-up is enabled on exactly the intended research subagents and off for stateful/action ones.
- `tsc --noEmit` clean for both `apps/xyne-claw` and `packages/xyne-claw-shared`.
- Full suite: no new failures (the pre-existing 7 file / provider-dependent failures are an environmental undici/Node mismatch present on the base branch too).