### PR TITLE
fix: XYNE-56319 scribe label handling and older recording layout

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1463,7 +1463,9 @@ export class CallController {
 
       await repositories.calls.update(call.id, {
         ...(input.title ? { title: input.title } : {}),
-        ...(input.labels ? { labels: [...new Set(input.labels)] } : {}),
+        ...(input.labels
+          ? { labels: await noteTakerTranscriptService.resolveLabelsToTagIds(call, input.labels) }
+          : {}),
         ...(input.markedItems !== undefined
           ? { markedItems: input.markedItems as Prisma.InputJsonValue[] }
           : {}),

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1464,7 +1464,14 @@ export class CallController {
       await repositories.calls.update(call.id, {
         ...(input.title ? { title: input.title } : {}),
         ...(input.labels
-          ? { labels: await noteTakerTranscriptService.resolveLabelsToTagIds(call, input.labels) }
+          ? {
+              labels: await noteTakerTranscriptService
+                .resolveLabelsToTagIds(call, input.labels)
+                .catch((error) => {
+                  logger.error(`Failed to resolve labels for recording ${callId}:`, error);
+                  return undefined;
+                }),
+            }
           : {}),
         ...(input.markedItems !== undefined
           ? { markedItems: input.markedItems as Prisma.InputJsonValue[] }

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1200,7 +1200,7 @@ export class CallController {
         return {
           id: call.id,
           externalId: call.externalId,
-          title: call.title || 'Impromptu Recording',
+          title: call.title,
           status: call.status,
           createdByUserId: call.createdByUserId,
           startedAt: call.startedAt,
@@ -1362,7 +1362,7 @@ export class CallController {
         recording: {
           id: call.id,
           externalId: call.externalId,
-          title: call.title || 'Impromptu Recording',
+          title: call.title,
           status: call.status,
           createdByUserId: call.createdByUserId,
           startedAt: call.startedAt,
@@ -1463,16 +1463,7 @@ export class CallController {
 
       await repositories.calls.update(call.id, {
         ...(input.title ? { title: input.title } : {}),
-        ...(input.labels
-          ? {
-              labels: await noteTakerTranscriptService
-                .resolveLabelsToTagIds(call, input.labels)
-                .catch((error) => {
-                  logger.error(`Failed to resolve labels for recording ${callId}:`, error);
-                  return undefined;
-                }),
-            }
-          : {}),
+        ...(input.labels ? { labels: [...new Set(input.labels)] } : {}),
         ...(input.markedItems !== undefined
           ? { markedItems: input.markedItems as Prisma.InputJsonValue[] }
           : {}),

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -293,6 +293,18 @@ export class CallRepository {
     return rowsUpdated > 0;
   }
 
+  async appendLabels(callId: string, labelIds: string[]): Promise<void> {
+    if (labelIds.length === 0) return;
+    await DatabaseClient.getInstance().$executeRaw`
+      UPDATE "calls"
+      SET "labels" = (
+        SELECT array_agg(DISTINCT x) FROM unnest("labels" || ${labelIds}::text[]) AS x
+      )
+      WHERE "id" = ${callId}
+    `;
+    queueCallVespaFeed(callId, { source: CallVespaFeedSource.CallRepositoryUpdate });
+  }
+
   async findById(id: string): Promise<Call | null> {
     const result = await DatabaseClient.getInstance().call.findUnique({
       where: { id }

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -2,7 +2,7 @@ import { DatabaseClient } from '../client';
 import { resolveWorkspaceIdFromModel } from '@/database/tenant/workspace-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { Prisma, type Call, type CallParticipant } from '@prisma/client';
-import { CallOrigin, CallStatus, CallType, InvitationResponse, MeetingStatus, MessageType, MessageArtifactStatus } from '@xyne/shared';
+import { CallOrigin, CallStatus, CallType, InvitationResponse, MeetingStatus, MessageType, MessageArtifactStatus, TagMethod } from '@xyne/shared';
 import { updateCallSystemMessageIfNeeded } from '@/zero/utils/systemMessagesUtils';
 import { repositories } from './index';
 import { logger } from '@/utils/logger';
@@ -295,13 +295,44 @@ export class CallRepository {
 
   async appendLabels(callId: string, labelIds: string[]): Promise<void> {
     if (labelIds.length === 0) return;
-    await DatabaseClient.getInstance().$executeRaw`
-      UPDATE "calls"
-      SET "labels" = (
-        SELECT array_agg(DISTINCT x) FROM unnest("labels" || ${labelIds}::text[]) AS x
-      )
-      WHERE "id" = ${callId}
-    `;
+    const lockKey = `call-labels:${callId}`;
+
+    await DatabaseClient.getInstance().$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
+
+      const call = await tx.call.findUnique({ where: { id: callId }, select: { labels: true } });
+      if (!call) return;
+
+      const relevantIds = [...new Set([...call.labels, ...labelIds])];
+      const tags = await tx.tag.findMany({
+        where: { id: { in: relevantIds }, sourceId: callId, isDeleted: false },
+        select: { id: true, tag: true, method: true },
+      });
+      const tagById = new Map(tags.map((tag) => [tag.id, tag]));
+      
+      const resolve = (id: string): { slug: string; method: TagMethod } => {
+        const tag = tagById.get(id);
+        return tag ? { slug: tag.tag, method: tag.method as TagMethod } : { slug: id, method: TagMethod.MANUAL };
+      };
+
+      const bySlug = new Map<string, string>();
+
+      for (const id of call.labels) {
+        const { slug, method } = resolve(id);
+        if (method === TagMethod.LLM) continue;
+        bySlug.set(slug, id);
+      }
+
+      for (const id of labelIds) {
+        const { slug } = resolve(id);
+        if (bySlug.has(slug)) continue;
+        bySlug.set(slug, id);
+      }
+
+      const labels = [...bySlug.values()];
+      await tx.call.update({ where: { id: callId }, data: { labels } });
+    });
+
     queueCallVespaFeed(callId, { source: CallVespaFeedSource.CallRepositoryUpdate });
   }
 

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -11,7 +11,7 @@ import { findExistingDetailedSummaryCanvas } from '@/services/canvasService';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { tagService, TagServiceError } from '@/tags/service';
 import { tagRepository } from '@/database/repositories/tagRepository';
-import { TAG_FORMAT_REGEX, TagMethod, EntityUserAccess } from '@xyne/shared';
+import { normalizeTagName, TAG_FORMAT_REGEX, TagMethod, EntityUserAccess } from '@xyne/shared';
 import { recordingSharingService } from '@/services/recordingSharingService';
 import {
   mergeRecordingSummaryMarkedItems,
@@ -136,7 +136,16 @@ class NoteTakerTranscriptService {
       const saveLabelsPromise = labelsPromise.then(async (labelIds) => {
         if (labelIds.length === 0) return labelIds;
         try {
-          await repositories.calls.update(call.id, { labels: labelIds });
+          const existing = (await repositories.calls.findByExternalId(call.externalId))?.labels ?? [];
+          const priorTags =
+            existing.length > 0 && call.workspaceId
+              ? await tagService.getTagsByIds(existing, call.workspaceId)
+              : [];
+          const stale = new Set(priorTags.filter(t => t.method === TagMethod.LLM).map(t => t.id));
+
+          await repositories.calls.update(call.id, {
+            labels: [...new Set([...existing.filter(id => !stale.has(id)), ...labelIds])],
+          });
           logger.info(`[${callId}] call_record_updated`, { fields_updated: 'labels', path: 'note_taker' });
         } catch (error) {
           logger.error(`[${callId}] labels_save_failed`, { error, path: 'note_taker' });
@@ -814,7 +823,7 @@ class NoteTakerTranscriptService {
       const slug = this.slugifyLabel(rawLabel);
       if (!slug) continue;
       try {
-        const tagId = await this.getOrCreateLabelTag(call, slug);
+        const tagId = await this.getOrCreateLabelTag(call, slug, TagMethod.LLM);
         if (tagId && !tagIds.includes(tagId)) tagIds.push(tagId);
       } catch (error) {
         logger.error(`[${callId}] label_tag_failed`, { label: slug, path: 'note_taker', error });
@@ -823,13 +832,34 @@ class NoteTakerTranscriptService {
     return tagIds;
   }
 
+  /**
+   * Labels arrive as a mix of Tag ids (already applied) and raw text (just typed), and
+   * leave as ids only — typed text becomes a real Tag marked `manual`.
+   */
+  async resolveLabelsToTagIds(call: Call, incoming: string[]): Promise<string[]> {
+    if (!call.workspaceId) return [...new Set(incoming)];
+
+    const known = await tagRepository.findByIds(incoming, call.workspaceId);
+    const knownIds = new Set(known.map((tag) => tag.id));
+    const ids: string[] = [];
+
+    for (const entry of incoming) {
+      if (knownIds.has(entry)) {
+        ids.push(entry);
+        continue;
+      }
+      const slug = this.slugifyLabel(entry);
+      if (!slug) continue;
+      const id = await this.getOrCreateLabelTag(call, slug, TagMethod.MANUAL);
+      if (id) ids.push(id);
+    }
+
+    return [...new Set(ids)];
+  }
+
   /** Normalize an LLM-generated label into the Tag framework's required format (lowercase, hyphenated). */
   private slugifyLabel(raw: string): string | null {
-    const slug = raw
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
+    const slug = normalizeTagName(raw);
     if (!slug) return null;
     const safe = /^[a-z]/.test(slug) ? slug : `l-${slug}`;
     return TAG_FORMAT_REGEX.test(safe) ? safe : null;
@@ -841,9 +871,19 @@ class NoteTakerTranscriptService {
    * so tagService.createTag doesn't require a workspace-level TagsConfig for
    * the "topic" category (see assertManualCategoryOrOverride).
    */
-  private async getOrCreateLabelTag(call: Call, slug: string): Promise<string | null> {
+  private async getOrCreateLabelTag(
+    call: Call,
+    slug: string,
+    method: TagMethod,
+  ): Promise<string | null> {
     const existing = await tagRepository.findActiveTag(call.id, NOTE_TAKER_TAG_SOURCE_TYPE, NOTE_TAKER_LABEL_CATEGORY, slug);
-    if (existing) return existing.id;
+    if (existing) {
+      // Typing a label the LLM only suggested asserts it just as the tick button does.
+      if (method === TagMethod.MANUAL && existing.method === TagMethod.LLM) {
+        await tagService.confirmTag(existing.id, call.workspaceId!);
+      }
+      return existing.id;
+    }
 
     try {
       const created = await tagService.createTag(
@@ -852,7 +892,7 @@ class NoteTakerTranscriptService {
         call.workspaceId!,
         NOTE_TAKER_LABEL_CATEGORY,
         slug,
-        TagMethod.LLM,
+        method,
       );
       return created.id;
     } catch (error) {

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -136,16 +136,7 @@ class NoteTakerTranscriptService {
       const saveLabelsPromise = labelsPromise.then(async (labelIds) => {
         if (labelIds.length === 0) return labelIds;
         try {
-          const existing = (await repositories.calls.findByExternalId(call.externalId))?.labels ?? [];
-          const priorTags =
-            existing.length > 0 && call.workspaceId
-              ? await tagService.getTagsByIds(existing, call.workspaceId)
-              : [];
-          const stale = new Set(priorTags.filter(t => t.method === TagMethod.LLM).map(t => t.id));
-
-          await repositories.calls.update(call.id, {
-            labels: [...new Set([...existing.filter(id => !stale.has(id)), ...labelIds])],
-          });
+          await repositories.calls.appendLabels(call.id, labelIds);
           logger.info(`[${callId}] call_record_updated`, { fields_updated: 'labels', path: 'note_taker' });
         } catch (error) {
           logger.error(`[${callId}] labels_save_failed`, { error, path: 'note_taker' });

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -63,7 +63,6 @@ import { useVisibleNavigationItems } from '../../../hooks/useVisibleNavigationIt
 import { useToolbarItems } from '../../../hooks/useToolbarItems';
 import { isRequiredToolbarPath } from '../../AppSidebar/navigationConfig';
 import type { PreferenceSection, PreferencesProps, NavItem } from '.';
-import { RecordingLayout } from '../../../stores/recordingStore';
 import { disconnectCalendar } from '../../../services/clients/calendarApi';
 import { toast } from 'sonner';
 
@@ -469,92 +468,6 @@ const VoiceSection: FC<{ state: PreferencesState }> = ({ state }) => (
 
 // ─── Calls ──────────────────────────────────────────────────────────────────
 
-// Visual preview for transcript layout - bullet points with lines
-const TranscriptPreview: FC = () => (
-  <div className='w-32 h-20 flex-shrink-0 rounded-lg bg-muted/60 border border-border p-3 flex flex-col justify-center gap-2'>
-    {/* Line with bullet */}
-    <div className='flex items-center gap-2'>
-      <div className='w-1.5 h-1.5 rounded-full bg-muted-foreground/40 flex-shrink-0' />
-      <div className='h-1.5 w-[85%] rounded-full bg-border' />
-    </div>
-    <div className='flex items-center gap-2'>
-      <div className='w-1.5 h-1.5 rounded-full bg-muted-foreground/40 flex-shrink-0' />
-      <div className='h-1.5 w-[70%] rounded-full bg-border' />
-    </div>
-    <div className='flex items-center gap-2'>
-      <div className='w-1.5 h-1.5 rounded-full bg-muted-foreground/40 flex-shrink-0' />
-      <div className='h-1.5 w-[78%] rounded-full bg-border' />
-    </div>
-    <div className='flex items-center gap-2'>
-      <div className='w-1.5 h-1.5 rounded-full bg-muted-foreground/40 flex-shrink-0' />
-      <div className='h-1.5 w-[60%] rounded-full bg-border' />
-    </div>
-  </div>
-);
-
-// Visual preview for split layout - two panels side by side
-const SplitPreview: FC = () => (
-  <div className='w-32 h-20 flex-shrink-0 rounded-lg bg-muted/60 border border-border p-1.5 flex gap-1.5'>
-    {/* Left panel - transcript lines */}
-    <div className='flex-1 rounded bg-background border border-border/50 p-2 flex flex-col justify-center gap-1.5'>
-      <div className='h-1 w-[90%] rounded-full bg-border' />
-      <div className='h-1 w-3/4 rounded-full bg-border' />
-      <div className='h-1 w-[85%] rounded-full bg-border' />
-      <div className='h-1 w-[65%] rounded-full bg-border' />
-    </div>
-    {/* Right panel - notes with colored header */}
-    <div className='flex-1 rounded bg-background border border-border/50 p-2 flex flex-col gap-1.5'>
-      <div className='h-1.5 w-4/5 rounded-full bg-action-primary' />
-      <div className='h-1 w-[90%] rounded-full bg-border mt-0.5' />
-      <div className='h-1 w-[70%] rounded-full bg-border' />
-      <div className='h-1 w-4/5 rounded-full bg-border' />
-    </div>
-  </div>
-);
-
-// Visual preview for notes layout - single notes panel
-const NotesPreview: FC = () => (
-  <div className='w-32 h-20 flex-shrink-0 rounded-lg bg-muted/60 border border-border p-2.5 flex items-center justify-center'>
-    <div className='w-full h-full rounded bg-background border border-border/50 p-2.5 flex flex-col gap-1.5'>
-      {/* Colored header bar */}
-      <div className='h-1.5 w-3/4 rounded-full bg-action-primary' />
-      {/* Content lines */}
-      <div className='h-1 w-[90%] rounded-full bg-border mt-1' />
-      <div className='h-1 w-[70%] rounded-full bg-border' />
-      <div className='h-1 w-4/5 rounded-full bg-border' />
-      <div className='h-1 w-3/5 rounded-full bg-border' />
-    </div>
-  </div>
-);
-
-interface LayoutOption {
-  value: RecordingLayout;
-  title: string;
-  description: string;
-  Preview: FC;
-}
-
-const LAYOUT_OPTIONS: LayoutOption[] = [
-  {
-    value: 'transcript',
-    title: 'Transcript',
-    description: 'Full-width live transcript',
-    Preview: TranscriptPreview,
-  },
-  {
-    value: 'split',
-    title: 'Split',
-    description: 'Transcript alongside your notes',
-    Preview: SplitPreview,
-  },
-  {
-    value: 'notes',
-    title: 'Notes',
-    description: 'Notes document only',
-    Preview: NotesPreview,
-  },
-];
-
 const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => {
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
@@ -642,55 +555,6 @@ const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => {
       <MenuBarIconToggle />
 
       <RecordingPillToggle />
-
-      {/* Recording section divider */}
-      <div className='pt-2'>
-        <p id='recording-tab-view-label' className='text-sm font-semibold text-foreground'>
-          Recording tab view
-        </p>
-        <p className='text-xs text-muted-foreground mt-0.5'>
-          Which view opens by default when notes are created during a recording
-        </p>
-      </div>
-
-      {/* Layout options */}
-      <div className='space-y-3' role='radiogroup' aria-labelledby='recording-tab-view-label'>
-        {LAYOUT_OPTIONS.map(option => {
-          const isSelected = state.recordingDefaultLayout === option.value;
-          return (
-            <button
-              key={option.value}
-              type='button'
-              role='radio'
-              aria-checked={isSelected}
-              onClick={() => state.setRecordingDefaultLayout(option.value)}
-              className={cn(
-                'w-full flex items-center gap-4 p-3 rounded-xl border transition-all duration-150',
-                isSelected
-                  ? 'border-action-primary bg-action-primary/5'
-                  : 'border-border bg-muted/30 hover:bg-muted/50',
-              )}
-              data-track-category='PREFERENCES'
-              data-track-name={`SelectRecordingLayout_${option.value}`}
-            >
-              <option.Preview />
-              <div className='flex-1 text-left min-w-0'>
-                <p className='text-sm font-medium text-foreground'>{option.title}</p>
-                <p className='text-xs text-muted-foreground mt-0.5'>{option.description}</p>
-              </div>
-              {/* Radio indicator */}
-              <div
-                className={cn(
-                  'w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-colors duration-150',
-                  isSelected ? 'border-action-primary' : 'border-border',
-                )}
-              >
-                {isSelected && <div className='w-2.5 h-2.5 rounded-full bg-action-primary' />}
-              </div>
-            </button>
-          );
-        })}
-      </div>
 
       {/* Calendar connection */}
       <div className='pt-2'>

--- a/apps/dashboard/src/components/ui/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/apps/dashboard/src/components/ui/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -38,6 +38,7 @@ export function SearchableMultiSelect({
   isOpen,
   onOpenChange,
   searchPlaceholder = 'Search...',
+  searchMaxLength,
   searchAriaLabel,
   listAriaLabel,
   emptyMessage = 'No results found',
@@ -156,6 +157,7 @@ export function SearchableMultiSelect({
           onChange={event => setSearchValue(event.target.value)}
           onKeyDown={handleSearchKeyDown}
           placeholder={searchPlaceholder}
+          maxLength={searchMaxLength}
           className='h-auto min-w-0 flex-1 rounded-none border-0 p-0 text-sm shadow-none placeholder:text-muted-foreground focus-visible:border-transparent focus-visible:ring-0'
           aria-label={searchAriaLabel}
           aria-expanded

--- a/apps/dashboard/src/components/ui/SearchableMultiSelect/SearchableMultiSelect.types.ts
+++ b/apps/dashboard/src/components/ui/SearchableMultiSelect/SearchableMultiSelect.types.ts
@@ -28,6 +28,8 @@ export interface SearchableMultiSelectProps {
 
   searchPlaceholder?: string;
 
+  searchMaxLength?: number;
+
   /** Accessible name for the search box (e.g. 'Search labels'). */
   searchAriaLabel: string;
 

--- a/apps/dashboard/src/hooks/useOverflowFit.ts
+++ b/apps/dashboard/src/hooks/useOverflowFit.ts
@@ -1,0 +1,59 @@
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import useMeasure from './useMeasure';
+
+interface UseOverflowFitOptions {
+  itemCount: number;
+  containerWidth: number;
+  gap: number;
+  minVisible?: number;
+}
+
+interface UseOverflowFitResult<T extends HTMLElement> {
+  /** Attach to an invisible twin: every item at natural width, plus a "+N" sample last. */
+  measureRef: RefObject<T | null>;
+  visibleCount: number;
+}
+
+export function useOverflowFit<T extends HTMLElement = HTMLElement>({
+  itemCount,
+  containerWidth,
+  gap,
+  minVisible = 0,
+}: UseOverflowFitOptions): UseOverflowFitResult<T> {
+  const measureRef = useRef<T>(null);
+  const { width: measuredWidth } = useMeasure({ ref: measureRef, observeResize: true });
+  const [visibleCount, setVisibleCount] = useState(itemCount);
+
+  useLayoutEffect(() => {
+    const twin = measureRef.current;
+    if (!twin || containerWidth <= 0) return;
+
+    // Last child is the "+N" sample.
+    const children = Array.from(twin.children) as HTMLElement[];
+    const overflowWidth = children[children.length - 1]?.getBoundingClientRect().width ?? 0;
+    const widths = children.slice(0, -1).map(child => child.getBoundingClientRect().width);
+
+    let used = 0;
+    let count = 0;
+    for (const width of widths) {
+      const next = used + width + (count > 0 ? gap : 0);
+      if (next > containerWidth) break;
+      used = next;
+      count += 1;
+    }
+
+    // Reserve room for the "+N" chip too.
+    if (count < widths.length) {
+      while (count > minVisible && used + gap + overflowWidth > containerWidth) {
+        count -= 1;
+        used -= (widths[count] ?? 0) + (count > 0 ? gap : 0);
+      }
+    }
+
+    setVisibleCount(Math.max(minVisible, count));
+  }, [containerWidth, measuredWidth, itemCount, gap, minVisible]);
+
+  return { measureRef, visibleCount };
+}
+
+export default useOverflowFit;

--- a/apps/dashboard/src/routes/RecordingDetailScreen/RecordingDetailScreen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailScreen/RecordingDetailScreen.tsx
@@ -22,6 +22,7 @@ import {
   Share2,
   Trash2,
   Download,
+  ScrollText,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
@@ -64,35 +65,51 @@ function isCanvas(value: unknown): value is Canvas {
   return content === undefined || Array.isArray(content);
 }
 
-function RecordingNotesSection({ notesCanvasId }: { notesCanvasId: string }): ReactElement {
-  const [canvasData, canvasDetails] = useCachedQuery(
-    queries.getCanvas({ canvasId: notesCanvasId }),
-    {
-      enabled: !!notesCanvasId,
-    },
-  );
+interface RecordingCanvasSectionProps {
+  canvasId: string;
+  title: string;
+  icon: ReactElement;
+  loadingLabel: string;
+  errorLabel: string;
+  placeholder: string;
+}
+
+function RecordingCanvasSection({
+  canvasId,
+  title,
+  icon,
+  loadingLabel,
+  errorLabel,
+  placeholder,
+}: RecordingCanvasSectionProps): ReactElement {
+  const [canvasData, canvasDetails] = useCachedQuery(queries.getCanvas({ canvasId }), {
+    enabled: !!canvasId,
+  });
   const canvas = isCanvas(canvasData) ? canvasData : null;
   const hasCanvasError =
     canvasDetails.type === 'error' || (canvasDetails.type === 'complete' && !canvas);
 
-  return (
-    <div className='mb-6 bg-background rounded-lg border border-border p-6'>
-      <div className='flex items-center gap-2 mb-4'>
-        <FileText className='w-4 h-4 text-muted-foreground' />
-        <h2 className='text-lg font-semibold text-foreground'>Notes</h2>
-      </div>
-
-      {hasCanvasError ? (
+  const renderBody = (): ReactElement => {
+    if (hasCanvasError) {
+      return (
         <div className='flex items-center gap-2 text-sm text-destructive'>
           <AlertCircle className='size-4' />
-          <span>Failed to load notes.</span>
+          <span>{errorLabel}</span>
         </div>
-      ) : !canvas ? (
+      );
+    }
+
+    if (!canvas) {
+      return (
         <div className='flex items-center gap-2 text-sm text-muted-foreground'>
           <Loader2 className='size-4 animate-spin' />
-          <span>Loading notes...</span>
+          <span>{loadingLabel}</span>
         </div>
-      ) : canvas.isCollaborative ? (
+      );
+    }
+
+    if (canvas.isCollaborative) {
+      return (
         <div className='min-h-[360px] overflow-hidden rounded-md border border-border'>
           <CollaborativeCanvasEditor
             key={canvas.id}
@@ -100,15 +117,28 @@ function RecordingNotesSection({ notesCanvasId }: { notesCanvasId: string }): Re
             channelId={canvas.channelId || undefined}
             title={canvas.title}
             editable={false}
-            placeholder='Recording notes...'
+            placeholder={placeholder}
             autoFocus={false}
           />
         </div>
-      ) : (
-        <div className='min-h-[240px] overflow-hidden rounded-md border border-border p-4'>
-          <CanvasEditor content={canvas.content} editable={false} canvasId={canvas.id} />
-        </div>
-      )}
+      );
+    }
+
+    return (
+      <div className='min-h-[240px] overflow-hidden rounded-md border border-border p-4'>
+        <CanvasEditor content={canvas.content} editable={false} canvasId={canvas.id} />
+      </div>
+    );
+  };
+
+  return (
+    <div className='mb-6 bg-background rounded-lg border border-border p-6'>
+      <div className='flex items-center gap-2 mb-4'>
+        {icon}
+        <h2 className='text-lg font-semibold text-foreground'>{title}</h2>
+      </div>
+
+      {renderBody()}
     </div>
   );
 }
@@ -505,17 +535,39 @@ export default function RecordingDetailScreen(): ReactElement {
           </div>
         )}
 
+        {/* Detailed Summary */}
+        {recording.detailedSummaryCanvasId && (
+          <RecordingCanvasSection
+            canvasId={recording.detailedSummaryCanvasId}
+            title='Detailed Summary'
+            icon={<ScrollText className='w-4 h-4 text-muted-foreground' />}
+            loadingLabel='Loading detailed summary...'
+            errorLabel='Failed to load detailed summary.'
+            placeholder='Detailed summary...'
+          />
+        )}
+
         {/* Notes */}
         {recording.notesCanvasId && (
-          <RecordingNotesSection notesCanvasId={recording.notesCanvasId} />
+          <RecordingCanvasSection
+            canvasId={recording.notesCanvasId}
+            title='Notes'
+            icon={<FileText className='w-4 h-4 text-muted-foreground' />}
+            loadingLabel='Loading notes...'
+            errorLabel='Failed to load notes.'
+            placeholder='Recording notes...'
+          />
         )}
 
         {/* No content message */}
-        {!recording.hasTranscript && !recording.hasSummary && !recording.notesCanvasId && (
-          <div className='bg-background rounded-lg border border-border p-12 text-center'>
-            <p className='text-muted-foreground'>Transcript and summary are being processed...</p>
-          </div>
-        )}
+        {!recording.hasTranscript &&
+          !recording.hasSummary &&
+          !recording.notesCanvasId &&
+          !recording.detailedSummaryCanvasId && (
+            <div className='bg-background rounded-lg border border-border p-12 text-center'>
+              <p className='text-muted-foreground'>Transcript and summary are being processed...</p>
+            </div>
+          )}
       </div>
 
       {/* Share Recording Dialog */}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -873,6 +873,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                   visibleTab={visibleTab}
                   secondTab={secondTab}
                   onSelect={handleTabSelect}
+                  hasSummary={hasDetailedSummary}
                   selectedTemplate={selectedSummaryTemplate}
                   {...(isLive || !isOwner
                     ? {}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -26,6 +26,7 @@ import {
   clearSummaryRequested,
   getSummaryProgress,
   getSummaryRequest,
+  getSummaryStage,
   markSummaryRequested,
   saveSummaryProgress,
 } from '../../utils/recordingSummaryRequest';
@@ -683,7 +684,8 @@ export default function RecordingDetailV2Screen(): ReactElement {
   }, [recording, message, notesCanvasId]);
 
   const handleSummaryProgressPause = useCallback(
-    (progress: number): void => saveSummaryProgress(recordingId, progress),
+    (progress: number, stageIndex: number): void =>
+      saveSummaryProgress(recordingId, progress, stageIndex),
     [recordingId],
   );
 
@@ -718,6 +720,21 @@ export default function RecordingDetailV2Screen(): ReactElement {
       return true;
     });
   }, [recordingId, transcriptText]);
+
+  // Seeds the summary-request record for the auto-detected pending state (server
+  // summarizing without an explicit "Generate summary" click), so its progress
+  // persists across unmounts the same way an explicit regenerate already does.
+  useEffect(() => {
+    if (!recordingId || recording?.externalId !== recordingId) return;
+    if (awaitingSummary || summaryFailed) return;
+    const hasDetailedSummaryNow =
+      !!recording?.detailedSummaryCanvasId && recording?.detailedSummaryReady !== false;
+    const hasTranscriptNow =
+      !!transcriptText?.trim() || !!recordingRow?.transcript || !!recording?.hasTranscript;
+    if (hasDetailedSummaryNow || !hasTranscriptNow) return;
+    if (getSummaryRequest(recordingId)) return;
+    markSummaryRequested(recordingId);
+  }, [recordingId, recording, recordingRow, transcriptText, awaitingSummary, summaryFailed]);
 
   if (loading) {
     return <RecordingDetailV2Skeleton />;
@@ -1045,6 +1062,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                   hasFailed={summaryFailed}
                   generationRunId={summaryRunNonce}
                   initialProgress={getSummaryProgress(recordingId)}
+                  initialStageIndex={getSummaryStage(recordingId)}
                   onProgressPause={handleSummaryProgressPause}
                   onReadTranscript={transcriptText ? openTranscriptPanel : undefined}
                 />

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingContentTabs.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingContentTabs.tsx
@@ -41,6 +41,7 @@ interface RecordingContentTabsProps {
   /** `transcript` while live, `summary` once ended. */
   secondTab: Exclude<RecordingContentTab, 'notes'>;
   onSelect: (tab: RecordingContentTab) => void;
+  hasSummary: boolean;
   /** The template selected for this recording; labels the segment. */
   selectedTemplate?: RecordingSummaryTemplate;
   /** Swaps the segment's icon for a spinner and locks the menu while regenerating. */
@@ -66,6 +67,7 @@ export const RecordingContentTabs = ({
   visibleTab,
   secondTab,
   onSelect,
+  hasSummary,
   selectedTemplate,
   isRegenerating = false,
   templates = [],
@@ -127,7 +129,7 @@ export const RecordingContentTabs = ({
 
   const renderSummaryTab = (): ReactElement => {
     const isActive = visibleTab === 'summary';
-    const fullLabel = selectedTemplate?.name ?? 'Default summary';
+    const fullLabel = hasSummary ? (selectedTemplate?.name ?? 'Default summary') : 'Summary';
     const label = truncateTemplateName(fullLabel);
 
     const indicator = isActive ? (
@@ -181,9 +183,19 @@ export const RecordingContentTabs = ({
         {indicator}
         <span className='relative z-10 flex items-center gap-2'>
           {icon}
-          {label}
+          <AnimatePresence mode='popLayout' initial={false}>
+            <motion.span
+              key={label}
+              initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
+              transition={{ duration: shouldReduceMotion ? 0 : 0.14 }}
+            >
+              {label}
+            </motion.span>
+          </AnimatePresence>
           <AnimatePresence initial={false}>
-            {isActive && onOpenTemplates && (
+            {isActive && onOpenTemplates && hasSummary && (
               <motion.span
                 initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.6, width: 0 }}
                 animate={{ opacity: 1, scale: 1, width: 14 }}
@@ -200,7 +212,7 @@ export const RecordingContentTabs = ({
       </button>
     );
 
-    if (!onOpenTemplates) return trigger;
+    if (!onOpenTemplates || !hasSummary) return trigger;
 
     return (
       <Popover

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -299,60 +299,58 @@ export const RecordingDetailV2Header = ({
       </div>
 
       {/* Actions row */}
-      <div className='flex flex-wrap items-center justify-between gap-3'>
-        <div className='flex flex-wrap items-center gap-2'>
-          {!isLive && recording.detailedSummaryCanvasId && (
-            <RecordingTicketLink
-              linkedTicketId={recording.linkedTicketId ?? null}
-              canEdit={isOwner}
-              isUpdating={isUpdatingTicketLink}
-              onChange={(ticketId, ticket) => void handleTicketLinkChange(ticketId, ticket)}
-            />
-          )}
-          <RecordingLabelPicker
-            labels={recording.labels ?? []}
-            canEdit={recording.createdByUserId === currentUser?.id}
-            onChange={labels => void handleLabelsChange(labels)}
+      <div className='flex flex-wrap items-center gap-2'>
+        {!isLive && recording.detailedSummaryCanvasId && (
+          <RecordingTicketLink
+            linkedTicketId={recording.linkedTicketId ?? null}
+            canEdit={isOwner}
+            isUpdating={isUpdatingTicketLink}
+            onChange={(ticketId, ticket) => void handleTicketLinkChange(ticketId, ticket)}
           />
-          {isOwner && !isLive && recording.detailedSummaryCanvasId && (
-            <>
-              <RecordingSharedWithAvatars
-                recordingExternalId={recording.externalId}
-                onOpen={() => setShowShareModal(true)}
-              />
-              <Tooltip content='Share' side='top'>
-                <Button
-                  type='button'
-                  variant='outline'
-                  size='iconSm'
-                  onClick={() => setShowShareModal(true)}
-                  className='w-8 h-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-                  aria-label='Share recording'
-                  data-track-category='RecordingDetailV2'
-                  data-track-name='share_recording'
-                >
-                  <Share02 className='size-3.5' />
-                </Button>
-              </Tooltip>
-            </>
-          )}
-          {onMinimize && (
-            <Tooltip content='Minimize to overlay' side='top'>
+        )}
+        <RecordingLabelPicker
+          labels={recording.labels ?? []}
+          canEdit={recording.createdByUserId === currentUser?.id}
+          onChange={labels => void handleLabelsChange(labels)}
+        />
+        {isOwner && !isLive && recording.detailedSummaryCanvasId && (
+          <>
+            <RecordingSharedWithAvatars
+              recordingExternalId={recording.externalId}
+              onOpen={() => setShowShareModal(true)}
+            />
+            <Tooltip content='Share' side='top'>
               <Button
                 type='button'
                 variant='outline'
                 size='iconSm'
-                onClick={onMinimize}
-                className='size-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-                aria-label='Minimize to floating overlay'
+                onClick={() => setShowShareModal(true)}
+                className='w-8 h-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                aria-label='Share recording'
                 data-track-category='RecordingDetailV2'
-                data-track-name='minimize_to_overlay'
+                data-track-name='share_recording'
               >
-                <MinimizeLineArrow className='size-3.5' />
+                <Share02 className='size-3.5' />
               </Button>
             </Tooltip>
-          )}
-        </div>
+          </>
+        )}
+        {onMinimize && (
+          <Tooltip content='Minimize to overlay' side='top'>
+            <Button
+              type='button'
+              variant='outline'
+              size='iconSm'
+              onClick={onMinimize}
+              className='size-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+              aria-label='Minimize to floating overlay'
+              data-track-category='RecordingDetailV2'
+              data-track-name='minimize_to_overlay'
+            >
+              <MinimizeLineArrow className='size-3.5' />
+            </Button>
+          </Tooltip>
+        )}
 
         {isOwner && !isLive && showShareModal && recording.detailedSummaryCanvasId && (
           <Dialog
@@ -375,7 +373,7 @@ export const RecordingDetailV2Header = ({
               variant='outline'
               size='sm'
               onClick={onAskAI}
-              className='h-8 gap-2 rounded-xl w-24 text-[13px] font-medium border-muted-foreground/20'
+              className='ml-auto h-8 gap-2 rounded-xl w-24 text-[13px] font-medium border-muted-foreground/20'
               data-track-category='RecordingDetailV2'
               data-track-name='ask_ai_recording'
             >

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -299,73 +299,75 @@ export const RecordingDetailV2Header = ({
       </div>
 
       {/* Actions row */}
-      <div className='flex flex-wrap items-center gap-2'>
-        {!isLive && recording.detailedSummaryCanvasId && (
-          <RecordingTicketLink
-            linkedTicketId={recording.linkedTicketId ?? null}
-            canEdit={isOwner}
-            isUpdating={isUpdatingTicketLink}
-            onChange={(ticketId, ticket) => void handleTicketLinkChange(ticketId, ticket)}
-          />
-        )}
-        <RecordingLabelPicker
-          labels={recording.labels ?? []}
-          canEdit={recording.createdByUserId === currentUser?.id}
-          onChange={labels => void handleLabelsChange(labels)}
-        />
-        {isOwner && !isLive && recording.detailedSummaryCanvasId && (
-          <>
-            <RecordingSharedWithAvatars
-              recordingExternalId={recording.externalId}
-              onOpen={() => setShowShareModal(true)}
+      <div className='flex items-start'>
+        <div className='flex flex-wrap items-center gap-2'>
+          {!isLive && recording.detailedSummaryCanvasId && (
+            <RecordingTicketLink
+              linkedTicketId={recording.linkedTicketId ?? null}
+              canEdit={isOwner}
+              isUpdating={isUpdatingTicketLink}
+              onChange={(ticketId, ticket) => void handleTicketLinkChange(ticketId, ticket)}
             />
-            <Tooltip content='Share' side='top'>
+          )}
+          <RecordingLabelPicker
+            labels={recording.labels ?? []}
+            canEdit={recording.createdByUserId === currentUser?.id}
+            onChange={labels => void handleLabelsChange(labels)}
+          />
+          {isOwner && !isLive && recording.detailedSummaryCanvasId && (
+            <>
+              <RecordingSharedWithAvatars
+                recordingExternalId={recording.externalId}
+                onOpen={() => setShowShareModal(true)}
+              />
+              <Tooltip content='Share' side='top'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='iconSm'
+                  onClick={() => setShowShareModal(true)}
+                  className='w-8 h-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                  aria-label='Share recording'
+                  data-track-category='RecordingDetailV2'
+                  data-track-name='share_recording'
+                >
+                  <Share02 className='size-3.5' />
+                </Button>
+              </Tooltip>
+            </>
+          )}
+          {onMinimize && (
+            <Tooltip content='Minimize to overlay' side='top'>
               <Button
                 type='button'
                 variant='outline'
                 size='iconSm'
-                onClick={() => setShowShareModal(true)}
-                className='w-8 h-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-                aria-label='Share recording'
+                onClick={onMinimize}
+                className='size-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                aria-label='Minimize to floating overlay'
                 data-track-category='RecordingDetailV2'
-                data-track-name='share_recording'
+                data-track-name='minimize_to_overlay'
               >
-                <Share02 className='size-3.5' />
+                <MinimizeLineArrow className='size-3.5' />
               </Button>
             </Tooltip>
-          </>
-        )}
-        {onMinimize && (
-          <Tooltip content='Minimize to overlay' side='top'>
-            <Button
-              type='button'
-              variant='outline'
-              size='iconSm'
-              onClick={onMinimize}
-              className='size-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-              aria-label='Minimize to floating overlay'
-              data-track-category='RecordingDetailV2'
-              data-track-name='minimize_to_overlay'
-            >
-              <MinimizeLineArrow className='size-3.5' />
-            </Button>
-          </Tooltip>
-        )}
+          )}
 
-        {isOwner && !isLive && showShareModal && recording.detailedSummaryCanvasId && (
-          <Dialog
-            open={showShareModal}
-            onOpenChange={open => !open && setShowShareModal(false)}
-            title='Share recording'
-            data-testid='recording-share-modal'
-          >
-            <RecordingShareModal
-              recording={recording}
-              onClose={() => setShowShareModal(false)}
-              onTicketLinkUpdated={onTicketLinkUpdated}
-            />
-          </Dialog>
-        )}
+          {isOwner && !isLive && showShareModal && recording.detailedSummaryCanvasId && (
+            <Dialog
+              open={showShareModal}
+              onOpenChange={open => !open && setShowShareModal(false)}
+              title='Share recording'
+              data-testid='recording-share-modal'
+            >
+              <RecordingShareModal
+                recording={recording}
+                onClose={() => setShowShareModal(false)}
+                onTicketLinkUpdated={onTicketLinkUpdated}
+              />
+            </Dialog>
+          )}
+        </div>
         {!isLive && (
           <Tooltip content='Ask AI about this recording' side='top'>
             <Button

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -190,7 +190,7 @@ export const RecordingDetailV2Header = ({
   };
 
   const handleStartEdit = (): void => {
-    if (isEditingTitle || isSavingTitle) return;
+    if (isEditingTitle || isSavingTitle || isGeneratingTitle) return;
     setEditedTitle(recording.title);
     setIsEditingTitle(true);
   };
@@ -255,7 +255,7 @@ export const RecordingDetailV2Header = ({
                 />
               </div>
             </div>
-          ) : isOwner ? (
+          ) : isOwner && !isGeneratingTitle ? (
             <div
               role='button'
               tabIndex={0}
@@ -276,8 +276,9 @@ export const RecordingDetailV2Header = ({
               </h1>
             </div>
           ) : (
-            /* Shared-with-me: the title is someone else's to change, so it isn't
-               focusable or clickable — no affordance to discover and be refused. */
+            /* Shared-with-me, or the AI title is still generating: not this
+               user's to change right now, so it isn't focusable or clickable
+               — no affordance to discover and be refused. */
             <h1 className='flex min-w-0 items-baseline gap-2 text-3xl font-medium text-foreground'>
               {isLive && <span className='shrink-0 text-muted-foreground/70'>Capturing:</span>}
               <HeaderTitle isGenerating={isGeneratingTitle} title={displayTitle} />

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -33,6 +33,9 @@ const SUGGESTION_CHIP_CLASS_NAME =
 const READ_ONLY_TRIGGER_CLASS_NAME =
   'inline-flex h-7 items-center gap-1.5 rounded-lg border bg-background px-2 text-xs font-normal text-foreground shadow-xs';
 
+const LIST_INHERITS_POPOVER_CLASS_NAME =
+  '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
+
 function LabelChip({ label }: { label: string }): ReactElement {
   return (
     <span className={CHIP_CLASS_NAME}>
@@ -111,6 +114,7 @@ export function RecordingLabelPicker({
   const options = useMemo<SearchableMultiSelectOption[]>(
     () =>
       normalizeRecordingTags([...suggestions, ...labels])
+        .filter(label => resolveMethod(label) !== TagMethod.LLM)
         .map(label => ({ value: label, displayLabel: resolveLabel(label) }))
         .sort((left, right) => left.displayLabel.localeCompare(right.displayLabel))
         .map(({ value, displayLabel }) => ({
@@ -125,7 +129,7 @@ export function RecordingLabelPicker({
             />
           ),
         })),
-    [labels, suggestions, resolveLabel],
+    [labels, suggestions, resolveLabel, resolveMethod],
   );
 
   const visibleLabels = confirmedLabels.slice(0, MAX_VISIBLE_LABELS);
@@ -201,6 +205,7 @@ export function RecordingLabelPicker({
         selectedValues={labels}
         onSelectedValuesChange={onChange}
         onCreateOption={handleCreate}
+        className={LIST_INHERITS_POPOVER_CLASS_NAME}
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         searchPlaceholder='Search or create...'
@@ -215,7 +220,7 @@ export function RecordingLabelPicker({
             variant='outline'
             size='sm'
             className={cn(
-              'h-7 gap-1.5 rounded-lg text-xs font-normal',
+              'h-7 gap-1.5 rounded-lg text-xs font-normal ',
               confirmedLabels.length === 0
                 ? 'border-dashed border-muted-foreground/40 px-3 text-muted-foreground hover:border-foreground/30 hover:text-foreground'
                 : 'px-2',

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -7,13 +7,18 @@ import { SearchableMultiSelect } from '../../../components/ui/SearchableMultiSel
 import type { SearchableMultiSelectOption } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect.types';
 import { Button } from '../../../components/ui/Button/Button';
 import { tagsApi } from '../../../api/tagsApi';
+import { useOverflowFit } from '../../../hooks/useOverflowFit';
 import { useRecordingLabelSuggestions } from '../../../hooks/useRecordingLabelSuggestions';
 import {
   markResolvedRecordingLabelMethod,
   useResolvedRecordingLabels,
 } from '../../../hooks/useResolvedRecordingLabels';
 import { cn } from '../../../utils/classNames';
-import { getRecordingTagDotColor, normalizeRecordingTags } from '../../../utils/recordingUtils';
+import {
+  getRecordingTagDotColor,
+  normalizeRecordingTags,
+  slugifyRecordingLabel,
+} from '../../../utils/recordingUtils';
 
 export interface RecordingLabelPickerProps {
   labels: string[];
@@ -21,8 +26,9 @@ export interface RecordingLabelPickerProps {
   onChange: (labels: string[]) => void;
 }
 
-/** Labels beyond this collapse into a "+n" chip so the header stays on one line. */
-const MAX_VISIBLE_LABELS = 3;
+const LABEL_STRIP_MAX_WIDTH = 388;
+const LABEL_CHIP_GAP = 6;
+const LABEL_MAX_LENGTH = 40;
 
 const CHIP_CLASS_NAME =
   'inline-flex shrink-0 items-center gap-1.5 rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-foreground whitespace-nowrap scrollbar-none data-[theme=midnight]:bg-muted/50';
@@ -36,14 +42,20 @@ const READ_ONLY_TRIGGER_CLASS_NAME =
 const LIST_INHERITS_POPOVER_CLASS_NAME =
   '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
 
-function LabelChip({ label }: { label: string }): ReactElement {
+function LabelChip({
+  label,
+  canTruncate = false,
+}: {
+  label: string;
+  canTruncate?: boolean;
+}): ReactElement {
   return (
-    <span className={CHIP_CLASS_NAME}>
+    <span className={cn(CHIP_CLASS_NAME, canTruncate && 'min-w-0 shrink')}>
       <span
         className={cn('size-1.5 shrink-0 rounded-full', getRecordingTagDotColor(label))}
         aria-hidden='true'
       />
-      <span>{label}</span>
+      <span className={cn(canTruncate && 'truncate')}>{label}</span>
     </span>
   );
 }
@@ -132,11 +144,24 @@ export function RecordingLabelPicker({
     [labels, suggestions, resolveLabel, resolveMethod],
   );
 
-  const visibleLabels = confirmedLabels.slice(0, MAX_VISIBLE_LABELS);
+  const { measureRef, visibleCount } = useOverflowFit<HTMLSpanElement>({
+    itemCount: confirmedLabels.length,
+    containerWidth: LABEL_STRIP_MAX_WIDTH,
+    gap: LABEL_CHIP_GAP,
+    minVisible: 1,
+  });
+
+  const shownCount = Math.min(visibleCount, confirmedLabels.length);
+  const visibleLabels = confirmedLabels.slice(0, shownCount);
   const overflowCount = confirmedLabels.length - visibleLabels.length;
 
   const handleCreate = (label: string): void => {
-    onChange(normalizeRecordingTags([...labels, label]));
+    const slug = slugifyRecordingLabel(label);
+    if (!slug) {
+      toast.error('Label needs at least one letter or number');
+      return;
+    }
+    onChange(normalizeRecordingTags([...labels, slug]));
   };
 
   /** Tick: keep the AI-suggested tag — flips its Tag row to `manual` in place, no labels change needed. */
@@ -156,14 +181,30 @@ export function RecordingLabelPicker({
   };
 
   const appliedLabels = (
-    <span className='flex max-w-72 w-full items-center gap-1.5 overflow-x-scroll scrollbar-none'>
+    <span
+      className='relative flex flex-nowrap items-center gap-1.5 overflow-hidden'
+      style={{ maxWidth: LABEL_STRIP_MAX_WIDTH }}
+    >
+      <span
+        ref={measureRef}
+        aria-hidden='true'
+        className='pointer-events-none invisible absolute left-0 top-0 flex w-max flex-nowrap items-center gap-1.5'
+      >
+        {confirmedLabels.map(label => (
+          <LabelChip key={label} label={resolveLabel(label)} />
+        ))}
+        <span className={cn(CHIP_CLASS_NAME, 'text-muted-foreground')}>
+          +{confirmedLabels.length}
+        </span>
+      </span>
+
       {visibleLabels.map(label => (
-        <LabelChip key={label} label={resolveLabel(label)} />
+        <LabelChip key={label} label={resolveLabel(label)} canTruncate />
       ))}
       {overflowCount > 0 && (
         <span
           className={cn(CHIP_CLASS_NAME, 'text-muted-foreground')}
-          title={confirmedLabels.slice(MAX_VISIBLE_LABELS).map(resolveLabel).join(', ')}
+          title={confirmedLabels.slice(shownCount).map(resolveLabel).join(', ')}
         >
           +{overflowCount}
         </span>
@@ -172,18 +213,16 @@ export function RecordingLabelPicker({
   );
 
   const suggestionPills =
-    canEdit && suggestedLabels.length > 0 ? (
-      <span className='flex shrink-0 items-center gap-1.5'>
-        {suggestedLabels.map(label => (
+    canEdit && suggestedLabels.length > 0
+      ? suggestedLabels.map(label => (
           <SuggestedLabelChip
             key={label}
             label={resolveLabel(label)}
             onConfirm={() => void handleConfirmSuggestion(label)}
             onReject={() => handleRejectSuggestion(label)}
           />
-        ))}
-      </span>
-    ) : null;
+        ))
+      : null;
 
   if (!canEdit) {
     if (labels.length === 0) return null;
@@ -199,7 +238,7 @@ export function RecordingLabelPicker({
   }
 
   return (
-    <div className='flex items-center gap-1.5'>
+    <>
       <SearchableMultiSelect
         options={options}
         selectedValues={labels}
@@ -209,6 +248,7 @@ export function RecordingLabelPicker({
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         searchPlaceholder='Search or create...'
+        searchMaxLength={LABEL_MAX_LENGTH}
         searchAriaLabel='Search or create a label'
         listAriaLabel='Labels'
         emptyMessage='No labels yet'
@@ -244,6 +284,6 @@ export function RecordingLabelPicker({
         }
       />
       {suggestionPills}
-    </div>
+    </>
   );
 }

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useState, type ReactElement } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type ReactElement } from 'react';
 import { AnimatePresence, motion, useMotionValue, useReducedMotion } from 'framer-motion';
 import { AlertCircle, Spinner } from '@xyne/icons';
 import { Button } from '../../../../components/ui/Button/Button';
@@ -23,7 +23,8 @@ export interface SummaryGenerationPanelProps {
   onReadTranscript?: (() => void) | undefined;
   generationRunId?: number;
   initialProgress?: number;
-  onProgressPause?: (progress: number) => void;
+  initialStageIndex?: number;
+  onProgressPause?: (progress: number, stageIndex: number) => void;
 }
 
 /** A status line shown while Scribe works, swapped in once `atMs` has elapsed. */
@@ -71,20 +72,32 @@ export const SummaryGenerationPanel = ({
   onReadTranscript,
   generationRunId = 0,
   initialProgress = 0,
+  initialStageIndex = 0,
   onProgressPause,
 }: SummaryGenerationPanelProps): ReactElement => {
   // —— State and hooks ———
   const shouldReduceMotion = useReducedMotion() ?? false;
-  const [stageIndex, setStageIndex] = useState(0);
+  const clampedInitialStageIndex = Math.min(
+    Math.max(0, initialStageIndex),
+    GENERATION_STAGES.length - 1,
+  );
+  const [stageIndex, setStageIndex] = useState(clampedInitialStageIndex);
+  const stageIndexRef = useRef(clampedInitialStageIndex);
   const progressWidth = useMotionValue(INITIAL_PROGRESS_WIDTH);
 
-  /** Status copy restarts when the panel remounts; only the bar position is persisted. */
   useEffect(() => {
-    setStageIndex(0);
+    stageIndexRef.current = stageIndex;
+  }, [stageIndex]);
+
+  useEffect(() => {
+    setStageIndex(clampedInitialStageIndex);
     if (!isAwaiting) return;
-    const timers = GENERATION_STAGES.slice(1).map((stage, index) =>
-      window.setTimeout(() => setStageIndex(index + 1), stage.atMs),
-    );
+    const baseMs = GENERATION_STAGES[clampedInitialStageIndex]?.atMs ?? 0;
+    const timers = GENERATION_STAGES.map((stage, index) => ({ stage, index }))
+      .filter(({ index }) => index > clampedInitialStageIndex)
+      .map(({ stage, index }) =>
+        window.setTimeout(() => setStageIndex(index), Math.max(0, stage.atMs - baseMs)),
+      );
     return (): void => {
       timers.forEach(window.clearTimeout);
     };
@@ -98,13 +111,14 @@ export const SummaryGenerationPanel = ({
     };
   }, [initialProgress, isAwaiting, generationRunId, progressWidth]);
 
-  // saves the current loading-bar percentage before the loading panel stops or disappears.
+  // Saves the current loading-bar percentage and stage label before the panel
+  // stops or disappears, so a remount resumes both in sync instead of just the bar.
   useEffect((): (() => void) | undefined => {
     if (!isAwaiting || !onProgressPause) return undefined;
     return (): void => {
       const progress = Number.parseFloat(progressWidth.get());
       if (Number.isFinite(progress)) {
-        onProgressPause(progress);
+        onProgressPause(progress, stageIndexRef.current);
       }
     };
   }, [isAwaiting, onProgressPause, progressWidth]);

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel.tsx
@@ -210,7 +210,7 @@ export const SummaryGenerationPanel = ({
                 size='sm'
                 onClick={onGenerate}
                 disabled={!canGenerate}
-                className='h-8 shrink-0 gap-2 rounded-xl px-3 text-xs font-medium bg-foreground hover:bg-foreground/80 disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed'
+                className='h-8 shrink-0 gap-2 rounded-xl px-3 text-xs font-medium bg-foreground text-background hover:bg-foreground/80 hover:text-background disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed'
                 data-track-category='RecordingDetailV2'
                 data-track-name='generate_summary'
               >

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactElement } from 're
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
 import { Spinner } from '@xyne/icons';
-import { CallStatus } from '@xyne/shared';
+import { CallStatus, TagMethod } from '@xyne/shared';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { PanelsTopLeft } from 'lucide-react';
 import AppNavigator from '../../components/AppNavigator/AppNavigator';
@@ -138,8 +138,18 @@ const RecordingsV2Screen = (): ReactElement => {
   );
   // recording.labels stores Tag ids (no FK), not display text — resolve them
   // to their actual value once here so both the filter dropdown and the
-  // per-row chips show real label names instead of raw ids.
-  const { resolveLabel } = useResolvedRecordingLabels(availableLabels);
+  // per-row chips show real label names instead of raw ids. Every id is passed
+  // in, including generated ones, since resolving is also what reveals the method.
+  const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(availableLabels);
+
+  const isManualLabel = useCallback(
+    (label: string): boolean => resolveMethod(label) !== TagMethod.LLM,
+    [resolveMethod],
+  );
+  const manualLabels = useMemo(
+    () => availableLabels.filter(isManualLabel),
+    [availableLabels, isManualLabel],
+  );
 
   /** An explicit pick in the People filter wins over the tab's shared-by picker. */
   const selectedCreatorIds = useMemo(
@@ -347,7 +357,7 @@ const RecordingsV2Screen = (): ReactElement => {
                 />
 
                 <RecordingLabelFilter
-                  labels={availableLabels}
+                  labels={manualLabels}
                   selectedLabels={selectedLabels}
                   onSelectedLabelsChange={setSelectedLabels}
                   resolveLabel={resolveLabel}
@@ -510,7 +520,7 @@ const RecordingsV2Screen = (): ReactElement => {
                       <RecordingsV2Pill
                         recording={row.recording}
                         creator={usersById.get(row.recording.createdByUserId) ?? null}
-                        tags={row.recording.labels}
+                        tags={row.recording.labels.filter(isManualLabel)}
                         resolveLabel={resolveLabel}
                         onOpen={handleOpenRecording}
                       />

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
-import { Spinner } from '@xyne/icons';
+import { LayersTo, Spinner } from '@xyne/icons';
 import { CallStatus, TagMethod } from '@xyne/shared';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { PanelsTopLeft } from 'lucide-react';
 import AppNavigator from '../../components/AppNavigator/AppNavigator';
 import { XyneAIStar } from '../../components/icons/xyne-ai';
 import { Button } from '../../components/ui/Button/Button';
@@ -373,7 +372,7 @@ const RecordingsV2Screen = (): ReactElement => {
                   data-track-category='RecordingsV2'
                   data-track-name='open_summary_templates'
                 >
-                  <PanelsTopLeft className='size-4' />
+                  <LayersTo className='size-4' strokeWidth={2} />
                   Templates
                 </Button>
                 <Button

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingLabelFilter.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingLabelFilter.tsx
@@ -15,6 +15,8 @@ interface RecordingLabelFilterProps {
 }
 
 const TRIGGER_CLASS_NAME = 'h-9 gap-1.5 rounded-xl border-border px-3 font-medium shadow-none';
+const LIST_INHERITS_POPOVER_CLASS_NAME =
+  '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
 
 export function RecordingLabelFilter({
   labels,
@@ -71,6 +73,7 @@ export function RecordingLabelFilter({
       emptyMessage='No labels found'
       trackCategory='RecordingsV2'
       trackName='toggle_label_filter'
+      className={LIST_INHERITS_POPOVER_CLASS_NAME}
       trigger={
         <Button
           type='button'

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -74,19 +74,19 @@ export const RecordingsV2LivePill = ({
   return (
     <section
       className={cn(
-        'flex w-full items-center gap-3 rounded-2xl border border-border/60 bg-background px-4 py-3 shadow-sm',
-        'transition-[border-color,box-shadow] duration-200 hover:border-foreground/15 hover:shadow-[0_5px_20px_rgb(0,0,0,0.08)]',
+        'flex w-full items-center gap-3 rounded-2xl border border-primary/30 bg-primary/10 px-4 py-3 shadow-sm',
+        'transition-[border-color,box-shadow] duration-200 hover:border-primary/50 hover:shadow-[0_5px_20px_rgb(0,0,0,0.08)]',
       )}
       aria-label={`${displayTitle}, recording in progress`}
     >
-      <span className='flex size-11 shrink-0 items-center justify-center rounded-xl bg-muted text-status-success'>
+      <span className='flex size-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary'>
         <MicOn size={16} strokeWidth={2} variant='Contrast' />
       </span>
 
       <span className='min-w-0 flex-1'>
         <span className='block truncate text-sm font-semibold text-foreground'>{displayTitle}</span>
-        <span className='mt-0.5 flex min-w-0 items-center gap-2 text-xs text-muted-foreground'>
-          <span className='size-2 shrink-0 rounded-full bg-status-success' aria-hidden='true' />
+        <span className='mt-0.5 flex min-w-0 items-center gap-2 text-xs text-primary'>
+          <span className='size-2 shrink-0 rounded-full bg-primary' aria-hidden='true' />
           <span>{isPaused ? 'Recording paused' : 'Recording in progress'}</span>
           <span aria-hidden='true'>·</span>
           <span className='font-mono tabular-nums'>{formatElapsedTime(elapsedMs)}</span>
@@ -95,12 +95,9 @@ export const RecordingsV2LivePill = ({
 
       <Button
         type='button'
-        variant='outline'
+        variant='ghost'
         onClick={onOpenWindow}
-        className={cn(
-          'h-9 shrink-0 rounded-xl border-border px-3 text-sm text-foreground shadow-none',
-          'hover:bg-muted/60 hover:border-foreground/30 hover:text-foreground',
-        )}
+        className='h-9 shrink-0 rounded-xl bg-foreground px-3 text-sm text-background hover:bg-foreground/90 hover:text-background'
         data-track-category='RecordingsV2'
         data-track-name='open_live_recording_window'
       >

--- a/apps/dashboard/src/utils/recordingSummaryRequest.ts
+++ b/apps/dashboard/src/utils/recordingSummaryRequest.ts
@@ -13,12 +13,14 @@ const REQUEST_TTL_MS = 60 * 60 * 1000;
 export interface SummaryRequestState {
   requestedAt: number;
   progress: number;
+  stageIndex: number;
   templateId?: string;
 }
 
 type RequestMap = Record<string, SummaryRequestState>;
 
 const normalizeProgress = (progress: number): number => Math.min(96, Math.max(0, progress));
+const normalizeStageIndex = (stageIndex: number): number => Math.max(0, Math.trunc(stageIndex));
 
 // Reads all pending summary-generation states from the session-storage key.
 const read = (): RequestMap => {
@@ -41,6 +43,9 @@ const read = (): RequestMap => {
         requests[recordingId] = {
           requestedAt: request.requestedAt,
           progress: normalizeProgress(request.progress),
+          stageIndex: normalizeStageIndex(
+            typeof request.stageIndex === 'number' ? request.stageIndex : 0,
+          ),
           ...(typeof request.templateId === 'string' ? { templateId: request.templateId } : {}),
         };
       }
@@ -72,6 +77,9 @@ export const getSummaryRequest = (
 export const getSummaryProgress = (recordingId: string | null | undefined): number =>
   getSummaryRequest(recordingId)?.progress ?? 0;
 
+export const getSummaryStage = (recordingId: string | null | undefined): number =>
+  getSummaryRequest(recordingId)?.stageIndex ?? 0;
+
 export const markSummaryRequested = (
   recordingId: string | null | undefined,
   templateId?: string,
@@ -82,6 +90,7 @@ export const markSummaryRequested = (
     [recordingId]: {
       requestedAt: Date.now(),
       progress: 0,
+      stageIndex: 0,
       ...(templateId ? { templateId } : {}),
     },
   });
@@ -90,13 +99,21 @@ export const markSummaryRequested = (
 export const saveSummaryProgress = (
   recordingId: string | null | undefined,
   progress: number,
+  stageIndex: number,
 ): void => {
   if (!recordingId || !Number.isFinite(progress)) return;
   const map = read();
   const request = map[recordingId];
   // Success/failure may clear the request before the panel cleanup runs.
   if (!request) return;
-  write({ ...map, [recordingId]: { ...request, progress: normalizeProgress(progress) } });
+  write({
+    ...map,
+    [recordingId]: {
+      ...request,
+      progress: normalizeProgress(progress),
+      stageIndex: normalizeStageIndex(stageIndex),
+    },
+  });
 };
 
 export const clearSummaryRequested = (recordingId: string | null | undefined): void => {

--- a/apps/dashboard/src/utils/recordingUtils.ts
+++ b/apps/dashboard/src/utils/recordingUtils.ts
@@ -93,9 +93,6 @@ export const generateRecordingTitle = (startTime: number | null): string => {
 export const DEFAULT_RECORDING_TITLE = 'Impromptu Recording';
 export const NO_TRANSCRIPT_RECORDING_TITLE = 'Recording (no transcript)';
 
-/** How long after the call ends a title still counts as on its way. */
-export const TITLE_SHIMMER_WINDOW_MS = 90 * 1000;
-
 /** How long a recording gets to produce a transcript before we say it has none. */
 export const NO_TRANSCRIPT_AFTER_MS = 5 * 60 * 1000;
 
@@ -126,7 +123,7 @@ export const getRecordingTitleState = (
 
   const sinceEndedMs = now - endedAtMs;
 
-  if (recording.hasTranscript && !recording.hasSummary && sinceEndedMs < TITLE_SHIMMER_WINDOW_MS) {
+  if (recording.hasTranscript && !recording.hasSummary) {
     return { kind: 'generating' };
   }
   if (!recording.hasTranscript && sinceEndedMs >= NO_TRANSCRIPT_AFTER_MS) {

--- a/apps/dashboard/src/utils/recordingUtils.ts
+++ b/apps/dashboard/src/utils/recordingUtils.ts
@@ -3,6 +3,7 @@
  * Common time formatting and display helpers for recording screens
  */
 
+import { normalizeTagName, TAG_FORMAT_REGEX } from '@xyne/shared';
 import { logger, Event } from './logger';
 
 /**
@@ -201,6 +202,14 @@ export const getRecordingTagDotColor = (tag: string): (typeof TAG_DOT_COLORS)[nu
  */
 export const normalizeRecordingTags = (tags: string[]): string[] => {
   return [...new Set(tags.map(tag => tag.trim()).filter(Boolean))];
+};
+
+/** Canonical tag name, or null when the text can't make one — tags must start with a letter. */
+export const slugifyRecordingLabel = (raw: string): string | null => {
+  const slug = normalizeTagName(raw);
+  if (!slug) return null;
+  const safe = /^[a-z]/.test(slug) ? slug : `l-${slug}`;
+  return TAG_FORMAT_REGEX.test(safe) ? safe : null;
 };
 
 /**


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->

Fixes few UX issues to Scribe (AI note-taker) and label handling for generated recording labels . 
Ticket: XYNE-56319.

**Label handling (backend + dashboard)**
- Unconfirmed AI-suggested labels showed up as selectable/applied labels in the picker, list-view chips, and filter dropdown — now excluded everywhere.
- Fixed AI label re-saves clobbering manually-applied labels under concurrent writes.
- Added a 40-character hard limit on the label search/create input
- Fixed chip overflow using a hardcoded "3 visible" count regardless of actual chip width — replaced with `useOverflowFit`, a width-measured fit.

**Recording detail screens**
- v1 `RecordingDetailScreen` never showed the Detailed Summary canvas, only Notes — added via a generalized `RecordingCanvasSection`.
- V2 summary tab showed the template name and an openable template picker even with no summary generated yet — now shows plain "Summary" and disables the picker until one exists.
- V2 header actions row overflowed/misaligned when wrapping — fixed layout.
- Removed the v1 "Recording tab view" layout picker from Preferences (retired feature).
- V2 Generating Summary Progress bar presistence across tab switch

**Polish**
- Live recording pill restyled to higher-contrast primary theme.
- Fixed "Open window" and "Generate" buttons losing text contrast on hover.
- Swapped Templates button icon for the correct `@xyne/icons` one.


## POT: [Scribe Fix changes locally tested ](https://drive.google.com/file/d/1gCBeO5u-OaCzu-LTCRGO6r5CA-JXupso/view?usp=sharing)

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [x] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

The call-update endpoint's `labels` input now accepts a mix of Tag ids and raw typed text (resolved server-side via `resolveLabelsToTagIds`), instead of ids only. Backward compatible — existing id-only callers are unaffected.

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
