### PR TITLE
fix: ignore URLs inside code blocks for link preview extraction

### DIFF
--- a/apps/backend/src/utils/urlUtils.test.ts
+++ b/apps/backend/src/utils/urlUtils.test.ts
@@ -1,0 +1,45 @@
+import { extractFirstUrl, extractUrls } from './urlUtils';
+
+describe('extractFirstUrl', () => {
+  it('returns a normal body URL', () => {
+    const input = '<p>See <a href="https://docs.example.com/page">https://docs.example.com/page</a></p>';
+    expect(extractFirstUrl(input)).toBe('https://docs.example.com/page');
+  });
+
+  it('ignores URLs inside <pre><code> blocks', () => {
+    const input = '<pre><code>https://wrong-site.com/config</code></pre>';
+    expect(extractFirstUrl(input)).toBeNull();
+  });
+
+  it('ignores URLs inside inline <code>', () => {
+    const input = '<p>Use <code>https://old.api.com</code> but prefer <a href="https://new.api.com">https://new.api.com</a></p>';
+    expect(extractFirstUrl(input)).toBe('https://new.api.com');
+  });
+
+  it('returns body URL when a code-block URL appears first', () => {
+    const input = '<p>Config:</p><pre><code>https://wrong-site.com/legacy-config</code></pre><p>Docs: <a href="https://docs.example.com/new">https://docs.example.com/new</a></p>';
+    expect(extractFirstUrl(input)).toBe('https://docs.example.com/new');
+  });
+
+  it('returns first non-code URL when the earliest URL is inside inline code', () => {
+    const input = '<p>Old: <code>https://a.com</code> New: https://b.com Other: https://c.com</p>';
+    expect(extractFirstUrl(input)).toBe('https://b.com');
+  });
+
+  it('returns null when the only URL is inside a nested code block', () => {
+    const input = '<pre class="language-typescript"><code class="language-typescript">const url = "https://only-here.dev";</code></pre>';
+    expect(extractFirstUrl(input)).toBeNull();
+  });
+});
+
+describe('extractUrls', () => {
+  it('dedupes URLs and preserves first-occurrence order outside code blocks', () => {
+    const input = '<p><a href="https://example.com/a">https://example.com/a</a> and <code>https://example.com/a</code> and https://example.com/b</p>';
+    expect(extractUrls(input)).toEqual(['https://example.com/a', 'https://example.com/b']);
+  });
+
+  it('excludes URLs that appear only inside code blocks', () => {
+    const input = '<pre><code>https://internal.dev</code></pre><p>Public docs: https://docs.dev.com</p>';
+    expect(extractUrls(input)).toEqual(['https://docs.dev.com']);
+  });
+});

--- a/apps/backend/src/utils/urlUtils.ts
+++ b/apps/backend/src/utils/urlUtils.ts
@@ -44,6 +44,10 @@ export function stripAndDecodeHtml(input: string): string {
   // 1) Remove tags
   let s = input.replace(/<script[\s\S]*?<\/script>/gi, " ");
   s = s.replace(/<style[\s\S]*?<\/style>/gi, " ");
+  // FIX: Strip code blocks and inline code so URLs inside them are not picked
+  // for link previews, notifications, or keyword matching.
+  s = s.replace(/<pre[\s\S]*?<\/pre>/gi, " ");
+  s = s.replace(/<code[\s\S]*?<\/code>/gi, " ");
   s = s.replace(/<\/?[^>]+>/g, " "); // remove remaining tags
 
   // 2) Decode common entities (basic, covers majority cases)


### PR DESCRIPTION
## Problem

When a message contains a URL inside a `<pre>` or `<code>` block AND a different URL in the message body, the link preview was generated for the code-block URL instead of the body URL.

## Root cause

`extractFirstUrl()` in `apps/backend/src/utils/urlUtils.ts` calls `stripAndDecodeHtml()` which strips ALL HTML tags indiscriminately, including `<pre>`/`<code>`. URLs inside code blocks survive in the text and can be selected as the first URL for link previews.

The frontend renderer (`RenderMessageWithHTML.tsx`) already skips auto-linking inside code blocks, but the backend does not share that logic.

## Fix

Added two regex replacements in `stripAndDecodeHtml()` to strip `<pre>...</pre>` and `<code>...</code>` content BEFORE the generic tag removal step. This makes the backend consistent with the frontend.

## Tests

Added `apps/backend/src/utils/urlUtils.test.ts` with 8 test cases covering:
- Normal body URLs (regression check)
- URLs inside `<pre><code>` blocks (ignored)
- URLs inside inline `<code>` (ignored)
- Code-block URL appearing before body URL (body URL wins)
- Multiple URLs with first in inline code
- Nested/classed code blocks
- Deduplication outside code blocks
- Code-block-only URLs excluded

All 8 tests pass.