### PR TITLE
fix: recording shortcut issue for pill (backport to release-20260810)

### DIFF
--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -11,7 +11,6 @@ import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout
 import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
 import { useSelf, useUsers } from '../../hooks/useUsers';
 import { xyneAIActor } from '../../machines/xyneAIMachine';
-import { useShortcutById } from '../../shortcuts';
 import { cn } from '../../utils/classNames';
 import { RecordingsEmptyStateIllustration } from './components/RecordingsEmptyStateIllustration';
 import { RecordingDateFilter } from './components/RecordingDateFilter';
@@ -74,10 +73,6 @@ const RecordingsV2Screen = (): ReactElement => {
       defaultLayout: getRecordingDefaultLayout(),
     });
   }, [recordingStatus]);
-
-  useShortcutById('recording.start', handleStartRecording, {
-    enabled: recordingStatus === 'idle' || recordingStatus === 'error',
-  });
 
   useEffect(() => {
     if (pendingAutoStart && (recordingStatus === 'idle' || recordingStatus === 'error')) {

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
@@ -33,6 +33,7 @@ export function NoteTakerOverlayHost(): ReactElement {
   // hide the overlay when live recording detail screen entered.
   const isViewingThisRecording =
     Boolean(externalId) && pathname.replace(/\/+$/, '').endsWith(`/recordings/${externalId}`);
+  const isOnRecordingsSection = /^\/[^/]+\/recordings(\/|$)/.test(pathname);
 
   const handleStop = useCallback((): void => {
     const stoppedRecordingId = externalId;
@@ -65,6 +66,11 @@ export function NoteTakerOverlayHost(): ReactElement {
 
   // ─── Native pill hand-off (Electron only) ─────────────────────────────────
   const isElectron = isElectronApp();
+
+  useEffect(() => {
+    if (!isElectron || !isActive) return;
+    sendRecordingEvent({ type: 'setTranscriptMinimized', isMinimized: !isOnRecordingsSection });
+  }, [isElectron, isActive, isOnRecordingsSection]);
 
   useEffect(() => {
     if (!isElectron) return;

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -113,7 +113,7 @@ export const shortcuts = {
   'recording.start': {
     keys: 'mod+alt+x',
     scope: 'global',
-    description: 'Start recording',
+    description: 'Start or stop recording',
     category: 'Recording',
     priority: 50,
     preventDefault: true,

--- a/apps/electron/src/services/global-shortcuts.ts
+++ b/apps/electron/src/services/global-shortcuts.ts
@@ -1,10 +1,10 @@
-import { app, BrowserWindow, globalShortcut } from 'electron';
+import { app, globalShortcut } from 'electron';
 import log from 'electron-log/main';
 import { toggleRecording } from './recording-controller';
 
 export const RECORDING_SHORTCUT = 'CommandOrControl+Alt+X';
 
-function registerRecordingShortcut(): void {
+export function registerGlobalShortcuts(): void {
   if (globalShortcut.isRegistered(RECORDING_SHORTCUT)) return;
 
   const registered = globalShortcut.register(RECORDING_SHORTCUT, () => {
@@ -18,35 +18,8 @@ function registerRecordingShortcut(): void {
   }
 
   log.info(`[GlobalShortcuts] Registered ${RECORDING_SHORTCUT} to toggle recording`);
-}
-
-function unregisterRecordingShortcut(): void {
-  if (!globalShortcut.isRegistered(RECORDING_SHORTCUT)) return;
-  globalShortcut.unregister(RECORDING_SHORTCUT);
-  log.info(`[GlobalShortcuts] Unregistered ${RECORDING_SHORTCUT} while Xyne is focused`);
-}
-
-function syncShortcutRegistration(): void {
-  if (BrowserWindow.getFocusedWindow()) {
-    unregisterRecordingShortcut();
-  } else {
-    registerRecordingShortcut();
-  }
-}
-
-export function registerGlobalShortcuts(): void {
-  const handleWindowFocus = (): void => unregisterRecordingShortcut();
-  const handleWindowBlur = (): void => {
-    setTimeout(syncShortcutRegistration, 0);
-  };
-
-  app.on('browser-window-focus', handleWindowFocus);
-  app.on('browser-window-blur', handleWindowBlur);
-  syncShortcutRegistration();
 
   app.once('will-quit', () => {
-    app.removeListener('browser-window-focus', handleWindowFocus);
-    app.removeListener('browser-window-blur', handleWindowBlur);
-    unregisterRecordingShortcut();
+    globalShortcut.unregister(RECORDING_SHORTCUT);
   });
 }


### PR DESCRIPTION
Backport of #755 to `release-20260810`.

## Problem

`Cmd+Option+X` did nothing while Xyne was focused, but worked when any other app was focused.

`global-shortcuts.ts` unregistered the accelerator on `browser-window-focus` and handed the chord over to a renderer-side shortcut. That renderer shortcut (`recording.start`) was only bound inside `RecordingsV2Screen`, a route component mounted just on `/:workspaceId/recordings` — so on every other screen nothing was listening and the keypress was a silent no-op. Even on `/recordings` it was gated to `idle`/`error`, so it could never stop a recording.

## Fix

- Keep the global shortcut registered at all times; `toggleRecording()` owns start/stop.
- Drop the route-scoped renderer binding, which is now unreachable (macOS consumes the chord via `RegisterEventHotKey`) and would otherwise double-start.
- Help-modal description updated to "Start or stop recording", since it is a real toggle now.
- `NoteTakerOverlayHost`: minimize the transcript when off the recordings section.

Also incidentally fixed: the recording pill / meeting popup / claw overlay (all `focusable: true`) used to kill the shortcut too, because `getFocusedWindow()` had no window-type filter.

## Difference from #755

#755 also changed `recording-controller.ts` to add `isMainWindowFocused()` and gate `syncPillVisibility()` on it. **That change is already present on `release-20260810`**, so it is deliberately excluded here — porting it would have dragged in the later `isRecordingPillEnabled()` feature and the changed `showRecordingPill()` signature, neither of which exists on this branch.

The other two files (`global-shortcuts.ts`, `NoteTakerOverlayHost.tsx`) are byte-identical to #755; `catalog.ts` and `RecordingsV2Screen.tsx` differ only in surrounding context.

## Verification

- `tsc --noEmit` clean (exit 0, zero output) on `apps/electron` and `apps/dashboard` — with a clean pre-change baseline on this branch to confirm the result is meaningful.
- `eslint` 0 errors on the dashboard files (45 warnings are pre-existing catalog naming-convention noise). The electron package has no eslint config on this branch — reproduces on untouched files.
- Not manually run. Worth a pass on: press Cmd+Option+X focused on a non-recordings screen (navigate + start), press again (stop), and confirm no double-start when already on `/recordings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)