### PR TITLE
fix: unify unread activity count between bell badge and Activity 'All' tab

### DIFF
--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -17,7 +17,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import * as Switch from '@radix-ui/react-switch';
 import { cn } from '../../../utils/classNames';
 import type { ActivityWithRelated } from '../../../types/activity';
-import { ActivityClassification } from '@xyne/shared';
+import { ActivityClassification, isVisibleUnreadActivity } from '@xyne/shared';
 import { groupActivities, type ActivityFeedItem } from '../activityGrouping';
 import {
   mixpanelService,
@@ -88,22 +88,6 @@ type TabConfig = {
 
 type ActivityCursor = NonNullable<Parameters<typeof queries.userActivitiesPaginatedV2>[0]['start']>;
 
-const isAllVisibleActivity = (activity: ActivityWithRelated): boolean => {
-  const classification = activity.classification ?? ActivityClassification.PENDING;
-  if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') {
-    return false;
-  }
-
-  if (classification === ActivityClassification.SKIP) return false;
-  if (activity.actorAction === 'direct_message') {
-    return (
-      classification === ActivityClassification.ACTIONABLE ||
-      classification === ActivityClassification.FYI
-    );
-  }
-  return true;
-};
-
 const CALL_ACTIVITY_TYPES = [
   'scheduled_call',
   'call_reminder',
@@ -121,7 +105,7 @@ export const isDirectUserMention = (messageContent: string, userId: string): boo
 };
 
 const TABS: TabConfig[] = [
-  { value: 'all', label: 'All', filter: isAllVisibleActivity },
+  { value: 'all', label: 'All', filter: isVisibleUnreadActivity },
   {
     value: 'your_mentions',
     label: 'Your Mentions',
@@ -721,10 +705,8 @@ const ActivityListView = (): ReactElement => {
     }
 
     unreadActivities.forEach(activity => {
-      // 'all' count includes everything visible
-      // Cast to ActivityWithRelated since unreadActivities has slightly different shape
-      // but isAllVisibleActivity only uses fields that exist in both
-      if (isAllVisibleActivity(activity as unknown as ActivityWithRelated)) {
+      // 'all' count uses the shared notification-visibility predicate
+      if (isVisibleUnreadActivity(activity)) {
         counts.all++;
       }
 

--- a/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
+++ b/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
@@ -1,13 +1,17 @@
 import { useMemo } from 'react';
 import { useSelector } from '@xstate/react';
-import { ActivityClassification } from '@xyne/shared';
+import { isVisibleUnreadActivity } from '@xyne/shared';
 import { stateMachineActor } from '../machines/stateMachine';
 
 /**
- * Hook to get unread activities count with cancelled reactions filtered out
- * Reads from state machine (populated by DeferredLoader)
+ * Hook to get the unread activities count shown on the left-rail bell badge.
+ * Reads from state machine (populated by DeferredLoader) and counts only
+ * activities that are user-facing notifications.
  *
- * @returns count - Number of unread activities
+ * Uses the shared `isVisibleUnreadActivity` predicate so this badge always
+ * matches the Activity 'All' tab count/feed (single source of truth).
+ *
+ * @returns count - Number of unread notification activities
  */
 export const useUnreadActivitiesCount = (): number => {
   const unreadActivities = useSelector(stateMachineActor, state => state.context.unreadActivities);
@@ -17,19 +21,6 @@ export const useUnreadActivitiesCount = (): number => {
       return 0;
     }
 
-    return unreadActivities.filter(activity => {
-      if (activity.actorAction === 'added_v2') return false;
-      if (activity.actorAction === 'removed') return false;
-      if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') return false;
-      const classification = activity.classification ?? ActivityClassification.PENDING;
-      if (classification === ActivityClassification.SKIP) return false;
-      if (activity.actorAction === 'direct_message') {
-        return (
-          classification === ActivityClassification.ACTIONABLE ||
-          classification === ActivityClassification.FYI
-        );
-      }
-      return true;
-    }).length;
+    return unreadActivities.filter(isVisibleUnreadActivity).length;
   }, [unreadActivities]);
 };

--- a/packages/shared/src/activity/index.ts
+++ b/packages/shared/src/activity/index.ts
@@ -32,3 +32,4 @@ export interface ActivityLogEntry extends ActivityLogPayload {
   serverTimestamp: string;
   severity: 'INFO' | 'WARNING' | 'ERROR';
 }
+export * from './notificationVisibility';

--- a/packages/shared/src/activity/notificationVisibility.ts
+++ b/packages/shared/src/activity/notificationVisibility.ts
@@ -1,0 +1,60 @@
+import { ActivityClassification } from '../zero/types';
+
+/**
+ * Minimal structural shape needed to decide whether an unread activity is a
+ * user-facing notification. Both the state-machine `UnreadActivity` and the
+ * dashboard `ActivityWithRelated` row types satisfy this (each provides
+ * `actorAction: string`, `actionSource: string`, `classification: ActivityClassification`).
+ */
+export interface UnreadActivityVisibilityInput {
+  actorAction?: string | null;
+  actionSource?: string | null;
+  classification?: ActivityClassification | null;
+}
+
+/**
+ * Single source of truth for "does this unread activity count as a notification
+ * and appear in the Activity 'All' feed?".
+ *
+ * Historically this rule was duplicated in two places that drifted apart:
+ *   - the left-rail bell badge (`useUnreadActivitiesCount`), and
+ *   - the Activity 'All' tab filter/count (`isAllVisibleActivity`).
+ * The bell excluded reaction events (`added_v2` / `removed`); the 'All' tab did
+ * not — so the two badges disagreed by exactly the number of unread reactions.
+ *
+ * The exclusion of reactions is the intended behavior and matches the backend:
+ * reactions are currently emitted with `actorAction: 'added_v2'`, and the
+ * backend unread-count query already filters `actorAction != 'added_v2'`
+ * (see apps/backend/src/zero/utils/unreadCountUtlis.ts). Reactions remain
+ * visible in the dedicated Reactions tab.
+ *
+ * Keep this the ONLY place that encodes the rule so the surfaces cannot drift
+ * again.
+ */
+export const isVisibleUnreadActivity = (
+  activity: UnreadActivityVisibilityInput,
+): boolean => {
+  // Reaction add (current event `added_v2`) and reaction removal are not
+  // notifications. The bell badge, the per-channel/dock count, and the backend
+  // unread-count query all exclude them.
+  if (activity.actorAction === 'added_v2') return false;
+  if (activity.actorAction === 'removed') return false;
+
+  // Missed calls surface via the Calls badge, not the activity feed.
+  if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') {
+    return false;
+  }
+
+  const classification = activity.classification ?? ActivityClassification.PENDING;
+  if (classification === ActivityClassification.SKIP) return false;
+
+  // Direct messages only notify when classified actionable / FYI.
+  if (activity.actorAction === 'direct_message') {
+    return (
+      classification === ActivityClassification.ACTIONABLE ||
+      classification === ActivityClassification.FYI
+    );
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Summary
The left-rail bell badge and the Activity "All" tab showed different unread counts (e.g. 60 vs 61). Each surface encoded its own copy of the "is this activity a notification?" rule and they drifted: the bell badge excluded reaction events (`added_v2` / `removed`) while the "All" tab did not, so the two disagreed by exactly the number of unread reactions.

This extracts a single shared predicate `isVisibleUnreadActivity` in `@xyne/shared` and points both the bell count (`useUnreadActivitiesCount`) and the Activity "All" tab (filter + count in `ActivityListView`) at it, so they can no longer diverge. Excluding reactions is the intended behavior and matches the backend unread-count query (`apps/backend/src/zero/utils/unreadCountUtlis.ts` already filters `actorAction != 'added_v2'`). Reactions remain visible in the dedicated Reactions tab.

---

1. Problem Description: The unread notification count on the left-rail bell badge did not match the "All" count inside the Activity tab. Root cause: two duplicated, drifted copies of the activity-visibility rule.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Traced all notification-count sources. Bell (`useUnreadActivitiesCount`) excluded reaction activities (`added_v2`/`removed`); the "All" tab predicate (`isAllVisibleActivity`) did not, so the counts differed by the number of unread reactions.
3. Explain the solution implemented in the PR: Added `isVisibleUnreadActivity` in `packages/shared/src/activity/notificationVisibility.ts`, exported from `@xyne/shared`, encoding the single rule (exclude `added_v2`/`removed` reactions, missed calls, SKIP-classified, and non-actionable/FYI DMs). Bell hook and the "All" tab filter + count now both call it. Behavior for the bell is unchanged; the "All" count/feed now excludes reactions to match (reactions still shown in the Reactions tab).
4. Documentation (link to docs created/updated for this change): N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): N/A
7. Environment variable Changes (if any): N/A
8. Testing (how it was tested; screenshots/links): `pnpm --filter @xyne/shared build` (tsc) passes; dashboard `tsc --noEmit` typecheck passes. No runtime/behavior change to the bell badge; the "All" count now equals the bell count.
9. Services to which this change is to be deployed: dashboard (frontend). `@xyne/shared` rebuild required.
10. Main PR link (if this PR is raised against a release branch): N/A