### PR TITLE
fix: plan approval/reject + plan persists in db + no stale inprogress…

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/agent-widget-binding.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-widget-binding.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { normalizePrUrl, readPrBindingData } from "./agent-widget-binding.js";
+import {
+  normalizePrUrl,
+  readPrBindingData,
+  planScreenId,
+  planExternalKey,
+  readPlanBindingData,
+} from "./agent-widget-binding.js";
 import type { AgentWidgetBinding } from "@prisma/client";
 
 /**
@@ -67,5 +73,59 @@ describe("readPrBindingData", () => {
     expect(readPrBindingData(bindingWith({ provider: "bitbucket" }))).toBeNull();
     expect(readPrBindingData(bindingWith({ title: "no provider" }))).toBeNull();
     expect(readPrBindingData(bindingWith(null))).toBeNull();
+  });
+});
+
+describe("plan binding keys", () => {
+  it("derives one screenId per plan card, from the card's own messageId", () => {
+    expect(planScreenId("msg-abc")).toBe("agent-plan-msg-abc");
+    expect(planScreenId("msg-abc")).not.toBe(planScreenId("msg-def"));
+  });
+
+  it("scopes the conversation correlate per agent, so two agents in one thread don't collide", () => {
+    expect(planExternalKey("conv-1", "credit-doctor")).not.toBe(planExternalKey("conv-1", "other-agent"));
+    expect(planExternalKey("conv-1", "credit-doctor")).toBe(planExternalKey("conv-1", "credit-doctor"));
+  });
+});
+
+describe("readPlanBindingData", () => {
+  it("parses a well-formed plan binding blob", () => {
+    const parsed = readPlanBindingData(
+      bindingWith({
+        todos: [
+          { id: "t1", title: "Pull the failing invoices" },
+          { id: "t2", title: "Reconcile against ledger" },
+        ],
+        title: "Credit reconciliation",
+        desc: "two steps",
+        document: "## Plan\n...",
+        ownerUserId: "user-1",
+      }),
+    );
+    expect(parsed).toMatchObject({
+      ownerUserId: "user-1",
+      title: "Credit reconciliation",
+      document: "## Plan\n...",
+    });
+    expect(parsed?.todos).toHaveLength(2);
+  });
+
+  // The row is the ONLY source of these two facts once Redis has expired, so a
+  // blob missing either can't be approved — half-resolving it would either run an
+  // empty plan or let the wrong user approve.
+  it("returns null without an owner or without executable todos", () => {
+    expect(readPlanBindingData(bindingWith({ todos: [{ id: "t1", title: "x" }] }))).toBeNull();
+    expect(readPlanBindingData(bindingWith({ todos: [], ownerUserId: "user-1" }))).toBeNull();
+    expect(readPlanBindingData(bindingWith(null))).toBeNull();
+  });
+
+  it("drops malformed todo entries rather than trusting them", () => {
+    const parsed = readPlanBindingData(
+      bindingWith({
+        todos: [{ id: "t1", title: "keep" }, { id: 7, title: "bad id" }, { id: "t3" }, null],
+        ownerUserId: "user-1",
+      }),
+    );
+    expect(parsed?.todos).toEqual([{ id: "t1", title: "keep" }]);
   });
 });

--- a/apps/xyne-claw-auth/backend/src/lib/agent-widget-binding.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-widget-binding.ts
@@ -9,7 +9,11 @@
  *
  * Generic across widget `kind`:
  *   - 'pr'   → externalKey = normalized PR URL; data = {provider,title,ticketId,url,desc,repo,number}
- *   - 'plan' → (future) externalKey null; data = plan-specific
+ *   - 'plan' → externalKey = `<conversationId>:<agentSlug>`; data = {todos,title,desc,document,ownerUserId}
+ *
+ * For 'plan' the table is more than an index: it is the durable REPLACEMENT for
+ * the Redis plan state, so a proposed card stays approvable indefinitely (see
+ * the Plan bindings section below).
  *
  * Everything here is BEST-EFFORT: a binding write/read must never break card
  * rendering, so callers wrap in try/catch.
@@ -140,4 +144,146 @@ export function readPrBindingData(row: AgentWidgetBinding): PrBindingData | null
     out.number = d["number"] as string | number;
   }
   return out;
+}
+
+// ── Plan bindings ────────────────────────────────────────────────────────────
+// A proposed plan card is actionable indefinitely, but every piece of state the
+// approve/reject handler needs used to live in Redis (SessionContext + the
+// `plan-active-card:` pointer, both 24h TTL). Past that window — or after any
+// Redis restart — the card was still on screen but every tap 409'd with "This
+// plan is no longer active". These bindings are the durable mirror: they carry
+// the executable todos, the card's routing, and the proposer, so approval works
+// days later with no Redis state at all. Redis stays the fast path; this is the
+// fallback and, for liveness (`status`), the authority.
+
+/** Lifecycle of a proposed plan card. Only 'proposed' is actionable. */
+export type PlanBindingStatus = "proposed" | "approved" | "rejected" | "superseded";
+
+/** The `data` blob a 'plan' binding stores so an approval long after the run
+ *  ended can rebuild the card and dispatch Turn 2 from the row alone. */
+export interface PlanBindingData {
+  todos: { id: string; title: string }[];
+  title?: string;
+  desc?: string;
+  document?: string;
+  /** The user the plan was proposed to — the ONLY one who may approve/reject. */
+  ownerUserId: string;
+}
+
+/** One row per posted plan card. Keyed on the card's own messageId (unique per
+ *  card), which is also what a flow-action arrives carrying. */
+export function planScreenId(messageId: string): string {
+  return `agent-plan-${messageId}`;
+}
+
+/** Conversation correlate for 'plan' rows — lets a re-plan find the outstanding
+ *  proposal to supersede without the Redis pointer. Rides the existing
+ *  (kind, externalKey) index. */
+export function planExternalKey(conversationId: string, agentSlug: string): string {
+  return `${conversationId}:${agentSlug}`;
+}
+
+export function readPlanBindingData(row: AgentWidgetBinding): PlanBindingData | null {
+  const d = row.data as Record<string, unknown> | null;
+  if (!d || typeof d !== "object") return null;
+  const ownerUserId = typeof d["ownerUserId"] === "string" ? (d["ownerUserId"] as string) : "";
+  const rawTodos = Array.isArray(d["todos"]) ? (d["todos"] as unknown[]) : [];
+  const todos = rawTodos
+    .filter(
+      (t): t is { id: string; title: string } =>
+        !!t &&
+        typeof t === "object" &&
+        typeof (t as { id?: unknown }).id === "string" &&
+        typeof (t as { title?: unknown }).title === "string",
+    )
+    .map((t) => ({ id: t.id, title: t.title }));
+  // A plan with no owner or no executable steps can't be approved — treat the
+  // row as unusable rather than half-resolving it.
+  if (!ownerUserId || todos.length === 0) return null;
+  const out: PlanBindingData = { todos, ownerUserId };
+  if (typeof d["title"] === "string") out.title = d["title"] as string;
+  if (typeof d["desc"] === "string") out.desc = d["desc"] as string;
+  if (typeof d["document"] === "string") out.document = d["document"] as string;
+  return out;
+}
+
+/** Record a freshly posted proposed plan card. Best-effort like every binding
+ *  write — a failure here costs durability, never the card itself. */
+export async function upsertPlanBinding(input: {
+  orgId: string;
+  conversationId: string;
+  channelId: string;
+  messageId: string;
+  spacesAppId: string;
+  spacesAppUserId: string;
+  agentSlug: string;
+  data: PlanBindingData;
+}): Promise<void> {
+  await upsertWidgetBinding({
+    orgId: input.orgId,
+    kind: "plan",
+    screenId: planScreenId(input.messageId),
+    externalKey: planExternalKey(input.conversationId, input.agentSlug),
+    conversationId: input.conversationId,
+    channelId: input.channelId,
+    messageId: input.messageId,
+    spacesAppId: input.spacesAppId,
+    spacesAppUserId: input.spacesAppUserId,
+    agentSlug: input.agentSlug,
+    status: "proposed" satisfies PlanBindingStatus,
+    data: input.data as unknown as Record<string, unknown>,
+  });
+}
+
+/** The binding for the exact card a flow-action targets. */
+export async function findPlanBindingByMessageId(
+  messageId: string,
+): Promise<AgentWidgetBinding | null> {
+  if (!messageId) return null;
+  return prisma.agentWidgetBinding.findUnique({
+    where: { kind_screenId: { kind: "plan", screenId: planScreenId(messageId) } },
+  });
+}
+
+/** The still-actionable proposal in a thread, if any — used by the re-plan path
+ *  to grey out the card it supersedes. */
+export async function findProposedPlanBinding(
+  conversationId: string,
+  agentSlug: string,
+): Promise<AgentWidgetBinding | null> {
+  if (!conversationId || !agentSlug) return null;
+  return prisma.agentWidgetBinding.findFirst({
+    where: {
+      kind: "plan",
+      externalKey: planExternalKey(conversationId, agentSlug),
+      status: "proposed" satisfies PlanBindingStatus,
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+}
+
+/**
+ * Durable single-use gate: flip 'proposed' → terminal, atomically. The WHERE
+ * clause is the lock — Postgres serializes the two UPDATEs of a double-tap and
+ * the loser matches 0 rows. This replaces the Redis `flow-action:plan:` NX key
+ * for any card that has a binding, because that key expires while the card does
+ * not: past its TTL a plan could otherwise be approved twice.
+ */
+export async function consumePlanBinding(
+  screenId: string,
+  next: PlanBindingStatus,
+): Promise<boolean> {
+  const { count } = await prisma.agentWidgetBinding.updateMany({
+    where: { kind: "plan", screenId, status: "proposed" satisfies PlanBindingStatus },
+    data: { status: next },
+  });
+  return count === 1;
+}
+
+/** Mark a proposal terminal without the single-use semantics (supersede). */
+export async function markPlanBindingStatus(
+  id: string,
+  status: PlanBindingStatus,
+): Promise<void> {
+  await prisma.agentWidgetBinding.update({ where: { id }, data: { status } });
 }

--- a/apps/xyne-claw-auth/backend/src/lib/session-context.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-context.ts
@@ -441,3 +441,55 @@ export async function deleteSession(sessionId: string): Promise<void> {
   }
 }
 
+
+// ── Last rendered plan todos (conversation-scoped) ───────────────────────────
+// The live plan card is fire-and-forget: every todo-write re-renders it and
+// nothing keeps the list afterwards. A todo only leaves `in_progress` when the
+// NEXT todo-write arrives, so a run that ends without one — the model forgot to
+// close the step, or it crashed mid-step — leaves the card frozen mid-flight
+// with a row spinning forever on a run that is definitively over.
+//
+// This snapshot is the only record of what the card currently shows, so it is
+// what /webhook/result reconciles against at run end. Written on every render;
+// cleared once reconciled.
+const PLAN_LAST_TODOS_PREFIX = "plan-last-todos:";
+
+/** Mirrors xyne-claw-shared's `Todo` structurally, without the dependency. */
+export interface PlanTodoSnapshot {
+  id: string;
+  title: string;
+  status: "pending" | "in_progress" | "completed" | "failed";
+}
+
+function planLastTodosKey(conversationId: string, agentSlug: string): string {
+  return `${PLAN_LAST_TODOS_PREFIX}${conversationId}:${agentSlug}`;
+}
+
+export async function setPlanLastTodos(
+  conversationId: string,
+  agentSlug: string,
+  todos: PlanTodoSnapshot[],
+): Promise<void> {
+  const redis = redisService.getConnection();
+  await redis.set(planLastTodosKey(conversationId, agentSlug), JSON.stringify(todos), "EX", SESSION_TTL);
+}
+
+export async function getPlanLastTodos(
+  conversationId: string,
+  agentSlug: string,
+): Promise<PlanTodoSnapshot[] | null> {
+  const redis = redisService.getConnection();
+  const raw = await redis.get(planLastTodosKey(conversationId, agentSlug));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as PlanTodoSnapshot[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearPlanLastTodos(conversationId: string, agentSlug: string): Promise<void> {
+  const redis = redisService.getConnection();
+  await redis.del(planLastTodosKey(conversationId, agentSlug)).catch(() => {});
+}

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action-plan-guard.test.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action-plan-guard.test.ts
@@ -13,6 +13,11 @@ const webhookSrc = readFileSync(resolve(here, "./webhook.ts"), "utf8");
 // (webhook.ts /result stores only { ...ctx, planMessageId }; pendingPlan is
 // first written when Turn 2 is dispatched). Every Approve/Reject click on a
 // proposed plan card therefore 409'd as "stale or missing server plan".
+//
+// The guard was subsequently rebuilt on the durable AgentWidgetBinding row so a
+// plan stays approvable after the 24h Redis TTL. That moved WHICH server record
+// pins the card, so the assertions below track the records that exist now —
+// the incident itself is still pinned by the first test.
 
 describe("plan-approval staleness guard", () => {
   const guard = flowActionSrc.slice(
@@ -24,19 +29,35 @@ describe("plan-approval staleness guard", () => {
     expect(guard).not.toContain("priorCtx.pendingPlan");
   });
 
-  it("still pins the exact card on both server records", () => {
-    // Anti-substitution: the click's messageId must match BOTH the active-card
-    // record and the conv-indexed session context.
+  it("still pins the exact card on the server's own records", () => {
+    // Anti-substitution: a click whose messageId doesn't match the live
+    // active-card record is a superseded card and must be refused.
     expect(guard).toContain("activePlan.messageId !== messageId");
-    expect(guard).toContain("priorCtx.planMessageId !== messageId");
-    // And the todos the dispatch trusts (serverTodos) must actually exist.
-    expect(guard).toContain("!activePlan.todos.length");
+    // The durable row is the authority on liveness — superseded / already
+    // approved / already rejected can never be re-actioned.
+    expect(guard).toContain('planBinding.status !== "proposed"');
+    // And the todos the dispatch trusts must actually exist on a server record.
+    expect(guard).toContain("activePlan?.todos?.length");
+    expect(guard).toContain("bindingData");
   });
 
-  it("matches Turn-1's actual session write (no pendingPlan on the proposed path)", () => {
+  it("does NOT gate on the 24h session, so a plan stays approvable for days", () => {
+    // The SessionContext (and its planMessageId) expires with Redis while the
+    // card in the thread does not. Requiring either here is what made an old
+    // but perfectly valid plan card un-approvable — the durable binding carries
+    // the routing and the plan owner instead. Re-adding either of these
+    // re-breaks approval after 24h.
+    expect(guard).not.toContain("priorCtx.planMessageId !== messageId");
+    expect(guard).not.toContain("!priorCtx ||");
+  });
+
+  it("matches Turn-1's actual writes: planMessageId-only session AND a durable binding", () => {
     // If someone later makes Turn-1 persist pendingPlan, this documents the
     // current contract they're changing: the proposed-plan /result write is
     // planMessageId-only.
     expect(webhookSrc).toContain("await setSession(sessionId, { ...ctx, planMessageId }).catch(() => {});");
+    // Durability rests entirely on this write — without it the guard silently
+    // degrades back to Redis-only, 24h-lifetime approval.
+    expect(webhookSrc).toContain("await upsertPlanBinding({");
   });
 });

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -33,6 +33,12 @@ import { executeTool as executeGatewayTool } from "../mcpgateway/services/execut
 import { GATEWAY_KEY_PREFIX, parseGatewayCatalogSource } from "../mcpgateway/key-format.js";
 import { redisService } from "../redis.js";
 import {
+  findPlanBindingByMessageId,
+  readPlanBindingData,
+  consumePlanBinding,
+  type PlanBindingStatus,
+} from "../lib/agent-widget-binding.js";
+import {
   QUEUE_CAP,
   QUEUE_ENABLED,
   enqueueMessage,
@@ -174,6 +180,33 @@ async function consumePlanAction(messageId: string): Promise<boolean> {
   const key = `flow-action:plan:${messageId}`;
   const result = await redisService.getConnection().set(key, "1", "EX", PLAN_ACTION_CONSUMED_TTL_SEC, "NX");
   return result === "OK";
+}
+
+/**
+ * Single-use gate for a plan card — durable whenever the card has a binding.
+ * The Redis NX key above expires in PLAN_ACTION_CONSUMED_TTL_SEC while the card
+ * itself never does, so for a bound card the authoritative gate is the row's
+ * atomic 'proposed' → terminal transition; without it a plan approved once could
+ * be approved again after the key lapsed. Cards posted before bindings existed
+ * keep the Redis behaviour. Fails CLOSED (a DB error refuses the action) — a
+ * blocked approve is recoverable, a double-dispatched plan is not.
+ */
+async function consumePlanCard(
+  messageId: string,
+  binding: { screenId: string } | null,
+  next: PlanBindingStatus,
+): Promise<boolean> {
+  if (!messageId) return false;
+  if (!binding) return consumePlanAction(messageId);
+  try {
+    return await consumePlanBinding(binding.screenId, next);
+  } catch (err) {
+    log.error(
+      `[flow-action] plan-approval: durable consume failed screenId=${binding.screenId}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return false;
+  }
 }
 
 // ── Spaces signature re-verification ─────────────────────────────────────────
@@ -1901,36 +1934,80 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       }
 
       const { getSessionByConv } = await import("./webhook.js");
-      const [priorCtx, activePlan] = await Promise.all([
+      const [priorCtx, activePlan, planBinding] = await Promise.all([
         getSessionByConv(flowConversationId, flowAgentSlug),
         getActivePlanCard(flowConversationId, flowAgentSlug),
+        findPlanBindingByMessageId(messageId).catch(() => null),
       ]);
-      // A plan action must target the exact outstanding server-created card.
-      // This rejects stale/replayed cards and a flow body with substituted plan
-      // text even when the transport itself was validly signed. The todos the
-      // dispatch trusts come from activePlan (the server-stored card record),
-      // so ctx.pendingPlan is NOT required here — Turn-1 never writes it (it's
-      // only set when Turn 2 is dispatched), and requiring it 409'd EVERY
-      // non-trivial plan approval (prod 2026-08-19, "App backend error 409"
-      // on all Approve clicks since the 2026-08-18 sync deploy).
-      if (
-        !priorCtx ||
-        !activePlan ||
-        !activePlan.todos.length ||
-        activePlan.messageId !== messageId ||
-        priorCtx.planMessageId !== messageId
-      ) {
+      const bindingData = planBinding ? readPlanBindingData(planBinding) : null;
+
+      // A plan action must target the exact outstanding server-created card, and
+      // every todo it runs must come from server state — never from the submitted
+      // flow body, which is user-mutable even when the transport was validly
+      // signed. Two server sources, in priority order:
+      //
+      //   1. Redis `plan-active-card:` — the live fast path (24h TTL).
+      //   2. The durable AgentWidgetBinding row ('plan') — the same facts with no
+      //      expiry. This is what makes a card posted days ago still approvable:
+      //      by then the Redis pointer AND the SessionContext are both gone.
+      //
+      // NOTE: ctx.pendingPlan is deliberately NOT part of this gate. Turn 1 never
+      // writes it (it is only set when Turn 2 is dispatched), so requiring it
+      // 409'd EVERY non-trivial plan approval — prod 2026-08-19, "App backend
+      // error 409" on all Approve clicks since the 2026-08-18 sync deploy. The
+      // todos the dispatch trusts come from the card record, never the session.
+      //
+      // A binding is the AUTHORITY on liveness. Anything but 'proposed' —
+      // superseded by a re-plan, or already approved/rejected — is refused
+      // outright, which is also what makes the single-use gate durable.
+      if (planBinding && planBinding.status !== "proposed") {
+        log.warn(`[flow-action] plan-approval: plan is '${planBinding.status}' conv=${flowConversationId} agent=${flowAgentSlug}`);
+        res.status(409).json({ type: "error", message: "This plan is no longer active. Ask the agent to create a new plan." } satisfies AppActionResponse);
+        return;
+      }
+      // Redis still holds a DIFFERENT live card for this thread ⇒ this one was
+      // superseded by a re-plan. Refuse even if the binding still reads
+      // 'proposed', since the binding's supersede write is best-effort.
+      if (activePlan && activePlan.messageId !== messageId) {
+        log.warn(`[flow-action] plan-approval: superseded card conv=${flowConversationId} agent=${flowAgentSlug}`);
+        res.status(409).json({ type: "error", message: "This plan is no longer active. Ask the agent to create a new plan." } satisfies AppActionResponse);
+        return;
+      }
+      const serverPlan =
+        activePlan?.todos?.length
+          ? {
+              todos: activePlan.todos,
+              title: activePlan.title ?? "Plan",
+              desc: activePlan.desc,
+              document: activePlan.document,
+            }
+          : bindingData
+            ? {
+                todos: bindingData.todos,
+                title: bindingData.title ?? "Plan",
+                desc: bindingData.desc,
+                document: bindingData.document,
+              }
+            : null;
+
+      // Card-scoped facts come from the binding first: it was written when THIS
+      // card was posted, whereas the session is conversation-scoped and any later
+      // turn overwrites it (a different sender's mention would otherwise hand us
+      // the wrong plan owner). The session is the fallback for cards proposed
+      // before bindings existed.
+      const planAgentSlug = planBinding?.agentSlug ?? priorCtx?.agentSlug ?? flowAgentSlug;
+      const planSpacesAppId = planBinding?.spacesAppId ?? priorCtx?.spacesAppId;
+      const planChannelId = planBinding?.channelId ?? priorCtx?.channelId;
+      const planConversationId = planBinding?.conversationId ?? priorCtx?.conversationId ?? flowConversationId;
+      const planUserId = bindingData?.ownerUserId ?? priorCtx?.senderId;
+
+      if (!serverPlan || !planUserId) {
         log.warn(`[flow-action] plan-approval: stale or missing server plan conv=${flowConversationId} agent=${flowAgentSlug}`);
         res.status(409).json({ type: "error", message: "This plan is no longer active. Ask the agent to create a new plan." } satisfies AppActionResponse);
         return;
       }
 
-      const planAgentSlug = priorCtx.agentSlug ?? flowAgentSlug;
-      const planSpacesAppId = priorCtx.spacesAppId;
-      const planChannelId = priorCtx.channelId;
-      const planConversationId = priorCtx.conversationId ?? flowConversationId;
-      const planUserId = priorCtx.senderId;
-      const serverTodos = activePlan.todos;
+      const serverTodos = serverPlan.todos;
 
       // Only the user the server recorded for this plan can approve/reject it.
       if (!callerUserId || callerUserId !== planUserId) {
@@ -1944,14 +2021,14 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       // a "Rejected by <name>" audit. NO Turn 2, NO plan-mode/config change, no
       // follow-ups — if they want a new plan they mention the agent again.
       if (actionId === "plan-reject") {
-        if (!(await consumePlanAction(messageId))) {
+        if (!(await consumePlanCard(messageId, planBinding, "rejected"))) {
           res.status(409).json({ type: "error", message: "This plan has already been acted on." } satisfies AppActionResponse);
           return;
         }
         const rejectedTodos = serverTodos;
-        const rejectTitle = activePlan.title ?? "Plan";
-        const rejectDesc = activePlan.desc;
-        const rejectDoc = activePlan.document;
+        const rejectTitle = serverPlan.title;
+        const rejectDesc = serverPlan.desc;
+        const rejectDoc = serverPlan.document;
         const rejecterName = await prisma.user
           .findUnique({ where: { id: callerUserId }, select: { name: true } })
           .then((u) => u?.name?.trim() ?? "")
@@ -2020,7 +2097,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
         return;
       }
 
-      if (!(await consumePlanAction(messageId))) {
+      if (!(await consumePlanCard(messageId, planBinding, "approved"))) {
         res.status(409).json({ type: "error", message: "This plan has already been acted on." } satisfies AppActionResponse);
         return;
       }
@@ -2032,9 +2109,9 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       // because the whole flow is replaced.
       resp = { type: "close_screen", finalMessage: `▶ Approved — running ${approved.length} step(s)…` };
       res.json(resp);
-      const planTitleForCard = activePlan.title ?? "Plan";
-      const planDescForCard = activePlan.desc;
-      const planDocForCard = activePlan.document;
+      const planTitleForCard = serverPlan.title;
+      const planDescForCard = serverPlan.desc;
+      const planDocForCard = serverPlan.document;
       // Who approved (already authz-checked === planUserId) — resolved once here
       // and reused for BOTH the immediate executing card and the durable exec
       // meta, so the card shows "Approved by <name>" with no flicker. Response is

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -104,6 +104,9 @@ import {
   clearPlanExecMeta,
   normalizePlanTitle,
   filterToApprovedTitles,
+  setPlanLastTodos,
+  getPlanLastTodos,
+  clearPlanLastTodos,
 } from "../lib/session-context.js";
 import { emitAgentWorkingSignal } from "../surfaces/spaces/client.js";
 import JSZip from "jszip";
@@ -500,6 +503,10 @@ import {
   readPrBindingData,
   normalizePrUrl,
   setWidgetBindingStatus,
+  upsertPlanBinding,
+  findProposedPlanBinding,
+  readPlanBindingData,
+  markPlanBindingStatus,
 } from "../lib/agent-widget-binding.js";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -4818,6 +4825,21 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     return;
   }
 
+  // The run is over and will NOT continue: every path that re-dispatches or
+  // re-queues (handoff, broken-SSE retry, session_locked, recovery retry) has
+  // already returned above. Settle the plan card here, so it covers a failed or
+  // cancelled run too — those are exactly the ones that die mid-step.
+  await reconcileStalePlanTodos(
+    sessionId,
+    ctx?.conversationId ?? payload.conversationId ?? null,
+    ctx?.agentSlug ?? payload.agentSlug ?? null,
+  ).catch((err) =>
+    clog.warn(
+      "[webhook/result] plan todo reconcile failed (non-fatal):",
+      err instanceof Error ? err.message : err,
+    ),
+  );
+
   if (payload.status !== "completed") {
     // Result-forward callers (Spaces auto-draft / automations) get the failure
     // via their callback and return BEFORE the bot-mention surfacing below —
@@ -5289,7 +5311,23 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       // re-planned). Grey it out + disable its Approve button so a superseded
       // plan can't be run. Best-effort; the new card posts regardless.
       if (ctx.conversationId && ctx.agentSlug) {
-        const prevCard = await getActivePlanCard(ctx.conversationId, ctx.agentSlug).catch(() => null);
+        // Redis is the fast path; the durable binding is what still finds a
+        // proposal older than the 24h TTL — without it an ancient card would
+        // stay tappable (and, now that approval survives, actually runnable)
+        // after the agent has already re-planned.
+        const prevBinding = await findProposedPlanBinding(ctx.conversationId, ctx.agentSlug).catch(() => null);
+        const prevBindingData = prevBinding ? readPlanBindingData(prevBinding) : null;
+        const prevCard =
+          (await getActivePlanCard(ctx.conversationId, ctx.agentSlug).catch(() => null)) ??
+          (prevBinding?.messageId && prevBindingData
+            ? {
+                messageId: prevBinding.messageId,
+                todos: prevBindingData.todos,
+                ...(prevBindingData.title ? { title: prevBindingData.title } : {}),
+                ...(prevBindingData.desc ? { desc: prevBindingData.desc } : {}),
+                ...(prevBindingData.document ? { document: prevBindingData.document } : {}),
+              }
+            : null);
         if (prevCard?.messageId) {
           try {
             const supersededFlow = withSpacesAppId(
@@ -5319,6 +5357,16 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
               error: e instanceof Error ? e.message : String(e),
             });
           }
+        }
+        // Terminal in the durable store too, whether or not the card repaint
+        // above succeeded: a superseded plan must fail the approve guard forever,
+        // not just until its Redis pointer is overwritten.
+        if (prevBinding) {
+          await markPlanBindingStatus(prevBinding.id, "superseded").catch((e) => {
+            log.warn("Failed to mark prior plan binding superseded (non-fatal)", {
+              error: e instanceof Error ? e.message : String(e),
+            });
+          });
         }
       }
 
@@ -5381,6 +5429,39 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             ...(pendingPlan.desc ? { desc: pendingPlan.desc } : {}),
             ...(pendingPlan.document ? { document: pendingPlan.document } : {}),
           }).catch(() => {});
+          // Durable mirror of the line above. The Redis pointer and the session
+          // both expire in 24h, but the card in the thread does not — this row is
+          // what lets someone approve a plan days later. It carries everything
+          // flow-action.ts needs with NO surviving Redis state: the executable
+          // todos, the card's routing, and the proposer (the only user allowed to
+          // act on it). Best-effort: a failure here costs durability, never the
+          // card, and the Redis fast path still covers the first 24h.
+          if (ctx.agentOrgId && ctx.spacesAppId && ctx.spacesAppUserId) {
+            await upsertPlanBinding({
+              orgId: ctx.agentOrgId,
+              conversationId: ctx.conversationId,
+              channelId: ctx.channelId,
+              messageId: planMessageId,
+              spacesAppId: ctx.spacesAppId,
+              spacesAppUserId: ctx.spacesAppUserId,
+              agentSlug: ctx.agentSlug,
+              data: {
+                todos: planTodos,
+                ownerUserId: ctx.senderId,
+                ...(pendingPlan.title ? { title: pendingPlan.title } : {}),
+                ...(pendingPlan.desc ? { desc: pendingPlan.desc } : {}),
+                ...(pendingPlan.document ? { document: pendingPlan.document } : {}),
+              },
+            }).catch((e) => {
+              log.warn("Failed to persist plan binding — approval will expire with Redis (non-fatal)", {
+                error: e instanceof Error ? e.message : String(e),
+              });
+            });
+          } else {
+            log.warn(
+              `Plan card posted without org/app context — no durable binding written, approval expires in 24h (conv=${ctx.conversationId})`,
+            );
+          }
           // Fresh proposal awaiting approval: reset any prior run's exec meta so
           // stale approvedTitles/autoApproved can't leak into this plan. The
           // approve flow-action writes the real meta before it dispatches Turn 2.
@@ -6745,6 +6826,15 @@ async function doRenderPlanCard(
     );
   }
 
+  // Snapshot exactly what this card is about to show. Nothing else records the
+  // todo list, so this is what reconcileStalePlanTodos reads at run end to find
+  // a step the agent left `in_progress` and never closed.
+  const snapConversationId = ctx.conversationId ?? conversationId ?? "";
+  const snapAgentSlug = ctx.agentSlug ?? agentSlug ?? "";
+  if (snapConversationId && snapAgentSlug) {
+    await setPlanLastTodos(snapConversationId, snapAgentSlug, renderTodos).catch(() => {});
+  }
+
   // Live todo cards are always in execution (auto mode). Pick the phase so the
   // PlanNode renders the executing/done layout (buildPlanFlow maps the internal
   // Todo status → the component's exec status). Once every todo is
@@ -6806,6 +6896,58 @@ function renderPlanCard(
     if (planRenderQueue.get(sessionId) === next) planRenderQueue.delete(sessionId);
   });
   return next;
+}
+
+/**
+ * Run-end reconciliation for the live plan card.
+ *
+ * A todo only leaves `in_progress` when the NEXT todo-write arrives. If the run
+ * ends without one — the model forgot to close the last step, or the run died
+ * mid-step — the card keeps rendering that row as `running`, so the user watches
+ * a spinner that can never resolve on a run that is definitively over.
+ *
+ * Those rows are reset to `pending`, NOT `completed`. The run ended without ever
+ * telling us the step succeeded, so marking it done would be inventing a result,
+ * and a false ✓ is the one outcome the user can't tell apart from a real one.
+ * `pending` also deliberately keeps the card out of the terminal 'done' phase
+ * (which needs every todo completed/failed), so the header stays "Approved"
+ * rather than claiming "Completed" over work that never finished.
+ *
+ * `failed` was the other candidate and is worse: it asserts the step broke,
+ * which is equally unverified, and it reads as an error the user should act on.
+ * Not-confirmed is the honest state, and `pending` is the only status that says
+ * that without also making a claim.
+ */
+async function reconcileStalePlanTodos(
+  sessionId: string,
+  conversationId: string | null,
+  agentSlug: string | null,
+): Promise<void> {
+  if (!conversationId || !agentSlug) return;
+  // Drain any todo-write render still queued for this session BEFORE reading the
+  // snapshot. Reading first would capture the previous render's list and then
+  // re-render it on top of the newer one, reverting a status the agent did
+  // legitimately write in its final tick.
+  await (planRenderQueue.get(sessionId) ?? Promise.resolve()).catch(() => {});
+  const last = await getPlanLastTodos(conversationId, agentSlug).catch(() => null);
+  if (!last?.length) return;
+  const stalled = last.filter((t) => t.status === "in_progress").length;
+  if (stalled === 0) {
+    // Card already settled itself — drop the snapshot so it can't be re-applied
+    // to a later run in this thread.
+    await clearPlanLastTodos(conversationId, agentSlug).catch(() => {});
+    return;
+  }
+  const reconciled: Todo[] = last.map((t) =>
+    t.status === "in_progress" ? { ...t, status: "pending" as const } : t,
+  );
+  clog.info(
+    `[plan] run ended with ${stalled} step(s) still in_progress — resetting to pending conv=${conversationId} agent=${agentSlug}`,
+  );
+  // Goes through the SAME serialized queue as every todo-write render, so it
+  // lands after any render still in flight instead of racing it.
+  await renderPlanCard(sessionId, reconciled, conversationId, agentSlug);
+  await clearPlanLastTodos(conversationId, agentSlug).catch(() => {});
 }
 
 // ── PR card render (create/merge PR subagent tool → kind:"pr" progress) ─────


### PR DESCRIPTION
… state

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
