### PR TITLE
feat: XYNE-56495 eta management new

### DIFF
--- a/apps/backend/src/apps/controllers/ticketController.ts
+++ b/apps/backend/src/apps/controllers/ticketController.ts
@@ -20,6 +20,8 @@ import {
   EmailType,
   DeskType,
   isDeskChannelType,
+  parseTicketEtaManagement,
+  mergeTicketEtaManagement,
 } from '@xyne/shared';
 import { syncConversationTicketMdFromPrismaTicket } from '@/utils/ticketMd';
 import { emitEventToWorkspaceApps } from '../core/eventSubscriptionUtils';
@@ -60,6 +62,17 @@ import {
 } from '@/services/ticketCustomFieldService';
 import { emitTicketUpdated } from '@/automations/triggers/ticket-updated.trigger';
 import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
+import { getTicketBotActorId } from '@/utils/etaNotificationUtils';
+import {
+  resolveStepEstimate,
+  loadBoardEtaContext,
+  evaluateEta,
+  buildEtaActivityIntents,
+  isTerminalStatus,
+  dispatchEtaNotifications,
+  etaSignalsFromResult,
+  writeEtaActivitiesPrisma,
+} from '@/services/etaManagement';
 
 const externalSourceRepo = new ExternalSourceRepository();
 const externalMessageRepo = new ExternalMessageRepository();
@@ -350,7 +363,28 @@ const transferTicketToBoard = async (params: {
   const { ticketId, targetBoardId, updatedBy } = params;
   const now = new Date();
 
-  await prismaClient.$transaction(async tx => {
+  const currentTicket = await prismaClient.ticket.findUnique({
+    where: { id: ticketId },
+    select: {
+      workspaceId: true,
+      channelId: true,
+      statusV2: true,
+      assignedTo: true,
+      createdBy: true,
+      userGroupId: true,
+      eta: true,
+      metadata: true,
+    },
+  });
+  if (!currentTicket) {
+    throw new Error(`Ticket ${ticketId} not found`);
+  }
+
+  // Resolved outside the transaction: a stable bot-user lookup, not part of the
+  // transactional state, and best kept off the held connection.
+  const systemActorId = await getTicketBotActorId(currentTicket.workspaceId);
+
+  const txResult = await prismaClient.$transaction(async tx => {
     const newBoardStages = await tx.stage.findMany({
       where: { boardId: targetBoardId },
       orderBy: { sequenceNumber: 'asc' },
@@ -361,8 +395,6 @@ const transferTicketToBoard = async (params: {
     }
 
     const firstStage = newBoardStages[0];
-    const totalEtaHours = newBoardStages.reduce((sum, stage) => sum + (stage.eta || 0), 0);
-    const ticketEta = totalEtaHours > 0 ? calculateETADeadline(now, totalEtaHours) : null;
 
     const firstTicketInStage = await tx.ticket.findFirst({
       where: {
@@ -381,13 +413,16 @@ const transferTicketToBoard = async (params: {
       kanbanPosition = generateKeyBetween(null, null);
     }
 
-    const updatedTicket = await tx.ticket.update({
+    // `eta` is deliberately left out of this base update - an automatic due date is only
+    // ever set by the domain-service evaluation below, and only when the target board has
+    // opted into automatic ETA management (never a blind stage-eta sum, and never a write
+    // that can shorten the ticket's existing due date).
+    await tx.ticket.update({
       where: { id: ticketId },
       data: {
         boardId: targetBoardId,
         stageName: firstStage.name,
         statusV2: firstStage.defaultTicketStatusV2 ?? undefined,
-        eta: ticketEta,
         kanbanPosition,
         updatedAt: now,
         updatedBy,
@@ -396,24 +431,122 @@ const transferTicketToBoard = async (params: {
 
     await tx.ticketStageEta.deleteMany({ where: { ticketId } });
 
+    let newStageEtaEntryId: string | null = null;
+    let stageEtaDeadline: Date | null = null;
     if (firstStage.eta !== null && firstStage.eta > 0) {
-      await tx.ticketStageEta.create({
+      stageEtaDeadline = calculateETADeadline(now, firstStage.eta);
+      const newStageEtaEntry = await tx.ticketStageEta.create({
         data: {
           ticketId,
           stageId: firstStage.id,
           stageEnteredAt: now,
           stageLeftAt: null,
-          stageEta: calculateETADeadline(now, firstStage.eta),
+          stageEta: stageEtaDeadline,
           updatedBy,
-          workspaceId: updatedTicket.workspaceId,
+          workspaceId: currentTicket.workspaceId,
         },
+        select: { id: true },
       });
+      newStageEtaEntryId = newStageEtaEntry.id;
     }
 
     await syncStageOverdueFlag(tx, ticketId, now);
+    // ETA domain-service evaluation: forecast (extend-only) + planning-risk state, mirroring
+    // the pattern already used by TicketRepository.updateTicketStage and the Zero
+    // ticket.update board-transfer branch.
+    const effectiveStatusV2 = (firstStage.defaultTicketStatusV2 ?? currentTicket.statusV2) as TicketStatusV2;
+    // metadata AND eta were both read before this transaction opened, so a concurrent write
+    // (e.g. acknowledgeEtaRisk, or a manual due-date edit) landing before ours would be lost.
+    // FOR UPDATE locks the row so that can't happen. Both locked values feed evaluateEta:
+    // eta is the extend-only baseline and a fingerprint input, so a stale one could decide
+    // against - and then overwrite - a due date someone else just moved.
+    const [lockedTicket] = await tx.$queryRaw<{ metadata: unknown; eta: Date | null }[]>`
+      SELECT "metadata", "eta"
+      FROM "tickets"
+      WHERE "id" = ${ticketId}
+      FOR UPDATE
+    `;
+    const lockedEta = lockedTicket?.eta ?? null;
+    const boardEtaCtx = await loadBoardEtaContext(tx, targetBoardId);
+    const currentTicketEtaManagement = parseTicketEtaManagement(lockedTicket?.metadata);
+    const stepEstimate = resolveStepEstimate(
+      { id: firstStage.id, eta: firstStage.eta },
+      null,
+      { requireExplicitTransition: false },
+    );
+
+    const etaResult = evaluateEta({
+      ticketId,
+      ticketStatus: effectiveStatusV2,
+      isTerminal: isTerminalStatus(effectiveStatusV2),
+      currentTicketEta: lockedEta,
+      currentTicketEtaManagement,
+      boardType: boardEtaCtx.boardType,
+      boardEtaManagement: boardEtaCtx.boardEtaManagement,
+      currentStageId: firstStage.id,
+      stages: boardEtaCtx.stages,
+      transitions: boardEtaCtx.transitions,
+      activeVisit: {
+        stageVisitId: newStageEtaEntryId,
+        transitionId: null,
+        deadline: stageEtaDeadline,
+        deadlineTracked: newStageEtaEntryId !== null,
+        estimateSource: stepEstimate.source,
+        estimateHours: stepEstimate.incomplete ? null : stepEstimate.hours,
+      },
+      trigger: 'STAGE_TRANSITION',
+      now,
+    });
+
+    const mergedMetadata = mergeTicketEtaManagement(
+      lockedTicket?.metadata,
+      etaResult.ticketEtaManagementPatch,
+    );
+
+    const updatedTicket = await tx.ticket.update({
+      where: { id: ticketId },
+      data: {
+        ...(etaResult.etaDecision.changed && etaResult.etaDecision.newEta
+          ? { eta: etaResult.etaDecision.newEta }
+          : {}),
+        metadata: mergedMetadata as Prisma.InputJsonValue,
+      },
+    });
+
+    const activityIntents = buildEtaActivityIntents(etaResult, {
+      currentStageId: firstStage.id,
+      oldEta: lockedEta ? lockedEta.getTime() : null,
+      trigger: 'STAGE_TRANSITION',
+      systemReason: `Automatic recalculation after moving ticket to board "${targetBoardId}"`,
+      previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+    });
+    await writeEtaActivitiesPrisma(tx, activityIntents, {
+      ticketId,
+      workspaceId: currentTicket.workspaceId,
+      channelId: currentTicket.channelId,
+      timestamp: now.getTime(),
+      systemActorId,
+    });
 
     await syncConversationTicketMdFromPrismaTicket(tx, updatedTicket);
+
+    return { updatedTicket, etaResult };
   });
+
+  // Post-commit notification dispatch - best-effort, must never affect the already-
+  // committed response. Suppressed while the ticket is paused.
+  if (txResult.updatedTicket.statusV2 !== TicketStatusV2.PAUSED) {
+    void dispatchEtaNotifications(etaSignalsFromResult(txResult.etaResult), {
+      ticketId,
+      createdBy: currentTicket.createdBy,
+      assignedTo: currentTicket.assignedTo,
+      ticketUserGroupId: currentTicket.userGroupId,
+      boardId: targetBoardId,
+      actorId: updatedBy,
+    }).catch(error => {
+      logger.error('[TicketController] Failed to dispatch ETA notifications', { ticketId, error });
+    });
+  }
 };
 
 export class TicketController {

--- a/apps/backend/src/database/repositories/boardRepository.ts
+++ b/apps/backend/src/database/repositories/boardRepository.ts
@@ -7,6 +7,8 @@ import {
   PRStatusEvent,
   serializeFlowPlan,
   TicketStatusV2,
+  mergeBoardEtaManagement,
+  defaultAutoRecomputeEnabled,
   type FlowPlan,
 } from '@xyne/shared';
 import { EntitySequenceService } from '@/services/entitySequenceService';
@@ -83,6 +85,17 @@ export class BoardRepository {
 
     // Use transaction to create board and stages together
     return await this.db.$transaction(async (tx) => {
+      const resolvedBoardType = data.boardType || BoardType.DEFAULT;
+      // Written explicitly (rather than left to the parse-time fallback) so a board's
+      // automation state is never ambiguous - but the VALUE comes from the same
+      // `defaultAutoRecomputeEnabled` a pre-existing board of this type falls back to at
+      // read time, so a new board and a pre-existing untouched board of the same type can
+      // never disagree.
+      const metadataWithEtaDefaults = mergeBoardEtaManagement(data.metadata ?? null, resolvedBoardType, {
+        autoRecomputeEnabled: defaultAutoRecomputeEnabled(resolvedBoardType),
+        standardPathStageIds: [],
+      });
+
       const board = await tx.board.create({
         data: {
           name: data.name,
@@ -90,8 +103,8 @@ export class BoardRepository {
           projectId: data.projectId,
           workspaceId: data.workspaceId,
           createdBy: data.createdBy,
-          boardType: data.boardType || BoardType.DEFAULT,
-          ...(data.metadata !== undefined && { metadata: data.metadata  as Prisma.InputJsonValue}),
+          boardType: resolvedBoardType,
+          metadata: metadataWithEtaDefaults as Prisma.InputJsonValue,
           ...(data.flowPlan !== undefined && { flowPlan: serializeFlowPlan(data.flowPlan) }),
         },
       });

--- a/apps/backend/src/database/repositories/ticketRepository.ts
+++ b/apps/backend/src/database/repositories/ticketRepository.ts
@@ -16,6 +16,9 @@ import {
   ActivityType,
   PRStatusEvent,
   EmailType,
+  parseTicketEtaManagement,
+  mergeTicketEtaManagement,
+  parseBoardEtaManagement,
 } from '@xyne/shared';
 import { syncConversationTicketMdFromPrismaTicket } from '@/utils/ticketMd';
 import { generateKeyBetween } from 'fractional-indexing';
@@ -32,6 +35,17 @@ import type { TicketLike } from '@/automations/triggers/ticket-context';
 import { dispatchCommittedTicketStatusChange } from '@/services/flowStatusChangeDispatcher';
 import { updateWhileFlowRunActive } from '@/services/flowActiveRunGuard';
 import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
+import { getTicketBotActorId } from '@/utils/etaNotificationUtils';
+import {
+  resolveStepEstimate,
+  loadBoardEtaContext,
+  evaluateEta,
+  buildEtaActivityIntents,
+  isTerminalStatus,
+  dispatchEtaNotifications,
+  etaSignalsFromResult,
+  writeEtaActivitiesPrisma,
+} from '@/services/etaManagement';
 //import { queueTicketIngestion } from '@/queues/vespaQueue';
 
 const prisma = DatabaseClient.getInstance();
@@ -155,14 +169,6 @@ export class TicketRepository {
       kanbanPosition = generateKeyBetween(null, null);
     }
 
-    // Calculate total ETA by summing only stages with ETA (in hours)
-    const totalEtaHours = stages.reduce((sum, stage) => sum + (stage.eta || 0), 0);
-
-    // Calculate ETA deadline only if at least one stage has ETA.
-    // If caller provides an explicit ETA (e.g. migration), prefer that.
-    const etaDeadline = totalEtaHours > 0 ? calculateETADeadline(new Date(), totalEtaHours) : null;
-    const resolvedEta = data.eta ?? etaDeadline;
-
     // Upsert merchant if merchantId is provided
     if (data.merchantId) {
       await db.merchant.upsert({
@@ -175,53 +181,146 @@ export class TicketRepository {
       logger.info(`[TicketRepository] Upserted merchant with mid: ${data.merchantId}`);
     }
 
-    // Create ticket with the conversationId, auto-assigned stageName, and calculated ETA
-    const ticket = await db.ticket.create({
-      data: {
-        ...(data.id && { id: data.id }),
-        title: data.title,
-        description: data.description,
-        createdBy: data.createdBy,
-        updatedBy: data.updatedBy,
-        assignedTo: data.assignedTo,
-        conversationId: data.conversationId,
-        ...(data.sourceMessageId && { messageId: data.sourceMessageId }),
-        channelId: data.channelId,
-        xyneId: data.xyneId,
-        projectId: data.projectId,
-        workspaceId: data.workspaceId,
-        userGroupId: data.userGroupId,
-        boardId: data.boardId,
-        stageName: selectedStage.name,
-        statusV2: data.statusV2 || TicketStatusV2.TODO,
-        priority: data.priority || TicketPriority.LOW,
-        ...(resolvedEta && { eta: resolvedEta }),
-        metadata: data.metadata as Prisma.InputJsonValue,
-        ...(data.rootId && { rootId: data.rootId }),
-        closedAt: data.closedAt,
-        closedBy: data.closedBy,
-        merchantId: data.merchantId,
-        ticketType: data.ticketType,
-        kanbanPosition,
-        ...(data.createdAt && { createdAt: data.createdAt }),
-        lastEmailAt: data.createdAt ?? new Date(),
+    // Ticket creation + initial stage visit + the ETA domain-service evaluation must commit atomically.
+    // Reuses the caller's transaction when one was passed in; otherwise opens its own.
+    const runCreate = async (client: PrismaTransaction | PrismaClient) => {
+      const board = await client.board.findUnique({ where: { id: data.boardId } });
+      if (!board) {
+        throw new Error(`Board ${data.boardId} not found`);
       }
-    });
+      const transitions = await client.stageTransition.findMany({ where: { boardId: data.boardId } });
+      const boardEtaManagement = parseBoardEtaManagement(board.metadata, board.boardType);
 
-    const stageEnteredAt = new Date();
-    // Only create TicketStageEta entry if the selected stage has ETA
-    if (!data.skipStageEta && selectedStage.eta !== null && selectedStage.eta > 0) {
-      const stageEtaDeadline = calculateETADeadline(stageEnteredAt, selectedStage.eta);
-      await db.ticketStageEta.create({
+      // Create ticket with the conversationId, auto-assigned stageName. `eta` is set here
+      // only when the caller explicitly provided one (e.g. migration) An automatic initial due date, when the board has opted in, is set
+      // by the domain-service evaluation below instead of a naive stage-sum here.
+      const ticket = await client.ticket.create({
         data: {
-          ticketId: ticket.id,
-          workspaceId: ticket.workspaceId,
-          stageId: selectedStage.id,
-          stageEnteredAt: stageEnteredAt,
-          stageLeftAt: null,
-          stageEta: stageEtaDeadline,
-          updatedBy: data.createdBy,
+          ...(data.id && { id: data.id }),
+          title: data.title,
+          description: data.description,
+          createdBy: data.createdBy,
+          updatedBy: data.updatedBy,
+          assignedTo: data.assignedTo,
+          // Non-null: validated by the `if (!data.conversationId) throw` guard above: TS
+          // narrowing doesn't cross into this nested closure's captured `data` reference.
+          conversationId: data.conversationId!,
+          ...(data.sourceMessageId && { messageId: data.sourceMessageId }),
+          channelId: data.channelId!,
+          xyneId: data.xyneId,
+          projectId: data.projectId,
+          workspaceId: data.workspaceId,
+          userGroupId: data.userGroupId,
+          boardId: data.boardId,
+          stageName: selectedStage.name,
+          statusV2: data.statusV2 || TicketStatusV2.TODO,
+          priority: data.priority || TicketPriority.LOW,
+          ...(data.eta && { eta: data.eta }),
+          metadata: data.metadata as Prisma.InputJsonValue,
+          ...(data.rootId && { rootId: data.rootId }),
+          closedAt: data.closedAt,
+          closedBy: data.closedBy,
+          merchantId: data.merchantId,
+          ticketType: data.ticketType,
+          kanbanPosition,
+          ...(data.createdAt && { createdAt: data.createdAt }),
+          lastEmailAt: data.createdAt ?? new Date(),
         }
+      });
+
+      const stageEnteredAt = new Date();
+      let stageVisitId: string | null = null;
+      let stageEtaDeadline: Date | null = null;
+      // Only create TicketStageEta entry if the selected stage has ETA
+      if (!data.skipStageEta && selectedStage.eta !== null && selectedStage.eta > 0) {
+        stageEtaDeadline = calculateETADeadline(stageEnteredAt, selectedStage.eta);
+        const stageEtaRow = await client.ticketStageEta.create({
+          data: {
+            ticketId: ticket.id,
+            workspaceId: ticket.workspaceId,
+            stageId: selectedStage.id,
+            stageEnteredAt: stageEnteredAt,
+            stageLeftAt: null,
+            stageEta: stageEtaDeadline,
+            updatedBy: data.createdBy,
+          }
+        });
+        stageVisitId = stageEtaRow.id;
+      }
+
+      const stepEstimate = resolveStepEstimate(
+        { id: selectedStage.id, eta: selectedStage.eta },
+        null,
+        { requireExplicitTransition: false },
+      );
+      const etaResult = evaluateEta({
+        ticketId: ticket.id,
+        ticketStatus: ticket.statusV2,
+        isTerminal: isTerminalStatus(ticket.statusV2),
+        currentTicketEta: ticket.eta,
+        currentTicketEtaManagement: parseTicketEtaManagement(ticket.metadata),
+        boardType: board.boardType,
+        boardEtaManagement,
+        currentStageId: selectedStage.id,
+        stages,
+        transitions,
+        activeVisit: {
+          stageVisitId,
+          transitionId: null,
+          deadline: stageEtaDeadline,
+          deadlineTracked: stageVisitId !== null,
+          estimateSource: stepEstimate.source,
+          estimateHours: stepEstimate.incomplete ? null : stepEstimate.hours,
+        },
+        trigger: 'CREATE',
+        now: stageEnteredAt,
+      });
+
+      const mergedMetadata = mergeTicketEtaManagement(ticket.metadata, etaResult.ticketEtaManagementPatch);
+      const finalTicket = await client.ticket.update({
+        where: { id: ticket.id },
+        data: {
+          ...(etaResult.etaDecision.changed && etaResult.etaDecision.newEta
+            ? { eta: etaResult.etaDecision.newEta }
+            : {}),
+          metadata: mergedMetadata as Prisma.InputJsonValue,
+        },
+      });
+
+      const activityIntents = buildEtaActivityIntents(etaResult, {
+        currentStageId: selectedStage.id,
+        oldEta: ticket.eta ? ticket.eta.getTime() : null,
+        trigger: 'CREATE',
+        systemReason: 'Automatic ETA set on ticket creation',
+        previousRiskFingerprint: null,
+      });
+      await writeEtaActivitiesPrisma(client as Prisma.TransactionClient, activityIntents, {
+        ticketId: ticket.id,
+        workspaceId: ticket.workspaceId,
+        channelId: ticket.channelId,
+        timestamp: stageEnteredAt.getTime(),
+      });
+
+      return { finalTicket, etaResult };
+    };
+
+    const createResult = tx
+      ? await runCreate(tx)
+      : await prisma.$transaction((innerTx) => runCreate(innerTx));
+    const ticket = createResult.finalTicket;
+
+    // Post-commit notification dispatch - best-effort, must never affect the already-
+    // committed response. suppressed if the ticket was created already paused.
+    if (ticket.statusV2 !== TicketStatusV2.PAUSED) {
+      void dispatchEtaNotifications(etaSignalsFromResult(createResult.etaResult), {
+        ticketId: ticket.id,
+        createdBy: ticket.createdBy,
+        assignedTo: ticket.assignedTo,
+        ticketUserGroupId: ticket.userGroupId,
+        boardId: ticket.boardId,
+        actorId: data.createdBy,
+      }).catch(error => {
+        logger.error('[TicketRepository] Failed to dispatch ETA notifications', { ticketId: ticket.id, error });
       });
     }
 
@@ -314,6 +413,7 @@ export class TicketRepository {
         ticketType: true,
         eta: true,
         createdAt: true,
+        metadata: true,
       }
     });
 
@@ -387,138 +487,350 @@ export class TicketRepository {
 
     const isForwardMovement = !currentStage || targetStage.sequenceNumber > currentStage.sequenceNumber;
     const now = new Date();
+    // Resolved outside the transaction: a stable bot-user lookup, not part of the
+    // transactional state, and best kept off the held connection.
+    const systemActorId = await getTicketBotActorId(currentTicket.workspaceId);
 
-    if (isForwardMovement) {
-      // FORWARD MOVEMENT: Mark old stage as left, create/reactivate new stage entry
+    // Everything below that mutates TicketStageEta, the ticket row (stage/status/eta/
+    // metadata), and TicketActivity rows must commit atomically - previously this ran as a
+    // sequence of separately-awaited, unguarded writes
+    const txResult = await prisma.$transaction(async (tx) => {
+      if (isForwardMovement) {
+        // FORWARD MOVEMENT: Mark old stage as left, create/reactivate new stage entry
 
-      // 1. Mark current stage as left (if exists)
-      if (currentStage) {
-        await prisma.ticketStageEta.updateMany({
+        // 1. Mark current stage as left (if exists)
+        if (currentStage) {
+          await tx.ticketStageEta.updateMany({
+            where: {
+              ticketId: ticketId,
+              stageId: currentStage.id,
+              stageLeftAt: null // Only update active entry
+            },
+            data: {
+              stageLeftAt: now,
+              updatedAt: now,
+              updatedBy: updatedBy
+            }
+          });
+        }
+
+        // 2. Check if target stage entry already exists (re-entry case)
+        const existingEntry = await tx.ticketStageEta.findFirst({
           where: {
             ticketId: ticketId,
-            stageId: currentStage.id,
-            stageLeftAt: null // Only update active entry
+            stageId: targetStage.id
+          }
+        });
+
+        if (existingEntry) {
+          // Re-entering a stage - reactivate it
+          await tx.ticketStageEta.update({
+            where: { id: existingEntry.id },
+            data: {
+              stageEnteredAt: now, // Update entered time to now
+              stageLeftAt: null, // Mark as active
+              updatedAt: now,
+              updatedBy: updatedBy
+            }
+          });
+        } else {
+          // First time entering this stage - create new entry only if stage has ETA
+          if (targetStage.eta !== null && targetStage.eta > 0) {
+
+            const stageEtaDeadline = calculateETADeadline(now, targetStage.eta);
+
+            await tx.ticketStageEta.create({
+              data: {
+                ticketId: ticketId,
+                workspaceId: currentTicket.workspaceId,
+                stageId: targetStage.id,
+                stageEnteredAt: now,
+                stageLeftAt: null,
+                stageEta: stageEtaDeadline,
+                updatedBy: updatedBy
+              }
+            });
+          }
+        }
+      } else {
+        // BACKWARD MOVEMENT: Delete all forward stage entries, reactivate target
+
+        // 1. Get all stageIds with sequenceNumber > target
+        const forwardStages = await tx.stage.findMany({
+          where: {
+            boardId: currentTicket.boardId,
+            sequenceNumber: { gt: targetStage.sequenceNumber }
           },
-          data: {
-            stageLeftAt: now,
-            updatedAt: now,
-            updatedBy: updatedBy
-          }
+          select: { id: true }
         });
-      }
 
-      // 2. Check if target stage entry already exists (re-entry case)
-      const existingEntry = await prisma.ticketStageEta.findFirst({
-        where: {
-          ticketId: ticketId,
-          stageId: targetStage.id
-        }
-      });
+        const forwardStageIds = forwardStages.map(s => s.id);
 
-      if (existingEntry) {
-        // Re-entering a stage - reactivate it
-        await prisma.ticketStageEta.update({
-          where: { id: existingEntry.id },
-          data: {
-            stageEnteredAt: now, // Update entered time to now
-            stageLeftAt: null, // Mark as active
-            updatedAt: now,
-            updatedBy: updatedBy
-          }
-        });
-      } else {
-        // First time entering this stage - create new entry only if stage has ETA
-        if (targetStage.eta !== null && targetStage.eta > 0) {
-
-          const stageEtaDeadline = calculateETADeadline(now, targetStage.eta);
-
-          await prisma.ticketStageEta.create({
-            data: {
+        // 2. Delete all entries for those forward stages
+        if (forwardStageIds.length > 0) {
+          await tx.ticketStageEta.deleteMany({
+            where: {
               ticketId: ticketId,
-              workspaceId: currentTicket.workspaceId,
-              stageId: targetStage.id,
-              stageEnteredAt: now,
-              stageLeftAt: null,
-              stageEta: stageEtaDeadline,
-              updatedBy: updatedBy
+              stageId: { in: forwardStageIds }
             }
           });
+
         }
-      }
-    } else {
-      // BACKWARD MOVEMENT: Delete all forward stage entries, reactivate target
 
-      // 1. Get all stageIds with sequenceNumber > target
-      const forwardStages = await prisma.stage.findMany({
-        where: {
-          boardId: currentTicket.boardId,
-          sequenceNumber: { gt: targetStage.sequenceNumber }
-        },
-        select: { id: true }
-      });
-
-      const forwardStageIds = forwardStages.map(s => s.id);
-
-      // 2. Delete all entries for those forward stages
-      if (forwardStageIds.length > 0) {
-        await prisma.ticketStageEta.deleteMany({
+        // 3. Reactivate target stage (set stageLeftAt to null)
+        const targetEntry = await tx.ticketStageEta.findFirst({
           where: {
             ticketId: ticketId,
-            stageId: { in: forwardStageIds }
+            stageId: targetStage.id
           }
         });
 
-      }
-
-      // 3. Reactivate target stage (set stageLeftAt to null)
-      const targetEntry = await prisma.ticketStageEta.findFirst({
-        where: {
-          ticketId: ticketId,
-          stageId: targetStage.id
-        }
-      });
-
-      if (targetEntry) {
-        // Entry exists - reactivate it
-        await prisma.ticketStageEta.update({
-          where: { id: targetEntry.id },
-          data: {
-            stageLeftAt: null,
-            updatedAt: now,
-            updatedBy: updatedBy
-          }
-        });
-      } else {
-        // Entry doesn't exist (edge case - create it)
-        if (targetStage.eta !== null && targetStage.eta > 0) {
-          const stageEtaDeadline = calculateETADeadline(now, targetStage.eta);
-          await prisma.ticketStageEta.create({
+        if (targetEntry) {
+          // Entry exists - reactivate it
+          await tx.ticketStageEta.update({
+            where: { id: targetEntry.id },
             data: {
-              ticketId: ticketId,
-              workspaceId: currentTicket.workspaceId,
-              stageId: targetStage.id,
-              stageEnteredAt: now,
               stageLeftAt: null,
-              stageEta: stageEtaDeadline,
+              updatedAt: now,
               updatedBy: updatedBy
             }
           });
+        } else {
+          // Entry doesn't exist (edge case - create it)
+          if (targetStage.eta !== null && targetStage.eta > 0) {
+            const stageEtaDeadline = calculateETADeadline(now, targetStage.eta);
+            await tx.ticketStageEta.create({
+              data: {
+                ticketId: ticketId,
+                workspaceId: currentTicket.workspaceId,
+                stageId: targetStage.id,
+                stageEnteredAt: now,
+                stageLeftAt: null,
+                stageEta: stageEtaDeadline,
+                updatedBy: updatedBy
+              }
+            });
+          }
         }
       }
-    }
 
-    // Update the ticket stage and status (synced with stage's default status)
-    const updatedTicket =
-      guardedUpdatedTicket ??
-      (await prisma.ticket.update({
-        where: { id: ticketId },
-        data: {
-          stageName: newStageName,
-          statusV2: newStatusV2,
-          updatedBy: updatedBy,
-          updatedAt: new Date()
-        }
-      }));
+      // Re-read the visit instead of trusting the branch-local vars above: the
+      // reactivate-without-reset branch leaves stageEta untouched, so only the row holds the
+      // deadline actually in effect. No StageTransition on this legacy path -> STAGE_DEFAULT.
+      const activeVisitRow = await tx.ticketStageEta.findFirst({
+        where: { ticketId, stageId: targetStage.id, stageLeftAt: null },
+        orderBy: { createdAt: 'desc' },
+      });
+      const deadlineTracked = activeVisitRow
+        ? activeVisitRow.stageEta.getTime() !== activeVisitRow.stageEnteredAt.getTime()
+        : false;
+      const stepEstimate = resolveStepEstimate(
+        { id: targetStage.id, eta: targetStage.eta },
+        null,
+        { requireExplicitTransition: false },
+      );
+      // metadata AND eta were both read before this transaction opened, so a concurrent write
+      // (e.g. acknowledgeEtaRisk, or a manual due-date edit) landing before ours would be lost.
+      // FOR UPDATE locks the row so that can't happen. Both locked values feed evaluateEta:
+      // eta is the extend-only baseline and a fingerprint input, so a stale one could decide
+      // against - and then overwrite - a due date someone else just moved.
+      const [lockedTicket] = await tx.$queryRaw<{ metadata: unknown; eta: Date | null }[]>`
+        SELECT "metadata", "eta"
+        FROM "tickets"
+        WHERE "id" = ${ticketId}
+        FOR UPDATE
+      `;
+      const lockedEta = lockedTicket?.eta ?? null;
+      const boardEtaCtx = await loadBoardEtaContext(tx, currentTicket.boardId);
+      const currentTicketEtaManagement = parseTicketEtaManagement(lockedTicket?.metadata);
+
+      const etaResult = evaluateEta({
+        ticketId,
+        ticketStatus: newStatusV2,
+        isTerminal: isTerminalStatus(newStatusV2),
+        currentTicketEta: lockedEta,
+        currentTicketEtaManagement,
+        boardType: boardEtaCtx.boardType,
+        boardEtaManagement: boardEtaCtx.boardEtaManagement,
+        currentStageId: targetStage.id,
+        stages: boardEtaCtx.stages,
+        transitions: boardEtaCtx.transitions,
+        activeVisit: {
+          stageVisitId: activeVisitRow?.id ?? null,
+          transitionId: null,
+          deadline: activeVisitRow?.stageEta ?? null,
+          deadlineTracked,
+          estimateSource: stepEstimate.source,
+          estimateHours: stepEstimate.incomplete ? null : stepEstimate.hours,
+        },
+        trigger: 'STAGE_TRANSITION',
+        now,
+      });
+      const mergedMetadata = mergeTicketEtaManagement(
+        lockedTicket?.metadata,
+        etaResult.ticketEtaManagementPatch,
+      );
+
+      // The optimistic-concurrency guard above already committed stageName/statusV2 but never
+      // eta/metadata, so those still need their own update on that branch.
+      const updatedTicket = guardedUpdatedTicket
+        ? await tx.ticket.update({
+            where: { id: ticketId },
+            data: {
+              updatedBy: updatedBy,
+              updatedAt: now,
+              ...(etaResult.etaDecision.changed && etaResult.etaDecision.newEta
+                ? { eta: etaResult.etaDecision.newEta }
+                : {}),
+              metadata: mergedMetadata as Prisma.InputJsonValue,
+            },
+          })
+        : await tx.ticket.update({
+            where: { id: ticketId },
+            data: {
+              stageName: newStageName,
+              statusV2: newStatusV2,
+              updatedBy: updatedBy,
+              updatedAt: now,
+              ...(etaResult.etaDecision.changed && etaResult.etaDecision.newEta
+                ? { eta: etaResult.etaDecision.newEta }
+                : {}),
+              metadata: mergedMetadata as Prisma.InputJsonValue,
+            },
+          });
+
+      // Create activity record for the stage change
+      if (source === ActivitySource.WEBHOOK && prActivityData) {
+        // For WEBHOOK source: Create PR activity with stage change info
+        // Align stage change with base activity structure (field, oldValue, newValue)
+        const activityValue: PRActivityValue = {
+          action: this.getActionTextForPREvent(prActivityData.prEvent),
+          prId: prActivityData.prId,
+          prUrl: prActivityData.prUrl,
+          repoName: prActivityData.repoName,
+          sourceBranch: prActivityData.sourceBranchName,
+          destinationBranch: prActivityData.destinationBranchName,
+          ...(prActivityData.prAuthor ? { authorName: prActivityData.prAuthor } : {}),
+          ...(stageChanged ? {
+            // Stage change info - aligned with base activity structure
+            field: 'stageName',
+            oldValue: oldStageName ?? undefined,
+            newValue: newStageName,
+          } : {}),
+          ...(prActivityData.remainingOpenPRs && prActivityData.remainingOpenPRs > 0 ? {
+            remainingOpenPRs: prActivityData.remainingOpenPRs
+          } : {})
+        };
+
+        await tx.ticketActivity.create({
+          data: {
+            ticketId: ticketId,
+            workspaceId: currentTicket.workspaceId,
+            updatedBy: updatedBy,
+            activityType: ActivityType.PR,
+            value: activityValue as Prisma.InputJsonValue,
+            channelId: currentTicket.channelId
+          }
+        });
+
+        logger.info('[TicketRepository] Created PR activity', {
+          ticketId,
+          prId: prActivityData.prId,
+          action: prActivityData.prEvent,
+          author: prActivityData.prAuthor || 'unknown',
+        });
+      } else if (source === ActivitySource.INTERNAL || source === ActivitySource.AUTOMATION) {
+        // For INTERNAL / AUTOMATION source: Create STAGE_NAME activity
+        await tx.ticketActivity.create({
+          data: {
+            ticketId: ticketId,
+            workspaceId: currentTicket.workspaceId,
+            updatedBy: updatedBy,
+            activityType: ActivityType.STAGE_NAME,
+            value: {
+              field: 'stageName',
+              oldValue: oldStageName,
+              newValue: newStageName,
+              source: source,
+              ...(source === ActivitySource.AUTOMATION ? { isAutomation: true } : {}),
+            } as Prisma.InputJsonValue,
+            channelId: currentTicket.channelId
+          }
+        });
+
+        logger.info('[TicketRepository] Created STAGE_NAME activity', {
+          ticketId,
+          oldStageName,
+          newStageName,
+        });
+      }
+
+      // Create STATUS activity if status changed (for both WEBHOOK and INTERNAL sources)
+      if (statusChanged) {
+        await recordTicketTimelineEvent(
+          {
+            activity: {
+              ticketId: ticketId,
+              workspaceId: currentTicket.workspaceId,
+              updatedBy: updatedBy,
+              activityType: ActivityType.STATUS,
+              value: {
+                field: 'statusV2',
+                oldValue: oldStatusV2,
+                newValue: newStatusV2,
+                source: source,
+                ...(source === ActivitySource.AUTOMATION ? { isAutomation: true } : {}),
+              } as Prisma.InputJsonValue,
+              channelId: currentTicket.channelId,
+            },
+          },
+          tx,
+        );
+
+        logger.info('[TicketRepository] Created STATUS activity', {
+          ticketId,
+          oldStatusV2,
+          newStatusV2,
+        });
+      }
+
+      // Audit trail for the ETA evaluation (auto-recompute, risk detected/reopened/resolved) -
+      // attributed to the system actor since these are computed by automatic recalculation,
+      // not authored by the user who moved the stage.
+      const activityIntents = buildEtaActivityIntents(etaResult, {
+        currentStageId: targetStage.id,
+        oldEta: lockedEta ? lockedEta.getTime() : null,
+        trigger: 'STAGE_TRANSITION',
+        systemReason: `Automatic recalculation after moving to stage "${newStageName}"`,
+        previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+      });
+      await writeEtaActivitiesPrisma(tx, activityIntents, {
+        ticketId,
+        workspaceId: currentTicket.workspaceId,
+        channelId: currentTicket.channelId,
+        timestamp: now.getTime(),
+        systemActorId,
+      });
+
+      return { updatedTicket, etaResult };
+    });
+
+    const updatedTicket = txResult.updatedTicket;
+
+    // Post-commit notification dispatch - best-effort, must never affect the already-
+    // committed response. suppressed while the ticket is paused.
+    if (updatedTicket.statusV2 !== TicketStatusV2.PAUSED) {
+      void dispatchEtaNotifications(etaSignalsFromResult(txResult.etaResult), {
+        ticketId,
+        createdBy: currentTicket.createdBy,
+        assignedTo: currentTicket.assignedTo,
+        ticketUserGroupId: currentTicket.userGroupId,
+        boardId: currentTicket.boardId,
+        actorId: updatedBy,
+      }).catch(error => {
+        logger.error('[TicketRepository] Failed to dispatch ETA notifications', { ticketId, error });
+      });
+    }
 
     await syncStageOverdueFlag(prisma, ticketId, now);
 
@@ -580,91 +892,10 @@ export class TicketRepository {
       },
     });
 
-    // Create activity record for the stage change
-    if (source === ActivitySource.WEBHOOK && prActivityData) {
-      // For WEBHOOK source: Create PR activity with stage change info
-      // Align stage change with base activity structure (field, oldValue, newValue)
-      const activityValue: PRActivityValue = {
-        action: this.getActionTextForPREvent(prActivityData.prEvent),
-        prId: prActivityData.prId,
-        prUrl: prActivityData.prUrl,
-        repoName: prActivityData.repoName,
-        sourceBranch: prActivityData.sourceBranchName,
-        destinationBranch: prActivityData.destinationBranchName,
-        ...(prActivityData.prAuthor ? { authorName: prActivityData.prAuthor } : {}),
-        ...(stageChanged ? {
-          // Stage change info - aligned with base activity structure
-          field: 'stageName',
-          oldValue: oldStageName ?? undefined,
-          newValue: newStageName,
-        } : {}),
-        ...(prActivityData.remainingOpenPRs && prActivityData.remainingOpenPRs > 0 ? {
-          remainingOpenPRs: prActivityData.remainingOpenPRs
-        } : {})
-      };
-
-      await prisma.ticketActivity.create({
-        data: {
-          ticketId: ticketId,
-          workspaceId: currentTicket.workspaceId,
-          updatedBy: updatedBy,
-          activityType: ActivityType.PR,
-          value: activityValue as Prisma.InputJsonValue,
-          channelId: currentTicket.channelId
-        }
-      });
-
-      logger.info(
-        `[TicketRepository] Created PR activity for ticket ${ticketId}, PR ${prActivityData.prId} ` +
-        `(action: ${prActivityData.prEvent}, author: ${prActivityData.prAuthor || 'unknown'})`
-      );
-    } else if (source === ActivitySource.INTERNAL || source === ActivitySource.AUTOMATION) {
-      // For INTERNAL / AUTOMATION source: Create STAGE_NAME activity
-      await prisma.ticketActivity.create({
-        data: {
-          ticketId: ticketId,
-          workspaceId: currentTicket.workspaceId,
-          updatedBy: updatedBy,
-          activityType: ActivityType.STAGE_NAME,
-          value: {
-            field: 'stageName',
-            oldValue: oldStageName,
-            newValue: newStageName,
-            source: source,
-            ...(source === ActivitySource.AUTOMATION ? { isAutomation: true } : {}),
-          } as Prisma.InputJsonValue,
-          channelId: currentTicket.channelId
-        }
-      });
-
-      logger.info(
-        `[TicketRepository] Created STAGE_NAME activity for ticket ${ticketId}: ${oldStageName} → ${newStageName}`
-      );
-    }
-
-    // Create STATUS activity if status changed (for both WEBHOOK and INTERNAL sources)
+    // Thread system message for the status change (activity rows for PR/STAGE_NAME/STATUS/ETA
+    // were already written inside the transaction above). Messages are posted post-commit,
+    // best-effort - a delivery failure here must not roll back the ticket transition.
     if (statusChanged) {
-      await recordTicketTimelineEvent({
-        activity: {
-          ticketId: ticketId,
-          workspaceId: currentTicket.workspaceId,
-          updatedBy: updatedBy,
-          activityType: ActivityType.STATUS,
-          value: {
-            field: 'statusV2',
-            oldValue: oldStatusV2,
-            newValue: newStatusV2,
-            source: source,
-            ...(source === ActivitySource.AUTOMATION ? { isAutomation: true } : {}),
-          } as Prisma.InputJsonValue,
-          channelId: currentTicket.channelId,
-        },
-      });
-
-      logger.info(
-        `[TicketRepository] Created STATUS activity for ticket ${ticketId}: ${oldStatusV2} → ${newStatusV2}`
-      );
-
       // Create system message for status change
       if (currentTicket.conversationId) {
         // Get user name for the message

--- a/apps/backend/src/services/etaManagement/activityIntents.ts
+++ b/apps/backend/src/services/etaManagement/activityIntents.ts
@@ -1,0 +1,207 @@
+import {
+  ActivityType,
+  parseTicketEtaManagement,
+  type EtaActivityOutbox,
+  type EtaAutoRecomputedActivityValue,
+  type EtaRiskAcknowledgedActivityValue,
+  type EtaChangeTrigger,
+  type EtaRiskDetectedActivityValue,
+  type EtaRiskReopenedActivityValue,
+  type EtaRiskResolvedActivityValue,
+} from '@xyne/shared';
+import type { EvaluateEtaResult } from './index';
+
+/**
+ * Stages built intents into the metadata outbox that
+ * `TicketsSideEffectHandler` drains post-commit. Pass the result straight into
+ * `mergeTicketEtaManagement` alongside the evaluation's own patch, so the rows
+ * a mutation intends and the state it writes commit together or not at all.
+ *
+ * Returns null for an empty intent list, which also clears any outbox left by
+ * a previous evaluation.
+ */
+export function stageEtaActivityOutbox(
+  intents: ReadonlyArray<EtaActivityIntent>,
+  at: number,
+): EtaActivityOutbox | null {
+  if (intents.length === 0) return null;
+  return {
+    at,
+    entries: intents.map(intent => ({
+      activityType: intent.activityType,
+      value: intent.value,
+      actorId: intent.actorId ?? null,
+    })),
+  };
+}
+
+/**
+ * Post-commit counterpart to {@link stageEtaActivityOutbox}: returns the
+ * intents a `tickets.update` side effect should write, or an empty list when
+ * this job's outbox was already drained (same `at`) or empty.
+ */
+export function drainEtaActivityOutbox(input: {
+  previousMetadata: unknown;
+  currentMetadata: unknown;
+}): EtaActivityIntent[] {
+  const prev = parseTicketEtaManagement(input.previousMetadata).pendingActivities;
+  const next = parseTicketEtaManagement(input.currentMetadata).pendingActivities;
+
+  if (!next || next.entries.length === 0) return [];
+  if (prev && prev.at === next.at) return [];
+
+  return next.entries.map(entry => ({
+    activityType: entry.activityType as ActivityType,
+    value: entry.value,
+    actorId: entry.actorId,
+  }));
+}
+
+/** Timestamp the drained rows should carry - the originating mutation's own. */
+export function drainedOutboxTimestamp(currentMetadata: unknown): number | null {
+  return parseTicketEtaManagement(currentMetadata).pendingActivities?.at ?? null;
+}
+
+/**
+ * Translates an `evaluateEta` result into the list of TicketActivity rows
+ * that should be recorded for it, using the typed value contracts from
+ * packages/shared/src/tickets/etaActivityValues.ts. Storage-agnostic - the
+ * Prisma call sites hand these to `recordTicketTimelineEvent`, Zero
+ * mutators write them via `tx.mutate.ticket_activities.insert`, both using
+ * the exact same shapes so the two write paths can never drift.
+ */
+export interface EtaActivityIntent {
+  activityType: ActivityType;
+  /** One of the typed Eta*ActivityValue interfaces - precise type already enforced at the push site below. */
+  value: unknown;
+  /**
+   * Attributing user for user-authored rows (ETA_MANUALLY_UPDATED,
+   * ETA_RISK_ACKNOWLEDGED). Omitted/null for automatic rows, which are
+   * attributed to the workspace ticket bot.
+   */
+  actorId?: string | null;
+  /**
+   * Body of the SYSTEM message that should accompany this row in the ticket's
+   * conversation thread. Filled in by the side-effect handler via
+   * {@link etaSystemMessageContent} once it has resolved the actor's display
+   * name; left unset for rows that get no thread message.
+   */
+  systemMessageContent?: string;
+}
+
+/**
+ * Body of the conversation-thread message for an ETA row, or null when that
+ * activity type gets a timeline row only.
+ *
+ * Kept out of the outbox itself: the metadata subtree stores the facts, and
+ * the rendered sentence (which needs a display-name lookup) is produced
+ * post-commit, so mutators don't pay for that query on the mutation path.
+ */
+export function etaSystemMessageContent(
+  intent: EtaActivityIntent,
+  actorName: string,
+): string | null {
+  switch (intent.activityType) {
+    case ActivityType.ETA_RISK_ACKNOWLEDGED: {
+      const reason = (intent.value as EtaRiskAcknowledgedActivityValue | undefined)?.reason ?? '';
+      return `${actorName} acknowledged the planning-risk warning: ${reason}`;
+    }
+    default:
+      return null;
+  }
+}
+
+export interface BuildActivityIntentsContext {
+  currentStageId: string;
+  oldEta: number | null;
+  trigger: EtaChangeTrigger;
+  systemReason: string;
+  /** The risk fingerprint that was persisted before this evaluation ran (for ETA_RISK_REOPENED). */
+  previousRiskFingerprint: string | null;
+}
+
+/**
+ * Activity intents for a risk-state transition alone, with no forecast or
+ * due-date change involved - the hourly reconciliation worker's case, since
+ * it deliberately never recomputes forecasts or extends dates. Avoids making
+ * that caller fabricate a whole `EvaluateEtaResult` just to reach the
+ * risk-transition branch of `buildEtaActivityIntents`.
+ */
+export function buildRiskTransitionActivityIntents(
+  planningRisk: EvaluateEtaResult['planningRisk'],
+  ctx: BuildActivityIntentsContext,
+): EtaActivityIntent[] {
+  return buildEtaActivityIntents(
+    {
+      forecast: {
+        status: 'NOT_APPLICABLE',
+        incompleteReason: null,
+        incompleteStageIds: [],
+        forecastEta: null,
+        standardPathUsed: false,
+      },
+      etaDecision: { newEta: null, changed: false },
+      planningRisk,
+      ticketEtaManagementPatch: {},
+    },
+    ctx,
+  );
+}
+
+export function buildEtaActivityIntents(
+  result: EvaluateEtaResult,
+  ctx: BuildActivityIntentsContext,
+): EtaActivityIntent[] {
+  const intents: EtaActivityIntent[] = [];
+
+  if (result.etaDecision.changed && result.etaDecision.newEta && result.forecast.forecastEta) {
+    const value: EtaAutoRecomputedActivityValue = {
+      trigger: ctx.trigger,
+      oldEta: ctx.oldEta,
+      forecastEta: result.forecast.forecastEta.getTime(),
+      finalEta: result.etaDecision.newEta.getTime(),
+      stageVisitId: result.ticketEtaManagementPatch.activeVisit?.stageVisitId ?? null,
+      standardPathUsed: result.forecast.standardPathUsed,
+      systemReason: ctx.systemReason,
+    };
+    intents.push({ activityType: ActivityType.ETA_AUTO_RECOMPUTED, value });
+  }
+
+  const risk = result.planningRisk.nextState;
+  switch (result.planningRisk.transitionKind) {
+    case 'DETECTED': {
+      const value: EtaRiskDetectedActivityValue = {
+        fingerprint: risk.fingerprint ?? '',
+        stageEta: risk.stageEta ?? 0,
+        ticketEta: risk.ticketEta ?? 0,
+        stageId: ctx.currentStageId,
+        stageVisitId: risk.stageVisitId ?? '',
+      };
+      intents.push({ activityType: ActivityType.ETA_RISK_DETECTED, value });
+      break;
+    }
+    case 'REOPENED': {
+      const value: EtaRiskReopenedActivityValue = {
+        previousFingerprint: ctx.previousRiskFingerprint,
+        newFingerprint: risk.fingerprint ?? '',
+        changedInputs: result.planningRisk.changedInputs,
+      };
+      intents.push({ activityType: ActivityType.ETA_RISK_REOPENED, value });
+      break;
+    }
+    case 'RESOLVED': {
+      const value: EtaRiskResolvedActivityValue = {
+        fingerprint: ctx.previousRiskFingerprint ?? '',
+        cause: result.planningRisk.changedInputs.includes('ticketStatus')
+          ? 'TERMINAL_STATUS'
+          : 'CONDITION_NO_LONGER_TRUE',
+      };
+      intents.push({ activityType: ActivityType.ETA_RISK_RESOLVED, value });
+      break;
+    }
+    default:
+      break;
+  }
+
+  return intents;
+}

--- a/apps/backend/src/services/etaManagement/dateAdapter.ts
+++ b/apps/backend/src/services/etaManagement/dateAdapter.ts
@@ -1,0 +1,15 @@
+/**
+ * Boundary conversion between Zero's epoch-ms timestamps and the domain
+ * service's `Date`-based pure functions. Zero mutators (mutators.ts) work
+ * entirely in epoch ms; Prisma call sites work entirely in `Date`. The
+ * domain service itself stays `Date`-based (matching Prisma, its first
+ * integration) - Zero call sites convert at the boundary instead of
+ * threading a second unit system through the pure functions.
+ */
+export function msToDate(ms: number | null | undefined): Date | null {
+  return ms === null || ms === undefined ? null : new Date(ms);
+}
+
+export function dateToMs(date: Date | null | undefined): number | null {
+  return date ? date.getTime() : null;
+}

--- a/apps/backend/src/services/etaManagement/estimateResolution.ts
+++ b/apps/backend/src/services/etaManagement/estimateResolution.ts
@@ -1,0 +1,104 @@
+import { VisitSlaMode } from '@xyne/shared';
+import type { StageLike, StepEstimate, TransitionLike } from './types';
+
+/**
+ * Resolve the working-hour estimate for one route step, from the actual
+ * transition configuration that would enter that stage. This is the single
+ * source of truth for the SLA-mode decision table - the live stage-entry
+ * path (formerly `TicketStageTransitionService.computeStageEta()`, now
+ * inlined at its one call site) delegates to this, so the two can never
+ * drift. Because that live path already ships and runs unconditionally
+ * (independent of this feature's rollout), its existing fallback behavior
+ * is preserved byte-for-byte here:
+ *
+ *   FIXED_HOURS + a positive fixedEtaHours  -> that value
+ *   FIXED_HOURS with no/invalid value       -> falls through to Stage.eta (pre-existing
+ *                                              self-healing behavior on the live path -
+ *                                              NOT treated as a hard config error here)
+ *   NONE                                    -> deliberately untracked, 0 hours, NOT an error
+ *   STAGE_DEFAULT (or no transition)        -> Stage.eta, when positive
+ *   no usable Stage.eta after the above     -> incomplete (missing estimate)
+ *   required transition missing entirely    -> config error (incomplete) - only reachable
+ *                                              via `requireExplicitTransition`, which only
+ *                                              Standard Path route steps set (M5); ordinary
+ *                                              linear/DEFAULT transitions never require this.
+ */
+export function resolveStepEstimate(
+  stage: Pick<StageLike, 'id' | 'eta'>,
+  transition: TransitionLike | null,
+  opts: { requireExplicitTransition: boolean },
+): StepEstimate {
+  if (transition === null && opts.requireExplicitTransition) {
+    return {
+      stageId: stage.id,
+      hours: 0,
+      source: 'STAGE_DEFAULT',
+      deadlineTracked: false,
+      incomplete: true,
+    };
+  }
+
+  const slaMode = transition?.visitSlaMode ?? VisitSlaMode.STAGE_DEFAULT;
+
+  switch (slaMode) {
+    case VisitSlaMode.FIXED_HOURS: {
+      if (transition?.fixedEtaHours && transition.fixedEtaHours > 0) {
+        return {
+          stageId: stage.id,
+          hours: transition.fixedEtaHours,
+          source: 'TRANSITION_FIXED',
+          deadlineTracked: true,
+          incomplete: false,
+        };
+      }
+      // Fixed-hours mode selected but no usable value - fall through to stage default,
+      // matching the pre-existing live-path behavior exactly (see module doc comment).
+      if (stage.eta && stage.eta > 0) {
+        return {
+          stageId: stage.id,
+          hours: stage.eta,
+          source: 'STAGE_DEFAULT',
+          deadlineTracked: true,
+          incomplete: false,
+        };
+      }
+      return {
+        stageId: stage.id,
+        hours: 0,
+        source: 'TRANSITION_FIXED',
+        deadlineTracked: false,
+        incomplete: true,
+      };
+    }
+
+    case VisitSlaMode.NONE:
+      // Deliberately no SLA - contributes 0 tracked hours, not treated as missing/incomplete.
+      return {
+        stageId: stage.id,
+        hours: 0,
+        source: 'STAGE_DEFAULT',
+        deadlineTracked: false,
+        incomplete: false,
+      };
+
+    case VisitSlaMode.STAGE_DEFAULT:
+    default: {
+      if (stage.eta && stage.eta > 0) {
+        return {
+          stageId: stage.id,
+          hours: stage.eta,
+          source: 'STAGE_DEFAULT',
+          deadlineTracked: true,
+          incomplete: false,
+        };
+      }
+      return {
+        stageId: stage.id,
+        hours: 0,
+        source: 'STAGE_DEFAULT',
+        deadlineTracked: false,
+        incomplete: true,
+      };
+    }
+  }
+}

--- a/apps/backend/src/services/etaManagement/etaActivityWriters.ts
+++ b/apps/backend/src/services/etaManagement/etaActivityWriters.ts
@@ -1,0 +1,71 @@
+import type { Prisma } from '@prisma/client';
+import { recordTicketTimelineEvent } from '@/services/ticketTimelineEventService';
+import { getTicketBotActorId } from '@/utils/etaNotificationUtils';
+import type { EtaActivityIntent } from './activityIntents';
+
+export interface EtaActivityWriteContext {
+  ticketId: string;
+  workspaceId: string;
+  channelId: string | null;
+  /** Event timestamp; pass the mutation's own `now` so client/server runs agree. */
+  timestamp: number;
+  /**
+   * Pre-resolved ticket-bot actor id. Optional, but pass it when the caller
+   * already resolved it outside its transaction - that lookup is a DB read,
+   * and callers holding a transaction shouldn't pay for it on the held
+   * connection. Omitted, the helper resolves it lazily (only when there is at
+   * least one intent to write).
+   */
+  systemActorId?: string;
+  /**
+   * Ticket's conversation, when it has one. Required for an intent's
+   * `systemMessageContent` to be written; without it only the timeline row is.
+   */
+  conversationId?: string | null;
+}
+
+/**
+ * Persist ETA activity intents from a Prisma write path, inside the caller's
+ * transaction. Attributed to the workspace's ticket-bot actor, since these
+ * rows record automatic recalculation rather than a user-authored edit.
+ *
+ * No-ops on an empty intent list, so the bot-user lookup is skipped entirely
+ * when an evaluation produced nothing to record (the common case).
+ */
+export async function writeEtaActivitiesPrisma(
+  client: Prisma.TransactionClient,
+  intents: ReadonlyArray<EtaActivityIntent>,
+  ctx: EtaActivityWriteContext,
+): Promise<void> {
+  if (intents.length === 0) return;
+  const systemActorId = ctx.systemActorId ?? (await getTicketBotActorId(ctx.workspaceId));
+  for (const intent of intents) {
+    const writtenBy = intent.actorId ?? systemActorId;
+    await recordTicketTimelineEvent(
+      {
+        activity: {
+          ticketId: ctx.ticketId,
+          updatedBy: writtenBy,
+          activityType: intent.activityType,
+          value: intent.value as Prisma.InputJsonValue,
+          workspaceId: ctx.workspaceId,
+          channelId: ctx.channelId,
+          timestamp: new Date(ctx.timestamp),
+        },
+        ...(intent.systemMessageContent && ctx.conversationId
+          ? {
+              message: {
+                conversationId: ctx.conversationId,
+                senderId: writtenBy,
+                content: intent.systemMessageContent,
+                activityType: intent.activityType,
+                workspaceId: ctx.workspaceId,
+                createdAt: new Date(ctx.timestamp),
+              },
+            }
+          : {}),
+      },
+      client,
+    );
+  }
+}

--- a/apps/backend/src/services/etaManagement/etaNotificationDispatch.ts
+++ b/apps/backend/src/services/etaManagement/etaNotificationDispatch.ts
@@ -1,0 +1,124 @@
+import { parseTicketEtaManagement, type TicketEtaManagement } from '@xyne/shared';
+import { notificationService } from '@/services/notificationService';
+import { resolveAwarenessRecipients, resolveActionRecipients } from './etaRecipients';
+import type { EvaluateEtaResult } from './index';
+
+export interface DispatchEtaNotificationsContext {
+  ticketId: string;
+  createdBy: string;
+  assignedTo: string | null;
+  ticketUserGroupId: string | null;
+  boardId: string;
+  /** Real acting user id for a manual change, or the system/ticket-bot actor id for an automatic one - excluded from its own notification either way. */
+  actorId: string;
+}
+
+/**
+ * The minimal "what happened" input the notification dispatch needs, kept
+ * deliberately separate from `EvaluateEtaResult` so it can be produced two
+ * ways:
+ *
+ *  - from the in-transaction evaluation result (Prisma paths, which already
+ *    own their post-commit side effects) via `etaSignalsFromResult`, and
+ *  - from a post-commit `Ticket.metadata` diff (the Zero side-effect
+ *    handler, which never sees the in-transaction result) via
+ *    `etaSignalsFromMetadataDiff`.
+ *
+ * Both feed the same `dispatchEtaNotifications`, so the two paths can never
+ * notify differently for the same underlying change.
+ */
+export interface EtaNotificationSignals {
+  /** Non-null only when a risk was newly detected or reopened - the two cases that notify. */
+  riskAlert: { stageDeadline: number; ticketDue: number } | null;
+  /** Set when the ticket due date actually moved. */
+  newEta: Date | null;
+}
+
+export function etaSignalsFromResult(
+  etaResult: Pick<EvaluateEtaResult, 'etaDecision' | 'planningRisk'>,
+): EtaNotificationSignals {
+  const { planningRisk, etaDecision } = etaResult;
+  const isAlert = planningRisk.transitionKind === 'DETECTED' || planningRisk.transitionKind === 'REOPENED';
+  const risk = planningRisk.nextState;
+  return {
+    riskAlert:
+      isAlert && risk.stageEta !== null && risk.ticketEta !== null
+        ? { stageDeadline: risk.stageEta, ticketDue: risk.ticketEta }
+        : null,
+    newEta: etaDecision.changed ? etaDecision.newEta : null,
+  };
+}
+
+/**
+ * Derive the same signals from before/after ticket state, for callers that
+ * only observe the committed result (the Zero side-effect handler). The
+ * DETECTED/REOPENED distinction collapses here because both notify
+ * identically; what matters is "this is a risk the recipients haven't been
+ * told about yet", which the fingerprint change captures exactly - and which
+ * also makes this naturally idempotent when one logical mutation produces
+ * several `tickets.update` side-effect jobs.
+ */
+export function etaSignalsFromMetadataDiff(input: {
+  previousMetadata: unknown;
+  currentMetadata: unknown;
+  previousEta: number | null;
+  currentEta: number | null;
+}): EtaNotificationSignals {
+  const prev: TicketEtaManagement = parseTicketEtaManagement(input.previousMetadata);
+  const next: TicketEtaManagement = parseTicketEtaManagement(input.currentMetadata);
+
+  const becameActive = next.planningRisk.state === 'ACTIVE';
+  const fingerprintChanged = next.planningRisk.fingerprint !== prev.planningRisk.fingerprint;
+  const wasAlreadyAlerted = prev.planningRisk.state === 'ACTIVE' && !fingerprintChanged;
+
+  const shouldAlert =
+    becameActive &&
+    !wasAlreadyAlerted &&
+    next.planningRisk.stageEta !== null &&
+    next.planningRisk.ticketEta !== null;
+
+  const etaChanged = input.currentEta !== null && input.currentEta !== input.previousEta;
+
+  return {
+    riskAlert: shouldAlert
+      ? { stageDeadline: next.planningRisk.stageEta!, ticketDue: next.planningRisk.ticketEta! }
+      : null,
+    newEta: etaChanged ? new Date(input.currentEta!) : null,
+  };
+}
+
+/**
+ * Post-commit notification delivery:
+ *  - planning risk detected/reopened -> action recipients (awareness
+ *    recipients who also hold the board's ETA-update permission).
+ *  - automatic or manual due-date change -> awareness recipients.
+ *  - resolved / unchanged / no date change -> nothing.
+ *  - acknowledgment is intentionally NOT handled here (record + system
+ *    message only, no notification) - see `ticket.acknowledgeEtaRisk`.
+ *
+ * Always call this AFTER the mutation has committed - it does its own
+ * reads/writes via `notificationService` and must never be able to roll back
+ * the ticket mutation on failure.
+ */
+export async function dispatchEtaNotifications(
+  signals: EtaNotificationSignals,
+  ctx: DispatchEtaNotificationsContext,
+): Promise<void> {
+  if (!signals.riskAlert && !signals.newEta) return;
+
+  const awareness = await resolveAwarenessRecipients(ctx.ticketId, ctx.createdBy, ctx.assignedTo, ctx.actorId);
+
+  if (signals.riskAlert) {
+    const action = await resolveActionRecipients(awareness, ctx.ticketUserGroupId, ctx.boardId);
+    await notificationService.sendPlanningRiskDetectedNotification(ctx.ticketId, action, signals.riskAlert);
+  }
+
+  if (signals.newEta) {
+    await notificationService.sendTicketDueDateChangedNotification(
+      ctx.ticketId,
+      awareness,
+      signals.newEta.toLocaleDateString(),
+      ctx.actorId,
+    );
+  }
+}

--- a/apps/backend/src/services/etaManagement/etaPermissions.ts
+++ b/apps/backend/src/services/etaManagement/etaPermissions.ts
@@ -1,0 +1,87 @@
+import { UserResponsibility, type BoardMetadata } from '@xyne/shared';
+
+/**
+ * Backend enforcement of the ticket-control permission (Assignee/ETA/Stage/
+ * Board changes, and planning-risk acknowledgment), extracted from the gate
+ * that was inlined in the Zero `ticket.update` mutator. Storage-agnostic: the
+ * caller supplies the two lookups via whatever client it holds - Prisma `tx`
+ * or Zero `tx.run(zql...)`.
+ *
+ * the backend is the only security boundary for this check -
+ * frontend visibility must never be treated as one, so this logic is not
+ * shared with or duplicated in the dashboard.
+ */
+export interface TicketControlUserGroupMapping {
+  roleId: string | null;
+  responsibility: string | null;
+}
+
+export interface EtaPermissionDataSource {
+  getBoardMetadata(boardId: string): Promise<unknown>;
+  getUserGroupMapping(
+    userId: string,
+    userGroupId: string,
+  ): Promise<TicketControlUserGroupMapping | null>;
+}
+
+export interface EtaPermissionResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+export async function canUserModifyTicketControl(
+  userId: string,
+  userGroupId: string | null,
+  boardId: string,
+  dataSource: EtaPermissionDataSource,
+): Promise<EtaPermissionResult> {
+  if (!userGroupId) {
+    return { allowed: true };
+  }
+
+  const boardMetadata = await dataSource.getBoardMetadata(boardId);
+  const metadata =
+    boardMetadata && typeof boardMetadata === 'object' ? (boardMetadata as BoardMetadata) : null;
+
+  const controlRoleIds = Array.isArray(metadata?.ticketControlRoleIds)
+    ? metadata!.ticketControlRoleIds!
+    : [];
+  const legacyIsAllowedToTransfer = metadata?.isAllowedToTransfer === true;
+
+  // Boards with neither config are unrestricted - no membership lookup needed.
+  if (controlRoleIds.length === 0 && !legacyIsAllowedToTransfer) {
+    return { allowed: true };
+  }
+
+  const mapping = await dataSource.getUserGroupMapping(userId, userGroupId);
+  if (!mapping) {
+    return {
+      allowed: false,
+      reason: 'You must be a member of the current user group to modify this ticket',
+    };
+  }
+
+  if (controlRoleIds.length > 0) {
+    // Role-driven: raw roleId membership, so custom roles work.
+    if (!mapping.roleId || !controlRoleIds.includes(mapping.roleId)) {
+      return {
+        allowed: false,
+        reason: 'Only users with a configured role can modify Assignee, ETA, Stage, or Board on this board',
+      };
+    }
+    return { allowed: true };
+  }
+
+  // Legacy enum fallback (only reachable when isAllowedToTransfer === true).
+  if (
+    mapping.responsibility !== UserResponsibility.MANAGER &&
+    mapping.responsibility !== UserResponsibility.TEAM_LEAD
+  ) {
+    return {
+      allowed: false,
+      reason:
+        'Only users with MANAGER or TEAM_LEAD responsibility can modify Assignee, ETA, Stage, or Board on this board',
+    };
+  }
+  return { allowed: true };
+}

--- a/apps/backend/src/services/etaManagement/etaRecipients.ts
+++ b/apps/backend/src/services/etaManagement/etaRecipients.ts
@@ -1,0 +1,85 @@
+import { db } from '@/database/client';
+import { getFormFieldUserActors } from '@/utils/ticketActorUtils';
+import { canUserModifyTicketControl } from './etaPermissions';
+
+/**
+ * Same "who might care about this ticket" set every existing
+ * `sendTicket*Notification` method in notificationService.ts already uses
+ * (see `TicketsSideEffectHandler`'s private `fetchTicketActors` in
+ * zero/side-effects/tables/tickets-handler.ts, reimplemented here rather
+ * than exported cross-module for a single shared call).
+ */
+async function fetchTicketActors(ticketId: string): Promise<string[]> {
+  const [roleAssignments, formFieldUserActors] = await Promise.all([
+    db.ticketAssignment.findMany({ where: { ticketId }, select: { userId: true } }),
+    getFormFieldUserActors(ticketId),
+  ]);
+  return roleAssignments
+    .map((a) => a.userId)
+    .filter((id): id is string => Boolean(id))
+    .concat(formFieldUserActors);
+}
+
+/**
+ * "Awareness recipients": assignee, creator, active ticket
+ * assignments, and user-valued ticket fields. Notification-preference
+ * filtering (mute/pause/channel level) happens separately in the actual
+ * send methods (`notificationFilterService`), not here.
+ */
+export async function resolveAwarenessRecipients(
+  ticketId: string,
+  createdBy: string,
+  assignedTo: string | null,
+  excludeUserId?: string,
+): Promise<string[]> {
+  const extraActors = await fetchTicketActors(ticketId);
+  const all = [createdBy, assignedTo, ...extraActors].filter(
+    (id, index, arr): id is string => Boolean(id) && arr.indexOf(id) === index,
+  );
+  return excludeUserId ? all.filter((id) => id !== excludeUserId) : all;
+}
+
+/**
+ * "Action recipients": awareness recipients who also satisfy the
+ * board's ETA-update permission policy. This is a net-new concept - no
+ * existing recipient-resolution function in this codebase filters by
+ * permission, only by notification preference (mute/pause/channel level).
+ */
+export async function resolveActionRecipients(
+  awarenessRecipients: string[],
+  ticketUserGroupId: string | null,
+  boardId: string,
+): Promise<string[]> {
+  if (!ticketUserGroupId || awarenessRecipients.length === 0) {
+    // No user group on the ticket: canUserModifyTicketControl's underlying gate is
+    // unrestricted for everyone in that case, so the full awareness set qualifies.
+    return awarenessRecipients;
+  }
+
+  const board = await db.board.findUnique({ where: { id: boardId }, select: { metadata: true } });
+
+  // Two queries total regardless of recipient count: the board above, and every
+  // relevant membership in one batch below. Notification fan-out can be large, so
+  // this must not scale with the recipient list.
+  const mappings = await db.userGroupMapping.findMany({
+    where: { userGroupId: ticketUserGroupId, userId: { in: awarenessRecipients } },
+    select: { userId: true, roleId: true, responsibility: true },
+  });
+  const mappingByUserId = new Map(
+    mappings.map((m) => [
+      m.userId,
+      { roleId: m.roleId ?? null, responsibility: m.responsibility ?? null },
+    ]),
+  );
+
+  const results = await Promise.all(
+    awarenessRecipients.map(async (userId) => {
+      const permission = await canUserModifyTicketControl(userId, ticketUserGroupId, boardId, {
+        getBoardMetadata: async () => board?.metadata ?? null,
+        getUserGroupMapping: async (uid) => mappingByUserId.get(uid) ?? null,
+      });
+      return permission.allowed ? userId : null;
+    }),
+  );
+  return results.filter((id): id is string => id !== null);
+}

--- a/apps/backend/src/services/etaManagement/extendOnly.ts
+++ b/apps/backend/src/services/etaManagement/extendOnly.ts
@@ -1,0 +1,20 @@
+import type { EtaUpdateDecision, ForecastResult } from './types';
+
+/**
+ * The one place automatic ETA math is ever applied: extend-only, never
+ * shorten. Every mutation path must route its automatic due-date change
+ * through this function instead of writing `calculateETADeadline`'s result
+ * directly.
+ */
+export function decideEtaUpdate(currentEta: Date | null, forecast: ForecastResult): EtaUpdateDecision {
+  if (forecast.status !== 'COMPLETE' || forecast.forecastEta === null) {
+    return { newEta: currentEta, changed: false };
+  }
+
+  if (currentEta === null) {
+    return { newEta: forecast.forecastEta, changed: true };
+  }
+
+  const newEta = forecast.forecastEta.getTime() > currentEta.getTime() ? forecast.forecastEta : currentEta;
+  return { newEta, changed: newEta.getTime() !== currentEta.getTime() };
+}

--- a/apps/backend/src/services/etaManagement/forecastBuilder.ts
+++ b/apps/backend/src/services/etaManagement/forecastBuilder.ts
@@ -1,0 +1,100 @@
+import { calculateETADeadline } from '@/utils/etaCalculation';
+import { resolveStepEstimate } from './estimateResolution';
+import type { ForecastResult, RouteResolution, StageLike } from './types';
+
+export interface BuildForecastInput {
+  route: RouteResolution;
+  /**
+   * The active stage's tracked deadline, already reenter-mode-adjusted (i.e.
+   * the real `TicketStageEta.stageEta` value after RESET/CONTINUE has been
+   * applied by the caller). Null when the current stage has no genuinely
+   * tracked deadline (no-SLA placeholder, or no active visit at all).
+   */
+  activeStageDeadline: Date | null;
+  now: Date;
+  stagesById: ReadonlyMap<string, Pick<StageLike, 'id' | 'eta'>>;
+}
+
+/**
+ * Build a forecast from the active stage deadline plus all resolvable
+ * remaining route estimates. Never treats a missing estimate as zero - any
+ * incomplete step marks the whole forecast INCOMPLETE with no `forecastEta`.
+ */
+export function buildForecast(input: BuildForecastInput): ForecastResult {
+  const { route, activeStageDeadline, now, stagesById } = input;
+
+  if (route.kind === 'NOT_APPLICABLE') {
+    return {
+      status: 'NOT_APPLICABLE',
+      incompleteReason: null,
+      incompleteStageIds: [],
+      forecastEta: null,
+      standardPathUsed: false,
+    };
+  }
+
+  if (route.kind === 'DEVIATED') {
+    return {
+      status: 'NOT_APPLICABLE',
+      incompleteReason: 'TICKET_OFF_STANDARD_PATH',
+      incompleteStageIds: [route.offPathStageId],
+      forecastEta: null,
+      // A deviation is only reachable on a board that has a Standard Path configured.
+      standardPathUsed: true,
+    };
+  }
+
+  if (activeStageDeadline === null) {
+    return {
+      status: 'INCOMPLETE',
+      incompleteReason: 'NO_TRACKED_ACTIVE_DEADLINE',
+      incompleteStageIds: [],
+      forecastEta: null,
+      standardPathUsed: route.standardPathUsed,
+    };
+  }
+
+  let totalHours = 0;
+  const incompleteStageIds: string[] = [];
+
+  for (const step of route.steps) {
+    const stage = stagesById.get(step.stageId);
+    if (!stage) {
+      incompleteStageIds.push(step.stageId);
+      continue;
+    }
+    const estimate = resolveStepEstimate(stage, step.transition, {
+      requireExplicitTransition: step.requireExplicitTransition,
+    });
+    if (estimate.incomplete) {
+      incompleteStageIds.push(step.stageId);
+      continue;
+    }
+    totalHours += estimate.hours;
+  }
+
+  if (incompleteStageIds.length > 0) {
+    return {
+      status: 'INCOMPLETE',
+      incompleteReason: 'MISSING_STAGE_ESTIMATE',
+      incompleteStageIds,
+      forecastEta: null,
+      standardPathUsed: route.standardPathUsed,
+    };
+  }
+
+  // Anchor at the later of the active deadline and now: an already-expired deadline
+  // (expired CONTINUE, or a RESET/fresh deadline that's since passed) must not produce a
+  // forecast in the past; a still-future deadline is kept as-is so existing buffer absorbs
+  // some or all of any detour.
+  const basis = activeStageDeadline.getTime() > now.getTime() ? activeStageDeadline : now;
+  const forecastEta = calculateETADeadline(basis, totalHours);
+
+  return {
+    status: 'COMPLETE',
+    incompleteReason: null,
+    incompleteStageIds: [],
+    forecastEta,
+    standardPathUsed: route.standardPathUsed,
+  };
+}

--- a/apps/backend/src/services/etaManagement/index.ts
+++ b/apps/backend/src/services/etaManagement/index.ts
@@ -1,0 +1,163 @@
+import type {
+  BoardEtaManagement,
+  EstimateSource,
+  EtaChangeTrigger,
+  TicketEtaManagement,
+} from '@xyne/shared';
+import { resolveForecastRoute } from './routeResolution';
+import { buildForecast } from './forecastBuilder';
+import { decideEtaUpdate } from './extendOnly';
+import { evaluatePlanningRisk } from './riskEvaluation';
+import type {
+  EtaUpdateDecision,
+  ForecastResult,
+  PlanningRiskDecision,
+  StageLike,
+  TransitionLike,
+} from './types';
+
+export * from './types';
+export { resolveForecastRoute } from './routeResolution';
+export { resolveStepEstimate } from './estimateResolution';
+export { buildForecast } from './forecastBuilder';
+export { decideEtaUpdate } from './extendOnly';
+export { evaluatePlanningRisk } from './riskEvaluation';
+export { canUserModifyTicketControl } from './etaPermissions';
+export {
+  buildEtaActivityIntents,
+  buildRiskTransitionActivityIntents,
+  stageEtaActivityOutbox,
+  drainEtaActivityOutbox,
+  etaSystemMessageContent,
+  drainedOutboxTimestamp,
+} from './activityIntents';
+export { writeEtaActivitiesPrisma } from './etaActivityWriters';
+export type { EtaActivityWriteContext } from './etaActivityWriters';
+export type { EtaActivityIntent, BuildActivityIntentsContext } from './activityIntents';
+export { loadBoardEtaContext, isTerminalStatus } from './prismaContext';
+export type { LoadedBoardEtaContext } from './prismaContext';
+export { loadZeroEtaContext } from './zeroContext';
+export type { LoadedZeroEtaContext } from './zeroContext';
+export { msToDate, dateToMs } from './dateAdapter';
+export { resolveAwarenessRecipients, resolveActionRecipients } from './etaRecipients';
+export {
+  dispatchEtaNotifications,
+  etaSignalsFromResult,
+  etaSignalsFromMetadataDiff,
+} from './etaNotificationDispatch';
+export type { DispatchEtaNotificationsContext, EtaNotificationSignals } from './etaNotificationDispatch';
+
+export interface ActiveVisitContext {
+  stageVisitId: string | null;
+  transitionId: string | null;
+  /** The visit's tracked deadline, already reenter-mode-adjusted (RESET/CONTINUE already applied). Ignored unless `deadlineTracked` is true. */
+  deadline: Date | null;
+  /** False for the no-SLA placeholder (stageEta === stageEnteredAt) or when there's no active visit. */
+  deadlineTracked: boolean;
+  estimateSource: EstimateSource;
+  estimateHours: number | null;
+}
+
+export interface EvaluateEtaInput {
+  ticketId: string;
+  ticketStatus: string;
+  isTerminal: boolean;
+  currentTicketEta: Date | null;
+  currentTicketEtaManagement: TicketEtaManagement;
+  boardType: string;
+  boardEtaManagement: BoardEtaManagement;
+  currentStageId: string;
+  stages: ReadonlyArray<Pick<StageLike, 'id' | 'sequenceNumber' | 'eta'>>;
+  transitions: ReadonlyArray<TransitionLike>;
+  activeVisit: ActiveVisitContext;
+  trigger: EtaChangeTrigger;
+  now: Date;
+}
+
+export interface EvaluateEtaResult {
+  forecast: ForecastResult;
+  etaDecision: EtaUpdateDecision;
+  planningRisk: PlanningRiskDecision;
+  /** Ready to pass as the `patch` argument to `mergeTicketEtaManagement`. */
+  ticketEtaManagementPatch: Partial<Omit<TicketEtaManagement, 'activeVisit' | 'planningRisk'>> & {
+    activeVisit?: Partial<TicketEtaManagement['activeVisit']>;
+    planningRisk?: Partial<TicketEtaManagement['planningRisk']>;
+  };
+}
+
+/**
+ * The single evaluation entry point every mutation path calls identically:
+ * resolve the route, build a forecast, apply the extend-only decision,
+ * evaluate planning risk against the final due date, and produce a
+ * ready-to-merge `Ticket.metadata.etaManagement` patch. Pure - no Prisma or
+ * Zero access. Callers load `EvaluateEtaInput` from their own storage layer
+ * and apply the returned `etaDecision`/`ticketEtaManagementPatch`
+ * themselves, inside the same transaction as the rest of the mutation.
+ */
+export function evaluateEta(input: EvaluateEtaInput): EvaluateEtaResult {
+  const {
+    ticketId,
+    ticketStatus,
+    isTerminal,
+    currentTicketEta,
+    currentTicketEtaManagement,
+    boardType,
+    boardEtaManagement,
+    currentStageId,
+    stages,
+    transitions,
+    activeVisit,
+    now,
+  } = input;
+
+  const route = resolveForecastRoute({
+    boardType,
+    currentStageId,
+    stages,
+    transitions,
+    standardPathStageIds: boardEtaManagement.standardPathStageIds,
+  });
+
+  const stagesById = new Map(stages.map((s) => [s.id, s]));
+  const forecast = buildForecast({
+    route,
+    activeStageDeadline: activeVisit.deadlineTracked ? activeVisit.deadline : null,
+    now,
+    stagesById,
+  });
+
+  // Automatic extension only applies when the board has opted in; detection (below)
+  // always runs regardless, per the Phase 1 (detect-only) / Phase 2 (auto-extend) split.
+  const etaDecision = boardEtaManagement.autoRecomputeEnabled
+    ? decideEtaUpdate(currentTicketEta, forecast)
+    : { newEta: currentTicketEta, changed: false };
+
+  const planningRisk = evaluatePlanningRisk({
+    ticketId,
+    activeStageVisitId: activeVisit.stageVisitId,
+    stageDeadline: activeVisit.deadlineTracked ? activeVisit.deadline : null,
+    deadlineTracked: activeVisit.deadlineTracked,
+    ticketDue: etaDecision.newEta,
+    ticketStatus,
+    now,
+    currentRisk: currentTicketEtaManagement.planningRisk,
+    isTerminal,
+  });
+
+  const ticketEtaManagementPatch: EvaluateEtaResult['ticketEtaManagementPatch'] = {
+    lastEvaluatedAt: now.getTime(),
+    forecastStatus: forecast.status,
+    forecastIncompleteReason: forecast.incompleteReason,
+    forecastIncompleteStageIds: forecast.incompleteStageIds,
+    activeVisit: {
+      stageVisitId: activeVisit.stageVisitId,
+      transitionId: activeVisit.transitionId,
+      deadlineTracked: activeVisit.deadlineTracked,
+      estimateSource: activeVisit.estimateSource,
+      estimateHours: activeVisit.estimateHours,
+    },
+    planningRisk: planningRisk.nextState,
+  };
+
+  return { forecast, etaDecision, planningRisk, ticketEtaManagementPatch };
+}

--- a/apps/backend/src/services/etaManagement/prismaContext.ts
+++ b/apps/backend/src/services/etaManagement/prismaContext.ts
@@ -1,0 +1,50 @@
+import type { Prisma, Stage, StageTransition } from '@prisma/client';
+import { TicketStatusV2, parseBoardEtaManagement, type BoardEtaManagement } from '@xyne/shared';
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  TicketStatusV2.COMPLETED,
+  TicketStatusV2.CANCELLED,
+]);
+
+export function isTerminalStatus(statusV2: string): boolean {
+  return TERMINAL_STATUSES.has(statusV2);
+}
+
+export interface LoadedBoardEtaContext {
+  boardType: string;
+  boardEtaManagement: BoardEtaManagement;
+  stages: Array<Pick<Stage, 'id' | 'sequenceNumber' | 'eta'>>;
+  transitions: StageTransition[];
+}
+
+/**
+ * Shared Prisma data-loading glue for the domain service's Prisma call
+ * sites (TicketStageTransitionService, ticketRepository). Loads exactly
+ * what `evaluateEta`'s pure functions need - board type/config, all stages,
+ * all transitions - within the caller's own transaction client so the read
+ * is consistent with whatever the caller is about to write.
+ */
+export async function loadBoardEtaContext(
+  tx: Prisma.TransactionClient,
+  boardId: string,
+): Promise<LoadedBoardEtaContext> {
+  const board = await tx.board.findUnique({ where: { id: boardId } });
+  if (!board) {
+    throw new Error(`Board ${boardId} not found while loading ETA context`);
+  }
+
+  const [stages, transitions] = await Promise.all([
+    tx.stage.findMany({
+      where: { boardId },
+      select: { id: true, sequenceNumber: true, eta: true },
+    }),
+    tx.stageTransition.findMany({ where: { boardId } }),
+  ]);
+
+  return {
+    boardType: board.boardType,
+    boardEtaManagement: parseBoardEtaManagement(board.metadata, board.boardType),
+    stages,
+    transitions,
+  };
+}

--- a/apps/backend/src/services/etaManagement/riskEvaluation.ts
+++ b/apps/backend/src/services/etaManagement/riskEvaluation.ts
@@ -1,0 +1,140 @@
+import { computeRiskFingerprint, type TicketEtaManagementPlanningRisk } from '@xyne/shared';
+import type { PlanningRiskDecision } from './types';
+
+export interface EvaluatePlanningRiskInput {
+  ticketId: string;
+  /** Active TicketStageEta.id, or null when there's no active visit. */
+  activeStageVisitId: string | null;
+  stageDeadline: Date | null;
+  /** False for the no-SLA placeholder (stageEta === stageEnteredAt) - never compared as a real deadline. */
+  deadlineTracked: boolean;
+  ticketDue: Date | null;
+  ticketStatus: string;
+  now: Date;
+  currentRisk: TicketEtaManagementPlanningRisk;
+  /** Ticket is in a terminal (Completed/Cancelled) status. */
+  isTerminal: boolean;
+}
+
+/**
+ * Three-state planning-risk evaluation, comparing new inputs against the
+ * currently persisted risk state to decide whether nothing changed, risk
+ * was newly detected, an acknowledged/active risk was reopened by changed
+ * inputs, or an active/acknowledged risk should now resolve. Planning risk
+ * is deliberately distinct from stage-overdue: `now <= stageDeadline` is
+ * part of the condition, so a breached deadline stops being a *planning*
+ * risk (it becomes a stage-overdue condition, handled elsewhere).
+ */
+export function evaluatePlanningRisk(input: EvaluatePlanningRiskInput): PlanningRiskDecision {
+  const {
+    ticketId,
+    activeStageVisitId,
+    stageDeadline,
+    deadlineTracked,
+    ticketDue,
+    ticketStatus,
+    now,
+    currentRisk,
+    isTerminal,
+  } = input;
+
+  if (isTerminal) {
+    return resolveIfActive(currentRisk, 'ticketStatus');
+  }
+
+  const hasComparableData =
+    deadlineTracked && stageDeadline !== null && ticketDue !== null && activeStageVisitId !== null;
+
+  if (!hasComparableData) {
+    return resolveIfActive(currentRisk, 'comparableData');
+  }
+
+  const conditionTrue =
+    stageDeadline!.getTime() > ticketDue!.getTime() && now.getTime() <= stageDeadline!.getTime();
+
+  const fingerprint = computeRiskFingerprint({
+    ticketId,
+    activeStageVisitId: activeStageVisitId!,
+    stageEta: stageDeadline!.getTime(),
+    ticketEta: ticketDue!.getTime(),
+    ticketStatus,
+  });
+
+  if (!conditionTrue) {
+    return resolveIfActive(currentRisk, 'condition');
+  }
+
+  if (currentRisk.state === 'NONE' || currentRisk.state === 'RESOLVED') {
+    return {
+      nextState: {
+        state: 'ACTIVE',
+        fingerprint,
+        detectedAt: now.getTime(),
+        stageVisitId: activeStageVisitId,
+        stageEta: stageDeadline!.getTime(),
+        ticketEta: ticketDue!.getTime(),
+        acknowledgedAt: null,
+        acknowledgedBy: null,
+        acknowledgmentReason: null,
+      },
+      transitionKind: 'DETECTED',
+      changedInputs: [],
+    };
+  }
+
+  // state is ACTIVE or ACKNOWLEDGED.
+  if (currentRisk.fingerprint === fingerprint) {
+    return { nextState: currentRisk, transitionKind: 'UNCHANGED', changedInputs: [] };
+  }
+
+  const changedInputs = diffFingerprintInputs(currentRisk, {
+    stageDeadline,
+    ticketDue,
+    activeStageVisitId,
+  });
+
+  return {
+    nextState: {
+      state: 'ACTIVE',
+      fingerprint,
+      detectedAt: now.getTime(),
+      stageVisitId: activeStageVisitId,
+      stageEta: stageDeadline!.getTime(),
+      ticketEta: ticketDue!.getTime(),
+      acknowledgedAt: null,
+      acknowledgedBy: null,
+      acknowledgmentReason: null,
+    },
+    transitionKind: 'REOPENED',
+    changedInputs,
+  };
+}
+
+function resolveIfActive(
+  currentRisk: TicketEtaManagementPlanningRisk,
+  changedInput: string,
+): PlanningRiskDecision {
+  if (currentRisk.state === 'ACTIVE' || currentRisk.state === 'ACKNOWLEDGED') {
+    return {
+      nextState: { ...currentRisk, state: 'RESOLVED' },
+      transitionKind: 'RESOLVED',
+      changedInputs: [changedInput],
+    };
+  }
+  return { nextState: currentRisk, transitionKind: 'UNCHANGED', changedInputs: [] };
+}
+
+function diffFingerprintInputs(
+  prev: TicketEtaManagementPlanningRisk,
+  next: {
+    stageDeadline: Date | null;
+    ticketDue: Date | null;
+    activeStageVisitId: string | null;
+  },
+): string[] {
+  const changed: string[] = [];
+  if (prev.stageEta !== (next.stageDeadline?.getTime() ?? null)) changed.push('stageEta');
+  if (prev.ticketEta !== (next.ticketDue?.getTime() ?? null)) changed.push('ticketEta');
+  if (prev.stageVisitId !== next.activeStageVisitId) changed.push('stageVisitId');
+  return changed;
+}

--- a/apps/backend/src/services/etaManagement/routeResolution.ts
+++ b/apps/backend/src/services/etaManagement/routeResolution.ts
@@ -1,0 +1,86 @@
+import { BoardType } from '@xyne/shared';
+import type { RouteResolution, RouteStep, StageLike, TransitionLike } from './types';
+
+export interface RouteResolutionInput {
+  boardType: string;
+  currentStageId: string;
+  /** All stages on the board. */
+  stages: ReadonlyArray<Pick<StageLike, 'id' | 'sequenceNumber'>>;
+  /** All configured transitions on the board (explicit fromStageId->toStageId and global fromStageId:null rows). */
+  transitions: ReadonlyArray<TransitionLike>;
+  /** Admin-configured Standard Path (ordered stage IDs). Empty = not configured. */
+  standardPathStageIds: ReadonlyArray<string>;
+}
+
+function findTransition(
+  transitions: ReadonlyArray<TransitionLike>,
+  fromStageId: string,
+  toStageId: string,
+): TransitionLike | null {
+  const explicit = transitions.find((t) => t.fromStageId === fromStageId && t.toStageId === toStageId);
+  if (explicit) return explicit;
+  const global = transitions.find((t) => t.fromStageId == null && t.toStageId === toStageId);
+  return global ?? null;
+}
+
+/**
+ * Resolve the remaining route (ordered stage steps) used to build a
+ * forecast from the ticket's current stage onward. Does not consult
+ * `Board.metadata.etaManagement.autoRecomputeEnabled` - that gate is the
+ * caller's responsibility (detection can run even when automatic extension
+ * is off).
+ */
+export function resolveForecastRoute(input: RouteResolutionInput): RouteResolution {
+  const { boardType, currentStageId, stages, transitions, standardPathStageIds } = input;
+
+  if (boardType === BoardType.DEFAULT || boardType === BoardType.RELEASE) {
+    const currentStage = stages.find((s) => s.id === currentStageId);
+    if (!currentStage) {
+      return { kind: 'NOT_APPLICABLE' };
+    }
+    const remaining = [...stages]
+      .filter((s) => s.sequenceNumber > currentStage.sequenceNumber)
+      .sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+
+    const steps: RouteStep[] = [];
+    let fromId = currentStageId;
+    for (const stage of remaining) {
+      steps.push({
+        stageId: stage.id,
+        transition: findTransition(transitions, fromId, stage.id),
+        requireExplicitTransition: false,
+      });
+      fromId = stage.id;
+    }
+    return { kind: 'ROUTE', steps, standardPathUsed: false };
+  }
+
+  if (boardType === BoardType.NON_LINEAR) {
+    if (standardPathStageIds.length === 0) {
+      // Non-linear boards cannot be forecast reliably without an expected route.
+      return { kind: 'NOT_APPLICABLE' };
+    }
+    const currentIndex = standardPathStageIds.indexOf(currentStageId);
+    if (currentIndex === -1) {
+      return { kind: 'DEVIATED', offPathStageId: currentStageId };
+    }
+    const remainingIds = standardPathStageIds.slice(currentIndex + 1);
+    const steps: RouteStep[] = [];
+    let fromId = currentStageId;
+    for (const stageId of remainingIds) {
+      steps.push({
+        stageId,
+        transition: findTransition(transitions, fromId, stageId),
+        requireExplicitTransition: true,
+      });
+      fromId = stageId;
+    }
+    return { kind: 'ROUTE', steps, standardPathUsed: true };
+  }
+
+  // FLOW (and any other board type): automatic due-date management is deferred this
+  // release regardless of forecast availability - callers that only need detection for
+  // Flow/Release boards with comparable ETA data work directly off the active stage
+  // deadline, not this route.
+  return { kind: 'NOT_APPLICABLE' };
+}

--- a/apps/backend/src/services/etaManagement/types.ts
+++ b/apps/backend/src/services/etaManagement/types.ts
@@ -1,0 +1,93 @@
+import type {
+  EstimateSource,
+  ForecastStatus,
+  TicketEtaManagementPlanningRisk,
+} from '@xyne/shared';
+
+/**
+ * Central ETA domain service types. Every function in this directory is
+ * pure (no Prisma/Zero access) so the same decision logic can be reused
+ * identically from Prisma call sites (ticketStageTransitionService.ts,
+ * ticketRepository.ts) and Zero mutators (mutators.ts) - only the
+ * data-loading glue differs per call site.
+ *
+ * `StageLike`/`TransitionLike` are deliberately minimal structural types
+ * rather than `@prisma/client`'s `Stage`/`StageTransition` - Zero's
+ * generated row types (also confusingly named `StageTransition`, exported
+ * from `@xyne/shared`) use `| undefined` for optional columns where Prisma
+ * uses `| null`, and carry different extra fields. Both the Prisma models
+ * and Zero rows structurally satisfy these narrower types, so the same
+ * pure functions run unmodified against either.
+ */
+
+export interface StageLike {
+  id: string;
+  sequenceNumber: number;
+  eta: number | null | undefined;
+}
+
+export interface TransitionLike {
+  id: string;
+  fromStageId: string | null | undefined;
+  toStageId: string;
+  visitSlaMode: string | null | undefined;
+  fixedEtaHours: number | null | undefined;
+}
+
+export interface RouteStep {
+  stageId: string;
+  /** The transition that would be used to enter this stage, when resolvable. */
+  transition: TransitionLike | null;
+  /**
+   * True when this step is a Standard-Path step on a graphed NON_LINEAR
+   * board, where an explicit or global StageTransition row is REQUIRED to
+   * resolve an estimate - a null `transition` in that case is a config
+   * error ("no matching transition on a graphed board"), not a
+   * legitimate "unrestricted move". False for linear/DEFAULT/RELEASE
+   * boards, where a null transition just means "use the stage default".
+   */
+  requireExplicitTransition: boolean;
+}
+
+export type RouteResolution =
+  /** `standardPathUsed` distinguishes a NON_LINEAR board's admin-configured Standard Path
+   *  from a DEFAULT/RELEASE board's implicit sequenceNumber order - both produce a ROUTE,
+   *  and the audit trail records which one a forecast came from. */
+  | { kind: 'ROUTE'; steps: RouteStep[]; standardPathUsed: boolean }
+  /** Current stage isn't on the configured Standard Path (NON_LINEAR only). */
+  | { kind: 'DEVIATED'; offPathStageId: string }
+  /** Board type/config doesn't support forecasting this release (Flow, non-linear with no Standard Path, unknown current stage). */
+  | { kind: 'NOT_APPLICABLE' };
+
+export interface StepEstimate {
+  stageId: string;
+  hours: number;
+  source: EstimateSource;
+  /** Genuinely tracked deadline, as opposed to a deliberate no-SLA step (contributes 0 hours, not an error). */
+  deadlineTracked: boolean;
+  /** Hard config error (e.g. FIXED_HOURS with no value, or a required transition missing) - blocks the forecast, distinct from a deliberate NONE. */
+  incomplete: boolean;
+}
+
+export interface ForecastResult {
+  status: ForecastStatus;
+  incompleteReason: string | null;
+  incompleteStageIds: string[];
+  forecastEta: Date | null;
+  /** Propagated from the route so ETA_AUTO_RECOMPUTED can record how the forecast was built. */
+  standardPathUsed: boolean;
+}
+
+export interface EtaUpdateDecision {
+  newEta: Date | null;
+  changed: boolean;
+}
+
+export type PlanningRiskTransitionKind = 'NONE' | 'DETECTED' | 'REOPENED' | 'RESOLVED' | 'UNCHANGED';
+
+export interface PlanningRiskDecision {
+  nextState: TicketEtaManagementPlanningRisk;
+  transitionKind: PlanningRiskTransitionKind;
+  /** Best-effort list of which fingerprint inputs changed, for the ETA_RISK_REOPENED activity. Ticket status is folded into the fingerprint but not separately stored, so a status-only change may not appear here even though it changed the fingerprint. */
+  changedInputs: string[];
+}

--- a/apps/backend/src/services/etaManagement/zeroContext.ts
+++ b/apps/backend/src/services/etaManagement/zeroContext.ts
@@ -1,0 +1,70 @@
+import type { Transaction } from '@rocicorp/zero';
+import type { Schema } from '@xyne/shared';
+import { parseTicketEtaManagement, type TicketEtaManagement } from '@xyne/shared';
+import { zql } from '@/zero/queries';
+import { resolveStepEstimate } from './estimateResolution';
+import type { ActiveVisitContext } from './index';
+import type { StageLike, TransitionLike } from './types';
+
+export interface LoadedZeroEtaContext {
+  stages: Array<Pick<StageLike, 'id' | 'sequenceNumber' | 'eta'>>;
+  transitions: TransitionLike[];
+  currentTicketEtaManagement: TicketEtaManagement;
+  /**
+   * Derived from the ticket's persisted open `ticket_stage_eta` row for the
+   * given stage. Callers whose deadline isn't persisted yet (a transition
+   * computing it in-flight, or a manual edit) override `deadline`/
+   * `estimateSource` on the returned object.
+   */
+  activeVisit: ActiveVisitContext;
+}
+
+/**
+ * Zero counterpart to `loadBoardEtaContext` - loads what `evaluateEta`'s
+ * pure functions need through the caller's own transaction, so the read is
+ * consistent with whatever that mutator is about to write.
+ *
+ * `stages` may be passed in when the caller already fetched them (several
+ * mutators need the ordered list for their own logic first).
+ */
+export async function loadZeroEtaContext(
+  tx: Transaction<Schema>,
+  input: {
+    ticketId: string;
+    boardId: string;
+    ticketMetadata: unknown;
+    stage: { id: string; eta: number | null | undefined };
+    transition?: TransitionLike | null;
+    stages?: Array<Pick<StageLike, 'id' | 'sequenceNumber' | 'eta'>>;
+  },
+): Promise<LoadedZeroEtaContext> {
+  const stages = input.stages ?? (await tx.run(zql.stages.where('boardId', input.boardId)));
+  const transitions = await tx.run(zql.stage_transitions.where('boardId', input.boardId));
+
+  const visits = await tx.run(
+    zql.ticket_stage_eta.where('ticketId', input.ticketId).where('stageId', input.stage.id),
+  );
+  const activeVisitRow = visits.find(v => v.stageLeftAt === null) ?? null;
+  const estimate = resolveStepEstimate(
+    { id: input.stage.id, eta: input.stage.eta },
+    input.transition ?? null,
+    { requireExplicitTransition: false },
+  );
+
+  return {
+    stages,
+    transitions,
+    currentTicketEtaManagement: parseTicketEtaManagement(input.ticketMetadata),
+    activeVisit: {
+      stageVisitId: activeVisitRow?.id ?? null,
+      transitionId: input.transition?.id ?? null,
+      deadline: activeVisitRow ? new Date(activeVisitRow.stageEta) : null,
+      // stageEta === stageEnteredAt is the no-SLA placeholder, not a real deadline.
+      deadlineTracked: activeVisitRow
+        ? activeVisitRow.stageEta !== activeVisitRow.stageEnteredAt
+        : false,
+      estimateSource: estimate.source,
+      estimateHours: estimate.incomplete ? null : estimate.hours,
+    },
+  };
+}

--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -2514,6 +2514,80 @@ class NotificationService {
   }
 
   /**
+   * Planning-risk detected/reopened : the current stage deadline is later than
+   * the ticket due date, not yet overdue. Sent only to "action recipients" (awareness
+   * recipients who also satisfy the board's ETA-update permission policy) - unlike every
+   * other ticket notification here, which goes to the full awareness set - since a
+   * planning-risk alert is only actionable for someone who can actually change the due
+   * date or stage deadline. Caller is responsible for the "once per fingerprint" dedup
+   * (comparing the previous vs. new fingerprint before calling).
+   */
+  async sendPlanningRiskDetectedNotification(
+    ticketId: string,
+    actionRecipients: string[],
+    details: { stageDeadline: number; ticketDue: number },
+  ): Promise<void> {
+    if (actionRecipients.length === 0) return;
+
+    try {
+      const ticket = await prisma.ticket.findUnique({
+        where: { id: ticketId },
+        select: {
+          id: true,
+          xyneId: true,
+          title: true,
+          channelId: true,
+          conversationId: true,
+          workspaceId: true,
+          channel: { select: { type: true } },
+        },
+      });
+      if (!ticket) {
+        logger.warn('[NotificationService] Ticket not found', { ticketId });
+        return;
+      }
+
+      const actionUrl = buildTicketActionUrl(ticket, ticketId);
+      const ticketDisplayId = ticket.xyneId || ticket.id;
+      const title = 'Planning Risk';
+      const message = `Ticket '${ticketDisplayId}' has a stage deadline later than its due date`;
+
+      await Promise.allSettled(
+        actionRecipients.map(async (userId) => {
+          const { desktopUsers, mobileUsers } = ticket.channelId
+            ? await notificationFilterService.filterUsers([userId], ticket.channelId, false, 'mention', {
+                notificationType: NotificationType.TICKET_ETA_PLANNING_RISK,
+              })
+            : await notificationFilterService.filterGlobalUsers([userId], NotificationType.TICKET_ETA_PLANNING_RISK, 'mention');
+
+          const receiveDesktop = desktopUsers.includes(userId);
+          const receiveMobile = mobileUsers.includes(userId);
+
+          if (!receiveDesktop && !receiveMobile) return;
+
+          await this.createNotification(userId, {
+            title,
+            message,
+            type: NotificationType.TICKET_ETA_PLANNING_RISK,
+            relatedEntityType: 'ticket',
+            relatedEntityId: ticketId,
+            actionUrl,
+            metadata: {
+              ticketId,
+              channelId: ticket.channelId,
+              conversationId: ticket.conversationId,
+              stageDeadline: details.stageDeadline,
+              ticketDue: details.ticketDue,
+            },
+          }, { sendDesktop: receiveDesktop, sendMobile: receiveMobile });
+        }),
+      );
+    } catch (error) {
+      logger.error('[NotificationService] Failed to send planning risk notification:', error);
+    }
+  }
+
+  /**
    * Shared pipeline for status-like ticket events - same TICKET_STATUS_CHANGE
    * preferences and delivery for every flavour. Callers own the finished copy;
    * the fetch below is only for routing (channel, conversation, actionUrl).

--- a/apps/backend/src/services/stageTransition/ticketStageTransitionService.ts
+++ b/apps/backend/src/services/stageTransition/ticketStageTransitionService.ts
@@ -4,11 +4,22 @@ import { DatabaseClient } from '@/database/client';
 import { logger } from '@/utils/logger';
 import { calculateETADeadline } from '@/utils/etaCalculation';
 import { syncConversationTicketMdFromPrismaTicket } from '@/utils/ticketMd';
-import { FormEntityType, BoardType, VisitSlaMode, ReenterMode, TicketStageRequestStatus, ApproverType } from '@xyne/shared';
+import { FormEntityType, BoardType, ReenterMode, TicketStageRequestStatus, ApproverType, TicketStatusV2, parseTicketEtaManagement, mergeTicketEtaManagement } from '@xyne/shared';
 import { formService } from '@/services/formService';
 import { decideVisitVersion, foldFormRowsToValues } from './visitVersioning';
 import { maybeCreateEntryApprovalRequest } from './stageEntryApproval';
 import { syncStageOverdueFlag } from '@/services/tickets/syncStageOverdueFlag';
+import { getTicketBotActorId } from '@/utils/etaNotificationUtils';
+import {
+  resolveStepEstimate,
+  loadBoardEtaContext,
+  evaluateEta,
+  buildEtaActivityIntents,
+  isTerminalStatus,
+  dispatchEtaNotifications,
+  etaSignalsFromResult,
+  writeEtaActivitiesPrisma,
+} from '@/services/etaManagement';
 
 const prisma = DatabaseClient.getInstance();
 
@@ -294,6 +305,10 @@ export class TicketStageTransitionService {
     }
 
     // ── 8. Execute transition ───────────────────────────────────────────────
+    // Resolved outside the transaction: a stable bot-user lookup, not part of the
+    // transactional state, and best kept off the held connection.
+    const systemActorId = await getTicketBotActorId(ticket.workspaceId);
+
     const result = await prisma.$transaction(async (tx) => {
       const now = new Date();
 
@@ -391,8 +406,12 @@ export class TicketStageTransitionService {
         existingEtaToReopen = decision.existingEtaId ? { id: decision.existingEtaId } : null;
       }
 
-      // 8c. Compute stage ETA
-      const stageEta = this.computeStageEta(now, targetStage.eta, transition);
+      // 8c. Compute stage ETA (shared decision table with the ETA domain service, so the
+      // live entry path and the forecast path can never drift - see estimateResolution.ts).
+      const stepEstimate = resolveStepEstimate(targetStage, transition, {
+        requireExplicitTransition: false,
+      });
+      const stageEta = stepEstimate.hours > 0 ? calculateETADeadline(now, stepEstimate.hours) : now;
 
       // 8d. Create or reopen TicketStageEta
       if (existingEtaToReopen) {
@@ -430,17 +449,90 @@ export class TicketStageTransitionService {
         });
       }
 
-      // 8e. Update ticket stage
+      // 8d-2. ETA domain-service evaluation: forecast (extend-only) + planning-risk state.
+      // Re-read the active visit rather than trusting local branch variables above, since a
+      // CONTINUE-preserved reopen leaves the row's stageEta untouched (not `stageEta` as
+      // just computed) - this is the one authoritative source for "the actual deadline now
+      // in effect" regardless of which branch fired.
+      const activeVisitRow = await tx.ticketStageEta.findFirst({
+        where: { ticketId, stageId: targetStage.id, stageLeftAt: null },
+        orderBy: { createdAt: 'desc' },
+      });
+      const deadlineTracked = activeVisitRow
+        ? activeVisitRow.stageEta.getTime() !== activeVisitRow.stageEnteredAt.getTime()
+        : false;
+      // metadata AND eta were both read before this transaction opened, so a concurrent write
+      // (e.g. acknowledgeEtaRisk, or a manual due-date edit) landing before ours would be lost.
+      // FOR UPDATE locks the row so that can't happen. Both locked values feed evaluateEta:
+      // eta is the extend-only baseline and a fingerprint input, so a stale one could decide
+      // against - and then overwrite - a due date someone else just moved.
+      const [lockedTicket] = await tx.$queryRaw<{ metadata: unknown; eta: Date | null }[]>`
+        SELECT "metadata", "eta"
+        FROM "tickets"
+        WHERE "id" = ${ticketId}
+        FOR UPDATE
+      `;
+      const lockedEta = lockedTicket?.eta ?? null;
+      const boardEtaCtx = await loadBoardEtaContext(tx, ticket.boardId);
+      const currentTicketEtaManagement = parseTicketEtaManagement(lockedTicket?.metadata);
+
+      const etaResult = evaluateEta({
+        ticketId,
+        ticketStatus: ticket.statusV2,
+        isTerminal: isTerminalStatus(ticket.statusV2),
+        currentTicketEta: lockedEta,
+        currentTicketEtaManagement,
+        boardType: boardEtaCtx.boardType,
+        boardEtaManagement: boardEtaCtx.boardEtaManagement,
+        currentStageId: targetStage.id,
+        stages: boardEtaCtx.stages,
+        transitions: boardEtaCtx.transitions,
+        activeVisit: {
+          stageVisitId: activeVisitRow?.id ?? null,
+          transitionId: transition?.id ?? null,
+          deadline: activeVisitRow?.stageEta ?? null,
+          deadlineTracked,
+          estimateSource: stepEstimate.source,
+          estimateHours: stepEstimate.incomplete ? null : stepEstimate.hours,
+        },
+        trigger: 'STAGE_TRANSITION',
+        now,
+      });
+
+      // 8e. Update ticket stage (+ ETA/metadata from the domain-service evaluation, in the
+      // same write - never a second `ticket.update` call for the same transaction).
+      const mergedMetadata = mergeTicketEtaManagement(lockedTicket?.metadata, etaResult.ticketEtaManagementPatch);
       const updatedTicket = await tx.ticket.update({
         where: { id: ticketId },
         data: {
           stageName: toStageName,
           updatedBy: userId,
           updatedAt: now,
+          ...(etaResult.etaDecision.changed && etaResult.etaDecision.newEta
+            ? { eta: etaResult.etaDecision.newEta }
+            : {}),
+          metadata: mergedMetadata as Prisma.InputJsonValue,
         },
       });
 
       await syncStageOverdueFlag(tx, ticketId, now);
+      // 8e-2. Audit trail for the ETA evaluation (auto-recompute, risk detected/reopened/
+      // resolved, forecast-incomplete) - attributed to the system actor since these are
+      // computed by automatic recalculation, not authored by the transitioning user.
+      const activityIntents = buildEtaActivityIntents(etaResult, {
+        currentStageId: targetStage.id,
+        oldEta: lockedEta ? lockedEta.getTime() : null,
+        trigger: 'STAGE_TRANSITION',
+        systemReason: `Automatic recalculation after moving to stage "${toStageName}"`,
+        previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+      });
+      await writeEtaActivitiesPrisma(tx, activityIntents, {
+        ticketId,
+        workspaceId: ticket.workspaceId,
+        channelId: ticket.channelId,
+        timestamp: now.getTime(),
+        systemActorId,
+      });
 
       // 8f. Persist form values (scoped to stage + visitIndex)
       if (formValues && transition?.formId) {
@@ -455,7 +547,7 @@ export class TicketStageTransitionService {
         );
       }
 
-      return { updatedTicket, newVisitIndex };
+      return { updatedTicket, newVisitIndex, etaResult };
     });
 
     // Sync conversation ticket_md outside the transaction
@@ -473,46 +565,27 @@ export class TicketStageTransitionService {
     // would only add latency to the transition response.
     void maybeCreateEntryApprovalRequest(ticketId, userId, toStageName);
 
+    // Post-commit notification dispatch - best-effort, must never affect the already-
+    // committed transition response. suppressed while the ticket is paused.
+    if (result.updatedTicket.statusV2 !== TicketStatusV2.PAUSED) {
+      void dispatchEtaNotifications(etaSignalsFromResult(result.etaResult), {
+        ticketId,
+        createdBy: ticket.createdBy,
+        assignedTo: ticket.assignedTo,
+        ticketUserGroupId: ticket.userGroupId,
+        boardId: ticket.boardId,
+        actorId: userId,
+      }).catch(error => {
+        logger.error('[TicketStageTransitionService] Failed to dispatch ETA notifications', { ticketId, error });
+      });
+    }
+
     return {
       success: true,
       ticket: result.updatedTicket,
       transition: transition || undefined,
       newVisitIndex: result.newVisitIndex,
     };
-  }
-
-  /**
-   * Compute the stage ETA deadline based on the transition's SLA mode.
-   */
-  private computeStageEta(
-    enteredAt: Date,
-    stageEtaHours: number | null,
-    transition: StageTransition | null,
-  ): Date {
-    const slaMode = transition?.visitSlaMode ?? VisitSlaMode.STAGE_DEFAULT;
-
-    switch (slaMode) {
-      case VisitSlaMode.FIXED_HOURS:
-        if (transition?.fixedEtaHours && transition.fixedEtaHours > 0) {
-          return calculateETADeadline(enteredAt, transition.fixedEtaHours);
-        }
-        // Fall through to stage default if fixed hours not set
-        if (stageEtaHours && stageEtaHours > 0) {
-          return calculateETADeadline(enteredAt, stageEtaHours);
-        }
-        return enteredAt;
-
-      case VisitSlaMode.NONE:
-        // No SLA tracking; use enteredAt as placeholder (schema requires non-null DateTime)
-        return enteredAt;
-
-      case VisitSlaMode.STAGE_DEFAULT:
-      default:
-        if (stageEtaHours && stageEtaHours > 0) {
-          return calculateETADeadline(enteredAt, stageEtaHours);
-        }
-        return enteredAt;
-    }
   }
 
   /**

--- a/apps/backend/src/workers/stageEtaDeadlineWorker.ts
+++ b/apps/backend/src/workers/stageEtaDeadlineWorker.ts
@@ -1,11 +1,53 @@
+import { Prisma } from '@prisma/client';
 import { logger } from '@/utils/logger';
 import { db, readReplicaDb } from '@/database/client';
+import { runAsServiceActor } from '@/database/tenant/context';
 import { stageEtaDeadlineQueue } from '@/queues/stageEtaDeadlineQueue';
-import { OPEN_STATUSES } from '@/utils/etaNotificationUtils';
-import { Prisma } from '@prisma/client';
+import {
+  getTicketBotActorId,
+  TicketWithStageInfo,
+  OPEN_STATUSES,
+} from '@/utils/etaNotificationUtils';
+import {
+  parseTicketEtaManagement,
+  mergeTicketEtaManagement,
+  BoardType,
+} from '@xyne/shared';
+import { recordTicketTimelineEvent } from '@/services/ticketTimelineEventService';
+import {
+  evaluatePlanningRisk,
+  buildRiskTransitionActivityIntents,
+  dispatchEtaNotifications,
+  etaSignalsFromResult,
+} from '@/services/etaManagement';
 
+interface TicketForReconciliation extends TicketWithStageInfo {
+  boardId: string;
+  userGroupId: string | null;
+  statusV2: string;
+  metadata: unknown;
+}
+
+// Batching for the bulk `isStageOverdue` flag sync.
 const BATCH_SIZE = parseInt(process.env.STAGE_ETA_DEADLINE_BATCH_SIZE || '15', 10);
 const BATCH_SLEEP_MS = parseInt(process.env.STAGE_ETA_DEADLINE_BATCH_SLEEP_MS || '1000', 10);
+
+// Batching for the planning-risk reconciliation pass, which does per-ticket writes
+// (metadata + timeline + notifications) rather than a bulk `updateMany`.
+const STAGE_ETA_REMINDER_BATCH_SIZE = 15;
+const STAGE_ETA_REMINDER_BATCH_DELAY_MS = 1000;
+// Page size for both cursor-paginated TicketStageEta scans below - shared so the two
+// stay in sync rather than drifting as two separately-tuned magic numbers.
+const QUERY_BATCH_SIZE = 10000;
+
+const chunkArray = <T>(items: T[], chunkSize: number): T[][] => {
+  if (chunkSize <= 0) return [items];
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
+};
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -47,7 +89,13 @@ class StageEtaDeadlineWorker {
       logger.info(
         '[STAGE-ETA-DEADLINE-WORKER] Processing stage ETA deadline check job',
       );
-      await this.syncStageOverdueFlags();
+      const now = new Date();
+      // Two independent passes over the same hourly tick, split by which side of `now`
+      // the active visit's deadline falls on: already-breached visits drive the
+      // denormalized `isStageOverdue` flag, not-yet-breached ones drive planning-risk
+      // reconciliation.
+      await this.syncStageOverdueFlags(now);
+      await this.reconcileOpenTicketPlanningRisk(now);
       logger.info('[STAGE-ETA-DEADLINE-WORKER] Stage ETA deadline check completed');
     } catch (error) {
       logger.error('[STAGE-ETA-DEADLINE-WORKER] Error checking stage ETA deadlines:', error);
@@ -127,6 +175,281 @@ class StageEtaDeadlineWorker {
 
     return allOverdueTicketIds;
   }
+
+  /**
+   * Loads the not-yet-breached active visits (`stageEta > now`) that planning-risk
+   * reconciliation operates on. Deliberately the complement of `getOverdueTicketIds`:
+   * once a stage deadline is breached it stops being a *planning* risk and becomes a
+   * stage-overdue condition, which the flag sync above owns.
+   */
+  private async reconcileOpenTicketPlanningRisk(now: Date): Promise<void> {
+    // Tickets whose overall ETA is already breached are excluded - the daily
+    // ticket-overdue worker owns those, and ticket-overdue outranks planning risk.
+    const todayMidnight = new Date(now);
+    todayMidnight.setHours(0, 0, 0, 0);
+
+    // Cursor-paginated and read-replica, like getOverdueTicketIds - and processed one page
+    // at a time (fetch, evaluate/write, discard, repeat) rather than accumulated into one
+    // array first, since each row here carries a full nested ticket including its metadata
+    // JSON blob. Unlike the ID-only overdue scan, an unbounded version of this query holds
+    // that full payload for every matching visit in a large workspace at once.
+    const readerDb = readReplicaDb ?? db;
+    let cursor: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const entries = await readerDb.ticketStageEta.findMany({
+        where: {
+          stageLeftAt: null,
+          stageEta: { gt: now },
+          ticket: {
+            statusV2: { in: OPEN_STATUSES },
+            OR: [
+              { eta: null },
+              { eta: { gte: todayMidnight } },
+            ],
+          },
+        },
+        select: {
+          id: true,
+          ticketId: true,
+          stageId: true,
+          stageEta: true,
+          stageEnteredAt: true,
+          ticket: {
+            select: {
+              id: true,
+              xyneId: true,
+              assignedTo: true,
+              createdBy: true,
+              channelId: true,
+              conversationId: true,
+              stageName: true,
+              eta: true,
+              workspaceId: true,
+              boardId: true,
+              userGroupId: true,
+              statusV2: true,
+              metadata: true,
+            },
+          },
+        },
+        take: QUERY_BATCH_SIZE,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+        orderBy: { id: 'asc' },
+      });
+
+      if (entries.length > 0) {
+        const ticketMap = new Map<string, TicketForReconciliation>(
+          entries.map(e => [e.ticketId, e.ticket as TicketForReconciliation]),
+        );
+
+        const stageIds = [...new Set(entries.map(e => e.stageId))];
+        const stages = await readerDb.stage.findMany({
+          where: { id: { in: stageIds } },
+          select: { id: true, name: true, eta: true },
+        });
+        const stageMap = new Map(stages.map(s => [s.id, s]));
+
+        await this.reconcilePlanningRisk(entries, ticketMap, stageMap, now);
+      }
+
+      hasMore = entries.length === QUERY_BATCH_SIZE;
+      if (hasMore) {
+        cursor = entries[entries.length - 1].id;
+      }
+    }
+  }
+
+  /**
+   * Scheduled counterpart to the immediate planning-risk evaluation wired into every ticket
+   * mutation path (services/etaManagement).
+   *
+   * Note it is NOT the clock that creates work here: the risk condition includes
+   * `now <= stageDeadline`, so as time passes the condition can only go true -> false. Time
+   * ends a planning risk (it becomes stage-overdue); it can never start one. What this pass
+   * catches is tickets never evaluated at all - written before this feature existed, or by a
+   * path that doesn't run the immediate evaluation (imports, flow cascades). Their metadata
+   * parses to state NONE even though the condition is already true.
+   *
+   * A board ETA-config change does NOT reopen an acknowledged/active risk on its own - the
+   * fingerprint depends only on the ticket's own stageEta/ticketEta/status/visit, all of
+   * which this pass reads fresh from current settings on every run, but none of which a
+   * config change alone can move. It only reopens if that fresh read produces a genuinely
+   * different value (e.g. auto-recompute pushing the due date out).
+   *
+   * Scope is deliberately the pre-breach window only - the loader filters `stageEta > now`,
+   * so a visit whose deadline has already passed is not seen here at all; that is
+   * stage-overdue, owned by syncStageOverdueFlags. One consequence: a risk that was ACTIVE
+   * when its deadline passed keeps that state until the ticket's next mutation. It is
+   * masked in the UI (stage-overdue outranks planning risk), but the stored state is stale.
+   *
+   * Read-only with respect to `Ticket.eta`/forecasts: it only ever updates the persisted
+   * planning-risk state, never extends a due date.
+   */
+  private async reconcilePlanningRisk(
+    entries: Array<{
+      id: string;
+      ticketId: string;
+      stageId: string;
+      stageEta: Date;
+      stageEnteredAt: Date;
+    }>,
+    ticketMap: Map<string, TicketForReconciliation>,
+    stageMap: Map<string, { id: string; name: string; eta: number | null }>,
+    now: Date,
+  ): Promise<void> {
+    if (entries.length === 0) return;
+
+    const boardIds = [
+      ...new Set(
+        entries
+          .map(e => ticketMap.get(e.ticketId)?.boardId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    const boards = await db.board.findMany({
+      where: { id: { in: boardIds } },
+      select: { id: true, boardType: true },
+    });
+    const boardMap = new Map(boards.map(b => [b.id, b]));
+
+    const metrics = { detected: 0, reopened: 0, resolved: 0, skippedStale: 0, evaluated: 0 };
+    const startedAt = Date.now();
+
+    const batches = chunkArray(entries, STAGE_ETA_REMINDER_BATCH_SIZE);
+
+    for (let batchIndex = 0; batchIndex < batches.length; batchIndex += 1) {
+      const batch = batches[batchIndex]!;
+
+      for (const entry of batch) {
+        const ticket = ticketMap.get(entry.ticketId);
+        if (!ticket) continue;
+
+        const board = boardMap.get(ticket.boardId);
+        // Flow boards are deferred this release; detection must not synthesize forecasts/
+        // visits there. Non-linear/Release boards are fine here since we only ever compare
+        // the ticket's OWN active visit deadline against its due date - no route needed.
+        if (!board || board.boardType === BoardType.FLOW) continue;
+
+        // Guard against a stale/orphaned open entry left over from a stage transition that
+        // didn't close it (same check the overdue branch above applies) - only evaluate risk
+        // against the entry that matches the ticket's actual current stage.
+        const stage = stageMap.get(entry.stageId);
+        if (!stage || stage.name !== ticket.stageName) continue;
+
+        const currentTicketEtaManagement = parseTicketEtaManagement(ticket.metadata);
+        const deadlineTracked = entry.stageEta.getTime() !== entry.stageEnteredAt.getTime();
+
+        metrics.evaluated += 1;
+        const decision = evaluatePlanningRisk({
+          ticketId: ticket.id,
+          activeStageVisitId: entry.id,
+          stageDeadline: entry.stageEta,
+          deadlineTracked,
+          ticketDue: ticket.eta,
+          ticketStatus: ticket.statusV2,
+          now,
+          currentRisk: currentTicketEtaManagement.planningRisk,
+          isTerminal: false, // OPEN_STATUSES excludes COMPLETED/CANCELLED already
+        });
+
+        if (decision.transitionKind === 'UNCHANGED') continue;
+
+        // Re-check the persisted fingerprint under a row lock and write in the same
+        // transaction, so an overlapping run or a retry can't pass the check and then
+        // both write. Without the lock this is check-then-write: two workers could
+        // duplicate the risk activities and notify twice for one fingerprint.
+        const systemActorId = await getTicketBotActorId(ticket.workspaceId);
+        const committed = await runAsServiceActor(
+          'stage-eta-deadline-worker',
+          ticket.workspaceId,
+          async () =>
+            db.$transaction(async tx => {
+              const [locked] = await tx.$queryRaw<{ metadata: unknown }[]>`
+                SELECT "metadata"
+                FROM "tickets"
+                WHERE "id" = ${ticket.id}
+                FOR UPDATE
+              `;
+              const freshRisk = parseTicketEtaManagement(locked?.metadata).planningRisk;
+              if (freshRisk.fingerprint !== currentTicketEtaManagement.planningRisk.fingerprint) {
+                return false;
+              }
+
+              const mergedMetadata = mergeTicketEtaManagement(locked?.metadata, {
+                planningRisk: decision.nextState,
+              });
+              await tx.ticket.update({
+                where: { id: ticket.id },
+                data: { metadata: mergedMetadata as Prisma.InputJsonValue },
+              });
+
+              const intents = buildRiskTransitionActivityIntents(decision, {
+                currentStageId: entry.stageId,
+                oldEta: ticket.eta ? ticket.eta.getTime() : null,
+                trigger: 'RECONCILIATION',
+                systemReason: 'Hourly reconciliation detected a planning-risk state change',
+                previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+              });
+              for (const intent of intents) {
+                await recordTicketTimelineEvent(
+                  {
+                    activity: {
+                      ticketId: ticket.id,
+                      updatedBy: systemActorId,
+                      activityType: intent.activityType,
+                      value: intent.value as Prisma.InputJsonValue,
+                      workspaceId: ticket.workspaceId,
+                      channelId: ticket.channelId,
+                    },
+                  },
+                  tx,
+                );
+              }
+              return true;
+            }),
+        );
+
+        if (!committed) {
+          metrics.skippedStale += 1;
+          continue;
+        }
+
+        // Post-commit, and never while paused. Only the run that actually won the lock
+        // reaches here, so one fingerprint notifies once.
+        if (ticket.statusV2 !== 'PAUSED') {
+          await runAsServiceActor('stage-eta-deadline-worker', ticket.workspaceId, () =>
+            dispatchEtaNotifications(
+              etaSignalsFromResult({ etaDecision: { newEta: null, changed: false }, planningRisk: decision }),
+              {
+                ticketId: ticket.id,
+                createdBy: ticket.createdBy ?? systemActorId,
+                assignedTo: ticket.assignedTo,
+                ticketUserGroupId: ticket.userGroupId,
+                boardId: ticket.boardId,
+                actorId: systemActorId,
+              },
+            ),
+          );
+        }
+
+        if (decision.transitionKind === 'DETECTED') metrics.detected += 1;
+        else if (decision.transitionKind === 'REOPENED') metrics.reopened += 1;
+        else if (decision.transitionKind === 'RESOLVED') metrics.resolved += 1;
+      }
+
+      if (batchIndex < batches.length - 1) {
+        await sleep(STAGE_ETA_REMINDER_BATCH_DELAY_MS);
+      }
+    }
+
+    logger.info('[STAGE-ETA-DEADLINE-WORKER] Planning-risk reconciliation complete', {
+      ...metrics,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+
 
   async shutdown(): Promise<void> {
     await stageEtaDeadlineQueue.close();

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -102,6 +102,11 @@ import {
   entityLinkContextSchema,
   updateSubTicketsMdFromZero,
   linkSubTicketConversationToParentFromZero,
+  parseBoardEtaManagement,
+  mergeBoardEtaManagement,
+  parseTicketEtaManagement,
+  mergeTicketEtaManagement,
+  type EtaRiskAcknowledgedActivityValue,
 } from '@xyne/shared';
 import {
   normalizeThreadTypeName,
@@ -119,6 +124,16 @@ import {
   withSlashCommandArtifactClosed,
 } from '@xyne/shared';
 import { isBaselineCanvasType, sdlcTrackStatusSchema } from '@xyne/shared';
+import {
+  evaluateEta,
+  buildEtaActivityIntents,
+  stageEtaActivityOutbox,
+  isTerminalStatus,
+  canUserModifyTicketControl,
+  msToDate,
+  dateToMs,
+  loadZeroEtaContext,
+} from '@/services/etaManagement';
 import {
   FLOW_STAGE_NAMES,
   FlowPlanSchema,
@@ -5818,6 +5833,7 @@ export function createMutators(
           isArchived: z.boolean().optional(),
           kanbanPosition: z.string().nullable().optional(),
           updatedAt: z.number(),
+          // Optional optimistic-concurrency guard + audit reason for a manual `eta` edit.
         }),
         async ({ tx, args: params }) => {
           const ticket = await tx.run(zql.tickets.where('id', params.id).one());
@@ -5894,50 +5910,69 @@ export function createMutators(
           const isAssigneeChanging = params.assignedTo !== undefined && params.assignedTo !== ticket.assignedTo;
           const isEtaChanging = params.eta !== undefined && params.eta !== ticket.eta;
           const isBoardChanging = params.boardId !== undefined && params.boardId !== ticket.boardId;
+          const isStageChanging = params.stageName !== undefined && params.stageName !== ticket.stageName;
+          const isEnteringTerminal =
+            params.statusV2 !== undefined &&
+            params.statusV2 !== ticket.statusV2 &&
+            (params.statusV2 === TicketStatusV2.COMPLETED || params.statusV2 === TicketStatusV2.CANCELLED);
+          const isLeavingTerminal =
+            params.statusV2 !== undefined &&
+            params.statusV2 !== ticket.statusV2 &&
+            (ticket.statusV2 === TicketStatusV2.COMPLETED || ticket.statusV2 === TicketStatusV2.CANCELLED);
+          const isResumingFromPause =
+            params.statusV2 !== undefined &&
+            ticket.statusV2 === TicketStatusV2.PAUSED &&
+            params.statusV2 !== TicketStatusV2.PAUSED;
+          // Board/etaManagement context, fetched once and reused by both the permission gate
+          // below and the ETA domain-service evaluation further down - only when one of the
+          // triggers that actually needs it is present, so an unrelated field edit (title,
+          // description, ...) never pays for this lookup.
+          const needsBoardEtaContext =
+            isAssigneeChanging ||
+            isEtaChanging ||
+            isBoardChanging ||
+            isStageChanging ||
+            isEnteringTerminal ||
+            isLeavingTerminal ||
+            isResumingFromPause;
+          const etaBoard = needsBoardEtaContext
+            ? await tx.run(zql.boards.where('id', ticket.boardId).one())
+            : null;
+          const boardEtaManagement = parseBoardEtaManagement(etaBoard?.metadata ?? null, etaBoard?.boardType ?? BoardType.DEFAULT);
 
-          if ((isAssigneeChanging || isEtaChanging || isBoardChanging) && ticket.userGroupId) {
-            // Get board to check if transfer is restricted
-            const board = await tx.run(zql.boards.where("id", ticket.boardId).one());
+          // Stage-only moves are gated because a move can trigger auto-recompute, so an
+          // ungated one is an indirect way to change the due date. The assignee is exempt:
+          // they are the one doing the work, and requiring a configured role just to progress
+          // their own ticket would break the normal workflow. Any other controlled change in
+          // the same call (eta/assignee/board) still gates them normally via the flags below.
+          const isActorAssignee = ticket.assignedTo === authData.sub;
+          const isStageChangingGated =
+            isStageChanging && boardEtaManagement.autoRecomputeEnabled && !isActorAssignee;
 
-            if (board?.metadata && typeof board.metadata === 'object') {
-              const metadata = board.metadata as BoardMetadata;
-
-              const controlRoleIds = Array.isArray(metadata.ticketControlRoleIds)
-                ? metadata.ticketControlRoleIds
-                : [];
-              // Restriction fires when the board has ticketControlRoleIds set
-              // (role-driven path) OR the legacy isAllowedToTransfer toggle is on
-              // (enum fallback). Boards with neither are unrestricted.
-              if (controlRoleIds.length > 0 || metadata.isAllowedToTransfer === true) {
-                // User must be part of the current user group with proper responsibility
-                const userGroupMapping = await tx.run(
-                  zql.user_group_mappings
-                    .where("userId", authData.sub)
-                    .where("userGroupId", ticket.userGroupId)
-                    .one()
-                );
-
-                if (!userGroupMapping) {
-                  throw new Error('You must be a member of the current user group to modify this ticket');
-                }
-
-                if (controlRoleIds.length > 0) {
-                  // Role-driven: raw roleId membership. Works for custom roles.
-                  if (!userGroupMapping.roleId || !controlRoleIds.includes(userGroupMapping.roleId)) {
-                    throw new Error('Only users with a configured role can modify Assignee, ETA, Stage, or Board on this board');
-                  }
-                } else {
-                  // Legacy enum fallback (only fires when isAllowedToTransfer===true).
-                  const responsibility = userGroupMapping.responsibility;
-                  if (responsibility !== UserResponsibility.MANAGER && responsibility !== UserResponsibility.TEAM_LEAD) {
-                    throw new Error('Only users with MANAGER or TEAM_LEAD responsibility can modify Assignee, ETA, Stage, or Board on this board');
-                  }
-                }
-              }
+          if ((isAssigneeChanging || isEtaChanging || isBoardChanging || isStageChangingGated) && ticket.userGroupId) {
+            const permission = await canUserModifyTicketControl(
+              authData.sub,
+              ticket.userGroupId,
+              ticket.boardId,
+              {
+                getBoardMetadata: async () => etaBoard?.metadata ?? null,
+                getUserGroupMapping: async (userId, userGroupId) => {
+                  const mapping = await tx.run(
+                    zql.user_group_mappings.where('userId', userId).where('userGroupId', userGroupId).one(),
+                  );
+                  return mapping
+                    ? { roleId: mapping.roleId ?? null, responsibility: mapping.responsibility ?? null }
+                    : null;
+                },
+              },
+            );
+            if (!permission.allowed) {
+              throw new Error(permission.reason ?? 'Not authorized to modify this ticket');
             }
           }
 
           const updateData: any = { updatedAt: params.updatedAt, updatedBy: authData.sub };
+          let latestTicketMetadata: unknown = ticket.metadata;
           const activities: any[] = [];
           const fields = ['title', 'description', 'statusV2', 'priority', 'stageName', 'assignedTo', 'userGroupId', 'eta', 'boardId', 'metadata', 'isArchived', 'kanbanPosition', 'ticketType'] as const;
           const oldAssignedTo = ticket.assignedTo;
@@ -5972,13 +6007,10 @@ export function createMutators(
 
             const firstStage = newBoardStages[0];
 
-            // 2. Calculate total ETA from new board's stages (same logic as ticket creation)
-            const totalEtaHours = newBoardStages.reduce((sum, stage) => sum + (stage.eta || 0), 0);
-            const newTicketEta = totalEtaHours > 0
-              ? calculateETADeadline(new Date(now), totalEtaHours).getTime()
-              : null;
-
-            // 3. Update ticket with first stage and new ETA
+            // 2. Update ticket with first stage. `eta` is deliberately left untouched here -
+            // an automatic due date is only ever set/changed by the domain-service
+            // evaluation below, and only when the target board has opted into automatic ETA
+            // management.
             const existingTicketsInFirstStage = await tx.run(
               zql.tickets
                 .where('boardId', params.boardId)
@@ -6000,7 +6032,6 @@ export function createMutators(
               ...(firstStage.defaultTicketStatusV2 && {
                 statusV2: firstStage.defaultTicketStatusV2
               }),
-              ...(newTicketEta && { eta: newTicketEta }),
               kanbanPosition: newKanbanPosition,
               updatedAt: now,
               updatedBy: authData.sub
@@ -6033,6 +6064,59 @@ export function createMutators(
                 updatedBy: authData.sub
               });
             }
+            // Forecast from the new board's first stage onward, extend-only against the
+            // ticket's pre-transfer due date. Boards without automation keep their date.
+            const targetBoardEtaManagement = parseBoardEtaManagement(targetBoard?.metadata ?? null, targetBoard?.boardType ?? BoardType.DEFAULT);
+            if (targetBoardEtaManagement.autoRecomputeEnabled) {
+              const effectiveStatusV2 = firstStage.defaultTicketStatusV2 ?? ticket.statusV2;
+              const etaCtx = await loadZeroEtaContext(tx, {
+                ticketId: params.id,
+                boardId: params.boardId,
+                ticketMetadata: ticket.metadata,
+                stage: firstStage,
+                stages: newBoardStages,
+              });
+              const { currentTicketEtaManagement } = etaCtx;
+
+              const etaResult = evaluateEta({
+                ticketId: params.id,
+                ticketStatus: effectiveStatusV2,
+                isTerminal: isTerminalStatus(effectiveStatusV2),
+                currentTicketEta: msToDate(ticket.eta),
+                currentTicketEtaManagement,
+                boardType: targetBoard?.boardType ?? '',
+                boardEtaManagement: targetBoardEtaManagement,
+                currentStageId: firstStage.id,
+                stages: etaCtx.stages,
+                transitions: etaCtx.transitions,
+                activeVisit: etaCtx.activeVisit,
+                trigger: 'STAGE_TRANSITION',
+                now: new Date(now),
+              });
+
+              const boardTransferActivityIntents = buildEtaActivityIntents(etaResult, {
+                currentStageId: firstStage.id,
+                oldEta: ticket.eta ?? null,
+                trigger: 'STAGE_TRANSITION',
+                systemReason: `Automatic recalculation after moving ticket to board "${targetBoard?.name ?? params.boardId}"`,
+                previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+              });
+              const mergedMetadata = mergeTicketEtaManagement(latestTicketMetadata, {
+                ...etaResult.ticketEtaManagementPatch,
+                pendingActivities: stageEtaActivityOutbox(boardTransferActivityIntents, now),
+              });
+              latestTicketMetadata = mergedMetadata;
+              await tx.mutate.tickets.update({
+                id: params.id,
+                ...(etaResult.etaDecision.changed && etaResult.etaDecision.newEta
+                  ? { eta: etaResult.etaDecision.newEta.getTime() }
+                  : {}),
+                metadata: mergedMetadata as ReadonlyJSONValue,
+                updatedAt: now,
+              });
+
+            }
+
             if (ticket.userGroupId) {
               // Fire and forget - retrigger autoassignment for the new board
               asyncTasks.push(async () => {
@@ -6370,6 +6454,99 @@ export function createMutators(
             }
           }
 
+          // Every trigger this mutator can produce that needs ETA re-evaluation. NON_LINEAR
+          // direct stage changes already threw above.
+          let etaActivityIntentsForTicketUpdate: ReturnType<typeof buildEtaActivityIntents> = [];
+          // Skipped when isBoardChanging: this block resolves the stage from the
+          // pre-transfer ticket.boardId, so running it here would clobber the transfer
+          // branch's already-correct evaluation with one against the deleted old visit.
+          const needsEtaEvaluation =
+            !isBoardChanging &&
+            (isStageChanging || isEtaChanging || isEnteringTerminal || isLeavingTerminal || isResumingFromPause);
+
+          if (needsEtaEvaluation) {
+            const effectiveStageName = (updateData.stageName as string | undefined) ?? ticket.stageName;
+            const effectiveStatusV2 = (updateData.statusV2 as string | undefined) ?? ticket.statusV2;
+            const effectiveStage = effectiveStageName
+              ? await tx.run(zql.stages.where('boardId', ticket.boardId).where('name', effectiveStageName).one())
+              : null;
+
+            if (effectiveStage) {
+              const etaCtx = await loadZeroEtaContext(tx, {
+                ticketId: params.id,
+                boardId: ticket.boardId,
+                ticketMetadata: ticket.metadata,
+                stage: effectiveStage,
+              });
+              const { currentTicketEtaManagement } = etaCtx;
+
+              // A manual due-date change or terminal-only transition must not let an automatic
+              // forecast override the value just set. Detection still runs either way.
+              const evalBoardEtaManagement =
+                isStageChanging || isResumingFromPause
+                  ? boardEtaManagement
+                  : { ...boardEtaManagement, autoRecomputeEnabled: false };
+
+              const baselineEtaMs = (updateData.eta as number | undefined) ?? ticket.eta ?? null;
+              const trigger = isStageChanging
+                ? 'STAGE_TRANSITION'
+                : isResumingFromPause
+                  ? 'RESUME'
+                  : isEnteringTerminal
+                    ? 'TERMINAL_ENTRY'
+                    : isLeavingTerminal
+                      ? 'TERMINAL_EXIT'
+                      : 'MANUAL_DUE_DATE';
+
+              const etaResult = evaluateEta({
+                ticketId: params.id,
+                ticketStatus: effectiveStatusV2,
+                isTerminal: isTerminalStatus(effectiveStatusV2),
+                currentTicketEta: msToDate(baselineEtaMs),
+                currentTicketEtaManagement,
+                boardType: etaBoard?.boardType ?? '',
+                boardEtaManagement: evalBoardEtaManagement,
+                currentStageId: effectiveStage.id,
+                stages: etaCtx.stages,
+                transitions: etaCtx.transitions,
+                activeVisit: etaCtx.activeVisit,
+                trigger,
+                now: new Date(params.updatedAt),
+              });
+
+              if (etaResult.etaDecision.changed && etaResult.etaDecision.newEta) {
+                updateData.eta = etaResult.etaDecision.newEta.getTime();
+              }
+              updateData.metadata = mergeTicketEtaManagement(
+                updateData.metadata ?? latestTicketMetadata,
+                etaResult.ticketEtaManagementPatch,
+              );
+
+              etaActivityIntentsForTicketUpdate = buildEtaActivityIntents(etaResult, {
+                currentStageId: effectiveStage.id,
+                oldEta: ticket.eta ?? null,
+                trigger,
+                systemReason: isStageChanging
+                  ? `Automatic recalculation after moving to stage "${params.stageName}"`
+                  : isResumingFromPause
+                    ? 'Automatic recalculation after resuming from pause'
+                    : isEnteringTerminal || isLeavingTerminal
+                      ? 'Planning risk resolved on terminal status change'
+                      : 'Planning risk re-evaluated after manual due-date change',
+                previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+              });
+            }
+          }
+
+          if (etaActivityIntentsForTicketUpdate.length > 0) {
+            updateData.metadata = mergeTicketEtaManagement(updateData.metadata ?? latestTicketMetadata, {
+              pendingActivities: stageEtaActivityOutbox(
+                etaActivityIntentsForTicketUpdate,
+                params.updatedAt,
+              ),
+            });
+          }
+
           await tx.mutate.tickets.update({ id: params.id, ...updateData });
 
           if (
@@ -6646,6 +6823,98 @@ export function createMutators(
           }
         },
       ),
+      /**
+       * Acknowledge the ticket's CURRENT planning-risk fingerprint: records that an
+       * authorized user reviewed this exact risk condition and intentionally kept the
+       * current values. Hides the actionable banner but never changes either ETA. Requires
+       * `expectedFingerprint` to match the persisted fingerprint at write time (optimistic
+       * concurrency - a stale client must refetch and retry rather than silently
+       * acknowledging a condition that has since changed).
+       */
+      acknowledgeEtaRisk: defineMutator(
+        z.object({
+          ticketId: z.string(),
+          expectedFingerprint: z.string(),
+          reason: z.string().min(1),
+          clientTimestamp: z.number(),
+        }),
+        async ({ tx, args: { ticketId, expectedFingerprint, reason, clientTimestamp } }) => {
+          const ticket = await tx.run(zql.tickets.where('id', ticketId).one());
+          if (!ticket) throw new Error('Ticket not found');
+
+          const currentTicketEtaManagement = parseTicketEtaManagement(ticket.metadata);
+          const currentRisk = currentTicketEtaManagement.planningRisk;
+
+          if (currentRisk.state !== 'ACTIVE' || currentRisk.fingerprint !== expectedFingerprint) {
+            throw new ApplicationError(
+              'This planning risk has changed since you loaded this ticket. Refresh and try again.',
+              {
+                details: {
+                  code: 'STALE_FINGERPRINT',
+                  currentState: currentRisk.state,
+                  currentFingerprint: currentRisk.fingerprint,
+                },
+              },
+            );
+          }
+
+          const board = await tx.run(zql.boards.where('id', ticket.boardId).one());
+          const permission = await canUserModifyTicketControl(
+            authData.sub,
+            ticket.userGroupId ?? null,
+            ticket.boardId,
+            {
+              getBoardMetadata: async () => board?.metadata ?? null,
+              getUserGroupMapping: async (userId, userGroupId) => {
+                const mapping = await tx.run(
+                  zql.user_group_mappings.where('userId', userId).where('userGroupId', userGroupId).one(),
+                );
+                return mapping
+                  ? { roleId: mapping.roleId ?? null, responsibility: mapping.responsibility ?? null }
+                  : null;
+              },
+            },
+          );
+          if (!permission.allowed) {
+            throw new Error(permission.reason ?? 'Not authorized to acknowledge this planning risk');
+          }
+
+          const now = Date.now();
+          // Record + system message only - no additional notification. The record is staged
+          // for TicketsSideEffectHandler like every other ETA row, and is user-attributed.
+          const mergedMetadata = mergeTicketEtaManagement(ticket.metadata, {
+            planningRisk: {
+              state: 'ACKNOWLEDGED',
+              acknowledgedAt: now,
+              acknowledgedBy: authData.sub,
+              acknowledgmentReason: reason,
+            },
+            pendingActivities: stageEtaActivityOutbox(
+              [
+                {
+                  activityType: ActivityType.ETA_RISK_ACKNOWLEDGED,
+                  value: {
+                    fingerprint: expectedFingerprint,
+                    reason,
+                    acknowledgedBy: authData.sub,
+                    acknowledgedAt: now,
+                  } satisfies EtaRiskAcknowledgedActivityValue,
+                  actorId: authData.sub,
+                },
+              ],
+              now,
+            ),
+          });
+
+          await tx.mutate.tickets.update({
+            id: ticketId,
+            metadata: mergedMetadata as ReadonlyJSONValue,
+            updatedAt: now,
+          });
+
+          void clientTimestamp; // display-consistency hint only; server timestamp (`now`) is authoritative for persistence.
+        },
+      ),
       archiveDeskTicket: defineMutator(
         z.object({
           id: z.string(),
@@ -6795,21 +7064,6 @@ export function createMutators(
             return;
           }
 
-          // 2. Upsert the current stage ETA entry (will create if not exists, update if exists)
-          await tx.mutate.ticket_stage_eta.upsert({
-            workspaceId: authData.workspaceId,
-            id,
-            ticketId: oldTicketStageEtaEntry?.ticketId ?? ticketId!,
-            stageId: oldTicketStageEtaEntry?.stageId ?? stageId!,
-            version: 1,
-            stageEnteredAt: oldTicketStageEtaEntry?.stageEnteredAt ?? now,
-            stageLeftAt: null,
-            stageEta,
-            createdAt: oldTicketStageEtaEntry?.createdAt ?? now,
-            updatedAt,
-            updatedBy: authData.sub,
-          });
-
           // 3. Use the old entry for other data
           const ticketStageEtaEntry = oldTicketStageEtaEntry ?? {
             id,
@@ -6831,54 +7085,122 @@ export function createMutators(
 
           if (!currentStage) return;
 
-          // 5. Fetch ALL stages for this board
-          const allBoardStages = await tx.run(
-            zql.stages.where('boardId', ticket.boardId)
-          );
+          const board = await tx.run(zql.boards.where('id', ticket.boardId).one());
+          const boardEtaManagement = parseBoardEtaManagement(board?.metadata ?? null, board?.boardType ?? BoardType.DEFAULT);
 
-          // 6. Filter to get FUTURE stages (after current stage)
-          const futureStages = allBoardStages
-            .filter(stage => stage.sequenceNumber > currentStage.sequenceNumber)
-            .sort((a, b) => a.sequenceNumber - b.sequenceNumber);
-
-          // 7. Calculate total hours needed for future stages (only stages with ETA)
-          const futureStagesHours = futureStages.reduce(
-            (totalHours, stage) => totalHours + (stage.eta || 0),
-            0
-          );
-
-          // 8. Get the NEW current stage deadline (what user just set)
-          const currentStageDeadline = new Date(stageEta);
-
-          // 9. Calculate overall ticket ETA only if there are future stages with ETA
-          if (futureStagesHours > 0) {
-            // Calculate overall ticket ETA using working hours logic
-            // Starting from: current stage deadline
-            // Adding: working hours for all future stages
-            const overallTicketEta = calculateETADeadline(
-              currentStageDeadline,  // Start from user's new deadline for current stage
-              futureStagesHours      // Add working hours for future stages
+          // This mutator changes Ticket.eta the same way ticket.update's eta-changing path
+          // does, but has never been gated by ticketControlRoleIds. Close that gap. No
+          // assignee exemption here, unlike the two stage-move gates: editing a stage
+          // deadline IS an ETA change, which is exactly what the role gate exists to restrict.
+          if (boardEtaManagement.autoRecomputeEnabled && ticket.userGroupId) {
+            const permission = await canUserModifyTicketControl(
+              authData.sub,
+              ticket.userGroupId,
+              ticket.boardId,
+              {
+                getBoardMetadata: async () => board?.metadata ?? null,
+                getUserGroupMapping: async (userId, userGroupId) => {
+                  const mapping = await tx.run(
+                    zql.user_group_mappings.where('userId', userId).where('userGroupId', userGroupId).one(),
+                  );
+                  return mapping
+                    ? { roleId: mapping.roleId ?? null, responsibility: mapping.responsibility ?? null }
+                    : null;
+                },
+              },
             );
+            if (!permission.allowed) {
+              throw new Error(permission.reason ?? 'Not authorized to modify this ticket');
+            }
+          }
 
-            // 10. Update the ticket's overall ETA
-            await tx.mutate.tickets.update({
-              id: ticket.id,
-              eta: overallTicketEta.getTime(),
-              updatedAt: Date.now(),
-            });
+          // 2. Upsert the current stage ETA entry (will create if not exists, update if exists)
+          await tx.mutate.ticket_stage_eta.upsert({
+            workspaceId: authData.workspaceId,
+            id,
+            ticketId: oldTicketStageEtaEntry?.ticketId ?? ticketId!,
+            stageId: oldTicketStageEtaEntry?.stageId ?? stageId!,
+            version: 1,
+            stageEnteredAt: oldTicketStageEtaEntry?.stageEnteredAt ?? now,
+            stageLeftAt: null,
+            stageEta,
+            createdAt: oldTicketStageEtaEntry?.createdAt ?? now,
+            updatedAt,
+            updatedBy: authData.sub,
+          });
 
+          const etaCtx = await loadZeroEtaContext(tx, {
+            ticketId: ticketStageEtaEntry.ticketId,
+            boardId: ticket.boardId,
+            ticketMetadata: ticket.metadata,
+            stage: currentStage,
+          });
+          const { currentTicketEtaManagement } = etaCtx;
+
+          const etaResult = evaluateEta({
+            ticketId: ticketStageEtaEntry.ticketId,
+            ticketStatus: ticket.statusV2,
+            isTerminal: isTerminalStatus(ticket.statusV2),
+            currentTicketEta: msToDate(ticket.eta),
+            currentTicketEtaManagement,
+            boardType: board?.boardType ?? '',
+            boardEtaManagement,
+            currentStageId: ticketStageEtaEntry.stageId,
+            stages: etaCtx.stages,
+            transitions: etaCtx.transitions,
+            // The value the user just set is the authoritative deadline for this visit,
+            // overriding whatever the persisted row said.
+            activeVisit: {
+              ...etaCtx.activeVisit,
+              stageVisitId: id,
+              deadline: new Date(stageEta),
+              deadlineTracked: true,
+              estimateSource: 'MANUAL',
+              estimateHours: null,
+            },
+            trigger: 'MANUAL_STAGE_DEADLINE',
+            now: new Date(now),
+          });
+
+          const currentStageDeadline = new Date(stageEta);
+          let finalEtaMs: number | null | undefined;
+
+          // Without automation, a stage-deadline edit never touches the ticket's due date.
+          if (boardEtaManagement.autoRecomputeEnabled) {
+            finalEtaMs = etaResult.etaDecision.changed ? dateToMs(etaResult.etaDecision.newEta) : undefined;
+          }
+
+          // ETA evaluation audit trail (auto-recompute/risk detected/reopened/resolved),
+          // staged for TicketsSideEffectHandler to write post-commit.
+          const etaActivityIntents = buildEtaActivityIntents(etaResult, {
+            currentStageId: ticketStageEtaEntry.stageId,
+            oldEta: ticket.eta ?? null,
+            trigger: 'MANUAL_STAGE_DEADLINE',
+            systemReason: `Manual stage deadline update for "${currentStage.name}"`,
+            previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+          });
+
+          const mergedMetadata = mergeTicketEtaManagement(ticket.metadata, {
+            ...etaResult.ticketEtaManagementPatch,
+            pendingActivities: stageEtaActivityOutbox(etaActivityIntents, now),
+          });
+          await tx.mutate.tickets.update({
+            id: ticket.id,
+            updatedAt: now,
+            ...(finalEtaMs !== undefined && finalEtaMs !== null ? { eta: finalEtaMs } : {}),
+            metadata: mergedMetadata as ReadonlyJSONValue,
+          });
+
+          if (finalEtaMs !== undefined && finalEtaMs !== null) {
             logger.info('[MUTATOR] Updated ticket ETA', {
               ticketId: ticket.id,
               currentStageDeadline: currentStageDeadline.toISOString(),
-              futureStagesHours,
-              newOverallEta: overallTicketEta.toISOString(),
+              newOverallEta: new Date(finalEtaMs).toISOString(),
             });
           } else {
-            logger.info('[MUTATOR] No future stages with ETA, ticket ETA not updated', {
-              ticketId: ticket.id,
-              futureStagesHours,
-            });
+            logger.info('[MUTATOR] Ticket ETA not updated', { ticketId: ticket.id });
           }
+
 
           // 11. Create ticket activity for stage ETA change
           const newStageEta = stageEta;
@@ -6934,6 +7256,9 @@ export function createMutators(
               },
             });
           }
+
+          // ETA notifications are dispatched post-commit by TicketsSideEffectHandler,
+          // which fires off the `tx.mutate.tickets.update` above.
         }
       ),
     },
@@ -7913,6 +8238,14 @@ export function createMutators(
           projectId: z.string().optional(),
           boardType: z.nativeEnum(BoardType).optional(),
           metadata: z.any().optional(),
+          // Automatic ETA management. Merged into `metadata.etaManagement` below rather
+          // than going through the raw `metadata` arg above, which is a whole-column
+          // overwrite and would drop sibling keys.
+          autoRecomputeEnabled: z.boolean().optional(),
+          // Standard Path (NON_LINEAR only). Omitted = leave the existing path untouched;
+          // [] explicitly clears it (disables Standard Path forecasting without changing
+          // allowed transitions).
+          standardPathStageIds: z.array(z.string()).optional(),
           stages: z
             .array(
               z.object({
@@ -7949,6 +8282,8 @@ export function createMutators(
             projectId,
             boardType,
             metadata,
+            autoRecomputeEnabled,
+            standardPathStageIds,
             stages,
             timestamp,
             stageIds = {},
@@ -7997,6 +8332,102 @@ export function createMutators(
             }
           }
 
+          // A same-call boardType change wins, so a board converted to NON_LINEAR can take
+          // a Standard Path in one shot.
+          const effectiveBoardType = boardType ?? board.boardType;
+
+          if (standardPathStageIds !== undefined && standardPathStageIds.length > 0) {
+            if (effectiveBoardType !== BoardType.NON_LINEAR) {
+              throw new Error('A Standard Path can only be configured on a non-linear board');
+            }
+
+            const uniqueIds = new Set(standardPathStageIds);
+            if (uniqueIds.size !== standardPathStageIds.length) {
+              throw new Error('Standard Path stages must be unique');
+            }
+
+            const [boardStages, boardTransitions] = await Promise.all([
+              tx.run(zql.stages.where('boardId', boardId)),
+              tx.run(zql.stage_transitions.where('boardId', boardId)),
+            ]);
+            const stagesById = new Map(boardStages.map(s => [s.id, s]));
+
+            for (const stageId of standardPathStageIds) {
+              if (!stagesById.has(stageId)) {
+                throw new Error(`Standard Path references a stage that does not belong to this board: ${stageId}`);
+              }
+            }
+
+            const firstStage = stagesById.get(standardPathStageIds[0]!)!;
+            const lastStage = stagesById.get(standardPathStageIds[standardPathStageIds.length - 1]!)!;
+            if (
+              firstStage.defaultTicketStatusV2 === TicketStatusV2.COMPLETED ||
+              firstStage.defaultTicketStatusV2 === TicketStatusV2.CANCELLED
+            ) {
+              throw new Error('Standard Path must start with a non-terminal stage');
+            }
+            if (lastStage.defaultTicketStatusV2 !== TicketStatusV2.COMPLETED) {
+              throw new Error('Standard Path must end in a Completed stage');
+            }
+            const hasEachRequiredStatus = [
+              TicketStatusV2.TODO,
+              TicketStatusV2.STARTED,
+              TicketStatusV2.COMPLETED,
+            ].every(status => standardPathStageIds.some(id => stagesById.get(id)?.defaultTicketStatusV2 === status));
+            if (!hasEachRequiredStatus) {
+              throw new Error('Standard Path must include at least one To Do, one Started, and one Completed stage');
+            }
+
+            const boardHasTransitions = boardTransitions.length > 0;
+            for (let i = 0; i < standardPathStageIds.length - 1; i++) {
+              const fromId = standardPathStageIds[i]!;
+              const toId = standardPathStageIds[i + 1]!;
+              const transition =
+                boardTransitions.find(t => t.fromStageId === fromId && t.toStageId === toId) ??
+                boardTransitions.find(t => t.fromStageId == null && t.toStageId === toId) ??
+                null;
+
+              const outgoingFromThisStage = boardTransitions.some(t => t.fromStageId === fromId);
+              // Traversable: an explicit edge, an applicable global edge, or the
+              // board's unrestricted-transition behavior (this stage has zero outgoing edges
+              // configured anywhere, mirroring nonLinear.transition's own edge-gating).
+              if (!transition && boardHasTransitions && outgoingFromThisStage) {
+                throw new Error(
+                  `Standard Path step "${stagesById.get(fromId)?.name ?? fromId}" -> "${stagesById.get(toId)?.name ?? toId}" is not a traversable transition`,
+                );
+              }
+
+              // Config error - checked against the raw transition config, stricter
+              // than the live path's resolveStepEstimate (which falls back to the stage
+              // default for a misconfigured FIXED_HOURS edge to avoid regressing existing
+              // traffic). Standard Path activation is opt-in, so it can afford to be strict.
+              // ("No matching transition on a graphed board" is already a hard traversal
+              // error above - not a separate case to check here.)
+              if (transition && transition.visitSlaMode === VisitSlaMode.FIXED_HOURS) {
+                if (!transition.fixedEtaHours || transition.fixedEtaHours <= 0) {
+                  throw new Error(
+                    `Standard Path step "${stagesById.get(fromId)?.name ?? fromId}" -> "${stagesById.get(toId)?.name ?? toId}" has fixed-hours SLA selected with no value set`,
+                  );
+                }
+              }
+            }
+          }
+
+          // ETA settings merge into the etaManagement subtree instead of replacing the whole
+          // column. Base is the caller's `metadata` when it sent one (so both survive),
+          // otherwise the board's current metadata.
+          const nextMetadata =
+            autoRecomputeEnabled !== undefined || standardPathStageIds !== undefined
+              ? mergeBoardEtaManagement(
+                  metadata !== undefined ? metadata : board.metadata,
+                  effectiveBoardType,
+                  {
+                    ...(autoRecomputeEnabled !== undefined && { autoRecomputeEnabled }),
+                    ...(standardPathStageIds !== undefined && { standardPathStageIds }),
+                  },
+                )
+              : metadata;
+
           // Update board
           await tx.mutate.boards.update({
             id: boardId,
@@ -8004,7 +8435,7 @@ export function createMutators(
             ...(description !== undefined && { description }),
             ...(projectId !== undefined && { projectId }),
             ...(boardType !== undefined && { boardType }),
-            ...(metadata !== undefined && { metadata: metadata as ReadonlyJSONValue }),
+            ...(nextMetadata !== undefined && { metadata: nextMetadata as ReadonlyJSONValue }),
             updatedBy: authData.sub,
             updatedAt: timestamp,
           });
@@ -17076,6 +17507,38 @@ export function createMutators(
           if (board?.boardType !== BoardType.NON_LINEAR) {
             throw new Error('nonLinear.transition is only valid for NON_LINEAR boards');
           }
+          const boardEtaManagement = parseBoardEtaManagement(board.metadata, board.boardType);
+
+          // Stage moves can trigger automatic ETA extension, so gate them the same way
+          // ticket.update gates assignee/eta/board changes - a user who can't otherwise touch
+          // ETA shouldn't be able to do it indirectly by moving the ticket. The assignee is
+          // exempt for the same reason as in ticket.update: progressing their own ticket is
+          // the normal workflow, not a way around the ETA restriction.
+          if (
+            boardEtaManagement.autoRecomputeEnabled &&
+            ticket.userGroupId &&
+            ticket.assignedTo !== authData.sub
+          ) {
+            const permission = await canUserModifyTicketControl(
+              authData.sub,
+              ticket.userGroupId,
+              ticket.boardId,
+              {
+                getBoardMetadata: async () => board.metadata,
+                getUserGroupMapping: async (userId, userGroupId) => {
+                  const mapping = await tx.run(
+                    zql.user_group_mappings.where('userId', userId).where('userGroupId', userGroupId).one(),
+                  );
+                  return mapping
+                    ? { roleId: mapping.roleId ?? null, responsibility: mapping.responsibility ?? null }
+                    : null;
+                },
+              },
+            );
+            if (!permission.allowed) {
+              throw new Error(permission.reason ?? 'Not authorized to modify this ticket');
+            }
+          }
 
           const targetStage = await tx.run(
             zql.stages.where('boardId', ticket.boardId).where('name', toStageName).one(),
@@ -17243,9 +17706,20 @@ export function createMutators(
             targetStage.eta,
           );
 
+          // Track the FINAL persisted deadline/entered-at regardless of which branch below
+          // fires - a CONTINUE-reopen leaves the row's stageEta/stageEnteredAt untouched (not
+          // `stageEtaDeadline` as just computed), and this is the one value the ETA domain
+          // service evaluation further below must use as "the actual deadline now in effect".
+          let finalStageEtaMs: number;
+          let finalStageEnteredAtMs: number;
+          let finalStageVisitId: string;
+
           if (existingEtaId) {
+            const existingRow = targetETAs.find(e => e.id === existingEtaId);
             // REUSE (form unchanged): rebaseEta (RESET) restarts the clock; CONTINUE keeps it.
             if (rebaseEta) {
+              finalStageEtaMs = stageEtaDeadline;
+              finalStageEnteredAtMs = now;
               await tx.mutate.ticket_stage_eta.update({
                 id: existingEtaId,
                 stageEnteredAt: now,
@@ -17256,6 +17730,8 @@ export function createMutators(
               });
             } else {
               // CONTINUE: only clear stageLeftAt (do NOT touch stageEnteredAt/stageEta).
+              finalStageEtaMs = existingRow?.stageEta ?? stageEtaDeadline;
+              finalStageEnteredAtMs = existingRow?.stageEnteredAt ?? now;
               await tx.mutate.ticket_stage_eta.update({
                 id: existingEtaId,
                 stageLeftAt: null,
@@ -17263,12 +17739,16 @@ export function createMutators(
                 updatedBy: authData.sub,
               });
             }
+            finalStageVisitId = existingEtaId;
           } else {
             // NEW visit version (first visit, or form changed): insert a fresh ETA row at
             // newVisitIndex with a clock started from now.
+            finalStageEtaMs = stageEtaDeadline;
+            finalStageEnteredAtMs = now;
+            finalStageVisitId = uuidv4();
             await tx.mutate.ticket_stage_eta.insert({
               workspaceId: authData.workspaceId,
-              id: uuidv4(),
+              id: finalStageVisitId,
               ticketId,
               stageId: targetStage.id,
               version: newVisitIndex,
@@ -17280,6 +17760,53 @@ export function createMutators(
             });
           }
 
+          const etaCtx = await loadZeroEtaContext(tx, {
+            ticketId,
+            boardId: ticket.boardId,
+            ticketMetadata: ticket.metadata,
+            stage: targetStage,
+            transition,
+          });
+          const { currentTicketEtaManagement } = etaCtx;
+
+          const etaResult = evaluateEta({
+            ticketId,
+            ticketStatus: ticket.statusV2,
+            isTerminal: isTerminalStatus(ticket.statusV2),
+            currentTicketEta: msToDate(ticket.eta),
+            currentTicketEtaManagement,
+            boardType: board.boardType,
+            boardEtaManagement,
+            currentStageId: targetStage.id,
+            stages: etaCtx.stages,
+            transitions: etaCtx.transitions,
+            // The visit row was written above in this same transaction; use the deadline
+            // this transition just resolved rather than re-reading it.
+            activeVisit: {
+              ...etaCtx.activeVisit,
+              stageVisitId: finalStageVisitId,
+              deadline: msToDate(finalStageEtaMs),
+              deadlineTracked: finalStageEtaMs !== finalStageEnteredAtMs,
+            },
+            trigger: 'STAGE_TRANSITION',
+            now: new Date(now),
+          });
+          // Audit trail for the ETA evaluation, staged into the same write as the state it
+          // describes; TicketsSideEffectHandler drains it post-commit (system-actor
+          // resolution needs an async lookup that doesn't belong on the mutation path).
+          const etaActivityIntents = buildEtaActivityIntents(etaResult, {
+            currentStageId: targetStage.id,
+            oldEta: ticket.eta ?? null,
+            trigger: 'STAGE_TRANSITION',
+            systemReason: `Automatic recalculation after moving to stage "${toStageName}"`,
+            previousRiskFingerprint: currentTicketEtaManagement.planningRisk.fingerprint,
+          });
+          const mergedMetadata = mergeTicketEtaManagement(ticket.metadata, {
+            ...etaResult.ticketEtaManagementPatch,
+            pendingActivities: stageEtaActivityOutbox(etaActivityIntents, now),
+          });
+          const finalEtaMs = etaResult.etaDecision.changed ? dateToMs(etaResult.etaDecision.newEta) : undefined;
+
           await tx.mutate.tickets.update({
             id: ticketId,
             stageName: toStageName,
@@ -17287,7 +17814,10 @@ export function createMutators(
               statusV2: targetStage.defaultTicketStatusV2,
             }),
             updatedAt: now,
+            ...(finalEtaMs !== undefined && finalEtaMs !== null ? { eta: finalEtaMs } : {}),
+            metadata: mergedMetadata as ReadonlyJSONValue,
           });
+
 
           // Defer the non-transactional side-effects (post-commit, via asyncTasks). All three
           // are safe here: the ETA close only touches stageLeftAt (the ticket_stage_eta handler
@@ -17366,6 +17896,10 @@ export function createMutators(
                 },
               });
             }
+
+            // ETA activity rows and notifications are both written post-commit by
+            // TicketsSideEffectHandler, off the `tx.mutate.tickets.update` this mutator
+            // performed - the rows from the outbox staged into that update's metadata.
             } catch (error) {
               logger.error('stage_transition_side_effects_failed', { ticketId, targetStageId, error });
             }

--- a/apps/backend/src/zero/side-effects/collector.ts
+++ b/apps/backend/src/zero/side-effects/collector.ts
@@ -164,6 +164,7 @@ export async function collectSideEffectJobs(
         userGroupId: entity.userGroupId,
         createdBy: entity.createdBy,
         channelId: entity.channelId,
+        metadata: entity.metadata,
       };
     }
   }

--- a/apps/backend/src/zero/side-effects/tables/tickets-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/tickets-handler.ts
@@ -1,5 +1,5 @@
 import { BaseSideEffectHandler } from '../base-handler';
-import { ActivityClassification } from '@xyne/shared';
+import { ActivityClassification, TicketStatusV2 } from '@xyne/shared';
 import type { SideEffectJobConfig, TicketPreviousValue } from '../types';
 import { db } from '@/database/client';
 import { withWorkspaceScope } from '@/database/tenant/context';
@@ -10,6 +10,14 @@ import { userActivityTrackingService } from '@/services/userActivityTrackingServ
 import { websocketService } from '@/services/websocketService';
 import { maybeCreateEntryApprovalRequest } from '@/services/stageTransition/stageEntryApproval';
 import { getFormFieldUserActors } from '@/utils/ticketActorUtils';
+import {
+  dispatchEtaNotifications,
+  drainEtaActivityOutbox,
+  drainedOutboxTimestamp,
+  etaSystemMessageContent,
+  etaSignalsFromMetadataDiff,
+  writeEtaActivitiesPrisma,
+} from '@/services/etaManagement';
 
 import {
   emitTicketUpdated,
@@ -194,12 +202,99 @@ export class TicketsSideEffectHandler extends BaseSideEffectHandler {
         workspaceId: true,
         createdBy: true,
         assignedTo: true,
+        userGroupId: true,
+        boardId: true,
+        eta: true,
+        statusV2: true,
+        metadata: true,
       },
     });
 
     if (!ticket) {
       logger.warn(`[TicketsSideEffectHandler] Ticket ${ticketId} not found`);
       return;
+    }
+
+    try {
+      const etaIntents = drainEtaActivityOutbox({
+        previousMetadata: prev.metadata,
+        currentMetadata: args.metadata,
+      });
+      if (etaIntents.length > 0) {
+        const messageActorIds = [
+          ...new Set(etaIntents.map(i => i.actorId).filter((id): id is string => !!id)),
+        ];
+        const messageActors = messageActorIds.length
+          ? await db.user.findMany({
+              where: { id: { in: messageActorIds } },
+              select: { id: true, name: true, displayName: true },
+            })
+          : [];
+        const actorNames = new Map(
+          messageActors.map(u => [u.id, u.displayName || u.name || 'Someone']),
+        );
+
+        const intentsWithMessages = etaIntents.map(intent => {
+          const actorName = intent.actorId ? actorNames.get(intent.actorId) : undefined;
+          const content = actorName ? etaSystemMessageContent(intent, actorName) : null;
+          return content ? { ...intent, systemMessageContent: content } : intent;
+        });
+
+        await writeEtaActivitiesPrisma(db, intentsWithMessages, {
+          ticketId,
+          workspaceId: ticket.workspaceId,
+          channelId: ticket.channelId,
+          conversationId: ticket.conversationId,
+          timestamp: drainedOutboxTimestamp(args.metadata) ?? Date.now(),
+        });
+      }
+    } catch (error) {
+      logger.error(`[TicketsSideEffectHandler] Failed to write staged ETA activities:`, error);
+    }
+
+    // ETA planning-risk alerts. Driven off the committed before-vs-after state rather
+    // than the in-transaction evaluation result, so one place covers every Zero mutator
+    // that writes a ticket (ticket.update, nonLinear.transition, ticketStageEta.update).
+    // The Prisma write paths own their own post-commit dispatch - they never reach here.
+    //
+    // Diffed against THIS job's own `args.metadata`, never the re-fetched `ticket.metadata`
+    // - same reason as the outbox drain above: one logical mutation can emit several
+    // `tickets.update` jobs (board transfer does), and `ticket.metadata` is the FINAL state
+    // for all of them. Using it as "current" for every job made every job whose own prev
+    // predated the risk-detecting write compute an identical "risk just appeared" diff
+    // against that same final state - not idempotent, a genuine duplicate alert per extra
+    // job. Gating on `args.metadata !== undefined` means only the one job that actually
+    // carried the metadata write evaluates a diff at all; jobs that only touched
+    // stageName/kanbanPosition/boardId etc. skip this block entirely.
+    //
+    // Deliberately drops the `newEta` signal: a due-date change is already notified by
+    // the generic `etaChanged` branch below, to the same awareness recipient set. Only
+    // the risk alert (which goes to the narrower "action recipients" set) is new here.
+    //
+    // Suppressed while paused - risk state stays visible, just labeled paused. Mirrors
+    // the guard in stageEtaDeadlineWorker.ts's reconciliation pass.
+    if (ticket.statusV2 !== TicketStatusV2.PAUSED && args.metadata !== undefined) {
+      try {
+        const { riskAlert } = etaSignalsFromMetadataDiff({
+          previousMetadata: prev.metadata,
+          currentMetadata: args.metadata,
+          previousEta: prev.eta,
+          currentEta: ticket.eta?.getTime() ?? null,
+        });
+        await dispatchEtaNotifications(
+          { riskAlert, newEta: null },
+          {
+            ticketId,
+            createdBy: ticket.createdBy,
+            assignedTo: ticket.assignedTo,
+            ticketUserGroupId: ticket.userGroupId,
+            boardId: ticket.boardId,
+            actorId,
+          },
+        );
+      } catch (error) {
+        logger.error(`[TicketsSideEffectHandler] Failed to dispatch ETA planning-risk notification:`, error);
+      }
     }
 
     // Fetch all role assignments (manager, team lead, dev, qa, pr reviewer, etc.)
@@ -294,7 +389,11 @@ export class TicketsSideEffectHandler extends BaseSideEffectHandler {
           logger.info(`[TicketsSideEffectHandler] Sent priority change notification for ticket ${ticketId} to users: ${notificationRecipients.join(', ')}`);
         }
 
-        if (etaChanged && args.eta !== undefined) {
+        // No notifications while paused. This is a plain field diff (fires for ANY eta
+        // write), and moving into a paused stage is itself a stage entry, which can
+        // trigger an automatic forecast extension - without this guard that extension
+        // would notify even though the ticket is being paused, not worked.
+        if (etaChanged && args.eta !== undefined && ticket.statusV2 !== TicketStatusV2.PAUSED) {
           const formattedDate = new Date(args.eta).toLocaleDateString('en-US', {
             month: 'long',
             day: 'numeric',

--- a/apps/backend/src/zero/side-effects/types.ts
+++ b/apps/backend/src/zero/side-effects/types.ts
@@ -17,6 +17,7 @@ export interface TicketPreviousValue {
   userGroupId: string | null;
   createdBy: string;
   channelId: string | null;
+  metadata: unknown;
 }
 
 export interface TicketStageEtaPreviousValue {

--- a/apps/dashboard/src/components/Board/BoardRolesConfigScreen/BoardRolesConfigScreen.tsx
+++ b/apps/dashboard/src/components/Board/BoardRolesConfigScreen/BoardRolesConfigScreen.tsx
@@ -6,10 +6,19 @@ import { mutators } from '../../../zero/mutators';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { Button } from '../../../components/ui/Button';
 import { Badge } from '../../../components/ui/Badge/Badge';
+import { Switch } from '../../../components/ui/Switch';
 import { EntitySelector } from '../../ui/EntitySelector/EntitySelector';
 import type { SelectorOption } from '../../ui/EntitySelector/EntitySelector.types';
 import { toast } from 'sonner';
 import { cn } from '../../../utils/classNames';
+import { BoardType, parseBoardEtaManagement } from '@xyne/shared';
+
+interface BoardStageInfo {
+  id: string;
+  name: string;
+  eta: number | null;
+  sequenceNumber: number;
+}
 
 interface BoardRolesConfigScreenProps {
   boardId: string;
@@ -163,10 +172,24 @@ const BoardRolesConfigScreen = ({
   >([]);
   const [prOpenedRoleId, setPrOpenedRoleId] = useState<string | null>(null);
   const [prMergedRoleId, setPrMergedRoleId] = useState<string | null>(null);
+  const [autoRecomputeEnabled, setAutoRecomputeEnabled] = useState(false);
+  const [savingAutoRecompute, setSavingAutoRecompute] = useState(false);
+  const [standardPathStageIds, setStandardPathStageIds] = useState<string[]>([]);
+  const [savingStandardPath, setSavingStandardPath] = useState(false);
 
   useEffect(() => {
     if (board && typeof board === 'object' && 'metadata' in board) {
       const metadata = board.metadata as Record<string, unknown>;
+      // Parse through the shared helper rather than reading the JSON by hand: a board that has
+      // never saved etaManagement has no key at all, and the helper applies the board-type
+      // default (auto-recompute ON) that the backend actually acts on. Reading the raw key
+      // would show "off" for every such board - and then save that false back.
+      const boardTypeForEta =
+        ('boardType' in board ? (board as { boardType?: string }).boardType : null) ??
+        BoardType.DEFAULT;
+      const etaManagement = parseBoardEtaManagement(metadata, boardTypeForEta);
+      setAutoRecomputeEnabled(etaManagement.autoRecomputeEnabled);
+      setStandardPathStageIds([...etaManagement.standardPathStageIds]);
       if (Array.isArray(metadata?.['ticketControlRoleIds'])) {
         setTicketControlRoleIds(
           (metadata['ticketControlRoleIds'] as unknown[]).filter(
@@ -234,6 +257,140 @@ const BoardRolesConfigScreen = ({
     board && typeof board === 'object' && 'name' in board
       ? (board as { name?: string }).name
       : null;
+
+  const boardType =
+    board && typeof board === 'object' && 'boardType' in board
+      ? (board as { boardType?: string }).boardType
+      : null;
+
+  // Offered for every board type whose forecast can actually act on the flag. RELEASE is
+  // included because routeResolution forecasts it identically to DEFAULT, so automation is
+  // live there and needs a way to be turned off. FLOW is excluded: its route always resolves
+  // NOT_APPLICABLE, so the toggle would control nothing.
+  const showAutoRecomputeToggle =
+    boardType === BoardType.DEFAULT ||
+    boardType === BoardType.NON_LINEAR ||
+    boardType === BoardType.RELEASE;
+
+  const handleToggleAutoRecompute = useCallback(
+    async (next: boolean) => {
+      if (!boardId) return;
+      setSavingAutoRecompute(true);
+      // Optimistic - revert on error.
+      setAutoRecomputeEnabled(next);
+      try {
+        const result = zero.mutate(
+          mutators.board.update({
+            boardId,
+            autoRecomputeEnabled: next,
+            timestamp: Date.now(),
+          }),
+        );
+        const res = await result.server;
+        if (res.type === 'error') {
+          setAutoRecomputeEnabled(!next);
+          toast.error('Failed to update automatic ETA management', {
+            description: res.error.message || 'You do not have permission to modify this board.',
+            duration: 5000,
+          });
+        }
+      } catch (error) {
+        setAutoRecomputeEnabled(!next);
+        toast.error('Failed to update automatic ETA management', {
+          description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+          duration: 5000,
+        });
+      } finally {
+        setSavingAutoRecompute(false);
+      }
+    },
+    [boardId, zero],
+  );
+
+  // ─── Standard Path (NON_LINEAR forecasting overlay, PRD §6.2) ─────────────
+  const boardStages: BoardStageInfo[] = useMemo(() => {
+    if (!board || typeof board !== 'object' || !('stages' in board)) return [];
+    const rawStages = (board as { stages?: ReadonlyArray<Record<string, unknown>> }).stages ?? [];
+    return rawStages.map(s => ({
+      id: s['id'] as string,
+      name: s['name'] as string,
+      eta: (s['eta'] as number | null) ?? null,
+      sequenceNumber: s['sequenceNumber'] as number,
+    }));
+  }, [board]);
+  const stagesById = useMemo(() => new Map(boardStages.map(s => [s.id, s])), [boardStages]);
+
+  const standardPathAvailable: SelectorOption[] = useMemo(
+    () =>
+      boardStages
+        .filter(s => !standardPathStageIds.includes(s.id))
+        .map(s => ({
+          value: s.id,
+          label: s.name,
+          subtitle: s.eta ? `${s.eta}h default` : 'No default estimate',
+          icon: <Ticket size={14} />,
+        })),
+    [boardStages, standardPathStageIds],
+  );
+
+  // Approximate preview only (stage defaults, ignoring transition-specific fixed-hours
+  // overrides which this modal doesn't load) - the mutator re-validates authoritatively
+  // against the real transition config on save.
+  const standardPathPreview = useMemo(() => {
+    let totalHours = 0;
+    const missingEstimateStages: string[] = [];
+    for (const id of standardPathStageIds) {
+      const stage = stagesById.get(id);
+      if (!stage || !stage.eta || stage.eta <= 0) {
+        missingEstimateStages.push(stage?.name ?? id);
+      } else {
+        totalHours += stage.eta;
+      }
+    }
+    return { totalHours, missingEstimateStages };
+  }, [standardPathStageIds, stagesById]);
+
+  const spMove = (index: number, direction: -1 | 1) => {
+    setStandardPathStageIds(prev => {
+      const next = [...prev];
+      const target = index + direction;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target]!, next[index]!];
+      return next;
+    });
+  };
+  const spRemove = (id: string) => setStandardPathStageIds(prev => prev.filter(s => s !== id));
+  const spAdd = (id: string) => setStandardPathStageIds(prev => [...prev, id]);
+
+  const handleSaveStandardPath = useCallback(async () => {
+    if (!boardId) return;
+    setSavingStandardPath(true);
+    try {
+      const result = zero.mutate(
+        mutators.board.update({
+          boardId,
+          standardPathStageIds,
+          timestamp: Date.now(),
+        }),
+      );
+      const res = await result.server;
+      if (res.type === 'error') {
+        toast.error('Failed to save Standard Path', {
+          description: res.error.message || 'Check that the path is valid and try again.',
+          duration: 6000,
+        });
+      } else {
+        toast.success('Standard Path saved');
+      }
+    } catch (error) {
+      toast.error('Failed to save Standard Path', {
+        description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+        duration: 6000,
+      });
+    } finally {
+      setSavingStandardPath(false);
+    }
+  }, [boardId, standardPathStageIds, zero]);
 
   const handleSave = useCallback(async () => {
     if (!boardId) return;
@@ -361,6 +518,131 @@ const BoardRolesConfigScreen = ({
             </Button>
           </div>
         </header>
+
+        {showAutoRecomputeToggle && (
+          <div className='flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0'>
+            <div className='min-w-0'>
+              <h3 className='text-sm font-medium text-foreground mb-0.5'>
+                Automatic ETA management
+              </h3>
+              <p className='text-xs text-muted-foreground leading-[1.5]'>
+                Extend the ticket due date automatically when a stage forecast runs later than the
+                current commitment. Never shortens an existing due date. Changes apply to tickets on
+                their next stage move or estimate change, not retroactively.
+              </p>
+            </div>
+            <Switch
+              checked={autoRecomputeEnabled}
+              onCheckedChange={value => void handleToggleAutoRecompute(value)}
+              disabled={savingAutoRecompute}
+              aria-label='Automatic ETA management'
+              id='auto-eta-management-toggle'
+            />
+          </div>
+        )}
+
+        {boardType === BoardType.NON_LINEAR && (
+          <div className='px-4 py-3 border-b border-border flex-shrink-0'>
+            <div className='flex items-start justify-between gap-4 mb-3'>
+              <div className='min-w-0'>
+                <h3 className='text-sm font-medium text-foreground mb-0.5'>Standard Path</h3>
+                <p className='text-xs text-muted-foreground leading-[1.5]'>
+                  An expected route through this board, used only to forecast ticket due dates - it
+                  never restricts which stage moves are actually allowed. Must start with a
+                  non-terminal stage, include a To Do/Started/Completed stage, and end Completed.
+                </p>
+              </div>
+              <Button
+                variant='secondary'
+                onClick={() => void handleSaveStandardPath()}
+                disabled={savingStandardPath || standardPathStageIds.length === 0}
+              >
+                {savingStandardPath ? 'Saving...' : 'Save Standard Path'}
+              </Button>
+            </div>
+
+            <div className='flex flex-col gap-1.5 mb-2'>
+              {standardPathStageIds.map((id, index) => {
+                const stage = stagesById.get(id);
+                return (
+                  <div
+                    key={`${id}-${index}`}
+                    className='flex items-center gap-2 px-2.5 py-2 border border-border rounded-md'
+                  >
+                    <span className='text-xs text-muted-foreground w-5 text-right'>
+                      {index + 1}
+                    </span>
+                    <span className='text-sm font-medium flex-1 text-foreground truncate'>
+                      {stage?.name ?? id}
+                    </span>
+                    <span className='text-xs text-muted-foreground'>
+                      {stage?.eta ? `${stage.eta}h` : 'no estimate'}
+                    </span>
+                    <button
+                      type='button'
+                      onClick={() => spMove(index, -1)}
+                      disabled={index === 0}
+                      aria-label='Move up'
+                      className='w-5 h-5 flex items-center justify-center text-muted-foreground hover:bg-muted rounded disabled:opacity-30'
+                      data-track-category='BOARD_ROLE_CONFIG'
+                      data-track-name='MOVE_STANDARD_PATH_STAGE_UP'
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type='button'
+                      onClick={() => spMove(index, 1)}
+                      disabled={index === standardPathStageIds.length - 1}
+                      aria-label='Move down'
+                      className='w-5 h-5 flex items-center justify-center text-muted-foreground hover:bg-muted rounded disabled:opacity-30'
+                      data-track-category='BOARD_ROLE_CONFIG'
+                      data-track-name='MOVE_STANDARD_PATH_STAGE_DOWN'
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type='button'
+                      onClick={() => spRemove(id)}
+                      aria-label={`Remove ${stage?.name ?? id}`}
+                      className='w-5 h-5 flex items-center justify-center text-muted-foreground hover:bg-red-50 hover:text-red-500 rounded'
+                      data-track-category='BOARD_ROLE_CONFIG'
+                      data-track-name='REMOVE_STANDARD_PATH_STAGE'
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+
+            <EntitySelector
+              options={standardPathAvailable}
+              selectedValue={null}
+              onSelect={value => {
+                if (value) spAdd(value);
+              }}
+              placeholder='Add stage to Standard Path'
+              searchPlaceholder='Search stages...'
+              showSearch={true}
+              width='100%'
+              testId='standard-path-stage-picker'
+            />
+
+            {standardPathStageIds.length > 0 && (
+              <div className='mt-2 text-xs text-muted-foreground'>
+                Approximate total: {standardPathPreview.totalHours}h across{' '}
+                {standardPathStageIds.length} stage
+                {standardPathStageIds.length === 1 ? '' : 's'} (stage defaults only - fixed-hour
+                transition overrides are resolved when you save).
+                {standardPathPreview.missingEstimateStages.length > 0 && (
+                  <span className='block mt-1 text-amber-600'>
+                    Missing estimate: {standardPathPreview.missingEstimateStages.join(', ')}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* ── 3-column layout ── */}
         <div className='flex-1 overflow-y-auto'>

--- a/apps/dashboard/src/components/Tickets/TicketActivity/TicketActivity.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketActivity/TicketActivity.tsx
@@ -20,6 +20,12 @@ import {
   type ReferenceTicketActivityValue,
   type SubticketActivityValue,
   type BaseActivityValue,
+  type EtaAutoRecomputedActivityValue,
+  type EtaManuallyUpdatedActivityValue,
+  type EtaRiskDetectedActivityValue,
+  type EtaRiskAcknowledgedActivityValue,
+  type EtaRiskReopenedActivityValue,
+  type EtaRiskResolvedActivityValue,
 } from '@xyne/shared';
 import { formatReferenceLabel } from '../../../hooks/useTicketReferences';
 import { formatDistanceToNow, format } from 'date-fns';
@@ -254,6 +260,23 @@ export const getActivityDescription = (
       };
     }
 
+    case ActivityType.ETA:
+      return {
+        description: 'changed due date',
+        details: (
+          <>
+            from{' '}
+            <span className='font-semibold'>
+              {value?.oldValue ? new Date(value.oldValue).toLocaleDateString() : 'none'}
+            </span>{' '}
+            to{' '}
+            <span className='font-semibold'>
+              {value?.newValue ? new Date(value.newValue).toLocaleDateString() : 'none'}
+            </span>
+          </>
+        ),
+      };
+
     case ActivityType.STAGE_ETA:
       return {
         description: `updated stage deadline`,
@@ -270,6 +293,94 @@ export const getActivityDescription = (
           </>
         ),
       };
+
+    case ActivityType.ETA_AUTO_RECOMPUTED: {
+      const v = activity.value as EtaAutoRecomputedActivityValue | null;
+      return {
+        description: 'automatically extended due date',
+        details: (
+          <>
+            from{' '}
+            <span className='font-semibold'>
+              {v?.oldEta ? new Date(v.oldEta).toLocaleDateString() : 'none'}
+            </span>{' '}
+            to{' '}
+            <span className='font-semibold'>
+              {v?.finalEta ? new Date(v.finalEta).toLocaleDateString() : ''}
+            </span>
+            {v?.standardPathUsed ? ' via the Standard Path' : ''}
+          </>
+        ),
+      };
+    }
+
+    case ActivityType.ETA_MANUALLY_UPDATED: {
+      const v = activity.value as EtaManuallyUpdatedActivityValue | null;
+      return {
+        description: 'manually changed due date',
+        details: (
+          <>
+            from{' '}
+            <span className='font-semibold'>
+              {v?.oldEta ? new Date(v.oldEta).toLocaleDateString() : 'none'}
+            </span>{' '}
+            to{' '}
+            <span className='font-semibold'>
+              {v?.newEta ? new Date(v.newEta).toLocaleDateString() : ''}
+            </span>
+            {v?.reason ? <>: {v.reason}</> : ''}
+          </>
+        ),
+      };
+    }
+
+    case ActivityType.ETA_RISK_DETECTED: {
+      const v = activity.value as EtaRiskDetectedActivityValue | null;
+      return {
+        description: 'detected planning risk',
+        details: (
+          <>
+            stage deadline{' '}
+            <span className='font-semibold'>
+              {v?.stageEta ? new Date(v.stageEta).toLocaleDateString() : ''}
+            </span>{' '}
+            is later than due date{' '}
+            <span className='font-semibold'>
+              {v?.ticketEta ? new Date(v.ticketEta).toLocaleDateString() : ''}
+            </span>
+          </>
+        ),
+      };
+    }
+
+    case ActivityType.ETA_RISK_ACKNOWLEDGED: {
+      const v = activity.value as EtaRiskAcknowledgedActivityValue | null;
+      return {
+        description: 'acknowledged planning risk',
+        details: v?.reason || '',
+      };
+    }
+
+    case ActivityType.ETA_RISK_REOPENED: {
+      const v = activity.value as EtaRiskReopenedActivityValue | null;
+      return {
+        description: 'planning risk reopened',
+        details: v?.changedInputs?.length ? `${v.changedInputs.join(', ')} changed` : '',
+      };
+    }
+
+    case ActivityType.ETA_RISK_RESOLVED: {
+      const v = activity.value as EtaRiskResolvedActivityValue | null;
+      const causeText: Record<string, string> = {
+        CONDITION_NO_LONGER_TRUE: 'the condition no longer applies',
+        TERMINAL_STATUS: 'the ticket reached a terminal status',
+        MANUAL_DATE_CHANGE: 'the due date was changed manually',
+      };
+      return {
+        description: 'planning risk resolved',
+        details: v?.cause ? causeText[v.cause] || '' : '',
+      };
+    }
 
     case ActivityType.USER_GROUP_ID: {
       const oldGroup = userGroups?.find(g => g.id === value?.oldValue);
@@ -643,6 +754,12 @@ export const getActivityIcon = (activity: TicketActivityType): ReactElement => {
       return <Tag size={12} className='text-gray-400' />;
     case ActivityType.ETA:
     case ActivityType.STAGE_ETA:
+    case ActivityType.ETA_AUTO_RECOMPUTED:
+    case ActivityType.ETA_MANUALLY_UPDATED:
+    case ActivityType.ETA_RISK_DETECTED:
+    case ActivityType.ETA_RISK_ACKNOWLEDGED:
+    case ActivityType.ETA_RISK_REOPENED:
+    case ActivityType.ETA_RISK_RESOLVED:
       return <Calendar size={12} />;
     case ActivityType.SUBTICKET_CREATED:
     case ActivityType.SUBTICKET_LINKED:

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -61,6 +61,9 @@ import {
   normalizeFlowPlan,
   flowGateOf,
   FLOW_STAGE_NAMES,
+  deriveEtaManagementView,
+  parseTicketEtaManagement,
+  parseBoardEtaManagement,
 } from '@xyne/shared';
 import { useNavigate, Link, useLocation } from 'react-router-dom';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -805,6 +808,64 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     !isNonLinearBoard &&
     ((boardData?.metadata as BoardMetadata | null | undefined)?.showNextStageFormInTicketDetails ??
       false) === true;
+
+  // ETA risk/overdue display state. The banner/badge is shown to everyone; the backend
+  // (`canUserModifyTicketControl`, wired into `acknowledgeEtaRisk`) is the sole authority
+  // on who may act, and rejects an unauthorized attempt with a clear error.
+  const etaManagementView = useMemo(() => {
+    if (!ticket) return null;
+    return deriveEtaManagementView({
+      ticketEtaManagement: parseTicketEtaManagement(ticket.metadata),
+      boardEtaManagement: parseBoardEtaManagement(
+        boardData?.metadata ?? null,
+        boardData?.boardType ?? BoardType.DEFAULT,
+      ),
+      ticketEta: ticket.eta ?? null,
+      ticketStatus: ticket.statusV2,
+      now: Date.now(),
+    });
+  }, [ticket, boardData]);
+
+  const [acknowledgeReason, setAcknowledgeReason] = useState('');
+  const [showAcknowledgeInput, setShowAcknowledgeInput] = useState(false);
+  const [submittingAcknowledge, setSubmittingAcknowledge] = useState(false);
+
+  const handleAcknowledgeRisk = useCallback(async () => {
+    if (!ticket || !acknowledgeReason.trim()) return;
+    const ticketEtaManagement = parseTicketEtaManagement(ticket.metadata);
+    const fingerprint = ticketEtaManagement.planningRisk.fingerprint;
+    if (!fingerprint) return;
+    setSubmittingAcknowledge(true);
+    try {
+      const result = zero.mutate(
+        mutators.ticket.acknowledgeEtaRisk({
+          ticketId: ticket.id,
+          expectedFingerprint: fingerprint,
+          reason: acknowledgeReason.trim(),
+          clientTimestamp: Date.now(),
+        }),
+      );
+      const res = await result.server;
+      if (res.type === 'error') {
+        toast.error('Failed to acknowledge planning risk', {
+          description:
+            res.error.message || 'The risk state may have changed - refresh and try again.',
+          duration: 6000,
+        });
+      } else {
+        toast.success('Planning risk acknowledged');
+        setShowAcknowledgeInput(false);
+        setAcknowledgeReason('');
+      }
+    } catch (error) {
+      toast.error('Failed to acknowledge planning risk', {
+        description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+        duration: 6000,
+      });
+    } finally {
+      setSubmittingAcknowledge(false);
+    }
+  }, [ticket, acknowledgeReason, zero]);
 
   // Plan-node titles for FLOW boards — form values are scoped by planNodeId,
   // so submissions/activity resolve their label through this map.
@@ -3979,10 +4040,95 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                           Overdue
                         </span>
                       )}
+                    {etaManagementView?.severity === 'PLANNING_RISK' && (
+                      <span
+                        className='inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium bg-amber-100 text-amber-700 rounded'
+                        title='The current stage deadline is later than this due date'
+                      >
+                        <AlertCircle size={11} />
+                        Planning Risk{etaManagementView.isPaused ? ' (paused)' : ''}
+                      </span>
+                    )}
+                    {etaManagementView?.forecastStatus === 'INCOMPLETE' && (
+                      <span
+                        className='inline-flex items-center px-1.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground rounded'
+                        title={
+                          etaManagementView.forecastIncompleteReason ?? 'Missing a stage estimate'
+                        }
+                      >
+                        Estimate Incomplete
+                      </span>
+                    )}
                   </div>
                 )
               }
             />
+            {etaManagementView?.severity === 'PLANNING_RISK' &&
+              etaManagementView.planningRiskState === 'ACTIVE' && (
+                <div className='mx-0 mb-2 px-3 py-2.5 rounded-md border border-amber-200 bg-amber-50 text-sm'>
+                  <div className='flex items-start justify-between gap-2'>
+                    <div className='text-amber-800'>
+                      <p className='font-medium'>Planning risk</p>
+                      <p className='text-xs text-amber-700 mt-0.5'>
+                        The current stage deadline
+                        {etaManagementView.stageDeadline
+                          ? ` (${formatETADisplay(etaManagementView.stageDeadline)})`
+                          : ''}{' '}
+                        is later than the ticket due date
+                        {etaManagementView.ticketDue
+                          ? ` (${formatETADisplay(etaManagementView.ticketDue)})`
+                          : ''}
+                        .
+                        {etaManagementView.autoEnabled
+                          ? ' Automatic recalculation is active for this board.'
+                          : ' Automatic recalculation is off for this board.'}
+                      </p>
+                    </div>
+                    {!showAcknowledgeInput && (
+                      <Button
+                        variant='secondary'
+                        onClick={() => setShowAcknowledgeInput(true)}
+                        data-track-category='TicketDetails'
+                        data-track-name='OpenAcknowledgeEtaRisk'
+                      >
+                        Acknowledge
+                      </Button>
+                    )}
+                  </div>
+                  {showAcknowledgeInput && (
+                    <div className='mt-2 flex items-center gap-2'>
+                      <input
+                        type='text'
+                        value={acknowledgeReason}
+                        onChange={e => setAcknowledgeReason(e.target.value)}
+                        placeholder='Reason for keeping the current dates...'
+                        className='flex-1 text-sm bg-background border border-input rounded px-2 py-1 outline-none focus:border-border'
+                        data-testid='acknowledge-eta-risk-reason'
+                        data-track-category='TicketDetails'
+                        data-track-name='AcknowledgeEtaRiskReasonInput'
+                      />
+                      <Button
+                        variant='secondary'
+                        onClick={() => void handleAcknowledgeRisk()}
+                        disabled={submittingAcknowledge || !acknowledgeReason.trim()}
+                        data-track-category='TicketDetails'
+                        data-track-name='SubmitAcknowledgeEtaRisk'
+                      >
+                        {submittingAcknowledge ? 'Saving...' : 'Confirm'}
+                      </Button>
+                      <Button
+                        variant='ghost'
+                        onClick={() => {
+                          setShowAcknowledgeInput(false);
+                          setAcknowledgeReason('');
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              )}
             {/* Status Deadline - only show if current stage has eta configured */}
             {currentStageInfo?.eta && (
               <TicketKeyValuePair

--- a/packages/shared/src/board-types/index.ts
+++ b/packages/shared/src/board-types/index.ts
@@ -6,6 +6,8 @@
 // their own module; re-exported here so `@xyne/shared` consumers are unchanged.
 export * from './flow-plan';
 
+import type { BoardEtaManagement } from '../validation/etaManagementSchema';
+
 export interface TicketFormConfig {
   userGroupsOnly?: {
     enabled: boolean;
@@ -105,4 +107,13 @@ export interface BoardMetadata {
    * Absent = treat as visible (backward compat for boards saved before this existed).
    */
   customFieldVisibility?: Record<string, boolean>;
+  /**
+   * Config + versioning for the ETA risk-detection/auto-recalculation
+   * feature (planning risk, Standard Path, automatic due-date extension).
+   * Absent = no Standard Path, automatic due-date recalculation defaulted per
+   * board type (see `defaultAutoRecomputeEnabled`) - go through
+   * `parseBoardEtaManagement` in `validation/etaManagementSchema.ts` rather
+   * than casting this field directly.
+   */
+  etaManagement?: BoardEtaManagement;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,3 +57,4 @@ export * from './templates/callSummary';
 export * from './types/flowUI';
 export * from './validation/flowSchema';
 export * from './sdlc';
+export * from './validation/etaManagementSchema';

--- a/packages/shared/src/tickets/etaActivityValues.ts
+++ b/packages/shared/src/tickets/etaActivityValues.ts
@@ -1,0 +1,80 @@
+/**
+ * Stored-`value` JSON contracts for the `ActivityType.ETA_*` TicketActivity
+ * rows (packages/shared/src/zero/types.ts `ActivityType`). One interface per
+ * type, matching the PRD's audit-trail field list. Timestamps are epoch ms
+ * (consistent with `TicketEtaManagement`/`BoardEtaManagement`), not ISO
+ * strings, so these values round-trip through `Json` columns without a
+ * serialization layer.
+ *
+ * Every write of one of these activity types must use the matching
+ * interface below rather than an ad hoc object literal, so the Prisma
+ * (`recordTicketTimelineEvent`) and Zero (`tx.mutate.ticket_activities`)
+ * write paths stay byte-for-byte consistent with each other.
+ */
+
+export type EtaChangeTrigger =
+  | 'CREATE'
+  | 'STAGE_TRANSITION'
+  | 'MANUAL_STAGE_DEADLINE'
+  | 'MANUAL_DUE_DATE'
+  | 'RESUME'
+  | 'TERMINAL_ENTRY'
+  | 'TERMINAL_EXIT'
+  | 'RECONCILIATION';
+
+/** ActivityType.ETA_AUTO_RECOMPUTED */
+export interface EtaAutoRecomputedActivityValue {
+  trigger: EtaChangeTrigger;
+  oldEta: number | null;
+  forecastEta: number;
+  finalEta: number;
+  stageVisitId: string | null;
+  /** Set when a Standard Path was used to build the forecast route. */
+  standardPathUsed: boolean;
+  systemReason: string;
+}
+
+/** ActivityType.ETA_MANUALLY_UPDATED */
+export interface EtaManuallyUpdatedActivityValue {
+  oldEta: number | null;
+  newEta: number;
+  reason: string;
+  actingUserId: string;
+}
+
+/** ActivityType.ETA_RISK_DETECTED */
+export interface EtaRiskDetectedActivityValue {
+  fingerprint: string;
+  stageEta: number;
+  ticketEta: number;
+  stageId: string;
+  stageVisitId: string;
+}
+
+/** ActivityType.ETA_RISK_ACKNOWLEDGED */
+export interface EtaRiskAcknowledgedActivityValue {
+  fingerprint: string;
+  reason: string;
+  acknowledgedBy: string;
+  acknowledgedAt: number;
+}
+
+/** ActivityType.ETA_RISK_REOPENED */
+export interface EtaRiskReopenedActivityValue {
+  previousFingerprint: string | null;
+  newFingerprint: string;
+  /** Which fingerprint inputs changed, e.g. ["stageEta", "ticketStatus"]. */
+  changedInputs: string[];
+}
+
+export type EtaRiskResolutionCause =
+  | 'CONDITION_NO_LONGER_TRUE'
+  | 'TERMINAL_STATUS'
+  | 'MANUAL_DATE_CHANGE';
+
+/** ActivityType.ETA_RISK_RESOLVED */
+export interface EtaRiskResolvedActivityValue {
+  fingerprint: string;
+  cause: EtaRiskResolutionCause;
+}
+

--- a/packages/shared/src/tickets/etaManagementView.ts
+++ b/packages/shared/src/tickets/etaManagementView.ts
@@ -1,0 +1,70 @@
+import type { BoardEtaManagement, TicketEtaManagement } from '../validation/etaManagementSchema';
+
+/**
+ * ETA display state for a single ticket, derived on the client from
+ * already-synced `Ticket.metadata`/`Board.metadata`. A single pure function
+ * so the severity/badge decision can never drift between wherever it's
+ * computed.
+ *
+ * Deliberately carries no permission signal: the backend is the only
+ * authority on who may change or acknowledge ETA state, and it enforces that
+ * on the mutation itself.
+ */
+
+export type EtaDisplaySeverity = 'TICKET_OVERDUE' | 'STAGE_OVERDUE' | 'PLANNING_RISK' | 'NONE';
+
+export interface DeriveEtaManagementViewInput {
+  ticketEtaManagement: TicketEtaManagement;
+  boardEtaManagement: BoardEtaManagement;
+  /** `Ticket.eta`, epoch ms. */
+  ticketEta: number | null;
+  /** `Ticket.statusV2`. */
+  ticketStatus: string;
+  /** Caller-supplied "now" (epoch ms) so the computation is deterministic/testable. */
+  now: number;
+}
+
+export interface EtaManagementView {
+  autoEnabled: boolean;
+  forecastStatus: TicketEtaManagement['forecastStatus'];
+  forecastIncompleteReason: string | null;
+  planningRiskState: TicketEtaManagement['planningRisk']['state'];
+  /** Risk/overdue state stays visible while paused, but labeled "(paused)" rather than hidden. */
+  isPaused: boolean;
+  /** Most severe condition, for the primary badge: ticket-overdue > stage-overdue > planning-risk. */
+  severity: EtaDisplaySeverity;
+  stageDeadline: number | null;
+  ticketDue: number | null;
+}
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['COMPLETED', 'CANCELLED']);
+const PAUSED_STATUS = 'PAUSED';
+
+export function deriveEtaManagementView(input: DeriveEtaManagementViewInput): EtaManagementView {
+  const { ticketEtaManagement, boardEtaManagement, ticketEta, ticketStatus, now } = input;
+  const { planningRisk, activeVisit } = ticketEtaManagement;
+
+  const isTerminal = TERMINAL_STATUSES.has(ticketStatus);
+  const isPaused = ticketStatus === PAUSED_STATUS;
+
+  const stageDeadline = activeVisit.deadlineTracked ? planningRisk.stageEta : null;
+  const isStageOverdue = !isTerminal && stageDeadline !== null && now > stageDeadline;
+  const isTicketOverdue = !isTerminal && ticketEta !== null && now > ticketEta;
+  const hasPlanningRisk = !isTerminal && (planningRisk.state === 'ACTIVE' || planningRisk.state === 'ACKNOWLEDGED');
+
+  let severity: EtaDisplaySeverity = 'NONE';
+  if (isTicketOverdue) severity = 'TICKET_OVERDUE';
+  else if (isStageOverdue) severity = 'STAGE_OVERDUE';
+  else if (hasPlanningRisk) severity = 'PLANNING_RISK';
+
+  return {
+    autoEnabled: boardEtaManagement.autoRecomputeEnabled,
+    forecastStatus: ticketEtaManagement.forecastStatus,
+    forecastIncompleteReason: ticketEtaManagement.forecastIncompleteReason,
+    planningRiskState: planningRisk.state,
+    isPaused,
+    severity,
+    stageDeadline,
+    ticketDue: ticketEta,
+  };
+}

--- a/packages/shared/src/tickets/index.ts
+++ b/packages/shared/src/tickets/index.ts
@@ -1,2 +1,5 @@
 export * from './utils';
 export * from './flow';
+export * from './etaActivityValues';
+export * from './riskFingerprint';
+export * from './etaManagementView';

--- a/packages/shared/src/tickets/riskFingerprint.ts
+++ b/packages/shared/src/tickets/riskFingerprint.ts
@@ -1,0 +1,51 @@
+/**
+ * Deterministic identity of a planning-risk condition's inputs. Used both by
+ * the immediate evaluation path (domain service, on every mutation) and the
+ * hourly reconciliation worker so risk-state transitions never drift between
+ * the two - both must always compute the exact same fingerprint for the
+ * same inputs.
+ *
+ * Deliberately a plain, synchronous, non-cryptographic hash (FNV-1a): this
+ * is an equality/dedup key, not a security boundary, and staying
+ * synchronous keeps the risk-evaluation pure functions synchronous too.
+ * Inputs are IDs, timestamps, a status string, and a version number only -
+ * no personal data, per the PRD's fingerprint requirement.
+ */
+
+export interface RiskFingerprintInput {
+  ticketId: string;
+  /** Active TicketStageEta.id at evaluation time. */
+  activeStageVisitId: string;
+  /** Stage deadline, epoch ms. */
+  stageEta: number;
+  /** Ticket due date, epoch ms. */
+  ticketEta: number;
+  ticketStatus: string;
+}
+
+const MAX_HASH_INPUT_LENGTH = 1024;
+
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  const length = Math.min(input.length, MAX_HASH_INPUT_LENGTH);
+  for (let i = 0; i < length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+// Bumped because boardConfigVersion left the canonical string below - a fingerprint's
+// meaning changed, not just its inputs' values.
+const FINGERPRINT_VERSION = 'v2';
+
+export function computeRiskFingerprint(input: RiskFingerprintInput): string {
+  const canonical = [
+    input.ticketId,
+    input.activeStageVisitId,
+    String(input.stageEta),
+    String(input.ticketEta),
+    input.ticketStatus,
+  ].join('|');
+  return `${FINGERPRINT_VERSION}:${fnv1a(canonical)}`;
+}

--- a/packages/shared/src/utils/etaCalculation.ts
+++ b/packages/shared/src/utils/etaCalculation.ts
@@ -9,6 +9,14 @@
 const IST_OFFSET_HOURS = 5.5;
 
 /**
+ * Safety cap on the day-stepping loops in `calculateETADeadline` and
+ * `calculateWorkingDurationMs`. Both walk forward one working day at a
+ * time, so a bogus or unbounded input (e.g. a multi-year estimate, or a
+ * corrupted date range) could otherwise loop indefinitely.
+ */
+const MAX_WORKING_DAY_ITERATIONS = 1000;
+
+/**
  * Working hours configuration interface
  */
 export interface WorkingHoursConfig {
@@ -175,19 +183,27 @@ export function calculateETADeadline(
   current = moveToNextWorkingDay(current, config);
   current = skipWeekends(current, config);
 
-  // Calculate full working days needed
-  const fullDaysNeeded = Math.floor(remainingHours / workingHoursPerDay);
-  if (fullDaysNeeded > 0) {
-    let workingDaysAdded = 0;
-    while (workingDaysAdded < fullDaysNeeded) {
-      current = moveToNextWorkingDay(current, config);
-      workingDaysAdded++;
+  // Leaves remainingHours in (0, workingHoursPerDay] rather than consuming every full day, so
+  // an exact multi-day estimate pins to the end of the last working day instead of the start
+  // of the next - matching how a single exact day is pinned above.
+  let dayIterations = 0;
+  while (remainingHours > workingHoursPerDay) {
+    if (dayIterations >= MAX_WORKING_DAY_ITERATIONS) {
+      throw new Error(
+        'Maximum iterations reached in calculateETADeadline - possible infinite loop'
+      );
     }
-    remainingHours -= fullDaysNeeded * workingHoursPerDay;
+    remainingHours -= workingHoursPerDay;
+    current = moveToNextWorkingDay(current, config);
+    dayIterations++;
   }
 
-  // Handle remaining partial day
-  if (remainingHours > 0) {
+  if (remainingHours === workingHoursPerDay) {
+    // Estimate exactly fills this day - pin to end of working day.
+    const istForCalc = utcToIST(current);
+    istForCalc.setUTCHours(config.end, 0, 0, 0);
+    current = istToUTC(istForCalc);
+  } else if (remainingHours > 0) {
     const istForPartial = utcToIST(current);
     const totalMinutesNeeded = remainingHours * 60;
     istForPartial.setUTCMinutes(istForPartial.getUTCMinutes() + totalMinutesNeeded);
@@ -214,9 +230,8 @@ export function calculateWorkingDurationMs(
   const end = new Date(endUtc);
   let totalMs = 0;
   let iterations = 0;
-  const MAX_ITERATIONS = 1000; // Safety limit for large date ranges
 
-  while (current < end && iterations < MAX_ITERATIONS) {
+  while (current < end && iterations < MAX_WORKING_DAY_ITERATIONS) {
     iterations++;
 
     // 1. Skip weekends
@@ -266,7 +281,7 @@ export function calculateWorkingDurationMs(
     }
   }
 
-  if (iterations >= MAX_ITERATIONS) {
+  if (iterations >= MAX_WORKING_DAY_ITERATIONS) {
     throw new Error(
       `Maximum iterations reached in calculateWorkingDurationMs - possible infinite loop. Range: ${startUtc.toISOString()} to ${endUtc.toISOString()}`
     );

--- a/packages/shared/src/validation/etaManagementSchema.ts
+++ b/packages/shared/src/validation/etaManagementSchema.ts
@@ -1,0 +1,245 @@
+import { z } from 'zod';
+
+// ============================================================================
+// BOARD ETA MANAGEMENT (stored in Board.metadata.etaManagement)
+//
+// Configuration + versioning for the "Ticket ETA Risk Detection and
+// Automatic Recalculation" feature. Stored as a JSON subtree so it requires
+// no schema migration; every reader/writer must go through the parse/merge
+// helpers below rather than casting the raw column.
+// ============================================================================
+
+export const boardEtaManagementSchema = z.object({
+  autoRecomputeEnabled: z.boolean(),
+  standardPathStageIds: z.array(z.string()),
+});
+
+export type BoardEtaManagement = z.infer<typeof boardEtaManagementSchema>;
+
+/**
+ * The single source of truth for what an unconfigured board should default
+ * to - used both when a board is first created (`boardRepository.createBoard`)
+ * and when an existing board with no saved `etaManagement` is read
+ * (`parseBoardEtaManagement`'s fallback below). One function shared by both
+ * moments in a board's life is what makes it impossible for "a new board of
+ * type X" and "a pre-existing board of type X" to silently end up with
+ * different automation defaults - every board type defaults to on, for both.
+ *
+ * `createTicket` and every stage-transition path only ever write `eta` when
+ * `autoRecomputeEnabled` is true, so this is what restores every
+ * pre-existing board's pre-feature guarantee that a ticket always gets a
+ * computed due date, and what keeps a stage-deadline edit or board transfer
+ * recalculating it the way it always used to (PRD H1/H2).
+ *
+ * The tradeoff, accepted deliberately: existing tickets - on every board
+ * type, not only linear ones - will have their due date auto-extended
+ * (never shortened - see `extendOnly.ts`) the next time a covered mutation
+ * touches them, not only new ones. In practice this only has a live effect
+ * on DEFAULT and RELEASE boards, which `routeResolution.ts` forecasts
+ * identically; NON_LINEAR stays inert until a Standard Path is configured
+ * (`standardPathStageIds: []` makes the route NOT_APPLICABLE regardless of
+ * this flag), and FLOW stays inert unconditionally (same file).
+ *
+ * `boardType` stays a parameter - not dropped now that every type resolves
+ * the same way - so this remains the one place a future per-type split would
+ * be made, rather than reappearing as two independently-maintained checks.
+ */
+export function defaultAutoRecomputeEnabled(_boardType: string): boolean {
+  return true;
+}
+
+export function validateBoardEtaManagement(data: unknown) {
+  return boardEtaManagementSchema.safeParse(data);
+}
+
+/**
+ * Tolerant parse: absent or invalid `etaManagement` falls back to no Standard
+ * Path and `defaultAutoRecomputeEnabled(boardType)`. `boardType` is required
+ * (not optional/defaulted) so a call site can't silently fall back to the
+ * wrong automation default for its board by omitting it.
+ */
+export function parseBoardEtaManagement(metadata: unknown, boardType: string): BoardEtaManagement {
+  const fallback: BoardEtaManagement = {
+    autoRecomputeEnabled: defaultAutoRecomputeEnabled(boardType),
+    standardPathStageIds: [],
+  };
+  if (metadata === null || typeof metadata !== 'object') {
+    return fallback;
+  }
+  const candidate = (metadata as Record<string, unknown>).etaManagement;
+  if (candidate === undefined) {
+    return fallback;
+  }
+  const result = validateBoardEtaManagement(candidate);
+  return result.success ? result.data : fallback;
+}
+
+/**
+ * Merge a patch into `Board.metadata.etaManagement` while preserving every
+ * unrelated key already on `Board.metadata` (ticketFormConfig,
+ * ticketControlRoleIds, slaPolicyType, ...). Callers write the returned
+ * object back as the full `metadata` column value.
+ */
+export function mergeBoardEtaManagement(
+  existingMetadata: unknown,
+  boardType: string,
+  patch: Partial<BoardEtaManagement>,
+): Record<string, unknown> {
+  const base =
+    existingMetadata !== null && typeof existingMetadata === 'object'
+      ? { ...(existingMetadata as Record<string, unknown>) }
+      : {};
+  const current = parseBoardEtaManagement(existingMetadata, boardType);
+  base.etaManagement = { ...current, ...patch } satisfies BoardEtaManagement;
+  return base;
+}
+
+// ============================================================================
+// TICKET ETA MANAGEMENT (stored in Ticket.metadata.etaManagement)
+//
+// Only the CURRENT forecast/risk state lives here. Full history stays in
+// TicketActivity rows (see packages/shared/src/tickets/etaActivityValues.ts)
+// so this JSON subtree stays small and bounded.
+// ============================================================================
+
+export const forecastStatusValues = ['COMPLETE', 'INCOMPLETE', 'NOT_APPLICABLE'] as const;
+export const estimateSourceValues = [
+  'STAGE_DEFAULT',
+  'TRANSITION_FIXED',
+  'MANUAL',
+  'LEGACY_INFERRED',
+] as const;
+export const planningRiskStateValues = ['NONE', 'ACTIVE', 'ACKNOWLEDGED', 'RESOLVED'] as const;
+
+export type ForecastStatus = (typeof forecastStatusValues)[number];
+export type EstimateSource = (typeof estimateSourceValues)[number];
+
+const activeVisitSchema = z.object({
+  stageVisitId: z.string().nullable(),
+  transitionId: z.string().nullable(),
+  /**
+   * Distinguishes a genuine tracked deadline from the existing no-SLA
+   * placeholder, where `TicketStageEta.stageEta` is stored equal to
+   * `stageEnteredAt` because the column is non-nullable. Must never be
+   * inferred purely from "is stageEta in the future" - the evaluator that
+   * builds this value owns that decision.
+   */
+  deadlineTracked: z.boolean(),
+  estimateSource: z.enum(estimateSourceValues),
+  estimateHours: z.number().nullable(),
+});
+
+const planningRiskSchema = z.object({
+  state: z.enum(planningRiskStateValues),
+  fingerprint: z.string().nullable(),
+  detectedAt: z.number().nullable(),
+  stageVisitId: z.string().nullable(),
+  stageEta: z.number().nullable(),
+  ticketEta: z.number().nullable(),
+  acknowledgedAt: z.number().nullable(),
+  acknowledgedBy: z.string().nullable(),
+  acknowledgmentReason: z.string().nullable(),
+});
+
+const etaActivityOutboxEntrySchema = z.object({
+  activityType: z.string(),
+  /** One of the typed Eta*ActivityValue shapes; see tickets/etaActivityValues.ts. */
+  value: z.unknown(),
+  /** Attributing user, or null for the workspace ticket bot (automatic rows). */
+  actorId: z.string().nullable(),
+});
+
+const etaActivityOutboxSchema = z.object({
+  at: z.number(),
+  entries: z.array(etaActivityOutboxEntrySchema),
+});
+
+export type EtaActivityOutboxEntry = z.infer<typeof etaActivityOutboxEntrySchema>;
+export type EtaActivityOutbox = z.infer<typeof etaActivityOutboxSchema>;
+
+export const ticketEtaManagementSchema = z.object({
+  lastEvaluatedAt: z.number().nullable(),
+  pendingActivities: etaActivityOutboxSchema.nullable().default(null),
+  forecastStatus: z.enum(forecastStatusValues),
+  forecastIncompleteReason: z.string().nullable(),
+  forecastIncompleteStageIds: z.array(z.string()),
+  activeVisit: activeVisitSchema,
+  planningRisk: planningRiskSchema,
+});
+
+export type TicketEtaManagementActiveVisit = z.infer<typeof activeVisitSchema>;
+export type TicketEtaManagementPlanningRisk = z.infer<typeof planningRiskSchema>;
+export type TicketEtaManagement = z.infer<typeof ticketEtaManagementSchema>;
+
+/** Default state for a ticket that has never been evaluated by this feature. */
+export const DEFAULT_TICKET_ETA_MANAGEMENT: TicketEtaManagement = {
+  lastEvaluatedAt: null,
+  pendingActivities: null,
+  forecastStatus: 'NOT_APPLICABLE',
+  forecastIncompleteReason: null,
+  forecastIncompleteStageIds: [],
+  activeVisit: {
+    stageVisitId: null,
+    transitionId: null,
+    deadlineTracked: false,
+    estimateSource: 'LEGACY_INFERRED',
+    estimateHours: null,
+  },
+  planningRisk: {
+    state: 'NONE',
+    fingerprint: null,
+    detectedAt: null,
+    stageVisitId: null,
+    stageEta: null,
+    ticketEta: null,
+    acknowledgedAt: null,
+    acknowledgedBy: null,
+    acknowledgmentReason: null,
+  },
+};
+
+export function validateTicketEtaManagement(data: unknown) {
+  return ticketEtaManagementSchema.safeParse(data);
+}
+
+/** Tolerant parse: absent or invalid `etaManagement` falls back to the documented defaults. */
+export function parseTicketEtaManagement(metadata: unknown): TicketEtaManagement {
+  if (metadata === null || typeof metadata !== 'object') {
+    return DEFAULT_TICKET_ETA_MANAGEMENT;
+  }
+  const candidate = (metadata as Record<string, unknown>).etaManagement;
+  if (candidate === undefined) {
+    return DEFAULT_TICKET_ETA_MANAGEMENT;
+  }
+  const result = validateTicketEtaManagement(candidate);
+  return result.success ? result.data : DEFAULT_TICKET_ETA_MANAGEMENT;
+}
+
+/**
+ * Merge a patch into `Ticket.metadata.etaManagement` while preserving every
+ * unrelated key already on `Ticket.metadata` (flow, reporterEmail,
+ * workflowType, ...). `activeVisit`/`planningRisk` are merged one level deep
+ * so a single-field patch (e.g. just `planningRisk.state`) doesn't clobber
+ * untouched sibling fields on the same nested object.
+ */
+export function mergeTicketEtaManagement(
+  existingMetadata: unknown,
+  patch: Partial<Omit<TicketEtaManagement, 'activeVisit' | 'planningRisk'>> & {
+    activeVisit?: Partial<TicketEtaManagementActiveVisit>;
+    planningRisk?: Partial<TicketEtaManagementPlanningRisk>;
+  },
+): Record<string, unknown> {
+  const base =
+    existingMetadata !== null && typeof existingMetadata === 'object'
+      ? { ...(existingMetadata as Record<string, unknown>) }
+      : {};
+  const current = parseTicketEtaManagement(existingMetadata);
+  const merged: TicketEtaManagement = {
+    ...current,
+    ...patch,
+    activeVisit: { ...current.activeVisit, ...(patch.activeVisit ?? {}) },
+    planningRisk: { ...current.planningRisk, ...(patch.planningRisk ?? {}) },
+  };
+  base.etaManagement = merged;
+  return base;
+}

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -114,6 +114,12 @@ import { SUMMARY_PROMPT_MAX_LENGTH } from '../templates/callSummary.js';
 import { z } from 'zod';
 import { isBaselineCanvasType, sdlcTrackStatusSchema } from '../sdlc.js';
 import type { CallParticipantMetadata } from '../types/call.js';
+import {
+  parseBoardEtaManagement,
+  mergeBoardEtaManagement,
+  parseTicketEtaManagement,
+  mergeTicketEtaManagement,
+} from '../validation/etaManagementSchema.js';
 
 const serializeCanvasCommentMentionedUserIds = (mentionedUserIds: string[]): string =>
   JSON.stringify([...new Set(mentionedUserIds)]);
@@ -4379,6 +4385,41 @@ export const mutators = defineMutators({
         await updateTicketMdFromZero(tx, zql, ticketId);
       },
     ),
+    acknowledgeEtaRisk: defineMutator(
+      z.object({
+        ticketId: z.string(),
+        expectedFingerprint: z.string(),
+        reason: z.string().min(1),
+        clientTimestamp: z.number(),
+      }),
+      async ({ tx, ctx, args: { ticketId, expectedFingerprint, reason, clientTimestamp } }) => {
+        const ticket = await tx.run(zql.tickets.where('id', ticketId).one());
+        if (!ticket) return;
+
+        const current = parseTicketEtaManagement(ticket.metadata);
+        // Optimistic no-op on a stale fingerprint - the server is authoritative and will
+        // reject with a conflict the client can refetch from; this just avoids the local
+        // optimistic UI flashing an acknowledgment that won't be confirmed.
+        if (current.planningRisk.state !== 'ACTIVE' || current.planningRisk.fingerprint !== expectedFingerprint) {
+          return;
+        }
+
+        const merged = mergeTicketEtaManagement(ticket.metadata, {
+          planningRisk: {
+            state: 'ACKNOWLEDGED',
+            acknowledgedAt: clientTimestamp,
+            acknowledgedBy: ctx.userID,
+            acknowledgmentReason: reason,
+          },
+        });
+
+        await tx.mutate.tickets.update({
+          id: ticketId,
+          metadata: merged as ReadonlyJSONValue,
+          updatedAt: clientTimestamp,
+        });
+      },
+    ),
   },
   ticketStageEta: {
     update: defineMutator(
@@ -4851,6 +4892,11 @@ export const mutators = defineMutators({
         projectId: z.string().optional(),
         boardType: z.nativeEnum(BoardType).optional(),
         metadata: z.any().optional(),
+        // Automatic ETA management - see the backend mutator for the Standard Path
+        // validation this optimistic client-side write deliberately skips (the server is
+        // authoritative and will reject an invalid path, rolling this write back).
+        autoRecomputeEnabled: z.boolean().optional(),
+        standardPathStageIds: z.array(z.string()).optional(),
         stages: z
           .array(
             z.object({
@@ -4887,6 +4933,8 @@ export const mutators = defineMutators({
           description,
           projectId,
           metadata,
+          autoRecomputeEnabled,
+          standardPathStageIds,
           stages,
           timestamp,
           stageIds = {},
@@ -4934,6 +4982,21 @@ export const mutators = defineMutators({
           }
         }
 
+        // ETA settings merge into the etaManagement subtree instead of replacing the whole
+        // column. Base is the caller's `metadata` when it sent one (so both survive),
+        // otherwise the board's current metadata.
+        const nextMetadata =
+          autoRecomputeEnabled !== undefined || standardPathStageIds !== undefined
+            ? mergeBoardEtaManagement(
+                metadata !== undefined ? metadata : board.metadata,
+                boardType ?? board.boardType,
+                {
+                  ...(autoRecomputeEnabled !== undefined && { autoRecomputeEnabled }),
+                  ...(standardPathStageIds !== undefined && { standardPathStageIds }),
+                },
+              )
+            : metadata;
+
         // Update board
         await tx.mutate.boards.update({
           id: boardId,
@@ -4941,7 +5004,7 @@ export const mutators = defineMutators({
           ...(description !== undefined && { description }),
           ...(projectId !== undefined && { projectId }),
           ...(boardType !== undefined && { boardType }),
-          ...(metadata !== undefined && { metadata: metadata as ReadonlyJSONValue }),
+          ...(nextMetadata !== undefined && { metadata: nextMetadata as ReadonlyJSONValue }),
           updatedBy: ctx.userID,
           updatedAt: timestamp,
         });

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -368,6 +368,17 @@ export enum ActivityType {
   EMAIL_SENT = 'EMAIL_SENT',
   TICKET_CREATED = 'TICKET_CREATED',
   CSAT_RECEIVED = 'CSAT_RECEIVED',
+  // ETA risk-detection / automatic-recalculation feature (see
+  // packages/shared/src/tickets/etaActivityValues.ts for each type's stored
+  // `value` shape). Distinct from the existing ETA/STAGE_ETA field-change
+  // activities above and from the pre-existing stage/ticket-overdue breach
+  // activities, which keep using their own actorAction values.
+  ETA_AUTO_RECOMPUTED = 'ETA_AUTO_RECOMPUTED',
+  ETA_MANUALLY_UPDATED = 'ETA_MANUALLY_UPDATED',
+  ETA_RISK_DETECTED = 'ETA_RISK_DETECTED',
+  ETA_RISK_ACKNOWLEDGED = 'ETA_RISK_ACKNOWLEDGED',
+  ETA_RISK_REOPENED = 'ETA_RISK_REOPENED',
+  ETA_RISK_RESOLVED = 'ETA_RISK_RESOLVED',
 }
 
 // @ts-ignore TS1294
@@ -614,6 +625,8 @@ export enum NotificationType {
   TICKET_SUBTICKET_ADDED = "TICKET_SUBTICKET_ADDED",
   TICKET_RELATED_TICKET_ADDED = "TICKET_RELATED_TICKET_ADDED",
   TICKET_RELATED_TICKET_REMOVED = "TICKET_RELATED_TICKET_REMOVED",
+  /** Planning-risk detected/reopened - stage deadline later than ticket due date, not yet overdue. */
+  TICKET_ETA_PLANNING_RISK = "TICKET_ETA_PLANNING_RISK",
   CHANNEL_MESSAGE = "CHANNEL_MESSAGE",
   MENTION = "MENTION",
   DIRECT_MESSAGE = "DIRECT_MESSAGE",


### PR DESCRIPTION
[POT-1](https://drive.google.com/file/d/11CYcTAiUwbsB2UUCPg9Quy3DGfnG1bUH/view?usp=sharing)

[POT-2](https://drive.google.com/file/d/17j-eQ4c2MD-0zikY5KaFqD2mm4hQkyQp/view?usp=sharing)

Environment-Changes:
  - ETA_MANAGEMENT_ENABLED: Deployment-level kill switch for the ETA risk-detection/auto-recalculation feature

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [x] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [x] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [x] No `Date.now()` / `uuid()` generated inside a mutator
- [x] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [x] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [x] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->

### Manual

**Users**
- [x] Single user
- [x] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
