### PR TITLE
fix: recording shortcut issue for pill

### DIFF
--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -18,7 +18,6 @@ import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout
 import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
 import { useSelf, useUsers } from '../../hooks/useUsers';
 import { xyneAIActor } from '../../machines/xyneAIMachine';
-import { useShortcutById } from '../../shortcuts';
 import { cn } from '../../utils/classNames';
 import { RecordingsEmptyStateIllustration } from './components/RecordingsEmptyStateIllustration';
 import { RecordingDateFilter } from './components/RecordingDateFilter';
@@ -113,10 +112,6 @@ const RecordingsV2Screen = (): ReactElement => {
       defaultLayout: getRecordingDefaultLayout(),
     });
   }, [recordingStatus]);
-
-  useShortcutById('recording.start', handleStartRecording, {
-    enabled: recordingStatus === 'idle' || recordingStatus === 'error',
-  });
 
   useEffect(() => {
     if (pendingAutoStart && (recordingStatus === 'idle' || recordingStatus === 'error')) {

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
@@ -33,6 +33,7 @@ export function NoteTakerOverlayHost(): ReactElement {
   // hide the overlay when live recording detail screen entered.
   const isViewingThisRecording =
     Boolean(externalId) && pathname.replace(/\/+$/, '').endsWith(`/recordings/${externalId}`);
+  const isOnRecordingsSection = /^\/[^/]+\/recordings(\/|$)/.test(pathname);
 
   const handleStop = useCallback((): void => {
     const stoppedRecordingId = externalId;
@@ -65,6 +66,11 @@ export function NoteTakerOverlayHost(): ReactElement {
 
   // ─── Native pill hand-off (Electron only) ─────────────────────────────────
   const isElectron = isElectronApp();
+
+  useEffect(() => {
+    if (!isElectron || !isActive) return;
+    sendRecordingEvent({ type: 'setTranscriptMinimized', isMinimized: !isOnRecordingsSection });
+  }, [isElectron, isActive, isOnRecordingsSection]);
 
   useEffect(() => {
     if (!isElectron) return;

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -126,7 +126,7 @@ export const shortcuts = {
   'recording.start': {
     keys: 'mod+alt+x',
     scope: 'global',
-    description: 'Start recording',
+    description: 'Start or stop recording',
     category: 'Recording',
     priority: 50,
     preventDefault: true,

--- a/apps/electron/src/services/global-shortcuts.ts
+++ b/apps/electron/src/services/global-shortcuts.ts
@@ -1,10 +1,10 @@
-import { app, BrowserWindow, globalShortcut } from 'electron';
+import { app, globalShortcut } from 'electron';
 import log from 'electron-log/main';
 import { toggleRecording } from './recording-controller';
 
 export const RECORDING_SHORTCUT = 'CommandOrControl+Alt+X';
 
-function registerRecordingShortcut(): void {
+export function registerGlobalShortcuts(): void {
   if (globalShortcut.isRegistered(RECORDING_SHORTCUT)) return;
 
   const registered = globalShortcut.register(RECORDING_SHORTCUT, () => {
@@ -18,35 +18,8 @@ function registerRecordingShortcut(): void {
   }
 
   log.info(`[GlobalShortcuts] Registered ${RECORDING_SHORTCUT} to toggle recording`);
-}
-
-function unregisterRecordingShortcut(): void {
-  if (!globalShortcut.isRegistered(RECORDING_SHORTCUT)) return;
-  globalShortcut.unregister(RECORDING_SHORTCUT);
-  log.info(`[GlobalShortcuts] Unregistered ${RECORDING_SHORTCUT} while Xyne is focused`);
-}
-
-function syncShortcutRegistration(): void {
-  if (BrowserWindow.getFocusedWindow()) {
-    unregisterRecordingShortcut();
-  } else {
-    registerRecordingShortcut();
-  }
-}
-
-export function registerGlobalShortcuts(): void {
-  const handleWindowFocus = (): void => unregisterRecordingShortcut();
-  const handleWindowBlur = (): void => {
-    setTimeout(syncShortcutRegistration, 0);
-  };
-
-  app.on('browser-window-focus', handleWindowFocus);
-  app.on('browser-window-blur', handleWindowBlur);
-  syncShortcutRegistration();
 
   app.once('will-quit', () => {
-    app.removeListener('browser-window-focus', handleWindowFocus);
-    app.removeListener('browser-window-blur', handleWindowBlur);
-    unregisterRecordingShortcut();
+    globalShortcut.unregister(RECORDING_SHORTCUT);
   });
 }

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -139,6 +139,12 @@ export function focusMainWindow(pathname?: string): BrowserWindow | null {
   return mainWindow;
 }
 
+function isMainWindowFocused(): boolean {
+  if (focusRequestTimer) return true;
+  const mainWindow = getMainWindow();
+  return !!mainWindow && !mainWindow.isDestroyed() && mainWindow.isFocused();
+}
+
 function syncPowerSaveBlocker(): void {
   if (active && powerSaveBlockerId === null) {
     powerSaveBlockerId = powerSaveBlocker.start('prevent-app-suspension');
@@ -157,7 +163,7 @@ function cancelPendingPillSync(): void {
 
 function syncPillVisibility(): void {
   cancelPendingPillSync();
-  if (active && isRecordingPillEnabled() && minimized) {
+  if (active && isRecordingPillEnabled() && (minimized || !isMainWindowFocused())) {
     showRecordingPill({
       startTime: startTime ?? Date.now(),
       paused,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
