### PR TITLE
feat: config-driven canonical base URL for shareable/deep links

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -525,6 +525,9 @@ FCM_SERVICE_ACCOUNT_BASE64=your-fcm-service-account-base64
 FCM_SERVICE_ACCOUNT_BASE64_NEW=
 FOLLOW_HEADER_REDIRECTION=true
 # FORCE_LOGOUT_BEFORE=0
+# Base URL used to build absolute shareable/deep links (tickets, canvases,
+# automations, invites, slack backlinks). In production set the canonical
+# public domain, e.g. FRONTEND_URL=https://spaces.xyne.juspay.net
 FRONTEND_URL=http://localhost:5173
 GCS_BUNDLE_BUCKET_NAME=xyne-frontend-bundles
 GCS_CANVAS_BUCKET_NAME=xyne-spaces-canvas-documents

--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/postprocessor.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/postprocessor.ts
@@ -7,6 +7,7 @@ import { PostprocessContext } from '../../core/types';
 import { ConversationRepository } from '../../../database/repositories/conversationRepository';
 import { ExternalSourceRepository } from '../../../database/repositories/externalSourceRepository';
 import { logger } from '../../../utils/logger';
+import { getFrontendUrl } from '../../../utils/publicUrls';
 import { decrypt } from '../../../services/encryptionService';
 import { botProcessor } from '../../../services/bots/botProcessor';
 
@@ -93,7 +94,8 @@ export class SlackPostprocessor extends BasePostprocessor {
         return;
       }
 
-      const xyneLink = `https://spaces.xyne.juspay.net/chat/${xyneChannelId}/${context.conversationId}`;
+      // Config-driven canonical base (env FRONTEND_URL) — never hardcode the domain.
+      const xyneLink = `${getFrontendUrl()}/chat/${xyneChannelId}/${context.conversationId}`;
 
       const response = await fetch('https://slack.com/api/chat.postMessage', {
         method: 'POST',

--- a/apps/backend/src/services/canvasService.ts
+++ b/apps/backend/src/services/canvasService.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DatabaseClient } from '@/database/client';
 import type { KnowledgeLearning } from '@/workflows/utils/knowledge-generator';
 import { logger } from '@/utils/logger';
+import { getFrontendUrl } from '@/utils/publicUrls';
 import { ServerBlockNoteEditor } from '@blocknote/server-util';
 import type { BlockNoteBlock } from '@/types/blockNoteTypes';
 import { vespaQueue } from '@/queues/vespaQueue';
@@ -302,7 +303,8 @@ export async function createKnowledgeCanvas(
  * unscoped form.
  */
 export function getCanvasUrl(canvasId: string, workspaceId?: string): string {
-  const frontendUrl = process.env.FRONTEND_URL || 'https://spaces.xyne.juspay.net';
+  // Config-driven canonical base (env FRONTEND_URL) — single source of truth.
+  const frontendUrl = getFrontendUrl();
   const path = workspaceId
     ? `/${workspaceId}/chat/canvas/${canvasId}`
     : `/chat/canvas/${canvasId}`;

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -5,6 +5,13 @@
 VITE_API_URL=http://localhost:3001/api
 VITE_API_BASE_URL=http://localhost:3001
 VITE_APPS_PUBLIC_BASE_URL=http://localhost:3001/api/apps
+
+# Canonical base URL for user-shareable / deep links (copy-link, invites,
+# canvas/ticket/message links). SINGLE source of truth for the public origin.
+# Leave blank to auto-resolve per environment (prod -> https://spaces.xyne.juspay.net,
+# sandbox -> https://spaces.sandbox.xyne.juspay.net, local -> current window origin).
+# Set explicitly to pin a specific domain in any environment.
+VITE_SHAREABLE_BASE_URL=
 VITE_API_TIMEOUT=10000
 
 # Keycloak Configuration

--- a/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
+++ b/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
@@ -5,6 +5,7 @@ import { invokeShortcut } from '../../shortcuts';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
 import { toast } from 'sonner';
+import { buildShareableUrl } from '../../utils/shareableUrl';
 
 const buttonClass = cn(
   'size-7 flex items-center justify-center rounded-[10px] border border-transparent transition-colors',
@@ -24,7 +25,7 @@ const AppNavigator = (): ReactElement => {
   const handleShareWorkspace = async (): Promise<void> => {
     if (!workspaceId) return;
 
-    const shareUrl = `${window.location.origin}/auth?workspaceId=${encodeURIComponent(workspaceId)}`;
+    const shareUrl = buildShareableUrl(`/auth?workspaceId=${encodeURIComponent(workspaceId)}`);
 
     try {
       await navigator.clipboard.writeText(shareUrl);

--- a/apps/dashboard/src/components/Canvas/CanvasCommentsPanel/CanvasCommentsPanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCommentsPanel/CanvasCommentsPanel.tsx
@@ -39,6 +39,7 @@ import {
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
 import { formatRelativeCommentTime } from '../canvasCommentTime';
+import { buildShareableUrl } from '../../../utils/shareableUrl';
 
 type UserLite = {
   id: string;
@@ -607,7 +608,7 @@ export function CanvasCommentsPanel({
       const path = `redirected?type=canvas&canvasId=${encodeURIComponent(canvasId)}&blockId=${encodeURIComponent(blockId)}${
         commentThreadId ? `&commentThreadId=${encodeURIComponent(commentThreadId)}` : ''
       }`;
-      const slackUrl = `${window.location.origin}/launch?path=${encodeURIComponent(path)}`;
+      const slackUrl = buildShareableUrl(`/launch?path=${encodeURIComponent(path)}`);
 
       uniqueMentionedUserIds.forEach(mentionId => {
         apiInstance

--- a/apps/dashboard/src/components/Canvas/CanvasInlineCommentThread/CanvasInlineCommentThread.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasInlineCommentThread/CanvasInlineCommentThread.tsx
@@ -25,6 +25,7 @@ import { formatRelativeCommentTime } from '../canvasCommentTime';
 import type { CanvasCommentAnchor } from '../CanvasCommentsPanel/CanvasCommentsPanel';
 import { OverlayZIndexContext } from '../../../contexts/OverlayZIndexContext';
 import type { CanvasCommentHighlightThread } from '../useCanvasCommentHighlights';
+import { buildShareableUrl } from '../../../utils/shareableUrl';
 
 type UserLite = {
   id: string;
@@ -322,7 +323,7 @@ export function CanvasInlineCommentThread({
     if (!blockId || !commentThreadId) return;
 
     const path = `redirected?type=canvas&canvasId=${encodeURIComponent(canvasId)}&blockId=${encodeURIComponent(blockId)}&commentThreadId=${encodeURIComponent(commentThreadId)}`;
-    const slackUrl = `${window.location.origin}/launch?path=${encodeURIComponent(path)}`;
+    const slackUrl = buildShareableUrl(`/launch?path=${encodeURIComponent(path)}`);
 
     uniqueMentionedUserIds.forEach(mentionId => {
       apiInstance

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -102,6 +102,7 @@ import {
   useCanvasVersionSave,
 } from '../../../utils/canvasVersioning';
 import { useCanvasArchiveToggle } from '../useCanvasArchiveToggle';
+import { buildShareableUrl } from '../../../utils/shareableUrl';
 
 interface LocationState {
   mode?: 'edit-message' | 'create-message';
@@ -883,7 +884,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
       const path = params.blockId
         ? `redirected?type=canvas&canvasId=${encodeURIComponent(canvas.id)}&blockId=${encodeURIComponent(params.blockId)}`
         : `redirected?type=canvas&canvasId=${encodeURIComponent(canvas.id)}`;
-      const slackUrl = `${window.location.origin}/launch?path=${encodeURIComponent(path)}`;
+      const slackUrl = buildShareableUrl(`/launch?path=${encodeURIComponent(path)}`);
       apiInstance
         .post(`/canvas/${canvas.id}/mentions`, {
           mentionType: params.type,

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -79,6 +79,7 @@ import { AnimatePresence } from 'framer-motion';
 import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
+import { buildShareableUrl } from '../../../utils/shareableUrl';
 
 const canvasDictionary = {
   ...en,
@@ -317,7 +318,7 @@ export const CollaborativeCanvasEditor = forwardRef<
         const path = params.blockId
           ? `redirected?type=canvas&canvasId=${encodeURIComponent(canvasId)}&blockId=${encodeURIComponent(params.blockId)}`
           : `redirected?type=canvas&canvasId=${encodeURIComponent(canvasId)}`;
-        const slackUrl = `${window.location.origin}/launch?path=${encodeURIComponent(path)}`;
+        const slackUrl = buildShareableUrl(`/launch?path=${encodeURIComponent(path)}`);
         apiInstance
           .post(`/canvas/${canvasId}/mentions`, {
             mentionType: params.type,

--- a/apps/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
+++ b/apps/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
@@ -277,7 +277,9 @@ const WorkspaceInviteButton = (): ReactElement | null => {
   }
 
   const handleCopyInviteLink = async (): Promise<void> => {
-    const inviteUrl = buildShareableUrl(`/community/join?workspaceId=${encodeURIComponent(workspaceId)}`);
+    const inviteUrl = buildShareableUrl(
+      `/community/join?workspaceId=${encodeURIComponent(workspaceId)}`,
+    );
 
     try {
       await navigator.clipboard.writeText(inviteUrl);

--- a/apps/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
+++ b/apps/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
@@ -25,6 +25,7 @@ import { formatElapsedTime } from '../../utils/recordingUtils';
 import { queries } from '../../zero/queries';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { WorkspaceJoinPolicy } from '@xyne/shared';
+import { buildShareableUrl } from '../../utils/shareableUrl';
 
 interface GlobalTopBarProps {
   onOpenErrorReport?: () => void;
@@ -276,7 +277,7 @@ const WorkspaceInviteButton = (): ReactElement | null => {
   }
 
   const handleCopyInviteLink = async (): Promise<void> => {
-    const inviteUrl = `${window.location.origin}/community/join?workspaceId=${encodeURIComponent(workspaceId)}`;
+    const inviteUrl = buildShareableUrl(`/community/join?workspaceId=${encodeURIComponent(workspaceId)}`);
 
     try {
       await navigator.clipboard.writeText(inviteUrl);

--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/createTicket.utils.ts
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/createTicket.utils.ts
@@ -6,6 +6,7 @@ import {
   CREATE_TICKET_PARAM_KEYS,
   CREATE_TICKET_URL_FLAG,
 } from './constants';
+import { buildShareableUrl } from '../../../utils/shareableUrl';
 export const TAG_COLORS = [
   'bg-cyan-600',
   'bg-yellow-600',
@@ -313,5 +314,5 @@ export function buildCreateTicketShareLink(
   clearCreateTicketParams(params);
   params.set(CREATE_TICKET_URL_FLAG, '1');
   writeCreateTicketFields(params, prefill);
-  return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+  return buildShareableUrl(`${window.location.pathname}?${params.toString()}`);
 }

--- a/apps/dashboard/src/config.ts
+++ b/apps/dashboard/src/config.ts
@@ -85,3 +85,28 @@ export const ENABLE_SUMMARY_ACTION_BUTTON: boolean =
 // Set VITE_DEFAULT_WORKSPACE_ID in .env.local to the default workspace ID.
 export const DEFAULT_WORKSPACE_ID: string =
   (import.meta.env['VITE_DEFAULT_WORKSPACE_ID'] as string) ?? '';
+
+// ---------------------------------------------------------------------------
+// Canonical base URL for user-shareable / deep links (copy-link, invites,
+// canvas/ticket/message links, etc.).
+//
+// This is the SINGLE source of truth for the public origin of shareable URLs.
+// Do NOT read window.location.origin at individual call sites — use
+// `useShareableOrigin()` (adds the workspace segment) or `buildShareableUrl()`
+// from `utils/shareableUrl.ts`.
+//
+// Resolution order:
+//   1. VITE_SHAREABLE_BASE_URL env override (any environment can pin its own).
+//   2. Per-environment fallback: prod → canonical domain, sandbox → sandbox
+//      domain, everything else (local/test) → the current window origin.
+// Never includes a trailing slash or a workspace segment.
+const SHAREABLE_BASE_URL_ENV = (
+  import.meta.env['VITE_SHAREABLE_BASE_URL'] as string | undefined
+)?.trim();
+
+export const SHAREABLE_BASE_URL: string = (() => {
+  if (SHAREABLE_BASE_URL_ENV) return SHAREABLE_BASE_URL_ENV.replace(/\/+$/, '');
+  if (isProd) return 'https://spaces.xyne.juspay.net';
+  if (isSandBox) return 'https://spaces.sandbox.xyne.juspay.net';
+  return typeof window !== 'undefined' ? window.location.origin : 'http://localhost:5173';
+})();

--- a/apps/dashboard/src/hooks/useShareableOrigin.ts
+++ b/apps/dashboard/src/hooks/useShareableOrigin.ts
@@ -1,5 +1,7 @@
 import { useParams } from 'react-router-dom';
 
+import { SHAREABLE_BASE_URL } from '../config';
+
 /** Add the active workspace segment to a same-origin app URL when missing. */
 export function withWorkspacePrefix(url: string, workspaceId?: string): string {
   if (!url || !workspaceId || typeof window === 'undefined') return url;
@@ -20,7 +22,13 @@ export function withWorkspacePrefix(url: string, workspaceId?: string): string {
 
 /**
  * Returns the base URL to use when constructing shareable/copyable links.
- * Automatically includes the current workspace segment when inside `/:workspaceId` context.
+ * Automatically includes the current workspace segment when inside
+ * `/:workspaceId` context.
+ *
+ * The origin comes from the config-driven `SHAREABLE_BASE_URL` (a single source
+ * of truth, env-overridable per environment) — NOT `window.location.origin` —
+ * so shared links always point at the canonical public domain regardless of
+ * which internal host actually served the page.
  *
  * Usage:
  *   const shareableOrigin = useShareableOrigin();
@@ -28,5 +36,5 @@ export function withWorkspacePrefix(url: string, workspaceId?: string): string {
  */
 export function useShareableOrigin(): string {
   const { workspaceId } = useParams<{ workspaceId?: string }>();
-  return workspaceId ? `${window.location.origin}/${workspaceId}` : window.location.origin;
+  return workspaceId ? `${SHAREABLE_BASE_URL}/${workspaceId}` : SHAREABLE_BASE_URL;
 }

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -198,6 +198,7 @@ import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
 import { useBoardsSlaPolicies } from '../../hooks/useChannelSlaPolicy';
 import { useKanbanCounts } from './useKanbanCounts';
 import { valuesToFilters } from '../../utils/savedViewSerialization';
+import { buildShareableUrl } from '../../utils/shareableUrl';
 import { useConfirmDialog } from '../../hooks/useConfirmDialog';
 import { getApiErrorMessage } from '../../utils/apiError';
 
@@ -1039,7 +1040,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     const cfg = { name: initialName ?? '', filters, groupBy: groupByKey };
     const encoded = btoa(encodeURIComponent(JSON.stringify(cfg)));
     const base = window.location.pathname.split('/projects')[0];
-    const link = `${window.location.origin}${base}/projects/views/new#cfg=${encoded}`;
+    const link = buildShareableUrl(`${base}/projects/views/new#cfg=${encoded}`);
     void navigator.clipboard.writeText(link).then(
       () => toast.success('Share link copied to clipboard'),
       () => toast.error('Failed to copy link'),

--- a/apps/dashboard/src/utils/savedViewSerialization.ts
+++ b/apps/dashboard/src/utils/savedViewSerialization.ts
@@ -1,5 +1,6 @@
 import { SavedConfigEntityName, TicketPriority } from '@xyne/shared';
 import type { TicketFilters } from '../components/Tickets/TicketFilters/types';
+import { buildShareableUrl } from './shareableUrl';
 
 type SavedConfigValueRow = {
   entityName: SavedConfigEntityName;
@@ -99,5 +100,5 @@ export function buildShareLink(view: ShareableView): string {
   const cfg = { name: view.name, filters, ...(groupBy ? { groupBy } : {}) };
   const encoded = btoa(encodeURIComponent(JSON.stringify(cfg)));
   const base = window.location.pathname.split('/projects')[0];
-  return `${window.location.origin}${base}/projects/views/new#cfg=${encoded}`;
+  return buildShareableUrl(`${base}/projects/views/new#cfg=${encoded}`);
 }

--- a/apps/dashboard/src/utils/shareableUrl.ts
+++ b/apps/dashboard/src/utils/shareableUrl.ts
@@ -1,0 +1,33 @@
+import { SHAREABLE_BASE_URL } from '../config';
+
+/**
+ * Shared, config-driven builder for user-shareable / deep links.
+ *
+ * Use this from plain functions / utilities that build links OUTSIDE React
+ * render (where the `useShareableOrigin` hook is unavailable). Inside
+ * components prefer `useShareableOrigin()`.
+ *
+ * The canonical origin comes from `SHAREABLE_BASE_URL` (config.ts) — the single
+ * source of truth. Never read `window.location.origin` at call sites.
+ */
+
+/** The canonical origin for shareable links (no trailing slash, no workspace segment). */
+export function getShareableBaseUrl(): string {
+  return SHAREABLE_BASE_URL;
+}
+
+/**
+ * Join the canonical shareable base with an app-relative path. The path may
+ * already include the workspace segment, query string, and hash — all of which
+ * are preserved verbatim.
+ *
+ *   buildShareableUrl('/ws_1/chat/canvas/c_9')      → `${base}/ws_1/chat/canvas/c_9`
+ *   buildShareableUrl('/launch?path=%2Finvite%3F..') → `${base}/launch?path=...`
+ */
+export function buildShareableUrl(pathWithQueryAndHash: string): string {
+  const base = SHAREABLE_BASE_URL.replace(/\/+$/, '');
+  const path = pathWithQueryAndHash.startsWith('/')
+    ? pathWithQueryAndHash
+    : `/${pathWithQueryAndHash}`;
+  return `${base}${path}`;
+}


### PR DESCRIPTION
## Summary
Establishes a single, config-driven source of truth for the public origin of user-shareable / deep links, so newly generated links use the canonical production domain `https://spaces.xyne.juspay.net` without hardcoding or repeating the domain across call sites. Local, sandbox, and production environments remain independently configurable.

## What changed

### Dashboard (frontend)
- **`config.ts`** — new `SHAREABLE_BASE_URL` constant. Resolution order:
  1. `VITE_SHAREABLE_BASE_URL` env override (any environment can pin its own domain), else
  2. per-environment fallback: prod → `https://spaces.xyne.juspay.net`, sandbox → `https://spaces.sandbox.xyne.juspay.net`, local/test → current `window.location.origin`.
- **`hooks/useShareableOrigin.ts`** — now derives its origin from `SHAREABLE_BASE_URL` instead of `window.location.origin` (still appends the `/:workspaceId` segment). This auto-migrates every call site already using the hook (support tickets, recordings, canvas links, automations, etc.).
- **`utils/shareableUrl.ts`** (new) — shared `getShareableBaseUrl()` + `buildShareableUrl(path)` helper for link builders that run outside React render.
- Migrated the remaining raw `window.location.origin` shareable-link call sites to the shared helper, preserving workspace IDs, paths, entity IDs, query params, and hashes verbatim:
  - saved views (`savedViewSerialization.ts`, `KanbanBoardScreen.tsx`)
  - create-ticket share link (`createTicket.utils.ts`)
  - workspace invite / share links (`GlobalTopBar.tsx`, `AppNavigator.tsx`)
  - canvas Slack-forward mention links (`CanvasCommentsPanel.tsx`, `CanvasInlineCommentThread.tsx`, `CanvasScreen.tsx`, `CollaborativeCanvasEditor.tsx`)

### Backend
- Replaced the two hardcoded `https://spaces.xyne.juspay.net` literals with the existing config-driven resolver `getFrontendUrl()` (driven by env `FRONTEND_URL`):
  - `services/canvasService.ts` (`getCanvasUrl`)
  - `integrations/adapters/slack-webhook-tickets/postprocessor.ts`
- The backend already funnels absolute deep links through `publicUrls.getFrontendUrl()` / `config.frontendUrl`, so no new mechanism was needed there.

### Config
- Documented `VITE_SHAREABLE_BASE_URL` (dashboard) and `FRONTEND_URL` (backend) in the respective `.env.example` files.

## Deployment / config
- **Production dashboard:** set `VITE_SHAREABLE_BASE_URL=https://spaces.xyne.juspay.net` (or rely on the prod fallback).
- **Production backend:** ensure `FRONTEND_URL=https://spaces.xyne.juspay.net`.
- Sandbox and local override independently via the same env vars.

## Validation
- `@xyne/shared` built, then `tsc --noEmit` on the dashboard: no errors introduced by this change (the only remaining errors are pre-existing missing optional `@blocknote/*` plugin modules, unrelated to these files).
- Backend `tsc --noEmit`: 0 errors.

## Follow-up (not in this PR)
- One-time Slack migration scripts under `apps/backend/src/migration/slack/*` still contain hardcoded `https://spaces.xyne.juspay.net` literals. They are backfill tooling (not newly generated product links) and use inconsistent path shapes, so they were intentionally left out; can be migrated to `config.frontendUrl` in a follow-up.