### PR TITLE
fix: reduce xyne-claw/xyne-claw-auth PII log exposure to count/shape-only

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-direct.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-direct.ts
@@ -742,7 +742,7 @@ export async function queryDirect(
     Object.assign(payload, Object.keys(explicit).length > 0 ? explicit : defaultNativeInputs(query));
   }
 
-  console.error("[vespa-direct] raw YQL:", safeYql, "| profile:", profile);
+  console.error(`[vespa-direct] YQL profile=${profile} len=${safeYql.length}`);
 
   const debug = { payloads: [{ stage: "direct", yql: safeYql, vespaParams: {} as Record<string, unknown> }] };
 

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
@@ -305,7 +305,7 @@ export interface QueryAST {
 
 export async function interact(ast: QueryAST, auth?: SpacesAuthContext): Promise<unknown> {
   const payload = JSON.stringify(ast);
-  console.error(`[spaces-client] POST /api/query/claw ${payload}`);
+  console.error(`[spaces-client] POST /api/query/claw model=${ast.model} op=${ast.operation} whereKeys=${ast.where ? Object.keys(ast.where).length : 0}`);
   const result = (await spacesFetch("/api/query/claw", {
     method: "POST",
     body: payload,
@@ -315,13 +315,13 @@ export async function interact(ast: QueryAST, auth?: SpacesAuthContext): Promise
 
 export async function search(params: Record<string, string>, auth?: SpacesAuthContext): Promise<unknown> {
   const qs = new URLSearchParams(params).toString();
-  console.error(`[spaces-client] GET /api/vespaSearch/claw?${qs}`);
+  console.error(`[spaces-client] GET /api/vespaSearch/claw paramKeys=[${Object.keys(params).join(",")}]`);
   return spacesFetch(`/api/vespaSearch/claw?${qs}`, undefined, auth);
 }
 
 export async function memorySearch(body: Record<string, unknown>, auth?: SpacesAuthContext): Promise<unknown> {
   const payload = JSON.stringify(body);
-  console.error(`[spaces-client] POST /api/memory/claw/search ${payload}`);
+  console.error(`[spaces-client] POST /api/memory/claw/search bodyKeys=[${Object.keys(body).join(",")}]`);
   return spacesFetch("/api/memory/claw/search", {
     method: "POST",
     body: payload,

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -851,7 +851,7 @@ const spacesSearch: ToolDef = {
       // Only forward groupBy when not already forced to "" by the offset path above.
       if (args["groupBy"] && !params["groupBy"]) params["groupBy"] = String(args["groupBy"]);
 
-      console.error("[spaces-search]", args);
+      console.error(`[spaces-search] argKeys=[${Object.keys(args).join(",")}]`);
 
       let data: {
         success: boolean;

--- a/apps/xyne-claw-auth/backend/src/mcpgateway/services/execution.ts
+++ b/apps/xyne-claw-auth/backend/src/mcpgateway/services/execution.ts
@@ -72,14 +72,14 @@ async function fetchAuthToken(
   // Check cache first
   const cached = await tokenCache.getToken(tenantId, serviceName, authEmail);
   if (cached) {
-    console.log(`[auth] Token retrieved from cache for service=${serviceName} email=${authEmail}`);
+    console.log(`[auth] Token retrieved from cache for service=${serviceName}`);
     return cached;
   }
 
   // Call token endpoint with JWT for verification
   const tokenUrl = `${backendUrl}${tokenEndpointUrl}`;
   
-  console.log(`[auth] Fetching new token from ${tokenUrl} for service=${serviceName} email=${authEmail}`);
+  console.log(`[auth] Fetching new token from ${tokenUrl} for service=${serviceName}`);
 
   const tokenRequestHeaders: Record<string, string> = {
     "Content-Type": "application/json",

--- a/apps/xyne-claw-auth/backend/src/routes/admin.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/admin.ts
@@ -95,7 +95,7 @@ router.post("/roles", requireClawAdmin, async (req: Request, res: Response) => {
       description: `${role} granted to ${targetUser.email}`,
       metadata: { targetEmail: targetUser.email, role },
     });
-    log.info(`[admin] ${role} granted to ${targetUser.email} by ${requesterId}`);
+    log.info(`[admin] ${role} granted to user=${targetUser.id} by ${requesterId}`);
     res.status(201).json({ success: true, data: grantedRole });
   } catch (err) {
     log.error("[admin] grant role error:", err);
@@ -119,7 +119,7 @@ router.delete("/roles/:userId", requireClawAdmin, async (req: Request<{ userId: 
 
     await userRoleRepository.delete(userId, role);
     await writeAuditLog({ actorUserId: requesterId, eventType: "ROLE_REVOKED", targetId: userId, description: `${role} revoked from ${targetUser.email}`, metadata: { targetEmail: targetUser.email, role } });
-    log.info(`[admin] ${role} revoked from ${targetUser.email} by ${requesterId}`);
+    log.info(`[admin] ${role} revoked from user=${targetUser.id} by ${requesterId}`);
     res.json({ success: true });
   } catch (err: unknown) {
     if (err instanceof Error && "code" in err && (err as { code: string }).code === "P2025") {

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -2520,7 +2520,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
       // Tools can legitimately run for minutes — pause the stall watchdog so a
       // slow tool isn't mistaken for a hung model.
       modelActive = false;
-      log.info(`[agent] Tool call: ${event.toolName} args=${JSON.stringify(event.args ?? {}).slice(0, 200)}`);
+      log.info(`[agent] Tool call: ${event.toolName} argCount=${Object.keys(event.args ?? {}).length} argKeys=[${Object.keys(event.args ?? {}).join(",")}]`);
       inflightCalls.set(event.toolCallId, { toolName: event.toolName, args: event.args, startedAt: Date.now() });
       pushDebugEvent("tool_execution_start", {
         toolName: event.toolName,

--- a/apps/xyne-claw/src/custom-tools.ts
+++ b/apps/xyne-claw/src/custom-tools.ts
@@ -292,7 +292,7 @@ export function loadCustomTools(
           log.error(`[custom-tool] ${ct.slug} threw:`, errMsg);
           result = `Error: ${errMsg}`;
         }
-        log.info(`[custom-tool] ${ct.slug} result: ${result.slice(0, 300)}`);
+        log.info(`[custom-tool] ${ct.slug} result: ${result.length} chars`);
 
         // Sandbox-capacity deferral (flag-gated, default off): the inner catch
         // above stringifies every tool throw and hands it to the LLM, which for a


### PR DESCRIPTION
## What
Removes cleartext PII from `xyne-claw` and `xyne-claw-auth` log sinks. Each affected log line is reduced to shape / counts / ids only — no raw values. No behavioural change beyond what is written to the log.

## Why
From the `/experiment` PII-in-logs audit, these Claw log sites emit user email, Prisma `where{}` filters, raw search queries / YQL (with bound perm & userId params), and full tool args/results in cleartext. These bypass the Node winston redaction (raw `console.*` / interpolated message strings), so they can only be fixed at the call site.

## Changes (7 files, 11 lines)
| Finding | File | Before | After |
|---|---|---|---|
| F64 | `apps/xyne-claw/src/agent.ts` | tool-call `args=JSON.stringify(event.args).slice(0,200)` | `argCount` + `argKeys` only |
| F65 | `apps/xyne-claw/src/custom-tools.ts` | `result: result.slice(0,300)` | `result: <n> chars` |
| F62 | `apps/xyne-claw-auth/backend/src/mcpgateway/services/execution.ts` | `email=${authEmail}` (x2) | dropped email |
| F63 | `apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts` | full Prisma AST payload / raw query string (x3) | `model/op/whereKeys`, `paramKeys`, `bodyKeys` |
| F63 | `apps/xyne-claw-auth/backend/src/mcp/servers/vespa-direct.ts` | `raw YQL: <safeYql>` | `profile` + yql length only |
| F63 | `apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts` | `[spaces-search] <args>` | `argKeys` only |
| F66 | `apps/xyne-claw-auth/backend/src/routes/admin.ts` | role grant/revoke logs `targetUser.email` (x2) | logs `targetUser.id` |

Note: the `writeAuditLog(... metadata:{ targetEmail })` persisted audit record in `admin.ts` is intentionally left unchanged — that is a deliberate access-controlled audit trail, not an application stdout log.

## Validation
- `tsc --noEmit` on both `apps/xyne-claw` and `apps/xyne-claw-auth/backend`: zero new errors at any edited line (verified against the pre-edit baseline — identical error count, none in the changed lines).
- Diff is 11 lines, mechanical, no control-flow changes.

## Base branch
Cut from and targeting `feature/deploy-xyneclaw` as requested.
