### PR TITLE
feat: centralize shareable URL generation behind config-driven appUrls builder

### DIFF
--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/postprocessor.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/postprocessor.ts
@@ -7,6 +7,7 @@ import { PostprocessContext } from '../../core/types';
 import { ConversationRepository } from '../../../database/repositories/conversationRepository';
 import { ExternalSourceRepository } from '../../../database/repositories/externalSourceRepository';
 import { logger } from '../../../utils/logger';
+import { conversationUrl } from '@/utils/appUrls';
 import { decrypt } from '../../../services/encryptionService';
 import { botProcessor } from '../../../services/bots/botProcessor';
 
@@ -93,7 +94,7 @@ export class SlackPostprocessor extends BasePostprocessor {
         return;
       }
 
-      const xyneLink = `https://spaces.xyne.juspay.net/chat/${xyneChannelId}/${context.conversationId}`;
+      const xyneLink = conversationUrl(xyneChannelId, context.conversationId);
 
       const response = await fetch('https://slack.com/api/chat.postMessage', {
         method: 'POST',

--- a/apps/backend/src/migration/slack/slackConversationService.ts
+++ b/apps/backend/src/migration/slack/slackConversationService.ts
@@ -4,6 +4,7 @@
  */
 
 import { logger } from '../../utils/logger';
+import { dirChannelUrl } from '@/utils/appUrls';
 import { ChannelScopeType, ChannelRole, ChannelVisibility, VespaInsertionStatus, VespaOperationType } from '@xyne/shared';
 import { getMigrationMessageBlocks, getMigrationMessageFallbackText } from './utils/blockKit';
 import { postMessage } from './utils/postMessage';
@@ -823,7 +824,7 @@ export async function runMigration(input: MigrationInput): Promise<MigrationResu
         const channelName = xyneChannel.name;
         const workspaceId = xyneChannel.workspaceId;
         wsConfig = getBotConfigByWorkspaceId(workspaceId);
-        xyneSpaceChannelLink = `<https://spaces.xyne.juspay.net/${workspaceId}/chat/dir/${input.xyneSpaceChannelId}|${channelName}>`;
+        xyneSpaceChannelLink = `<${dirChannelUrl(input.xyneSpaceChannelId, workspaceId)}|${channelName}>`;
         if (xyneChannel.isMigrated) {
           const project = xyneChannel.projectId
             ? await db.project.findUnique({ where: { id: xyneChannel.projectId }, select: { name: true } })
@@ -1110,7 +1111,7 @@ export async function runMigration(input: MigrationInput): Promise<MigrationResu
         xyneSpaceWorkspaceId = ch?.workspaceId;
       }
       const xyneSpacesLink = input.xyneSpaceChannelId && xyneSpaceWorkspaceId
-        ? `<https://spaces.xyne.juspay.net/${xyneSpaceWorkspaceId}/chat/dir/${input.xyneSpaceChannelId}|Xyne Spaces>`
+        ? `<${dirChannelUrl(input.xyneSpaceChannelId, xyneSpaceWorkspaceId)}|Xyne Spaces>`
         : 'Xyne Spaces';
       let finalMessage = `<!channel> This Channel has been migrated to ${xyneSpacesLink}. Please move your conversations there only this channel will be soon archived.`;
       const finalMsgSuffix = wsConfig.migrationFinalMessage;
@@ -1250,7 +1251,7 @@ export async function runMigrationDm(input: DmMigrationInput): Promise<Migration
     // DM flow (sync-dm): prefer the caller-supplied channel so all updates land
     // in the dedicated sync-dm channel, not the generic workspace migration log.
     const dmLogChannelId = responseChannelId || dmWsConfig.slackMigrationLogChannelId || dmChannelId;
-    const xyneSpaceChannelLink = `<https://spaces.xyne.juspay.net/${xyneSpaceWorkspaceId}/chat/dir/${xyneSpaceChannelId}|${channelName}>`;
+    const xyneSpaceChannelLink = `<${dirChannelUrl(xyneSpaceChannelId, xyneSpaceWorkspaceId)}|${channelName}>`;
 
     // Post thread-starter to log channel
     const blocks = getMigrationMessageBlocks({

--- a/apps/backend/src/migration/slack/slackJiraffeService.ts
+++ b/apps/backend/src/migration/slack/slackJiraffeService.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../utils/logger';
+import { channelUrl } from '@/utils/appUrls';
 import { ExternalEntityType, MessageDirection, VespaInsertionStatus, VespaOperationType } from '@xyne/shared';
 import { ChannelRepository } from '../../database/repositories/channelRepository';
 import { WebClient } from '@slack/web-api';
@@ -554,7 +555,7 @@ export async function runMigrationJiraffe(input: MigrationJiraffeInput) {
     const xyneChannel = await channelRepo.findById(input.xyneSpaceChannelId);
     if (xyneChannel) {
       const channelName = xyneChannel.name;
-      xyneSpaceChannelLink = `<https://spaces.xyne.juspay.net/chat/${input.xyneSpaceChannelId}|${channelName}>`;
+      xyneSpaceChannelLink = `<${channelUrl(input.xyneSpaceChannelId)}|${channelName}>`;
       jiraffeBotToken = getBotConfigByWorkspaceId(xyneChannel.workspaceId).slackBotToken;
     }
   }

--- a/apps/backend/src/migration/slack/syncParticipants.ts
+++ b/apps/backend/src/migration/slack/syncParticipants.ts
@@ -6,6 +6,7 @@
 import { Request, Response } from 'express';
 import { WebClient } from '@slack/web-api';
 import { logger } from '../../utils/logger';
+import { dirChannelUrl } from '@/utils/appUrls';
 import { postMessage } from './utils/postMessage';
 import { addChannelParticipantsBeforeMigration } from './slackConversationService';
 import { checkUserAuthorization } from './command';
@@ -87,7 +88,7 @@ export async function runSyncParticipants({
   const token = wsConfig.slackBotToken;
   const client = new WebClient(token);
   const logChannelId = wsConfig.slackMigrationLogChannelId || slackChannelId;
-  const xyneSpaceChannelLink = `<https://spaces.xyne.juspay.net/${workspaceId}/chat/dir/${xyneSpaceChannelId}|${xyneChannel.name}>`;
+  const xyneSpaceChannelLink = `<${dirChannelUrl(xyneSpaceChannelId, workspaceId)}|${xyneChannel.name}>`;
   const startedTs = await postMessage({
     channelId: logChannelId,
     text: `🔄 <@${userId}> :: Started Participant sync for xyne-space channel ${xyneSpaceChannelLink}...`,

--- a/apps/backend/src/services/canvasService.ts
+++ b/apps/backend/src/services/canvasService.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DatabaseClient } from '@/database/client';
 import type { KnowledgeLearning } from '@/workflows/utils/knowledge-generator';
 import { logger } from '@/utils/logger';
+import { canvasUrl } from '@/utils/appUrls';
 import { ServerBlockNoteEditor } from '@blocknote/server-util';
 import type { BlockNoteBlock } from '@/types/blockNoteTypes';
 import { vespaQueue } from '@/queues/vespaQueue';
@@ -302,11 +303,7 @@ export async function createKnowledgeCanvas(
  * unscoped form.
  */
 export function getCanvasUrl(canvasId: string, workspaceId?: string): string {
-  const frontendUrl = process.env.FRONTEND_URL || 'https://spaces.xyne.juspay.net';
-  const path = workspaceId
-    ? `/${workspaceId}/chat/canvas/${canvasId}`
-    : `/chat/canvas/${canvasId}`;
-  return `${frontendUrl}${path}`;
+  return canvasUrl(canvasId, workspaceId);
 }
 
 type LooseInline = { type?: string; text?: string; props?: Record<string, unknown>; styles?: unknown };

--- a/apps/backend/src/services/pullRequestValidationService.ts
+++ b/apps/backend/src/services/pullRequestValidationService.ts
@@ -3,6 +3,7 @@ import { PRMetricsRepository } from '@/database/repositories/pullRequestsReposit
 import { BitbucketManager } from '@/bitbucket/apis';
 import { logger } from '@/utils/logger';
 import { sanitizeProjectCode, isValidProjectCode } from '@xyne/shared';
+import { appBaseUrl } from '@/utils/appUrls';
 
 // Bitbucket PR validation configuration constants
 const BITBUCKET_PR_CONFIG = {
@@ -19,8 +20,6 @@ const BITBUCKET_PR_CONFIG = {
   BUILD_STATUS: {
     KEY: 'xyne-ticket-check',
     NAME: 'Ticket Validation',
-    SUCCESS_URL: 'https://xyne.juspay.net',
-    FAILED_URL: 'https://spaces.xyne.juspay.net',
   },
 } as const;
 
@@ -185,7 +184,7 @@ export class PullRequestValidationService {
         'SUCCESSFUL',
         BITBUCKET_PR_CONFIG.BUILD_STATUS.KEY,
         BITBUCKET_PR_CONFIG.BUILD_STATUS.NAME,
-        process.env.FRONTEND_URL || '' ,
+        appBaseUrl(),
         description,
       );
     } catch (error) {
@@ -203,7 +202,7 @@ export class PullRequestValidationService {
         'FAILED',
         BITBUCKET_PR_CONFIG.BUILD_STATUS.KEY,
         BITBUCKET_PR_CONFIG.BUILD_STATUS.NAME,
-        process.env.FRONTEND_URL || '' ,
+        appBaseUrl(),
         description
       );
     } catch (error) {

--- a/apps/backend/src/utils/appUrls.ts
+++ b/apps/backend/src/utils/appUrls.ts
@@ -1,0 +1,78 @@
+// backend/src/utils/appUrls.ts
+//
+// Single source of truth for building shareable/deep-link URLs that point at
+// the Xyne Spaces frontend.
+//
+// WHY THIS EXISTS
+// ----------------
+// Shareable links (canvas, ticket, message, channel, support, automation,
+// Slack notifications, PR build-status targets, …) must resolve to the correct
+// host for the environment they are generated in — `http://localhost:5173`
+// locally, the sandbox domain in sandbox, and `https://spaces.xyne.juspay.net`
+// in production. The canonical base is the env var `FRONTEND_URL`
+// (`config.frontendUrl`); DO NOT hardcode the production domain at call sites.
+//
+// Set FRONTEND_URL per environment:
+//   local    → http://localhost:5173      (Joi default)
+//   sandbox  → https://spaces.sandbox.xyne.juspay.net
+//   prod     → https://spaces.xyne.juspay.net
+//
+// NOTE: This module is for URL GENERATION only. It is intentionally separate
+// from the multi-host *detection* allowlists (TRUSTED_ORIGINS in
+// `@xyne/shared`, INTERNAL_HOSTS in `urlUtils.ts`) — those must continue to
+// list every host we accept inbound and must NOT be collapsed to one origin.
+
+import { config } from '@/config/env';
+
+/**
+ * Canonical frontend base URL for the current environment, with any trailing
+ * slash stripped. Driven entirely by `FRONTEND_URL`; never hardcoded.
+ */
+export function appBaseUrl(): string {
+  return (config.frontendUrl ?? '').replace(/\/+$/, '');
+}
+
+/**
+ * Join the canonical base with an app-relative path, preserving the caller's
+ * path, query, and hash exactly. Pass the same path/query/hash the call site
+ * already produced — this only swaps the hardcoded host for the env base.
+ */
+export function appUrl(path: string): string {
+  if (!path) return appBaseUrl();
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return `${appBaseUrl()}${suffix}`;
+}
+
+/** Optional `/{workspaceId}` segment used by workspace-scoped routes. */
+function wsPrefix(workspaceId?: string): string {
+  return workspaceId ? `/${encodeURIComponent(workspaceId)}` : '';
+}
+
+// ---------------------------------------------------------------------------
+// Typed builders. Each mirrors the exact route shape already used in the app
+// so migrating a call site is a pure host swap — no path/query/hash changes.
+// ---------------------------------------------------------------------------
+
+/** Shareable canvas link: `/{ws}/chat/canvas/{canvasId}` (ws optional). */
+export function canvasUrl(canvasId: string, workspaceId?: string): string {
+  return appUrl(`${wsPrefix(workspaceId)}/chat/canvas/${canvasId}`);
+}
+
+/** Directory channel link: `/{ws}/chat/dir/{channelId}`. */
+export function dirChannelUrl(channelId: string, workspaceId?: string): string {
+  return appUrl(`${wsPrefix(workspaceId)}/chat/dir/${channelId}`);
+}
+
+/** Generic channel link: `/{ws}/chat/{channelId}`. */
+export function channelUrl(channelId: string, workspaceId?: string): string {
+  return appUrl(`${wsPrefix(workspaceId)}/chat/${channelId}`);
+}
+
+/** Conversation deep-link within a channel: `/{ws}/chat/{channelId}/{conversationId}`. */
+export function conversationUrl(
+  channelId: string,
+  conversationId: string,
+  workspaceId?: string,
+): string {
+  return appUrl(`${wsPrefix(workspaceId)}/chat/${channelId}/${conversationId}`);
+}


### PR DESCRIPTION
## What & why
Newly generated shareable/deep-link URLs must resolve to the correct host per environment (local `http://localhost:5173`, sandbox, prod `https://spaces.xyne.juspay.net`). Several backend call sites hardcoded the production domain, so links generated in local/sandbox pointed at prod. This introduces a single config-driven URL builder and migrates the hardcoded sites onto it.

## Change
- **New:** `apps/backend/src/utils/appUrls.ts` — single source of truth. `appBaseUrl()` reads `config.frontendUrl` (`FRONTEND_URL`); `appUrl(path)` + typed builders (`canvasUrl`, `dirChannelUrl`, `channelUrl`, `conversationUrl`) mirror the exact existing route shapes.
- **Migrated hardcoded `spaces.xyne.juspay.net` generation sites:**
  - `services/canvasService.ts` — `getCanvasUrl` now uses `canvasUrl()`; dropped the `|| 'https://spaces.xyne.juspay.net'` fallback.
  - Slack links: `integrations/adapters/slack-webhook-tickets/postprocessor.ts`, `migration/slack/syncParticipants.ts`, `migration/slack/slackConversationService.ts` (×3), `migration/slack/slackJiraffeService.ts`.
  - `services/pullRequestValidationService.ts` — build-status target now uses `appBaseUrl()`; removed the dead hardcoded `BUILD_STATUS.SUCCESS_URL`/`FAILED_URL` constants (were never referenced).

## Preserved intentionally
- Paths, workspace IDs, entity IDs, query params, and hashes are byte-for-byte unchanged — only the host is now env-driven.
- **Not touched (already correct):** automations deep-links (`approval-notifications.ts`) already use `config.frontendUrl`; invitations (`buildInvitationLink`) resolve per-request via Origin + CAC; support/ticket/message deep-links (`notify-action-url.ts`) already return host-agnostic relative paths; frontend already derives origin via `useShareableOrigin()` / `window.location.origin`.
- **Deliberately NOT collapsed:** inbound host-detection allowlists (`urlUtils.ts` `INTERNAL_HOSTS`, `@xyne/shared` `TRUSTED_ORIGINS`) — these are multi-host security allowlists, not generators.

## Config
Set `FRONTEND_URL` per environment (Joi default `http://localhost:5173`): sandbox → sandbox domain; prod → `https://spaces.xyne.juspay.net`.

## Validation
Backend `tsc --noEmit` passes with 0 errors.