### PR TITLE
fix: linearize channel derivation freezing the main thread on every click

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.utils.ts
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.utils.ts
@@ -94,6 +94,13 @@ export const groupChannelsByScope = (
   const starred: VisibleChannel[] = [];
   const channels: VisibleChannel[] = [];
   const directMessages: VisibleChannel[] = [];
+  // Index statuses by channelId once (O(n)) so the per-channel lookup below is
+  // O(1) — same pattern used by bucketChannelsBySection. Previously this used
+  // `allChannelsUserStatus.find(...)` per channel, giving O(n * m) behaviour.
+  const statusByChannelId = new Map<string, ChannelUserStatus>();
+  for (const status of allChannelsUserStatus) {
+    statusByChannelId.set(status.channelId, status);
+  }
   for (const channel of channelData) {
     // EMAIL channels live in Xyne Desk, not in the chat directory.
     // TODO: filter this out at the source by excluding EMAIL-type channels in the
@@ -102,7 +109,7 @@ export const groupChannelsByScope = (
       continue;
     }
 
-    const currentUserParticipation = allChannelsUserStatus.find(p => p.channelId === channel.id);
+    const currentUserParticipation = statusByChannelId.get(channel.id);
 
     // Skip closed DMs (soft-deleted by user)
     if (currentUserParticipation?.isClosed && isDMChannel(channel.scopeType)) {

--- a/apps/dashboard/src/components/GlobalCommandMenu/GlobalCommandMenu.tsx
+++ b/apps/dashboard/src/components/GlobalCommandMenu/GlobalCommandMenu.tsx
@@ -216,8 +216,11 @@ const GlobalCommandMenu = ({
   const { starred, channels, directMessages } = useMemo(() => {
     if (!channelData.length) return { starred: [], channels: [], directMessages: [] };
 
+    // Index visible channels by id once (O(n)); the previous `.find` inside this
+    // `.map` was O(n * m) over ~749 all x ~431 visible channels per recompute.
+    const visibleById = new Map(visibleAllChannels.map(vc => [vc.id, vc]));
     const visibleChannels = channelData.map(channel => {
-      const vc = visibleAllChannels.find(vc => vc.id === channel.id);
+      const vc = visibleById.get(channel.id);
       if (vc) {
         return vc;
       }

--- a/packages/shared/src/hooks/useChannels.ts
+++ b/packages/shared/src/hooks/useChannels.ts
@@ -39,8 +39,12 @@ export const useAllChannels = (): Channel[] => {
   );
   return useMemo(() => {
     const combined = [...channels];
+    // Set-based dedup: O(n + m) instead of the previous O(n * m) `combined.some`
+    // scan, which cost ~1.7s/recompute over ~749 all + ~431 visible channels.
+    const seenIds = new Set(channels.map(c => c.id));
     for (const visibleChannel of visibleChannels) {
-      if (!combined.some(c => c.id === visibleChannel.id)) {
+      if (!seenIds.has(visibleChannel.id)) {
+        seenIds.add(visibleChannel.id);
         combined.push(visibleChannel);
       }
     }


### PR DESCRIPTION
## Problem
On `app.spaces.xyne.juspay.net`, every click froze the UI for ~1.3–1.5s. A CPU trace showed the main thread stuck in synchronous channel-derivation, not network or Zero. Three O(n·m) loops re-ran over the full ~749 all-channel / ~431 visible-channel set on every state-machine channel update:

1. `useAllChannels` (`packages/shared/src/hooks/useChannels.ts`) — `combined.some(c => c.id === vc.id)` inside a loop over visible channels (~320k comparisons, ~1.7s of the trace).
2. `groupChannelsByScope` (`apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.utils.ts`) — `allChannelsUserStatus.find(...)` per channel.
3. `GlobalCommandMenu` grouping memo — `visibleAllChannels.find(...)` inside `channelData.map(...)`. This one also runs while the menu is closed because the component is globally mounted.

## Fix
All three are replaced with O(n+m) Set/Map lookups. `groupChannelsByScope` now uses the exact same `Map<channelId, status>` pattern that `bucketChannelsBySection` (directly below it) already uses.

Changes are behavior-preserving: identical outputs and ordering, only the lookup complexity changes.

## Not included (intentional)
- Reference stability at the state-machine source (the removed O(n) shallowEqual comparators) was already addressed on `main`; the assigners return stable context refs and `useSelector` uses O(1) `===`.
- Gating `GlobalCommandMenu` derivation behind `open` is a structural/behavioral change and is now far less urgent since the memo is linear (~1k ops instead of ~320k while closed). Left as an optional follow-up.

## Validation
- `tsc --noEmit` (dashboard `tsconfig.app.json`) passes.
- Recommend re-capturing a CPU trace on a build with this change to confirm the remaining click cost.