### PR TITLE
fix: XYNE-56409 fix input box behaviour in Post Recording Modal

### DIFF
--- a/apps/backend/src/services/recordingSummaryTemplates.ts
+++ b/apps/backend/src/services/recordingSummaryTemplates.ts
@@ -8,6 +8,7 @@ BRAND NAME CORRECTION:
 
 FORMATTING:
 - Use Markdown headings, short paragraphs, and bullet lists. DO NOT use markdown tables anywhere.
+- Never leave a bare paragraph line as the last line of a section, directly above a \`---\` separator — Markdown turns it into a setext heading. Write such content as a bullet instead.
 - Preserve every section heading from the MARKDOWN TEMPLATE exactly, including its leading \`###\` marker and emoji.
 - Never convert a template heading into plain text, bold text, or a list item.
 - Keep bullets concise; put supporting detail inline after an em dash.
@@ -37,7 +38,7 @@ INSTRUCTIONS:
 - Include specific names, numbers, dates mentioned
 - Preserve chronological order where it matters
 - Keep all template section titles as level-three Markdown headings (\`###\`)
-- Skip sections that have no relevant content (write "Not discussed" rather than inventing detail)
+- Skip sections that have no relevant content — write the single bullet \`- Not discussed\` rather than inventing detail. It MUST be a bullet: a bare \`Not discussed\` line sits directly above the template's \`---\` separator, which Markdown then parses as a setext heading and renders in huge heading text.
 - Add Chapters ONLY for long calls, per the STRUCTURE rule above; never force chapters onto a short or medium call
 - In Action Items: Use @ before FULL NAMES for participants in the call (e.g., @Mayank Bansal)
 - In Action Items: For people NOT in the participant list, write their name plainly with "(not in channel)" notation

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -1053,6 +1053,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
           onOpenChange={open => !open && setShowPostToChannelModal(false)}
           title='Post to channel'
           data-testid='post-recording-to-channel-modal'
+          onOpenAutoFocus={event => event.preventDefault()}
         >
           <PostRecordingToChannelModal
             recording={recording}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToChannelModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToChannelModal.tsx
@@ -1,17 +1,22 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
 import { Hash } from 'lucide-react';
-import { MessageType } from '@xyne/shared';
-import { useChannelSearch } from '@xyne/shared/hooks';
+import { ChannelScopeType, ChannelVisibility, MessageType } from '@xyne/shared';
+import type { MentionResult } from '@xyne/shared';
+import { useChannelSearch, useUserGroupSearch } from '@xyne/shared/hooks';
 import Avatar from '../../../components/ui/Avatar/Avatar';
 import { Button } from '../../../components/ui/Button/Button';
+import { InputBox } from '../../../components/ui/InputBox';
+import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
 import { SearchParticipants } from '../../CallHistoryScreen/SearchParticipants';
-import { useActiveUsers } from '../../../hooks/useUsers';
+import { useActiveUsers, useActiveUserSearch } from '../../../hooks/useUsers';
+import { useAuth } from '../../../hooks/useAuth';
+import { useMentionSearch } from '../../../hooks/useMentionSearch';
 import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
 import { channelService } from '../../../services/Chat/channelService';
-import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { getUserDisplayName, userToMentionResult } from '../../../utils/userDisplayName';
 import { logRecordingError } from '../../../utils/recordingUtils';
 import { getApiErrorMessage } from '../../../utils/apiError';
 import { useShareableOrigin } from '../../../hooks/useShareableOrigin';
@@ -25,6 +30,9 @@ export interface PostRecordingToChannelModalProps {
   recording: RecordingDetail;
   onClose?: () => void;
 }
+
+const MENTION_USER_LIMIT = 20;
+const MENTION_GROUP_LIMIT = 10;
 
 const escapeHtml = (value: string): string =>
   value
@@ -50,15 +58,79 @@ export const PostRecordingToChannelModal: React.FC<PostRecordingToChannelModalPr
   onClose,
 }) => {
   const zero = useZero();
+  const { user: currentUser } = useAuth();
   const activeUsers = useActiveUsers();
   const shareableOrigin = useShareableOrigin();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedValues, setSelectedValues] = useState<string[]>([]);
-  const [note, setNote] = useState('');
+  const [noteHtml, setNoteHtml] = useState('');
+  const [noteText, setNoteText] = useState('');
   const [posting, setPosting] = useState(false);
+  const inputBoxRef = useRef<InputBoxHandle>(null);
 
   const channels = useChannelSearch(searchQuery, 10);
+  const selectedChannelId = useMemo(
+    () =>
+      selectedValues.find(value => value.startsWith('channel:'))?.replace('channel:', '') ??
+      undefined,
+    [selectedValues],
+  );
+
+  const { results: channelScopedMentions, searchMentions: searchChannelScopedMentions } =
+    useMentionSearch(selectedChannelId);
+
+  // Fall back to a plain workspace search for DM targets — the same
+  // pattern SendMessageRichTextField uses for a non-concrete channel.
+  const [mentionQuery, setMentionQuery] = useState('');
+  const mentionUsers = useActiveUserSearch(mentionQuery, MENTION_USER_LIMIT);
+  const mentionGroups = useUserGroupSearch(mentionQuery, MENTION_GROUP_LIMIT);
+  const workspaceMentions = useMemo<MentionResult[]>(
+    () => [
+      ...mentionUsers.map(u => userToMentionResult(u, u.id === currentUser?.id)),
+      ...mentionGroups.map(
+        (g): MentionResult => ({
+          id: g.id,
+          name: g.name,
+          type: 'group',
+          ...(g.alias && { alias: g.alias }),
+          ...(g.description && { description: g.description }),
+          memberCount: 0,
+          isDeactivated: g.isActive === false,
+        }),
+      ),
+    ],
+    [mentionUsers, mentionGroups, currentUser?.id],
+  );
+
+  const mentionResults = selectedChannelId ? channelScopedMentions : workspaceMentions;
+  const handleMentionSearch = useCallback(
+    (query: string) => {
+      if (selectedChannelId) {
+        searchChannelScopedMentions(query);
+      } else {
+        setMentionQuery(query);
+      }
+    },
+    [selectedChannelId, searchChannelScopedMentions],
+  );
+
+  // #-channel search for the optional note.
+  const [channelMentionQuery, setChannelMentionQuery] = useState('');
+  const channelMentionResults = useChannelSearch(channelMentionQuery, 10);
+
+  const channelMentionItems = useMemo(
+    () =>
+      channelMentionResults
+        .filter(channel => channel.scopeType === ChannelScopeType.DEFAULT)
+        .map(channel => ({
+          id: channel.id,
+          name: channel.name,
+          isPrivate: channel.visibility === ChannelVisibility.PRIVATE,
+          ...(channel.description && { description: channel.description }),
+        })),
+    [channelMentionResults],
+  );
 
   // Combined target search — active workspace users (for DM) and channels.
   // Selecting a channel is exclusive (SearchParticipants default behavior);
@@ -90,8 +162,9 @@ export const PostRecordingToChannelModal: React.FC<PostRecordingToChannelModalPr
     // (the /recordings/:id route only exists nested under /:workspaceId).
     const link = `${shareableOrigin}/recordings/${recording.externalId}`;
     const parts: string[] = [];
-    if (note.trim()) {
-      parts.push(`<p>${escapeHtml(note.trim())}</p>`);
+    // noteHtml is already rich-text markup from InputBox — don't escape it.
+    if (noteText.trim()) {
+      parts.push(noteHtml);
     }
     parts.push(
       `<p>\uD83C\uDFA5 <strong>${escapeHtml(title)}</strong><br/><a href="${link}">View recording</a></p>`,
@@ -158,7 +231,8 @@ export const PostRecordingToChannelModal: React.FC<PostRecordingToChannelModalPr
         toast.success('Recording shared');
         setSelectedValues([]);
         setSearchQuery('');
-        setNote('');
+        setNoteHtml('');
+        setNoteText('');
         onClose?.();
       }
     } catch (error) {
@@ -186,19 +260,46 @@ export const PostRecordingToChannelModal: React.FC<PostRecordingToChannelModalPr
         />
       </div>
 
-      <div className='space-y-1.5'>
+      <div
+        className='space-y-1.5'
+        data-track-category='RecordingDetailV2'
+        data-track-name='post_recording_note_input'
+        onKeyDownCapture={event => {
+          if (event.key === 'Enter' && !event.shiftKey && selectedValues.length > 0) {
+            if (inputBoxRef.current?.isSuggestionOpen()) return;
+            event.preventDefault();
+            event.stopPropagation();
+            void handlePost();
+          }
+        }}
+      >
         <label htmlFor='post-recording-note' className='text-muted-foreground text-[13px]'>
           Add a message (optional)
         </label>
-        <textarea
+        <InputBox
+          ref={inputBoxRef}
           id='post-recording-note'
-          value={note}
-          onChange={event => setNote(event.target.value)}
           placeholder='Say something about this recording...'
-          rows={3}
-          className='w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring'
-          data-track-category='RecordingDetailV2'
-          data-track-name='post_recording_note_input'
+          onSendMessage={() => {}}
+          onContentChange={(html, text) => {
+            setNoteHtml(html);
+            setNoteText(text);
+          }}
+          mentionItems={mentionResults}
+          onMentionSearch={handleMentionSearch}
+          channelItems={channelMentionItems}
+          onChannelSearch={setChannelMentionQuery}
+          features={{
+            richText: true,
+            mentions: true,
+            commands: false,
+            fileAttachments: false,
+            emojiPicker: true,
+          }}
+          showTypingIndicator={false}
+          disabled={posting}
+          disableEnterToSend
+          hideSendButton
         />
       </div>
 

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToChannelModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToChannelModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
 import { Hash } from 'lucide-react';
@@ -68,6 +68,10 @@ export const PostRecordingToChannelModal: React.FC<PostRecordingToChannelModalPr
   const [noteText, setNoteText] = useState('');
   const [posting, setPosting] = useState(false);
   const inputBoxRef = useRef<InputBoxHandle>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, []);
 
   const channels = useChannelSearch(searchQuery, 10);
   const selectedChannelId = useMemo(
@@ -252,6 +256,7 @@ export const PostRecordingToChannelModal: React.FC<PostRecordingToChannelModalPr
           Post this recording to a channel, or send it to people
         </p>
         <SearchParticipants
+          ref={searchInputRef}
           options={options}
           selectedValues={selectedValues}
           onMultiSelect={setSelectedValues}


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
1.replaced plain message box with InputBox component with tagging channel/people options.

2.changed prompt for making the heading smaller.

3.added auto focus on the search bar in the modal

https://drive.google.com/file/d/10JPMIn-1MFmqwTLHyD7mn4cO8sdm6jYq/view?usp=sharing


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
