### PR TITLE
feature: XYNE-17198 add entity filters in vespa-search tool

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
@@ -172,6 +172,43 @@ export interface SearchArea {
   embeddingFields?: string[];
 }
 
+/**
+ * Entities resolved by the nightly entity-extraction worker (xyne-spaces
+ * backend: writeEntitiesToVespa in services/entityExtraction/channelSource.ts).
+ * It writes the SAME three columns onto both `ticket` and `chat_message` docs,
+ * so both areas share these defs.
+ *
+ * Only ONE of the three columns is exposed — `entityNames` (index + attribute +
+ * bm25, token match on the canonical registry name). The other two are withheld
+ * on purpose:
+ *   - `entityIds` IS matchable (attribute, fast-search) but there is no way for
+ *     the agent to learn an entity id: the registry lives in the xyne-spaces
+ *     Postgres and claw has no tool that returns ids, so an id filter could only
+ *     ever be hallucinated. Expose it once something hands the agent real ids.
+ *   - `entitySurfaceForms` is `indexing: summary` ONLY in both .sd files — not
+ *     matchable at all, so filtering on it would silently match nothing.
+ *
+ * entityNames is array<string> → containsAny (matches if ANY element hits).
+ * containsAny is the ONLY operator exposed. `nin` is deliberately withheld until
+ * the entity backfill lands: extraction only ever ran forward from its rollout,
+ * so most docs have EMPTY entity arrays, and `!(entityNames contains "X")` would
+ * match every un-extracted doc — presenting "not yet processed" as "does not
+ * mention X". That reads as a confident negative and is wrong at scale. Add nin
+ * back once the backfill is complete.
+ *
+ * It is multi-valued, so it must NOT be added to allowedGroupByFields (the
+ * module-load guard below rejects grouping an array — one doc lands in one group
+ * per element).
+ */
+const entityFields = (subject: string): FieldDef[] => [
+  strField(
+    "entityName",
+    `Canonical name of an entity mentioned in the ${subject} (e.g. a product, customer or service), token-matched. Positive match only: a doc without this entity may simply not have been through extraction yet, so absence is NOT evidence the ${subject} is unrelated.`,
+    ["containsAny"],
+    "entityNames",
+  ),
+];
+
 const chatFields = (tsField: string): FieldDef[] => [
   strField("conversationId", "Conversation/thread id.", ["in"], "threadId"),
   strField("channelId", "Channel the message belongs to.", ["contains", "in"]),
@@ -180,6 +217,7 @@ const chatFields = (tsField: string): FieldDef[] => [
   strField("messageType", "Message type (USER/BOT/SYSTEM/FORWARDED).", ["in", "nin"]),
   boolField("isDM", "Set true for messages in a direct-message (1:1) channel.", "isIm"),
   boolField("isGroupDM", "Set true for messages in a group-DM channel.", "isMpim"),
+  ...entityFields("message's thread"),
   dateField("createdDate", "Message creation date (dd/mm/yy, IST).", tsField),
 ];
 
@@ -266,6 +304,7 @@ export const SEARCH_AREAS: Record<string, SearchArea> = {
       strField("xyneId", "Human ticket id, e.g. XYNE-13292 (what people cite).", ["in", "contains"]),
       strField("ticketId", "Internal ticket doc id — prefer xyneId for the human-facing id.", ["in"], "docId"),
       strField("conversationId", "Ticket conversation/thread id.", ["in"], "convId"),
+      ...entityFields("ticket"),
       dateField("createdDate", "Ticket creation date (dd/mm/yy, IST).", "createdAtTimestamp"),
     ],
     // createdAt = day-string ("12/05/2026") → per-day grouping (not the ms timestamp).


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
