### PR TITLE
fix: auth middleware set user role

### DIFF
--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -186,7 +186,7 @@ export class AuthMiddleware {
         isApiKeyUser: false,
         scopes: [],
         role: user.role,
-        orgRole: user.orgRole!,
+        orgRole: user.orgMember.role,
         memberId: user.orgMemberId,
       };
 
@@ -480,7 +480,7 @@ export class AuthMiddleware {
 
       let effectiveWorkspaceId: string | undefined = payload.workspaceId;
       let effectiveMemberId: string | undefined = payload.memberId;
-      let effectiveOrgRole: string | undefined = payload.orgRole;
+      let effectiveOrgRole: string = user.orgMember.role;
 
       if (!hasWorkspaceClaims) {
         logger.info(`[AUTH] LEGACY JWT FORMAT - User ${payload.sub} using pre-workspace client`, {
@@ -492,7 +492,7 @@ export class AuthMiddleware {
         // Use user's workspace and orgMember from DB (already fetched at line 456)
         effectiveWorkspaceId = user.workspaceId ?? undefined;
         effectiveMemberId = user.orgMemberId ?? undefined;
-        effectiveOrgRole = user.orgMember?.role;
+        effectiveOrgRole = user.orgMember.role;
       }
 
       if (!effectiveWorkspaceId || !effectiveMemberId) {
@@ -521,7 +521,7 @@ export class AuthMiddleware {
         isApiKeyUser: false,
         scopes: [],
         role: user.role,
-        orgRole: effectiveOrgRole ?? 'MEMBER',
+        orgRole: effectiveOrgRole,
         memberId: effectiveMemberId,
       };
 

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -186,7 +186,7 @@ export class AuthMiddleware {
         isApiKeyUser: false,
         scopes: [],
         role: user.role,
-        orgRole: user.orgMember.role,
+        orgRole: user.orgRole,
         memberId: user.orgMemberId,
       };
 

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -43,7 +43,7 @@ interface GoogleUserData {
 }
 
 export interface UserWithOrgRole extends User {
-  orgRole?: string;
+  orgRole: string;
 }
 
 export class UserService {
@@ -385,7 +385,8 @@ export class UserService {
         }
 
         // Fetch org role
-        const orgRole = user.orgMemberId ? await this.getOrgRole(user.orgMemberId) : undefined;
+        const orgRole = await this.getOrgRole(user.orgMemberId);
+        if (!orgRole) throw new Error(`orgRole not found for user ${user.id}`);
 
         return { user: { ...user, orgRole }, isNewUser };
       }
@@ -406,7 +407,8 @@ export class UserService {
         });
 
         // Fetch org role
-        const orgRole = user.orgMemberId ? await this.getOrgRole(user.orgMemberId) : undefined;
+        const orgRole = await this.getOrgRole(user.orgMemberId);
+        if (!orgRole) throw new Error(`orgRole not found for user ${user.id}`);
 
         return { user: { ...user, orgRole }, isNewUser };
       }
@@ -417,7 +419,8 @@ export class UserService {
       isNewUser = true;
 
       // Fetch org role for new user
-      const orgRole = user.orgMemberId ? await this.getOrgRole(user.orgMemberId) : undefined;
+      const orgRole = await this.getOrgRole(user.orgMemberId);
+      if (!orgRole) throw new Error(`orgRole not found for user ${user.id}`);
 
       // Note: ensureUserPresence is called in createUser(), so no need to call it here
 

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -455,7 +455,7 @@ export class UserService {
   /**
    * Get user by ID with org member data
    */
-  async getUserById(userId: string): Promise<(User & { orgMember?: { memberId: string; role: string } | null }) | null> {
+  async getUserById(userId: string): Promise<(User & { orgMember: { memberId: string; role: string } }) | null> {
     try {
       const user = await this.prisma.user.findUnique({
         where: { id: userId },
@@ -466,14 +466,19 @@ export class UserService {
       }
       
       // Fetch org member separately since there's no explicit relation
-      const orgMember = user.orgMemberId ? await this.prisma.orgMember.findUnique({
+      const orgMember = await this.prisma.orgMember.findUnique({
         where: { memberId: user.orgMemberId },
         select: {
           memberId: true,
           role: true,
         },
-      }) : null;
-      
+      });
+
+      if (!orgMember) {
+        logger.warn(`getUserById: orgMember not found for user ${userId}`);
+        return null;
+      }
+
       return {
         ...user,
         orgMember,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
