### PR TITLE
fix: scope automation approval DM send to service actor to stop empty duplicate DMs

### DIFF
--- a/apps/backend/src/automations/services/approval-notifications.ts
+++ b/apps/backend/src/automations/services/approval-notifications.ts
@@ -2,6 +2,7 @@ import { repositories } from '@/database/repositories';
 import { AccessType, MessageType } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 import { conversationService } from '@/services/conversationService';
+import { runAsServiceActor } from '@/database/tenant/context';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service';
 import { config } from '@/config/env';
 import type { AutomationView } from '../types/workflow-adapter';
@@ -70,18 +71,29 @@ async function dmToUser(
   workspaceId: string,
   content: string,
 ): Promise<void> {
-  const channelId = await repositories.channels.findOrCreateDMChannel(
-    fromUserId,
-    [toUserId],
-    repositories.channelParticipants,
-    workspaceId,
-  );
-  await conversationService.createConversationWithMessage({
-    channelId,
-    userId: fromUserId,
-    content,
-    msgType: MessageType.BOT,
-    isBot: true,
+  // The automation bot sends this DM on behalf of the workspace, but the ambient
+  // tenant context is the submitter/approver — a user who is NOT a participant of the
+  // private bot<->recipient DM. Under that per-user channel ACL, both the
+  // find-or-create probe AND createConversationWithMessage's findById fail to see the
+  // channel: the probe mints an empty duplicate DM and the message insert throws
+  // 'Channel not found', so the notification never lands (the empty "No messages yet"
+  // Automations DMs). Run the whole send as a service actor scoped to the DM's
+  // workspace so the per-user ACL is dropped and only workspace scope applies. This
+  // completes PR #517, which scoped only the read-side existence probe.
+  await runAsServiceActor(fromUserId, workspaceId, async () => {
+    const channelId = await repositories.channels.findOrCreateDMChannel(
+      fromUserId,
+      [toUserId],
+      repositories.channelParticipants,
+      workspaceId,
+    );
+    await conversationService.createConversationWithMessage({
+      channelId,
+      userId: fromUserId,
+      content,
+      msgType: MessageType.BOT,
+      isBot: true,
+    });
   });
 }
 

--- a/apps/backend/src/automations/services/approval-notifications.ts
+++ b/apps/backend/src/automations/services/approval-notifications.ts
@@ -71,15 +71,6 @@ async function dmToUser(
   workspaceId: string,
   content: string,
 ): Promise<void> {
-  // The automation bot sends this DM on behalf of the workspace, but the ambient
-  // tenant context is the submitter/approver — a user who is NOT a participant of the
-  // private bot<->recipient DM. Under that per-user channel ACL, both the
-  // find-or-create probe AND createConversationWithMessage's findById fail to see the
-  // channel: the probe mints an empty duplicate DM and the message insert throws
-  // 'Channel not found', so the notification never lands (the empty "No messages yet"
-  // Automations DMs). Run the whole send as a service actor scoped to the DM's
-  // workspace so the per-user ACL is dropped and only workspace scope applies. This
-  // completes PR #517, which scoped only the read-side existence probe.
   await runAsServiceActor(fromUserId, workspaceId, async () => {
     const channelId = await repositories.channels.findOrCreateDMChannel(
       fromUserId,


### PR DESCRIPTION
## Summary
Follow-up to #517. #517 scoped only the DM **read** probe (`getDMChannel`/`getGroupChannelByMembers`) under `withWorkspaceScope`, which stopped *new* duplicate channels from being minted — but it did **not** fix delivery. The automation approval DM still fails and admins get empty "No messages yet" Automations DMs.

## 1. Problem Description
Admins see many empty "Automations" DM conversations ("No messages yet"), and approval notifications never actually arrive. The approval-notification fan-out (`dmToUser` in `apps/backend/src/automations/services/approval-notifications.ts`) runs under the **submitter/approver's** per-user tenant context. That user is **not** a participant of the private bot↔recipient DM, so under the per-user channel ACL:
- the find-or-create probe couldn't see the existing DM → minted an empty duplicate channel, and
- `conversationService.createConversationWithMessage`'s `channelRepository.findById(channelId)` also couldn't see the channel → threw `Channel not found`, so the message was never persisted.

## 2. How the issue was identified
Prod logs (`xyne-backend`, module `[approval-notifications]`) show `submission DM fan-out OK` immediately followed by `DM to admin … failed Channel not found` (conversationService `findById`), starting 2026-08-12 08:48 UTC after the fan-out went live. #517 fixed only the read probe; the write path (`findById` + inserts) is still evaluated under the caller's ACL on `main`.

## 3. Solution implemented
Wrap the entire send in `dmToUser` in `runAsServiceActor(fromUserId, workspaceId, …)` so both the find-or-create and `createConversationWithMessage` run as a **service actor** scoped to the DM's workspace. This drops the per-user channel ACL (keeping the workspace tenant boundary), so `findById` resolves the channel and the message is delivered. Mirrors #517's read-side fix on the write side. Single choke point — covers submission, decision, and archive-request DMs.

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
None.

## 6. Data fix Details (if any)
Not in this PR. Recommended follow-ups (same as #517's follow-up list): (a) backfill/cleanup of the existing empty duplicate bot↔admin DM channels minted 12–13 Aug; (b) a partial unique index on 1:1 DM channel name to make duplicate minting structurally impossible — must run AFTER the cleanup or the index creation will fail on existing duplicates.

## 7. Environment variable Changes (if any)
None.

## 8. Testing
- `npx tsc --noEmit` on `apps/backend` clean for the touched file.
- Manual: submit an automation for approval → exactly one bot→admin DM thread exists and contains the message; no new empty channel is created; no `[approval-notifications] … Channel not found` warnings.

## 9. Services to which this change is to be deployed
xyne-backend.

## 10. Main PR link (if this PR is raised against a release branch)
N/A (raised against main).