### PR TITLE
fix: ignore URLs inside code blocks for link preview extraction

### DIFF
--- a/apps/backend/src/utils/urlUtils.ts
+++ b/apps/backend/src/utils/urlUtils.ts
@@ -44,6 +44,10 @@ export function stripAndDecodeHtml(input: string): string {
   // 1) Remove tags
   let s = input.replace(/<script[\s\S]*?<\/script>/gi, " ");
   s = s.replace(/<style[\s\S]*?<\/style>/gi, " ");
+  // FIX: Strip code blocks and inline code so URLs inside them are not picked
+  // for link previews, notifications, or keyword matching.
+  s = s.replace(/<pre[\s\S]*?<\/pre>/gi, " ");
+  s = s.replace(/<code[\s\S]*?<\/code>/gi, " ");
   s = s.replace(/<\/?[^>]+>/g, " "); // remove remaining tags
 
   // 2) Decode common entities (basic, covers majority cases)


### PR DESCRIPTION
## Problem

When a message contains a URL inside a `<pre>` or `<code>` block AND a different URL in the message body, the link preview was generated for the code-block URL instead of the body URL.

## Root cause

`stripAndDecodeHtml()` in `apps/backend/src/utils/urlUtils.ts` strips ALL HTML tags indiscriminately, including `<pre>`/`<code>`. URLs inside code blocks survive in the text and can be selected as the first URL for link previews.

The frontend renderer (`RenderMessageWithHTML.tsx`) already skips auto-linking inside code blocks, but the backend does not share that logic.

## Fix

Added two regex replacements in `stripAndDecodeHtml()` to strip `<pre>...</pre>` and `<code>...</code>` content BEFORE the generic tag removal step:

```typescript
s = s.replace(/<pre[\s\S]*?<\/pre>/gi, " ");
s = s.replace(/<code[\s\S]*?<\/code>/gi, " ");
```

This makes the backend consistent with the frontend renderer.

## Test file removed

Test file was removed per reviewer request. The fix was verified with 8 test cases covering code blocks, inline code, and normal URLs — all passed.