### PR TITLE
fix: XYNE-56396 claw security audit — remediate all 21 findings (4 Critical, 5 High, 11 Medium, 1 Low-Medium)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.ts
@@ -175,11 +175,6 @@ export async function handleWebfetch(
   }
 
   try {
-    // SSRF guard: validate the destination (and EVERY redirect hop) against the
-    // shared private/reserved-range blocklist before connecting. We follow
-    // redirects manually with `redirect: "manual"` because `redirect: "follow"`
-    // would let a public URL bounce to an internal target (e.g. the cloud
-    // metadata endpoint) without re-validation. See mcpgateway http-client.
     const MAX_FETCH_REDIRECTS = 5;
     let currentUrl = url;
     let redirectCount = 0;
@@ -204,7 +199,6 @@ export async function handleWebfetch(
         if (redirectCount > MAX_FETCH_REDIRECTS) {
           return "Error: Fetch failed: too many redirects";
         }
-        // Free the socket before following the redirect.
         await response.body?.cancel().catch(() => undefined);
         currentUrl = new URL(location, currentUrl).toString();
         continue;

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.ts
@@ -20,6 +20,7 @@ import { Readability } from "@mozilla/readability";
 import { parseHTML } from "linkedom";
 import TurndownService from "turndown";
 import type { McpToolInfo } from "../types.js";
+import { assertSafeOutboundUrl } from "../../mcpgateway/services/http-client.js";
 
 import { createLogger } from "../../logger.js";
 const log = createLogger("webfetch");
@@ -174,15 +175,42 @@ export async function handleWebfetch(
   }
 
   try {
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(fetchTimeoutMs),
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
-        Accept: "text/html, text/plain;q=0.9, */*;q=0.1",
-      },
-      redirect: "follow",
-    });
+    // SSRF guard: validate the destination (and EVERY redirect hop) against the
+    // shared private/reserved-range blocklist before connecting. We follow
+    // redirects manually with `redirect: "manual"` because `redirect: "follow"`
+    // would let a public URL bounce to an internal target (e.g. the cloud
+    // metadata endpoint) without re-validation. See mcpgateway http-client.
+    const MAX_FETCH_REDIRECTS = 5;
+    let currentUrl = url;
+    let redirectCount = 0;
+    let response: Response;
+    for (;;) {
+      await assertSafeOutboundUrl(currentUrl);
+      response = await fetch(currentUrl, {
+        signal: AbortSignal.timeout(fetchTimeoutMs),
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+          Accept: "text/html, text/plain;q=0.9, */*;q=0.1",
+        },
+        redirect: "manual",
+      });
+
+      const status = response.status;
+      if (status === 301 || status === 302 || status === 303 || status === 307 || status === 308) {
+        const location = response.headers.get("location");
+        if (!location) break;
+        redirectCount += 1;
+        if (redirectCount > MAX_FETCH_REDIRECTS) {
+          return "Error: Fetch failed: too many redirects";
+        }
+        // Free the socket before following the redirect.
+        await response.body?.cancel().catch(() => undefined);
+        currentUrl = new URL(location, currentUrl).toString();
+        continue;
+      }
+      break;
+    }
 
     if (!response.ok) {
       return `Error: Fetch failed: ${response.status} ${response.statusText}`;

--- a/apps/xyne-claw-auth/backend/src/middleware/verify-spaces-signature.ts
+++ b/apps/xyne-claw-auth/backend/src/middleware/verify-spaces-signature.ts
@@ -31,6 +31,58 @@ import { prisma } from "../db.js";
 import { createLogger } from "../logger.js";
 const log = createLogger("verify-spaces-signature");
 
+// L-12 replay protection. Spaces signs the raw body with HMAC-SHA256, so the
+// signed payload's own `timestamp` (and `payload.createdAt`) are tamper-proof:
+// an attacker cannot alter or strip them from a captured request without
+// invalidating the signature. We therefore reject validly-signed requests whose
+// signed timestamp is outside a bounded skew window (mirrors the Slack adapter's
+// MAX_TIMESTAMP_SKEW_SECONDS=300), and additionally drop exact duplicates seen
+// within that window via a bounded in-memory signature cache.
+const MAX_TIMESTAMP_SKEW_MS = 5 * 60 * 1000; // 300s
+const SEEN_SIGNATURE_TTL_MS = MAX_TIMESTAMP_SKEW_MS;
+const MAX_SEEN_SIGNATURES = 10_000;
+const seenSignatures = new Map<string, number>(); // signature hex -> expiry epoch ms
+
+function pruneSeenSignatures(now: number): void {
+  if (seenSignatures.size < MAX_SEEN_SIGNATURES) return;
+  for (const [sig, expiry] of seenSignatures) {
+    if (expiry <= now) seenSignatures.delete(sig);
+  }
+  // Hard cap: if still oversized (many live entries), evict oldest-inserted.
+  if (seenSignatures.size >= MAX_SEEN_SIGNATURES) {
+    const overflow = seenSignatures.size - MAX_SEEN_SIGNATURES + 1;
+    let i = 0;
+    for (const sig of seenSignatures.keys()) {
+      seenSignatures.delete(sig);
+      if (++i >= overflow) break;
+    }
+  }
+}
+
+function parseSignedEpochMs(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1e12 ? value : value * 1000; // ms vs seconds heuristic
+  }
+  if (typeof value === "string" && value.length > 0) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric > 1e12 ? numeric : numeric * 1000;
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+// Extract the tamper-proof timestamp from an already-signature-verified raw body.
+// Returns null when the body carries no recognizable timestamp (older/other
+// webhook shapes) — those pass through the skew check unchanged.
+function signedTimestampMs(rawBody: Buffer): number | null {
+  let parsed: unknown;
+  try { parsed = JSON.parse(rawBody.toString("utf8")); } catch { return null; }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as { timestamp?: unknown; payload?: { createdAt?: unknown } };
+  return parseSignedEpochMs(obj.timestamp) ?? parseSignedEpochMs(obj.payload?.createdAt);
+}
+
 function parseGcmBundle(blob: string): [string, string, string] | null {
   const parts = blob.split(":");
   if (parts.length !== 3) return null;
@@ -148,6 +200,22 @@ export async function verifySpacesSignature(
     verificationFailure("mismatch", "invalid signature", `bodyBytes=${rawBody.length} headerLen=${received.length} ${diagnoseMismatch(rawBody, plaintextSecret, received)}`);
     return;
   }
+
+  // L-12: signature is valid — now enforce replay protection using the SIGNED
+  // (tamper-proof) timestamp and a short-lived duplicate cache.
+  const now = Date.now();
+  const signedTs = signedTimestampMs(rawBody);
+  if (signedTs !== null && Math.abs(now - signedTs) > MAX_TIMESTAMP_SKEW_MS) {
+    verificationFailure("stale_timestamp", "signature timestamp outside allowed window", `skewMs=${now - signedTs}`);
+    return;
+  }
+  const priorExpiry = seenSignatures.get(received);
+  if (priorExpiry !== undefined && priorExpiry > now) {
+    verificationFailure("replayed_signature", "duplicate signature");
+    return;
+  }
+  pruneSeenSignatures(now);
+  seenSignatures.set(received, now + SEEN_SIGNATURE_TTL_MS);
 
   next();
 }

--- a/apps/xyne-claw-auth/backend/src/middleware/verify-spaces-signature.ts
+++ b/apps/xyne-claw-auth/backend/src/middleware/verify-spaces-signature.ts
@@ -31,24 +31,16 @@ import { prisma } from "../db.js";
 import { createLogger } from "../logger.js";
 const log = createLogger("verify-spaces-signature");
 
-// L-12 replay protection. Spaces signs the raw body with HMAC-SHA256, so the
-// signed payload's own `timestamp` (and `payload.createdAt`) are tamper-proof:
-// an attacker cannot alter or strip them from a captured request without
-// invalidating the signature. We therefore reject validly-signed requests whose
-// signed timestamp is outside a bounded skew window (mirrors the Slack adapter's
-// MAX_TIMESTAMP_SKEW_SECONDS=300), and additionally drop exact duplicates seen
-// within that window via a bounded in-memory signature cache.
-const MAX_TIMESTAMP_SKEW_MS = 5 * 60 * 1000; // 300s
+const MAX_TIMESTAMP_SKEW_MS = 5 * 60 * 1000;
 const SEEN_SIGNATURE_TTL_MS = MAX_TIMESTAMP_SKEW_MS;
 const MAX_SEEN_SIGNATURES = 10_000;
-const seenSignatures = new Map<string, number>(); // signature hex -> expiry epoch ms
+const seenSignatures = new Map<string, number>();
 
 function pruneSeenSignatures(now: number): void {
   if (seenSignatures.size < MAX_SEEN_SIGNATURES) return;
   for (const [sig, expiry] of seenSignatures) {
     if (expiry <= now) seenSignatures.delete(sig);
   }
-  // Hard cap: if still oversized (many live entries), evict oldest-inserted.
   if (seenSignatures.size >= MAX_SEEN_SIGNATURES) {
     const overflow = seenSignatures.size - MAX_SEEN_SIGNATURES + 1;
     let i = 0;
@@ -61,7 +53,7 @@ function pruneSeenSignatures(now: number): void {
 
 function parseSignedEpochMs(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
-    return value > 1e12 ? value : value * 1000; // ms vs seconds heuristic
+    return value > 1e12 ? value : value * 1000;
   }
   if (typeof value === "string" && value.length > 0) {
     const numeric = Number(value);
@@ -72,9 +64,6 @@ function parseSignedEpochMs(value: unknown): number | null {
   return null;
 }
 
-// Extract the tamper-proof timestamp from an already-signature-verified raw body.
-// Returns null when the body carries no recognizable timestamp (older/other
-// webhook shapes) — those pass through the skew check unchanged.
 function signedTimestampMs(rawBody: Buffer): number | null {
   let parsed: unknown;
   try { parsed = JSON.parse(rawBody.toString("utf8")); } catch { return null; }
@@ -201,8 +190,6 @@ export async function verifySpacesSignature(
     return;
   }
 
-  // L-12: signature is valid — now enforce replay protection using the SIGNED
-  // (tamper-proof) timestamp and a short-lived duplicate cache.
   const now = Date.now();
   const signedTs = signedTimestampMs(rawBody);
   if (signedTs !== null && Math.abs(now - signedTs) > MAX_TIMESTAMP_SKEW_MS) {

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -1641,12 +1641,6 @@ router.post("/:slug/chat/:convId/regenerate", async (req: Request<{ slug: string
       return;
     }
 
-    // L-19: scope to the caller's OWN turns in THIS agent's thread. A
-    // conversationId is shared across every user in a thread (and across
-    // agents), so the old unscoped findByConversation let any caller read
-    // another user's message content and regenerate on their turn. Filtering to
-    // m.userId === userId makes a non-participant see an empty history (400)
-    // rather than someone else's prompt — same boundary as GET .../messages.
     const messages = (await chatMessageRepository.findByConversationAndAgent(convId, slug)).filter(
       (m) => m.userId === userId,
     );
@@ -1985,12 +1979,6 @@ router.post("/:slug/chat/:convId/fork", async (req: Request<{ slug: string; conv
       return;
     }
 
-    // C-10: fork only the caller's OWN slice of the thread. A conversationId is
-    // shared across every user in the thread, so an unfiltered copy let an
-    // attacker clone a victim's entire history (message content + PI session
-    // context) into an attacker-owned conversation, rewriting every userId to
-    // their own. Filtering to m.userId === userId means a non-participant sees
-    // an empty source (404) and can fork nothing but their own turns.
     const sourceMessages = (await chatMessageRepository.findByConversationAndAgent(convId, slug)).filter(
       (m) => m.userId === userId,
     );

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -1634,14 +1634,22 @@ router.post("/:slug/chat/cancel", async (req: Request<{ slug: string }>, res: Re
 // assistant under the same user message.
 router.post("/:slug/chat/:convId/regenerate", async (req: Request<{ slug: string; convId: string }>, res: Response) => {
   try {
-    const { convId } = req.params;
+    const { slug, convId } = req.params;
     const userId = getRequesterId(req);
     if (!userId) {
       res.status(400).json({ success: false, error: "userId or x-user-id header required" });
       return;
     }
 
-    const messages = await chatMessageRepository.findByConversation(convId);
+    // L-19: scope to the caller's OWN turns in THIS agent's thread. A
+    // conversationId is shared across every user in a thread (and across
+    // agents), so the old unscoped findByConversation let any caller read
+    // another user's message content and regenerate on their turn. Filtering to
+    // m.userId === userId makes a non-participant see an empty history (400)
+    // rather than someone else's prompt — same boundary as GET .../messages.
+    const messages = (await chatMessageRepository.findByConversationAndAgent(convId, slug)).filter(
+      (m) => m.userId === userId,
+    );
     const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");
     if (!lastAssistant) {
       res.status(400).json({ success: false, error: "No assistant message found" });
@@ -1977,7 +1985,15 @@ router.post("/:slug/chat/:convId/fork", async (req: Request<{ slug: string; conv
       return;
     }
 
-    const sourceMessages = await chatMessageRepository.findByConversationAndAgent(convId, slug);
+    // C-10: fork only the caller's OWN slice of the thread. A conversationId is
+    // shared across every user in the thread, so an unfiltered copy let an
+    // attacker clone a victim's entire history (message content + PI session
+    // context) into an attacker-owned conversation, rewriting every userId to
+    // their own. Filtering to m.userId === userId means a non-participant sees
+    // an empty source (404) and can fork nothing but their own turns.
+    const sourceMessages = (await chatMessageRepository.findByConversationAndAgent(convId, slug)).filter(
+      (m) => m.userId === userId,
+    );
     if (sourceMessages.length === 0) {
       res.status(404).json({ success: false, error: "Source conversation is empty" });
       return;

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -20,11 +20,13 @@ import {
   requireClawAdmin,
   requireAgentOwnerOrAdmin,
   requireAgentOwnerContributorOrAdmin,
+  getAgentEditAccess,
   getRequesterId,
   getOrgId,
   isClawAdmin,
 } from "../middleware/agent-acl.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
+import { s2sKeyMatches } from "../middleware/require-auth.js";
 import { writeAuditLog } from "../lib/audit.js";
 import { buildAvailableToolsCatalog } from "./tools.js";
 import { validateAgentModelConfig } from "../lib/agent-config-validation.js";
@@ -437,7 +439,19 @@ router.get("/:slug", async (req: Request<{ slug: string }>, res: Response) => {
       return;
     }
 
-    res.json({ success: true, data: sanitizeAgent(agent as unknown as Record<string, unknown>) });
+    // L-21: full agent internals (systemPrompt, promptNote, config, tool +
+    // skill configs, KB grants) are only for the owner / admin / contributors,
+    // and the trusted runtime (S2S) that has to RUN the agent. Any other org
+    // member gets the light projection — the same fields the agent list already
+    // exposes — so a slug read can't leak another user's prompt/config/creds.
+    const record = agent as unknown as Record<string, unknown>;
+    const viewerId = getRequesterId(req);
+    let full = s2sKeyMatches(req.headers["x-s2s-key"]);
+    if (!full && viewerId) {
+      const access = await getAgentEditAccess(viewerId, req.params.slug, getOrgId(req)).catch(() => null);
+      full = Boolean(access?.canEdit) || (await isClawAdmin(viewerId));
+    }
+    res.json({ success: true, data: full ? sanitizeAgent(record) : lightAgentProjection(record) });
   } catch (err) {
     log.error("[agents] get error:", err);
     res.status(500).json({ success: false, error: "Internal server error" });
@@ -489,6 +503,14 @@ router.post("/", async (req: Request, res: Response) => {
     const admin = requesterId ? await isClawAdmin(requesterId) : false;
     const effectiveScope = scope === "global" && admin ? "global" : "personal";
 
+    // C-8: prevent ownerUserId mass-assignment. A non-admin may only create an
+    // agent owned by itself; forging ownerUserId=<victim> would produce an agent
+    // that LOOKS victim-owned but carries the attacker's Spaces identity
+    // (spacesAppUserId) — a trojan agent. Mirrors the PUT owner-change guard.
+    if (ownerUserId && ownerUserId !== requesterId && !admin) {
+      res.status(403).json({ success: false, error: "Only an admin can create an agent owned by another user" });
+      return;
+    }
     // For personal agents, owner is required
     const effectiveOwner = ownerUserId ?? requesterId;
     if (effectiveScope === "personal" && !effectiveOwner) {
@@ -2391,7 +2413,7 @@ function spacesUserAuthHeaders(
 
 // ── Step-by-step Spaces App registration (3 separate buttons) ────────
 
-router.post("/:slug/create-app", async (req: Request<{ slug: string }>, res: Response) => {
+router.post("/:slug/create-app", requireAgentOwnerOrAdmin, async (req: Request<{ slug: string }>, res: Response) => {
   try {
     const userToken = extractUserToken(req);
     if (!userToken) { res.status(401).json({ success: false, error: "User token required" }); return; }
@@ -2449,7 +2471,7 @@ router.post("/:slug/create-app", async (req: Request<{ slug: string }>, res: Res
   }
 });
 
-router.post("/:slug/install-app", async (req: Request<{ slug: string }>, res: Response) => {
+router.post("/:slug/install-app", requireAgentOwnerOrAdmin, async (req: Request<{ slug: string }>, res: Response) => {
   try {
     const userToken = extractUserToken(req);
     if (!userToken) { res.status(401).json({ success: false, error: "User token required" }); return; }
@@ -2500,7 +2522,7 @@ router.post("/:slug/install-app", async (req: Request<{ slug: string }>, res: Re
   }
 });
 
-router.post("/:slug/configure-webhook", async (req: Request<{ slug: string }>, res: Response) => {
+router.post("/:slug/configure-webhook", requireAgentOwnerOrAdmin, async (req: Request<{ slug: string }>, res: Response) => {
   try {
     const userToken = extractUserToken(req);
     if (!userToken) { res.status(401).json({ success: false, error: "User token required" }); return; }
@@ -2575,7 +2597,7 @@ const CLAW_APP_PERMISSIONS = [
 // THEN install (the existing-installation branch re-approves + re-issues the JWT).
 // Without this the bot 403s with `missing_permission required:chat:write granted:[]`
 // the moment it tries to post a result back to the thread.
-router.post("/:slug/grant-permissions", async (req: Request<{ slug: string }>, res: Response) => {
+router.post("/:slug/grant-permissions", requireAgentOwnerOrAdmin, async (req: Request<{ slug: string }>, res: Response) => {
   try {
     const userToken = extractUserToken(req);
     if (!userToken) { res.status(401).json({ success: false, error: "User token required" }); return; }
@@ -2676,6 +2698,7 @@ const pictureUpload = multer({
 
 router.post(
   "/:slug/upload-picture",
+  requireAgentOwnerOrAdmin,
   pictureUpload.single("picture") as unknown as RequestHandler<{ slug: string }>,
   async (req: Request<{ slug: string }>, res: Response) => {
     try {
@@ -2754,7 +2777,7 @@ router.put("/:slug/user-config/:userId", pinUserIdParam, async (req: Request<{ s
 
 // ── User Chain Config (per-user agent chaining) ──────────────────────
 
-router.get("/:slug/chain-config/:userId", async (req: Request<{ slug: string; userId: string }>, res: Response) => {
+router.get("/:slug/chain-config/:userId", pinUserIdParam, async (req: Request<{ slug: string; userId: string }>, res: Response) => {
   try {
     const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));
     if (!agent) { logAgentScopedMiss(req, "agents/get-chain-config", req.params.slug); res.status(404).json({ success: false, error: "Agent not found" }); return; }
@@ -2766,7 +2789,7 @@ router.get("/:slug/chain-config/:userId", async (req: Request<{ slug: string; us
   }
 });
 
-router.put("/:slug/chain-config/:userId", async (req: Request<{ slug: string; userId: string }>, res: Response) => {
+router.put("/:slug/chain-config/:userId", pinUserIdParam, async (req: Request<{ slug: string; userId: string }>, res: Response) => {
   try {
     const chainConfig = req.body.chainConfig ?? null;
 
@@ -3050,7 +3073,7 @@ router.get("/:slug/skills", async (req: Request<{ slug: string }>, res: Response
   }
 });
 
-router.post("/:slug/skills", async (req: Request<{ slug: string }>, res: Response) => {
+router.post("/:slug/skills", requireAgentOwnerOrAdmin, async (req: Request<{ slug: string }>, res: Response) => {
   try {
     const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));
     if (!agent) {
@@ -3071,7 +3094,7 @@ router.post("/:slug/skills", async (req: Request<{ slug: string }>, res: Respons
   }
 });
 
-router.delete("/:slug/skills/:skillId", async (req: Request<{ slug: string; skillId: string }>, res: Response) => {
+router.delete("/:slug/skills/:skillId", requireAgentOwnerOrAdmin, async (req: Request<{ slug: string; skillId: string }>, res: Response) => {
   try {
     const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));
     if (!agent) {

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type RequestHandler, type Response } from "express";
+import { assertSafeOutboundUrl } from "../mcpgateway/services/http-client.js";
 import multer from "multer";
 import crypto from "node:crypto";
 import { Prisma } from "@prisma/client";
@@ -2829,6 +2830,8 @@ export async function fetchAnthropicModels(apiKey: string, baseUrl?: string, aut
   } else {
     headers["x-api-key"] = apiKey;
   }
+  // SSRF guard: baseUrl is user-supplied; block private/reserved destinations.
+  await assertSafeOutboundUrl(`${root}/v1/models`);
   const res = await fetch(`${root}/v1/models`, {
     method: "GET",
     headers,
@@ -3962,6 +3965,8 @@ router.get(
         headers["User-Agent"] = "codex-cli";
       }
 
+      // SSRF guard: cred.baseUrl is user-supplied; block private/reserved destinations.
+      await assertSafeOutboundUrl(url);
       const upstream = await fetch(url, { headers, signal: AbortSignal.timeout(20_000) });
       if (!upstream.ok) {
         const text = await upstream.text().catch(() => "");
@@ -4028,6 +4033,8 @@ router.post(
 
       const root = (baseUrl || CONFIG.litellmBaseUrl).replace(/\/+$/, "");
       log.info(`[agents] litellm/models fetching ${root}/v1/models (keyLen=${apiKey.length}, source=${typedKey ? "typed" : "saved-cred"})`);
+      // SSRF guard: baseUrl is user-supplied; block private/reserved destinations.
+      await assertSafeOutboundUrl(`${root}/v1/models`);
       const upstream = await fetch(`${root}/v1/models`, {
         headers: { Authorization: `Bearer ${apiKey}`, "User-Agent": "xyne-claw-auth" },
         signal: AbortSignal.timeout(20_000),

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -439,11 +439,6 @@ router.get("/:slug", async (req: Request<{ slug: string }>, res: Response) => {
       return;
     }
 
-    // L-21: full agent internals (systemPrompt, promptNote, config, tool +
-    // skill configs, KB grants) are only for the owner / admin / contributors,
-    // and the trusted runtime (S2S) that has to RUN the agent. Any other org
-    // member gets the light projection — the same fields the agent list already
-    // exposes — so a slug read can't leak another user's prompt/config/creds.
     const record = agent as unknown as Record<string, unknown>;
     const viewerId = getRequesterId(req);
     let full = s2sKeyMatches(req.headers["x-s2s-key"]);
@@ -503,10 +498,6 @@ router.post("/", async (req: Request, res: Response) => {
     const admin = requesterId ? await isClawAdmin(requesterId) : false;
     const effectiveScope = scope === "global" && admin ? "global" : "personal";
 
-    // C-8: prevent ownerUserId mass-assignment. A non-admin may only create an
-    // agent owned by itself; forging ownerUserId=<victim> would produce an agent
-    // that LOOKS victim-owned but carries the attacker's Spaces identity
-    // (spacesAppUserId) — a trojan agent. Mirrors the PUT owner-change guard.
     if (ownerUserId && ownerUserId !== requesterId && !admin) {
       res.status(403).json({ success: false, error: "Only an admin can create an agent owned by another user" });
       return;
@@ -2853,7 +2844,6 @@ export async function fetchAnthropicModels(apiKey: string, baseUrl?: string, aut
   } else {
     headers["x-api-key"] = apiKey;
   }
-  // SSRF guard: baseUrl is user-supplied; block private/reserved destinations.
   await assertSafeOutboundUrl(`${root}/v1/models`);
   const res = await fetch(`${root}/v1/models`, {
     method: "GET",
@@ -3988,7 +3978,6 @@ router.get(
         headers["User-Agent"] = "codex-cli";
       }
 
-      // SSRF guard: cred.baseUrl is user-supplied; block private/reserved destinations.
       await assertSafeOutboundUrl(url);
       const upstream = await fetch(url, { headers, signal: AbortSignal.timeout(20_000) });
       if (!upstream.ok) {
@@ -4056,7 +4045,6 @@ router.post(
 
       const root = (baseUrl || CONFIG.litellmBaseUrl).replace(/\/+$/, "");
       log.info(`[agents] litellm/models fetching ${root}/v1/models (keyLen=${apiKey.length}, source=${typedKey ? "typed" : "saved-cred"})`);
-      // SSRF guard: baseUrl is user-supplied; block private/reserved destinations.
       await assertSafeOutboundUrl(`${root}/v1/models`);
       const upstream = await fetch(`${root}/v1/models`, {
         headers: { Authorization: `Bearer ${apiKey}`, "User-Agent": "xyne-claw-auth" },

--- a/apps/xyne-claw-auth/backend/src/routes/chain-workflows.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/chain-workflows.ts
@@ -730,6 +730,17 @@ router.put("/bindings/upsert", async (req: Request, res: Response) => {
     // scoped (e.g. an admin binding for another user, or "*" for any user).
     const targetUserId = userId?.trim() || requesterId;
 
+    // L-11: targetUserId is body-controlled and canAccessWorkflow only proves
+    // the caller may use the WORKFLOW — not that they may bind it to run on
+    // ANOTHER user's behalf. Without this gate a workflow creator could send
+    // userId=<victim> (or the "*" = all-users sentinel) so their workflow runs
+    // under the victim's identity whenever the victim messages the channel.
+    // Binding for anyone other than yourself is therefore admin-only.
+    if (targetUserId !== requesterId && !(await isClawAdmin(requesterId))) {
+      res.status(403).json({ success: false, error: "Only an admin can bind a workflow for another user" });
+      return;
+    }
+
     const workflow = await agentChainWorkflowRepository.findWorkflowById(workflowId.trim());
     if (!workflow) { res.status(404).json({ success: false, error: "Workflow not found" }); return; }
 

--- a/apps/xyne-claw-auth/backend/src/routes/chain-workflows.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/chain-workflows.ts
@@ -730,12 +730,6 @@ router.put("/bindings/upsert", async (req: Request, res: Response) => {
     // scoped (e.g. an admin binding for another user, or "*" for any user).
     const targetUserId = userId?.trim() || requesterId;
 
-    // L-11: targetUserId is body-controlled and canAccessWorkflow only proves
-    // the caller may use the WORKFLOW — not that they may bind it to run on
-    // ANOTHER user's behalf. Without this gate a workflow creator could send
-    // userId=<victim> (or the "*" = all-users sentinel) so their workflow runs
-    // under the victim's identity whenever the victim messages the channel.
-    // Binding for anyone other than yourself is therefore admin-only.
     if (targetUserId !== requesterId && !(await isClawAdmin(requesterId))) {
       res.status(403).json({ success: false, error: "Only an admin can bind a workflow for another user" });
       return;

--- a/apps/xyne-claw-auth/backend/src/routes/memory.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/memory.ts
@@ -22,7 +22,7 @@ import type { MemoryRecord, EntityGraphEdge } from "xyne-claw-shared";
 import { prisma } from "../db.js";
 import { agentRepository } from "../repositories/index.js";
 import { createLogger, createTraceId } from "../logger.js";
-import { requireAuth, requireUserAuth } from "../middleware/require-auth.js";
+import { requireAuth, requireUserAuth, s2sKeyMatches } from "../middleware/require-auth.js";
 import { isClawAdmin, requireClawAdmin, getOrgId, getRequesterId } from "../middleware/agent-acl.js";
 import { curateApprovedTranscript, persistSubsystemReviews, readSessionTranscript, type SessionTranscript } from "../services/memoryCronService.js";
 import { classifySessionSubsystemForBank, distillSessionFile, parseSessionFile } from "../services/sessionCurator.js";
@@ -58,6 +58,32 @@ function isDigitalTwinAgent(agentSlug: string | undefined): boolean {
   return !!agentSlug && bankIdForAgent(agentSlug) === DIGITAL_TWIN_BANK;
 }
 
+/**
+ * C-5: The file-memory endpoints below are internal S2S tools (mid-chat
+ * read/write-memory-file, prompt-file loader) that act on behalf of a specific
+ * end user, identified by a `userId` in the query/body. `requireAuth` also
+ * admits ordinary cookie/CLI user sessions, so without this check any
+ * authenticated user could pass another user's id and read or OVERWRITE their
+ * memory files — including `soul.md`, which is injected verbatim into the
+ * agent's system prompt (data theft + persistent prompt injection).
+ *
+ * Rule: a trusted S2S caller (the xyne-claw runtime) may target any userId —
+ * end-user attribution was already resolved upstream. A regular user session
+ * may only touch its OWN files, unless it is a claw admin.
+ */
+async function assertMemoryUserAccess(
+  req: Request,
+  res: Response,
+  targetUserId: string,
+): Promise<boolean> {
+  if (s2sKeyMatches(req.headers["x-s2s-key"])) return true;
+  const requesterId = getRequesterId(req);
+  if (requesterId && requesterId === targetUserId) return true;
+  if (requesterId && (await isClawAdmin(requesterId))) return true;
+  res.status(403).json({ success: false, error: "You can only access your own memory files." });
+  return false;
+}
+
 export const memoryRouter = Router();
 
 /**
@@ -80,6 +106,7 @@ memoryRouter.get("/agent-prompt-files", requireAuth, async (req, res) => {
       res.json({ success: true, data: { files: [] } });
       return;
     }
+    if (!(await assertMemoryUserAccess(req, res, userId))) return;
     const files = await getPromptFiles(agentSlug, userId);
     res.json({
       success: true,
@@ -110,6 +137,7 @@ memoryRouter.get("/agent-file", requireAuth, async (req, res) => {
       res.json({ success: true, data: { file: null, files: [] } });
       return;
     }
+    if (!(await assertMemoryUserAccess(req, res, userId))) return;
     if (name) {
       const f = await getAgentFile(agentSlug, userId, name);
       res.json({
@@ -153,6 +181,7 @@ memoryRouter.post("/agent-file", requireAuth, async (req, res) => {
       res.status(400).json({ success: false, error: "userId, valid name, and content are required" });
       return;
     }
+    if (!(await assertMemoryUserAccess(req, res, userId))) return;
     let finalContent = content;
     if (mode === "append") {
       const current = await getAgentFile(agentSlug, userId, name);
@@ -1883,6 +1912,25 @@ memoryRouter.post("/banks/:agentSlug/backfill", requireUserAuth, async (req, res
       });
       return;
     }
+    // L-23: backfill triggers an expensive per-session curate (an LLM call each)
+    // over another owner's history. It previously never loaded the agent, so any
+    // org member could enqueue a cross-user backfill. Load org-scoped + gate to
+    // owner-or-admin, matching the enable/disable/clear-all surfaces.
+    const requesterId = getRequesterId(req);
+    if (!requesterId) {
+      res.status(401).json({ success: false, error: "Unauthenticated" });
+      return;
+    }
+    const agent = await agentRepository.findBySlug(agentSlug, getOrgId(req));
+    if (!agent) {
+      logger.warn(`[memory/backfill] agent org-scoped miss slug=${agentSlug} orgId=${getOrgId(req) ?? "none"} userId=${requesterId}`);
+      res.status(404).json({ success: false, error: "Agent not found" });
+      return;
+    }
+    if (!(await isClawAdmin(requesterId)) && agent.ownerUserId !== requesterId) {
+      res.status(403).json({ success: false, error: "Only the agent owner or an admin can backfill this agent's memory." });
+      return;
+    }
     const body = (req.body ?? {}) as { from?: string; to?: string; days?: number };
 
     let from: string;
@@ -2051,6 +2099,19 @@ memoryRouter.post("/banks/:agentSlug/enable", requireUserAuth, async (req, res) 
       res.status(404).json({ success: false, error: "Agent not found" });
       return;
     }
+    const requesterId = getRequesterId(req);
+    if (!requesterId) {
+      res.status(401).json({ success: false, error: "Unauthenticated" });
+      return;
+    }
+    // L-23: checkTwinAccess only guards the shared digital-twin bank; for a
+    // normal agent it returns true, so this bank op had NO ownership check —
+    // any org member could change another owner's memory config. Mirror the
+    // clear-all / subsystem-delete owner-or-admin guard.
+    if (!(await isClawAdmin(requesterId)) && agent.ownerUserId !== requesterId) {
+      res.status(403).json({ success: false, error: "Only the agent owner or an admin can manage this agent's memory." });
+      return;
+    }
 
     const config = { ...((agent.config as Record<string, unknown>) ?? {}) };
     config["memoryEnabled"] = true;
@@ -2090,6 +2151,19 @@ memoryRouter.post("/banks/:agentSlug/disable", requireUserAuth, async (req, res)
     if (!agent) {
       logger.warn(`[memory/disable] agent org-scoped miss slug=${agentSlug} orgId=${getOrgId(req) ?? "none"}`);
       res.status(404).json({ success: false, error: "Agent not found" });
+      return;
+    }
+    const requesterId = getRequesterId(req);
+    if (!requesterId) {
+      res.status(401).json({ success: false, error: "Unauthenticated" });
+      return;
+    }
+    // L-23: checkTwinAccess only guards the shared digital-twin bank; for a
+    // normal agent it returns true, so this bank op had NO ownership check —
+    // any org member could change another owner's memory config. Mirror the
+    // clear-all / subsystem-delete owner-or-admin guard.
+    if (!(await isClawAdmin(requesterId)) && agent.ownerUserId !== requesterId) {
+      res.status(403).json({ success: false, error: "Only the agent owner or an admin can manage this agent's memory." });
       return;
     }
 

--- a/apps/xyne-claw-auth/backend/src/routes/memory.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/memory.ts
@@ -58,19 +58,6 @@ function isDigitalTwinAgent(agentSlug: string | undefined): boolean {
   return !!agentSlug && bankIdForAgent(agentSlug) === DIGITAL_TWIN_BANK;
 }
 
-/**
- * C-5: The file-memory endpoints below are internal S2S tools (mid-chat
- * read/write-memory-file, prompt-file loader) that act on behalf of a specific
- * end user, identified by a `userId` in the query/body. `requireAuth` also
- * admits ordinary cookie/CLI user sessions, so without this check any
- * authenticated user could pass another user's id and read or OVERWRITE their
- * memory files — including `soul.md`, which is injected verbatim into the
- * agent's system prompt (data theft + persistent prompt injection).
- *
- * Rule: a trusted S2S caller (the xyne-claw runtime) may target any userId —
- * end-user attribution was already resolved upstream. A regular user session
- * may only touch its OWN files, unless it is a claw admin.
- */
 async function assertMemoryUserAccess(
   req: Request,
   res: Response,
@@ -1912,10 +1899,6 @@ memoryRouter.post("/banks/:agentSlug/backfill", requireUserAuth, async (req, res
       });
       return;
     }
-    // L-23: backfill triggers an expensive per-session curate (an LLM call each)
-    // over another owner's history. It previously never loaded the agent, so any
-    // org member could enqueue a cross-user backfill. Load org-scoped + gate to
-    // owner-or-admin, matching the enable/disable/clear-all surfaces.
     const requesterId = getRequesterId(req);
     if (!requesterId) {
       res.status(401).json({ success: false, error: "Unauthenticated" });
@@ -2104,10 +2087,6 @@ memoryRouter.post("/banks/:agentSlug/enable", requireUserAuth, async (req, res) 
       res.status(401).json({ success: false, error: "Unauthenticated" });
       return;
     }
-    // L-23: checkTwinAccess only guards the shared digital-twin bank; for a
-    // normal agent it returns true, so this bank op had NO ownership check —
-    // any org member could change another owner's memory config. Mirror the
-    // clear-all / subsystem-delete owner-or-admin guard.
     if (!(await isClawAdmin(requesterId)) && agent.ownerUserId !== requesterId) {
       res.status(403).json({ success: false, error: "Only the agent owner or an admin can manage this agent's memory." });
       return;
@@ -2158,10 +2137,6 @@ memoryRouter.post("/banks/:agentSlug/disable", requireUserAuth, async (req, res)
       res.status(401).json({ success: false, error: "Unauthenticated" });
       return;
     }
-    // L-23: checkTwinAccess only guards the shared digital-twin bank; for a
-    // normal agent it returns true, so this bank op had NO ownership check —
-    // any org member could change another owner's memory config. Mirror the
-    // clear-all / subsystem-delete owner-or-admin guard.
     if (!(await isClawAdmin(requesterId)) && agent.ownerUserId !== requesterId) {
       res.status(403).json({ success: false, error: "Only the agent owner or an admin can manage this agent's memory." });
       return;

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -872,6 +872,20 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       res.status(400).json({ success: false, error: "callbackUrl is not an allowed target" });
       return;
     }
+    // L-24: progressUrl is caller-supplied and is later POSTed to with the
+    // internal x-s2s-key on every streamed event. It MUST pass the same origin
+    // allowlist as callbackUrl, otherwise any authenticated caller can name their
+    // own server as progressUrl and harvest the platform S2S key. Legit webhook /
+    // scheduled flows point progressUrl at the same Spaces backend origin as
+    // callbackUrl, so this rejects only untrusted targets.
+    if (progressUrl !== undefined && typeof progressUrl !== "string") {
+      res.status(400).json({ success: false, error: "progressUrl must be a string" });
+      return;
+    }
+    if (progressUrl && !isInternalCallbackOrigin(progressUrl) && !isAllowedExternalCallbackUrl(progressUrl)) {
+      res.status(400).json({ success: false, error: "progressUrl is not an allowed target" });
+      return;
+    }
     if (callbackSecret !== undefined && (typeof callbackSecret !== "string" || callbackSecret.length > 256)) {
       res
         .status(400)

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -872,12 +872,6 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       res.status(400).json({ success: false, error: "callbackUrl is not an allowed target" });
       return;
     }
-    // L-24: progressUrl is caller-supplied and is later POSTed to with the
-    // internal x-s2s-key on every streamed event. It MUST pass the same origin
-    // allowlist as callbackUrl, otherwise any authenticated caller can name their
-    // own server as progressUrl and harvest the platform S2S key. Legit webhook /
-    // scheduled flows point progressUrl at the same Spaces backend origin as
-    // callbackUrl, so this rejects only untrusted targets.
     if (progressUrl !== undefined && typeof progressUrl !== "string") {
       res.status(400).json({ success: false, error: "progressUrl must be a string" });
       return;

--- a/apps/xyne-claw-auth/backend/src/routes/users.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/users.ts
@@ -265,8 +265,26 @@ async function autoConfigureSpaces(userId: string, token: string): Promise<void>
 
 router.get("/:id", async (req: Request<{ id: string }>, res: Response) => {
   try {
-    const user = await prisma.user.findUnique({
-      where: { id: req.params.id },
+    // C-4: scope the lookup to the caller's org and return only display fields.
+    // A bare findUnique by id leaked name+email+orgId (and every other User
+    // column) for ANY user in ANY org. Mirror the typeahead sibling (GET /):
+    // resolve the caller's orgId, filter by it, and `select` minimal fields so
+    // a cross-org id resolves to a 404 instead of an information disclosure.
+    const requesterId = getRequesterId(req);
+    const orgId =
+      getOrgId(req) ??
+      (requesterId
+        ? (await prisma.user.findUnique({ where: { id: requesterId }, select: { orgId: true } }))?.orgId
+        : undefined);
+    if (!orgId) {
+      log.error(`[users] orgId is required; refusing cross-org user lookup requesterId=${requesterId ?? "none"} id=${req.params.id}`);
+      res.status(400).json({ success: false, error: "orgId is required" });
+      return;
+    }
+
+    const user = await prisma.user.findFirst({
+      where: { id: req.params.id, orgId },
+      select: { id: true, email: true, name: true },
     });
 
     if (!user) {

--- a/apps/xyne-claw-auth/backend/src/routes/users.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/users.ts
@@ -265,11 +265,6 @@ async function autoConfigureSpaces(userId: string, token: string): Promise<void>
 
 router.get("/:id", async (req: Request<{ id: string }>, res: Response) => {
   try {
-    // C-4: scope the lookup to the caller's org and return only display fields.
-    // A bare findUnique by id leaked name+email+orgId (and every other User
-    // column) for ANY user in ANY org. Mirror the typeahead sibling (GET /):
-    // resolve the caller's orgId, filter by it, and `select` minimal fields so
-    // a cross-org id resolves to a 404 instead of an information disclosure.
     const requesterId = getRequesterId(req);
     const orgId =
       getOrgId(req) ??

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -782,7 +782,6 @@ async function pendingActionTargetValidation(
   }
 }
 
-
 /**
  * Digital Twin (approval mode): open a DM with the mentioned user and send the
  * agent's result as an approve/decline flow — with attachments when present.
@@ -1380,7 +1379,6 @@ async function postWriteApprovalAction(args: {
   }, token);
 }
 
-
 // ── POST /webhook and /webhook/:agentSlug — receive events from Xyne Spaces ──
 
 async function handleWebhook(req: Request, res: Response): Promise<void> {
@@ -1523,7 +1521,6 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
     if (mentionedUserIds.length > 0) {
       // First check if the mentioned user is an agent bot
       agent = await resolveAgentByAppUserId(mentionedUserIds[0]!);
-
 
       // If not an agent bot, check if the mentioned user is registered in claw-auth
       // (i.e. they have a Digital Twin set up with MCP connections)
@@ -4214,12 +4211,6 @@ async function forwardResult(
   // escaped JSON.
   const isAutomationCallback = url.includes("/automations/claw-callback/");
   const resultField = isAutomationCallback ? coerceAutomationForwardResult(result) : result;
-  // L-18: `url` is derived from caller-supplied resultForwardUrl / automation
-  // callbackUrl. Legit forward targets are always internal origins (the Spaces
-  // backend /automations/claw-callback, auto-draft, or /webhook/result). Never
-  // forward the internal x-s2s-key to a target that is not an internal origin —
-  // otherwise a body-controlled URL harvests the platform S2S key. Refuse any
-  // target that is neither an internal origin nor an explicitly allowed callback.
   const forwardToInternal = isInternalCallbackOrigin(url);
   if (!forwardToInternal && !isAllowedExternalCallbackUrl(url)) {
     clog.warn(`[webhook/result] refusing to forward result to non-allowlisted url origin`);

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -91,7 +91,7 @@ import { requireStrictS2S, s2sKeyMatches, requireResultToken } from "../middlewa
 import { isClawAdmin } from "../middleware/agent-acl.js";
 import { renderAttachmentsToPdf } from "../lib/result-pdf.js";
 import { renderMarkdownToHtml } from "../lib/result-html.js";
-import { sendStoredExternalResultCallback, type ExternalResultCallbackConfig } from "../surfaces/external-api/delivery.js";
+import { sendStoredExternalResultCallback, isInternalCallbackOrigin, isAllowedExternalCallbackUrl, type ExternalResultCallbackConfig } from "../surfaces/external-api/delivery.js";
 import { encryptSurfaceSecret } from "../lib/surface-resolver.js";
 import { deliverSlackResult, type SlackDeliveryTarget } from "../surfaces/slack/delivery.js";
 import { designShareUrl, upsertDesignShare } from "./design-shares.js";
@@ -4214,12 +4214,23 @@ async function forwardResult(
   // escaped JSON.
   const isAutomationCallback = url.includes("/automations/claw-callback/");
   const resultField = isAutomationCallback ? coerceAutomationForwardResult(result) : result;
+  // L-18: `url` is derived from caller-supplied resultForwardUrl / automation
+  // callbackUrl. Legit forward targets are always internal origins (the Spaces
+  // backend /automations/claw-callback, auto-draft, or /webhook/result). Never
+  // forward the internal x-s2s-key to a target that is not an internal origin —
+  // otherwise a body-controlled URL harvests the platform S2S key. Refuse any
+  // target that is neither an internal origin nor an explicitly allowed callback.
+  const forwardToInternal = isInternalCallbackOrigin(url);
+  if (!forwardToInternal && !isAllowedExternalCallbackUrl(url)) {
+    clog.warn(`[webhook/result] refusing to forward result to non-allowlisted url origin`);
+    return;
+  }
   try {
     const res = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+        ...(forwardToInternal && CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
       },
       body: JSON.stringify({
         sessionId: payload.sessionId,

--- a/apps/xyne-claw-auth/backend/src/surfaces/external-api/delivery.ts
+++ b/apps/xyne-claw-auth/backend/src/surfaces/external-api/delivery.ts
@@ -97,10 +97,6 @@ export async function sendExternalResultCallback(
     return "refused";
   }
 
-  // Defense in depth: the check above is a literal-hostname blocklist and cannot
-  // catch DNS names that resolve to private/reserved IPs (DNS rebinding) or the
-  // many private CIDRs not enumerated in BLOCKED_HOSTNAMES. Resolve the host and
-  // reject every private/reserved destination via the shared outbound guard.
   try {
     await assertSafeOutboundUrl(callback.url);
   } catch {

--- a/apps/xyne-claw-auth/backend/src/surfaces/external-api/delivery.ts
+++ b/apps/xyne-claw-auth/backend/src/surfaces/external-api/delivery.ts
@@ -2,6 +2,7 @@ import { CONFIG } from "../../config.js";
 import { createLogger } from "../../logger.js";
 import { decryptSurfaceSecret } from "../../lib/surface-resolver.js";
 import { postExternalCallback } from "./api.js";
+import { assertSafeOutboundUrl } from "../../mcpgateway/services/http-client.js";
 import {
   RETRY_DELAYS_MS,
   MAX_DELIVERY_ATTEMPTS,
@@ -93,6 +94,17 @@ export async function sendExternalResultCallback(
 ): Promise<"delivered" | "refused" | "failed"> {
   if (!isAllowedExternalCallbackUrl(callback.url)) {
     log.warn(`[external-callback] refused unsafe callback target session=${payload.sessionId}`);
+    return "refused";
+  }
+
+  // Defense in depth: the check above is a literal-hostname blocklist and cannot
+  // catch DNS names that resolve to private/reserved IPs (DNS rebinding) or the
+  // many private CIDRs not enumerated in BLOCKED_HOSTNAMES. Resolve the host and
+  // reject every private/reserved destination via the shared outbound guard.
+  try {
+    await assertSafeOutboundUrl(callback.url);
+  } catch {
+    log.warn(`[external-callback] refused callback target resolving to a blocked address session=${payload.sessionId}`);
     return "refused";
   }
 

--- a/packages/xyne-claw-shared/package.json
+++ b/packages/xyne-claw-shared/package.json
@@ -27,6 +27,7 @@
     "pdfkit": "^0.15.2",
     "playwright": "^1.59.1",
     "pptxgenjs": "^4.0.1",
+    "sanitize-html": "^2.17.7",
     "winston": "^3.19.0",
     "yaml": "^2.7.0"
   },
@@ -34,6 +35,7 @@
     "@types/node": "^22.0.0",
     "@types/pdf-parse": "^1.1.5",
     "@types/pdfkit": "^0.13.9",
+    "@types/sanitize-html": "^2.16.1",
     "typescript": "^5.7.0",
     "vitest": "^2.1.9"
   }

--- a/packages/xyne-claw-shared/src/tools/create-report/template.ts
+++ b/packages/xyne-claw-shared/src/tools/create-report/template.ts
@@ -10,6 +10,8 @@
  * `marked.parse()`). Any sanitization happens BEFORE this template wraps it.
  */
 
+import sanitizeHtml from "sanitize-html";
+
 export interface HtmlTemplateInput {
   /** Becomes both <title> and the visible <h1>. */
   title: string;
@@ -166,44 +168,52 @@ function escapeHtml(s: string): string {
 }
 
 /**
- * Strip the small set of HTML tags that pose real script-execution risk
- * when the resulting file is opened in a browser. Defense in depth — agents
- * aren't expected to emit these, but a prompt-injected agent could be
- * convinced to. We're explicitly NOT installing DOMPurify (would need jsdom
- * server-side, heavy dep) since the threat model is narrow: agent-emitted
- * markdown rendered to a downloadable file, not user-uploaded HTML.
+ * Sanitize already-rendered HTML (the output of `marked.parse()`) before the
+ * report template wraps it and it is written to a downloadable file.
  *
- * Removed: <script>...</script>, <style>...</style>, <iframe>, <object>,
- * <embed>, <link>, <meta>, <form>, on* event handler attributes,
- * javascript: URLs in href/src.
+ * Uses `sanitize-html` — a pure-JS, allow-list parser with NO jsdom — instead of
+ * the previous regex denylist. The regex was bypassable (finding C-2): it only
+ * stripped whitespace-preceded event handlers, so `<img src=x /onerror=...>`
+ * survived. An allow-list closes that whole bug class by construction: anything
+ * not explicitly permitted (event handlers, <script>/<iframe>/<svg>/<object>,
+ * javascript:/vbscript:/data:text-html schemes) is dropped by the parser.
+ *
+ * We deliberately keep the inline HTML the report feature supports — <details>,
+ * <summary>, <code>, <pre>, tables, headings — and raster `data:` images used by
+ * embedded charts. `<img>`-loaded SVG cannot execute script, but
+ * data:image/svg+xml and data:text/html srcs are dropped anyway as defense in
+ * depth via exclusiveFilter.
  */
 export function sanitizeHtmlBody(html: string): string {
-  return (
-    html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
-      // <svg>/<math> are foreign-content roots that enable mutation-XSS and are
-      // not needed in a text report (charts are embedded as <img> data: rasters).
-      .replace(/<(iframe|object|embed|form|link|meta|base|svg|math)\b[^>]*>/gi, "")
-      .replace(/<\/(iframe|object|embed|form|svg|math)>/gi, "")
-      // C-2: event-handler attributes. The old pattern required a WHITESPACE
-      // delimiter (\son\w+), so a slash-separated handler — `<img src=x
-      // /onerror=alert(1)>` — slipped through and executed. Match a handler
-      // preceded by ANY non-name delimiter (whitespace, slash, quote) and
-      // re-insert a space so neighbouring attributes don't fuse.
-      .replace(/[\s/]on\w+\s*=\s*"[^"]*"/gi, " ")
-      .replace(/[\s/]on\w+\s*=\s*'[^']*'/gi, " ")
-      .replace(/[\s/]on\w+\s*=\s*[^\s>]+/gi, " ")
-      // Dangerous URL schemes in href/src/xlink:href. javascript: and vbscript:
-      // are always unsafe; data:text/html and data:image/svg+xml can carry
-      // script, but raster data: images (png/jpeg/gif/webp — used by embedded
-      // charts) are preserved. Tolerant of leading whitespace after `=`.
-      .replace(/(href|src|xlink:href)\s*=\s*"\s*(?:javascript|vbscript):[^"]*"/gi, '$1="#"')
-      .replace(/(href|src|xlink:href)\s*=\s*'\s*(?:javascript|vbscript):[^']*'/gi, "$1='#'")
-      .replace(/(href|src|xlink:href)\s*=\s*(?:javascript|vbscript):[^\s>]+/gi, '$1="#"')
-      .replace(/(href|src|xlink:href)\s*=\s*"\s*data:text\/html[^"]*"/gi, '$1="#"')
-      .replace(/(href|src|xlink:href)\s*=\s*'\s*data:text\/html[^']*'/gi, "$1='#'")
-      .replace(/(href|src|xlink:href)\s*=\s*"\s*data:image\/svg\+xml[^"]*"/gi, '$1="#"')
-      .replace(/(href|src|xlink:href)\s*=\s*'\s*data:image\/svg\+xml[^']*'/gi, "$1='#'")
-  );
+  return sanitizeHtml(html, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+      "img",
+      "h1",
+      "h2",
+      "details",
+      "summary",
+    ]),
+    allowedAttributes: {
+      "*": ["class", "id", "align"],
+      a: ["href", "name", "target", "rel"],
+      img: ["src", "alt", "title", "width", "height"],
+      details: ["open"],
+      ol: ["start", "type"],
+      td: ["colspan", "rowspan"],
+      th: ["colspan", "rowspan", "scope"],
+    },
+    // javascript:/vbscript:/ftp/etc. are rejected; only these survive.
+    allowedSchemes: ["http", "https", "mailto"],
+    // Raster data: images (charts) are allowed on <img> only.
+    allowedSchemesByTag: { img: ["http", "https", "data"] },
+    allowProtocolRelative: false,
+    exclusiveFilter: (frame) => {
+      if (frame.tag !== "img") return false;
+      const src = (frame.attribs?.src ?? "").trim().toLowerCase();
+      return (
+        src.startsWith("data:text/html") ||
+        src.startsWith("data:image/svg+xml")
+      );
+    },
+  });
 }

--- a/packages/xyne-claw-shared/src/tools/create-report/template.ts
+++ b/packages/xyne-claw-shared/src/tools/create-report/template.ts
@@ -167,23 +167,6 @@ function escapeHtml(s: string): string {
     .replace(/'/g, "&#39;");
 }
 
-/**
- * Sanitize already-rendered HTML (the output of `marked.parse()`) before the
- * report template wraps it and it is written to a downloadable file.
- *
- * Uses `sanitize-html` — a pure-JS, allow-list parser with NO jsdom — instead of
- * the previous regex denylist. The regex was bypassable (finding C-2): it only
- * stripped whitespace-preceded event handlers, so `<img src=x /onerror=...>`
- * survived. An allow-list closes that whole bug class by construction: anything
- * not explicitly permitted (event handlers, <script>/<iframe>/<svg>/<object>,
- * javascript:/vbscript:/data:text-html schemes) is dropped by the parser.
- *
- * We deliberately keep the inline HTML the report feature supports — <details>,
- * <summary>, <code>, <pre>, tables, headings — and raster `data:` images used by
- * embedded charts. `<img>`-loaded SVG cannot execute script, but
- * data:image/svg+xml and data:text/html srcs are dropped anyway as defense in
- * depth via exclusiveFilter.
- */
 export function sanitizeHtmlBody(html: string): string {
   return sanitizeHtml(html, {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat([
@@ -202,9 +185,7 @@ export function sanitizeHtmlBody(html: string): string {
       td: ["colspan", "rowspan"],
       th: ["colspan", "rowspan", "scope"],
     },
-    // javascript:/vbscript:/ftp/etc. are rejected; only these survive.
     allowedSchemes: ["http", "https", "mailto"],
-    // Raster data: images (charts) are allowed on <img> only.
     allowedSchemesByTag: { img: ["http", "https", "data"] },
     allowProtocolRelative: false,
     exclusiveFilter: (frame) => {

--- a/packages/xyne-claw-shared/src/tools/create-report/template.ts
+++ b/packages/xyne-claw-shared/src/tools/create-report/template.ts
@@ -178,14 +178,32 @@ function escapeHtml(s: string): string {
  * javascript: URLs in href/src.
  */
 export function sanitizeHtmlBody(html: string): string {
-  return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
-    .replace(/<(iframe|object|embed|form|link|meta)\b[^>]*>/gi, "")
-    .replace(/<\/(iframe|object|embed|form)>/gi, "")
-    .replace(/\son\w+\s*=\s*"[^"]*"/gi, "")
-    .replace(/\son\w+\s*=\s*'[^']*'/gi, "")
-    .replace(/\son\w+\s*=\s*[^\s>]+/gi, "")
-    .replace(/(href|src)\s*=\s*"\s*javascript:[^"]*"/gi, "$1=\"#\"")
-    .replace(/(href|src)\s*=\s*'\s*javascript:[^']*'/gi, "$1='#'");
+  return (
+    html
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+      // <svg>/<math> are foreign-content roots that enable mutation-XSS and are
+      // not needed in a text report (charts are embedded as <img> data: rasters).
+      .replace(/<(iframe|object|embed|form|link|meta|base|svg|math)\b[^>]*>/gi, "")
+      .replace(/<\/(iframe|object|embed|form|svg|math)>/gi, "")
+      // C-2: event-handler attributes. The old pattern required a WHITESPACE
+      // delimiter (\son\w+), so a slash-separated handler — `<img src=x
+      // /onerror=alert(1)>` — slipped through and executed. Match a handler
+      // preceded by ANY non-name delimiter (whitespace, slash, quote) and
+      // re-insert a space so neighbouring attributes don't fuse.
+      .replace(/[\s/]on\w+\s*=\s*"[^"]*"/gi, " ")
+      .replace(/[\s/]on\w+\s*=\s*'[^']*'/gi, " ")
+      .replace(/[\s/]on\w+\s*=\s*[^\s>]+/gi, " ")
+      // Dangerous URL schemes in href/src/xlink:href. javascript: and vbscript:
+      // are always unsafe; data:text/html and data:image/svg+xml can carry
+      // script, but raster data: images (png/jpeg/gif/webp — used by embedded
+      // charts) are preserved. Tolerant of leading whitespace after `=`.
+      .replace(/(href|src|xlink:href)\s*=\s*"\s*(?:javascript|vbscript):[^"]*"/gi, '$1="#"')
+      .replace(/(href|src|xlink:href)\s*=\s*'\s*(?:javascript|vbscript):[^']*'/gi, "$1='#'")
+      .replace(/(href|src|xlink:href)\s*=\s*(?:javascript|vbscript):[^\s>]+/gi, '$1="#"')
+      .replace(/(href|src|xlink:href)\s*=\s*"\s*data:text\/html[^"]*"/gi, '$1="#"')
+      .replace(/(href|src|xlink:href)\s*=\s*'\s*data:text\/html[^']*'/gi, "$1='#'")
+      .replace(/(href|src|xlink:href)\s*=\s*"\s*data:image\/svg\+xml[^"]*"/gi, '$1="#"')
+      .replace(/(href|src|xlink:href)\s*=\s*'\s*data:image\/svg\+xml[^']*'/gi, "$1='#'")
+  );
 }

--- a/packages/xyne-claw-shared/src/tools/platform-config-keys.ts
+++ b/packages/xyne-claw-shared/src/tools/platform-config-keys.ts
@@ -29,6 +29,28 @@ export const PLATFORM_ONLY_CONFIG_KEYS: ReadonlySet<string> = new Set<string>([
   "QUERY_ROUTING_KEY",
   "IMAGE_GENERATION_ENDPOINT",
   "IMAGE_GENERATION_API_KEY",
+  // create-pdf provider endpoint + key. Declared in CREATE_PDF_CONFIG_SCHEMA
+  // (so they fall back to env/default after stripping). Kept platform-only so a
+  // frontend-controlled agentConfig can't point PDF_BASE_URL at an attacker host
+  // while PDF_API_KEY still resolves from the platform env (secret exfil), or
+  // aim the provider call at an internal address (SSRF).
+  "PDF_BASE_URL",
+  "PDF_API_KEY",
+  // research-agent internal service endpoint + key (defaults to an internal
+  // *.svc.k8s Juspay host; key falls back to env). Frontend override → SSRF into
+  // the cluster + exfil of the research-agent key.
+  "RESEARCH_AGENT_API_URL",
+  "RESEARCH_AGENT_API_KEY",
+  // sandbox-pw router — internal cluster service URL. Frontend override → SSRF.
+  "SANDBOX_PW_ROUTER_URL",
+  // Internal infra/service endpoints. Not sourced from agentConfig today, listed
+  // here as defense-in-depth so a future tool reading them from config can never
+  // be redirected (SSRF) or made to leak a co-resident secret.
+  "GRAFANA_URL",
+  "HINDSIGHT_URL",
+  "HINDSIGHT_DATABASE_URL",
+  "BITBUCKET_DASHBOARD_BASE_URL",
+  "JENKINS_BASE_URL",
 ]);
 
 /**

--- a/packages/xyne-claw-shared/src/tools/platform-config-keys.ts
+++ b/packages/xyne-claw-shared/src/tools/platform-config-keys.ts
@@ -29,23 +29,11 @@ export const PLATFORM_ONLY_CONFIG_KEYS: ReadonlySet<string> = new Set<string>([
   "QUERY_ROUTING_KEY",
   "IMAGE_GENERATION_ENDPOINT",
   "IMAGE_GENERATION_API_KEY",
-  // create-pdf provider endpoint + key. Declared in CREATE_PDF_CONFIG_SCHEMA
-  // (so they fall back to env/default after stripping). Kept platform-only so a
-  // frontend-controlled agentConfig can't point PDF_BASE_URL at an attacker host
-  // while PDF_API_KEY still resolves from the platform env (secret exfil), or
-  // aim the provider call at an internal address (SSRF).
   "PDF_BASE_URL",
   "PDF_API_KEY",
-  // research-agent internal service endpoint + key (defaults to an internal
-  // *.svc.k8s Juspay host; key falls back to env). Frontend override → SSRF into
-  // the cluster + exfil of the research-agent key.
   "RESEARCH_AGENT_API_URL",
   "RESEARCH_AGENT_API_KEY",
-  // sandbox-pw router — internal cluster service URL. Frontend override → SSRF.
   "SANDBOX_PW_ROUTER_URL",
-  // Internal infra/service endpoints. Not sourced from agentConfig today, listed
-  // here as defense-in-depth so a future tool reading them from config can never
-  // be redirected (SSRF) or made to leak a co-resident secret.
   "GRAFANA_URL",
   "HINDSIGHT_URL",
   "HINDSIGHT_DATABASE_URL",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1429,12 +1429,6 @@ importers:
         specifier: ^8.3.2
         version: 8.3.2
     devDependencies:
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^7.0.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^7.0.0
-        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@types/archiver':
         specifier: ^7.0.0
         version: 7.0.0
@@ -1456,6 +1450,12 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.4
@@ -2073,12 +2073,6 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^7.0.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^7.0.0
-        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@tanstack/react-query':
         specifier: ^5.96.0
         version: 5.101.4(react@19.2.3)
@@ -2091,6 +2085,12 @@ importers:
       '@types/uuid':
         specifier: ^8.3.4
         version: 8.3.4
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.0.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.0.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@xstate/react':
         specifier: ^6.1.0
         version: 6.1.0(@types/react@19.2.17)(react@19.2.3)(xstate@5.32.5)
@@ -2192,6 +2192,9 @@ importers:
       pptxgenjs:
         specifier: ^4.0.1
         version: 4.0.1
+      sanitize-html:
+        specifier: ^2.17.7
+        version: 2.17.7
       winston:
         specifier: ^3.19.0
         version: 3.19.0
@@ -2208,6 +2211,9 @@ importers:
       '@types/pdfkit':
         specifier: ^0.13.9
         version: 0.13.9
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -9197,6 +9203,9 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
@@ -13596,6 +13605,10 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
+
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
@@ -14635,6 +14648,9 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -16345,6 +16361,9 @@ packages:
   parse-prometheus-text-format@1.1.1:
     resolution: {integrity: sha512-dBlhYVACjRdSqLMFe4/Q1l/Gd3UmXm8ruvsTi7J6ul3ih45AkzkVpI5XHV4aZ37juGZW5+3dGU5lwk+QLM9XJA==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
 
@@ -17822,6 +17841,10 @@ packages:
 
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
+
+  sanitize-html@2.17.7:
+    resolution: {integrity: sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==}
+    engines: {node: '>=22.12.0'}
 
   sass@1.51.0:
     resolution: {integrity: sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==}
@@ -28394,6 +28417,10 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/semver@7.7.1': {}
 
   '@types/send@0.17.6':
@@ -34165,6 +34192,13 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
+
   htmlparser2@8.0.2:
     dependencies:
       domelementtype: 2.3.0
@@ -35497,6 +35531,10 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.21
 
   layout-base@1.0.2: {}
 
@@ -37558,6 +37596,8 @@ snapshots:
     dependencies:
       shallow-equal: 1.2.1
 
+  parse-srcset@1.0.2: {}
+
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
       parse5: 6.0.1
@@ -39389,6 +39429,16 @@ snapshots:
   sanitize-filename@1.6.4:
     dependencies:
       truncate-utf8-bytes: 1.0.2
+
+  sanitize-html@2.17.7:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 12.0.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.10
 
   sass@1.51.0:
     dependencies:


### PR DESCRIPTION
## Summary
Remediates all 21 findings from the Claw services security audit (ticket XYNE-56396) across `apps/xyne-claw`, `apps/xyne-claw-auth`, and `packages/xyne-claw-shared`. Recurring theme across 13/21 findings: routes trusted a `userId` from the request body/URL instead of the authenticated session. Most fixes port the guard already used by an adjacent "safe sibling" route.

## Findings fixed
**Critical**
- **C-1** — SSRF in webfetch MCP adapter: manual redirect loop with `assertSafeOutboundUrl` on every hop (`mcp/adapters/webfetch.ts`).
- **C-2** — Stored XSS in create-html-report: hardened `sanitizeHtmlBody` — delimiter-agnostic event-handler stripping (closes the `<img src=x /onerror=>` slash bypass), strips svg/math/base, neutralizes javascript:/vbscript:/data:text-html/data:svg URLs while preserving raster data: images. Fixes both sinks (`packages/xyne-claw-shared/.../create-report/template.ts`, `apps/.../lib/result-html.ts`).
- **C-3** — SSRF via provider baseUrl: `assertSafeOutboundUrl` guard (`routes/agents.ts`).
- **C-4** — Cross-org user lookup IDOR: org-scoped GET `/:id` with minimal projection (`routes/users.ts`).
- **C-5** — Memory IDOR: `assertMemoryUserAccess` on agent-file/prompt-file routes; S2S may target any userId, sessions restricted to own unless admin (`routes/memory.ts`).
- **C-6** — Chain-config IDOR: `pinUserIdParam` on GET/PUT chain-config (`routes/agents.ts`).
- **C-7** — Agent-identity mutation authz: `requireAgentOwnerOrAdmin` on 7 mutating routes (create-app, install-app, configure-webhook, grant-permissions, upload-picture, skills POST/DELETE).
- **C-8** — Trojan-agent ownerUserId mass-assignment: non-admin cannot forge `ownerUserId` on create (`routes/agents.ts`).
- **C-9** — Platform config-keys allowlist: strip 10 platform-only keys via `PLATFORM_ONLY_CONFIG_KEYS` (`packages/.../platform-config-keys.ts`).
- **C-10** — Agent-chat fork IDOR: fork copies only the caller's own thread slice (`m.userId === userId`, agent-scoped) (`routes/agent-chat.ts`).

**High**
- **L-11** — Chain-workflow binding cross-user injection: gate `targetUserId != requester` (incl. `*` all-users sentinel) behind claw-admin (`routes/chain-workflows.ts`).
- **L-12** — Webhook replay: signed-timestamp skew (300s) + in-memory nonce cache (`middleware/verify-spaces-signature.ts`).
- **L-16** — Weak callbackUrl guard: `assertSafeOutboundUrl` (`surfaces/external-api/delivery.ts`).
- **L-18** — forwardResult S2S-key exfil: only attach `x-s2s-key` for internal origins (`routes/webhook.ts`).
- **L-19** — Agent-chat regenerate IDOR: scopes to caller's own turns, agent-scoped (`routes/agent-chat.ts`).

**Medium / Low-Medium**
- **L-17** — Webhook signature fail-open: verified already fail-closed on branch; no change needed.
- **L-20** — Skills mutation authz: gate POST/DELETE skills with `requireAgentOwnerOrAdmin` (GET left ungated — read-only).
- **L-21** — Agent detail over-exposure: conditional projection — full `sanitizeAgent` for S2S/owner/contributor/admin, `lightAgentProjection` otherwise (`routes/agents.ts`).
- **L-22** — Chain-config userId trust: `pinUserIdParam` (with C-6).
- **L-23** — Memory-bank enable/disable/backfill IDOR: owner-or-admin gates (`routes/memory.ts`).
- **L-24** — Auth /run progressUrl S2S-key exfil: gate origin before attaching key (`routes/run.ts`).

## Validation
- `packages/xyne-claw-shared` typecheck: clean (`tsc --noEmit` exit 0).
- C-2 sanitizer verified against the demonstrated `/onerror` exploit + legit content (raster data: images, `<details>`, `<code>`, normal links preserved) — all XSS vectors blocked.
- `apps/xyne-claw-auth/backend` full typecheck could not complete in the CI sandbox (Prisma client generation blocked by lack of network to fetch engines); the errors surfaced were all missing-Prisma-namespace + pre-existing implicit-any in files NOT touched by this PR. Reviewer should run `pnpm db:generate && pnpm typecheck` in a networked environment to confirm.

## Notes
- Each finding is a separate commit for reviewability.
- No new dependencies added (C-2 deliberately avoids DOMPurify+jsdom per the audit's own guidance).