### PR TITLE
fix: remove PII (email, OAuth codes, search payloads) from xyne-spaces backend logs

### DIFF
--- a/apps/backend/src/controllers/emailController.ts
+++ b/apps/backend/src/controllers/emailController.ts
@@ -369,7 +369,6 @@ export class EmailController {
         event: 'email_sent',
         type,
         channelName: channel.name,
-        userEmail: req.user?.email,
       });
 
       // 6. Save reply in database
@@ -1113,7 +1112,6 @@ export class EmailController {
           type: 'COMPOSE',
           channelName: channel.name,
           ticketId: ticket.id,
-          userEmail: req.user?.email,
         });
 
         return res.status(200).json({

--- a/apps/backend/src/database/middleware/userSessionLogging.ts
+++ b/apps/backend/src/database/middleware/userSessionLogging.ts
@@ -52,7 +52,7 @@ export function setupUserSessionLogging(prisma: PrismaClient, enabled: boolean =
     const operation = params.action.toUpperCase();
     const result = await next(params);
     const affectedRows = getAffectedRows(params.action, result);
-    const identifiers = await resolveLogIdentifiers(prisma, params.args?.data, params.args?.where, result, context?.emailId);
+    const identifiers = await resolveLogIdentifiers(prisma, params.args?.data, params.args?.where, result);
 
     if (params.action === 'delete' || params.action === 'deleteMany') {
       logDeleteOperation(

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -614,7 +614,6 @@ export class AuthMiddleware {
       // Generate a new custom JWT token for the user
       logger.info(`[AUTH] refreshTokenBySession generating custom token`, {
         userId: session.user.id,
-        email: session.user.email,
       });
       
       const customToken = jwtService.generateToken({
@@ -638,7 +637,6 @@ export class AuthMiddleware {
 
       logger.info(`[AUTH] refreshTokenBySession completed successfully`, {
         userId: session.user.id,
-        email: session.user.email,
       });
       return { success: true, customToken };
     } catch (error) {

--- a/apps/backend/src/middleware/requestLogger.ts
+++ b/apps/backend/src/middleware/requestLogger.ts
@@ -10,7 +10,7 @@ export const requestLogger = (req: CustomRequest, res: Response, next: NextFunct
     requestId: (req.headers['x-request-id'] as string) || uuidv4(),
     zeroClientId: (req.headers['x-client-id'] as string) || undefined,
     zeroClientGroupId: (req.headers['x-zero-client-group-id'] as string) || req.get('x-zero-client-group-id') || undefined,
-    emailId: req.headers['x-user-email'] as string,
+    userId: req.headers['x-user-id'] as string,
     clientSessionId: req.headers['x-client-session-id'] as string || undefined,
     appVersion: (req.headers['x-app-version'] as string) || undefined,
   };

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -622,7 +622,7 @@ class WebSocketService {
     try {
       const { userId, userName, userEmail } = socket;
 
-      logger.info(`🔍 [TYPING-DEBUG] Socket ${socket.id} - User ${userName} (${userEmail}) [ID: ${userId}] started typing in session: ${sessionId}`);
+      logger.info(`[TYPING-DEBUG] Socket ${socket.id} - User [ID: ${userId}] started typing in session: ${sessionId}`);
 
       // Create typing user object
       const typingUser: TypingUser = {
@@ -657,7 +657,7 @@ class WebSocketService {
       // Use Redis-only for all typing events (both same-pod and cross-pod)
       await typingService.broadcastTypingUpdate(sessionId, allTypingUsers, isChannel, 'typing_start');
 
-      logger.info(`Typing users in ${sessionId}: ${allTypingUsers.map(u => u.userName).join(', ')}`);
+      logger.info(`Typing users in ${sessionId}: ${allTypingUsers.length} user(s)`);
     } catch (error) {
       logger.error('Error handling typing start:', error);
     }
@@ -665,9 +665,9 @@ class WebSocketService {
 
   private async handleTypingStop(socket: AuthenticatedSocket, sessionId: string): Promise<void> {
     try {
-      const { userId, userName } = socket;
+      const { userId } = socket;
 
-      logger.info(`User ${userName} stopped typing in session: ${sessionId}`);
+      logger.info(`User [ID: ${userId}] stopped typing in session: ${sessionId}`);
 
       // Determine if this is a channel or conversation
       const isChannel = await this.isChannelSession(sessionId);
@@ -695,7 +695,7 @@ class WebSocketService {
       // Use Redis-only for all typing events (both same-pod and cross-pod)
       await typingService.broadcastTypingUpdate(sessionId, allTypingUsers, isChannel, 'typing_stop');
 
-      logger.info(`Typing users in ${sessionId}: ${allTypingUsers.map(u => u.userName).join(', ')}`);
+      logger.info(`Typing users in ${sessionId}: ${allTypingUsers.length} user(s)`);
     } catch (error) {
       logger.error('Error handling typing stop:', error);
     }

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -9,7 +9,7 @@ export interface LogContext {
   zeroClientId?: string;
   zeroClientGroupId?: string;
   clientSessionId?: string;
-  emailId?: string;
+  userId?: string;
   appVersion?: string;
 }
 

--- a/apps/backend/src/utils/redact.ts
+++ b/apps/backend/src/utils/redact.ts
@@ -3,7 +3,65 @@
 // URL reaches the logs.
 const WEBHOOK_SECRET_URL = /(\/api\/automation-webhooks\/[^/?#]+\/)([^/?#]+)/g;
 
+// Query-string parameters whose VALUES are sensitive — OAuth authorization
+// codes, tokens, the authenticated user's email, raw search text, and request
+// signatures. Their values are replaced with [REDACTED] before the URL reaches
+// the logs. Matched case-insensitively against the raw key.
+const SENSITIVE_QUERY_PARAMS = new Set([
+  'code',
+  'state',
+  'token',
+  'access_token',
+  'id_token',
+  'refresh_token',
+  'email',
+  'password',
+  'secret',
+  'api_key',
+  'apikey',
+  'key',
+  'sig',
+  'signature',
+  'auth',
+  'authorization',
+  'q',
+  'query',
+  'search',
+]);
+
+function redactQueryString(query: string): string {
+  return query
+    .split('&')
+    .map((pair) => {
+      const eq = pair.indexOf('=');
+      if (eq === -1) return pair;
+      const rawKey = pair.slice(0, eq);
+      if (SENSITIVE_QUERY_PARAMS.has(rawKey.toLowerCase())) {
+        return `${rawKey}=[REDACTED]`;
+      }
+      return pair;
+    })
+    .join('&');
+}
+
 export function redactSensitiveUrl(url: string | undefined | null): string {
   if (!url) return url ?? '';
-  return url.replace(WEBHOOK_SECRET_URL, (_match, prefix: string) => `${prefix}[REDACTED]`);
+
+  // 1. Strip the webhook path secret (path segment).
+  const redactedPath = url.replace(
+    WEBHOOK_SECRET_URL,
+    (_match, prefix: string) => `${prefix}[REDACTED]`
+  );
+
+  // 2. Scrub sensitive query-string VALUES (OAuth codes, tokens, email, q, ...).
+  const qIndex = redactedPath.indexOf('?');
+  if (qIndex === -1) return redactedPath;
+
+  const path = redactedPath.slice(0, qIndex);
+  const afterQ = redactedPath.slice(qIndex + 1);
+  const hashIndex = afterQ.indexOf('#');
+  const query = hashIndex === -1 ? afterQ : afterQ.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : afterQ.slice(hashIndex);
+
+  return `${path}?${redactQueryString(query)}${hash}`;
 }

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -476,7 +476,7 @@ export class SearchService {
         {}
       );
       const payload = buildPayload(false, useSemanticAnyway, enableWorkspaceFiltering ? effectiveWorkspaceId : undefined);
-      this.logger.info(`Payload: ${JSON.stringify(payload)}`);
+      this.logger.info(`Payload built (${JSON.stringify(payload).length} bytes)`);
       if (captureDebug) {
         captureDebug({
           stage: "exact",
@@ -536,7 +536,7 @@ export class SearchService {
         response,
         async () => {
           const fuzzyPayload = buildPayload(true, useSemanticAnyway, enableWorkspaceFiltering ? effectiveWorkspaceId : undefined);
-          this.logger.info(`Fuzzy Search Payload: ${JSON.stringify(fuzzyPayload)}`);
+          this.logger.info(`Fuzzy Search Payload built (${JSON.stringify(fuzzyPayload).length} bytes)`);
           if (captureDebug) {
             captureDebug({
               stage: "fuzzy-fallback",


### PR DESCRIPTION
## What
Application-log PII remediation for `apps/backend`, from the `/experiment` PII-in-logs audit. Each change removes cleartext PII from a log sink while preserving the operational signal (ids / counts / shape). No behavioural change beyond what is written to the log. 8 files, +69/-15.

## Root fix
- **F50 — `utils/redact.ts`**: `redactSensitiveUrl` now scrubs sensitive query-string **values** (`code`, `state`, `token` / `*_token`, `email`, `q` / `query`, `sig` / `signature`, `api_key`, ...) in addition to the existing webhook path secret. This protects every logged URL at once — `requestLogger` REQUEST_START / REQUEST_END, `errorHandler`, and `app.ts`. OAuth authorization codes and user email that arrive in query strings no longer reach the logs.

## Systemic context field
- **F2 — `utils/logger.ts` + `middleware/requestLogger.ts`**: the per-request `LogContext` no longer carries the user's email (`x-user-email`); it now carries `userId` (`x-user-id`), which `injectContext` stamps onto every log line. This removes email from effectively all request-scoped logs. `database/middleware/userSessionLogging.ts` updated for the rename — its session-audit log still resolves the actor email from the DB/result and is kept intentionally as an access-controlled audit trail.

## Call sites
| Finding | File | Change |
|---|---|---|
| F51 | `middleware/auth.ts` | Drop `email` from the two silent `refreshTokenBySession` log lines (keep `userId`). JWT claim untouched. |
| F56 / F14 | `services/websocketService.ts` | Typing start/stop logs drop `userName` + `userEmail` (keep `[ID]`); the two "Typing users" name lists reduced to a count. |
| F53 | `controllers/emailController.ts` | Drop `userEmail` from the two `email_sent` logs (keep `channelName` / `ticketId`). |
| F35 | `vespa/src/services/searchService.ts` | Reduce the two full-payload dumps (query text + bound permission filters) to a byte-length shape. |

## Deliberately NOT changed here (follow-ups)
- **Client IP** in `auth.ts` security logs (`clientIp: req.ip`) and request-start `ip` — kept for incident response / abuse investigation. IP-retention is a policy call, not a clear PII bug; flagging for the team to decide separately.
- **Interactive Google-login email lines** in `authV2Controller.ts` (~11 `logger.info(... ${...email})`) — lower-volume interactive OAuth path, and several have no `userId` available pre-provisioning. Worth a dedicated pass.
- **Uploaded filenames** in upload/document/collection controllers (can embed PII) — broad, separate PR.
- **Third-party `superposition-provider` `console.log`** (~28.6M email lines/wk in the audit) — lives in `node_modules`, needs a `patch-package` patch + build-tooling change.

## Validation
- Backend `tsc --noEmit` diagnostic pass reported **0 type errors**; the only cross-file ripple from the `emailId`→`userId` rename (`userSessionLogging.ts`) is fixed in this PR.
- All edits are anchored, mechanical, and preserve control flow.

## Relationship to PR #733
Companion to #733 (Claw / claw-auth PII logs, base `feature/deploy-xyneclaw`). This PR is the `apps/backend` half and targets `main`.