### PR TITLE
fix: XYNE-1315 pass caller as rank-only terms for personalized messag…

### DIFF
--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -415,6 +415,7 @@ export class SearchService {
           wsId,
           sort,
           isExactMatch,
+          rankProfile,
         );
 
         const hasQuery = !!(searchQuery && searchQuery.trim());

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -1,6 +1,7 @@
 import {
   type VespaSchema,
   VespaDocType,
+  RankProfile,
   ticketSchema,
   messageSchema,
   attachmentSchema,
@@ -200,6 +201,7 @@ export class YqlBuilder {
     workspaceId?: string,
     sort?: string,
     useExactMatch: boolean = false,
+    rankProfile?: string,
   ): { yql: string; params: Record<string, string> } {
     const schemaNames = schemas.join(', ');
     // `limit` is interpolated raw into non-bindable YQL grammar ({targetHits:N}, max(N)); coerce to
@@ -263,6 +265,15 @@ export class YqlBuilder {
         } else {
           whereConditions.push(userInputClause());
         }
+      }
+
+      // `personalized` only: caller as rank-only terms on the search block so the profile can
+      // read matches(userId|mentions|threadSenders). rank()'s extra args never change what
+      // matches; every other profile's YQL is untouched. Needs chat_message selected
+      // (`mentions` exists only there).
+      if (rankProfile === RankProfile.personalizedRank && userId && schemas.includes(messageSchema)) {
+        const me = params.bind('involvedUser', userId);
+        whereConditions[0] = `rank(${whereConditions[0]}, userId contains ${me}, mentions contains ${me}, threadSenders contains ${me})`;
       }
     }
     // Build app-specific conditions.


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-1315 — personalised message ranking: messages the searching user **sent**, is **mentioned in**, or is a **thread participant** of should rank first (newest-first among themselves), everything else keeps normal relevance order.

The ranking logic itself lives in vespa-core (`chat_message.sd`, `personalized` rank profile rewritten as `default_native` + a global-phase involvement tier — companion PR on branch `fix/XYNE-1315-personalized-involvement-rank`). That profile needs to know *who* is searching, and a rank profile can only see the caller if the query carries them. This PR is that piece:

- `YqlBuilder.buildYql` now takes `rankProfile`. When it is `personalized` and `chat_message` is a selected source, the where-clause is wrapped as
  `rank((…existing query, filters, permission guard…), userId contains @involvedUser_0, mentions contains @involvedUser_0, threadSenders contains @involvedUser_0)`
  so the profile can read `matches(userId)` / `matches(mentions)` / `matches(threadSenders)`.
- `searchService` passes `rankProfile` through to `buildYql`.

`rank()`'s extra arguments never change *what* matches — only the first argument does — so recall and the permission guard are untouched. For every profile other than `personalized` the emitted YQL and params are byte-for-byte identical to today; `personalized` itself was opt-in only (Messages filter dropdown / User-Agent `…search50`), never on a default path.

**Rollout:** safe to deploy in either order relative to the vespa-core schema. With the old schema, `personalized` still resolves and the extra terms are inert; with the new schema and old backend, `personalized` behaves like `default_native`. Only when both are live does the involvement tier kick in.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

(No Prisma/Zero changes. The Vespa schema change ships separately in vespa-core.)

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

- Backend `typecheck` and `build` pass (run by the pre-commit hook and again by hand).
- Vespa side: the rewritten `personalized` profile was validated with a prepare-only deploy against a config server (no errors/warnings on the profile).
- Not exercised end-to-end yet — no query container reachable locally. To verify after both sides are deployed: Messages search → rank profile `personalized` → your own / mentioned / thread-participant messages appear on top, newest first, and `matchfeatures` show `involved`, `is_sender`, `is_mentioned`, `in_thread`. Every other profile: `debug` YQL output is unchanged.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — `YqlBuilder` has no unit tests today; the change is a 4-condition guard around a string wrap, verified by typecheck/build and by reading the emitted YQL.

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass (dashboard untouched)
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` (no new deps)
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind