### PR TITLE
fix: search stale/out-of-order vespaSearch response race (from:<user> black screen)

### DIFF
--- a/apps/dashboard/src/hooks/__tests__/searchRaceGuard.test.mjs
+++ b/apps/dashboard/src/hooks/__tests__/searchRaceGuard.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * Reproduction test for the search stale-response race (from:<user> black screen).
+ *
+ * The dashboard has no unit-test runner, so this is a self-contained Node script
+ * that models the EXACT resolution path of performSearch in useSearchMetrics.ts:
+ *   - each search run captures `seq = ++searchSeqRef.current`
+ *   - after `await vespaSearch(...)`, it commits results ONLY if `seq` is still latest
+ *
+ * It drives the real-world timeline from the bug report:
+ *   Request A: q="from"   -> resolves LATE (3300ms) with an EMPTY payload (stale)
+ *   Request B: q=""+from: -> resolves FAST (459ms)  with the correct results
+ * B is dispatched after A, so B is the "latest" run.
+ *
+ * WITHOUT the guard, A resolves last and overwrites B -> blank screen (the bug).
+ * WITH the guard, A is detected as stale and dropped -> correct results survive.
+ */
+import assert from 'node:assert/strict';
+
+const FRESH = [{ id: 'msg-1', title: 'hello from Vimal' }, { id: 'msg-2', title: 'ping' }];
+const STALE_EMPTY = [];
+
+function makeVespa(latencyMs, payload) {
+  return () => new Promise(res => setTimeout(() => res(payload), latencyMs));
+}
+
+// --- BUGGY model: no sequence guard (mirrors code BEFORE the fix) ---
+function makeBuggyHook() {
+  const state = { searchResults: null };
+  async function performSearch(vespa) {
+    const results = await vespa();
+    state.searchResults = results; // unconditional commit
+  }
+  return { state, performSearch };
+}
+
+// --- FIXED model: monotonic sequence guard (mirrors code AFTER the fix) ---
+function makeFixedHook() {
+  const state = { searchResults: null };
+  const searchSeqRef = { current: 0 };
+  async function performSearch(vespa) {
+    const seq = ++searchSeqRef.current;
+    const isStale = () => seq !== searchSeqRef.current;
+    const results = await vespa();
+    if (isStale()) return; // drop out-of-order response
+    state.searchResults = results;
+  }
+  return { state, performSearch };
+}
+
+async function drive(hook) {
+  // A dispatched first (slow, stale, empty). B dispatched right after (fast, correct).
+  const a = hook.performSearch(makeVespa(120, STALE_EMPTY)); // scaled 3300ms -> 120ms
+  const b = hook.performSearch(makeVespa(20, FRESH)); //         scaled  459ms -> 20ms
+  await Promise.all([a, b]);
+  return hook.state.searchResults;
+}
+
+const results = [];
+function check(name, cond) {
+  results.push({ name, pass: cond });
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}`);
+}
+
+const buggy = await drive(makeBuggyHook());
+const fixed = await drive(makeFixedHook());
+
+console.log('\n--- observed final searchResults ---');
+console.log('buggy (no guard):', JSON.stringify(buggy));
+console.log('fixed (guard)  :', JSON.stringify(fixed));
+console.log('------------------------------------\n');
+
+// The bug: stale empty response wins -> blank screen.
+check('reproduces bug: without guard, stale empty response clobbers fresh results',
+  Array.isArray(buggy) && buggy.length === 0);
+// The fix: fresh results survive the late stale response.
+check('fix: with guard, fresh results survive the late stale response',
+  Array.isArray(fixed) && fixed.length === 2 && fixed[0].id === 'msg-1');
+
+const failed = results.filter(r => !r.pass).length;
+console.log(`\n${results.length - failed}/${results.length} checks passed`);
+assert.equal(failed, 0, 'race-guard test failed');
+console.log('ALL CHECKS PASSED');

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -446,6 +446,13 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
   const pendingSearchCountRef = useRef(0);
   const latestResultsRef = useRef<DisplaySearchResult[]>([]);
   const sessionFiltersRef = useRef<Set<string>>(new Set());
+  // Guards out-of-order search responses. Each performSearch run claims the next
+  // sequence number; only the latest run is allowed to commit. A slow/stale response
+  // (e.g. a partial `from` query that resolves seconds after the completed `from:`
+  // filter) is discarded instead of overwriting fresh results with an empty payload.
+  const searchSeqRef = useRef(0);
+  // Cancels the previous in-flight vespaSearch when a newer search is dispatched.
+  const searchAbortRef = useRef<AbortController | null>(null);
 
   /**
    * Generate a unique session ID
@@ -905,6 +912,14 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       }>,
       onComplete?: (results: DisplaySearchResult[], query: string) => void,
     ) => {
+      // Claim this run's sequence and abort any previous in-flight request so a slow,
+      // stale response can neither waste the network nor overwrite fresh results.
+      const seq = ++searchSeqRef.current;
+      const isStale = () => seq !== searchSeqRef.current;
+      searchAbortRef.current?.abort();
+      const abortController = new AbortController();
+      searchAbortRef.current = abortController;
+
       const {
         searchText,
         board: boardFilter,
@@ -1231,7 +1246,10 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
                   : options.groupByDocType && { groupBy: 'docType' }),
                 searchId: currentSessionId,
                 presentationSummary: 'lean',
-              });
+              }, abortController.signal);
+
+              // A newer search superseded this one — drop this out-of-order response.
+              if (isStale()) return;
 
               // Honor the backend grouping decision: flat response => flat ALL view.
               setIsGrouped(vespaResponse.grouped);
@@ -1271,7 +1289,11 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
                 ...searchFilters,
                 searchId: currentSessionId,
                 presentationSummary: 'lean',
-              });
+              }, abortController.signal);
+
+              // A newer search superseded this one — drop this out-of-order response.
+              if (isStale()) return;
+
               mergedResults = results.results;
               totalCount = results.totalCount;
               currentOffset = results.results.length;
@@ -1297,14 +1319,21 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
             }));
           }
         } catch (searchError) {
-          setSearchError(searchError instanceof Error ? searchError.message : 'Search failed');
-          setSearchResults([]);
-          // Reset to the default (sectioned) mode so a failed search doesn't render
-          // stale results in the previous grouped/flat mode.
-          setIsGrouped(true);
+          // Ignore failures from a superseded/aborted request (e.g. axios CanceledError
+          // when a newer search aborted this one) — they must not clear fresh results.
+          if (!isStale()) {
+            setSearchError(searchError instanceof Error ? searchError.message : 'Search failed');
+            setSearchResults([]);
+            // Reset to the default (sectioned) mode so a failed search doesn't render
+            // stale results in the previous grouped/flat mode.
+            setIsGrouped(true);
+          }
         } finally {
-          setIsSearching(false);
           pendingSearchCountRef.current -= 1;
+          // Only the latest run may flip the shared loading flag off.
+          if (!isStale()) {
+            setIsSearching(false);
+          }
           if (
             pendingSearchCountRef.current === 0 &&
             latestResultsRef.current.length > 0 &&

--- a/apps/dashboard/src/services/searchService.ts
+++ b/apps/dashboard/src/services/searchService.ts
@@ -23,7 +23,7 @@ export class SearchService {
   /**
    * Perform Vespa search across all indexed documents
    */
-  async vespaSearch(filters: VespaSearchFilters): Promise<{
+  async vespaSearch(filters: VespaSearchFilters, signal?: AbortSignal): Promise<{
     results: DisplaySearchResult[];
     totalCount: number;
     offset: number;
@@ -41,6 +41,7 @@ export class SearchService {
 
       const response = await apiInstance.get<VespaSearchResponse>(this.vespaBaseUrl, {
         params,
+        ...(signal ? { signal } : {}),
       });
 
       if (!response.data.success || !response.data.data) {


### PR DESCRIPTION
## Problem
Typing a `from:<user>` filter in the global search / command palette sometimes blanks the results ("black screen"). Root cause is a last-write-wins race in `apps/dashboard/src/hooks/useSearchMetrics.ts`: `performSearch` awaits `vespaSearch` and **unconditionally** commits the response, with no request sequencing or cancellation. A slow, stale request (e.g. the partial `q=from` query, ~3.3s, empty payload) can resolve *after* a newer, correct one (`q=""` + `from:` filter, ~459ms) and overwrite fresh results with an empty payload → blank screen. The 300ms debounce only cancels a not-yet-fired timer; it does not cancel an already-dispatched request.

## Fix
- **Monotonic sequence guard** in `performSearch`: each run captures `seq = ++searchSeqRef.current`; after every `await vespaSearch(...)` and in the `catch`/`finally`, it bails if `seq !== searchSeqRef.current`. Only the latest run may commit results, flip the loading flag, or surface an error. This eliminates the blank screen.
- **AbortController**: an optional `signal` is threaded through `SearchService.vespaSearch` → `apiInstance.get(url, { params, signal })`; the previous in-flight request is aborted when a newer search is dispatched, so the slow query is cancelled server-side instead of running to completion. Aborted promises reject into the `catch`, which the stale-guard swallows.

## Files
- `apps/dashboard/src/hooks/useSearchMetrics.ts` — sequence guard + abort wiring
- `apps/dashboard/src/services/searchService.ts` — optional `AbortSignal` param
- `apps/dashboard/src/hooks/__tests__/searchRaceGuard.test.mjs` — self-contained Node reproduction

## Validation
- `tsc --noEmit --project tsconfig.app.json` → 0 errors
- `eslint` on both changed files → 0 errors (9 pre-existing warnings, none introduced)
- `node src/hooks/__tests__/searchRaceGuard.test.mjs` → 2/2 pass: without the guard the stale empty response clobbers fresh results (bug reproduced); with the guard the fresh results survive.

## Notes / follow-up
- `loadMoreResults` uses a separate `vespaSearch` call that is not aborted by this controller; a stale pagination append is a much narrower edge and is left as a follow-up to keep this change scoped.

Reported by Mamtha Venkattaramanujam.