### PR TITLE
fix: XYNE-56405 discard stale out-of-order vespaSearch responses

### DIFF
--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -540,6 +540,10 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
 
   const pendingSearchCountRef = useRef(0);
   const latestResultsRef = useRef<DisplaySearchResult[]>([]);
+  // The query that produced latestResultsRef, so onComplete always receives a
+  // matching pair. Without it a superseded run — which no longer commits its own
+  // results — would hand the callback fresh results labelled with its stale query.
+  const latestQueryRef = useRef('');
   const sessionFiltersRef = useRef<Set<string>>(new Set());
   // Guards out-of-order search responses. Each performSearch run claims the next
   // sequence number; only the latest run is allowed to commit. A slow/stale response
@@ -1407,6 +1411,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
 
             setSearchResults(mergedResults);
             latestResultsRef.current = mergedResults;
+            latestQueryRef.current = searchText;
 
             setPaginationState(prev => ({
               ...prev,
@@ -1435,12 +1440,16 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
           if (!isStale()) {
             setIsSearching(false);
           }
+          // Fires once every dispatched search has settled — including when a
+          // superseded run is the last to settle — so it must report the results
+          // that were actually committed and the query they came from, not this
+          // run's (possibly stale) searchText.
           if (
             pendingSearchCountRef.current === 0 &&
             latestResultsRef.current.length > 0 &&
             onComplete
           ) {
-            onComplete(latestResultsRef.current, searchText);
+            onComplete(latestResultsRef.current, latestQueryRef.current);
           }
         }
       } else {

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -541,6 +541,13 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
   const pendingSearchCountRef = useRef(0);
   const latestResultsRef = useRef<DisplaySearchResult[]>([]);
   const sessionFiltersRef = useRef<Set<string>>(new Set());
+  // Guards out-of-order search responses. Each performSearch run claims the next
+  // sequence number; only the latest run is allowed to commit. A slow/stale response
+  // (e.g. a partial `from` query that resolves seconds after the completed `from:`
+  // filter) is discarded instead of overwriting fresh results with an empty payload.
+  const searchSeqRef = useRef(0);
+  // Cancels the previous in-flight vespaSearch when a newer search is dispatched.
+  const searchAbortRef = useRef<AbortController | null>(null);
 
   /**
    * Generate a unique session ID
@@ -1000,6 +1007,14 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       }>,
       onComplete?: (results: DisplaySearchResult[], query: string) => void,
     ) => {
+      // Claim this run's sequence and abort any previous in-flight request so a slow,
+      // stale response can neither waste the network nor overwrite fresh results.
+      const seq = ++searchSeqRef.current;
+      const isStale = () => seq !== searchSeqRef.current;
+      searchAbortRef.current?.abort();
+      const abortController = new AbortController();
+      searchAbortRef.current = abortController;
+
       const {
         searchText,
         board: boardFilter,
@@ -1315,18 +1330,24 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
 
             if (activeTab === TabType.ALL) {
               const currentSessionId = searchSessionId || '';
-              const vespaResponse = await searchService.vespaSearch({
-                ...searchFilters,
-                //unified rank profile filters
-                ...(effectiveRankProfile === 'unified'
-                  ? {
-                      groupBy: '',
-                      apps: `${VespaApps.CHAT},${VespaApps.TICKET},${VespaApps.FILE}`,
-                    }
-                  : options.groupByDocType && { groupBy: 'docType' }),
-                searchId: currentSessionId,
-                presentationSummary: 'lean',
-              });
+              const vespaResponse = await searchService.vespaSearch(
+                {
+                  ...searchFilters,
+                  //unified rank profile filters
+                  ...(effectiveRankProfile === 'unified'
+                    ? {
+                        groupBy: '',
+                        apps: `${VespaApps.CHAT},${VespaApps.TICKET},${VespaApps.FILE}`,
+                      }
+                    : options.groupByDocType && { groupBy: 'docType' }),
+                  searchId: currentSessionId,
+                  presentationSummary: 'lean',
+                },
+                abortController.signal,
+              );
+
+              // A newer search superseded this one — drop this out-of-order response.
+              if (isStale()) return;
 
               // Honor the backend grouping decision: flat response => flat ALL view.
               setIsGrouped(vespaResponse.grouped);
@@ -1362,11 +1383,18 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
                 currentOffset + BACKEND_RESULTS_LIMIT <= MAX_BACKEND_OFFSET;
             } else {
               const currentSessionId = searchSessionId || '';
-              const results = await searchService.vespaSearch({
-                ...searchFilters,
-                searchId: currentSessionId,
-                presentationSummary: 'lean',
-              });
+              const results = await searchService.vespaSearch(
+                {
+                  ...searchFilters,
+                  searchId: currentSessionId,
+                  presentationSummary: 'lean',
+                },
+                abortController.signal,
+              );
+
+              // A newer search superseded this one — drop this out-of-order response.
+              if (isStale()) return;
+
               mergedResults = results.results;
               totalCount = results.totalCount;
               currentOffset = results.results.length;
@@ -1392,14 +1420,21 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
             }));
           }
         } catch (searchError) {
-          setSearchError(searchError instanceof Error ? searchError.message : 'Search failed');
-          setSearchResults([]);
-          // Reset to the default (sectioned) mode so a failed search doesn't render
-          // stale results in the previous grouped/flat mode.
-          setIsGrouped(true);
+          // Ignore failures from a superseded/aborted request (e.g. axios CanceledError
+          // when a newer search aborted this one) — they must not clear fresh results.
+          if (!isStale()) {
+            setSearchError(searchError instanceof Error ? searchError.message : 'Search failed');
+            setSearchResults([]);
+            // Reset to the default (sectioned) mode so a failed search doesn't render
+            // stale results in the previous grouped/flat mode.
+            setIsGrouped(true);
+          }
         } finally {
-          setIsSearching(false);
           pendingSearchCountRef.current -= 1;
+          // Only the latest run may flip the shared loading flag off.
+          if (!isStale()) {
+            setIsSearching(false);
+          }
           if (
             pendingSearchCountRef.current === 0 &&
             latestResultsRef.current.length > 0 &&

--- a/apps/dashboard/src/services/searchService.ts
+++ b/apps/dashboard/src/services/searchService.ts
@@ -23,7 +23,10 @@ export class SearchService {
   /**
    * Perform Vespa search across all indexed documents
    */
-  async vespaSearch(filters: VespaSearchFilters): Promise<{
+  async vespaSearch(
+    filters: VespaSearchFilters,
+    signal?: AbortSignal,
+  ): Promise<{
     results: DisplaySearchResult[];
     totalCount: number;
     offset: number;
@@ -41,6 +44,7 @@ export class SearchService {
 
       const response = await apiInstance.get<VespaSearchResponse>(this.vespaBaseUrl, {
         params,
+        ...(signal ? { signal } : {}),
       });
 
       if (!response.data.success || !response.data.data) {


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-56405 — typing `from:<user>` in the command palette could blank the search
results ("black screen").

`performSearch` awaited `vespaSearch` and committed the response unconditionally,
with nothing sequencing or cancelling in-flight requests. One typing sequence
fires two searches — the literal `q=from` text query, then the resolved `from:`
filter query — so a slow, stale response could resolve after a newer one and
overwrite fresh results with an empty payload. Last write wins, regardless of
dispatch order.

**1. Monotonic sequence guard** (`useSearchMetrics.performSearch`). Each run claims
`seq = ++searchSeqRef.current`; only the latest run may commit results, flip the
loading flag, or surface an error. The guard also covers the `catch` path — without
it, a superseded request's failure (including the `CanceledError` raised by the
abort below) would run `setSearchResults([])` and blank the screen just the same.
This alone fixes the reported bug.

**2. AbortController** threaded into `SearchService.vespaSearch` via an optional
`signal`, so the superseded request is cancelled on the next keystroke instead of
running a multi-second backend query to completion. This is an efficiency win, and
it is only safe *because* of the guard above.

Known gap, left as a follow-up: `loadMoreResults` issues its own `vespaSearch` with
no signal and no sequence check, so a late pagination response can still append rows
from a previous query. Narrower trigger path; kept out of scope.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

`vespaSearch` gains an optional second parameter (`signal?: AbortSignal`) — additive,
existing call sites are unaffected. No change to the HTTP contract.

---

## How did you test it?

Reproduced the bug and verified the fix against the full local stack (backend :3001,
dashboard :5173, Vespa, Postgres, zero-cache), driving the real UI with Playwright.

To make an inherently timing-dependent bug deterministic, the driver patches
`XMLHttpRequest.prototype.send` to *hold* one `/vespaSearch` request in flight and
release it on command. Nothing about the app is stubbed: the released request hits
the real backend and gets a real response, so the only thing controlled is arrival
order — exactly what a congested network does.

**Before (this branch's parent):** query text `kubernetes` on screen with 2 results;
the stale `q=zzzz` response lands with 0 results and wipes the list. Blank panel, no
error, query text unchanged. Matches the reported symptom.

**After (this branch), both defences verified independently:**

1. Stale request is cancelled by the newer search — never reaches the server.
2. With `AbortController.prototype.abort` no-op'd in the page so cancellation cannot
   help, the stale response is forced to arrive last (`q="zzzz" 146 ms · 0 results`
   after `q="kubernetes" 147 ms · 2 results`) and is discarded — fresh results stay
   on screen. The run asserts this programmatically and fails if the list empties.

Screen recordings of both runs attached (before / after), with an on-screen log of
every `vespaSearch` call, its duration and result count.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests

The dashboard has no unit-test runner (no vitest/jest), and a `.mjs` repro placed
under `src/` breaks `pnpm run lint` — a non-TS file isn't in the typed-lint project,
so `@typescript-eslint/await-thenable` throws and takes the whole lint run down.
The Playwright repro/verification script therefore lives outside the repo. Happy to
land it under `tools/xyne-automation` as a proper e2e case if reviewers want it.

### Manual

**Users**
- [x] Single user
- [ ] Two users at once — not relevant, client-side render race with no shared state
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (backend + dashboard dev servers)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — n/a, no Zero involvement

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme — not applicable, no rendering change
- [x] Empty state — the stale payload *is* the empty case; it no longer clears results
- [ ] Large / realistic data volume
- [x] Error paths — cancelled/superseded request rejects into `catch`; verified it no
      longer clears fresh results or flips the loading flag off early

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes — not run; no shared package touched
- [ ] Backend `typecheck` + `build` pass — not run; no backend files touched
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass — see note below
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>` — n/a, no new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [x] Docs / guidelines updated where behaviour changed — n/a, no behaviour docs affected
- [x] No debug logging or commented-out code left behind

**Note on dashboard checks:** `lint:errors-only` reports 118 errors and `tsc --noEmit`
reports 119 errors in 22 files — **identical counts on an unmodified branch off the
same base**, and none in the two files this PR touches. Both are pre-existing repo
state, not introduced here. `prettier --check` is clean on the changed files.
`build` not run.


[xyne-search-stale-response-race.webm](https://github.com/user-attachments/assets/c39c085a-3dbe-4401-8d7e-4d0e61a460b3)

[xyne-search-race-AFTER-fix.webm](https://github.com/user-attachments/assets/bf5201f6-6e38-4355-80f2-8667fdf020cd)
