### PR TITLE
fix: scope automation approval DM send to service actor to stop empty duplicate DMs

### DIFF
--- a/apps/backend/src/automations/services/approval-notifications.ts
+++ b/apps/backend/src/automations/services/approval-notifications.ts
@@ -2,6 +2,7 @@ import { repositories } from '@/database/repositories';
 import { AccessType, MessageType } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 import { conversationService } from '@/services/conversationService';
+import { runAsServiceActor } from '@/database/tenant/context';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service';
 import { config } from '@/config/env';
 import type { AutomationView } from '../types/workflow-adapter';
@@ -70,18 +71,20 @@ async function dmToUser(
   workspaceId: string,
   content: string,
 ): Promise<void> {
-  const channelId = await repositories.channels.findOrCreateDMChannel(
-    fromUserId,
-    [toUserId],
-    repositories.channelParticipants,
-    workspaceId,
-  );
-  await conversationService.createConversationWithMessage({
-    channelId,
-    userId: fromUserId,
-    content,
-    msgType: MessageType.BOT,
-    isBot: true,
+  await runAsServiceActor(fromUserId, workspaceId, async () => {
+    const channelId = await repositories.channels.findOrCreateDMChannel(
+      fromUserId,
+      [toUserId],
+      repositories.channelParticipants,
+      workspaceId,
+    );
+    await conversationService.createConversationWithMessage({
+      channelId,
+      userId: fromUserId,
+      content,
+      msgType: MessageType.BOT,
+      isBot: true,
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
Backport of #741 to `release-20260817`. Completes #517 (which scoped only the DM **read** probe) by scoping the **write** path too, so approval-notification DMs actually deliver instead of producing empty "No messages yet" Automations DMs.

## 1. Problem Description
The approval-notification fan-out (`dmToUser` in `apps/backend/src/automations/services/approval-notifications.ts`) runs under the submitter/approver's per-user tenant context. That user is not a participant of the private bot↔recipient DM, so `conversationService.createConversationWithMessage`'s `channelRepository.findById(channelId)` cannot see the channel and throws `Channel not found` — the message is never persisted. #517 scoped only the read probe, so it stopped new duplicate channels but did not fix delivery.

## 2. How the issue was identified
Prod logs (`xyne-backend`, `[approval-notifications]`) show `submission DM fan-out OK` immediately followed by `Channel not found` from conversationService's `findById`, starting after the fan-out went live on 2026-08-12.

## 3. Solution implemented
Wrap the entire send in `dmToUser` with `runAsServiceActor(fromUserId, workspaceId, …)` so both the find-or-create and `createConversationWithMessage` run as a service actor scoped to the DM's workspace. Drops the per-user channel ACL (keeps the workspace tenant boundary) so `findById` resolves the channel and the message delivers. Identical code to #741 (no explanatory comments).

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
None.

## 6. Data fix Details (if any)
Not in this PR. Follow-ups: (a) cleanup of existing empty duplicate bot↔admin DM channels; (b) partial unique index on 1:1 DM channel name — must run AFTER the cleanup.

## 7. Environment variable Changes (if any)
None.

## 8. Testing
`npx tsc --noEmit` clean for the touched file. Manual: submit an automation for approval → exactly one bot→admin DM thread with the message present; no new empty channel; no `[approval-notifications] … Channel not found` warnings.

## 9. Services to which this change is to be deployed
xyne-backend.

## 10. Main PR link (if this PR is raised against a release branch)
Main PR: #741 (base `main`).