### PR TITLE
fix: automation runs use app-spaces MCP (swap out user xyne-spaces)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-spaces-app-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-spaces-app-tools.ts
@@ -31,6 +31,7 @@ export const xyneSpacesAppToolsAdapter: StdioMcpAdapter = {
     const appToken = (credentials["app_token"] as string | undefined) ?? "";
     const spacesUrl = (credentials["url"] as string | undefined) ?? "";
     const workspaceId = (credentials["workspaceId"] as string | undefined) ?? "";
+    const userId = (credentials["userId"] as string | undefined) ?? "";
     return {
       cmd: "node",
       args: ["--import", "tsx/esm", SERVER_PATH],
@@ -38,6 +39,15 @@ export const xyneSpacesAppToolsAdapter: StdioMcpAdapter = {
         XYNE_SPACES_APP_TOKEN: appToken,
         XYNE_SPACES_URL: spacesUrl,
         XYNE_SPACES_WORKSPACE_ID: workspaceId,
+        // The app-tools server now also mounts the shared Spaces tool registry
+        // (see xyne-spaces-app-tools-server.ts). Those tools read XYNE_SPACES_TOKEN
+        // + XYNE_SPACES_AUTH_MODE via the shared client, so mirror the app token
+        // into XYNE_SPACES_TOKEN and pin app mode. This server ALWAYS acts as the
+        // bot, so the mode is unconditionally "app".
+        XYNE_SPACES_TOKEN: appToken,
+        XYNE_SPACES_AUTH_MODE: "app",
+        XYNE_USER_ID: userId,
+        INTERNAL_S2S_KEY: process.env["INTERNAL_S2S_KEY"] ?? "",
       },
     };
   },

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-app-tools-server.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-app-tools-server.ts
@@ -16,10 +16,12 @@ import { ListToolsRequestSchema, CallToolRequestSchema, type CallToolResult } fr
 import { expandSpacesMentions, resolveUnboundMentions } from "../../lib/mention-transform.js";
 import { buildSpacesMentionLookupsDb } from "../../lib/mention-lookups.js";
 import { spacesDbAvailable } from "../../lib/spaces-db.js";
+import { tools as spacesTools } from "./xyne-spaces-tools.js";
 
 const APP_TOKEN = process.env["XYNE_SPACES_APP_TOKEN"] ?? "";
 const SPACES_URL = process.env["XYNE_SPACES_URL"] ?? "";
 const WORKSPACE_ID = process.env["XYNE_SPACES_WORKSPACE_ID"]?.trim() ?? "";
+const USER_ID = process.env["XYNE_USER_ID"] ?? "";
 
 const COUNT_USER_MENTION_RE =
   /(^|[^A-Za-z0-9_>])@([A-Za-z0-9 ._\-']+?)\[([A-Za-z0-9_-]{8,64})\]/g;
@@ -141,8 +143,21 @@ const SEND_MESSAGE_TOOL = {
   },
 };
 
+// The app-tools server is the SOLE Spaces MCP for automation/app-user runs
+// (routes/mcp.ts drops the user `xyne-spaces` server for those runs). So it must
+// surface the full Spaces toolset — reuse the SAME shared registry the user
+// server uses, running every tool in app mode. Local `ping` + `apps-send-message`
+// are app-tools-only and are appended. For interactive runs, routes/mcp.ts hides
+// the registry tools here (they'd duplicate the user server), leaving only the
+// app-only tools — so nothing changes for interactive users.
+const REGISTRY_TOOL_DEFS = spacesTools.map((t) => ({
+  name: t.name,
+  description: t.description,
+  inputSchema: t.inputSchema,
+}));
+
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [PING_TOOL, SEND_MESSAGE_TOOL],
+  tools: [...REGISTRY_TOOL_DEFS, PING_TOOL, SEND_MESSAGE_TOOL],
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
@@ -223,6 +238,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToo
       const msg = e instanceof Error ? e.message : String(e);
       return { content: [{ type: "text", text: `apps-send-message error: ${msg}` }], isError: true };
     }
+  }
+
+  // Any other tool name → the shared Spaces registry, run in APP MODE: prefer a
+  // tool's dedicated app-token implementation (`appHandler`, the /api/apps/*
+  // route) and otherwise fall through to its regular `handler`, which hits the
+  // app-token-capable /api/*/claw endpoints. This is the same dispatch the user
+  // `xyne-spaces` server uses in app mode — kept identical so behaviour matches.
+  const registryTool = spacesTools.find((t) => t.name === name);
+  if (registryTool) {
+    const ctx = { userId: USER_ID, authMode: "app" as const };
+    const result = registryTool.appHandler
+      ? await registryTool.appHandler(args ?? {}, ctx)
+      : await registryTool.handler(args ?? {}, ctx);
+    return result as CallToolResult;
   }
 
   return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
@@ -263,6 +263,35 @@ export async function appFetch(path: string, init?: RequestInit, auth?: SpacesAu
   return response.json();
 }
 
+/**
+ * Binary download over the APP-token surface (`/api/apps/*`). The app twin of
+ * spacesFetchBuffer: authenticates with the agent's app token (Bearer) instead
+ * of a user session, so it works in headless/automation runs where there is no
+ * user JWT. Used by tools that must pull raw bytes (e.g. attachment download)
+ * through an app endpoint such as `/api/apps/files/download/:attachmentId`.
+ */
+export async function appFetchBuffer(
+  path: string,
+  auth?: SpacesAuthContext,
+): Promise<{ buffer: Buffer; contentType: string }> {
+  const token = auth?.token ?? process.env["XYNE_SPACES_TOKEN"] ?? "";
+  const baseUrl = resolveBaseUrl(auth?.baseUrl);
+  if (!baseUrl) throw new Error("Spaces base URL is not configured.");
+  if (!token) throw new Error("Spaces app token is missing for this request.");
+
+  const url = `${baseUrl}/api/apps${path}`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Spaces app API ${response.status}: ${text.slice(0, 300)}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  return { buffer, contentType: response.headers.get("content-type") ?? "application/octet-stream" };
+}
+
 export interface QueryAST {
   model: string;
   operation: "findMany" | "count";

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -13,6 +13,7 @@ import {
   spacesFetchBuffer,
   spacesFetchText,
   appFetch,
+  appFetchBuffer,
 } from "./xyne-spaces-client.js";
 import { esc, queryDirect, type DirectSearchResponse } from "./vespa-direct.js";
 import { buildYqlFromParams, AREA_NAMES, AREA_ALIASES, describeAreasForPrompt } from "./vespa-search-areas.js";
@@ -5459,6 +5460,80 @@ const spacesThreadAttachments: ToolDef = {
   },
 };
 
+/**
+ * Shared render tail for spaces-fetch-attachment. Given resolved bytes (as a
+ * signed URL or base64 `data`) + metadata, ingest readable docs to markdown or
+ * return small raw files inline. Both the user-session `handler` and the
+ * app-token `appHandler` funnel through here so the two auth surfaces produce
+ * identical output — only the byte-fetch step differs.
+ */
+async function renderFetchedAttachment(params: {
+  source: AttachmentSource;
+  resolvedName: string;
+  resolvedMime: string;
+  declaredSize: number;
+  sourceLabel: string;
+  inlineBuffer?: Buffer | undefined;
+}): Promise<ToolResult> {
+  const { source, resolvedName, resolvedMime, declaredSize, sourceLabel, inlineBuffer } = params;
+      // Sanitise filename to keep it within .context/ — strip path separators
+      // and leading dots so the agent can't be tricked into reading outside.
+      const safeName = resolvedName.replace(/[/\\]/g, "_").replace(/^\.+/, "") || "attachment";
+
+      if (isReadableAttachment(safeName, resolvedMime)) {
+        try {
+          const files = await ingestAttachmentToMarkdown(safeName, resolvedMime, source, declaredSize);
+          if (files.length === 0) {
+            return ok(
+              `Fetched attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) via ${sourceLabel}, ` +
+              "but no extractable text was produced. If this is image-only/scanned content, OCR is required.",
+            );
+          }
+          const rendered = files
+            .map((f) => `# ${f.path}\n\n${f.content}`)
+            .join("\n\n---\n\n");
+          return ok(
+            `Fetched attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) via ${sourceLabel} and extracted it to markdown. ` +
+            `Use the content below to answer the user; if the runtime saved this result to a tool-output file, read that file for the full text.\n\n${rendered}`,
+          );
+        } catch (ingestErr) {
+          return err(
+            `Could not extract attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) from ${sourceLabel}: ` +
+            `${ingestErr instanceof Error ? ingestErr.message : String(ingestErr)}. ` +
+            `The raw file was not returned through MCP; ask the user for an OCR/text version if it is scanned, image-only, unsupported, or the source expired.`,
+          );
+        }
+      }
+
+      if (declaredSize > RAW_ATTACHMENT_INLINE_LIMIT_BYTES) {
+        return err(
+          `Attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) is too large for the raw inline fallback. ` +
+          `Limit: ${formatAttachmentBytes(RAW_ATTACHMENT_INLINE_LIMIT_BYTES)}. ` +
+          `This file type is not supported by the text extraction path, so it was not returned as base64 through MCP. ` +
+          "Ask the user for a smaller file or a text/PDF/DOCX/XLSX/PPTX/HTML/ZIP version.",
+        );
+      }
+
+      // Raw inline base64 for unsupported-but-small files. Reuse the bytes we
+      // already pulled for the /download fallback; otherwise fetch them from the
+      // signed URL now.
+      const buffer = inlineBuffer ?? (
+        "url" in source
+          ? await downloadSmallAttachmentFromSignedUrl(safeName, resolvedMime, declaredSize, source.url)
+              .catch((downloadErr) => {
+                throw new Error(
+                  `Could not download unsupported attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) from ${sourceLabel}: ` +
+                  `${downloadErr instanceof Error ? downloadErr.message : String(downloadErr)}`,
+                );
+              })
+          : Buffer.from(source.data, "base64")
+      );
+
+      // Marker format consumed by xyne-claw/src/mcp.ts which decodes the
+      // base64 and writes the buffer to .context/<fileName> in the workspace.
+      return ok(`[SPACES_ATTACHMENT:${safeName}:${resolvedMime}]\n${buffer.toString("base64")}`);
+}
+
 const spacesFetchAttachment: ToolDef = {
   name: "spaces-fetch-attachment",
   description:
@@ -5542,62 +5617,60 @@ const spacesFetchAttachment: ToolDef = {
         }
       }
 
-      // Sanitise filename to keep it within .context/ — strip path separators
-      // and leading dots so the agent can't be tricked into reading outside.
-      const safeName = resolvedName.replace(/[/\\]/g, "_").replace(/^\.+/, "") || "attachment";
+      return renderFetchedAttachment({ source, resolvedName, resolvedMime, declaredSize, sourceLabel, inlineBuffer });
+    } catch (e) {
+      return err(`Fetch attachment error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  },
+  /**
+   * App-token download. Headless/automation runs (no user session) cannot use
+   * the user-only `/api/attachments/:id/{signed-url,download}` routes — they
+   * 401. This path pulls the bytes through the app surface
+   * `/api/apps/files/download/:attachmentId` (authenticateApp + files:read,
+   * workspace-scoped) using the agent's app token, then funnels through the
+   * SAME renderFetchedAttachment tail so output matches the user path exactly.
+   */
+  async appHandler(args) {
+    try {
+      const attachmentId = String(args["attachmentId"] ?? "");
+      if (!attachmentId) return err("attachmentId is required");
 
-      if (isReadableAttachment(safeName, resolvedMime)) {
-        try {
-          const files = await ingestAttachmentToMarkdown(safeName, resolvedMime, source, declaredSize);
-          if (files.length === 0) {
-            return ok(
-              `Fetched attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) via ${sourceLabel}, ` +
-              "but no extractable text was produced. If this is image-only/scanned content, OCR is required.",
-            );
-          }
-          const rendered = files
-            .map((f) => `# ${f.path}\n\n${f.content}`)
-            .join("\n\n---\n\n");
-          return ok(
-            `Fetched attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) via ${sourceLabel} and extracted it to markdown. ` +
-            `Use the content below to answer the user; if the runtime saved this result to a tool-output file, read that file for the full text.\n\n${rendered}`,
-          );
-        } catch (ingestErr) {
-          return err(
-            `Could not extract attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) from ${sourceLabel}: ` +
-            `${ingestErr instanceof Error ? ingestErr.message : String(ingestErr)}. ` +
-            `The raw file was not returned through MCP; ask the user for an OCR/text version if it is scanned, image-only, unsupported, or the source expired.`,
-          );
-        }
+      // Metadata via /api/query/claw (dual-auth — accepts the app token).
+      const meta = (await interact({
+        model: "messageAttachment",
+        operation: "findMany",
+        where: { id: { equals: attachmentId }, isDeleted: { equals: false } },
+        take: 1,
+      })) as MessageAttachmentRow[];
+      if (!meta || meta.length === 0) {
+        return err(`Attachment ${attachmentId} not found or deleted`);
       }
+      const m = meta[0]!;
 
-      if (declaredSize > RAW_ATTACHMENT_INLINE_LIMIT_BYTES) {
+      let dl: { buffer: Buffer; contentType: string };
+      try {
+        dl = await appFetchBuffer(`/files/download/${encodeURIComponent(attachmentId)}`);
+      } catch (e) {
+        // The app download route runs the real workspace/ACL check, so a
+        // failure here is the honest signal — the file is gone, or the agent's
+        // installed app is missing the `files:read` scope (403). Surface that
+        // plainly rather than masquerading as a storage outage.
         return err(
-          `Attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) is too large for the raw inline fallback. ` +
-          `Limit: ${formatAttachmentBytes(RAW_ATTACHMENT_INLINE_LIMIT_BYTES)}. ` +
-          `This file type is not supported by the text extraction path, so it was not returned as base64 through MCP. ` +
-          "Ask the user for a smaller file or a text/PDF/DOCX/XLSX/PPTX/HTML/ZIP version.",
+          `Could not fetch attachment "${m.originalFilename}" (${m.mimetype}, ${formatAttachmentBytes(m.size)}) ` +
+          `via the app download route: ${e instanceof Error ? e.message : String(e)}. ` +
+          "If this is a 403, grant the agent's app the `files:read` scope; if 404, the file was deleted.",
         );
       }
 
-      // Raw inline base64 for unsupported-but-small files. Reuse the bytes we
-      // already pulled for the /download fallback; otherwise fetch them from the
-      // signed URL now.
-      const buffer = inlineBuffer ?? (
-        "url" in source
-          ? await downloadSmallAttachmentFromSignedUrl(safeName, resolvedMime, declaredSize, source.url)
-              .catch((downloadErr) => {
-                throw new Error(
-                  `Could not download unsupported attachment "${safeName}" (${resolvedMime}, ${formatAttachmentBytes(declaredSize)}) from ${sourceLabel}: ` +
-                  `${downloadErr instanceof Error ? downloadErr.message : String(downloadErr)}`,
-                );
-              })
-          : Buffer.from(source.data, "base64")
-      );
-
-      // Marker format consumed by xyne-claw/src/mcp.ts which decodes the
-      // base64 and writes the buffer to .context/<fileName> in the workspace.
-      return ok(`[SPACES_ATTACHMENT:${safeName}:${resolvedMime}]\n${buffer.toString("base64")}`);
+      const resolvedMime = m.mimetype || dl.contentType || "application/octet-stream";
+      return renderFetchedAttachment({
+        source: { data: dl.buffer.toString("base64") },
+        resolvedName: m.originalFilename,
+        resolvedMime,
+        declaredSize: dl.buffer.length,
+        sourceLabel: "an app-token direct download",
+        inlineBuffer: dl.buffer,
+      });
     } catch (e) {
       return err(`Fetch attachment error: ${e instanceof Error ? e.message : String(e)}`);
     }

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -1141,6 +1141,74 @@ router.get("/:sessionId/mcp/tools", async (req: Request<{ sessionId: string }>, 
       writeTools: [],
     });
 
+    // ── Automation MCP swap ────────────────────────────────────────────────
+    // Anurag's directive: automation (app-user) runs must use the APP surface
+    // only. So for those runs we drop the user `xyne-spaces` MCP entirely and
+    // keep only `xyne-spaces-app-tools`, which now mounts the full Spaces
+    // registry in app mode (see xyne-spaces-app-tools-server.ts). This is a
+    // clean server swap — not a per-tool patch.
+    //
+    // `resolveMentions === true` is set ONLY by the automation webhook path
+    // (never by interactive or email auto-draft), so it is the reliable
+    // automation signal; `externalResultCallback` covers the external-callback
+    // automation variant. We additionally require that the app token actually
+    // resolves — if it does NOT, we do NOT swap (that would strip Spaces access
+    // and silently break the run); we keep xyne-spaces and log loudly instead.
+    {
+      const { getSession } = await import("./webhook.js");
+      const swapRunCtx = await getSession(req.params.sessionId).catch(() => null);
+      const isAutomationRun =
+        swapRunCtx?.resolveMentions === true || !!swapRunCtx?.externalResultCallback;
+      const appToolsPresent = data.some((s2) => s2.serverType === "xyne-spaces-app-tools");
+
+      if (isAutomationRun) {
+        const appCreds = await getAppTokenCredentials(userId);
+        if (appCreds && appToolsPresent) {
+          const before = data.length;
+          for (let i = data.length - 1; i >= 0; i--) {
+            if (data[i]!.serverType === "xyne-spaces") data.splice(i, 1);
+          }
+          log.info(
+            `[mcp/tools] automation swap: dropped xyne-spaces user MCP (${before - data.length} server group(s)); ` +
+            `xyne-spaces-app-tools now serves Spaces tools in app mode for userId=${userId}`,
+          );
+        } else {
+          log.warn(
+            `[mcp/tools] automation swap SKIPPED for userId=${userId}: ` +
+            `appCreds=${!!appCreds} appToolsPresent=${appToolsPresent}. ` +
+            "Keeping xyne-spaces user MCP to avoid stripping Spaces access. " +
+            "If this is an automation run, the agent's app is likely not installed / app token missing.",
+          );
+        }
+      } else if (appToolsPresent) {
+        // ── Interactive de-dup ───────────────────────────────────────────────
+        // Interactive runs list BOTH servers. Now that app-tools mounts the full
+        // registry, its tool names would collide with xyne-spaces (the user
+        // server) and could route a user's call to the app/bot identity. Strip
+        // from app-tools every tool that xyne-spaces already provides, leaving
+        // only the app-only tools (ping, apps-send-message, …). Interactive
+        // behaviour is therefore unchanged.
+        const spacesServer = data.find((s2) => s2.serverType === "xyne-spaces");
+        const appToolsIdx = data.findIndex((s2) => s2.serverType === "xyne-spaces-app-tools");
+        if (spacesServer && appToolsIdx >= 0) {
+          const userToolNames = new Set(spacesServer.tools.map((t) => t.name));
+          const appTools = data[appToolsIdx]!;
+          const kept = appTools.tools.filter((t) => !userToolNames.has(t.name));
+          const removed = appTools.tools.length - kept.length;
+          // McpServerTools.tools/writeTools are readonly — replace the object.
+          data[appToolsIdx] = {
+            ...appTools,
+            tools: kept,
+            writeTools: appTools.writeTools.filter((n) => !userToolNames.has(n)),
+          };
+          log.info(
+            `[mcp/tools] interactive de-dup: removed ${removed} registry tool(s) from ` +
+            `xyne-spaces-app-tools (already provided by xyne-spaces) for userId=${userId}`,
+          );
+        }
+      }
+    }
+
     if (strictAgentToolsConfig && sessionAgentTools) {
       const entryTypes = new Map<string, EnforcementLogType>();
       for (const entry of entries) {


### PR DESCRIPTION
## What
For automation / app-user runs, drop the user-session `xyne-spaces` MCP and serve Spaces tools through `xyne-spaces-app-tools`, which now mounts the full shared tool registry in **app mode**. Headless automation runs therefore go through the app-token surface end to end.

This fixes the RCA agent failing to download a PDF attachment during an automation RUN_AGENT step: `spaces-fetch-attachment` was hitting the user-only `/api/attachments/:id/{signed-url,download}` routes, which 401 with an app token (no user session).

## Changes
- **xyne-spaces-client**: add `appFetchBuffer()` — app-token binary download (`/api/apps/*`, Bearer app token, no session cookie).
- **xyne-spaces-tools**: extract the shared render/ingest tail into `renderFetchedAttachment()`; add an `appHandler` to `spaces-fetch-attachment` that downloads via `/api/apps/files/download/:attachmentId` and funnels through the same render tail so output matches the user path exactly.
- **xyne-spaces-app-tools-server**: mount the full shared `tools` registry (dispatch `appHandler` ?? `handler` in app mode), keeping the local `ping` + `apps-send-message`.
- **xyne-spaces-app-tools adapter**: thread `XYNE_SPACES_TOKEN` (app token) + `XYNE_SPACES_AUTH_MODE=app` + `XYNE_USER_ID` + `INTERNAL_S2S_KEY` so the registry runs in app mode.
- **routes/mcp.ts** (`GET /:sessionId/mcp/tools`):
  - **Automation runs** (`resolveMentions === true` or `externalResultCallback`, AND the app token resolves): drop the `xyne-spaces` server group — `xyne-spaces-app-tools` now serves Spaces tools in app mode. This is the literal server swap.
  - **Interactive runs**: de-dup — strip from `xyne-spaces-app-tools` any registry tool name already provided by `xyne-spaces`, leaving only the app-only tools (`ping`, `apps-send-message`). Interactive behaviour is unchanged.
  - **Safety**: if it's an automation run but the app token does NOT resolve, keep `xyne-spaces` and log loudly rather than stripping Spaces access silently.

## Config prerequisite
The agent's installed app must have the **`files:read`** scope, or `/api/apps/files/download/:id` returns 403 (the `appHandler` surfaces this explicitly).

## Validation
- `tsc --noEmit` on `apps/xyne-claw-auth/backend`: no new errors introduced (remaining errors are pre-existing implicit-any/prisma baseline on unchanged lines).

## Notes
Supersedes the narrower PR #718 (`fix/automation-app-attachment-download`), which patched only the download branch. This implements the full server swap requested.