### PR TITLE
fix: match DM panel corner radius when a conversation is open

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
+++ b/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
@@ -249,7 +249,7 @@ const ChatView = (): ReactElement => {
       <div
         ref={chatViewContainerRef}
         data-component='ChatView'
-        className={`w-full h-full overflow-hidden relative ${isInPanelWebview ? '' : 'rounded-lg'}`}
+        className={`w-full h-full overflow-hidden relative ${isInPanelWebview ? '' : 'rounded-2xl'}`}
       >
         <Outlet />
       </div>
@@ -306,7 +306,7 @@ const ChatView = (): ReactElement => {
     <div
       ref={chatViewContainerRef}
       data-component='ChatView'
-      className={`w-full h-full overflow-hidden relative ${isInPanelWebview ? '' : 'rounded-lg'}`}
+      className={`w-full h-full overflow-hidden relative ${isInPanelWebview ? '' : 'rounded-2xl'}`}
     >
       {isThreadSummaryActive && conversationId && channelId ? (
         // Thread Summary Mode — unchanged; ConversationPanelV2 is not rendered
@@ -314,7 +314,7 @@ const ChatView = (): ReactElement => {
         shouldStack ? (
           <>
             <ThreadMessages channelId={channelId} conversationId={conversationId} />
-            <div className='absolute inset-0 bg-background z-10 rounded-lg animate-slide-in-from-right'>
+            <div className='absolute inset-0 bg-background z-10 rounded-2xl animate-slide-in-from-right'>
               <ThreadSummary
                 conversationId={conversationId}
                 channelName={channel?.['name'] || 'thread'}
@@ -432,7 +432,7 @@ const ChatView = (): ReactElement => {
 
           {/* Overlay secondary panel — slides over chat when viewport is narrow */}
           {showSecondaryPanel && shouldStack && !shouldStackThreadFromParent && (
-            <div className='absolute inset-0 bg-background z-10 rounded-lg animate-slide-in-from-right'>
+            <div className='absolute inset-0 bg-background z-10 rounded-2xl animate-slide-in-from-right'>
               {secondaryPanelContent}
             </div>
           )}


### PR DESCRIPTION
## What

On `/chat/dm` the right-hand panel changed shape depending on whether a conversation was open — ~16px corners on the empty state, ~8px once a DM was selected.

Two different elements paint that corner:

- **No DM open** — the `dm-content` wrapper, `DmsPage.tsx:778`: `bg-background relative h-full rounded-2xl`.
- **DM open** — that wrapper has no `overflow-hidden`, so `<Outlet />` renders `ChatView`, which paints its own opaque `bg-background` at `rounded-lg` (8px) directly over the parent's 16px corners.

## Change

`ChatView.tsx` moves to `rounded-2xl` — both container branches (252, 309) and the two `animate-slide-in-from-right` overlays (317, 435), so the slide-in panels stay flush with the container radius.

## Scope

`ChatView` is shared with the channel view, but there is no visible change there: it sits inside `ChatScreen.tsx:174`, already `rounded-2xl overflow-hidden` over the same `bg-background`. DMs were the only place the mismatch surfaced, because the DM wrapper deliberately skips `overflow-hidden` so the wallpaper shows through the DM list.

Prettier passes. The change is className strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)