### PR TITLE
fix: collapse the recording overlay into the pill off the recordings screens

### DIFF
--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
@@ -33,6 +33,7 @@ export function NoteTakerOverlayHost(): ReactElement {
   // hide the overlay when live recording detail screen entered.
   const isViewingThisRecording =
     Boolean(externalId) && pathname.replace(/\/+$/, '').endsWith(`/recordings/${externalId}`);
+  const isOnRecordingsSection = /^\/[^/]+\/recordings(\/|$)/.test(pathname);
 
   const handleStop = useCallback((): void => {
     const stoppedRecordingId = externalId;
@@ -65,6 +66,14 @@ export function NoteTakerOverlayHost(): ReactElement {
 
   // ─── Native pill hand-off (Electron only) ─────────────────────────────────
   const isElectron = isElectronApp();
+
+  // Electron only: collapse into the native pill when leaving the recordings
+  // section, expand again on return. The web build has no pill to collapse
+  // into, so there it keeps the overlay up wherever the user navigates.
+  useEffect(() => {
+    if (!isElectron || !isActive) return;
+    sendRecordingEvent({ type: 'setTranscriptMinimized', isMinimized: !isOnRecordingsSection });
+  }, [isElectron, isActive, isOnRecordingsSection]);
 
   useEffect(() => {
     if (!isElectron) return;


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1W9hNizRaTCx1SxswPNNALd3P2MSOKYvQ/view?usp=sharing

## Problem

While a recording is live, the note-taker overlay stayed expanded on **every** screen. Navigating to a channel or a call left a large panel sitting over the content, with no way to get it out of the way short of minimising it by hand each time.

## Behaviour after this change (Electron)

| Route | Overlay |
|---|---|
| `/:workspace/recordings` | big |
| `/:workspace/recordings/:id` | big (the screen renders its own live UI; the overlay is already suppressed there by `isViewingThisRecording`) |
| anything else | collapsed into the native recording pill |

Clicking **Open** on the pill expands the overlay on whatever screen you are currently on.

## No new pill was built

The existing native pill already does the whole return trip — this was verified end to end before writing any code:

```
pill "Open"
  -> recording-pill:open-app
  -> handlers.ts:585   focusMainWindow() + setOverlayMinimized(false)
  -> recording-controller.ts:192   sends 'recording:minimized-changed'
  -> preload.ts:366   recordingPill.onMinimizedChanged
  -> NoteTakerOverlayHost.tsx:79   setTranscriptMinimized(false)
  -> overlay expands on the current screen
```

`focusMainWindow()` is called without a pathname, so it focuses the window without navigating — the overlay expands where you already are rather than dragging you back to `/recordings`.

So the only missing piece was the route-driven collapse, which is what this adds.

## Why it is gated to Electron

The recording pill is an Electron OS-level window. The web build has nothing to collapse into, so collapsing there would hide the overlay and show nothing in its place — a regression for anyone using the app in a browser. Chrome behaviour is unchanged.

## Implementation notes

- Keyed on a **section boolean**, not the raw pathname. Moving between the recordings list and a recording's detail page does not re-fire the effect, so a manual minimise inside the section is preserved until you actually leave it.
- The route matcher mirrors the existing `isOnAIPage` pattern in `AppRoot.tsx`. Checked against real paths including the `\/recordingsomething` lookalike, which correctly does **not** match.
- Placed after `const isElectron`, deliberately. An earlier placement referenced it from a dependency array before its declaration, which is a temporal-dead-zone crash that `tsc` does not catch.

## Checked

- `focusMainWindow()` does not navigate, so Open cannot bounce the user out of the current screen.
- `RecordingsV2Screen` has no live-recording UI of its own, so the big overlay on the list is not duplicating anything.
- `RecordingDetailV2Screen` does render live UI (`LiveRecordingControlBar`, `LiveTranscriptSection`, `isLive`), and since `minimized` is false there the pill stays hidden — no double indicator.
- No IPC echo loop: `setOverlayMinimized` early-returns when the value is unchanged, so renderer → main → renderer settles in one hop.
- `pnpm run typecheck` (`--project tsconfig.app.json`) exit 0, eslint clean, prettier clean.

## Worth a reviewer's opinion

Starting a recording from a chat now collapses straight to the pill. Start is triggered from `ThreadPannel.tsx:838`, `ChatBubble.tsx:494` and `useSlashCommands.ts:493`, none of which navigate to `/recordings`, so `isActive` flips while you are on a channel and the effect collapses immediately. That seems right, but it is a behaviour change beyond the literal ask — say the word if it should stay expanded until the user navigates.

**Not verified:** not exercised in a running app. Worth confirming: leaving `/recordings` mid-recording collapses to the pill, Open restores the overlay on the current screen, returning to `/recordings` makes it big again, and Chrome is untouched.

v1 (`RecordingOverlay`) is deliberately not changed; it is only reachable through the `xyne:recording-version` override.