### PR TITLE
fix: show a recording-specific placeholder in the notes editor

### DIFF
--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -80,14 +80,18 @@ import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasIn
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
 
-const canvasDictionary = {
+const DEFAULT_CANVAS_PLACEHOLDER = "Write something, or press '/' for commands";
+
+const buildCanvasDictionary = (placeholder: string): typeof en => ({
   ...en,
   placeholders: {
     ...en.placeholders,
-    default: "Write something, or press '/' for commands",
-    emptyDocument: "Write something, or press '/' for commands",
+    default: placeholder,
+    emptyDocument: placeholder,
   },
-};
+});
+
+const canvasDictionary = buildCanvasDictionary(DEFAULT_CANVAS_PLACEHOLDER);
 
 interface CollaborativeCanvasEditorProps {
   canvasId: string;
@@ -127,7 +131,7 @@ export const CollaborativeCanvasEditor = forwardRef<
       channelId,
       title,
       editable = true,
-      placeholder: _placeholder,
+      placeholder,
       className = '',
       onFileUpload,
       onChange,
@@ -191,9 +195,14 @@ export const CollaborativeCanvasEditor = forwardRef<
     const shouldUseCollaboration = hasCollaborationInitializedRef.current || isCollaborationReady;
     const canMountEditor = shouldUseCollaboration && !!provider && !!fragment;
 
+    const dictionary = useMemo(
+      () => (placeholder ? buildCanvasDictionary(placeholder) : canvasDictionary),
+      [placeholder],
+    );
+
     const baseEditorOptions = {
       schema: canvasSchema,
-      dictionary: canvasDictionary,
+      dictionary,
       ...(onFileUpload ? { uploadFile: onFileUpload } : {}),
       resolveFileUrl,
       tables: canvasTableOptions,

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -1187,7 +1187,7 @@ function NotesCanvas({ canvasId }: { canvasId: string }): ReactElement {
       channelId={canvas.channelId || undefined}
       title={canvas.title}
       editable={true}
-      placeholder='Start typing your notes…'
+      placeholder='Add your notes here, you can view the transcript live in the transcript tab'
       className={`min-h-0 w-full flex-1 ${CANVAS_POPOVER_LAYER_CLASS}
         [&_.bn-side-menu]:!hidden
         [&_.thin-scrollbar]:!pt-2

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
@@ -302,6 +302,7 @@ const NotesTab = ({ notesCanvasId, channelId }: NotesTabProps): ReactElement => 
         channelId={channelId ?? undefined}
         editable
         autoFocus
+        placeholder='Add your notes here, you can view the transcript live in the transcript tab'
         onFileUpload={handleFileUpload}
         className='floating-recording-notes h-full w-full
           [&_.bn-side-menu]:!hidden


### PR DESCRIPTION

<img width="504" height="354" alt="Screenshot 2026-08-20 at 12 49 06" src="https://github.com/user-attachments/assets/014eed6a-cd84-47a3-878b-cce5f3b7a27e" />


## What

Both recording notes editors — the note-taker overlay and the recording detail screen — now show:

> Add your notes here, you can view the transcript live in the transcript tab

instead of the generic *"Write something, or press '/' for commands"*.

## The bug underneath

`CollaborativeCanvasEditor` **declared a `placeholder` prop and threw it away**. It was destructured as `placeholder: _placeholder` (`CollaborativeCanvasEditor.tsx:130`), and the BlockNote dictionary was a module-level constant with the string hardcoded:

```ts
const canvasDictionary = {
  ...en,
  placeholders: {
    ...en.placeholders,
    default: "Write something, or press '/' for commands",
    emptyDocument: "Write something, or press '/' for commands",
  },
};
```

So every canvas in the app showed the same text no matter what was passed. `RecordingDetailV2Screen.tsx:1190` was already passing `placeholder='Start typing your notes…'` and it had never had any effect.

The dictionary is now built from the prop, memoised on it so the editor isn't recreated (it is read once at editor creation, so it needs to be stable rather than reactive), and falls back to the previous constant when no prop is given — **every other canvas renders exactly as before**.

## Auto-focus: no change needed

The request also asked for the notes editor to be auto-focused. It already is, and I verified rather than assumed:

- `NoteTakerOverlay.tsx:304` and `RecordingDetailV2Screen.tsx:1202` both pass `autoFocus`.
- The effect in `CollaborativeCanvasEditor` retries on a 50ms interval until content is present, so it survives collaboration sync and migration being pending, then focuses and puts the cursor at the end.
- Notes is already the default pane: `DEFAULT_RECORDING_V2_TAB = 'notes'` in `utils/recordingTabPreference.ts`, so a recording nobody has picked a pane for opens on notes.

One existing behaviour worth knowing, not introduced here: auto-focus is deliberately skipped while the Xyne AI sidebar is open (the `isXyneAIOpen` guard), so the editor will not steal focus from it.

## Scope

Applied to **both** recording notes editors, since the overlay and the detail screen are the two places you take notes during a recording. Easy to narrow to one if that is not wanted.

## Testing

- `pnpm run typecheck` (`--project tsconfig.app.json`) exit 0.
- `prettier --check` clean on all three files.
- Lint: `CollaborativeCanvasEditor.tsx` reports **21 problems / 11 errors both before and after** this change — verified by linting the `HEAD` version of the file side by side. Those are pre-existing `no-unsafe-*` findings that appear when `packages/shared/dist` is not built locally; this diff adds none.

**Not verified:** not exercised in a running app. Worth confirming on review that the new placeholder renders in the empty editor in both surfaces, and that no other canvas placeholder changed.