### PR TITLE
fix: copy FlowJSON messages as readable text instead of "Flow JSON" placeholder

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -36,7 +36,11 @@ import { convertHtmlToBlocks } from './ChatBubble.utils';
 import { sanitizeHtmlString } from '../../../utils/sanitizer';
 import { isSlashCommandArtifactMessage } from '../SlashCommandArtifacts';
 import { cn } from '../../../utils/classNames';
-import { copyHtmlToClipboard, markdownToHtml } from '../../../utils/clipboardUtils';
+import {
+  copyHtmlToClipboard,
+  copyMessageContentToClipboard,
+  markdownToHtml,
+} from '../../../utils/clipboardUtils';
 import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWithHTML';
 import { getEmojiFontSizeClass } from '../../../utils/emojiUtils';
 import ReplyLayoutV2 from '../ReplyLayout/ReplyLayoutV2';
@@ -707,19 +711,26 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
           ? parseForwardedMessageXml(message.content)?.content || message.content
           : message.content;
 
+      // FlowJSON messages are stored as `<div data-flow-json=\"...\">Flow JSON</div>`;
+      // copying the raw content would only yield the placeholder "Flow JSON". Detect
+      // and route those through the flow-aware helper before the markdown/plain paths.
+      const isFlowContent = contentToCopy.includes('data-flow-json');
+
       // Convert markdown to HTML if needed, then normalize headings to bold paragraphs
-      const copyPromise = isMarkdownContent
-        ? markdownToHtml(contentToCopy)
-            .then(html => copyHtmlToClipboard(html))
-            .catch(error => {
-              logger.warn(Event.FRONTEND_ERROR, {
-                type: 'migrated_console_warn',
-                message: String('Markdown processing failed, falling back to raw content:'),
-                context: [error],
-              });
-              return copyHtmlToClipboard(contentToCopy);
-            })
-        : copyHtmlToClipboard(contentToCopy);
+      const copyPromise = isFlowContent
+        ? copyMessageContentToClipboard(contentToCopy)
+        : isMarkdownContent
+          ? markdownToHtml(contentToCopy)
+              .then(html => copyHtmlToClipboard(html))
+              .catch(error => {
+                logger.warn(Event.FRONTEND_ERROR, {
+                  type: 'migrated_console_warn',
+                  message: String('Markdown processing failed, falling back to raw content:'),
+                  context: [error],
+                });
+                return copyHtmlToClipboard(contentToCopy);
+              })
+          : copyHtmlToClipboard(contentToCopy);
 
       copyPromise
         .then(() => {
@@ -943,7 +954,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   // and resolve this bubble's handlers via the hover-actions registry below.
   const handleCopyContent = (): void => {
     if (message?.content) {
-      copyHtmlToClipboard(message.content)
+      copyMessageContentToClipboard(message.content)
         .then(() => {
           toast.success('Message content copied to clipboard');
         })

--- a/apps/dashboard/src/utils/clipboardUtils.ts
+++ b/apps/dashboard/src/utils/clipboardUtils.ts
@@ -1,4 +1,5 @@
 import { logger, Event as LogEvent } from './logger';
+import { getFlowJsonCopyHtml } from './flowPreview';
 /**
  * Clipboard utilities for copying HTML content with proper formatting preservation
  */
@@ -300,6 +301,22 @@ export const copyHtmlToClipboard = async (html: string): Promise<void> => {
     // If the fancy clipboard API fails, fall back to plain text
     await navigator.clipboard.writeText(plainText);
   }
+};
+
+/**
+ * Copies a chat message's stored `content` to the clipboard.
+ *
+ * FlowJSON messages are stored as `<div data-flow-json=\"...\">Flow JSON</div>`,
+ * so copying the raw content puts only the literal placeholder \"Flow JSON\" on the
+ * clipboard. For those, extract a readable HTML representation from the flow
+ * payload first; everything else copies exactly as before.
+ */
+export const copyMessageContentToClipboard = async (content: string): Promise<void> => {
+  if (!content) {
+    throw new Error('No content to copy');
+  }
+  const flowHtml = getFlowJsonCopyHtml(content);
+  return copyHtmlToClipboard(flowHtml ?? content);
 };
 
 /**

--- a/apps/dashboard/src/utils/flowPreview.ts
+++ b/apps/dashboard/src/utils/flowPreview.ts
@@ -4,11 +4,21 @@
  * flow. FlowJSON messages are stored as `<div data-flow-json="...">Flow JSON</div>`;
  * feeding that to the HTML renderer mounts the entire flow card (title, textarea,
  * buttons), which breaks list-row layout. These helpers collapse it to plain text.
+ *
+ * The same parse/walk is reused by the copy-to-clipboard path (see
+ * `getFlowJsonCopyHtml`): without it, copying a FlowJSON message only puts the
+ * literal placeholder text "Flow JSON" on the clipboard, because the raw content
+ * is a single `<div>` whose only text node is that placeholder.
  */
 
-/** Strips mrkdwn / standard-markdown emphasis and Xyne tokens for a clean preview. */
-function stripFlowMarkup(raw: string): string {
-  return raw
+/**
+ * Strips mrkdwn / standard-markdown emphasis and Xyne tokens for a clean preview.
+ * When `preserveNewlines` is true, only horizontal whitespace is collapsed so the
+ * copy path can keep multi-line structure; otherwise everything collapses to a
+ * single line (list/preview use case).
+ */
+function stripFlowMarkup(raw: string, preserveNewlines = false): string {
+  const cleaned = raw
     .replace(/<userid:[^>]+>/g, '')
     .replace(/<channelid:[^>]+>/g, '#channel')
     .replace(/<broadcast:channel>/gi, '@channel')
@@ -21,17 +31,26 @@ function stripFlowMarkup(raw: string): string {
     .replace(/_([^_\n]+)_/g, '$1') // italic
     .replace(/~([^~\n]+)~/g, '$1') // strike
     .replace(/`([^`\n]+)`/g, '$1') // inline code
-    .replace(/^\s*>\s?/gm, '') // blockquote markers
-    .replace(/\s+/g, ' ')
-    .trim();
+    .replace(/^\s*>\s?/gm, ''); // blockquote markers
+
+  if (preserveNewlines) {
+    return cleaned
+      .replace(/[^\S\n]+/g, ' ') // collapse horizontal whitespace, keep newlines
+      .replace(/ *\n */g, '\n') // trim spaces around newlines
+      .replace(/\n{3,}/g, '\n\n') // cap consecutive blank lines
+      .trim();
+  }
+  return cleaned.replace(/\s+/g, ' ').trim();
 }
 
 /**
- * Returns a clean single-line preview string for a FlowJSON message, or null if
- * the content is not a FlowJSON message. Joins the flow title with every text
- * `content` prop in the component tree, plus plan `desc` / `todos[].text`.
+ * Parses a FlowJSON message's `data-flow-json` payload into ordered text lines
+ * (flow title, then every component text `content`, plus plan `desc` and
+ * `todos[].text`). Returns null if `content` is not a FlowJSON message.
+ * Shared by the single-line preview and the multi-line copy paths so they can
+ * never drift.
  */
-export function getFlowJsonPreviewText(content: string): string | null {
+export function extractFlowJsonTextLines(content: string): string[] | null {
   if (!content.includes('data-flow-json')) return null;
   const attrMatch = content.match(/data-flow-json="([^"]+)"/);
   if (!attrMatch?.[1]) return null;
@@ -81,9 +100,48 @@ export function getFlowJsonPreviewText(content: string): string | null {
     };
     if (Array.isArray(flow.components)) walk(flow.components);
 
-    const preview = stripFlowMarkup(texts.join(' — '));
-    return preview || null;
+    return texts;
   } catch {
     return null;
   }
+}
+
+/**
+ * Returns a clean single-line preview string for a FlowJSON message, or null if
+ * the content is not a FlowJSON message. Joins the flow title with every text
+ * `content` prop in the component tree, plus plan `desc` / `todos[].text`.
+ */
+export function getFlowJsonPreviewText(content: string): string | null {
+  const texts = extractFlowJsonTextLines(content);
+  if (!texts) return null;
+  const preview = stripFlowMarkup(texts.join(' — '));
+  return preview || null;
+}
+
+/**
+ * Returns a simple, readable HTML representation of a FlowJSON message for the
+ * copy-to-clipboard path (title as bold, each subsequent line as a paragraph),
+ * or null if `content` is not a FlowJSON message. Handing this to
+ * `copyHtmlToClipboard` yields a faithful rich (`text/html`) flavor and, via the
+ * existing `htmlToFormattedText` walk, a matching multi-line plain-text flavor —
+ * instead of the placeholder "Flow JSON".
+ */
+export function getFlowJsonCopyHtml(content: string): string | null {
+  const texts = extractFlowJsonTextLines(content);
+  if (!texts) return null;
+
+  const lines = texts.map(t => stripFlowMarkup(t, true)).filter(Boolean);
+  if (!lines.length) return null;
+
+  const escapeHtml = (s: string): string =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  const html = lines
+    .map((line, index) => {
+      const safe = escapeHtml(line).replace(/\n/g, '<br>');
+      return index === 0 ? `<p><strong>${safe}</strong></p>` : `<p>${safe}</p>`;
+    })
+    .join('');
+
+  return html;
 }


### PR DESCRIPTION
## Problem
Copying a FlowJSON bot message via the 3-dot menu "Copy message" (or the `mod+shift+c` shortcut) put the literal placeholder text **"Flow JSON"** on the clipboard instead of the message content. The success toast still fired, so it looked like it worked.

## Root cause
FlowJSON messages are stored as `<div data-flow-json="...">Flow JSON</div>`. Both copy handlers in `ChatBubble.tsx` (`handleCopyMessage`, `handleCopyContent`) passed this raw content to `copyHtmlToClipboard`, whose `htmlToFormattedText` walk sees only the `<div>`'s single text node — the placeholder `Flow JSON`.

## Fix
- `flowPreview.ts`: extracted the flow parse/walk into a shared `extractFlowJsonTextLines`, and added `getFlowJsonCopyHtml` which renders the flow (title + component `content` + plan `desc`/`todos[].text`) into simple readable HTML. The existing single-line preview now reuses the shared extractor so the two can't drift.
- `clipboardUtils.ts`: added `copyMessageContentToClipboard(content)` — routes FlowJSON content through `getFlowJsonCopyHtml`, and delegates all other content to the existing `copyHtmlToClipboard` unchanged.
- `ChatBubble.tsx`: wired both copy entry points to the new helper (flow detection takes precedence over the markdown/plain branches; forwarded-message and emoji handling unchanged).

## Validation
- `tsc --noEmit` (dashboard) clean for the touched files.
- POT against the **real shipped modules** in a browser (real `DOMParser` + clipboard API):
  - Old path on raw flow content → `"Flow JSON"` (reproduces the bug).
  - New path → full multi-line summary (title, content, plan desc, every todo) written as both `text/html` and `text/plain`.
  - Regression: a normal HTML message returns `null` from `getFlowJsonCopyHtml` and falls through to the unchanged copy path.

## Scope
Copy-only. No change to flow rendering or forwarding. Normal and markdown messages are unaffected.