### PR TITLE
fix: log whether a link opened in the in-app or external browser

### DIFF
--- a/apps/dashboard/src/components/BrowserPanel/BrowserPanelHandler.tsx
+++ b/apps/dashboard/src/components/BrowserPanel/BrowserPanelHandler.tsx
@@ -33,7 +33,7 @@ export function BrowserPanelHandler(): null {
     const cleanup = api.onOpenInBrowserPanel((url: string) => {
       xyneAIActor.send({ type: 'CLOSE' });
 
-      logger.info(Event.BROWSER_LINK_CLICK, { url });
+      logger.info(Event.BROWSER_LINK_CLICK, { url, openedIn: 'in-app' });
 
       if (browserPanelState === 'open' || isOnBrowserRoute) {
         browserPanelActor.send({ type: 'OPEN_URLS', urls: [url] });
@@ -44,6 +44,21 @@ export function BrowserPanelHandler(): null {
 
     return cleanup;
   }, [isOnBrowserRoute, browserPanelState]);
+
+  // Links main routed to the external browser: logged here so external opens are
+  // counted alongside the in-app ones above.
+  useEffect(() => {
+    if (!isElectronApp()) return;
+
+    const api = window.electronAPI;
+    if (!api?.onLinkOpenedExternal) return;
+
+    const cleanup = api.onLinkOpenedExternal((url: string) => {
+      logger.info(Event.BROWSER_LINK_CLICK, { url, openedIn: 'external' });
+    });
+
+    return cleanup;
+  }, []);
 
   // Handle XyneAI context from Chrome extension deep link
   useEffect(() => {

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -1295,9 +1295,6 @@ const parseNode = (
         (props as { href: string; target: string; rel: string }).rel = 'noopener noreferrer';
         const externalHref = href;
         props['onClick'] = (e: React.MouseEvent<HTMLAnchorElement>): void => {
-          if (e.metaKey || e.ctrlKey) {
-            logger.info(Event.BROWSER_LINK_CMD_CLICK, { url: externalHref });
-          }
           e.preventDefault();
           openLink(externalHref, e);
         };

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -53,6 +53,8 @@ export interface ElectronAPI {
   onBrowserFindInPage: (callback: () => void) => () => void;
   onNavigateToTicketThread: (callback: (data: { ticketId: string }) => void) => () => void;
   onOpenInBrowserPanel: (callback: (url: string) => void) => () => void;
+  // Optional: absent on Electron builds older than the one that added it.
+  onLinkOpenedExternal?: (callback: (url: string) => void) => () => void;
   onReloadActiveBrowserTab: (callback: () => void) => () => void;
   onOpenXyneAIWithContext: (
     callback: (data: {

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -329,9 +329,6 @@ export const createMarkdownComponents = (
       const handleClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (!href) return;
         event.preventDefault();
-        if (event.metaKey || event.ctrlKey) {
-          logger.info(Event.BROWSER_LINK_CMD_CLICK, { url: href });
-        }
         openLink(href, event);
       };
       return (

--- a/apps/dashboard/src/utils/openLink.ts
+++ b/apps/dashboard/src/utils/openLink.ts
@@ -2,6 +2,7 @@ import { toast } from 'sonner';
 import { isElectronApp } from './electronApp';
 import { detectReactNativeWebView, reactNativeBridge } from './reactNativeBridge';
 import { browserPanelActor } from '../machines/browserPanelMachine';
+import { logger, Event } from './logger';
 
 const LINK_OPEN_EXTERNAL_KEY = 'xyne:link-open-external-default';
 const LINK_OPEN_HINT_DISMISSED_KEY = 'xyne:link-open-hint-dismissed';
@@ -51,11 +52,29 @@ export interface OpenLinkOpts {
 
 export const linkOpenPrefIsRelevant = (): boolean => isElectronApp() || detectReactNativeWebView();
 
-export const openLink = (url: string, event?: MouseLike | null, opts?: OpenLinkOpts): void => {
+const wantsExternal = (event?: MouseLike | null, opts?: OpenLinkOpts): boolean => {
   const externalDefault = getLinkOpenExternalDefault();
   const modifier = !!(event?.metaKey || event?.ctrlKey);
 
-  const wantExternal = opts?.force ? opts.force === 'external' : externalDefault !== modifier;
+  return opts?.force ? opts.force === 'external' : externalDefault !== modifier;
+};
+
+// Where the link actually lands: the in-app panel only exists in Electron, so off
+// it both branches of openLink end up in the system browser.
+export const resolveLinkTarget = (
+  event?: MouseLike | null,
+  opts?: OpenLinkOpts,
+): 'external' | 'in-app' =>
+  !wantsExternal(event, opts) && isElectronApp() ? 'in-app' : 'external';
+
+export const openLink = (url: string, event?: MouseLike | null, opts?: OpenLinkOpts): void => {
+  const wantExternal = wantsExternal(event, opts);
+  const modifier = !!(event?.metaKey || event?.ctrlKey);
+
+  logger.info(modifier ? Event.BROWSER_LINK_CMD_CLICK : Event.BROWSER_LINK_CLICK, {
+    url,
+    openedIn: resolveLinkTarget(event, opts),
+  });
 
   if (wantExternal) {
     openExternal(url);

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -150,6 +150,12 @@ const electronAPI = {
     return () => ipcRenderer.removeListener('open-in-browser-panel', listener);
   },
 
+  onLinkOpenedExternal: (callback: (url: string) => void) => {
+    const listener = (_event: unknown, url: string) => callback(url);
+    ipcRenderer.on('link-opened-external', listener);
+    return () => ipcRenderer.removeListener('link-opened-external', listener);
+  },
+
   onReloadActiveBrowserTab: (callback: () => void) => {
     const listener = () => callback();
     ipcRenderer.on('reload-active-browser-tab', listener);

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -123,6 +123,12 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
     options?.inactive ? mainWindow?.showInactive() : mainWindow?.show(),
   );
 
+  // Mirrors 'open-in-browser-panel' so links sent to the external browser are
+  // logged too, not just the ones routed into the panel.
+  const notifyExternalOpen = (externalUrl: string): void => {
+    mainWindow?.webContents.send('link-opened-external', externalUrl);
+  };
+
   // Handle external links
   mainWindow.webContents.setWindowOpenHandler((details) => {
      try {
@@ -142,6 +148,7 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
 
       if(currentUrlObj.origin === config.MTLS_FRONTEND_URL) {
         shell.openExternal(url);
+        notifyExternalOpen(url);
         return { action: 'deny' };
       }
 
@@ -153,6 +160,7 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
         const wantExternal = prefExternal !== modifier;
         if (wantExternal) {
           shell.openExternal(url);
+          notifyExternalOpen(url);
         } else {
           mainWindow?.webContents.send('open-in-browser-panel', url);
         }
@@ -203,12 +211,14 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
       if (currentUrlObj.origin === config.MTLS_FRONTEND_URL) {
         event.preventDefault();
         shell.openExternal(navUrl);
+        notifyExternalOpen(navUrl);
         return;
       }
 
       event.preventDefault();
       if (browserSettingsService.getSettings().openLinksExternally) {
         shell.openExternal(navUrl);
+        notifyExternalOpen(navUrl);
       } else {
         mainWindow?.webContents.send('open-in-browser-panel', navUrl);
       }


### PR DESCRIPTION
## Problem

`browser_link_click` / `browser_link_cmd_click` recorded **which key was held**, not **where the link actually went**. Preferences → Messaging has an "open links externally" toggle, and when it is on a Cmd/Ctrl-click *inverts* the preference and opens the link in the in-app browser panel. So `browser_link_cmd_click` was firing for clicks that landed in the panel, and the numbers can't be trusted.

Separately, only *in-app* opens were ever logged. Links the Electron main process sent to the external browser (plain anchors, `will-navigate`, mTLS redirects) produced no event at all, so any external/in-app split was biased toward in-app by construction.

## What changed

- Logging moves into `openLink()`, the single choke point every renderer link click already goes through. Each click logs exactly once with a new **`openedIn`** field (`'external' | 'in-app'`), derived from the same rule that routes the link. `LinksTab`, which never logged at all, is covered as a side effect.
- The two call-site logs (`markdownComponents`, `RenderMessageWithHTML`) are removed so nothing double-counts.
- `manager.ts` now mirrors the existing `open-in-browser-panel` message with a `link-opened-external` notification, wired through `preload.ts` → `BrowserPanelHandler`, so main-routed external opens are counted alongside the in-app ones.

`openedIn` is `in-app` only when Electron is actually present — off it (web, React-Native webview) both branches of `openLink` end in `window.open`, i.e. the system browser.

**Link routing behaviour is unchanged.** Only a log line was added; the routing expression is byte-identical to before.

## Testing

A differential harness bundled the real `openLink.ts` and the pre-change version with stubbed deps and ran both under a fake DOM:

- **282 scenarios pass** — platform (Electron / Electron-without-`openExternal` / RN / RN-without-bridge / web) x preference x modifier x `force` x `silent` x panel state, plus every event shape (`undefined`, `null`, meta, ctrl, both, neither).
- Each scenario asserts: side effects **byte-identical** to the pre-change code, exactly one log emitted, correct event name, and — as ground truth — that the logged `openedIn` matches **the side effect that actually fired**, not a re-run of the same formula.
- Verified no double-log path: the renderer's own `openExternal` IPC handler does not send the new notification, and `browserPanelActor` doesn't round-trip through IPC.
- `prettier --check` clean; `tsc` and `eslint` add zero new problems over the base commit (verified by running both with the patch stashed).

## Rollout / compatibility

Safe in either release order — the dashboard is loaded remotely (`useBundledUI` defaults to `false`), so shell/dashboard skew is normal:

- **New dashboard, old Electron:** `onLinkOpenedExternal` is absent, the effect returns at its guard. All `openLink` labelling still works — it's pure renderer logic with no IPC.
- **New Electron, old dashboard:** nothing listens on the new channel and Electron drops the message. There is no catch-all channel bridge in the preload.
- `notifyExternalOpen` fires *after* `shell.openExternal`, inside the existing try/catch, so it cannot affect link opening even if it throws.

The type is declared optional (`onLinkOpenedExternal?`) so a future caller can't use it unguarded against an older shell.

## Note for whoever owns the dashboards

`browser_link_cmd_click` no longer means "opened externally" — it means "a modifier was held". Group by `openedIn` instead. `browser_link_click` volume also rises, since it now covers every plain link click rather than only main-routed panel opens. During rollout, older clients emit these events with **no `openedIn` field**; treat missing as unknown rather than folding it into either bucket.
