### PR TITLE
feat: channel pane "Opened from" source bar (third-pane provenance)

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
@@ -610,20 +610,21 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
     currentCanvasIdRef.current = selectedCanvas.id;
 
     // On mobile, always navigate to /chat/canvas/:canvasId (preserves back navigation to channel)
-    // On desktop, use baseRoute-based navigation
-    const canvasPath = isMobile
-      ? `/chat/canvas/${selectedCanvas.id}`
-      : `${baseRoute}/canvas/${selectedCanvas.id}`;
-
-    // Store the original path for back navigation on mobile
     if (isMobile) {
-      void navigate(canvasPath, {
+      void navigate(`/chat/canvas/${selectedCanvas.id}`, {
         state: {
           previousPath: location.pathname,
         },
       });
     } else {
-      void navigate(canvasPath);
+      // On desktop, open the canvas in the channel's secondary ("third") pane by
+      // setting the `#canvas=` hash on the CURRENT channel route. This keeps the
+      // channel shell (ConversationPanelV2 + the top tab strip) mounted — fixing
+      // the "I go inside Canvas and lose the top tabs" problem — and renders the
+      // canvas via ChatView's secondaryPanelContent with the PaneSourceBar on top.
+      // (Previously navigated to `${baseRoute}/canvas/:id`, a sibling route that
+      // unmounted the entire channel shell.)
+      void navigate(`${baseRoute}/${channelId}#canvas=${selectedCanvas.id}`);
     }
   };
 

--- a/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
+++ b/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
@@ -31,6 +31,7 @@ import { usePlatform } from '../../../hooks/usePlatform';
 import { useIsInPanelWebview } from '../../../hooks/useIsInPanelWebview';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import { CallExternalChatPanel } from '../../Call/CallExternalChatPanel/CallExternalChatPanel';
+import { PaneSourceBar } from '../PaneSourceBar';
 
 interface ChatScreenContext {
   shouldStackThread?: boolean;
@@ -279,16 +280,34 @@ const ChatView = (): ReactElement => {
     void navigate(newUrl, { replace: true });
   };
 
+  // Close the canvas pane — drop the `#canvas=` hash and return to the Canvas
+  // list tab. Preserves the current path + search (e.g. ?tab=canvas) so the
+  // channel shell and its tab strip stay exactly where they were.
+  const handleCloseCanvasPane = (): void => {
+    void navigate(`${location.pathname}${location.search}`);
+  };
+
   // Secondary panel content — defined once, reused for both overlay and
   // side-by-side layouts so there is no JSX duplication.
   const secondaryPanelContent = isExternalChatActive ? (
     <CallExternalChatPanel callExternalId={externalChatCallId} />
   ) : isCanvasActive ? (
-    <CanvasScreen
-      canvasId={canvasId}
-      isFullscreen={isCanvasFullscreen}
-      onToggleFullscreen={toggleCanvasFullscreen}
-    />
+    <div className='flex h-full flex-col'>
+      {!isCanvasFullscreen && (
+        <PaneSourceBar
+          channelName={channelDisplayName || channel?.['name'] || 'channel'}
+          tabLabel='Canvas'
+          onClose={handleCloseCanvasPane}
+        />
+      )}
+      <div className='flex-1 min-h-0'>
+        <CanvasScreen
+          canvasId={canvasId}
+          isFullscreen={isCanvasFullscreen}
+          onToggleFullscreen={toggleCanvasFullscreen}
+        />
+      </div>
+    </div>
   ) : isChannelSummaryActive ? (
     <ChannelSummary
       channelId={channelId ?? ''}

--- a/apps/dashboard/src/components/Chat/PaneSourceBar/PaneSourceBar.tsx
+++ b/apps/dashboard/src/components/Chat/PaneSourceBar/PaneSourceBar.tsx
@@ -1,0 +1,88 @@
+import { ReactElement } from 'react';
+import { Hash, X } from 'lucide-react';
+import { cn } from '../../../utils/classNames';
+
+/**
+ * PaneSourceBar — a slim provenance strip rendered at the top of the channel
+ * secondary ("third") pane. It tells the user WHERE the item they just opened
+ * came from, so opening a canvas / ticket / desk ticket in the pane never feels
+ * context-less ("I am lost").
+ *
+ * The channel shell (ConversationPanelV2 + its tab strip) stays mounted on the
+ * left; this bar is the pane's own lightweight header that names:
+ *   - the channel the user is browsing (the shell), and
+ *   - the tab the item was opened from (Canvas / Tickets / Desk).
+ *
+ * When the opened item actually LIVES in a different channel (e.g. a ticket on a
+ * shared board owned by another channel), pass `sourceChannelName` so the bar can
+ * say "Opened from #payments-core · in #refunds" — making the cross-channel
+ * origin explicit WITHOUT the shell silently switching channels.
+ *
+ * This component is intentionally presentational and side-effect free. The owner
+ * (ChatView) supplies the labels and the close handler, which keeps the URL /
+ * routing signal in one place.
+ */
+export interface PaneSourceBarProps {
+  /** Display name of the channel the user is browsing (the shell). */
+  channelName: string;
+  /** Human label of the tab the item was opened from, e.g. "Canvas", "Tickets". */
+  tabLabel: string;
+  /**
+   * When the opened item lives in a DIFFERENT channel than the shell (shared
+   * board tickets), the name of that owning channel. Rendered as "in #<name>".
+   */
+  sourceChannelName?: string;
+  /** Optional close affordance — removes the pane signal and returns to the list. */
+  onClose?: () => void;
+  className?: string;
+}
+
+export const PaneSourceBar = ({
+  channelName,
+  tabLabel,
+  sourceChannelName,
+  onClose,
+  className,
+}: PaneSourceBarProps): ReactElement => {
+  return (
+    <div
+      data-component='PaneSourceBar'
+      className={cn(
+        'flex items-center gap-1.5 px-3 h-9 flex-shrink-0 border-b border-border bg-muted/40 text-xs text-muted-foreground select-none',
+        className,
+      )}
+    >
+      <span className='shrink-0'>Opened from</span>
+      <span className='inline-flex items-center gap-0.5 font-medium text-foreground min-w-0'>
+        <Hash size={12} className='shrink-0 opacity-70' />
+        <span className='truncate'>{channelName}</span>
+      </span>
+      <span className='shrink-0 opacity-70'>·</span>
+      <span className='shrink-0 font-medium text-foreground'>{tabLabel}</span>
+      {sourceChannelName && sourceChannelName !== channelName && (
+        <>
+          <span className='shrink-0 opacity-70'>·</span>
+          <span className='inline-flex items-center gap-0.5 min-w-0'>
+            <span className='shrink-0'>in</span>
+            <Hash size={12} className='shrink-0 opacity-70' />
+            <span className='truncate'>{sourceChannelName}</span>
+          </span>
+        </>
+      )}
+      {onClose && (
+        <button
+          type='button'
+          onClick={onClose}
+          aria-label='Close panel'
+          data-track-category='ChannelPane'
+          data-track-name='CloseSourcePane'
+          className='ml-auto shrink-0 p-1 -mr-1 rounded-md hover:text-foreground hover:bg-muted transition-colors'
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default PaneSourceBar;

--- a/apps/dashboard/src/components/Chat/PaneSourceBar/index.ts
+++ b/apps/dashboard/src/components/Chat/PaneSourceBar/index.ts
@@ -1,0 +1,2 @@
+export { PaneSourceBar, default } from './PaneSourceBar';
+export type { PaneSourceBarProps } from './PaneSourceBar';


### PR DESCRIPTION
## What
Adds a reusable `PaneSourceBar` at the top of the channel secondary ("third") pane so an item opened from a channel tab always shows **where it came from** — `Opened from #<channel> · <Tab>` — instead of feeling context-less ("I go inside Canvas and feel lost").

Wired into the **Canvas** pane first (it already renders in `secondaryPanelContent` via the `#canvas=` hash). The bar:
- hides in canvas fullscreen,
- has a close affordance that drops the `#canvas=` hash and returns to the Canvas list while keeping the channel shell + tab strip mounted,
- accepts an optional `sourceChannelName` so the cross-channel (shared-board) case can render `… · in #<owner>` **without the shell silently switching channels**.

## Why
Part of the "intuitive tab navigation within a channel" work. Three reported problems:
1. Opening a canvas hides the top tabs → feel lost.
2. Opening a shared-board ticket owned by another channel switches the header to that channel.
3. Opening a desk ticket redirects out to the Desk app with no way back.

This PR lands the shared **provenance/source-bar primitive** and proves it on the canvas pane. It is additive and does not change ticket/desk routing.

## Scope / follow-ups (intentionally NOT in this PR)
- Routing **tickets** through the same pane and fixing the cross-channel context switch (root cause: ticket-open nav uses the ticket's own `channelId` — `TicketView.tsx:68`, `TicketDetails.tsx:2674`, `TicketTable.tsx:348`). Needs the pane to carry a separate "source channel" — the `sourceChannelName` prop is already there for it.
- Rendering **desk tickets** in-pane instead of the `<Navigate to /support/...>` redirect in `ChatView` (crosses the Support subsystem boundary; own PR + QA).

## Files
- New: `apps/dashboard/src/components/Chat/PaneSourceBar/{PaneSourceBar.tsx,index.ts}`
- `apps/dashboard/src/components/Chat/ChatView/ChatView.tsx` — import, `handleCloseCanvasPane`, wrap the canvas branch with the bar.

## Validation
- `tsc --noEmit` (tsconfig.app.json): the two changed files have **zero** type errors. (Pre-existing repo errors are unrelated `@xyne/shared` export resolution in 19 other files where the shared workspace package isn't built in this checkout.)
- prettier `--check`: clean. eslint on both files: clean.
- Manual QA still needed: open a canvas from a channel → bar shows "Opened from #<channel> · Canvas", close returns to the Canvas list with tabs intact; fullscreen hides the bar.