### PR TITLE
fix: surface admin-approval flow for shared MCP connector definition edits

### DIFF
--- a/apps/xyne-claw-auth/frontend/src/components/DashboardPage.tsx
+++ b/apps/xyne-claw-auth/frontend/src/components/DashboardPage.tsx
@@ -822,9 +822,14 @@ export function DashboardPage({ userId, isAdmin }: Props) {
         }}
         onSubmit={handleAddConnection}
         onCreateServer={async (payload) => {
-          const created = await createServer(payload, userId);
+          const result = await createServer(payload, userId);
           await loadServers();
-          return created;
+          if (result.kind === "editRequest") {
+            // Shared connector — change queued for admin approval, nothing to
+            // reconnect. Surface the message in the dialog's error banner.
+            throw new Error(result.message);
+          }
+          return result.server;
         }}
         servers={servers}
         credentialFields={credentialFields}

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -164,6 +164,17 @@ export async function listServers(userId?: string): Promise<McpServer[]> {
   return data.data;
 }
 
+/**
+ * Outcome of POST /api/v1/servers.
+ *  - "saved":       a personal connector was created/updated in place.
+ *  - "editRequest": a shared (scope=global) connector edit was queued for
+ *                   admin approval; the live definition is unchanged and there
+ *                   is nothing to reconnect. Callers MUST branch on `kind`.
+ */
+export type CreateServerResult =
+  | { kind: "saved"; server: McpServer }
+  | { kind: "editRequest"; editRequestId: string; message: string };
+
 export async function createServer(
   payload: {
     name: string;
@@ -179,12 +190,30 @@ export async function createServer(
     connectorMeta?: Record<string, unknown>;
   },
   userId: string,
-): Promise<McpServer> {
-  const data = await request<{ success: boolean; data: McpServer }>(
+): Promise<CreateServerResult> {
+  const data = await request<{ success: boolean; data: unknown }>(
     `${AUTH_API_URL}/api/v1/servers`,
     { method: "POST", headers: { "x-user-id": userId }, body: JSON.stringify(payload) },
   );
-  return data.data;
+  const payloadData = data.data;
+  // A scope=global connector definition is never edited in place. The backend
+  // queues an McpConnectorEditRequest (HTTP 202) for admin review and returns
+  // { editRequest, message } instead of a server row. Detect that shape so
+  // callers can show an approval toast instead of silently reverting the form.
+  if (
+    payloadData &&
+    typeof payloadData === "object" &&
+    "editRequest" in payloadData &&
+    (payloadData as { editRequest?: unknown }).editRequest
+  ) {
+    const queued = payloadData as { editRequest: { id: string }; message?: string };
+    return {
+      kind: "editRequest",
+      editRequestId: queued.editRequest.id,
+      message: queued.message ?? "Change submitted for admin review.",
+    };
+  }
+  return { kind: "saved", server: payloadData as McpServer };
 }
 
 export async function requestServerPublish(serverId: string, userId: string): Promise<void> {

--- a/apps/xyne-claw-auth/frontend/src/v2/components/MCPPageV2.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v2/components/MCPPageV2.tsx
@@ -386,9 +386,14 @@ export function MCPPageV2({ userId }: Props) {
         }}
         onSubmit={handleAddConnection}
         onCreateServer={async (payload) => {
-          const created = await createServer(payload, userId);
+          const result = await createServer(payload, userId);
           await loadConnections();
-          return created;
+          if (result.kind === "editRequest") {
+            // Shared connector — change queued for admin approval, nothing to
+            // reconnect. Surface the message in the dialog's error banner.
+            throw new Error(result.message);
+          }
+          return result.server;
         }}
         servers={servers}
         credentialFields={credentialFields}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/MCPPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/MCPPageV3.tsx
@@ -495,7 +495,22 @@ export function MCPPageV3({ userId }: Props) {
 
   const handleCreateServer = useCallback(
     async (payload: Parameters<typeof createServer>[0]) => {
-      const created = await createServer(payload, userId);
+      const result = await createServer(payload, userId);
+      // Shared (scope=global) connector: the edit was queued for admin approval,
+      // the live definition is unchanged. Tell the user explicitly instead of
+      // letting the form silently revert to the old content.
+      if (result.kind === "editRequest") {
+        showSnackbar({
+          variant: "success",
+          title: "Sent to admin for approval",
+          description:
+            result.message ||
+            "This is a shared connector, so your changes were submitted for admin review.",
+        });
+        reload();
+        return result;
+      }
+      const created = result.server;
       // Make a newly-created connector's form immediately available to the
       // reconnect dialog instead of waiting for the page-level credential map
       // (which is fetched only on mount).
@@ -504,9 +519,9 @@ export function MCPPageV3({ userId }: Props) {
         [created.type]: created.credentialForm?.fields ?? payload.credentialForm?.fields ?? [],
       }));
       reload();
-      return created;
+      return result;
     },
-    [userId, reload]
+    [userId, reload, showSnackbar]
   );
 
   const handleRequestPublish = useCallback(

--- a/apps/xyne-claw-auth/frontend/src/v3/components/dialogs/AddConnectionDialog.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/dialogs/AddConnectionDialog.tsx
@@ -6,6 +6,7 @@ import { ServerIcon } from "../ui/ServerIcon";
 import { ArrowLeftIcon, PlusIcon } from "@phosphor-icons/react";
 import { useState, useEffect, type FormEvent, type ChangeEvent } from "react";
 import type { McpServer, CredentialField } from "../../../lib/types";
+import type { CreateServerResult } from "../../../lib/api";
 
 interface Props {
   open: boolean;
@@ -22,7 +23,7 @@ interface Props {
     httpConfigTemplate?: { url: string; headers: Record<string, string> };
     healthcheckSpec?: { name: string; params: Record<string, unknown> };
     writeToolPolicy?: { mode?: "allowlist" | "denylist" | "allAsk" | "allowAll"; tools?: string[] };
-  }) => Promise<McpServer>;
+  }) => Promise<CreateServerResult>;
   servers: McpServer[];
   credentialFields: Record<string, CredentialField[]>;
   connectedServerIds?: Set<string>;
@@ -497,6 +498,14 @@ export function AddConnectionDialog({
   // ── derived ─────────────────────────────────────────────────────────
   const isEditMode = !!editServerId;
   const isDefinitionEditMode = !!editDefinitionServerId;
+  // A shared (scope=global) connector cannot be edited in place — saving queues
+  // the change for admin approval. Drives the button label and the notice.
+  const definitionServer = isDefinitionEditMode
+    ? servers.find((s) => s.id === editDefinitionServerId)
+    : undefined;
+  const isGlobalDefinitionEdit =
+    (definitionServer?.connectorMeta as { scope?: string } | null | undefined)?.scope ===
+    "global";
   const selectedServer = createdServer ?? servers.find((s) => s.id === selectedServerId);
   const fields = (() => {
     if (!selectedServer) return [];
@@ -589,6 +598,7 @@ export function AddConnectionDialog({
     const form = new FormData(e.currentTarget);
     let activeServerId = selectedServerId;
     let activeServer = selectedServer;
+    let definitionEditQueued = false;
 
     if (mode === "new") {
       if (!newServerName.trim() || !newServerType.trim() || !newServerUrl.trim()) {
@@ -629,10 +639,16 @@ export function AddConnectionDialog({
             tools?: string[];
           }>("write tool policy", newWritePolicy),
         } as const;
-        const created = await onCreateServer(payload);
-        setCreatedServer(created);
-        activeServer = created;
-        activeServerId = created.id;
+        const result = await onCreateServer(payload);
+        if (result.kind === "editRequest") {
+          // Shared connector edit queued for admin approval — there is no live
+          // server to reconnect and the page already showed the approval toast.
+          definitionEditQueued = true;
+        } else {
+          setCreatedServer(result.server);
+          activeServer = result.server;
+          activeServerId = result.server.id;
+        }
       } catch (err) {
         setCreateError(err instanceof Error ? err.message : "Failed to create connector");
         setCreating(false);
@@ -640,6 +656,12 @@ export function AddConnectionDialog({
       } finally {
         setCreating(false);
       }
+    }
+
+    if (definitionEditQueued) {
+      // Nothing to reconnect for a shared connector awaiting approval — close.
+      handleOpenChange(false);
+      return;
     }
 
     if (!activeServerId || !activeServer) return;
@@ -718,12 +740,16 @@ export function AddConnectionDialog({
                 disabled={creating || (mode === "existing" && !selectedServerId)}
               >
                 {creating
-                  ? "Saving…"
+                  ? isGlobalDefinitionEdit
+                    ? "Sending…"
+                    : "Saving…"
                   : isEditMode
                     ? "Save & Reconnect"
                     : mode === "new"
                       ? isDefinitionEditMode
-                        ? "Save & Reconnect"
+                        ? isGlobalDefinitionEdit
+                          ? "Send for approval"
+                          : "Save & Reconnect"
                         : "Create & Connect"
                       : "Connect"}
               </Button>
@@ -872,7 +898,9 @@ export function AddConnectionDialog({
                 <div className="space-y-3">
                   <p className="text-[12px] leading-5 text-xyne-fg-muted">
                     {isDefinitionEditMode
-                      ? "Edit connector definition and overwrite the existing type, then reconnect with credentials below."
+                      ? isGlobalDefinitionEdit
+                        ? "This is a shared connector. Edit the definition below — your changes are sent to an admin for approval, not applied immediately."
+                        : "Edit connector definition and overwrite the existing type, then reconnect with credentials below."
                       : "Define the MCP endpoint and the fields each user must enter. You will test it with your own credentials before publishing it for others."}
                   </p>
                   <TextField


### PR DESCRIPTION
## Problem
Editing a shared (scope=global) MCP connector definition via **Edit definition → Save & Reconnect** appeared to "flash and revert" — the change never persisted and no message was shown. Users didn't know their edit was actually queued for admin approval.

Root cause: the edit posts to `POST /api/v1/servers`, which for a global-scope connector does **not** update the live row — it creates an `McpConnectorEditRequest` and returns **HTTP 202** with `{ editRequest, message }`. The frontend `createServer()` treated any 2xx body as a saved `McpServer`, then `reload()`ed and re-rendered the unchanged connector — with no error and no "submitted for review" message.

## Fix (frontend only; backend behavior unchanged)
- `createServer()` now returns a discriminated `CreateServerResult` (`"saved"` | `"editRequest"`) so callers can distinguish an in-place save from a queued approval instead of misreading the 202 body.
- `MCPPageV3` shows a **"Sent to admin for approval"** success toast on the `editRequest` outcome.
- `AddConnectionDialog` labels the submit button **"Send for approval"** and shows an explanatory notice when editing a shared connector, and skips the reconnect step on that outcome (there is no updated live server yet).
- Legacy v2 `MCPPage` / `DashboardPage` call sites adapted to the new result type.

## Testing
- `tsc -b` typecheck passes for `apps/xyne-claw-auth/frontend`.

Files changed: apps/xyne-claw-auth/frontend/src/lib/api.ts, v3/components/MCPPageV3.tsx, v3/components/dialogs/AddConnectionDialog.tsx, v2/components/MCPPageV2.tsx, components/DashboardPage.tsx