### PR TITLE
improve metrics, add feature dialog and banner

### DIFF
--- a/apps/backend/src/controllers/dailyBriefController.ts
+++ b/apps/backend/src/controllers/dailyBriefController.ts
@@ -7,6 +7,9 @@ import {
   saveDailyBriefSettings,
   getLatestDailyBrief,
   getDailyBriefHistory,
+  getDailyBriefDates,
+  getDailyBriefByDate,
+  postDailyBriefSwitched,
   regenerateDailyBriefStream,
 } from '../services/clawAgentService';
 
@@ -105,6 +108,48 @@ export async function getHistory(req: Request, res: Response) {
   } catch (error) {
     logger.error('[DailyBrief] Error fetching history:', error);
     return res.status(500).json({ error: 'Failed to load daily brief history' });
+  }
+}
+
+/** GET /api/daily-brief/dates — days the user has briefs for (date + status only). */
+export async function getDates(req: Request, res: Response) {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const limitRaw = Number(req.query.limit);
+    const limit = Number.isFinite(limitRaw) ? limitRaw : undefined;
+    const result = await getDailyBriefDates(req, userId, limit);
+    return res.json(unwrap(result));
+  } catch (error) {
+    logger.error('[DailyBrief] Error fetching dates:', error);
+    return res.status(500).json({ error: 'Failed to load daily brief dates' });
+  }
+}
+
+/** GET /api/daily-brief/by-date/:date — the stored brief for one YYYY-MM-DD bucket. */
+export async function getByDate(req: Request, res: Response) {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const { status, json } = await getDailyBriefByDate(req, userId, String(req.params.date ?? ''));
+    return res.status(status).json(unwrap(json));
+  } catch (error) {
+    logger.error('[DailyBrief] Error fetching brief by date:', error);
+    return res.status(500).json({ error: 'Failed to load daily brief' });
+  }
+}
+
+/** POST /api/daily-brief/switched — beacon: the user switched to another brief. */
+export async function postSwitched(req: Request, res: Response) {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const source = typeof req.body?.source === 'string' ? req.body.source : 'history_menu';
+    const status = await postDailyBriefSwitched(req, userId, source);
+    return res.status(status === 204 ? 204 : 500).end();
+  } catch (error) {
+    logger.error('[DailyBrief] Error recording brief switch:', error);
+    return res.status(500).end();
   }
 }
 

--- a/apps/backend/src/routes/dailyBrief.ts
+++ b/apps/backend/src/routes/dailyBrief.ts
@@ -7,6 +7,9 @@ import {
   saveSettings,
   getLatest,
   getHistory,
+  getDates,
+  getByDate,
+  postSwitched,
   regenerate,
 } from '../controllers/dailyBriefController';
 
@@ -18,6 +21,9 @@ router.get('/settings', authMiddleware.authenticate, getSettings);
 router.put('/settings', authMiddleware.authenticate, saveSettings);
 router.get('/latest', authMiddleware.authenticate, getLatest);
 router.get('/history', authMiddleware.authenticate, getHistory);
+router.get('/dates', authMiddleware.authenticate, getDates);
+router.get('/by-date/:date', authMiddleware.authenticate, getByDate);
+router.post('/switched', authMiddleware.authenticate, postSwitched);
 router.post('/regenerate', authMiddleware.authenticate, regenerate);
 
 export default router;

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -1661,6 +1661,50 @@ export async function getDailyBriefHistory(
   return response.json();
 }
 
+/** GET the days the user has briefs for (date + status only — powers the date picker). */
+export async function getDailyBriefDates(
+  req: { headers?: { cookie?: string } },
+  userId: string,
+  limit?: number
+): Promise<unknown> {
+  const qs = typeof limit === 'number' && Number.isFinite(limit) ? `?limit=${encodeURIComponent(limit)}` : '';
+  const response = await fetch(`${DAILY_BRIEF_BASE()}/dates${qs}`, {
+    method: 'GET',
+    headers: { ...extractCookieHeader(req), ...extractUserIdHeader(userId) },
+  });
+  if (!response.ok) {
+    throw new Error(`[ClawAgentService] daily-brief dates GET ${response.status}: ${await safeReadText(response)}`);
+  }
+  return response.json();
+}
+
+/** GET the user's stored brief for one YYYY-MM-DD bucket. */
+export async function getDailyBriefByDate(
+  req: { headers?: { cookie?: string } },
+  userId: string,
+  date: string
+): Promise<{ status: number; json: unknown }> {
+  const response = await fetch(`${DAILY_BRIEF_BASE()}/by-date/${encodeURIComponent(date)}`, {
+    method: 'GET',
+    headers: { ...extractCookieHeader(req), ...extractUserIdHeader(userId) },
+  });
+  return { status: response.status, json: await response.json().catch(() => ({})) };
+}
+
+/** POST the "user switched briefs" beacon (fire-and-forget; never surfaced to the user). */
+export async function postDailyBriefSwitched(
+  req: { headers?: { cookie?: string } },
+  userId: string,
+  source: string
+): Promise<number> {
+  const response = await fetch(`${DAILY_BRIEF_BASE()}/switched`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...extractCookieHeader(req), ...extractUserIdHeader(userId) },
+    body: JSON.stringify({ source }),
+  });
+  return response.status;
+}
+
 /**
  * Regenerate the brief now, streaming the SSE straight through to the dashboard.
  * claw-auth already emits dashboard-facing frames (start / progress / complete /

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@300..700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Inconsolata:wght@400;500&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
     <title>Xyne Spaces</title>
     <!-- <title>Dev Factory - File Manager</title> -->
     <script src="https://apis.google.com/js/api.js"></script>

--- a/apps/dashboard/src/api/dailyBriefApi.ts
+++ b/apps/dashboard/src/api/dailyBriefApi.ts
@@ -6,6 +6,9 @@ import { apiInstance, BASE_URL } from '../services/clients/apiClient';
  * Minimal surface for the Daily Brief dashboard page:
  *   - getLatest()  → today's stored brief (or the most recent one)
  *   - getHistory() → the user's recent briefs, newest first
+ *   - getDates()   → every day the user has a brief for (date + status only)
+ *   - getByDate()  → the stored brief for one day
+ *   - trackSwitch() → beacon: the user switched to another brief
  *   - regenerate() → re-run the brief now, streaming progress over SSE
  *
  * This is intentionally thin — a starting point for UI developers to build on.
@@ -58,6 +61,12 @@ export interface DailyBriefHistoryItem {
   data?: DailyBriefPayload | null;
   agentSlug?: string | null;
   generatedAt?: string | null;
+}
+
+/** One day the user has a brief for (GET /daily-brief/dates) — no content. */
+export interface DailyBriefDate {
+  date: string;
+  status: string;
 }
 
 /** Callbacks for the regenerate SSE stream. */
@@ -120,6 +129,35 @@ export const dailyBriefApi = {
       params: { limit },
     });
     return Array.isArray(res.data) ? res.data : [];
+  },
+
+  /** Every day the user has a brief for, newest first — the date picker's calendar. */
+  getDates: async (limit = 365): Promise<DailyBriefDate[]> => {
+    const res = await apiInstance.get<DailyBriefDate[]>('/daily-brief/dates', {
+      params: { limit },
+    });
+    return Array.isArray(res.data) ? res.data : [];
+  },
+
+  /** The stored brief for one YYYY-MM-DD bucket (`status: 'none'` when there isn't one). */
+  getByDate: async (date: string): Promise<DailyBriefLatest> => {
+    const res = await apiInstance.get<DailyBriefLatest>(
+      `/daily-brief/by-date/${encodeURIComponent(date)}`,
+    );
+    return res.data;
+  },
+
+  /**
+   * Tell the server this user switched briefs. Counted server-side because the
+   * screen keeps the recent window in memory, so a switch is otherwise invisible.
+   * Fire-and-forget: a failed beacon must never surface to the reader.
+   */
+  trackSwitch: async (source: 'history_menu' | 'date_picker'): Promise<void> => {
+    try {
+      await apiInstance.post('/daily-brief/switched', { source });
+    } catch {
+      // best-effort telemetry
+    }
   },
 
   /**

--- a/apps/dashboard/src/components/AIScreen/AISidebar.tsx
+++ b/apps/dashboard/src/components/AIScreen/AISidebar.tsx
@@ -67,7 +67,7 @@ interface AINavItem {
 
 const NAV_ITEMS: AINavItem[] = [
   { key: 'knowledge', label: 'Knowledge', icon: Notebook as NavIcon, to: '/ai/knowledge' },
-  { key: 'library', label: 'Library', icon: LayoutGridStackDown as NavIcon, to: '/ai/library' },
+  { key: 'agent-hub', label: 'Agent Hub', icon: LayoutGridStackDown as NavIcon, to: '/ai/library' },
   { key: 'digital-twin', label: 'Digital twin', icon: UserTwo as NavIcon, to: '/ai/digital-twin' },
   {
     key: 'organization',

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -3474,12 +3474,16 @@ img.inline-emoji,
  * The blend design system uses styled-components with hardcoded light-mode colors
  * from module-level defaults (R.colors.gray). Hover states use !important CSS
  * which can't be overridden by inline styles from the ThemeProvider context.
+ *
+ * `.rdp-root` is excluded because react-day-picker builds a real <table>: each
+ * week is a <tr> of day <td>s, so without the guard hovering any day paints the
+ * whole week row. :where() keeps the exclusion specificity-free.
  */
-[data-theme="midnight"] tr:hover > td {
+[data-theme="midnight"] tr:hover:not(:where(.rdp-root *)) > td {
   background-color: #222530 !important;
 }
 
-[data-theme="midnight"] tr:hover {
+[data-theme="midnight"] tr:hover:not(:where(.rdp-root *)) {
   background-color: #222530 !important;
 }
 
@@ -3803,22 +3807,32 @@ img.inline-emoji,
 /* Blend DataTable header cells - ensure proper dark mode text color.
    These target app data grids. Message tables must be excluded: the markdown
    renderer emits a real <thead> (the composer does not), so without the guard
-   the two paths get different header colours in midnight. */
+   the two paths get different header colours in midnight. `.rdp-root` is
+   excluded for the same reason — react-day-picker's weekday row is a real
+   <thead><th>, which otherwise picks up the data-grid header surface. */
 [data-theme="midnight"]
-  th:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *),
+  th:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ),
 [data-theme="midnight"]
   th
-  *:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *),
+  *:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ),
 [data-theme="midnight"]
   th
-  span:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *) {
+  span:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ) {
   color: #d1d5db !important;
 }
 
 /* Specific targeting for table header text with lower contrast */
 [data-theme="midnight"]
   thead
-  th:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *) {
+  th:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ) {
   color: #d1d5db !important;
   background-color: #1a1a1a !important;
 }
@@ -3827,7 +3841,7 @@ img.inline-emoji,
 [data-theme="midnight"]
   th
   :is(p, div, span):not(
-    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
   ) {
   color: #d1d5db !important;
 }
@@ -3835,7 +3849,9 @@ img.inline-emoji,
 /* Ensure high contrast for all header content */
 [data-theme="midnight"]
   thead
-  *:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *) {
+  *:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ) {
   color: #d1d5db !important;
 }
 

--- a/apps/dashboard/src/routes/AIScreen/library/LibraryV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/LibraryV2.tsx
@@ -100,7 +100,7 @@ const LibraryV2 = (): ReactElement => {
         <div className='flex items-center gap-5 pt-5'>
           <div className='flex min-w-0 flex-1 flex-col justify-center gap-1'>
             <h1 className='text-2xl font-semibold leading-[1.2] tracking-[-0.24px] text-foreground'>
-              Library
+              Agent Hub
             </h1>
             <p className='text-[15px] leading-[1.2] text-muted-foreground'>
               View and manage agents, subagent, skills and MCP.

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefFeaturesDialog.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefFeaturesDialog.tsx
@@ -1,0 +1,309 @@
+import { ComponentType, ReactElement, Ref, useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useMeasure } from 'react-use';
+import { ListAiGenerated, ReminderAnticlockwise, Settings02 } from '@xyne/icons';
+import { Dialog } from '../../components/ui/Dialog/Dialog';
+import { cn } from '../../utils/classNames';
+import {
+  CARD_CHROME,
+  MiniBriefCard,
+  MiniBriefSkeleton,
+  MiniHistoryCard,
+  MiniSettingsCard,
+} from './briefFeatureViews';
+
+type FeatureTab = 'default' | 'settings' | 'regenerate' | 'history';
+
+// Both curves are strong ease-outs: fast start, gentle settle. Size and content
+// share a duration so the panel reads as one entity rather than two animations.
+const SIZE_EASE = [0.25, 1, 0.5, 1] as const;
+const CONTENT_EASE = [0.19, 1, 0.22, 1] as const;
+const SIZE_DURATION = 0.27;
+const ENTER_DURATION = 0.27;
+// The user has already decided by the time something leaves — exits get out of the way.
+const EXIT_DURATION = 0.27;
+/** Height of the absolutely-positioned title + tabs bar. The stage below it is
+ *  inset by this much so centring happens in the space actually left over. */
+const HEADER_H = 56;
+/** How long the regenerate demo holds on its skeleton before the brief resolves. */
+const SKELETON_MS = 1100;
+/** Order the stepper walks, and how long each step holds before advancing. */
+const STEPS: FeatureTab[] = ['default', 'regenerate', 'settings', 'history'];
+const STEP_MS = 3400;
+
+interface TabSpec {
+  value: Exclude<FeatureTab, 'default'>;
+  label: string;
+  icon: ComponentType<{ size?: number; className?: string }>;
+}
+
+const TABS: TabSpec[] = [
+  { value: 'regenerate', label: 'Regenerate', icon: ListAiGenerated },
+  { value: 'settings', label: 'Settings', icon: Settings02 },
+  { value: 'history', label: 'History', icon: ReminderAnticlockwise },
+];
+
+const TITLES: Record<FeatureTab, string> = {
+  default: 'Your morning brief',
+  regenerate: 'Re-run it any time',
+  settings: 'Make it yours',
+  history: 'Every brief, kept',
+};
+
+const DESCRIPTIONS: Record<FeatureTab, string> = {
+  default: 'Everything that needs you, is overdue, waiting, and assigned to you summarized',
+  settings: 'Customize tone, priorities, and what each section covers.',
+  regenerate: 'Re-run the brief with your latest tickets, threads, and approvals.',
+  history: 'Browse past briefs and see what changed day to day.',
+};
+
+interface BriefFeaturesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BriefFeaturesDialog({
+  open,
+  onOpenChange,
+}: BriefFeaturesDialogProps): ReactElement {
+  const [tab, setTab] = useState<FeatureTab>('default');
+  const [regenSettled, setRegenSettled] = useState(false);
+  const [autoplay, setAutoplay] = useState(true);
+  const reduce = useReducedMotion();
+  const enter = reduce
+    ? { from: { opacity: 0 }, to: { opacity: 1 } }
+    : {
+        from: { opacity: 0, filter: 'blur(2px)', scale: 0.96 },
+        to: { opacity: 1, filter: 'blur(0px)', scale: 1 },
+      };
+  const [frameRef] = useMeasure();
+  const [contentRef, content] = useMeasure();
+
+  useEffect(() => {
+    if (!open) return;
+    setTab('default');
+    setAutoplay(true);
+  }, [open]);
+
+  // Regenerate demo: hold the skeleton, then resolve. Re-runs on every entry to
+  // the tab so the animation is the thing you actually see.
+  // Regenerate holds longer: its own skeleton eats the first second of the step.
+  const dwellMs = tab === 'regenerate' ? STEP_MS + SKELETON_MS : STEP_MS;
+
+  // Auto-advance. Off under reduced motion — auto-updating content is exactly
+  // what that preference asks us not to do — and off for good once the reader
+  // picks a tab themselves, so the stepper never fights them.
+  useEffect(() => {
+    if (!open || !autoplay || reduce) return undefined;
+    const id = window.setTimeout(() => {
+      setTab(current => STEPS[(STEPS.indexOf(current) + 1) % STEPS.length] ?? 'default');
+    }, dwellMs);
+    return () => window.clearTimeout(id);
+  }, [open, autoplay, reduce, tab, dwellMs]);
+
+  useEffect(() => {
+    if (tab !== 'regenerate') return undefined;
+    setRegenSettled(false);
+    const id = window.setTimeout(() => setRegenSettled(true), SKELETON_MS);
+    return () => window.clearTimeout(id);
+  }, [tab]);
+
+  const body = useMemo(() => {
+    switch (tab) {
+      case 'default':
+        return <MiniBriefCard />;
+      case 'regenerate':
+        return regenSettled ? <MiniBriefCard regenerated /> : <MiniBriefSkeleton />;
+      case 'settings':
+        return <MiniSettingsCard />;
+      case 'history':
+        return <MiniHistoryCard />;
+    }
+  }, [tab, regenSettled]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Xyne Brief'
+      description='What you can do with your daily brief'
+      className='h-[560px] w-[540px] max-w-[540px] rounded-[28px] border border-border p-1.5 pb-5'
+    >
+      <div className='flex h-full flex-col items-center gap-4'>
+        <div className='flex min-h-0 flex-1 flex-col items-center gap-3 self-stretch'>
+          {/* The frame is fixed; only what sits inside it changes size. */}
+          <div
+            ref={frameRef as Ref<HTMLDivElement> | undefined}
+            className={cn(
+              'relative min-h-0 flex-1 self-stretch overflow-hidden rounded-[22px] border border-border',
+              'shadow-[0px_43px_17px_0px_rgba(0,0,0,0.01),0px_24px_15px_0px_rgba(0,0,0,0.02),0px_11px_11px_0px_rgba(0,0,0,0.03),0px_3px_6px_0px_rgba(0,0,0,0.04)]',
+            )}
+          >
+            {/* Reuses the app's themed wallpaper variable rather than a new asset, so
+                midnight gets its own image for free. Scaled past the edges because
+                the blur would otherwise pull the frame's border inward. */}
+            <div
+              aria-hidden
+              className='app-wallpaper-image pointer-events-none absolute inset-0 scale-125 bg-cover bg-center bg-no-repeat blur-2xl'
+            />
+            <div aria-hidden className='pointer-events-none absolute inset-0 bg-background/50' />
+
+            {/* Everything that animates lives in a stage inset below the header,
+                so `justify-center` centres it in the free area rather than the
+                whole frame — otherwise the header's height all lands underneath.
+                It also gives the back cards' `calc(50% - …)` the right basis. */}
+            <div
+              className='absolute inset-x-0 bottom-0 flex items-center justify-center'
+              style={{ top: HEADER_H }}
+            >
+              {/* The container carries the card chrome, so its size change IS the
+                visible morph. z-10 keeps it above the transformed card behind it,
+                which would otherwise paint on top by CSS painting order. */}
+              <motion.div
+                className={cn(
+                  CARD_CHROME,
+                  'relative z-10 flex items-start justify-center overflow-hidden rounded-[16px] select-none',
+                )}
+                animate={{ width: content.width, height: content.height }}
+                transition={reduce ? { duration: 0 } : { duration: SIZE_DURATION, ease: SIZE_EASE }}
+              >
+                <div ref={contentRef as Ref<HTMLDivElement> | undefined} className='w-fit'>
+                  <AnimatePresence initial={false} mode='popLayout'>
+                    <motion.div
+                      key={tab === 'regenerate' ? `regenerate-${regenSettled}` : tab}
+                      initial={enter.from}
+                      animate={enter.to}
+                      exit={enter.from}
+                      transition={{ duration: ENTER_DURATION, ease: CONTENT_EASE }}
+                    >
+                      {body}
+                    </motion.div>
+                  </AnimatePresence>
+                </div>
+              </motion.div>
+            </div>
+
+            <div className='absolute top-0 inset-x-0 flex justify-between p-1.5 items-center'>
+              <p className='font-serif text-base italic leading-normal text-muted-foreground pl-2.5'>
+                Xyne Brief
+              </p>
+              <div className='bg-background flex shrink-0 items-center justify-center gap-2 border-[0.5px] border-border rounded-2xl p-2'>
+                {TABS.map(({ value, label, icon: IconComponent }) => {
+                  const isActive = tab === value;
+                  return (
+                    <button
+                      key={value}
+                      type='button'
+                      onClick={() => {
+                        setTab(isActive ? 'default' : value);
+                        setAutoplay(false);
+                      }}
+                      aria-pressed={isActive}
+                      data-track-category='DailyBrief'
+                      data-track-name='daily-brief-features-tab'
+                      data-track-metadata={JSON.stringify({ tab: value })}
+                      className={cn(
+                        'flex h-9 items-center rounded-[10px] px-2.5 transition-colors duration-200 ease-out',
+                        isActive
+                          ? 'bg-accent text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+                      )}
+                    >
+                      <span className='flex size-5 shrink-0 items-center justify-center'>
+                        <IconComponent size={20} />
+                      </span>
+                      <span
+                        className={cn(
+                          'grid overflow-hidden transition-[grid-template-columns,opacity,margin] duration-200 ease-out',
+                          isActive
+                            ? 'ml-2 grid-cols-[1fr] opacity-100'
+                            : 'grid-cols-[0fr] opacity-0',
+                        )}
+                      >
+                        <span className='min-w-0 overflow-hidden whitespace-nowrap text-[14px] font-medium leading-[1.2] tracking-[-0.1px]'>
+                          {label}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className='flex shrink-0 flex-col items-center gap-2'>
+          <div className='grid h-7 place-items-center'>
+            <AnimatePresence initial={false} mode='popLayout'>
+              <motion.p
+                key={tab}
+                initial={enter.from}
+                animate={enter.to}
+                exit={enter.from}
+                transition={{ duration: EXIT_DURATION, ease: CONTENT_EASE }}
+                className='col-start-1 row-start-1 text-center text-[17px] font-semibold tracking-[-0.2px] text-foreground'
+              >
+                {TITLES[tab]}
+              </motion.p>
+            </AnimatePresence>
+          </div>
+          <div className='grid h-16 place-items-start px-3'>
+            <AnimatePresence initial={false} mode='popLayout'>
+              <motion.p
+                key={tab}
+                initial={enter.from}
+                animate={enter.to}
+                exit={enter.from}
+                transition={{ duration: EXIT_DURATION, ease: CONTENT_EASE }}
+                className='col-start-1 row-start-1 text-center text-base font-normal leading-[1.5] tracking-[-0.1px] text-foreground'
+              >
+                {DESCRIPTIONS[tab]}
+              </motion.p>
+            </AnimatePresence>
+          </div>
+
+          <div className='flex items-center justify-center gap-1.5'>
+            {STEPS.map(step => {
+              const isActive = tab === step;
+              return (
+                <button
+                  key={step}
+                  type='button'
+                  aria-label={TITLES[step]}
+                  aria-current={isActive ? 'step' : undefined}
+                  onClick={() => {
+                    setTab(step);
+                    setAutoplay(false);
+                  }}
+                  data-track-category='DailyBrief'
+                  data-track-name='daily-brief-features-step'
+                  data-track-metadata={JSON.stringify({ step })}
+                  className={cn(
+                    'h-1.5 overflow-hidden rounded-full bg-muted-foreground/25 transition-all duration-300 ease-out',
+                    isActive ? 'w-7' : 'w-1.5 hover:bg-muted-foreground/50',
+                  )}
+                >
+                  {isActive && (
+                    <motion.span
+                      // Re-keyed per step so the fill restarts rather than resuming.
+                      key={`${step}-${String(autoplay)}`}
+                      className='block h-full rounded-full bg-primary'
+                      initial={{ width: autoplay && !reduce ? '0%' : '100%' }}
+                      animate={{ width: '100%' }}
+                      // A progress timer is constant motion — linear is correct here.
+                      transition={
+                        autoplay && !reduce
+                          ? { duration: dwellMs / 1000, ease: 'linear' }
+                          : { duration: 0 }
+                      }
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefHistoryMenu.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefHistoryMenu.tsx
@@ -1,45 +1,72 @@
-import { ReactElement, useState } from 'react';
-import { ChevronBigDown, ClockDefault, File02Default } from '@xyne/icons';
+import { ReactElement, Ref, useCallback, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useMeasure } from 'react-use';
+import { ClockDefault } from '@xyne/icons';
 import { Popover } from '../../components/ui/Popover';
 import { cn } from '../../utils/classNames';
 import { APP_NO_DRAG_STYLE } from '../../utils/electronApp';
+import { BriefListView } from './BriefListView';
+import { CalendarView } from './CalendarView';
 import type { DailyBriefHistoryItem } from '../../api/dailyBriefApi';
 
 export const HEADER_ICON_CLASS =
   'flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] text-muted-foreground ' +
   'transition-colors hover:bg-accent hover:text-foreground';
 
-function briefMenuLabel(date: string): string {
-  const parsed = new Date(`${date}T00:00:00`);
-  if (Number.isNaN(parsed.getTime())) return `Morning Brief ${date}`;
-  const day = parsed.getDate();
-  const month = parsed.toLocaleDateString(undefined, { month: 'short' });
-  return `Morning Brief ${day} ${month}`;
-}
+type BriefMenuView = 'list' | 'calendar';
 
 interface BriefHistoryMenuProps {
   history: DailyBriefHistoryItem[];
+  availableDates: string[];
   selectedDate: string | null;
-  onSelect: (date: string) => void;
+  onSelect: (date: string, source: 'history_menu' | 'date_picker') => void;
 }
-
-const COLLAPSED_COUNT = 5;
 
 export function BriefHistoryMenu({
   history,
+  availableDates,
   selectedDate,
   onSelect,
 }: BriefHistoryMenuProps): ReactElement {
   const [open, setOpen] = useState(false);
-  const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<BriefMenuView>('list');
+  const [elementRef, bounds] = useMeasure();
 
-  const handleOpenChange = (next: boolean): void => {
+  const handleOpenChange = useCallback((next: boolean): void => {
     setOpen(next);
-    if (!next) setExpanded(false);
-  };
+    if (next) setView('list');
+  }, []);
 
-  const visible = expanded ? history : history.slice(0, COLLAPSED_COUNT);
-  const hiddenCount = history.length - visible.length;
+  const handleSelect = useCallback(
+    (date: string, source: 'history_menu' | 'date_picker'): void => {
+      onSelect(date, source);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  const content = useMemo(() => {
+    switch (view) {
+      case 'list':
+        return (
+          <BriefListView
+            history={history}
+            selectedDate={selectedDate}
+            onSelect={handleSelect}
+            onBrowseDates={() => setView('calendar')}
+          />
+        );
+      case 'calendar':
+        return (
+          <CalendarView
+            availableDates={availableDates}
+            selectedDate={selectedDate}
+            onSelect={handleSelect}
+            onBack={() => setView('list')}
+          />
+        );
+    }
+  }, [view, history, availableDates, selectedDate, handleSelect]);
 
   return (
     <Popover
@@ -49,7 +76,7 @@ export function BriefHistoryMenu({
       align='end'
       sideOffset={8}
       collisionPadding={12}
-      className='w-[232px] max-h-[250px] overflow-y-auto rounded-[12px] border-border bg-popover p-1.5 shadow-lg'
+      className='w-[276px] overflow-hidden rounded-[12px] border-border bg-popover p-1.5 shadow-lg'
       trigger={
         <button
           type='button'
@@ -63,54 +90,30 @@ export function BriefHistoryMenu({
         </button>
       }
     >
-      {history.length === 0 ? (
-        <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No past briefs.</div>
-      ) : (
-        <ul className='flex flex-col gap-px'>
-          {visible.map(item => {
-            const isActive = selectedDate === item.date;
-            return (
-              <li key={item.date}>
-                <button
-                  type='button'
-                  onClick={() => {
-                    onSelect(item.date);
-                    setOpen(false);
-                  }}
-                  data-track-category='DailyBrief'
-                  data-track-name='daily-brief-history-item'
-                  className={cn(
-                    'flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left',
-                    'text-[14px] tracking-[-0.1px] transition-colors',
-                    isActive
-                      ? 'bg-accent font-medium text-foreground'
-                      : 'font-normal text-muted-foreground hover:bg-accent hover:text-foreground',
-                  )}
-                >
-                  <File02Default size={16} className='shrink-0 text-muted-foreground' />
-                  <span className='truncate'>{briefMenuLabel(item.date)}</span>
-                </button>
-              </li>
-            );
-          })}
-          {hiddenCount > 0 && (
-            <li>
-              <button
-                type='button'
-                onClick={() => setExpanded(true)}
-                data-track-category='DailyBrief'
-                data-track-name='daily-brief-history-show-all'
-                className='flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left text-[13px] font-medium tracking-[-0.1px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-              >
-                <span className='flex size-4 shrink-0 items-center justify-center'>
-                  <ChevronBigDown size={14} />
-                </span>
-                <span className='truncate'>Show all ({history.length})</span>
-              </button>
-            </li>
-          )}
-        </ul>
-      )}
+      <motion.div
+        className='~overflow-hidden'
+        animate={{
+          height: bounds.height,
+          transition: {
+            duration: 0.27,
+            ease: [0.25, 1, 0.5, 1],
+          },
+        }}
+      >
+        <div ref={elementRef as Ref<HTMLDivElement> | undefined}>
+          <AnimatePresence initial={false} mode='popLayout' custom={view}>
+            <motion.div
+              key={view}
+              initial={{ opacity: 0, scale: 1 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 1 }}
+              transition={{ duration: 0.27, ease: [0.26, 0.08, 0.25, 1] }}
+            >
+              {content}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </motion.div>
     </Popover>
   );
 }

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
@@ -1,0 +1,48 @@
+import { ReactElement } from 'react';
+import { MultipleCrossCancelDefault } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+
+interface BriefIntroBannerProps {
+  onSeeMore: () => void;
+  onDismiss: () => void;
+}
+
+export function BriefIntroBanner({ onSeeMore, onDismiss }: BriefIntroBannerProps): ReactElement {
+  return (
+    <div
+      className={cn(
+        'isolate relative mb-8 overflow-hidden rounded-[16px] border border-border px-6 py-5 bg-white/5 ~bg-gradient-to-r ~from-primary/25 ~via-primary/10 ~to-primary/30',
+        'shadow-[0px_43px_26px_0px_rgba(0,0,0,0.01),0px_19px_19px_0px_rgba(0,0,0,0.02),0px_5px_10px_0px_rgba(0,0,0,0.02)]',
+        'before:pointer-events-none before:-z-10 before:absolute before:-inset-x-[12%] before:h-[550%] before:bottom-full before:translate-y-[9%] before:bg-[radial-gradient(50%_50%_at_50%_50%,hsl(var(--primary))_54%,transparent)] before:blur-2xl',
+      )}
+    >
+      <button
+        type='button'
+        aria-label='Dismiss'
+        onClick={onDismiss}
+        data-track-category='DailyBrief'
+        data-track-name='daily-brief-intro-dismiss'
+        className='absolute right-3 top-3 flex size-6 items-center justify-center rounded-[6px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+      >
+        <MultipleCrossCancelDefault size={14} />
+      </button>
+      <div className='flex flex-col items-center gap-2 text-center'>
+        <p className='font-serif text-[16px] font-bold italic leading-[20px] text-foreground'>
+          Your Morning Brief
+        </p>
+        <p className='text-[16px] font-normal leading-[20px] text-foreground/80'>
+          Everything that needs you, is overdue, waiting, and assigned to you summarized
+        </p>
+        <button
+          type='button'
+          onClick={onSeeMore}
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-intro-see-more'
+          className='mt-1 flex h-7 items-center rounded-[8px] border border-border bg-background px-2.5 text-[14px] font-semibold leading-[20px] text-foreground shadow-sm transition-colors hover:bg-accent'
+        >
+          Learn more
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefListView.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefListView.tsx
@@ -1,0 +1,73 @@
+import { ReactElement } from 'react';
+import { CalendarFilled, ChevronBigRight, File02Default } from '@xyne/icons';
+import { cn } from '../../utils/classNames';
+import type { DailyBriefHistoryItem } from '../../api/dailyBriefApi';
+
+function briefMenuLabel(date: string): string {
+  const parsed = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return `Morning Brief ${date}`;
+  const day = parsed.getDate();
+  const month = parsed.toLocaleDateString(undefined, { month: 'short' });
+  return `Morning Brief ${day} ${month}`;
+}
+
+interface BriefListViewProps {
+  history: DailyBriefHistoryItem[];
+  selectedDate: string | null;
+  onSelect: (date: string, source: 'history_menu' | 'date_picker') => void;
+  onBrowseDates: () => void;
+}
+
+export function BriefListView({
+  history,
+  selectedDate,
+  onSelect,
+  onBrowseDates,
+}: BriefListViewProps): ReactElement {
+  return (
+    <div className='flex flex-col'>
+      {history.length === 0 ? (
+        <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No past briefs.</div>
+      ) : (
+        <ul className='flex flex-col gap-px'>
+          {history.map(item => {
+            const isActive = selectedDate === item.date;
+            return (
+              <li key={item.date}>
+                <button
+                  type='button'
+                  onClick={() => onSelect(item.date, 'history_menu')}
+                  data-track-category='DailyBrief'
+                  data-track-name='daily-brief-history-item'
+                  className={cn(
+                    'flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left',
+                    'text-[14px] tracking-[-0.1px] transition-colors',
+                    isActive
+                      ? 'bg-accent font-medium text-foreground'
+                      : 'font-normal text-muted-foreground hover:bg-accent hover:text-foreground',
+                  )}
+                >
+                  <File02Default size={16} className='shrink-0 text-muted-foreground' />
+                  <span className='truncate'>{briefMenuLabel(item.date)}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <div className='mt-1 border-t border-border pt-1'>
+        <button
+          type='button'
+          onClick={onBrowseDates}
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-browse-by-date'
+          className='flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left text-[14px] font-normal tracking-[-0.1px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        >
+          <CalendarFilled size={16} className='shrink-0' />
+          <span className='flex-1 truncate'>Find a Brief</span>
+          <ChevronBigRight size={14} className='shrink-0' />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefSettingsDialog.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefSettingsDialog.tsx
@@ -184,6 +184,7 @@ export function BriefSettingsDialog({
               disabled={saving}
               data-track-category='DailyBrief'
               data-track-name='daily-brief-settings-cancel'
+              className='rounded-lg'
             >
               Cancel
             </Button>
@@ -194,6 +195,7 @@ export function BriefSettingsDialog({
               disabled={loading || saving || overLimit || busy}
               data-track-category='DailyBrief'
               data-track-name='daily-brief-settings-save-regenerate'
+              className='rounded-lg'
             >
               Save & regenerate
             </Button>
@@ -204,6 +206,7 @@ export function BriefSettingsDialog({
               loading={saving}
               data-track-category='DailyBrief'
               data-track-name='daily-brief-settings-save'
+              className='rounded-lg'
             >
               Save
             </Button>

--- a/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
@@ -1,0 +1,86 @@
+import { ReactElement, useMemo } from 'react';
+import { format } from 'date-fns';
+import { Calendar } from '../../components/ui/Calendar';
+import { ChevronBigLeft } from '@xyne/icons';
+
+const BUCKET_FORMAT = 'yyyy-MM-dd';
+
+function parseBucket(date: string): Date | null {
+  const parsed = new Date(`${date}T00:00:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+interface CalendarViewProps {
+  /** Every day the user has a brief for, as YYYY-MM-DD buckets. */
+  availableDates: string[];
+  selectedDate: string | null;
+  onSelect: (date: string, source: 'history_menu' | 'date_picker') => void;
+  onBack: () => void;
+}
+
+export function CalendarView({
+  availableDates,
+  selectedDate,
+  onSelect,
+  onBack,
+}: CalendarViewProps): ReactElement {
+  const dateSet = useMemo(() => new Set(availableDates), [availableDates]);
+
+  const bounds = useMemo(() => {
+    const parsed = availableDates
+      .map(parseBucket)
+      .filter((value): value is Date => value !== null)
+      .sort((a, b) => a.getTime() - b.getTime());
+    return { earliest: parsed[0] ?? null, latest: parsed[parsed.length - 1] ?? null };
+  }, [availableDates]);
+
+  const selectedObj = selectedDate ? parseBucket(selectedDate) : null;
+  const defaultMonth = selectedObj ?? bounds.latest ?? new Date();
+
+  const handleSelect = (date: Date | undefined): void => {
+    if (!date) return;
+    onSelect(format(date, BUCKET_FORMAT), 'date_picker');
+  };
+
+  return (
+    <div className='flex flex-col'>
+      <div className='flex items-center gap-1 pb-1 pl-0.5 pr-2.5'>
+        <button
+          type='button'
+          onClick={onBack}
+          aria-label='Back to recent briefs'
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-calendar-back'
+          className='flex size-7 shrink-0 items-center justify-center rounded-[8px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        >
+          <ChevronBigLeft size={14} />
+        </button>
+        <span className='text-[13px] font-medium tracking-[-0.1px] text-foreground'>
+          Select a date
+        </span>
+      </div>
+      {availableDates.length === 0 ? (
+        <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No briefs yet.</div>
+      ) : (
+        <Calendar
+          mode='single'
+          {...(selectedObj && { selected: selectedObj })}
+          onSelect={handleSelect}
+          defaultMonth={defaultMonth}
+          {...(bounds.earliest && { startMonth: bounds.earliest })}
+          {...(bounds.latest && { endMonth: bounds.latest })}
+          disabled={date => !dateSet.has(format(date, BUCKET_FORMAT))}
+          classNames={{
+            day: 'relative flex-1 p-0 text-center text-sm focus-within:relative focus-within:z-20',
+            selected:
+              'bg-primary text-white hover:bg-primary hover:text-white focus:bg-primary focus:text-white rounded-md',
+            // root: 'relative',
+          }}
+          // navLayout='around'
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-calendar-day'
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
@@ -3,13 +3,16 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Settings01 } from '@xyne/icons';
+import { InformationCircle, ListAiGenerated, Settings01 } from '@xyne/icons';
 import { createMarkdownComponents } from '../../utils/markdownComponents';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
 import { useIsInPanelWebview } from '../../hooks/useIsInPanelWebview';
 import { BriefHistoryMenu, HEADER_ICON_CLASS } from './BriefHistoryMenu';
 import { BriefSettingsDialog } from './BriefSettingsDialog';
+import { BriefIntroBanner } from './BriefIntroBanner';
+import { BriefFeaturesDialog } from './BriefFeaturesDialog';
+import { useBriefIntroSeen } from './useBriefIntroSeen';
 import { BriefLine, useBriefRenderContext, type BriefRenderContext } from './briefText';
 import { RawBriefView } from './RawBriefView';
 import { BriefSkeleton } from './BriefSkeleton';
@@ -22,6 +25,7 @@ import {
 import {
   trackDailyBriefRegenerateAbandoned,
   trackDailyBriefSwitched,
+  type BriefSwitchSource,
 } from '../../services/otel/dailyBriefMetrics';
 
 const REMARK_PLUGINS = [remarkGfm];
@@ -167,17 +171,25 @@ function BriefSection({
 
 const BRIEF_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const TODAY_SEGMENT = 'today';
+// Today's brief plus the previous seven. Anything older is fetched on demand
+// when the date picker routes to it.
+const HISTORY_LIMIT = 7;
 
 const DailyBriefScreen = (): ReactElement => {
   const [latest, setLatest] = useState<DailyBriefLatest | null>(null);
   const [history, setHistory] = useState<DailyBriefHistoryItem[]>([]);
+  const [availableDates, setAvailableDates] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // A brief older than the loaded window, pulled in by URL/date-picker.
+  const [fetched, setFetched] = useState<SelectedBrief | null>(null);
+  const [fetching, setFetching] = useState(false);
 
   const [regenerating, setRegenerating] = useState(false);
   const [progress, setProgress] = useState<string | null>(null);
   const [showRaw, setShowRaw] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [featuresOpen, setFeaturesOpen] = useState(false);
   const mountedRef = useRef(true);
   const navigate = useNavigate();
   const { workspaceId, briefDate } = useParams();
@@ -190,6 +202,7 @@ const DailyBriefScreen = (): ReactElement => {
   // Read on unmount, where component state is already stale.
   const regenerateStartedAtRef = useRef<number | null>(null);
   const isInPanelWebview = useIsInPanelWebview();
+  const { introSeen, markIntroSeen } = useBriefIntroSeen();
 
   const load = useCallback(async (opts?: { quiet?: boolean }) => {
     if (!mountedRef.current) return;
@@ -198,13 +211,15 @@ const DailyBriefScreen = (): ReactElement => {
       setError(null);
     }
     try {
-      const [latestRes, historyRes] = await Promise.all([
+      const [latestRes, historyRes, datesRes] = await Promise.all([
         dailyBriefApi.getLatest(),
-        dailyBriefApi.getHistory(),
+        dailyBriefApi.getHistory(HISTORY_LIMIT),
+        dailyBriefApi.getDates(),
       ]);
       if (!mountedRef.current) return;
       setLatest(latestRes);
       setHistory(historyRes);
+      setAvailableDates(datesRes.map(item => item.date));
     } catch {
       if (mountedRef.current && !opts?.quiet) setError('Failed to load daily brief.');
     } finally {
@@ -234,13 +249,46 @@ const DailyBriefScreen = (): ReactElement => {
     void navigate(todayPath, { replace: true });
   }, [briefDate, navigate, todayPath]);
 
-  // A well-formed date with no brief behind it would otherwise render the
-  // latest brief under a URL that disagrees with it.
+  const inHistory = selectedDate !== null && history.some(item => item.date === selectedDate);
+
+  // Dates outside the loaded window are legitimate — the picker can reach any
+  // day the user has a brief for, so fetch it rather than bouncing to today.
   useEffect(() => {
-    if (loading || selectedDate === null) return;
-    if (history.some(item => item.date === selectedDate)) return;
-    void navigate(todayPath, { replace: true });
-  }, [loading, selectedDate, history, navigate, todayPath]);
+    if (loading || selectedDate === null || inHistory) {
+      setFetched(null);
+      setFetching(false);
+      return undefined;
+    }
+    let cancelled = false;
+    setFetching(true);
+    void dailyBriefApi
+      .getByDate(selectedDate)
+      .then(res => {
+        if (cancelled) return;
+        if (!res || res.status === 'none') {
+          setFetched(null);
+          void navigate(todayPath, { replace: true });
+          return;
+        }
+        setFetched({
+          date: res.date ?? selectedDate,
+          status: res.status,
+          content: res.content ?? '',
+          data: res.data ?? null,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFetched(null);
+        setError('Failed to load that brief.');
+      })
+      .finally(() => {
+        if (!cancelled) setFetching(false);
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [loading, selectedDate, inHistory, navigate, todayPath]);
 
   const selected = useMemo((): SelectedBrief | null => {
     if (selectedDate) {
@@ -253,6 +301,7 @@ const DailyBriefScreen = (): ReactElement => {
           data: fromHistory.data ?? null,
         };
       }
+      return fetched?.date === selectedDate ? fetched : null;
     }
     if (latest && latest.status !== 'none') {
       return {
@@ -263,7 +312,7 @@ const DailyBriefScreen = (): ReactElement => {
       };
     }
     return null;
-  }, [selectedDate, history, latest]);
+  }, [selectedDate, history, latest, fetched]);
 
   const briefStatus = selected?.status;
   const briefGenerating = briefStatus === 'generating';
@@ -334,10 +383,14 @@ const DailyBriefScreen = (): ReactElement => {
   }, [generationInFlight, load, navigate, todayPath]);
 
   const currentDate = selected?.date ?? null;
+  const activeDate = currentDate ?? selectedDate;
   const handleSelectDate = useCallback(
-    (date: string) => {
+    (date: string, source: BriefSwitchSource) => {
       if (date !== currentDate) {
-        trackDailyBriefSwitched();
+        trackDailyBriefSwitched(source);
+        // Device-scoped `instance` cannot answer "how many users" — the server
+        // counts distinct userIds behind this beacon instead.
+        void dailyBriefApi.trackSwitch(source);
       }
       void navigate(date === todayBucket ? todayPath : `${briefPath}/${date}`);
     },
@@ -363,10 +416,13 @@ const DailyBriefScreen = (): ReactElement => {
   // A regeneration always targets today, so it only blanks the body when today
   // is what you're looking at — other briefs stay readable while it runs.
   const isBusy =
-    (loading && !selected) || (viewingToday && regenerating) || (!showRaw && briefGenerating);
+    (loading && !selected) ||
+    fetching ||
+    (viewingToday && regenerating) ||
+    (!showRaw && briefGenerating);
 
   const actionLabel = ((): string => {
-    if (loading && !selected) return 'Loading…';
+    if ((loading && !selected) || fetching) return 'Loading…';
     if (regenerating) return hasBrief ? 'Regenerating…' : 'Generating…';
     if (briefGenerating) return 'Generating…';
     return hasBrief ? 'Regenerate' : 'Generate';
@@ -476,8 +532,9 @@ const DailyBriefScreen = (): ReactElement => {
             style={APP_NO_DRAG_STYLE}
             data-track-category='DailyBrief'
             data-track-name='daily-brief-regenerate'
-            className='mr-1 rounded-[8px] border border-border px-3 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
+            className='mr-1 flex items-center gap-1.5 rounded-[8px] border border-border px-3 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
           >
+            <ListAiGenerated size={16} className='shrink-0' />
             {actionLabel}
           </button>
           <button
@@ -493,9 +550,21 @@ const DailyBriefScreen = (): ReactElement => {
           </button>
           <BriefHistoryMenu
             history={history}
-            selectedDate={currentDate}
+            availableDates={availableDates}
+            selectedDate={activeDate}
             onSelect={handleSelectDate}
           />
+          <button
+            type='button'
+            aria-label='About the daily brief'
+            onClick={() => setFeaturesOpen(true)}
+            style={APP_NO_DRAG_STYLE}
+            data-track-category='DailyBrief'
+            data-track-name='daily-brief-open-features'
+            className={cn(HEADER_ICON_CLASS, featuresOpen && 'bg-accent text-foreground')}
+          >
+            <InformationCircle size={18} />
+          </button>
         </div>
       </header>
 
@@ -507,6 +576,9 @@ const DailyBriefScreen = (): ReactElement => {
 
       <main className='min-h-0 flex-1 overflow-y-auto px-6 pb-16'>
         <article className='mx-auto w-full max-w-[750px]'>
+          {!introSeen && !isBusy && (
+            <BriefIntroBanner onSeeMore={() => setFeaturesOpen(true)} onDismiss={markIntroSeen} />
+          )}
           {hasBrief && !isBusy && (
             <h1 className='py-10 text-center font-serif text-[40px] font-semibold italic leading-[1.2] text-foreground'>
               {formatBriefTitle(selected.date)}
@@ -539,6 +611,8 @@ const DailyBriefScreen = (): ReactElement => {
           {renderBody()}
         </article>
       </main>
+
+      <BriefFeaturesDialog open={featuresOpen} onOpenChange={setFeaturesOpen} />
 
       <BriefSettingsDialog
         open={settingsOpen}

--- a/apps/dashboard/src/routes/DailyBriefScreen/briefFeatureViews.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/briefFeatureViews.tsx
@@ -1,0 +1,223 @@
+import { ReactElement, ReactNode } from 'react';
+import { format, subDays } from 'date-fns';
+import { CalendarFilled, ChevronBigRight, File02Default } from '@xyne/icons';
+import { cn } from '../../utils/classNames';
+
+/** Chrome (border/bg/shadow/radius) belongs to the animated container in
+ *  BriefFeaturesDialog — a view that drew its own would snap to size while an
+ *  invisible box animated around it. Views declare width and padding only. */
+export const CARD_CHROME =
+  'border border-border bg-background shadow-[0px_3px_6px_0px_rgba(0,0,0,0.04)]';
+const BRIEF_BODY = 'w-[380px] px-5 pb-6 pt-5';
+const LABEL = 'w-[80px] shrink-0 text-[8px] font-semibold leading-[1.5] text-foreground';
+const BODY = 'text-[8px] leading-[1.5] text-muted-foreground';
+
+const Em = ({ children }: { children: ReactNode }): ReactElement => (
+  <b className='font-semibold text-foreground'>{children}</b>
+);
+const Mention = ({ children }: { children: ReactNode }): ReactElement => (
+  <span className='text-[color:var(--mention-color)]'>{children}</span>
+);
+
+interface MiniSectionSpec {
+  label: string;
+  lines: ReactNode[];
+  dotted?: boolean;
+  /** Wrapped visual rows this section occupies — the skeleton mirrors it so the
+   *  card does not change height when the real content resolves into place. */
+  rows: number;
+}
+
+const SECTIONS: MiniSectionSpec[] = [
+  {
+    label: 'What needs you',
+    rows: 3,
+    lines: [
+      <>
+        Today is about closing the outage confirmation loop, deciding the product solution, and
+        clearing two stage-approval requests in your Tickets feed.
+      </>,
+    ],
+  },
+  {
+    label: 'Overdue',
+    dotted: true,
+    rows: 3,
+    lines: [
+      <>
+        <Em>Outage handoff, verify</Em>: approved 1:38pm, related request routed to{' '}
+        <Mention>@Maya Mehta</Mention>
+      </>,
+      <>
+        <Em>2 stage-approvals pending</Em>: check Tickets → Approvals.
+      </>,
+    ],
+  },
+  {
+    label: 'Waiting on others',
+    dotted: true,
+    rows: 2,
+    lines: [
+      <>
+        <Em>Cashfree error-description PR</Em> CC&apos;d you at 1:29pm, waiting on merge.{' '}
+        <Mention>@Maya Chen</Mention>
+      </>,
+    ],
+  },
+  {
+    label: 'Assigned to you',
+    dotted: true,
+    rows: 2,
+    lines: [
+      <>
+        <Em>Auth flow refactor</Em> HIGH priority, no update since 2 Jul, flagged stale.
+      </>,
+    ],
+  },
+];
+
+function MiniSection({ label, lines, dotted }: MiniSectionSpec): ReactElement {
+  return (
+    <div className='flex w-full items-start gap-2.5'>
+      <p className={LABEL}>{label}</p>
+      <div className='flex min-w-0 flex-1 flex-col gap-[4px]'>
+        {lines.map((line, i) => (
+          <div key={i} className='flex items-start gap-1'>
+            {dotted && (
+              <span className='mt-[4px] size-[3px] shrink-0 rounded-full bg-muted-foreground' />
+            )}
+            <p className={cn('min-w-0 flex-1', BODY)}>{line}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The dummy brief card, dated relative to today so the mock never looks stale. */
+export function MiniBriefCard({ regenerated = false }: { regenerated?: boolean }): ReactElement {
+  return (
+    <div className={BRIEF_BODY} aria-hidden>
+      <div className='mb-3 flex items-center justify-center gap-1.5'>
+        <p className='text-center font-serif text-[14px] font-bold italic text-foreground'>
+          Brief // {format(new Date(), 'MMM d')}
+        </p>
+        {regenerated && (
+          <span className='inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-[2px] text-[8px] font-semibold leading-none text-primary'>
+            <span className='size-[4px] rounded-full bg-primary' />
+            Regenerated
+          </span>
+        )}
+      </div>
+      <div className='flex flex-col gap-3'>
+        {SECTIONS.map(s => (
+          <MiniSection key={s.label} {...s} />
+        ))}
+        <div className='flex w-full items-start gap-2'>
+          <p className={LABEL}>Today&apos;s schedule</p>
+          <div className='min-w-0 flex-1 border-l-2 border-xyne-orange-500 pl-2'>
+            <p className='text-[8px] font-semibold leading-[1.5] text-foreground'>
+              Auth flow design review, 10:00 AM
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Placeholder for the regenerate demo. Row counts come from SECTIONS, so it
+ * occupies the same height as the card it resolves into — without that the
+ * crossfade also animates a height change and reads as a jump.
+ */
+export function MiniBriefSkeleton(): ReactElement {
+  return (
+    <div className={BRIEF_BODY} aria-hidden>
+      <div className='mx-auto mb-3 h-[11px] w-[88px] animate-pulse rounded-full bg-muted' />
+      <div className='flex flex-col gap-3'>
+        {[...SECTIONS.map(s => s.rows), 1].map((rows, i) => (
+          <div key={i} className='flex w-full items-start gap-2'>
+            <div className='h-[8px] w-[58px] shrink-0 animate-pulse rounded-full bg-muted' />
+            <div className='flex min-w-0 flex-1 flex-col gap-[5px]'>
+              {Array.from({ length: rows }).map((_, r) => (
+                <div
+                  key={r}
+                  className='h-[6px] animate-pulse rounded-full bg-muted'
+                  style={{ width: `${100 - r * 14}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Compact mirror of BriefSettingsDialog — the parts worth showing, nothing more. */
+export function MiniSettingsCard(): ReactElement {
+  return (
+    <div className='w-[404px] p-4' aria-hidden>
+      <p className='text-[12px] font-semibold text-foreground'>Brief settings</p>
+      <p className={cn('mt-1', BODY)}>
+        Add your own instructions to shape how the brief is written. The five sections always stay
+        the same.
+      </p>
+      <p className='mt-3 text-[9px] font-semibold text-foreground'>Your instructions</p>
+      <div className='mt-1 rounded-[6px] border border-border bg-muted/30 p-2'>
+        <p className='text-[9px] leading-[1.6] text-muted-foreground'>
+          Keep each section short and skimmable. Lead the Overdue section with the highest-risk item
+          first, and always call out who I&apos;m blocked on.
+        </p>
+      </div>
+      <div className='mt-3 flex items-center justify-between'>
+        <span className='rounded-[6px] border border-border px-3 py-1.5 text-[9px] font-semibold text-foreground'>
+          Cancel
+        </span>
+        <div className='flex items-center gap-1.5'>
+          <span className='rounded-[6px] border border-border px-3 py-1.5 text-[9px] font-semibold text-foreground'>
+            Save &amp; regenerate
+          </span>
+          <span className='rounded-[6px] bg-primary px-3 py-1.5 text-[9px] font-semibold text-primary-foreground'>
+            Save
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Mirror of BriefListView — past briefs plus the calendar entry point. */
+export function MiniHistoryCard(): ReactElement {
+  const today = new Date();
+  const rows = [1, 2, 3].map(back => format(subDays(today, back), 'd MMM'));
+  return (
+    <div className='w-[348px] p-3' aria-hidden>
+      <ul className='flex flex-col gap-px'>
+        {rows.map((label, i) => (
+          <li key={label}>
+            <div
+              className={cn(
+                'flex items-center gap-3 rounded-[10px] px-3 py-3 text-[14px] tracking-[-0.1px]',
+                i === 1
+                  ? 'bg-accent font-medium text-foreground'
+                  : 'font-normal text-muted-foreground',
+              )}
+            >
+              <File02Default size={18} className='shrink-0 text-muted-foreground' />
+              <span className='truncate'>Morning Brief {label}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className='mt-1 border-t border-border pt-1'>
+        <div className='flex items-center gap-3 rounded-[10px] px-3 py-3 text-[14px] font-normal tracking-[-0.1px] text-muted-foreground'>
+          <CalendarFilled size={18} className='shrink-0' />
+          <span className='flex-1 truncate text-left'>Find a Brief</span>
+          <ChevronBigRight size={16} className='shrink-0' />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/useBriefIntroSeen.ts
+++ b/apps/dashboard/src/routes/DailyBriefScreen/useBriefIntroSeen.ts
@@ -1,0 +1,57 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'daily-brief-intro-seen';
+
+const read = (): boolean => {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    // localStorage may be unavailable in private mode or with corrupted data
+    return false;
+  }
+};
+
+const write = (): void => {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // Ignore storage errors (private mode, quota exceeded, etc.)
+  }
+};
+
+let seen = read();
+const subscribers = new Set<() => void>();
+
+const subscribe = (listener: () => void): (() => void) => {
+  subscribers.add(listener);
+  return () => {
+    subscribers.delete(listener);
+  };
+};
+
+const getSnapshot = (): boolean => seen;
+
+export interface BriefIntroSeenResult {
+  introSeen: boolean;
+  markIntroSeen: () => void;
+}
+
+/**
+ * Whether the Daily Brief intro banner has already been shown on this device.
+ * Read through `useSyncExternalStore` so every mounted copy — the brief screen
+ * and the panel webview — flips together the moment it is dismissed.
+ */
+export const useBriefIntroSeen = (): BriefIntroSeenResult => {
+  const introSeen = useSyncExternalStore(subscribe, getSnapshot);
+
+  const markIntroSeen = useCallback(() => {
+    if (seen) return;
+    seen = true;
+    write();
+    subscribers.forEach(listener => listener());
+  }, []);
+
+  return { introSeen, markIntroSeen };
+};

--- a/apps/dashboard/src/services/otel/dailyBriefMetrics.ts
+++ b/apps/dashboard/src/services/otel/dailyBriefMetrics.ts
@@ -21,12 +21,15 @@ function getMeter(): Meter {
 
 let _dailyBriefSwitchedTotal: Counter | null = null;
 
-/** Counter: Switches to another brief from the history menu. */
+/** Which control the switch came from. Bounded to two values — never widen without checking cardinality. */
+export type BriefSwitchSource = 'history_menu' | 'date_picker';
+
+/** Counter: Switches to another brief, split by the control used. */
 const dailyBriefSwitchedTotal: Counter = new Proxy({} as Counter, {
   get(_target, prop) {
     if (!_dailyBriefSwitchedTotal) {
       _dailyBriefSwitchedTotal = getMeter().createCounter('daily_brief_switched_total', {
-        description: 'Total number of switches between briefs from the Daily Brief history menu',
+        description: 'Total number of switches between briefs, by the control used',
         unit: '1',
       });
     }
@@ -34,10 +37,11 @@ const dailyBriefSwitchedTotal: Counter = new Proxy({} as Counter, {
   },
 });
 
-/** Track a switch to another brief from the history menu. */
-export function trackDailyBriefSwitched(): void {
+/** Track a switch to another brief. Device-scoped: `instance` counts devices, not
+ *  users — the distinct-user figure comes from the server-side beacon instead. */
+export function trackDailyBriefSwitched(source: BriefSwitchSource): void {
   safeRecordMetric(() => {
-    dailyBriefSwitchedTotal.add(1);
+    dailyBriefSwitchedTotal.add(1, { source });
   });
 }
 

--- a/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
@@ -5,6 +5,7 @@ import { prisma } from "../db.js";
 import { redisService } from "../redis.js";
 import { createLogger } from "../logger.js";
 import { DAILY_BRIEF_KIND } from "../repositories/index.js";
+import { formatDayIST } from "../lib/ist-time.js";
 
 const log = createLogger("otel-daily-brief");
 
@@ -22,6 +23,26 @@ const REGEN_USERS_KEY = "daily_brief:regen_users";
 const DEFAULT_REJECTED_USERS_KEY = "daily_brief:default_rejected_users";
 /** Users who ever re-ran a brief they had already regenerated once. */
 const REPEAT_REGEN_USERS_KEY = "daily_brief:repeat_regen_users";
+/** Which control the user switched briefs from. Bounded — never widen without checking cardinality. */
+export type BriefSwitchSource = "history_menu" | "date_picker";
+
+/**
+ * Switching briefs is client state the server never sees on its own (the screen
+ * holds the recent window in memory), so the dashboard beacons it here. Counted
+ * by userId in Redis rather than as a metric label: one series per user would be
+ * unbounded cardinality and PII in a store with no per-series access control.
+ */
+const SWITCH_USERS_KEY = "daily_brief:switch_users";
+/** Switch events, not people — one INCR per switch, globally and per control. */
+const SWITCH_COUNT_KEY = "daily_brief:switches";
+const switchSourceCountKey = (source: BriefSwitchSource): string =>
+  `daily_brief:switches:src:${source}`;
+const switchSourceKey = (source: BriefSwitchSource): string =>
+  `daily_brief:switch_users:src:${source}`;
+/** HyperLogLog per day: a windowed distinct count without one Redis member per user per day. */
+const switchDayKey = (dateBucket: string): string => `daily_brief:switch_users:day:${dateBucket}`;
+const SWITCH_DAY_TTL_SECONDS = 35 * 24 * 60 * 60;
+
 /** Per user per day, so we know which attempt a request is. Two days is plenty. */
 const dayAttemptKey = (userId: string, dateBucket: string): string =>
   `daily_brief:regen:${userId}:${dateBucket}`;
@@ -183,6 +204,37 @@ export async function recordDailyBriefRegeneration(
   }
 }
 
+/** Record that a user switched to a different brief, from a given entry point. */
+export async function recordDailyBriefSwitch(
+  userId: string,
+  source: BriefSwitchSource,
+  dateBucket: string,
+): Promise<void> {
+  try {
+    const redis = redisService.getConnection();
+    const dayKey = switchDayKey(dateBucket);
+    await redis
+      .multi()
+      .incr(SWITCH_COUNT_KEY)
+      .incr(switchSourceCountKey(source))
+      .sadd(SWITCH_USERS_KEY, userId)
+      .sadd(switchSourceKey(source), userId)
+      .pfadd(dayKey, userId)
+      .expire(dayKey, SWITCH_DAY_TTL_SECONDS)
+      .exec();
+  } catch {
+    // metrics must never break a request
+  }
+}
+
+/** The last `days` day-bucket keys, newest first — the union PFCOUNT reads. */
+function switchDayKeysBack(days: number): string[] {
+  const now = Date.now();
+  return Array.from({ length: days }, (_, i) =>
+    switchDayKey(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
+  );
+}
+
 /**
  * Global lifetime totals, re-read on every export tick:
  *   daily_brief_users_total   — users who have at least one brief (generated_content)
@@ -216,27 +268,76 @@ export function registerDailyBriefGauges(): void {
   const repeatRegenGauge = meter.createObservableGauge("daily_brief_repeat_regen_users_total", {
     description: "Users who have re-run a brief they had already regenerated",
   });
+  const switchUsersGauge = meter.createObservableGauge("daily_brief_switch_users_total", {
+    description: "Users who have ever switched to a different brief",
+  });
+  const switchUsersWindowGauge = meter.createObservableGauge("daily_brief_switch_users_window", {
+    description: "Distinct users who switched briefs within a trailing window (HyperLogLog, ~0.81% error)",
+  });
+  const switchUsersSourceGauge = meter.createObservableGauge("daily_brief_switch_users_by_source", {
+    description: "Users who have ever switched briefs, by the control they used",
+  });
+  const switchesGauge = meter.createObservableGauge("daily_brief_switches_total", {
+    description: "Brief switches ever served globally (events, not people)",
+  });
+  const switchesSourceGauge = meter.createObservableGauge("daily_brief_switches_by_source", {
+    description: "Brief switches ever served, by the control used (events, not people)",
+  });
 
   meter.addBatchObservableCallback(
     async (result) => {
       try {
         const where = { kind: DAILY_BRIEF_KIND, generatedAt: { not: null } };
         const redis = redisService.getConnection();
-        const [briefs, users, regenerations, regenUsers, defaultRejected, repeatRegen] =
-          await Promise.all([
-            prisma.generatedContent.count({ where }),
-            prisma.generatedContent.groupBy({ by: ["userId"], where }),
-            redis.get(REGEN_COUNT_KEY).catch(() => null),
-            redis.scard(REGEN_USERS_KEY).catch(() => 0),
-            redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
-            redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
-          ]);
+        const [
+          briefs,
+          users,
+          regenerations,
+          regenUsers,
+          defaultRejected,
+          repeatRegen,
+          switchUsers,
+          switch7d,
+          switch30d,
+          switchHistoryMenu,
+          switchDatePicker,
+          switches,
+          switchesHistoryMenu,
+          switchesDatePicker,
+        ] = await Promise.all([
+          prisma.generatedContent.count({ where }),
+          prisma.generatedContent.groupBy({ by: ["userId"], where }),
+          redis.get(REGEN_COUNT_KEY).catch(() => null),
+          redis.scard(REGEN_USERS_KEY).catch(() => 0),
+          redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
+          redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
+          redis.scard(SWITCH_USERS_KEY).catch(() => 0),
+          redis.pfcount(...switchDayKeysBack(7)).catch(() => 0),
+          redis.pfcount(...switchDayKeysBack(30)).catch(() => 0),
+          redis.scard(switchSourceKey("history_menu")).catch(() => 0),
+          redis.scard(switchSourceKey("date_picker")).catch(() => 0),
+          redis.get(SWITCH_COUNT_KEY).catch(() => null),
+          redis.get(switchSourceCountKey("history_menu")).catch(() => null),
+          redis.get(switchSourceCountKey("date_picker")).catch(() => null),
+        ]);
         result.observe(usersGauge, users.length);
         result.observe(briefsGauge, briefs);
         result.observe(regenerationsGauge, Number(regenerations ?? 0));
         result.observe(regenUsersGauge, regenUsers);
         result.observe(defaultRejectedGauge, defaultRejected);
         result.observe(repeatRegenGauge, repeatRegen);
+        result.observe(switchUsersGauge, switchUsers);
+        result.observe(switchUsersWindowGauge, switch7d, { window: "7d" });
+        result.observe(switchUsersWindowGauge, switch30d, { window: "30d" });
+        result.observe(switchUsersSourceGauge, switchHistoryMenu, { source: "history_menu" });
+        result.observe(switchUsersSourceGauge, switchDatePicker, { source: "date_picker" });
+        result.observe(switchesGauge, Number(switches ?? 0));
+        result.observe(switchesSourceGauge, Number(switchesHistoryMenu ?? 0), {
+          source: "history_menu",
+        });
+        result.observe(switchesSourceGauge, Number(switchesDatePicker ?? 0), {
+          source: "date_picker",
+        });
       } catch (err) {
         // OTel swallows a rejected callback silently — log so a broken read is visible.
         log.warn(`[otel] daily-brief gauges skipped: ${err instanceof Error ? err.message : String(err)}`);
@@ -249,6 +350,11 @@ export function registerDailyBriefGauges(): void {
       regenUsersGauge,
       defaultRejectedGauge,
       repeatRegenGauge,
+      switchUsersGauge,
+      switchUsersWindowGauge,
+      switchUsersSourceGauge,
+      switchesGauge,
+      switchesSourceGauge,
     ],
   );
 }

--- a/apps/xyne-claw-auth/backend/src/repositories/generatedContentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/generatedContentRepository.ts
@@ -29,6 +29,15 @@ export const generatedContentRepository = {
       take: limit,
     }),
 
+  /** Day buckets + status only (no content) — powers the brief date picker. */
+  findDateBuckets: (userId: string, kind: string, limit = 365) =>
+    prisma.generatedContent.findMany({
+      where: { userId, kind },
+      orderBy: [{ dateBucket: "desc" }],
+      take: limit,
+      select: { dateBucket: true, status: true },
+    }),
+
   /** Mark generation as started (idempotent per day) so a fetch can show "generating". */
   markGenerating: (params: {
     userId: string;

--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -16,7 +16,11 @@ import {
   DAILY_BRIEF_SLUG,
   type DailyBriefPayload,
 } from "../services/dailyBrief.js";
-import { recordDailyBriefRegeneration } from "../otel/daily-brief-metrics.js";
+import {
+  recordDailyBriefRegeneration,
+  recordDailyBriefSwitch,
+  type BriefSwitchSource,
+} from "../otel/daily-brief-metrics.js";
 
 const log = createLogger("daily-brief-routes");
 const MAX_INSTRUCTIONS = 8000;
@@ -181,6 +185,90 @@ router.get("/history", async (req: Request, res: Response) => {
   } catch (err) {
     log.error("[daily-brief] get history", err);
     res.status(500).json({ success: false, error: "Failed to load daily brief history" });
+  }
+});
+
+/** GET /dates — every day the user has a brief for, newest first (date + status, no content). */
+router.get("/dates", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    const limitRaw = Number(req.query.limit);
+    const limit = Number.isFinite(limitRaw)
+      ? Math.min(Math.max(Math.trunc(limitRaw), 1), 1000)
+      : 365;
+    const rows = await generatedContentRepository.findDateBuckets(userId, DAILY_BRIEF_KIND, limit);
+    res.json({
+      success: true,
+      data: rows.map((row) => ({ date: row.dateBucket, status: row.status })),
+    });
+  } catch (err) {
+    log.error("[daily-brief] get dates", err);
+    res.status(500).json({ success: false, error: "Failed to load daily brief dates" });
+  }
+});
+
+/** GET /by-date/:date — the stored brief for one YYYY-MM-DD bucket. */
+router.get("/by-date/:date", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    const date = String(req.params.date ?? "");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      res.status(400).json({ success: false, error: "date must be YYYY-MM-DD" });
+      return;
+    }
+    const row = await generatedContentRepository.findForBucket(userId, DAILY_BRIEF_KIND, date);
+    if (!row) {
+      res.json({ success: true, data: { status: "none", date } });
+      return;
+    }
+    res.json({
+      success: true,
+      data: {
+        status: row.status,
+        date: row.dateBucket,
+        content: row.content,
+        data: row.data,
+        agentSlug: row.agentSlug,
+        generatedAt: row.generatedAt,
+        isToday: row.dateBucket === briefDateBucket(),
+      },
+    });
+  } catch (err) {
+    log.error("[daily-brief] get by date", err);
+    res.status(500).json({ success: false, error: "Failed to load daily brief" });
+  }
+});
+
+/**
+ * POST /switched — beacon for "this user switched to another brief". The screen
+ * holds the recent window in memory, so most switches never hit the server and
+ * cannot be inferred from any other route.
+ */
+router.post("/switched", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    // Coerced, not validated: `source` is client-supplied and lands on a metric
+    // label, so an unknown value must collapse into a known one rather than
+    // open the label up to arbitrary cardinality.
+    const body = req.body as { source?: unknown };
+    const source: BriefSwitchSource = body.source === "date_picker" ? "date_picker" : "history_menu";
+    await recordDailyBriefSwitch(userId, source, briefDateBucket());
+    res.status(204).end();
+  } catch (err) {
+    log.error("[daily-brief] post switched", err);
+    res.status(500).json({ success: false, error: "Failed to record brief switch" });
   }
 });
 

--- a/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
+++ b/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
@@ -25,11 +25,24 @@
   "timezone": "",
   "title": "Daily Brief",
   "uid": "xyne-daily-brief",
-  "version": 10,
+  "version": 15,
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Adoption & volume",
+      "type": "row"
+    },
+    {
       "type": "stat",
-      "title": "Users with a brief",
+      "title": "Users with a brief (all time)",
       "description": "Users who have at least one generated brief. Read from generated_content, so it is exact and independent of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -39,7 +52,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 1,
       "fieldConfig": {
@@ -85,7 +98,7 @@
     },
     {
       "type": "stat",
-      "title": "Users who requested a regen",
+      "title": "Users who requested a regen (all time)",
       "description": "Users who have requested at least one regeneration. Counted by user id in Redis when the request reaches claw-auth, so it is exact and independent of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -95,7 +108,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 0
+        "y": 1
       },
       "id": 2,
       "fieldConfig": {
@@ -151,73 +164,7 @@
     },
     {
       "type": "stat",
-      "title": "Users (devices) who switched briefs",
-      "description": "Distinct devices that picked a different brief from the history menu within the selected time range. Switching is a client-only action, so the only identity available is a per-browser id \u2014 the same person on web and Electron counts twice.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "id": 3,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "count(count by (instance) (increase(daily_brief_switched_total[$__range]) > 0))"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Briefs generated",
+      "title": "Briefs generated (all time)",
       "description": "Briefs that exist globally (one per user per day; a regeneration overwrites that day's brief rather than adding one). Read from generated_content, so it is exact and independent of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -226,8 +173,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 18,
-        "y": 0
+        "x": 12,
+        "y": 1
       },
       "id": 4,
       "fieldConfig": {
@@ -273,7 +220,7 @@
     },
     {
       "type": "stat",
-      "title": "Regenerations",
+      "title": "Regenerations (all time)",
       "description": "Regeneration requests ever served, globally. Counted in Redis when the request reaches claw-auth, so it survives restarts and is exact regardless of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -282,8 +229,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 0,
-        "y": 6
+        "x": 18,
+        "y": 1
       },
       "id": 5,
       "fieldConfig": {
@@ -337,9 +284,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 18,
-        "x": 6,
-        "y": 6
+        "w": 24,
+        "x": 0,
+        "y": 7
       },
       "id": 6,
       "fieldConfig": {
@@ -388,8 +335,300 @@
       ]
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Brief switching",
+      "type": "row"
+    },
+    {
       "type": "stat",
-      "title": "Users who rejected the auto brief",
+      "title": "Total brief switches (all time)",
+      "description": "Every brief switch ever served, counted server-side (Redis INCR). Events, not people \u2014 compare against \"Users who switched briefs\" to see switches-per-person.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 24,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_switches_total)",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Users who switched briefs (last 30 days)",
+      "description": "Distinct users who switched to a different brief in the last 30 days, counted server-side by userId (Redis HyperLogLog, ~0.81% error). Replaces an earlier device-based count: the client metric carries a per-device localStorage id, so it counted browsers rather than people \u2014 one person on three devices read as three. A beacon can be blocked or lost on a fast page close, so treat this as a tight lower bound. See \"Brief switches by control\" for event volume.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_switch_users_window{window=\"30d\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "title": "Switches: list vs calendar (all time)",
+      "description": "Share of switch events by control, server-side. The calendar is the ONLY way to reach a brief older than the 8 most recent, so date_picker volume is the direct read on whether people want older briefs. Events, so one heavy user can dominate \u2014 read alongside panel \"Users reaching for older briefs\".",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 25,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max by (source) (daily_brief_switches_by_source)",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "{{source}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Users reaching for older briefs (all time)",
+      "description": "Distinct users who have used each control at least once. NOTE: these sets OVERLAP \u2014 someone who used both is counted in both, so the bars do not sum to the total user count and must not be drawn as a pie. date_picker here = how many people ever went past the recent window, which is the per-person version of the question.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 26,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max by (source) (daily_brief_switch_users_by_source)",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "{{source}}"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Regeneration behaviour & outcomes",
+      "type": "row"
+    },
+    {
+      "type": "stat",
+      "title": "Users who rejected the auto brief (all time)",
       "description": "Users who have re-run a brief the cron produced for them \u2014 dissatisfaction with the default. Exact, lifetime.",
       "datasource": {
         "type": "prometheus",
@@ -399,7 +638,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 12
+        "y": 27
       },
       "id": 7,
       "fieldConfig": {
@@ -445,7 +684,7 @@
     },
     {
       "type": "stat",
-      "title": "Users who regenerated more than once",
+      "title": "Users who regenerated more than once (all time)",
       "description": "Users who re-ran a brief they had already regenerated \u2014 the regeneration itself did not satisfy them. Exact, lifetime.",
       "datasource": {
         "type": "prometheus",
@@ -455,7 +694,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 12
+        "y": 27
       },
       "id": 8,
       "fieldConfig": {
@@ -500,114 +739,18 @@
       ]
     },
     {
-      "type": "barchart",
-      "title": "Why briefs get regenerated",
-      "description": "replacing_scheduled_brief = rejecting the cron brief \u00b7 replacing_own_regeneration = rejecting their own re-run \u00b7 retry_after_failure = the previous run errored, not a quality signal \u00b7 first_brief_of_day = no brief existed yet.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 12
-      },
-      "id": 9,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (origin) (increase(daily_brief_regeneration_attempts_total[$__range]))",
-          "legendFormat": "{{origin}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "How many regenerations it takes",
-      "description": "Attempt depth within a single day per user. A tall 1 with a short 2 means one re-run usually settles it; a long tail means the brief is not converging.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 18
-      },
-      "id": 10,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "auto",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (attempt) (increase(daily_brief_regeneration_attempts_total{origin!=\"retry_after_failure\"}[$__range]))",
-          "legendFormat": "attempt {{attempt}}"
-        }
-      ]
-    },
-    {
       "type": "stat",
       "title": "Rejection rate of the auto brief",
-      "description": "Share of cron-generated briefs that the user immediately re-ran. The headline quality number for the scheduled brief.",
+      "description": "Share of cron-generated briefs that the user immediately re-ran. The headline quality number for the scheduled brief. Reads as blank rather than 0 when the cron has produced nothing in the window: clamp_min only rescues a denominator of zero, not a denominator that is an empty vector, so an empty panel here means 'no scheduled runs in range', not 'broken'.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
       },
       "gridPos": {
         "h": 6,
-        "w": 12,
+        "w": 6,
         "x": 12,
-        "y": 18
+        "y": 27
       },
       "id": 11,
       "fieldConfig": {
@@ -663,6 +806,295 @@
     },
     {
       "type": "stat",
+      "title": "Regeneration success rate",
+      "description": "Share of on-demand regeneration runs that produced a brief, within the selected range. Reliability of the Regenerate button, as distinct from the quality signals above. CAVEAT: the denominator includes runs cut short by an HTTP connection close (tab close, reload, network drop, proxy timeout), which are currently recorded as 'failed', so this reads LOWER than true pipeline reliability. Treat it as a floor until 'aborted' is split out server-side.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 27
+      },
+      "id": 22,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "\u2014"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum(increase(daily_brief_generated_total{trigger=\"regenerate\",status=\"ready\"}[$__range])) / clamp_min(sum(increase(daily_brief_generated_total{trigger=\"regenerate\"}[$__range])), 1)"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Why briefs get regenerated",
+      "description": "replacing_scheduled_brief = rejecting the cron brief \u00b7 replacing_own_regeneration = rejecting their own re-run \u00b7 retry_after_failure = the previous run errored, not a quality signal \u00b7 first_brief_of_day = no brief existed yet.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (origin) (increase(daily_brief_regeneration_attempts_total[$__range]))",
+          "legendFormat": "{{origin}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Regeneration outcomes",
+      "description": "How on-demand regenerations actually ended, from the server-side completion counter. Recorded when the run finishes, unlike 'Regenerations' which is counted when the request arrives \u2014 the difference between the two is runs that started and never completed. CAVEAT: 'failed' currently absorbs runs the server aborted because the HTTP connection closed (tab close, reload, network drop, proxy timeout), so it overstates genuine pipeline failures by an unknown amount; splitting an 'aborted' status out of it is a pending server-side change. This is NOT the same event as 'Regenerations abandoned' below: that histogram fires on component unmount (an in-app route change), and the dashboard passes no AbortSignal, so navigating away inside the app does not abort the run. The two count different things and do not double-count \u2014 except on a tab close, which can trigger both.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 21,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (status) (increase(daily_brief_generated_total{trigger=\"regenerate\"}[$__range]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "How far the regeneration ladder goes",
+      "description": "SURVIVAL CURVE, NOT A DISTRIBUTION. Bar N = share of the day's regenerating users who reached at least attempt N, normalised to attempt 1. A user-day that went three deep is counted in bars 1, 2 AND 3, so bar heights do NOT mean 'N users needed N regenerations' \u2014 read 'Where people stop' for that. Bars only ever descend. CAVEAT: attempts 1\u20133 count user-days (the per-user-per-day Redis key increments once per depth), but 4+ aggregates every request at depth \u22654, so the 4+ bar is a REQUEST tally in different units and can exceed 100%. The origin filter was removed deliberately: origin is computed with 'previous run failed' taking precedence over attempt depth, so one failed or connection-dropped run relabels every later attempt that day as retry_after_failure and used to delete the entire tail of this chart. Origin belongs in 'Why briefs get regenerated'.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (attempt) (increase(daily_brief_regeneration_attempts_total[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"1\"}[$__range])), 1))",
+          "legendFormat": "reached attempt {{attempt}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Where people stop",
+      "description": "How many regenerations it actually took, derived by differencing the ladder: users who reached depth N but not N+1. This is the panel that answers 'how many regens does it take' \u2014 the ladder panel next to it cannot, because every user-day is counted at every depth it passed through. APPROXIMATE AT BUCKET 3: 'stopped at 3' subtracts the 4+ bar, which counts requests rather than user-days, so it under-reports whenever anyone is deep in the tail; all three are clamped at 0 because that subtraction can otherwise go negative (it does on the current sample data). The 4+ bar is shown separately and in different units on purpose \u2014 do not add it to the other three. A short time range can also clip a user-day's attempt 1 outside the window while its attempt 2 falls inside, which biases the first bar down. WILL CHANGE: once client-abort is split out of 'failed' server-side, fewer days will be misclassified and these buckets will shift.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 20,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"1\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"2\"}[$__range])), 0)",
+          "legendFormat": "stopped at 1"
+        },
+        {
+          "refId": "B",
+          "instant": true,
+          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"2\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"3\"}[$__range])), 0)",
+          "legendFormat": "stopped at 2"
+        },
+        {
+          "refId": "C",
+          "instant": true,
+          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"3\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"4+\"}[$__range])), 0)",
+          "legendFormat": "stopped at 3 (approx)"
+        },
+        {
+          "refId": "D",
+          "instant": true,
+          "expr": "sum(increase(daily_brief_regeneration_attempts_total{attempt=\"4+\"}[$__range]))",
+          "legendFormat": "4+ (requests, not user-days)"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Generation performance",
+      "type": "row"
+    },
+    {
+      "type": "stat",
       "title": "Avg generation time",
       "description": "Mean wall-clock time of a successful brief run. sum/count is the exact mean; the quantile panel next to it is bucket-approximated.",
       "datasource": {
@@ -671,9 +1103,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
+        "w": 8,
         "x": 0,
-        "y": 24
+        "y": 46
       },
       "id": 12,
       "fieldConfig": {
@@ -737,9 +1169,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 24
+        "w": 8,
+        "x": 8,
+        "y": 46
       },
       "id": 13,
       "fieldConfig": {
@@ -803,9 +1235,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 24
+        "w": 8,
+        "x": 16,
+        "y": 46
       },
       "id": 14,
       "fieldConfig": {
@@ -860,6 +1292,78 @@
       ]
     },
     {
+      "type": "timeseries",
+      "title": "Generation time by trigger",
+      "description": "p50 and p95 of successful runs, cron versus on-demand.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 16,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto"
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{trigger}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{trigger}}"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Abandonment",
+      "type": "row"
+    },
+    {
       "type": "stat",
       "title": "Regenerations abandoned",
       "description": "Times someone left the screen while a regeneration was still running. Cross with the wait buckets below to see when we lose them.",
@@ -869,9 +1373,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 24
+        "w": 8,
+        "x": 0,
+        "y": 60
       },
       "id": 15,
       "fieldConfig": {
@@ -926,117 +1430,6 @@
       ]
     },
     {
-      "type": "timeseries",
-      "title": "Generation time by trigger",
-      "description": "p50 and p95 of successful runs, cron versus on-demand.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 30
-      },
-      "id": 16,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "showPoints": "auto"
-          },
-          "mappings": [],
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "histogram_quantile(0.5, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
-          "legendFormat": "p50 {{trigger}}"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
-          "legendFormat": "p95 {{trigger}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "How long people wait before giving up",
-      "description": "Share of abandonments that had already happened by each wait threshold \u2014 read it as a cumulative curve: the bar at 60s is everyone who left within 60s. Where it crosses 50% is median patience. Compare that against p50 generation time: if patience is shorter, the pipeline is losing people mid-run.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 30
-      },
-      "id": 17,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "custom": {
-            "fillOpacity": 85,
-            "lineWidth": 1,
-            "axisPlacement": "auto"
-          },
-          "mappings": [],
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0,
-        "showValue": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket{le!=\"+Inf\"}[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])), 1))",
-          "legendFormat": "within {{le}}s"
-        }
-      ]
-    },
-    {
       "type": "stat",
       "title": "Median patience",
       "description": "The wait at which half of the people who walked away had already gone. Put this next to p50 generation time \u2014 if it is smaller, you are losing people before the brief can possibly arrive.",
@@ -1046,9 +1439,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 37
+        "w": 8,
+        "x": 8,
+        "y": 60
       },
       "id": 18,
       "fieldConfig": {
@@ -1112,9 +1505,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 37
+        "w": 8,
+        "x": 16,
+        "y": 60
       },
       "id": 19,
       "fieldConfig": {
@@ -1165,6 +1558,58 @@
           "refId": "A",
           "instant": true,
           "expr": "sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])) / clamp_min(sum(increase(daily_brief_regeneration_attempts_total[$__range])), 1)"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "How long people wait before giving up",
+      "description": "Share of abandonments that had already happened by each wait threshold \u2014 read it as a cumulative curve: the bar at 60s is everyone who left within 60s. Where it crosses 50% is median patience. Compare that against p50 generation time: if patience is shorter, the pipeline is losing people mid-run.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 17,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "custom": {
+            "fillOpacity": 85,
+            "lineWidth": 1,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket{le!=\"+Inf\"}[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])), 1))",
+          "legendFormat": "within {{le}}s"
         }
       ]
     }


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
## XYNE-55716 — Daily Brief: date navigation, feature tour, and user-level metrics

Adds on-demand access to any past brief, an intro banner + feature dialog explaining what the
brief can do, and reworks the switch metric so it counts **people instead of devices**.

---

### Backend — new endpoints

**claw-auth** (`routes/daily-brief.ts`)

- `GET /dates` — every day the user has a brief for (`date` + `status` only, no content). Backs the calendar; new `generatedContentRepository.findDateBuckets` selects just the two columns.
- `GET /by-date/:date` — one brief by `YYYY-MM-DD` bucket. Regex-validated; returns `status: "none"` when the day has no brief rather than 404.
- `POST /switched` — beacon recording that a user switched briefs. `source` is **coerced**, not validated: it lands on a metric label, so an unknown value collapses to a known one instead of opening the label to arbitrary cardinality.

**Spaces backend** — matching proxy for all three (`clawAgentService` → `dailyBriefController` → `routes/dailyBrief.ts`), unwrapping claw-auth's `{ success, data }` envelope as the existing handlers do.

### Backend — distinct-user metrics

The switch counter was tagged with `service.instance.id`, a per-device `localStorage` UUID, so it counted browsers: one person on three devices read as three. A `user_id` label isn't an option — unbounded cardinality, PII in a store with no per-series ACL, and the frontend OTLP receiver is unauthenticated, so the label would be forgeable.

Identity is now resolved **server-side** and only aggregates leave Redis:

- `SADD daily_brief:switch_users <userId>` — exact lifetime distinct count, inspectable
- `PFADD daily_brief:switch_users:day:<bucket>` — per-day HyperLogLog (~0.81% error, 35d TTL) so a trailing window can be counted without one key per user per day
- `INCR daily_brief:switches` + per-source keys — event volume, separate axis from people

Six new gauges on the existing batch callback: `daily_brief_switch_users_total`, `..._window{7d,30d}`, `..._by_source{source}`, `daily_brief_switches_total`, `..._by_source{source}`.

Idempotent by construction — re-adding a member is a no-op and the same id hashes to the same HLL register, so **switching devices, browsers, or clearing storage cannot inflate the count**.

The rest covers Grafana (five row groups, the fixed regeneration-ladder panel, (all time) labelling) and a compact frontend section, then a Notes for review block flagging four things a reviewer should see rather than discover: the permissive requireAuth on that router, HLL approximation, the beacon being a lower bound, and that no UI sets dailyBriefEnabled.


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
