### PR TITLE
feat: add LLM endpoint verification script and update setup process

### DIFF
--- a/docs/setup/ai-providers.md
+++ b/docs/setup/ai-providers.md
@@ -55,6 +55,20 @@ names with yours.
 Check the endpoint answers, so you are debugging one thing rather than two:
 
 ```bash
+pnpm run doctor:llm
+```
+
+It reads whatever is in the env files and sends one real completion to it, then
+says which of the three things is wrong — the URL, the key, or the model name. It
+exits non-zero on failure, so CI can run it too. `pnpm run env:setup` runs the same
+check automatically on the values you just entered.
+
+Rate limiting counts as a pass: a `429` proves the URL resolved, the key was
+accepted, and the model exists.
+
+The equivalent by hand, if you want to see the raw response:
+
+```bash
 curl -s "$LITELLM_BASE_URL/chat/completions" \
   -H "Authorization: Bearer $LITELLM_API_KEY" \
   -H "Content-Type: application/json" \
@@ -63,6 +77,9 @@ curl -s "$LITELLM_BASE_URL/chat/completions" \
 
 A JSON body containing `choices` means the gateway is good. `401` means the key is
 wrong; a connection error means the URL is wrong or the proxy is not running.
+
+One gotcha worth knowing: most OpenAI-compatible gateways expect the base URL to end
+in `/v1`. Without it the request 404s, which is easy to misread as a bad key.
 
 Env files are read at process start, so **restart the apps** after editing:
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "doctor": "node scripts/xyne-doctor.mjs",
     "doctor:demo": "node scripts/xyne-doctor.mjs --demo",
     "doctor:test": "node --test scripts/xyne-doctor.test.mjs",
+    "doctor:llm": "node scripts/ping-llm.mjs",
     "services": "node scripts/xyne-doctor.mjs services",
     "services:raw": "node scripts/select-services.mjs",
     "services:sh": "chmod +x scripts/start-services.sh && ./scripts/start-services.sh",

--- a/scripts/ping-llm.mjs
+++ b/scripts/ping-llm.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Verify that the configured LLM endpoint actually answers.
+ *
+ * Run it directly (`pnpm run doctor:llm`) to check what is on disk, or import
+ * pingModel() to check values before they are written.
+ *
+ * The check is a real one-token chat completion, not a /models list and not a
+ * /health probe. A gateway can list models and still reject chat, and "the
+ * gateway is up" is a different question from "these credentials can complete
+ * with this model" — anything less can pass here and still fail on the first
+ * real request, which is the failure this whole script exists to prevent.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const BACKEND_ENV = "apps/backend/.env.local";
+const CLAW_ENV = "apps/xyne-claw/.env";
+
+const TIMEOUT_MS = Number(process.env.LLM_PING_TIMEOUT_MS ?? 15000);
+
+/** Pull the human-readable bit out of an OpenAI-shaped error body. */
+function errorMessage(body) {
+  try {
+    const parsed = JSON.parse(body);
+    const message = parsed?.error?.message ?? parsed?.message;
+    if (message) return String(message).slice(0, 300);
+  } catch {
+    // Not JSON — usually a proxy or login page answering instead of the gateway.
+  }
+  return body.trim().slice(0, 300) || "(empty response body)";
+}
+
+/**
+ * Ping the endpoint and return { ok, title, detail, hint }.
+ *
+ * The verdicts are grouped by what the reader has to go and fix — URL, key, or
+ * model — rather than by retry semantics. That is why 429 is a pass: it proves
+ * the URL resolved, the key was accepted, and the model exists. The request the
+ * user makes a minute later will work.
+ */
+export async function pingModel(baseUrl, apiKey, model) {
+  const url = `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
+
+  let response;
+  let body;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "ping" }],
+        max_tokens: 1,
+        temperature: 0,
+      }),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    body = await response.text();
+  } catch (error) {
+    const reason =
+      error?.name === "TimeoutError"
+        ? `no answer within ${TIMEOUT_MS / 1000}s`
+        : (error?.cause?.code ?? error?.message ?? "connection failed");
+    return {
+      ok: false,
+      title: "Could not reach the endpoint",
+      detail: `POST ${url} — ${reason}`,
+      hint: "Check the base URL, and that the gateway is running and reachable from this machine.",
+    };
+  }
+
+  if (response.status === 429) {
+    return {
+      ok: true,
+      title: "Credentials work — the provider is rate limiting right now",
+      detail: errorMessage(body),
+      hint: "",
+    };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return {
+      ok: false,
+      title: `Endpoint rejected the API key (${response.status})`,
+      detail: errorMessage(body),
+      hint: "The URL is right and something answered — the key is wrong, expired, or not allowed to use this model.",
+    };
+  }
+
+  if (response.status === 404) {
+    return {
+      ok: false,
+      title: "Nothing at that path (404)",
+      detail: `POST ${url} — ${errorMessage(body)}`,
+      hint: `Most OpenAI-compatible gateways want the base URL to end in /v1 — try ${baseUrl.replace(/\/+$/, "")}/v1. A model name the gateway does not serve can also 404.`,
+    };
+  }
+
+  if (response.status >= 500) {
+    return {
+      ok: false,
+      title: `Endpoint returned ${response.status}`,
+      detail: errorMessage(body),
+      hint: "That is the provider's side rather than your config. Worth retrying before changing anything.",
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      title: `Endpoint returned ${response.status}`,
+      detail: errorMessage(body),
+      hint: `Check that "${model}" is a model this endpoint serves.`,
+    };
+  }
+
+  // A 200 is not proof on its own: some gateways answer 200 with an error
+  // payload, and the apps need `choices` specifically.
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return {
+      ok: false,
+      title: "Endpoint answered, but not with JSON",
+      detail: body.trim().slice(0, 300),
+      hint: "Something is answering that URL, but it is not a model gateway — check for a proxy or login page in front of it.",
+    };
+  }
+  if (!Array.isArray(parsed?.choices) || parsed.choices.length === 0) {
+    return {
+      ok: false,
+      title: "Endpoint answered 200, but with no completion",
+      detail: errorMessage(body),
+      hint: `The gateway took the request and returned no choices — usually a model name ("${model}") it does not actually serve.`,
+    };
+  }
+
+  return { ok: true, title: `${model} answered`, detail: "", hint: "" };
+}
+
+/** Print a result the same way whether it came from setup or from the CLI. */
+export function reportPing(result) {
+  console.log(`\n ${result.ok ? "✓" : "✗"} ${result.title}`);
+  if (result.detail) console.log(`   ${result.detail}`);
+  if (result.hint) console.log(`   ${result.hint}`);
+  if (!result.ok) console.log("   More: docs/setup/ai-providers.md");
+}
+
+// ---------------------------------------------------------------------------
+// Standalone run
+// ---------------------------------------------------------------------------
+
+/** Read the current value of KEY from an env file, ignoring commented lines. */
+function readEnvValue(relPath, key) {
+  const file = join(repoRoot, relPath);
+  if (!existsSync(file)) return "";
+  const line = readFileSync(file, "utf8")
+    .split("\n")
+    .reverse() // last assignment wins, same as dotenv
+    .find((l) => l.trimStart().startsWith(`${key}=`));
+  return line ? line.slice(line.indexOf("=") + 1).trim() : "";
+}
+
+/** Placeholders shipped in .env.example that should be treated as "unset". */
+function isPlaceholder(value) {
+  if (!value) return true;
+  return (
+    value.startsWith("your-") ||
+    value.startsWith("set-me") ||
+    value.includes("example.com") ||
+    value.includes("example.net")
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const baseUrl = readEnvValue(BACKEND_ENV, "LITELLM_BASE_URL") || readEnvValue(CLAW_ENV, "LITELLM_URL");
+  const apiKey = readEnvValue(BACKEND_ENV, "LITELLM_API_KEY") || readEnvValue(CLAW_ENV, "LITELLM_API_KEY");
+  const model = readEnvValue(BACKEND_ENV, "LITELLM_BEST_MODEL") || readEnvValue(CLAW_ENV, "LITELLM_MODEL");
+
+  if (isPlaceholder(baseUrl) || isPlaceholder(apiKey)) {
+    console.log("\n No AI credentials configured yet.");
+    console.log(" Run `pnpm run env:setup` to add them, or see docs/setup/ai-providers.md");
+    process.exit(1);
+  }
+  if (!model) {
+    console.log("\n A base URL and key are set, but no model is.");
+    console.log(` Set LITELLM_BEST_MODEL in ${BACKEND_ENV}, or re-run \`pnpm run env:setup\`.`);
+    process.exit(1);
+  }
+
+  console.log(`\n Pinging ${baseUrl} with ${model} ...`);
+  const result = await pingModel(baseUrl, apiKey, model);
+  reportPing(result);
+  process.exit(result.ok ? 0 : 1);
+}

--- a/scripts/setup-env-files.mjs
+++ b/scripts/setup-env-files.mjs
@@ -19,6 +19,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { pingModel, reportPing } from "./ping-llm.mjs";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -262,8 +263,12 @@ async function configureAi() {
 
     console.log("");
     for (const file of touched) console.log(` ✓ Updated ${file}`);
-    console.log("\n Verify the endpoint answers before starting the apps:");
-    console.log("   docs/setup/ai-providers.md#verify-before-you-restart-the-app");
+    console.log("\n Checking the endpoint answers...");
+    const ping = await pingModel(baseUrl, apiKey, bestModel);
+    reportPing(ping);
+    if (!ping.ok) {
+      console.log("   The values above are saved — fix them and re-check with `pnpm run doctor:llm`.");
+    }
   } catch (error) {
     // stdin closing mid-prompt (Ctrl+D, a piped heredoc running out, a runner that
     // detaches the terminal) rejects the pending question. Treat it as "skip" —


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
