### PR TITLE
feat: enable Xyne AI homescreen (Open AI on launch) by default

### DIFF
--- a/apps/dashboard/src/hooks/useAILandingDefault.ts
+++ b/apps/dashboard/src/hooks/useAILandingDefault.ts
@@ -10,7 +10,9 @@ const subscribe = (listener: () => void): (() => void) => {
   return () => listeners.delete(listener);
 };
 
-const getSnapshot = (): boolean => localStorage.getItem(AI_LANDING_KEY) === 'true';
+// Default ON: the Xyne AI landing page is shown on launch for everyone unless
+// the user has explicitly turned it off (stored as the string 'false').
+const getSnapshot = (): boolean => localStorage.getItem(AI_LANDING_KEY) !== 'false';
 
 export const useAILandingDefault = (): {
   aiLandingDefault: boolean;


### PR DESCRIPTION
1. Problem Description:
The rollout goal is to enable three things for everyone by default (users can still turn them off): the Xyne AI homescreen (Open AI on launch), the new recording experience, and Show Claw Agents in the sidebar. On investigation, two of the three are already default-on in code, so only one code change is needed.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Enhancement. Traced the three preferences to their hooks in apps/dashboard/src/hooks: useAILandingDefault (Open AI on launch), useRecordingVersion (new recording experience), useClawDashboardVisibility (Show Claw Agents). Found useRecordingVersion already defaults to 'v2' (new experience) and useClawDashboardVisibility already defaults to true (shown unless explicitly set to 'false'). Only useAILandingDefault defaulted OFF.

3. Explain the solution implemented in the PR:
Changed the default in apps/dashboard/src/hooks/useAILandingDefault.ts. getSnapshot now returns `localStorage.getItem(AI_LANDING_KEY) !== 'false'` instead of `=== 'true'`. This makes the "Open AI on launch" preference default ON for users who have never set it, while users who explicitly turned it off (stored as the string 'false' by setAiLandingDefault) keep their choice. No change was required for the recording experience or Show Claw Agents since both are already default-on. The Preferences toggle ("Open AI on launch") continues to let users opt out.

4. Documentation (link to docs created/updated for this change): N/A

5. DB Alter Details (if any): N/A — this is a per-device localStorage default computed on the client; no schema change and no backfill.

6. Data fix Details (if any): N/A

7. Environment variable Changes (if any): N/A

8. Testing (how it was tested; screenshots/links):
Manual: with no `xyne:ai-landing-default` key in localStorage, HomeScreen (apps/dashboard/src/routes/HomeScreen/HomeScreen.tsx) now redirects to `/ai` on desktop launch. Setting the Preferences toggle off writes 'false' and reverts to chat; toggling back on writes 'true'. Explicit 'false' is preserved across the default change.

9. Services to which this change is to be deployed: dashboard (frontend)

10. Main PR link (if this PR is raised against a release branch): N/A — raised against main.