### PR TITLE
fix: gate Release Manager (SDLC) screen behind SDLC resource access

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
+++ b/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
@@ -19,4 +19,5 @@ export const PATH_TO_RESOURCE: Record<string, string> = {
   '/workspace-management': 'WORKSPACE',
   '/organisations': 'ORGANIZATIONS',
   '/team-intelligence': 'TEAM-INTELLIGENCE-DASHBOARD',
+  '/releaseManager': 'SDLC',
 };

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -1316,7 +1316,11 @@ export const router = createBrowserRouter([
               },
               {
                 path: 'releaseManager',
-                element: <ReleaseManagerView />,
+                element: (
+                  <ResourceProtectedRoute resourceName='SDLC'>
+                    <ReleaseManagerView />
+                  </ResourceProtectedRoute>
+                ),
               },
               {
                 path: 'listProjects/:projectId',


### PR DESCRIPTION
Hides the Release Manager (SDLC) screen behind a resource-access check, matching how other gated screens (Analytics, Support, Forms, etc.) already work.

Changes (frontend only):
- `AppRoot.tsx` — wrap the `releaseManager` route element in `<ResourceProtectedRoute resourceName='SDLC'>` so users without SDLC access are redirected home.
- `resourceMapping.ts` — map `/releaseManager` → `SDLC` so the sidebar nav item is hidden for users without ADMIN on SDLC (works even though it is a required-toolbar path, because the toolbar/More lists derive from the already permission-filtered visible-nav set).

NOTE: No migration is included. The `SDLC` resource row must be inserted separately (SQL provided out-of-band). Until that row + grants exist, no one will have access and the screen will be hidden for everyone.

Requested by @nikunj.gupta@juspay.in.