### PR TITLE
feat: number shortcuts for the sidebar rail, and shortcut hints in tooltips

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
@@ -1,6 +1,8 @@
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Tooltip } from '../ui/Tooltip/Tooltip';
+import { ShortcutHint } from '../ui/ShortcutHint';
+import { useShortcutById } from '../../shortcuts';
 import { useAuth } from '../../hooks/useAuth';
 import { mixpanelService, EVENTS } from '../../services/Analytics/mixpanelService';
 import { useCanViewAnalytics } from '../../hooks/usePermissions';
@@ -43,6 +45,11 @@ import { reactNativeBridge } from '../../utils/reactNativeBridge';
 import { useVisibleNavigationItems } from '../../hooks/useVisibleNavigationItems';
 import { useToolbarItems } from '../../hooks/useToolbarItems';
 import type { NavigationItem } from './navigationConfig';
+import {
+  RAIL_SHORTCUT_LIMIT,
+  railItemIndexFromEvent,
+  railShortcutsAvailable,
+} from './navigationConfig';
 import { useKeyboard } from '../../contexts/KeyboardContext';
 import { useAILandingDefault } from '../../hooks/useAILandingDefault';
 import XyneAISidebarIcon from '../icons/xyne-ai/XyneAISidebarIcon';
@@ -287,6 +294,19 @@ const AppSidebar = (): ReactElement => {
     mixpanelService.track(EVENTS.NAVIGATION, { item: label });
   };
 
+  const railShortcuts = railShortcutsAvailable();
+
+  useShortcutById(
+    'global.goToRailItem',
+    event => {
+      const item = toolbarItems[railItemIndexFromEvent(event)];
+      if (!item) return;
+      handleNavigationClick(item.label);
+      void navigate(prefixWs(item.path));
+    },
+    { enabled: railShortcuts && !isSupportContext },
+  );
+
   const handleMoreNavigate = (label: string): void => {
     setIsMoreOpen(false);
     handleNavigationClick(label);
@@ -363,7 +383,9 @@ const AppSidebar = (): ReactElement => {
                   </li>
                 )}
 
-                {toolbarItems.map(item => {
+                {toolbarItems.map((item, index) => {
+                  const shortcutIndex =
+                    railShortcuts && index < RAIL_SHORTCUT_LIMIT ? index + 1 : null;
                   const isActive = activeRoute === item.path;
                   const showMissedCallBadge = item.path === '/calls' && missedCallCount > 0;
                   const showPendingDmDot = item.path === '/chat/dm' && hasPendingDirectMessages;
@@ -375,7 +397,20 @@ const AppSidebar = (): ReactElement => {
 
                   return (
                     <li key={item.path} className='relative'>
-                      <Tooltip content={item.label} side='right' delayDuration={0}>
+                      <Tooltip
+                        content={
+                          shortcutIndex ? (
+                            <span className='flex items-center gap-2'>
+                              {item.label}
+                              <ShortcutHint keys={`mod+${shortcutIndex}`} />
+                            </span>
+                          ) : (
+                            item.label
+                          )
+                        }
+                        side='right'
+                        delayDuration={0}
+                      >
                         <Link
                           to={prefixWs(item.path)}
                           onClick={() => handleNavigationClick(item.label)}

--- a/apps/dashboard/src/components/AppSidebar/SupportRail.tsx
+++ b/apps/dashboard/src/components/AppSidebar/SupportRail.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
   NotificationBellOn,
@@ -11,8 +11,15 @@ import {
   LightningThunderElectricOn,
 } from '@xyne/icons';
 import { Tooltip } from '../ui/Tooltip/Tooltip';
+import { ShortcutHint } from '../ui/ShortcutHint';
 import { cn } from '../../utils/classNames';
+import { useShortcutById } from '../../shortcuts';
 import type { PikaIcon } from './navigationConfig';
+import {
+  RAIL_SHORTCUT_LIMIT,
+  railItemIndexFromEvent,
+  railShortcutsAvailable,
+} from './navigationConfig';
 
 interface RailContext {
   activeRoute: string;
@@ -109,11 +116,25 @@ export const SupportRail = ({
   activeRoute,
 }: SupportRailProps): ReactElement => {
   const ctx: RailContext = { activeRoute };
+  const navigate = useNavigate();
 
   const handleBack = (): void => onNavigationClick('Support: Back');
 
   const items = SUPPORT_RAIL_ITEMS.filter(
     item => !item.gatedPath || permittedGlobalPaths.has(item.gatedPath),
+  );
+
+  const railShortcuts = railShortcutsAvailable();
+
+  useShortcutById(
+    'global.goToRailItem',
+    event => {
+      const item = items[railItemIndexFromEvent(event)];
+      if (!item) return;
+      onNavigationClick(`Support: ${item.label}`);
+      void navigate(prefixWs(item.path));
+    },
+    { enabled: railShortcuts },
   );
 
   return (
@@ -140,11 +161,26 @@ export const SupportRail = ({
       <span aria-hidden='true' className='my-0.5 h-px w-5 bg-sidebar-border' />
 
       {/* Support sub-navigation */}
-      {items.map(item => {
+      {items.map((item, index) => {
         const active = item.isActive(ctx);
         const Icon = item.icon;
+        const shortcutIndex = railShortcuts && index < RAIL_SHORTCUT_LIMIT ? index + 1 : null;
         return (
-          <Tooltip key={item.key} content={item.label} side='right' delayDuration={0}>
+          <Tooltip
+            key={item.key}
+            content={
+              shortcutIndex ? (
+                <span className='flex items-center gap-2'>
+                  {item.label}
+                  <ShortcutHint keys={`mod+${shortcutIndex}`} />
+                </span>
+              ) : (
+                item.label
+              )
+            }
+            side='right'
+            delayDuration={0}
+          >
             <Link
               to={prefixWs(item.path)}
               onClick={() => onNavigationClick(`Support: ${item.label}`)}

--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -40,6 +40,15 @@ import { AccessType } from '@xyne/shared';
 
 /** A themeable pika-icon component (accepts size, color, variant, strokeWidth, className). */
 export type PikaIcon = ComponentType<PikaIconProps>;
+export const RAIL_SHORTCUT_LIMIT = 9;
+export const railShortcutsAvailable = (): boolean => isElectronApp();
+
+// Read the number off event.code, not event.key: mod+1..9 match on physical key
+// position, and on layouts like AZERTY that key types '&' rather than '1'.
+export const railItemIndexFromEvent = (event: KeyboardEvent): number => {
+  const positional = /^(?:Digit|Numpad)([1-9])$/.exec(event.code)?.[1];
+  return Number(positional ?? event.key) - 1;
+};
 
 export interface NavigationItem {
   path: string;

--- a/apps/dashboard/src/components/ShortcutsHelpModal/ShortcutsHelpModal.tsx
+++ b/apps/dashboard/src/components/ShortcutsHelpModal/ShortcutsHelpModal.tsx
@@ -1,20 +1,9 @@
 import type { ReactElement } from 'react';
 import { Dialog } from '../ui/Dialog';
-import { getShortcutsByCategory } from '../../shortcuts';
+import { getShortcutsByCategory, formatShortcut } from '../../shortcuts';
 import { X, Keyboard } from 'lucide-react';
 import { usePlatform } from '../../hooks/usePlatform';
-
-const formatKey = (key: string, isMac: boolean): string => {
-  return key
-    .replace('mod+', isMac ? '⌘' : 'Ctrl+')
-    .replace('shift+', isMac ? '⇧' : 'Shift+')
-    .replace('alt+', isMac ? '⌥' : 'Alt+')
-    .replace('ctrl+', isMac ? '⌃' : 'Ctrl+')
-    .split('+')
-    .map(k => k.trim())
-    .map(k => k.charAt(0).toUpperCase() + k.slice(1))
-    .join(' ');
-};
+import { isElectronApp } from '../../utils/electronApp';
 
 // Category order for consistent display
 const CATEGORY_ORDER = ['Navigation', 'Messages', 'Composer', 'Canvas', 'Huddle', 'Sidebar'];
@@ -35,7 +24,9 @@ export const ShortcutsHelpModal = ({ isOpen, onClose }: ShortcutsHelpModalProps)
   const filteredShortcuts = Object.entries(shortcuts).reduce(
     (acc, [category, items]) => {
       if (EXCLUDED_CATEGORIES.includes(category)) return acc;
-      const filtered = items.filter(item => item.description);
+      const filtered = items.filter(
+        item => item.description && (!item.electronOnly || isElectronApp()),
+      );
       if (filtered.length > 0) {
         acc[category] = filtered;
       }
@@ -104,8 +95,9 @@ export const ShortcutsHelpModal = ({ isOpen, onClose }: ShortcutsHelpModalProps)
                   )}
                 </div>
                 <div className='space-y-1'>
-                  {items.map(({ id, keys, description }) => {
-                    const keyList = Array.isArray(keys) ? keys : [keys];
+                  {items.map(({ id, keys, displayKeys, description }) => {
+                    const shown = displayKeys ?? keys;
+                    const keyList = Array.isArray(shown) ? shown : [shown];
                     return (
                       <div
                         key={id}
@@ -120,7 +112,7 @@ export const ShortcutsHelpModal = ({ isOpen, onClose }: ShortcutsHelpModalProps)
                               key={idx}
                               className='inline-flex items-center justify-center px-2 py-1 text-xs font-medium font-mono bg-background dark:bg-gray-700 text-foreground dark:text-gray-200 rounded-md border border-border dark:border-gray-600 shadow-sm min-w-[28px]'
                             >
-                              {formatKey(key, isMac)}
+                              {formatShortcut(key, isMac)}
                             </kbd>
                           ))}
                         </div>

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -29,6 +29,7 @@ import { all, createLowlight } from 'lowlight';
 import { Plus, Loader2, X, Ticket, FileText, Clock } from 'lucide-react';
 import { ArrowUp, AtMark, ChevronBigDown, FontAa, Hashtag, PaperclipSlant } from '@xyne/icons';
 import Tooltip from '../Tooltip/Tooltip';
+import { ShortcutHint } from '../ShortcutHint';
 import Avatar from '../Avatar/Avatar';
 import {
   DropdownMenu,
@@ -1764,16 +1765,27 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                 <div className='flex min-w-0 items-center gap-1'>
                   {!hideComposerTools && features.fileAttachments && (
                     <DropdownMenu open={isPlusMenuOpen} onOpenChange={setIsPlusMenuOpen}>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type='button'
-                          className='p-1.5 rounded hover:bg-accent transition-all duration-200 ease-in-out'
-                          aria-label='Add content'
-                          disabled={disabled || isSending}
-                        >
-                          <PaperclipSlant className='h-4 w-4 text-muted-foreground' />
-                        </button>
-                      </DropdownMenuTrigger>
+                      <Tooltip
+                        content={
+                          <span className='flex items-center gap-2'>
+                            Attach files
+                            <ShortcutHint keys='mod+o' />
+                          </span>
+                        }
+                        side='top'
+                        delayDuration={300}
+                      >
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type='button'
+                            className='p-1.5 rounded hover:bg-accent transition-all duration-200 ease-in-out'
+                            aria-label='Add content'
+                            disabled={disabled || isSending}
+                          >
+                            <PaperclipSlant className='h-4 w-4 text-muted-foreground' />
+                          </button>
+                        </DropdownMenuTrigger>
+                      </Tooltip>
                       <DropdownMenuContent side='top' align='start' className={overlayZIndex}>
                         <DropdownMenuItem
                           onClick={() => {
@@ -1782,6 +1794,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                           }}
                         >
                           <Plus className='h-4 w-4' /> Upload Files
+                          <ShortcutHint keys='mod+o' className='ml-auto pl-6' />
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={() => {

--- a/apps/dashboard/src/components/ui/ShortcutHint.tsx
+++ b/apps/dashboard/src/components/ui/ShortcutHint.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react';
+import { cn } from '../../utils/classNames';
+import { usePlatform } from '../../hooks/usePlatform';
+import { formatShortcut } from '../../shortcuts';
+
+interface ShortcutHintProps {
+  keys: string;
+  className?: string;
+}
+
+export const ShortcutHint = ({ keys, className }: ShortcutHintProps): ReactElement | null => {
+  const { isMobile, isMac } = usePlatform();
+
+  if (isMobile) return null;
+
+  return (
+    <span aria-hidden='true' className={cn('opacity-60 tabular-nums', className)}>
+      {formatShortcut(keys, isMac)}
+    </span>
+  );
+};
+
+export default ShortcutHint;

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -2,6 +2,8 @@ import type { ShortcutScope } from './shortcutsRegistry';
 
 export interface ShortcutDefinition {
   keys: string | string[];
+  displayKeys?: string[];
+  electronOnly?: boolean;
   scope?: ShortcutScope;
   priority?: number;
   allowInInputs?: boolean;
@@ -65,6 +67,17 @@ export const shortcuts = {
     priority: 50,
     allowInInputs: true,
     useKey: true,
+  },
+  'global.goToRailItem': {
+    keys: ['mod+1', 'mod+2', 'mod+3', 'mod+4', 'mod+5', 'mod+6', 'mod+7', 'mod+8', 'mod+9'],
+    displayKeys: ['mod+1', 'mod+9'],
+    // In a browser these keys switch tabs, so the rail only claims them in Electron.
+    electronOnly: true,
+    scope: 'global',
+    allowInInputs: true,
+    priority: 50,
+    description: 'Jump to sidebar item 1-9',
+    category: 'Navigation',
   },
   'global.openActivity': {
     keys: 'mod+shift+a',
@@ -265,6 +278,7 @@ export const shortcuts = {
 
   // ===== COMPOSER SHORTCUTS =====
   'composer.attach': {
+    // Not mod+u: that is TipTap's underline binding inside the composer.
     keys: 'mod+o',
     scope: 'composer',
     allowInInputs: true,

--- a/apps/dashboard/src/shortcuts/formatShortcut.ts
+++ b/apps/dashboard/src/shortcuts/formatShortcut.ts
@@ -1,0 +1,17 @@
+/**
+ * Render a registered key combination for display, e.g. 'mod+shift+a' becomes
+ * '⌘⇧A' on macOS and 'Ctrl Shift A' elsewhere.
+ *
+ * Shared so the shortcuts modal, tooltips and menus can never drift apart.
+ */
+export const formatShortcut = (key: string, isMac: boolean): string => {
+  return key
+    .replace('mod+', isMac ? '⌘' : 'Ctrl+')
+    .replace('shift+', isMac ? '⇧' : 'Shift+')
+    .replace('alt+', isMac ? '⌥' : 'Alt+')
+    .replace('ctrl+', isMac ? '⌃' : 'Ctrl+')
+    .split('+')
+    .map(k => k.trim())
+    .map(k => k.replace(/[a-z]/i, c => c.toUpperCase()))
+    .join(' ');
+};

--- a/apps/dashboard/src/shortcuts/index.ts
+++ b/apps/dashboard/src/shortcuts/index.ts
@@ -2,5 +2,6 @@ export { ShortcutsProvider } from '../providers/ShortcutsProvider';
 export { useShortcut, useScope, useShortcutById } from './hooks';
 export { shortcuts, getShortcut, getShortcutsByCategory, findConflicts } from './catalog';
 export { invokeShortcut } from './shortcutsRegistry';
+export { formatShortcut } from './formatShortcut';
 export type { ShortcutConfig, ShortcutRegistration, ShortcutScope } from './shortcutsRegistry';
 export type { ShortcutDefinition, ShortcutId } from './catalog';


### PR DESCRIPTION
POT - https://drive.google.com/file/d/13H6mb1toWW2JztXrSGOl6Yj2EN1hUpar/view?usp=sharing
## What this adds

**⌘1–⌘9 jump to sidebar rail items — in Electron.** The numbers follow whichever rail is on screen, top-down, so the number always matches what you are looking at. The main rail and the support rail each own the numbering while visible, and the Xyne AI button is skipped so nav numbers do not shift when "open AI on launch" is toggled. Items past the ninth have no shortcut and show no hint. For a default rail — which is exactly nine items — that means Chat, DMs, Activity, Calls, Recordings, Tickets, Support, User Guide, Release Manager.

**Not offered on the web.** In a browser ⌘/Ctrl+1–9 switch tabs and a page cannot reliably cancel them, so on the web the shortcut is never registered, the tooltips show no hint, and the entry is hidden from the shortcuts modal. Web users see exactly what they see today.

**Shortcut hints in tooltips.** Each rail item's tooltip shows its key as muted text beside the label. The composer's attach button — which previously had **no tooltip at all**, only an `aria-label` — gains one advertising its existing `⌘O`, and the same hint appears beside "Upload Files" in its menu, the way a native menu shows an accelerator.

Upload is unchanged and stays available everywhere. It deliberately does **not** move to `⌘U`: that is TipTap's underline binding inside the composer (StarterKit bundles Underline, and the formatting toolbar advertises `⌘U` for it).

## Notable details

- The digit is read off `event.code`, not `event.key`. `react-hotkeys-hook@5` matches on physical key position (`f(code)` strips the `digit|key|numpad` prefix), so on layouts like AZERTY the "1" key types `&` and `event.key` would not be a number at all — the shortcut would fire and navigate nowhere.
- The shortcuts modal's private key formatter is lifted into a shared `formatShortcut()` so tooltips, menus and the modal cannot drift apart. This also fixes its macOS casing: it uppercased the leading glyph rather than the letter, so letter keys rendered as `⌘o` / `⌘k` instead of `⌘O` / `⌘K`. The modal picks up that correction.
- Two new optional catalog fields: `displayKeys` lets a shortcut advertise fewer keys than it registers (collapsing the nine digit keys into `⌘1 ⌘9` in the modal instead of nine chips), and `electronOnly` hides an entry from the modal on the web.
- Hints render nothing on mobile and are `aria-hidden`; the controls keep their own accessible names.

## Verification

- Electron/web gating checked both ways: on the web `railShortcutsAvailable()` is false, the shortcut is not registered, and tooltips carry no hint.
- `findConflicts()` reports no new conflicts — only the four pre-existing `viewer` collisions. `mod+u` is confirmed unbound, so underline is untouched.
- Digit resolution checked across US QWERTY, AZERTY, QWERTZ, numpad, first/last item, the `invokeShortcut` synthetic event, and garbage input.
- Tooltip/handler round-trip checked across rail sizes 0, 1, 5, 9, 12 and 31: the item a tooltip advertises is always the item the handler opens, and the hint count never exceeds nine.
- No double registration between the two rails — the main rail's `enabled` and SupportRail's mount condition are complementary.
- prettier clean, `tsc` 0 errors, eslint 0 errors.

## One caveat worth knowing

`⌘O` only fires while the composer has focus (scope `composer`, and `InputBox` defaults to `autoFocus = null`), so on a freshly opened channel the hint is visible before the shortcut is live. That behaviour is pre-existing — only the advertising is new.
