### PR TITLE
feat: XYNE-56427 instant share recordings

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -382,6 +382,7 @@ export class CallController {
     const correlationId = uuidv4();
     let callExternalId: string | undefined;
     let headlessNotesCanvasId: string | undefined;
+    let headlessDetailedSummaryCanvasId: string | undefined;
     // Tracks which stage was active when an error is thrown; used in catch log.
     let stage = 'setup';
 
@@ -417,6 +418,31 @@ export class CallController {
           title: 'Untitled Notes',
         });
 
+        stage = 'detailed_summary_canvas_creation';
+        const xyneAutomaticBot = await unifiedBotUserService.getBotByBotId(
+          'xyne-automatic',
+          req.user!.workspaceId!,
+        );
+        if (!xyneAutomaticBot) {
+          throw new Error('Xyne Automatic bot not found - make sure bot registry is initialized');
+        }
+        const detailedSummaryCanvasId = await callDocumentService.createDetailedSummaryCanvas(
+          callExternalId,
+          '_Detailed summary will appear here once the recording ends._',
+          xyneAutomaticBot.id,
+          null,
+          null,
+          new Date(),
+          userId,
+          undefined,
+          undefined,
+          req.user!.workspaceId,
+        );
+        if (!detailedSummaryCanvasId) {
+          throw new Error('Failed to create detailed summary canvas');
+        }
+        headlessDetailedSummaryCanvasId = detailedSummaryCanvasId;
+
         // Thread-linked recording: validate the conversation up front (fail
         // fast with a 404 instead of creating a LiveKit room for nothing) and
         // stamp channelId/conversationId onto the room metadata. The actual
@@ -450,6 +476,7 @@ export class CallController {
           createdBy: userId,
           workspaceId: req.user!.workspaceId,
           notesCanvasId,
+          detailedSummaryCanvasId,
           ...(channelId && conversationId ? { channelId, conversationId } : {}),
         });
 
@@ -486,6 +513,7 @@ export class CallController {
           roomLink,
           channelId: null,
           notesCanvasId,
+          detailedSummaryCanvasId,
           ...(conversationId ? { conversationId } : {}),
         });
         return;
@@ -725,6 +753,19 @@ export class CallController {
         } catch (cleanupError) {
           logger.error(`[${callIdForLog}] headless_notes_canvas_cleanup_failed`, {
             canvasId: headlessNotesCanvasId,
+            cleanupError,
+          });
+        }
+      }
+      if (headlessDetailedSummaryCanvasId) {
+        try {
+          await db.$transaction([
+            db.canvasParticipant.deleteMany({ where: { canvasId: headlessDetailedSummaryCanvasId } }),
+            db.canvas.deleteMany({ where: { id: headlessDetailedSummaryCanvasId } }),
+          ]);
+        } catch (cleanupError) {
+          logger.error(`[${callIdForLog}] headless_detailed_summary_canvas_cleanup_failed`, {
+            canvasId: headlessDetailedSummaryCanvasId,
             cleanupError,
           });
         }
@@ -1331,6 +1372,7 @@ export class CallController {
             typeof callMetadata?.detailedSummaryCanvasId === 'string'
               ? callMetadata.detailedSummaryCanvasId
               : null,
+          detailedSummaryReady: !!callMetadata?.detailedSummaryReady,
           linkedTicketId:
             typeof callMetadata?.linkedTicketId === 'string'
               ? callMetadata.linkedTicketId

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1372,7 +1372,16 @@ export class CallController {
             typeof callMetadata?.detailedSummaryCanvasId === 'string'
               ? callMetadata.detailedSummaryCanvasId
               : null,
-          detailedSummaryReady: !!callMetadata?.detailedSummaryReady,
+          // Tri-state, not a plain boolean: `true`/`false` are recordings
+          // created after this flag existed (still generating vs done);
+          // `null` means the key is entirely absent from metadata (a
+          // recording from before this flag existed at all) — those already
+          // finished generating long ago, so the frontend treats `null` the
+          // same as `true` and only treats an explicit `false` as "not ready".
+          detailedSummaryReady:
+            typeof callMetadata?.detailedSummaryReady === 'boolean'
+              ? callMetadata.detailedSummaryReady
+              : null,
           linkedTicketId:
             typeof callMetadata?.linkedTicketId === 'string'
               ? callMetadata.linkedTicketId

--- a/apps/backend/src/controllers/noteTakerWebhookController.ts
+++ b/apps/backend/src/controllers/noteTakerWebhookController.ts
@@ -95,6 +95,10 @@ class NoteTakerWebhookController {
       typeof roomMetadata.createdBy === 'string' ? roomMetadata.createdBy : participant.identity;
     const notesCanvasId =
       typeof roomMetadata.notesCanvasId === 'string' ? roomMetadata.notesCanvasId : undefined;
+    const detailedSummaryCanvasId =
+      typeof roomMetadata.detailedSummaryCanvasId === 'string'
+        ? roomMetadata.detailedSummaryCanvasId
+        : undefined;
     // Present only when the recording was started from inside a thread (see
     // callController's headless-initiate branch, which stamps these two onto
     // the LiveKit room metadata synchronously). messageId is generated here,
@@ -116,6 +120,10 @@ class NoteTakerWebhookController {
       logger.error(`[NoteTaker Webhook] Missing notesCanvasId in room metadata for ${roomName}`);
       return;
     }
+    if (!detailedSummaryCanvasId) {
+      logger.error(`[NoteTaker Webhook] Missing detailedSummaryCanvasId in room metadata for ${roomName}`);
+      return;
+    }
 
     const callId = uuidv4();
     const roomLink = buildCallInviteUrl(roomName);
@@ -128,6 +136,7 @@ class NoteTakerWebhookController {
         workspaceId,
         createdBy,
         notesCanvasId,
+        detailedSummaryCanvasId,
         roomLink,
         now: new Date(),
       });
@@ -190,6 +199,7 @@ class NoteTakerWebhookController {
           createdBy,
           workspaceId,
           notesCanvasId,
+          detailedSummaryCanvasId,
         });
         if (!posted) {
           logger.error('[NoteTaker Webhook] thread_anchor_message_conversation_mismatch', {
@@ -208,10 +218,9 @@ class NoteTakerWebhookController {
     }
 
     // Thread-linked recording: view access to the recording is granted to
-    // the thread's channel later, once the detailed summary canvas exists
-    // (recordingSharingService requires it) — see
-    // noteTakerTranscriptService.shareThreadRecordingIfLinked, called at the
-    // end of transcript/summary processing.
+    // the thread's channel once the recording actually ends — see
+    // handleParticipantLeft / handleRoomFinished below
+    // (noteTakerTranscriptService.shareThreadRecordingIfLinked).
 
     // Auto-start an audio recording for the whole call — note-taker calls have
     // no manual "start recording" UI action, so this replaces that trigger.
@@ -275,6 +284,13 @@ class NoteTakerWebhookController {
         logger.error(`[NoteTaker Webhook] Failed to stop recording for call ${roomName}:`, stopErr);
       }
 
+      // Thread-linked recording: grant the thread's channel VIEW access to
+      // this recording immediately now that it has ended — both canvases
+      // already exist (created up front at call-initiate time), so there's
+      // no need to wait for the post-call AI summary pipeline. Best-effort
+      // — a failure here must not block ending the call.
+      await noteTakerTranscriptService.shareThreadRecordingIfLinked(result.call);
+
       await this.emitCallEndedAutomation(result.call, now);
     }
   }
@@ -313,6 +329,8 @@ class NoteTakerWebhookController {
 
     if (result.shouldEndCall) {
       logger.info(`[NoteTaker Webhook] Marked call ${roomName} as ENDED (room_finished)`);
+
+      await noteTakerTranscriptService.shareThreadRecordingIfLinked(result.call);
       await this.emitCallEndedAutomation(result.call, now);
     }
 

--- a/apps/backend/src/database/repositories/noteTakerCallRepository.ts
+++ b/apps/backend/src/database/repositories/noteTakerCallRepository.ts
@@ -17,6 +17,7 @@ export interface CreateNoteTakerCallParams {
 interface NoteTakerCallMetadata {
   notesCanvasId?: string;
   detailedSummaryCanvasId?: string;
+  detailedSummaryReady?: boolean;
   conversationId?: string;
   messageId?: string;
   channelId?: string;
@@ -38,13 +39,11 @@ export class NoteTakerCallRepository {
   async createCall(params: CreateNoteTakerCallParams): Promise<Call> {
     const { callId, roomName, workspaceId, createdBy, notesCanvasId, detailedSummaryCanvasId, roomLink, now } = params;
 
-    // Thread-linkage (conversationId/messageId/channelId) is deliberately NOT
-    // stamped here — it's only added to metadata by createThreadAnchorMessage,
-    // and only once that method's workspace/channel/membership checks pass.
-    // Writing it here unconditionally would let a later-failed validation
-    // still leave metadata.channelId behind for shareThreadRecordingIfLinked /
-    // updateThreadMessageOnEnd to act on.
-    const metadata: NoteTakerCallMetadata = { notesCanvasId, detailedSummaryCanvasId };
+    const metadata: NoteTakerCallMetadata = {
+      notesCanvasId,
+      detailedSummaryCanvasId,
+      detailedSummaryReady: false,
+    };
 
     return this.db.call.create({
       data: {
@@ -219,10 +218,16 @@ export class NoteTakerCallRepository {
       });
 
 
+      const currentCall = await tx.call.findUnique({ where: { id: callId }, select: { metadata: true } });
+      const currentCallMetadata: Record<string, unknown> =
+        currentCall?.metadata && typeof currentCall.metadata === 'object' && !Array.isArray(currentCall.metadata)
+          ? (currentCall.metadata as Record<string, unknown>)
+          : {};
       await tx.call.update({
         where: { id: callId },
         data: {
           metadata: {
+            ...currentCallMetadata,
             notesCanvasId,
             detailedSummaryCanvasId,
             conversationId,

--- a/apps/backend/src/database/repositories/noteTakerCallRepository.ts
+++ b/apps/backend/src/database/repositories/noteTakerCallRepository.ts
@@ -9,12 +9,14 @@ export interface CreateNoteTakerCallParams {
   workspaceId: string;
   createdBy: string;
   notesCanvasId: string;
+  detailedSummaryCanvasId: string;
   roomLink: string;
   now: Date;
 }
 
 interface NoteTakerCallMetadata {
   notesCanvasId?: string;
+  detailedSummaryCanvasId?: string;
   conversationId?: string;
   messageId?: string;
   channelId?: string;
@@ -34,7 +36,7 @@ export class NoteTakerCallRepository {
   }
 
   async createCall(params: CreateNoteTakerCallParams): Promise<Call> {
-    const { callId, roomName, workspaceId, createdBy, notesCanvasId, roomLink, now } = params;
+    const { callId, roomName, workspaceId, createdBy, notesCanvasId, detailedSummaryCanvasId, roomLink, now } = params;
 
     // Thread-linkage (conversationId/messageId/channelId) is deliberately NOT
     // stamped here — it's only added to metadata by createThreadAnchorMessage,
@@ -42,7 +44,7 @@ export class NoteTakerCallRepository {
     // Writing it here unconditionally would let a later-failed validation
     // still leave metadata.channelId behind for shareThreadRecordingIfLinked /
     // updateThreadMessageOnEnd to act on.
-    const metadata: NoteTakerCallMetadata = { notesCanvasId };
+    const metadata: NoteTakerCallMetadata = { notesCanvasId, detailedSummaryCanvasId };
 
     return this.db.call.create({
       data: {
@@ -149,9 +151,19 @@ export class NoteTakerCallRepository {
     createdBy: string;
     workspaceId: string;
     notesCanvasId: string;
+    detailedSummaryCanvasId: string;
   }): Promise<boolean> {
-    const { callId, conversationId, channelId, messageId, callExternalId, createdBy, workspaceId, notesCanvasId } =
-      params;
+    const {
+      callId,
+      conversationId,
+      channelId,
+      messageId,
+      callExternalId,
+      createdBy,
+      workspaceId,
+      notesCanvasId,
+      detailedSummaryCanvasId,
+    } = params;
 
     const conversation = await repositories.conversations.findByIdAndWorkspace(conversationId, workspaceId);
     if (!conversation || conversation.channelId !== channelId) {
@@ -206,10 +218,18 @@ export class NoteTakerCallRepository {
         },
       });
 
-      // Persist the thread linkage onto the Call row itself.
+
       await tx.call.update({
         where: { id: callId },
-        data: { metadata: { notesCanvasId, conversationId, messageId, channelId } as Prisma.InputJsonValue },
+        data: {
+          metadata: {
+            notesCanvasId,
+            detailedSummaryCanvasId,
+            conversationId,
+            messageId,
+            channelId,
+          } as Prisma.InputJsonValue,
+        },
       });
     });
 

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -152,22 +152,21 @@ class NoteTakerTranscriptService {
         metadata: {
           transcriptEntryCount: entries.length,
           detailedSummaryCanvasId: detailedSummary?.canvasId,
+          detailedSummaryReady: detailedSummary ? true : undefined,
         },
         summaryTemplateId: detailedSummary?.summaryTemplateId,
         ...(detailedSummary ? { markedItems: detailedSummary.markedItems } : {}),
       });
       await this.queueVespaIndexing(call);
 
-      // Thread-linked recording (started from inside a thread — see
-      // callController's headless-initiate branch): now that the detailed
-      // summary canvas exists, auto-share the recording to that thread's
-      // channel. Must wait until here — recordingSharingService requires both
-      // notesCanvasId AND detailedSummaryCanvasId to be on Call.metadata
-      // before it can sync canvas access, so calling it any earlier (e.g. at
-      // call-start) always fails with "Detailed summary canvas is not ready yet".
-      if (detailedSummary?.canvasId) {
-        await this.shareThreadRecordingIfLinked(call);
-      }
+      // Thread-linked recording: already auto-shared to the thread's channel
+      // immediately when the recording ended (see
+      // noteTakerWebhookController.handleParticipantLeft /
+      // handleRoomFinished). This call is now just an idempotent fallback in
+      // case that earlier attempt failed — recordingSharingService's grant
+      // is a safe upsert, so re-running it here is harmless even when the
+      // earlier share already succeeded.
+      await this.shareThreadRecordingIfLinked(call);
     } finally {
       await releaseLock(lockHandle);
     }
@@ -183,6 +182,7 @@ class NoteTakerTranscriptService {
   ): Promise<{
     summaryTemplateId: string;
     detailedSummaryCanvasId: string | null;
+    detailedSummaryReady: boolean;
   } | null> {
     const formattedTranscript = await transcriptService.getTranscriptContent(call.externalId);
     if (!formattedTranscript) return null;
@@ -209,6 +209,7 @@ class NoteTakerTranscriptService {
       metadata: {
         ...currentMetadata,
         detailedSummaryCanvasId: detailedSummary.canvasId,
+        detailedSummaryReady: true,
       },
       summaryTemplateId: detailedSummary.summaryTemplateId,
       markedItems,
@@ -217,6 +218,7 @@ class NoteTakerTranscriptService {
     return {
       summaryTemplateId: detailedSummary.summaryTemplateId,
       detailedSummaryCanvasId: detailedSummary.canvasId,
+      detailedSummaryReady: true,
     };
   }
 
@@ -257,9 +259,13 @@ class NoteTakerTranscriptService {
    * so every thread/channel member can see the recording message card and
    * open /recordings/:callId. No-op for recordings not started from a thread
    * (no channelId on Call.metadata). Best-effort — a failure here must never
-   * block transcript/summary processing.
+   * block transcript/summary processing. Public so
+   * noteTakerWebhookController can call this immediately once the recording
+   * ends (handleParticipantLeft / handleRoomFinished) — both canvases
+   * already exist by then via eager creation, so there's no reason to wait
+   * for the detailed-summary pipeline anymore.
    */
-  private async shareThreadRecordingIfLinked(call: Call): Promise<void> {
+  async shareThreadRecordingIfLinked(call: Call): Promise<void> {
     const metadata =
       call.metadata && typeof call.metadata === 'object' && !Array.isArray(call.metadata)
         ? (call.metadata as Record<string, unknown>)

--- a/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RecordingBubble.tsx
@@ -44,10 +44,8 @@ export const RecordingBubble: React.FC<RecordingBubbleProps> = ({ message, callI
   const isActive = !isEnded;
   const startedAt = message.createdAt ? Number(message.createdAt) : undefined;
   const duration = useCallDuration(startedAt, isActive);
-  // Only the recording's creator has view access (see callShareService.canView)
-  // until it's explicitly shared — other thread participants would just land
-  // on a not-found/access-denied screen, so don't offer them the click at all.
-  const canView = !!user?.id && metadata?.createdBy === user.id;
+
+  const canView = isEnded || (!!user?.id && metadata?.createdBy === user.id);
 
   const goToRecording = (): void => {
     if (!canView) return;

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -383,6 +383,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
       const linkedTicketId = typeof rawLinkedTicketId === 'string' ? rawLinkedTicketId : null;
       const rawLinkedTicketMessageId = metadata?.['linkedTicketMessageId'];
       const rawDetailedSummaryCanvasId = metadata?.['detailedSummaryCanvasId'];
+      const rawDetailedSummaryReady = metadata?.['detailedSummaryReady'];
       const rawNotesCanvasId = metadata?.['notesCanvasId'] ?? metadata?.['notesCanvasViewAccessId'];
       const next: RecordingDetail = {
         ...prev,
@@ -395,7 +396,10 @@ export default function RecordingDetailV2Screen(): ReactElement {
           typeof rawDetailedSummaryCanvasId === 'string'
             ? rawDetailedSummaryCanvasId
             : prev.detailedSummaryCanvasId,
-        detailedSummaryReady: !!metadata?.['detailedSummaryReady'] || prev.detailedSummaryReady,
+        detailedSummaryReady:
+          typeof rawDetailedSummaryReady === 'boolean'
+            ? rawDetailedSummaryReady
+            : prev.detailedSummaryReady,
         notesCanvasId:
           prev.notesCanvasId ?? (typeof rawNotesCanvasId === 'string' ? rawNotesCanvasId : null),
         markedItems: recordingRow.markedItems ?? prev.markedItems,
@@ -542,7 +546,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
     // Picking the template the existing summary was already written with is a no-op
     if (
       recording.detailedSummaryCanvasId &&
-      recording.detailedSummaryReady &&
+      recording.detailedSummaryReady !== false &&
       summaryTemplateId === recording.summaryTemplateId
     ) {
       handleTabSelect('summary');
@@ -731,7 +735,13 @@ export default function RecordingDetailV2Screen(): ReactElement {
   // Polling has given up (or was skipped for an old recording) and there is still no
   // stitched audio, so the control bar shows an unavailable indicator, not a spinner.
   const audioUnavailable = !isLive && !recording.hasRecording && audioPollExhausted;
-  const hasDetailedSummary = !!recording.detailedSummaryCanvasId && recording.detailedSummaryReady;
+  // The canvas itself now exists from call-start (so sharing works
+  // immediately) — gate on detailedSummaryReady too, otherwise this would
+  // flip true instantly and skip straight past the shimmer. `null` means the
+  // recording predates this flag (already finished generating long ago), so
+  // only an explicit `false` counts as "still generating".
+  const hasDetailedSummary =
+    !!recording.detailedSummaryCanvasId && recording.detailedSummaryReady !== false;
   const isOwner = recording.createdByUserId === currentUser?.id;
   const summaryTemplateOptions: RecordingSummaryTemplate[] = [
     DEFAULT_SUMMARY_TEMPLATE_OPTION,

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -395,6 +395,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
           typeof rawDetailedSummaryCanvasId === 'string'
             ? rawDetailedSummaryCanvasId
             : prev.detailedSummaryCanvasId,
+        detailedSummaryReady: !!metadata?.['detailedSummaryReady'] || prev.detailedSummaryReady,
         notesCanvasId:
           prev.notesCanvasId ?? (typeof rawNotesCanvasId === 'string' ? rawNotesCanvasId : null),
         markedItems: recordingRow.markedItems ?? prev.markedItems,
@@ -417,14 +418,14 @@ export default function RecordingDetailV2Screen(): ReactElement {
     const request = getSummaryRequest(recordingId);
     if (!request || recording?.externalId !== recordingId) return;
     const requestedSummaryIsReady = request.templateId
-      ? recording?.summaryTemplateId === request.templateId
-      : !!recording?.detailedSummaryCanvasId;
+      ? recording?.summaryTemplateId === request.templateId && !!recording?.detailedSummaryReady
+      : !!recording?.detailedSummaryReady;
     if (!requestedSummaryIsReady) return;
     setAwaitingSummary(false);
     setPendingSummaryTemplateId(null);
     clearSummaryRequested(recordingId);
   }, [
-    recording?.detailedSummaryCanvasId,
+    recording?.detailedSummaryReady,
     recording?.externalId,
     recording?.summaryTemplateId,
     recordingId,
@@ -539,7 +540,11 @@ export default function RecordingDetailV2Screen(): ReactElement {
     if (!recording || isRegeneratingSummary) return;
 
     // Picking the template the existing summary was already written with is a no-op
-    if (recording.detailedSummaryCanvasId && summaryTemplateId === recording.summaryTemplateId) {
+    if (
+      recording.detailedSummaryCanvasId &&
+      recording.detailedSummaryReady &&
+      summaryTemplateId === recording.summaryTemplateId
+    ) {
       handleTabSelect('summary');
       return;
     }
@@ -565,6 +570,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
               summaryTemplateId: result.summaryTemplateId,
               detailedSummaryCanvasId:
                 result.detailedSummaryCanvasId ?? current.detailedSummaryCanvasId,
+              detailedSummaryReady: result.detailedSummaryReady,
             }
           : current,
       );
@@ -725,7 +731,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
   // Polling has given up (or was skipped for an old recording) and there is still no
   // stitched audio, so the control bar shows an unavailable indicator, not a spinner.
   const audioUnavailable = !isLive && !recording.hasRecording && audioPollExhausted;
-  const hasDetailedSummary = !!recording.detailedSummaryCanvasId;
+  const hasDetailedSummary = !!recording.detailedSummaryCanvasId && recording.detailedSummaryReady;
   const isOwner = recording.createdByUserId === currentUser?.id;
   const summaryTemplateOptions: RecordingSummaryTemplate[] = [
     DEFAULT_SUMMARY_TEMPLATE_OPTION,
@@ -754,6 +760,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
   // Nothing to summarize without a transcript, so the offer waits for one to exist.
   const hasTranscript =
     !!transcriptText?.trim() || !!recordingRow?.transcript || !!recording.hasTranscript;
+
+  const showSummaryShimmer =
+    awaitingSummary || (!hasDetailedSummary && hasTranscript && !summaryFailed);
 
   const handleMarkerSelect = (item: MarkedItem): void => {
     // A moment already announces itself in the transcript with a divider, so only
@@ -985,7 +994,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
               <div className='flex items-center justify-between'>
                 <div className='flex items-center gap-2.5'>
                   <h2 className='text-lg font-semibold text-foreground'>Summary</h2>
-                  {!hasDetailedSummary && !awaitingSummary && (
+                  {!hasDetailedSummary && !showSummaryShimmer && (
                     <span className='rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground'>
                       Not generated
                     </span>
@@ -1013,7 +1022,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                 />
               ) : (
                 <SummaryGenerationPanel
-                  isAwaiting={awaitingSummary}
+                  isAwaiting={showSummaryShimmer}
                   canGenerate={hasTranscript}
                   onGenerate={handleShowSummaryShimmer}
                   onRetry={() => void handleRegenerateSummary(selectedSummaryTemplate.id)}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -301,7 +301,7 @@ export const RecordingDetailV2Header = ({
       {/* Actions row */}
       <div className='flex flex-wrap items-center justify-between gap-3'>
         <div className='flex flex-wrap items-center gap-2'>
-          {recording.detailedSummaryCanvasId && (
+          {!isLive && recording.detailedSummaryCanvasId && (
             <RecordingTicketLink
               linkedTicketId={recording.linkedTicketId ?? null}
               canEdit={isOwner}
@@ -314,7 +314,7 @@ export const RecordingDetailV2Header = ({
             canEdit={recording.createdByUserId === currentUser?.id}
             onChange={labels => void handleLabelsChange(labels)}
           />
-          {isOwner && recording.detailedSummaryCanvasId && (
+          {isOwner && !isLive && recording.detailedSummaryCanvasId && (
             <>
               <RecordingSharedWithAvatars
                 recordingExternalId={recording.externalId}
@@ -354,7 +354,7 @@ export const RecordingDetailV2Header = ({
           )}
         </div>
 
-        {isOwner && showShareModal && recording.detailedSummaryCanvasId && (
+        {isOwner && !isLive && showShareModal && recording.detailedSummaryCanvasId && (
           <Dialog
             open={showShareModal}
             onOpenChange={open => !open && setShowShareModal(false)}

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -133,6 +133,7 @@ export interface RecordingSharingResult {
 export interface RegenerateRecordingSummaryResult {
   summaryTemplateId: string;
   detailedSummaryCanvasId: string | null;
+  detailedSummaryReady: boolean;
 }
 
 export interface ExportRecordingGoogleDocResult {
@@ -175,6 +176,7 @@ export interface RecordingDetail extends Recording {
   messageId: string | null;
   notesCanvasId: string | null;
   detailedSummaryCanvasId: string | null;
+  detailedSummaryReady: boolean;
   citationSegments: CitationSegment[];
   hasRecording?: boolean;
   linkedTicketId?: string | null;

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -176,7 +176,7 @@ export interface RecordingDetail extends Recording {
   messageId: string | null;
   notesCanvasId: string | null;
   detailedSummaryCanvasId: string | null;
-  detailedSummaryReady: boolean;
+  detailedSummaryReady: boolean | null;
   citationSegments: CitationSegment[];
   hasRecording?: boolean;
   linkedTicketId?: string | null;


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1kYO22WG6poCIn-0uMhf8f50NNk3QEeIU/view?usp=sharing

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
