### PR TITLE
fix: unify private channel lock icon across sidebar, header and Cmd+K

### DIFF
--- a/apps/dashboard/src/components/Chat/ChannelIcon/ChannelIcon.tsx
+++ b/apps/dashboard/src/components/Chat/ChannelIcon/ChannelIcon.tsx
@@ -1,6 +1,7 @@
 import { ChannelScopeType, ChannelVisibility, Channel } from '@xyne/shared';
 import { useAuthContextValues } from '../../../hooks/useAuth';
-import { Hashtag, LockClose } from '@xyne/icons';
+import { Hashtag } from '@xyne/icons';
+import ChatLock from '../../icons/ChatLock';
 import Avatar, { type AvatarSize } from '../../ui/Avatar/Avatar';
 import { getDMParticipantIdsToFetch } from '../ChatDirectory/ChatDirectory.utils';
 
@@ -33,7 +34,11 @@ const ChannelIcon = ({
     if (channel.visibility === ChannelVisibility.PUBLIC) {
       return <Hashtag size={16} className={glyphClassName} />;
     }
-    return <LockClose size={16} className={glyphClassName} />;
+    return (
+      <span className={glyphClassName}>
+        <ChatLock />
+      </span>
+    );
   }
 
   if (channel.scopeType === ChannelScopeType.DM) {

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -8,7 +8,6 @@ import {
   UserTwo,
   UserDefault,
   Hashtag,
-  Lock02Close,
   TicketToken,
   FolderDefault,
   File02Text,
@@ -25,6 +24,7 @@ import {
   CheckTickSingle,
   FilterFunnel,
 } from '@xyne/icons';
+import ChatLock from '../../icons/ChatLock';
 import * as Tabs from '@radix-ui/react-tabs';
 import * as Popover from '@radix-ui/react-popover';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
@@ -2049,7 +2049,7 @@ const ChannelCommandMenu = ({
       }
     }
     if (channel.visibility === ChannelVisibility.PRIVATE) {
-      return <Lock02Close size={16} />;
+      return <ChatLock />;
     }
     return <Hashtag size={16} />;
   };
@@ -4400,10 +4400,9 @@ const ChannelCommandMenu = ({
                               >
                                 {isChannelTab &&
                                   (item.isPrivate ? (
-                                    <Lock02Close
-                                      size={16}
-                                      className='text-muted-foreground flex-shrink-0'
-                                    />
+                                    <span className='text-muted-foreground flex-shrink-0'>
+                                      <ChatLock />
+                                    </span>
                                   ) : (
                                     <Hashtag
                                       size={16}


### PR DESCRIPTION
## Problem
A private channel showed a different lock image in the left sidebar vs the top of the central conversation bar. Root cause: the private-channel lock glyph is defined independently in three places and had drifted into three different icons:

- Left sidebar (`ChannelItemV2.tsx`) → local `ChatLock`
- Central-bar header / info panel / message cards / support screen (shared `ChannelIcon.tsx`) → `LockClose` from `@xyne/icons`
- Cmd+K palette (`ChannelCommandMenu.tsx`) → `Lock02Close` from `@xyne/icons`

## Fix
Consolidate the shared `ChannelIcon` component and the Cmd+K palette onto the sidebar's `ChatLock`, so a private channel shows the same lock everywhere. Only the private-channel branch changed; hashtag/DM/avatar rendering and sizes are untouched. Color is preserved by wrapping `ChatLock` (which uses `currentColor`) in the existing `glyphClassName`/muted spans.

## Files changed
- `apps/dashboard/src/components/Chat/ChannelIcon/ChannelIcon.tsx`
- `apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx`

## Validation
- ESLint: 0 errors on both changed files.
- Typecheck: no new errors introduced by these files.