### PR TITLE
feature: XYNE-17198 add More tags

### DIFF
--- a/apps/backend/src/services/messageClassification/prompt.ts
+++ b/apps/backend/src/services/messageClassification/prompt.ts
@@ -1,4 +1,4 @@
-import { MESSAGE_ACTS, NO_ACT, THREAD_TYPES } from '@xyne/shared';
+import { MESSAGE_ACTS, NO_ACT, THREAD_TYPES, threadTypesByAxis } from '@xyne/shared';
 
 /**
  * The classifier prompt is GENERATED from the vocabularies rather than written out by hand,
@@ -16,6 +16,20 @@ const numbered = (entries: readonly { name: string; description: string }[]): st
 
 const ACT_NAMES = MESSAGE_ACTS.map(entry => entry.name);
 const THREAD_TYPE_CHOICES = THREAD_TYPES;
+
+/**
+ * Axis membership is read off the vocabulary rather than spelled out here, for the same
+ * reason the tag list is: a hand-written "any of A, B, C" in the prose silently stops
+ * matching the moment someone adds an entry.
+ */
+const names = (axis: Parameters<typeof threadTypesByAxis>[0]): string =>
+  threadTypesByAxis(axis)
+    .map(entry => entry.name)
+    .join(', ');
+
+const OUTCOME_NAMES = names('outcome');
+const ANSWER_NAMES = names('answer');
+const SIGNAL_NAMES = names('signal');
 
 export const buildClassifierPrompt = (): string => `You classify workplace chat messages.
 
@@ -72,13 +86,13 @@ dominant act.
 
 ## Second task — the thread as a whole
 
-Also classify the ENTIRE thread, on TWO independent axes.
+Also classify the ENTIRE thread, on THREE independent axes.
 
 ${numbered(THREAD_TYPE_CHOICES)}
 
 ### Axis 1 — outcome (one, rarely two)
 
-Pick ONE of ISSUE, ALERT, QUESTION, REQUEST, FEATURE_REQUEST, DISCUSSION, ANNOUNCEMENT by
+Pick ONE of ${OUTCOME_NAMES} by
 what "done" would mean for the thread. Return a second one only when the thread genuinely
 is two things at once (a bug report that also requests a feature) — never more than two.
 
@@ -97,9 +111,8 @@ When no other type fits, DISCUSSION.
 
 ### Axis 2 — answer types (usually NONE)
 
-Then add any of HOW_TO, WHAT_HAPPENED, WHY_DECISION, WHAT_IS, KNOWN_ISSUE, REFERENCE,
-EXAMPLE, POLICY_LIMIT that apply. These are independent of the outcome — an ISSUE whose
-resolution spells out the fix is both ISSUE and HOW_TO.
+Then add any of ${ANSWER_NAMES} that apply. These are independent of the outcome — an ISSUE
+whose resolution spells out the fix is both ISSUE and HOW_TO.
 
 The bar is high and most threads clear none of it: add one ONLY if someone who was never in
 this thread could get their question answered by THIS THREAD ALONE. Tag what the thread
@@ -113,10 +126,31 @@ WHY_DECISION, and a value someone is unsure about is not POLICY_LIMIT.
 
 ANNOUNCEMENT is an outcome, not an answer type — a release note is ANNOUNCEMENT alone.
 
+### Axis 3 — significance (usually none)
+
+Finally, add any of ${SIGNAL_NAMES} that apply. These rate how VALUABLE the thread is and to
+whom — not what it answers — so they are independent of both axes above and of each other. A
+thread can be an ISSUE, a HOW_TO and a GOLD_NUGGET at once.
+
+Judge the thread's best content, not its average: one masterclass reply in an otherwise
+ordinary thread still earns GOLD_NUGGET.
+
+These two are not a quality score to sprinkle on anything useful, and they are not
+interchangeable — they differ in WHO needs the thread:
+- GOLD_NUGGET is deep and narrow: hard-won expertise a specialist would want, even if most
+  of the team never needs it.
+- MUST_READ is broad and basic: baseline knowledge nearly everyone on the team needs, even
+  when the content itself is not technically deep.
+
+A thread that is merely correct, helpful, or well written earns neither. The great majority
+of threads get none of these — returning none is the normal, correct outcome. Do not add one
+to look thorough, and do not add both unless the thread genuinely is deep expertise AND
+team-wide required reading.
+
 ## Output
 
 {
-  "threadTypes": [the outcome type first, then any answer types — from ${THREAD_TYPE_CHOICES.map(e => e.name).join(', ')}],
+  "threadTypes": [the outcome type first, then any answer types, then any significance types — from ${THREAD_TYPE_CHOICES.map(e => e.name).join(', ')}],
   "classifications": [
     { "id": "<message id from thread_messages>", "messageActs": [one or more of ${ACT_NAMES.join(', ')}, or exactly ["${NO_ACT}"]] }
   ]

--- a/packages/shared/src/tags/vocabularies.ts
+++ b/packages/shared/src/tags/vocabularies.ts
@@ -12,9 +12,17 @@ export interface ActEntry {
   description: string;
 }
 
+/**
+ * Which of the three independent axes a thread type belongs to. Explicit rather than
+ * positional: the prompt generates one section per axis, and deriving that from array
+ * position meant every insertion silently reshuffled the prompt.
+ */
+export type ThreadAxis = 'outcome' | 'answer' | 'signal';
+
 export interface VocabularyEntry extends ActEntry {
   label: string;
   color: string;
+  axis: ThreadAxis;
 }
 
 /**
@@ -60,23 +68,25 @@ export const MESSAGE_ACTS: readonly ActEntry[] = [
 ];
 
 /**
- * How a thread is classified, on two independent axes that share this one vocabulary.
+ * How a thread is classified, on three independent axes that share this one vocabulary.
  *
- * The first seven are OUTCOME types — what "done" would mean for the thread. A thread
- * carries exactly one.
+ * OUTCOME types are what "done" would mean for the thread. A thread carries exactly one.
  *
- * The rest are ANSWER types — what question the thread's content answers for someone who
- * was never in it. A thread carries any number, and most carry none: the bar is that a
- * reader could get their question answered by this thread alone, so tag what it answers,
- * not what it discusses.
+ * ANSWER types are what question the thread's content answers for someone who was never in
+ * it. A thread carries any number, and most carry none: the bar is that a reader could get
+ * their question answered by this thread alone, so tag what it answers, not what it
+ * discusses.
  *
- * The two are independent — a thread can be an ISSUE whose resolution is also a HOW_TO.
+ * SIGNAL types rate how valuable the thread is and to whom, independent of what it answers.
+ * A thread can be an ISSUE that is also a HOW_TO and also a GOLD_NUGGET.
+ *
  * Descriptions are prompt copy, so the "not" clauses matter as much as the definitions:
  * near-misses are what the classifier gets wrong, and each one here is load-bearing.
  */
 export const THREAD_TYPES: readonly VocabularyEntry[] = [
   {
     name: 'ISSUE',
+    axis: 'outcome',
     label: 'Issue',
     color: '#ef4444',
     description:
@@ -84,6 +94,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'ALERT',
+    axis: 'outcome',
     label: 'Alert',
     color: '#f59e0b',
     description:
@@ -91,6 +102,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'QUESTION',
+    axis: 'outcome',
     label: 'Question',
     color: '#f97316',
     description:
@@ -98,6 +110,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'REQUEST',
+    axis: 'outcome',
     label: 'Request',
     color: '#3b82f6',
     description:
@@ -105,6 +118,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'FEATURE_REQUEST',
+    axis: 'outcome',
     label: 'Feature request',
     color: '#8b5cf6',
     description:
@@ -112,6 +126,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'DISCUSSION',
+    axis: 'outcome',
     label: 'Discussion',
     color: '#6b7280',
     description:
@@ -119,6 +134,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'ANNOUNCEMENT',
+    axis: 'outcome',
     label: 'Announcement',
     color: '#14b8a6',
     description:
@@ -131,6 +147,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   // ─── Answer types — what a reader could learn from this thread ──────────────
   {
     name: 'HOW_TO',
+    axis: 'answer',
     label: 'How-to',
     color: '#0891b2',
     description:
@@ -143,6 +160,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'WHAT_HAPPENED',
+    axis: 'answer',
     label: 'What happened',
     color: '#b45309',
     description:
@@ -154,6 +172,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'WHY_DECISION',
+    axis: 'answer',
     label: 'Why (decision)',
     color: '#4f46e5',
     description:
@@ -164,6 +183,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'WHAT_IS',
+    axis: 'answer',
     label: 'What is',
     color: '#059669',
     description:
@@ -175,6 +195,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'KNOWN_ISSUE',
+    axis: 'answer',
     label: 'Known issue',
     color: '#be123c',
     description:
@@ -185,6 +206,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'REFERENCE',
+    axis: 'answer',
     label: 'Reference',
     color: '#334155',
     description:
@@ -196,6 +218,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'EXAMPLE',
+    axis: 'answer',
     label: 'Example',
     color: '#65a30d',
     description:
@@ -206,6 +229,7 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
   },
   {
     name: 'POLICY_LIMIT',
+    axis: 'answer',
     label: 'Policy / limit',
     color: '#c026d3',
     description:
@@ -213,6 +237,34 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
       'durations, rate limits, settlement cutoffs, retry policies, compliance thresholds. NOT a ' +
       'limit being asked about, disputed or guessed at ("I think it is 15K?"), NOT a limit ' +
       'being breached during an incident (that is WHAT_HAPPENED).',
+  },
+
+  // ─── Signal types — how valuable the thread is, and to whom ─────────────────
+  {
+    name: 'GOLD_NUGGET',
+    axis: 'signal',
+    label: 'Gold nugget',
+    color: '#a16207',
+    description:
+      'An advanced, non-obvious insight worth keeping: a solution to a genuinely hard ' +
+      'technical or operational problem, the deep "why" behind a counter-intuitive design ' +
+      'choice or system behaviour, a hard-fought lesson learned, an edge-case bug diagnosis, ' +
+      'or a masterclass-level breakdown. High-signal and reference-worthy even when only ' +
+      'domain experts would need it. NOT routine updates, NOT a bare PR or doc link, NOT a ' +
+      'simple QA answer, NOT a mandatory operational policy (that is POLICY_LIMIT).',
+  },
+  {
+    name: 'MUST_READ',
+    axis: 'signal',
+    label: 'Must read',
+    color: '#b91c1c',
+    description:
+      'Critical baseline knowledge essential for onboarding or daily execution: a major ' +
+      'architectural shift, a breaking change, a core system workflow, or a team-wide ' +
+      'standard, security protocol or production safety guideline. Applies broadly to the ' +
+      'whole engineering or product team rather than a small subset of experts. NOT ' +
+      'specialised edge-case debugging or a deep optional write-up (that is GOLD_NUGGET), ' +
+      'NOT casual channel banter.',
   },
 ];
 
@@ -241,7 +293,7 @@ export const MESSAGE_ACT_NAMES = [
 /**
  * Thread types as a const tuple — z.enum needs a literal tuple. Order is display order, and
  * it is also the chip sort order via `rank()` in both mutator copies, so outcome types stay
- * first and answer types trail them.
+ * first, answer types follow, and signal types trail them.
  */
 export const THREAD_TYPE_NAMES = [
   'ISSUE',
@@ -259,8 +311,14 @@ export const THREAD_TYPE_NAMES = [
   'REFERENCE',
   'EXAMPLE',
   'POLICY_LIMIT',
+  'GOLD_NUGGET',
+  'MUST_READ',
 ] as const;
 
 /** Built-in thread type by name; undefined for a free-form tag. */
 export const threadTypeEntry = (name: string): VocabularyEntry | undefined =>
   THREAD_TYPES.find(entry => entry.name === name);
+
+/** Thread types on one axis, in declaration order. Used to generate the prompt sections. */
+export const threadTypesByAxis = (axis: ThreadAxis): readonly VocabularyEntry[] =>
+  THREAD_TYPES.filter(entry => entry.axis === axis);


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
