### PR TITLE
feature: XYNE:12830 added askAI ui changes for the canvas

### DIFF
--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -14,8 +14,13 @@ import { getGroupMembersForNotification } from '../utils/mentionUtils.js';
 import { getSlackRecipientEmails } from '../utils/notificationHelper.js';
 import { cleanupProxiedFile } from '../utils/attachmentUtils';
 import { v4 as uuidv4 } from 'uuid';
-import {initializeYSweetDoc, syncToYSweet} from '../utils/ysweetUtils.js';
-import { convertMarkdownToBlockNote, convertBlockNoteToMarkdown, getCanvasUrl, getCanvasById } from '../services/canvasService.js';
+import { initializeYSweetDoc, syncToYSweet } from '../utils/ysweetUtils.js';
+import {
+  convertMarkdownToBlockNote,
+  convertBlockNoteToMarkdown,
+  getCanvasUrl,
+  getCanvasById,
+} from '../services/canvasService.js';
 
 export class CanvasController {
   private messageAttachmentRepository: MessageAttachmentRepository;
@@ -24,7 +29,7 @@ export class CanvasController {
     this.messageAttachmentRepository = messageAttachmentRepository;
   }
 
-    createCanvas = async (req: Request, res: Response): Promise<void> => {
+  createCanvas = async (req: Request, res: Response): Promise<void> => {
     try {
       const userId = req.user?.id;
       if (!userId) {
@@ -55,8 +60,8 @@ export class CanvasController {
             title,
             content: [],
             workspaceId: req.user!.workspaceId!,
-            createdBy: creatorId,  // <-- AUTHENTICATED USER
-            channelId: channelId || null,  // <-- ASSOCIATE WITH CHANNEL IF PROVIDED
+            createdBy: creatorId, // <-- AUTHENTICATED USER
+            channelId: channelId || null, // <-- ASSOCIATE WITH CHANNEL IF PROVIDED
             visibility: visibility === 'PUBLIC' ? 'PUBLIC' : 'PRIVATE',
             isTemplate: false,
             isCollaborative: true,
@@ -71,7 +76,7 @@ export class CanvasController {
             id: participantId,
             canvasId,
             workspaceId: req.user!.workspaceId!,
-            userId: creatorId,  // <-- AUTHENTICATED USER IS OWNER
+            userId: creatorId, // <-- AUTHENTICATED USER IS OWNER
             role: CanvasRole.OWNER,
             joinedAt: now,
             updatedAt: now,
@@ -123,7 +128,7 @@ export class CanvasController {
         await canvasAuthService.requireEditAccess(canvasId, userId);
       } catch (error) {
         logger.warn(`[CANVAS-UPLOAD] Permission denied for user ${userId} on canvas ${canvasId}`, {
-          error: error instanceof Error ? error.message : 'Unknown error'
+          error: error instanceof Error ? error.message : 'Unknown error',
         });
         await cleanupProxiedFile(file, { logPrefix: 'CANVAS-UPLOAD' });
         res.status(403).json({ error: 'Permission denied' });
@@ -151,7 +156,10 @@ export class CanvasController {
       const uploadResults = await uploadFiles([file]);
 
       if (!uploadResults || uploadResults.length === 0) {
-        logger.error('[CANVAS-UPLOAD] The file upload service did not return a valid result for file:', { fileName: file.originalname });
+        logger.error(
+          '[CANVAS-UPLOAD] The file upload service did not return a valid result for file:',
+          { fileName: file.originalname }
+        );
         await cleanupProxiedFile(file, { logPrefix: 'CANVAS-UPLOAD' });
         res.status(500).json({ error: 'Failed to process the uploaded file.' });
         return;
@@ -242,8 +250,15 @@ export class CanvasController {
         return;
       }
 
-      const { mentionType, mentionId, blockId, commentThreadId, canvasTitle, mentionContext, slackUrl } =
-        validatedBody.data;
+      const {
+        mentionType,
+        mentionId,
+        blockId,
+        commentThreadId,
+        canvasTitle,
+        mentionContext,
+        slackUrl,
+      } = validatedBody.data;
       const userId = req.user?.id;
 
       if (!userId) {
@@ -283,7 +298,7 @@ export class CanvasController {
 
       // Resolve mentioned users
       const mentionedUsers: { userId: string; mentionSource: 'direct' | 'group' }[] = [];
-      
+
       if (mentionType === 'user' && mentionId !== userId) {
         mentionedUsers.push({ userId: mentionId, mentionSource: 'direct' });
       } else if (mentionType === 'group') {
@@ -301,8 +316,8 @@ export class CanvasController {
       }
 
       // Batch check canvas access for all mentioned users in a single query
-      const uniqueUserIds = [...new Set(mentionedUsers.map(u => u.userId))];
-      
+      const uniqueUserIds = [...new Set(mentionedUsers.map((u) => u.userId))];
+
       // Fetch canvas details, canvas participants, sender name, and mentioned users' emails in one batch
       const [canvas, canvasParticipants, sender, mentionedUserRecords] = await Promise.all([
         db.canvas.findUnique({
@@ -322,12 +337,11 @@ export class CanvasController {
           select: { id: true, email: true },
         }),
       ]);
-      
+
       // Determine which users have access (canvas creator or canvas participant)
-      const canvasParticipantIds = new Set(canvasParticipants.map(p => p.userId));
-      const usersWithAccessIds = uniqueUserIds.filter(uid => 
-        uid === canvas?.createdBy || 
-        canvasParticipantIds.has(uid)
+      const canvasParticipantIds = new Set(canvasParticipants.map((p) => p.userId));
+      const usersWithAccessIds = uniqueUserIds.filter(
+        (uid) => uid === canvas?.createdBy || canvasParticipantIds.has(uid)
       );
 
       if (usersWithAccessIds.length === 0) {
@@ -336,14 +350,17 @@ export class CanvasController {
       }
 
       // Filter to users with access and create activities
-      const mentionedUsersWithAccess = mentionedUsers.filter(u => usersWithAccessIds.includes(u.userId));
-      const activities = mentionedUsersWithAccess.map(u => ({
+      const mentionedUsersWithAccess = mentionedUsers.filter((u) =>
+        usersWithAccessIds.includes(u.userId)
+      );
+      const activities = mentionedUsersWithAccess.map((u) => ({
         id: uuidv4(),
         userId: u.userId,
         actorId: userId,
         actorAction: u.mentionSource === 'direct' ? 'mentioned_user' : 'group_mention',
         actionSource: mentionContext === 'comment' ? 'canvas_comment' : 'canvas',
-        actionSourceId: mentionContext === 'comment' && commentThreadId ? commentThreadId : canvasId,
+        actionSourceId:
+          mentionContext === 'comment' && commentThreadId ? commentThreadId : canvasId,
         channelId: canvasChannelId ?? undefined,
         canvasId: canvasId,
         blockId: blockId ?? undefined,
@@ -355,8 +372,8 @@ export class CanvasController {
       const usersWithAccessSet = new Set(usersWithAccessIds);
       const userEmailMap = new Map(
         mentionedUserRecords
-          .filter(u => u.email && usersWithAccessSet.has(u.id))
-          .map(u => [u.id, u.email!])
+          .filter((u) => u.email && usersWithAccessSet.has(u.id))
+          .map((u) => [u.id, u.email!])
       );
       const mentionedEmails = Array.from(userEmailMap.values());
 
@@ -378,12 +395,19 @@ export class CanvasController {
           blockId,
           commentThreadId,
           canvasChannelId ?? undefined,
-          mentionContext,
+          mentionContext
         );
 
-        slackRecipientEmails = getSlackRecipientEmails(mentionedEmails, deliveredUserIds, userEmailMap);
+        slackRecipientEmails = getSlackRecipientEmails(
+          mentionedEmails,
+          deliveredUserIds,
+          userEmailMap
+        );
       } catch (error) {
-        logger.error('[CANVAS-MENTIONS] Spaces notification failed — sending Slack to all recipients', { error });
+        logger.error(
+          '[CANVAS-MENTIONS] Spaces notification failed — sending Slack to all recipients',
+          { error }
+        );
       }
 
       // Step 3: Send Slack notifications only to users who didn't receive app notification
@@ -391,7 +415,7 @@ export class CanvasController {
         slackRecipientEmails,
         senderName,
         canvasTitle ?? 'Canvas',
-        slackUrl!,
+        slackUrl!
       );
 
       res.status(200).json({

--- a/apps/backend/src/services/canvasService.ts
+++ b/apps/backend/src/services/canvasService.ts
@@ -14,7 +14,6 @@ import { CanvasRole, CanvasVisibility } from '@xyne/shared';
 // Y-Sweet XML fragment name used by the frontend collaborative editor
 export const YSWEET_XML_FRAGMENT = 'document-store';
 
-
 /**
  * Convert markdown to BlockNote JSON format
  */
@@ -223,7 +222,9 @@ export async function createKnowledgeCanvas(
     const participantId = uuidv4();
 
     // Generate title with fallback to default
-    const finalTitle = canvasTitle ? `📚 ${canvasTitle}` : `📚 Knowledge Learnings - ${new Date().toLocaleDateString()}`;
+    const finalTitle = canvasTitle
+      ? `📚 ${canvasTitle}`
+      : `📚 Knowledge Learnings - ${new Date().toLocaleDateString()}`;
 
     // Format learnings to BlockNote content
     const content = formatLearningsToBlockNote(learnings, workflowExecutionId, finalTitle);
@@ -287,7 +288,7 @@ export async function createKnowledgeCanvas(
       logger.error(`[CanvasService] Failed to queue Vespa job for canvas ${canvasId}:`, error);
       // Don't fail the canvas creation if Vespa queueing fails
     }
-    
+
     return canvasId;
   } catch (error) {
     logger.error('[CanvasService] Failed to create knowledge canvas:', error);
@@ -303,13 +304,16 @@ export async function createKnowledgeCanvas(
  */
 export function getCanvasUrl(canvasId: string, workspaceId?: string): string {
   const frontendUrl = process.env.FRONTEND_URL || 'https://spaces.xyne.juspay.net';
-  const path = workspaceId
-    ? `/${workspaceId}/chat/canvas/${canvasId}`
-    : `/chat/canvas/${canvasId}`;
+  const path = workspaceId ? `/${workspaceId}/chat/canvas/${canvasId}` : `/chat/canvas/${canvasId}`;
   return `${frontendUrl}${path}`;
 }
 
-type LooseInline = { type?: string; text?: string; props?: Record<string, unknown>; styles?: unknown };
+type LooseInline = {
+  type?: string;
+  text?: string;
+  props?: Record<string, unknown>;
+  styles?: unknown;
+};
 type LooseBlock = {
   type?: string;
   content?: unknown;
@@ -319,6 +323,7 @@ type LooseBlock = {
 // ServerBlockNoteEditor.create() only knows the default schema, so custom inline
 // nodes must be rewritten before Markdown export.
 const CUSTOM_INLINE_TYPES = new Set(['mention', 'citation']);
+const CUSTOM_STYLE_KEYS = new Set(['canvasCommentThread']);
 
 // Render a custom inline node as plain text, mirroring the frontend display
 // logic (CanvasMentionSpec: prefer the group name for group mentions, otherwise
@@ -351,13 +356,26 @@ function normalizeInlineContent(content: unknown): unknown {
   }
 
   return Object.fromEntries(
-    Object.entries(content).map(([key, value]) => [key, normalizeInlineContent(value)]),
+    Object.entries(content).map(([key, value]) => {
+      if (key === 'styles' && value && typeof value === 'object' && !Array.isArray(value)) {
+        return [
+          key,
+          Object.fromEntries(
+            Object.entries(value as Record<string, unknown>).filter(
+              ([styleKey]) => !CUSTOM_STYLE_KEYS.has(styleKey)
+            )
+          ),
+        ];
+      }
+
+      return [key, normalizeInlineContent(value)];
+    })
   );
 }
 
 // Remove citation blocks and replace custom inline nodes before serialization.
 function normalizeBlocksForMarkdown(blocks: LooseBlock[]): LooseBlock[] {
-  return blocks.flatMap(block => {
+  return blocks.flatMap((block) => {
     if (block.type === 'citation') return [];
 
     const next: LooseBlock = { ...block };
@@ -568,9 +586,12 @@ export async function approveKnowledgeCanvas(
       });
       logger.info(`[CanvasService] Queued Vespa update for approved canvas ${canvasId}`);
     } catch (error) {
-      logger.error(`[CanvasService] Failed to queue Vespa update for approved canvas ${canvasId}:`, error);
+      logger.error(
+        `[CanvasService] Failed to queue Vespa update for approved canvas ${canvasId}:`,
+        error
+      );
     }
-    
+
     return { success: true, documentIds: [document.id] };
   } catch (error) {
     logger.error('[CanvasService] Failed to approve knowledge canvas:', error);

--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -75,6 +75,7 @@ import { CanvasCommentsPanel } from '../CanvasCommentsPanel/CanvasCommentsPanel'
 import { AnimatePresence } from 'framer-motion';
 
 import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
+import { CanvasInlineAIEdit } from '../CanvasInlineAIEdit/CanvasInlineAIEdit';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
 
@@ -383,14 +384,17 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       isCommentsOpen,
       setIsCommentsOpen,
       inlineCommentThread,
+      inlineAIEdit,
       activeCommentBlockId,
       activeCommentThreadId,
       activeCommentAnchor,
       refreshCommentHighlights,
       openCommentsForCurrentBlock,
+      openAskAIForCurrentSelection,
       focusCommentBlock,
       clearActiveCommentAnchor,
       closeInlineCommentThread,
+      closeInlineAIEdit,
       applyCommentAnchorStyle,
       removeCommentAnchorStyle,
     } = useCanvasCommentEditorBridge({
@@ -532,8 +536,9 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
           ...(canvasId && { canvasId }),
           ...(_canvasTitle && { canvasTitle: _canvasTitle }),
           canComment: editable,
+          onAskAI: openAskAIForCurrentSelection,
         }),
-      [_canvasTitle, canvasId, editable, openCommentsForCurrentBlock],
+      [_canvasTitle, canvasId, editable, openAskAIForCurrentSelection, openCommentsForCurrentBlock],
     );
 
     const handleSave = useCallback((): void => {
@@ -624,6 +629,17 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
               onBeforeCreateThread={applyCommentAnchorStyle}
               onCreateThreadCreated={clearActiveCommentAnchor}
               onCreateThreadFailed={removeCommentAnchorStyle}
+            />
+          )}
+
+          {canvasId && inlineAIEdit && (
+            <CanvasInlineAIEdit
+              canvasId={canvasId}
+              canvasTitle={_canvasTitle}
+              channelId={channelId}
+              selectedText={inlineAIEdit.selectedText}
+              anchorRect={inlineAIEdit.rect}
+              onClose={closeInlineAIEdit}
             />
           )}
         </div>

--- a/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
@@ -9,63 +9,26 @@ import {
 } from '@blocknote/react';
 import { MessageSquarePlus } from 'lucide-react';
 import type { FC, ReactElement } from 'react';
-import { useCallback, useEffect, useRef } from 'react';
-import { xyneAIActor, type SelectionInfo } from '../../../machines/xyneAIMachine';
+import { useCallback } from 'react';
 
 type CanvasFormattingToolbarOptions = {
   canvasId?: string;
   canvasTitle?: string;
   canComment?: boolean;
+  onAskAI?: () => void;
 };
 
 function CanvasToolbarAttachedActions({
   onAddComment,
   canvasId,
-  canvasTitle,
   canComment = true,
+  onAskAI,
 }: {
   onAddComment: () => void;
 } & CanvasFormattingToolbarOptions): ReactElement {
-  const selectedTextRef = useRef('');
-
-  useEffect(() => {
-    const updateSelectedText = (): void => {
-      const selectedText = window.getSelection()?.toString().trim() ?? '';
-      if (selectedText) {
-        selectedTextRef.current = selectedText;
-      }
-    };
-
-    updateSelectedText();
-    document.addEventListener('selectionchange', updateSelectedText);
-    return (): void => document.removeEventListener('selectionchange', updateSelectedText);
-  }, []);
-
   const handleAskAI = useCallback((): void => {
-    if (!canvasId) return;
-
-    const selectedText = window.getSelection()?.toString().trim() || selectedTextRef.current;
-    if (!selectedText) return;
-
-    const preview = selectedText.length > 50 ? `${selectedText.substring(0, 50)}...` : selectedText;
-    const selectionInfo: SelectionInfo = {
-      text: selectedText,
-      preview,
-      canvasId,
-      ...(canvasTitle && { canvasTitle }),
-    };
-
-    xyneAIActor.send({
-      type: 'OPEN',
-      canvasInfo: {
-        canvasId,
-        ...(canvasTitle && { title: canvasTitle }),
-      },
-      selectionInfo,
-    });
-
-    window.getSelection()?.removeAllRanges();
-  }, [canvasId, canvasTitle]);
+    onAskAI?.();
+  }, [onAskAI]);
 
   return (
     <div className='canvas-formatting-menu__attached-actions'>

--- a/apps/dashboard/src/components/Canvas/CanvasInlineAIEdit/CanvasInlineAIEdit.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasInlineAIEdit/CanvasInlineAIEdit.tsx
@@ -1,0 +1,391 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent, PointerEvent } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Bug, Check, FileText, Loader2, Send, TextQuote, X } from 'lucide-react';
+
+import { ActivityBlock } from '../../Chat/XyneAISidebar/components/ActivityBlock';
+import { AskAIDebugPanel } from '../../Chat/XyneAISidebar/components/AskAIDebugPanel';
+import { PendingActionBlock } from '../../Chat/XyneAISidebar/components/PendingActionBlock';
+import type {
+  DebugEventRecord,
+  Message,
+  SelectionContext,
+} from '../../Chat/XyneAISidebar/utils/XyneAITypes';
+import { respondToPendingAction } from '../../../services/XyneAI/XyneAIPendingActionService';
+import { useXyneAIStream } from '../../../hooks/useXyneAIStream';
+import { cn } from '../../../utils/classNames';
+
+interface CanvasInlineAIEditProps {
+  canvasId: string;
+  canvasTitle?: string | undefined;
+  channelId?: string | undefined;
+  selectedText: string;
+  anchorRect: DOMRect;
+  onClose: () => void;
+}
+
+const createInlineAIStreamKey = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `canvas-inline-ai-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+};
+
+const INLINE_ASK_AI_POPOVER_WIDTH = 560;
+
+const InlineContextChip = ({
+  icon,
+  label,
+}: {
+  icon: React.ReactNode;
+  label: string;
+}): React.JSX.Element => (
+  <div className='inline-flex h-7 min-w-0 max-w-[220px] items-center gap-1.5 rounded-lg border border-border bg-muted/50 px-2 text-xs font-medium text-muted-foreground'>
+    <span className='shrink-0 text-muted-foreground'>{icon}</span>
+    <span className='truncate'>{label}</span>
+  </div>
+);
+
+interface PopoverPosition {
+  left: number;
+  top: number;
+}
+
+const clampPopoverPosition = (position: PopoverPosition): PopoverPosition => {
+  if (typeof window === 'undefined') return position;
+
+  const maxLeft = Math.max(window.innerWidth - INLINE_ASK_AI_POPOVER_WIDTH - 16, 16);
+  const maxTop = Math.max(window.innerHeight - 120, 16);
+
+  return {
+    left: Math.min(Math.max(position.left, 16), maxLeft),
+    top: Math.min(Math.max(position.top, 16), maxTop),
+  };
+};
+
+const getInitialPopoverPosition = (rect: DOMRect): PopoverPosition => {
+  if (typeof window === 'undefined') return { left: rect.left, top: rect.bottom + 12 };
+
+  const top = Math.min(rect.bottom + 12, window.innerHeight - 260);
+  const preferredLeft = rect.width === 0 ? rect.left : rect.left;
+  const left = Math.min(
+    Math.max(preferredLeft, 16),
+    Math.max(window.innerWidth - INLINE_ASK_AI_POPOVER_WIDTH - 16, 16),
+  );
+  return { left, top };
+};
+
+const getPopoverStyle = (position: PopoverPosition): React.CSSProperties => {
+  const maxHeight =
+    typeof window === 'undefined' ? 420 : Math.max(280, window.innerHeight - position.top - 24);
+  return {
+    position: 'fixed',
+    top: position.top,
+    left: position.left,
+    width: INLINE_ASK_AI_POPOVER_WIDTH,
+    maxHeight,
+    zIndex: 90,
+  };
+};
+
+export function CanvasInlineAIEdit({
+  canvasId,
+  canvasTitle,
+  channelId,
+  selectedText,
+  anchorRect,
+  onClose,
+}: CanvasInlineAIEditProps): React.JSX.Element {
+  const streamKeyRef = useRef(createInlineAIStreamKey());
+  const [prompt, setPrompt] = useState('');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [conversationId, setConversationId] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showDebugger, setShowDebugger] = useState(false);
+  const [debugEvents, setDebugEvents] = useState<DebugEventRecord[]>([]);
+  const [debugArtifactsReadyVersion, setDebugArtifactsReadyVersion] = useState(0);
+  const [popoverPosition, setPopoverPosition] = useState<PopoverPosition>(() =>
+    getInitialPopoverPosition(anchorRect),
+  );
+  const dragStateRef = useRef<{
+    pointerId: number;
+    offsetLeft: number;
+    offsetTop: number;
+  } | null>(null);
+
+  const selectionContexts = useMemo<SelectionContext[]>(
+    () => [
+      {
+        canvasId,
+        selectedText,
+        preview: selectedText.length > 80 ? `${selectedText.slice(0, 80)}...` : selectedText,
+        ...(canvasTitle && { canvasTitle }),
+      },
+    ],
+    [canvasId, canvasTitle, selectedText],
+  );
+
+  const { submitQuery, abortCurrentRequest } = useXyneAIStream({
+    channelIds: [],
+    conversationId,
+    streamSessionKey: streamKeyRef.current,
+    canvasId,
+    setMessages,
+    setConversationId,
+    setDebugEvents,
+    setDebugArtifactsReadyVersion,
+    isV2: true,
+    suppressCompletionToast: true,
+    channelId,
+    canvasIds: [canvasId],
+  });
+
+  const botMessage = [...messages].reverse().find(message => message.type === 'bot');
+  const userMessage = [...messages].reverse().find(message => message.type === 'user');
+  const responseText = botMessage?.streamingContent || botMessage?.content || '';
+  const isStreaming = messages.some(message => message.isStreaming);
+  const canShowDebugger = messages.length > 0 || debugEvents.length > 0 || Boolean(conversationId);
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    const nextPrompt = prompt.trim();
+    if (!nextPrompt || isSubmitting || isStreaming) return;
+    setIsSubmitting(true);
+    try {
+      await submitQuery(nextPrompt, [], selectionContexts, nextPrompt);
+      setPrompt('');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [isStreaming, isSubmitting, prompt, selectionContexts, submitQuery]);
+
+  const handleClose = useCallback((): void => {
+    abortCurrentRequest();
+    onClose();
+  }, [abortCurrentRequest, onClose]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (event.key !== 'Enter' || event.shiftKey) return;
+    event.preventDefault();
+    void handleSubmit();
+  };
+
+  const handleDragStart = useCallback(
+    (event: PointerEvent<HTMLDivElement>): void => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      dragStateRef.current = {
+        pointerId: event.pointerId,
+        offsetLeft: event.clientX - popoverPosition.left,
+        offsetTop: event.clientY - popoverPosition.top,
+      };
+    },
+    [popoverPosition.left, popoverPosition.top],
+  );
+
+  const handleDragMove = useCallback((event: PointerEvent<HTMLDivElement>): void => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+
+    setPopoverPosition(
+      clampPopoverPosition({
+        left: event.clientX - dragState.offsetLeft,
+        top: event.clientY - dragState.offsetTop,
+      }),
+    );
+  }, []);
+
+  const handleDragEnd = useCallback((event: PointerEvent<HTMLDivElement>): void => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+    dragStateRef.current = null;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  }, []);
+
+  return (
+    <div
+      data-canvas-inline-ai-edit='true'
+      className='flex flex-col overflow-hidden rounded-[18px] border border-input bg-background shadow-[0_18px_60px_rgba(15,23,42,0.16)]'
+      style={getPopoverStyle(popoverPosition)}
+    >
+      <div className='thin-scrollbar min-h-0 flex-1 overflow-y-auto px-5 py-4'>
+        <div className='mb-3 flex items-start justify-between gap-3'>
+          <div className='min-w-0'>
+            <div
+              className='flex cursor-move touch-none select-none items-center gap-2 text-sm font-semibold text-foreground'
+              onPointerDown={handleDragStart}
+              onPointerMove={handleDragMove}
+              onPointerUp={handleDragEnd}
+              onPointerCancel={handleDragEnd}
+            >
+              <img alt='AI' width='14' height='14' src='/svgs/icons/ai-bot-gradient-star.svg' />
+              Ask AI
+            </div>
+            <blockquote className='mt-3 line-clamp-3 border-l-2 border-blue-400 pl-3 text-sm text-muted-foreground'>
+              {selectedText}
+            </blockquote>
+            <div className='mt-3 flex flex-wrap items-center gap-2'>
+              <InlineContextChip
+                icon={<FileText className='size-3.5' />}
+                label={canvasTitle || 'Current canvas'}
+              />
+              <InlineContextChip icon={<TextQuote className='size-3.5' />} label='Selected text' />
+            </div>
+          </div>
+          <button
+            type='button'
+            className='inline-flex size-8 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground'
+            onClick={handleClose}
+            aria-label='Close Ask AI'
+            data-track-category='CANVAS'
+            data-track-name='Inline_Ask_AI_Close'
+            data-track-metadata={JSON.stringify({ canvasId })}
+          >
+            <X className='size-4' />
+          </button>
+        </div>
+        {messages.length > 0 && (
+          <div className='space-y-3 border-t border-border pt-3'>
+            <div className='flex items-start justify-between gap-3'>
+              {userMessage?.content ? (
+                <div className='min-w-0 rounded-xl bg-muted/45 px-3 py-2 text-sm text-foreground'>
+                  {userMessage.content}
+                </div>
+              ) : (
+                <span />
+              )}
+
+              {canShowDebugger && (
+                <button
+                  type='button'
+                  className='inline-flex size-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition hover:bg-accent hover:text-foreground'
+                  onClick={() => setShowDebugger(open => !open)}
+                  aria-label='Toggle debug panel'
+                  aria-pressed={showDebugger}
+                  data-track-category='CANVAS'
+                  data-track-name='Inline_Ask_AI_Debug_Toggle'
+                  data-track-metadata={JSON.stringify({ canvasId })}
+                >
+                  <Bug className='size-3.5' />
+                </button>
+              )}
+            </div>
+
+            {botMessage && (
+              <ActivityBlock
+                reasoning={botMessage.reasoning}
+                toolInvocations={botMessage.toolInvocations}
+                streaming={botMessage.isStreaming}
+                messageAborted={!!botMessage.isAborted}
+              />
+            )}
+
+            {responseText ? (
+              <div className='xyne-ai-markdown text-sm leading-6 text-foreground'>
+                <ReactMarkdown>{responseText}</ReactMarkdown>
+              </div>
+            ) : null}
+
+            {!botMessage?.isStreaming && botMessage?.followUpSuggestions?.length ? (
+              <div className='flex flex-wrap gap-2' data-testid='inline-ask-ai-follow-ups'>
+                {botMessage.followUpSuggestions.map(suggestion => (
+                  <button
+                    key={suggestion}
+                    type='button'
+                    className='rounded-full border border-border bg-card px-3 py-1.5 text-left text-xs font-medium leading-5 text-muted-foreground transition-colors hover:bg-accent'
+                    onClick={() => setPrompt(suggestion)}
+                    data-track-category='CANVAS'
+                    data-track-name='Inline_Ask_AI_Follow_Up_Suggestion'
+                    data-track-metadata={JSON.stringify({ canvasId, suggestion })}
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+
+            {!botMessage && (
+              <ActivityBlock
+                reasoning={undefined}
+                toolInvocations={undefined}
+                streaming
+                messageAborted={false}
+              />
+            )}
+
+            {botMessage?.pendingActions && botMessage.pendingActions.length > 0 && (
+              <PendingActionBlock
+                actions={botMessage.pendingActions}
+                onApprove={async (action, index) => {
+                  await respondToPendingAction(botMessage, action, index, true);
+                }}
+                onDecline={async (action, index) => {
+                  await respondToPendingAction(botMessage, action, index, false);
+                }}
+              />
+            )}
+
+            {botMessage?.pendingActions?.some(action => action.resolution === 'approved') && (
+              <div className='flex items-center gap-2 text-xs text-emerald-600'>
+                <Check className='size-3.5' />
+                Approved
+              </div>
+            )}
+          </div>
+        )}
+
+        {showDebugger && (
+          <div className='mt-4 h-[420px] overflow-hidden rounded-xl border border-border'>
+            <AskAIDebugPanel
+              open={showDebugger}
+              inline
+              width={560}
+              conversationId={conversationId || streamKeyRef.current}
+              agentSlug='ask-ai'
+              liveEvents={debugEvents}
+              running={isStreaming}
+              artifactsReadyVersion={debugArtifactsReadyVersion}
+              selectedTurnIndex={null}
+              selectedTurnLive={isStreaming}
+              selectedSessionId={botMessage?.debugSessionId ?? null}
+              focusToolCallId={null}
+              onClose={() => setShowDebugger(false)}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className='flex items-center gap-3 border-t border-border bg-background px-5 py-3'>
+        <textarea
+          value={prompt}
+          onChange={event => setPrompt(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder='Ask AI to edit this selection...'
+          rows={1}
+          className='max-h-24 min-h-[38px] flex-1 resize-none rounded-[20px] border border-input bg-background px-4 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-ring'
+          data-track-category='CANVAS'
+          data-track-name='Inline_Ask_AI_Prompt'
+          data-track-metadata={JSON.stringify({ canvasId })}
+        />
+        <button
+          type='button'
+          className={cn(
+            'inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground',
+          )}
+          onClick={() => void handleSubmit()}
+          disabled={!prompt.trim() || isSubmitting || isStreaming}
+          aria-label='Send Ask AI prompt'
+          data-track-category='CANVAS'
+          data-track-name='Inline_Ask_AI_Submit'
+          data-track-metadata={JSON.stringify({ canvasId })}
+        >
+          {isSubmitting || isStreaming ? (
+            <Loader2 className='size-4 animate-spin' />
+          ) : (
+            <Send className='size-4' />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -74,6 +74,7 @@ import { CanvasCommentsPanel } from '../CanvasCommentsPanel/CanvasCommentsPanel'
 import { AnimatePresence } from 'framer-motion';
 
 import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
+import { CanvasInlineAIEdit } from '../CanvasInlineAIEdit/CanvasInlineAIEdit';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
 
@@ -485,14 +486,17 @@ export const CollaborativeCanvasEditor = forwardRef<
       isCommentsOpen,
       setIsCommentsOpen,
       inlineCommentThread,
+      inlineAIEdit,
       activeCommentBlockId,
       activeCommentThreadId,
       activeCommentAnchor,
       refreshCommentHighlights,
       openCommentsForCurrentBlock,
+      openAskAIForCurrentSelection,
       focusCommentBlock,
       clearActiveCommentAnchor,
       closeInlineCommentThread,
+      closeInlineAIEdit,
       applyCommentAnchorStyle,
       removeCommentAnchorStyle,
     } = useCanvasCommentEditorBridge({
@@ -572,8 +576,16 @@ export const CollaborativeCanvasEditor = forwardRef<
           ...(canvasId && { canvasId }),
           ...(title && { canvasTitle: title }),
           canComment: editable && !isReadOnly,
+          onAskAI: openAskAIForCurrentSelection,
         }),
-      [canvasId, editable, isReadOnly, openCommentsForCurrentBlock, title],
+      [
+        canvasId,
+        editable,
+        isReadOnly,
+        openAskAIForCurrentSelection,
+        openCommentsForCurrentBlock,
+        title,
+      ],
     );
 
     useEffect((): (() => void) | void => {
@@ -722,6 +734,17 @@ export const CollaborativeCanvasEditor = forwardRef<
               onBeforeCreateThread={applyCommentAnchorStyle}
               onCreateThreadCreated={clearActiveCommentAnchor}
               onCreateThreadFailed={removeCommentAnchorStyle}
+            />
+          )}
+
+          {inlineAIEdit && (
+            <CanvasInlineAIEdit
+              canvasId={canvasId}
+              canvasTitle={title}
+              channelId={channelId}
+              selectedText={inlineAIEdit.selectedText}
+              anchorRect={inlineAIEdit.rect}
+              onClose={closeInlineAIEdit}
             />
           )}
         </div>

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
@@ -40,6 +40,11 @@ export type CanvasInlineCommentThreadState =
     }
   | null;
 
+export type CanvasInlineAIEditState = {
+  selectedText: string;
+  rect: DOMRect;
+} | null;
+
 interface TiptapEditorLike {
   state: {
     selection: { from: number; to: number; empty?: boolean };
@@ -110,6 +115,7 @@ const getCommentThreadRect = (
 
 const INLINE_COMMENT_INTERACTIVE_SELECTOR = [
   '[data-canvas-inline-comment-thread="true"]',
+  '[data-canvas-inline-ai-edit="true"]',
   '[data-overlay-portal]',
   '[data-radix-popper-content-wrapper]',
   '[data-testid="user-search-results"]',
@@ -132,6 +138,7 @@ export function useCanvasCommentEditorBridge({
   const [activeCommentAnchor, setActiveCommentAnchor] = useState<CanvasCommentAnchor | null>(null);
   const [inlineCommentThread, setInlineCommentThread] =
     useState<CanvasInlineCommentThreadState>(null);
+  const [inlineAIEdit, setInlineAIEdit] = useState<CanvasInlineAIEditState>(null);
   const [commentThreads, setCommentThreads] = useState<CanvasCommentHighlightThread[]>([]);
   const [commentHighlightVersion, setCommentHighlightVersion] = useState(0);
   const openedInitialThreadKeyRef = useRef<string | null>(null);
@@ -146,6 +153,7 @@ export function useCanvasCommentEditorBridge({
       setActiveCommentBlockId(thread.blockId);
       setActiveCommentThreadId(thread.id);
       setActiveCommentAnchor(null);
+      setInlineAIEdit(null);
       if (rect) {
         setInlineCommentThread({
           mode: 'thread',
@@ -181,7 +189,7 @@ export function useCanvasCommentEditorBridge({
   }, [commentThreads]);
 
   useEffect(() => {
-    if (!inlineCommentThread) return;
+    if (!inlineCommentThread && !inlineAIEdit) return;
 
     const handlePointerDown = (event: PointerEvent): void => {
       const target = event.target;
@@ -202,7 +210,7 @@ export function useCanvasCommentEditorBridge({
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [inlineCommentThread]);
+  }, [inlineCommentThread, inlineAIEdit]);
 
   useEffect(() => {
     const editor = getEditor();
@@ -372,6 +380,28 @@ export function useCanvasCommentEditorBridge({
     toast.error('Select text to add a comment');
   }, [containerRef, getCurrentBlockId, getCurrentCommentAnchor, getEditor]);
 
+  const openAskAIForCurrentSelection = useCallback((): void => {
+    const blockId = getCurrentBlockId();
+    const anchor = getCurrentCommentAnchor();
+    if (!blockId || !anchor?.anchorText) {
+      toast.error('Select text to ask AI');
+      return;
+    }
+
+    const rect = getSelectionRect(containerRef.current, blockId);
+    if (!rect) {
+      toast.error('Unable to locate selected text');
+      return;
+    }
+
+    setIsCommentsOpen(false);
+    setInlineCommentThread(null);
+    setInlineAIEdit({
+      selectedText: anchor.anchorText,
+      rect,
+    });
+  }, [containerRef, getCurrentBlockId, getCurrentCommentAnchor]);
+
   const focusCommentBlock = useCallback(
     (blockId: string): void => {
       setActiveCommentBlockId(blockId);
@@ -400,18 +430,25 @@ export function useCanvasCommentEditorBridge({
     setActiveCommentThreadId(null);
   }, []);
 
+  const closeInlineAIEdit = useCallback((): void => {
+    setInlineAIEdit(null);
+  }, []);
+
   return {
     isCommentsOpen,
     setIsCommentsOpen,
     inlineCommentThread,
+    inlineAIEdit,
     activeCommentBlockId,
     activeCommentThreadId,
     activeCommentAnchor,
     refreshCommentHighlights,
     openCommentsForCurrentBlock,
+    openAskAIForCurrentSelection,
     focusCommentBlock,
     clearActiveCommentAnchor,
     closeInlineCommentThread,
+    closeInlineAIEdit,
     applyCommentAnchorStyle,
     removeCommentAnchorStyle,
   };


### PR DESCRIPTION
## Type of Change
POT : [POT](https://drive.google.com/file/d/1cvmvhpS_rnCQlddrb5ozLhdezZ5hFhDY/view?usp=drive_link)
- [ ✅] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [✅ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [✅ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
