### PR TITLE
fix: XYNE-56400 making workspaceId non nullable in external_sources t…

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1494,7 +1494,7 @@ export const externalSourceTable = table("external_sources")
     displayName: string(),
     channelId: string().optional(),
     externalIdentifier: string().optional(),
-    workspaceId: string().optional(),
+    workspaceId: string(),
     boardId: string().optional(),
     ownerUserId: string().optional(),
     credentials: string(),

--- a/apps/backend/prisma/migrations/20260818120000_external_source_workspace_id_non_optional/migration.sql
+++ b/apps/backend/prisma/migrations/20260818120000_external_source_workspace_id_non_optional/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `workspaceId` on table `external_sources` required. This step will fail if there are existing NULL values in that column.
+*/
+
+-- AlterTable
+ALTER TABLE "workflow"."external_sources" ALTER COLUMN "workspaceId" SET NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2437,7 +2437,7 @@ model ExternalSource {
   displayName     String                    // "Zoho (Euler Team)" or user email for calendar sources
   channelId       String?                   // Target workspace channel for messages
   externalIdentifier String?                // External provider identifier: Google Calendar channel id, Microsoft subscription id, etc.
-  workspaceId     String?
+  workspaceId     String                    // denormalized tenant key (stamped on insert)
   boardId         String?                   // @deprecated - Use EmailChannelPreference.boardId instead. Target board for ticket creation (no FK constraint) - N:1 with Board
   ownerUserId     String?                   // Owner for user-scoped integrations (calendar, gmail search)
   credentials     String                    // Encrypted credentials (IV:ciphertext format)

--- a/apps/backend/src/integrations/core/core.ts
+++ b/apps/backend/src/integrations/core/core.ts
@@ -60,10 +60,7 @@ export class ExternalSourceCore {
   }
 
   private async resolveChannelMessageSenderId(source: ExternalSource): Promise<string> {
-    if (
-      this.channelEmailAliasService.isChannelEmailSourceType(source.sourceType) &&
-      source.workspaceId
-    ) {
+    if (this.channelEmailAliasService.isChannelEmailSourceType(source.sourceType)) {
       let botUser = await unifiedBotUserService.getBotByBotId(XYNE_MAIL_BOT_ID, source.workspaceId);
       if (!botUser) {
         await unifiedBotUserService.syncAllBotUsers(source.workspaceId);
@@ -170,7 +167,7 @@ export class ExternalSourceCore {
       throw new SourceNotFoundError(sourceName);
     }
 
-    if (source.workspaceId && !source.channelId) {
+    if (!source.channelId) {
       const resolvedChannelIds = await this.resolveDlChannels(source, normalizedData);
       if (resolvedChannelIds.length === 0) {
         return [{ success: true, conversationId: '', entityId: '', action: 'skipped' }];
@@ -395,7 +392,7 @@ export class ExternalSourceCore {
     source: ExternalSource,
     normalizedData: NormalizedData,
   ): Promise<string[]> {
-    const workspaceId = source.workspaceId!;
+    const workspaceId = source.workspaceId;
     if (source.sourceType === 'ozonetel') {
       const channelId =
         typeof normalizedData.metadata.ozonetelChannelId === 'string'

--- a/apps/backend/src/integrations/routes/external-source-sync.ts
+++ b/apps/backend/src/integrations/routes/external-source-sync.ts
@@ -80,18 +80,10 @@ router.post(
 
       // Execute core ingestion: preprocess → transform → sync.
       // Unauthenticated webhook → no HTTP tenant scope. Open one so ingested
-      // emails/drafts/assignments get workspaceId stamped. ExternalSource.workspaceId
-      // is nullable, so prefer it but fall back to the source's bound channel
-      // (Channel.workspaceId is NOT NULL) — without this, a channel-bound source with a
-      // null workspaceId column would ingest unscoped and leak NULL.
-      let ingestWorkspaceId: string | null = source?.workspaceId ?? null;
-      if (!ingestWorkspaceId && source?.channelId) {
-        const channel = await db.channel.findUnique({
-          where: { id: source.channelId },
-          select: { workspaceId: true },
-        });
-        ingestWorkspaceId = channel?.workspaceId ?? null;
-      }
+      // emails/drafts/assignments get workspaceId stamped. ExternalSource.workspaceId is
+      // NOT NULL, so a resolved source always carries its own tenant; we refuse only when
+      // no source resolved at all, since there is nothing to scope the ingest to.
+      const ingestWorkspaceId: string | null = source?.workspaceId ?? null;
       if (!ingestWorkspaceId) {
         logger.error('[External-Source] ingest with no resolvable workspaceId — refusing to ingest untenanted', {
           sourceName,

--- a/apps/backend/src/integrations/social-media/socialMediaService.ts
+++ b/apps/backend/src/integrations/social-media/socialMediaService.ts
@@ -36,13 +36,7 @@ function plainText(value: string): string {
 class SocialMediaService {
   private async getSourceContext(sourceId: string): Promise<SocialMediaSource> {
     const source = await db.externalSource.findUnique({ where: { id: sourceId } });
-    if (
-      !source ||
-      !source.isActive ||
-      !source.channelId ||
-      !source.workspaceId ||
-      !source.ownerUserId
-    ) {
+    if (!source || !source.isActive || !source.channelId || !source.ownerUserId) {
       throw new Error('Active social media source is not configured');
     }
     return source as SocialMediaSource;


### PR DESCRIPTION
…able

Migration-Changes:
  - making workspaceid as non optional

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
