### PR TITLE
feat: XYNE-56391 added slack adapter api to fetch user conversation

### DIFF
--- a/apps/backend/src/apps/platform-adapters/slack/controller.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/controller.ts
@@ -39,6 +39,7 @@ import {
 	transformHistory,
 	transformList,
 	transformReplies,
+	transformUsersConversations,
 } from "./request-transformers/conversations";
 import { transformFilesUpload } from "./request-transformers/files";
 import {
@@ -55,6 +56,7 @@ import {
 	transformListResponse,
 	transformOpenResponse,
 	transformRepliesResponse,
+	transformUsersConversationsResponse,
 } from "./response-transformers/conversations";
 import { deriveFiletype, transformFilesUploadResponse } from "./response-transformers/files";
 import { transformUsergroupsListResponse } from "./response-transformers/usergroups";
@@ -207,6 +209,18 @@ const ConversationsOpenSchema = z
 
 const UsersInfoSchema = z.object({
 	user: z.string().min(1, "user is required"),
+});
+
+const UsersConversationsSchema = z.object({
+	user: z.string().optional(),
+	types: z.string().optional(),
+	limit: z
+		.union([z.number(), z.string()])
+		.optional()
+		.transform((val) => (val ? Number(val) : 100)),
+	cursor: z.string().optional(),
+	exclude_archived: SlackBooleanSchema.default(false),
+	team_id: z.string().optional(),
 });
 
 const UsersLookupByEmailSchema = z.object({
@@ -662,6 +676,63 @@ export class SlackController {
 				statusExpiryAt: user.statusExpiryAt,
 			}),
 		);
+	});
+
+	usersConversations = wrapSlackHandler(async (req: Request, res: Response) => {
+		const parsed = UsersConversationsSchema.safeParse(getSlackParams(req));
+		if (!parsed.success) {
+			res.status(200).json({ ok: false, error: "invalid_arguments" });
+			return;
+		}
+
+		const context = getSlackAuthContext(req);
+		// Slack defaults to the authed user when `user` is omitted
+		const targetUserId = parsed.data.user ?? context.userId;
+		if (!targetUserId) {
+			res.status(200).json({ ok: false, error: "user_not_found" });
+			return;
+		}
+
+		if (parsed.data.user) {
+			const targetUser = await repositories.users.findById(targetUserId);
+			if (!targetUser) {
+				res.status(200).json({ ok: false, error: "user_not_found" });
+				return;
+			}
+		}
+
+		const args = transformUsersConversations({
+			...parsed.data,
+			user: targetUserId,
+		});
+		if (args.unknownTypes.length > 0) {
+			res.status(200).json({ ok: false, error: "invalid_types" });
+			return;
+		}
+
+		const channels = await repositories.channels.findManyPaginated({
+			where: args.where,
+			limit: args.limit + 1,
+			cursor: args.cursor,
+		});
+
+		const hasMore = channels.length > args.limit;
+		const items = hasMore ? channels.slice(0, args.limit) : channels;
+		const slackResponse = transformUsersConversationsResponse({
+			items: items.map((channel) => ({
+				id: channel.id,
+				name: channel.name,
+				description: channel.description || undefined,
+				scopeType: channel.scopeType,
+				visibility: channel.visibility,
+				projectId: channel.projectId,
+				createdBy: channel.createdBy,
+				createdAt: channel.createdAt,
+			})),
+			hasMore,
+			nextCursor: hasMore ? items[items.length - 1]?.id : undefined,
+		});
+		res.status(200).json(slackResponse);
 	});
 
 	filesUpload = wrapSlackHandler(async (req: Request, res: Response) => {

--- a/apps/backend/src/apps/platform-adapters/slack/request-transformers/conversations.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/request-transformers/conversations.ts
@@ -2,6 +2,7 @@ import type {
 	SlackConversationsHistoryRequest,
 	SlackConversationsListRequest,
 	SlackConversationsRepliesRequest,
+	SlackUsersConversationsRequest,
 } from "../types";
 
 export interface HistoryArgs {
@@ -69,5 +70,52 @@ export function transformList(
 		where,
 		limit: Math.min(slackReq.limit ?? 100, 1000),
 		cursor: slackReq.cursor,
+	};
+}
+
+export interface UsersConversationsArgs {
+	where: Record<string, unknown>;
+	limit: number;
+	cursor?: string;
+	unknownTypes: string[];
+}
+
+export function transformUsersConversations(
+	slackReq: SlackUsersConversationsRequest & { user: string },
+): UsersConversationsArgs {
+	const types = (slackReq.types ?? "public_channel")
+		.split(",")
+		.map((type) => type.trim())
+		.filter(Boolean);
+
+	const filters: Record<string, unknown>[] = [];
+	const unknownTypes: string[] = [];
+	for (const type of types) {
+		const filter = SLACK_TYPE_TO_XYNE[type];
+		if (filter) {
+			filters.push(filter);
+		} else {
+			unknownTypes.push(type);
+		}
+	}
+
+	const typeWhere =
+		filters.length === 1 ? { ...filters[0] } : { OR: filters };
+
+	const where: Record<string, unknown> = {
+		...typeWhere,
+		// Membership is what makes these "the user's" conversations
+		participants: { some: { userId: slackReq.user } },
+	};
+
+	if (slackReq.exclude_archived) {
+		where.isArchived = false;
+	}
+
+	return {
+		where,
+		limit: Math.min(slackReq.limit ?? 100, 1000),
+		cursor: slackReq.cursor,
+		unknownTypes,
 	};
 }

--- a/apps/backend/src/apps/platform-adapters/slack/response-transformers/conversations.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/response-transformers/conversations.ts
@@ -14,6 +14,7 @@ import type {
 	SlackConversationsRepliesResponse,
 	SlackFileObject,
 	SlackMessageObject,
+	SlackUsersConversationsResponse,
 } from "../types";
 import { deriveFiletype } from "./files";
 
@@ -151,6 +152,21 @@ export function transformListResponse(
 	result: ChannelListResponse,
 ): SlackConversationsListResponse {
 	const response: SlackConversationsListResponse = {
+		ok: true,
+		channels: result.items.map(transformChannel),
+	};
+
+	if (result.hasMore && result.nextCursor) {
+		response.response_metadata = { next_cursor: result.nextCursor };
+	}
+
+	return response;
+}
+
+export function transformUsersConversationsResponse(
+	result: ChannelListResponse,
+): SlackUsersConversationsResponse {
+	const response: SlackUsersConversationsResponse = {
 		ok: true,
 		channels: result.items.map(transformChannel),
 	};

--- a/apps/backend/src/apps/platform-adapters/slack/routes.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/routes.ts
@@ -88,6 +88,17 @@ router.post("/users.info", requirePermission("users:read"), controller.usersInfo
 router.get("/users.lookupByEmail", requirePermission("users:read"), controller.usersLookupByEmail);
 router.post("/users.lookupByEmail", requirePermission("users:read"), controller.usersLookupByEmail);
 
+router.get(
+	"/users.conversations",
+	requirePermission("channels:read"),
+	controller.usersConversations,
+);
+router.post(
+	"/users.conversations",
+	requirePermission("channels:read"),
+	controller.usersConversations,
+);
+
 router.get("/usergroups.list", requirePermission("usergroups:read"), controller.usergroupsList);
 router.post("/usergroups.list", requirePermission("usergroups:read"), controller.usergroupsList);
 

--- a/apps/backend/src/apps/platform-adapters/slack/types.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/types.ts
@@ -231,6 +231,25 @@ export interface SlackConversationsListResponse {
 	};
 }
 
+// ========== users.conversations ==========
+
+export interface SlackUsersConversationsRequest {
+	user?: string;
+	types?: string;
+	limit?: number;
+	cursor?: string;
+	exclude_archived?: boolean;
+	team_id?: string;
+}
+
+export interface SlackUsersConversationsResponse {
+	ok: true;
+	channels: SlackChannelObject[];
+	response_metadata?: {
+		next_cursor: string;
+	};
+}
+
 // ========== conversations.open ==========
 
 export interface SlackConversationsOpenResponse {


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
