### PR TITLE
fix: enforce workspace ownership on workflow artifact endpoints

### DIFF
--- a/apps/backend/src/controllers/workflowController.ts
+++ b/apps/backend/src/controllers/workflowController.ts
@@ -97,6 +97,21 @@ export class WorkflowController {
   }
 
   /**
+   * Extract the executionId from a workflow-artifacts GCS path so it can be
+   * workspace-authorized. Expected shape: `workflow-artifacts/<executionId>/...`.
+   * Returns null for anything that does not match or that tries path traversal.
+   */
+  private parseArtifactExecutionId(gcsPath: string): string | null {
+    const parts = gcsPath.split('/');
+    if (parts.length < 3 || parts[0] !== 'workflow-artifacts') return null;
+    const executionId = parts[1];
+    if (!executionId || executionId === '.' || executionId === '..' || executionId.includes('..')) {
+      return null;
+    }
+    return executionId;
+  }
+
+  /**
    * Copy parent execution's agentic step data to new execution for rerun scenarios.
    * Loads from parent's Redis/GCS storage and copies to new execution's storage.
    * Optionally appends a user continuation message.
@@ -1733,6 +1748,9 @@ export class WorkflowController {
         return;
       }
 
+      // Only list artifacts for executions the caller's workspace owns.
+      if (!(await this.authorizeExecution(req, res, executionId))) return;
+
       const vrBucketName = config.gcs.workflowVRBucketName;
       const storageService = getStorageService(vrBucketName);
 
@@ -1831,6 +1849,16 @@ export class WorkflowController {
         return;
       }
 
+      // Enforce workspace ownership. The executionId embedded in the path must belong to
+      // the caller's workspace; otherwise any authenticated user could read another
+      // workspace's artifacts by supplying its executionId (cross-workspace IDOR).
+      const artifactExecutionId = this.parseArtifactExecutionId(gcsPath);
+      if (!artifactExecutionId) {
+        res.status(400).json({ error: 'Invalid path: expected workflow-artifacts/{executionId}/...' });
+        return;
+      }
+      if (!(await this.authorizeExecution(req, res, artifactExecutionId))) return;
+
       const vrBucketName = config.gcs.workflowVRBucketName;
       const storageService = getStorageService(vrBucketName);
 
@@ -1881,6 +1909,16 @@ export class WorkflowController {
         res.status(400).json({ error: 'Invalid path: must start with workflow-artifacts/' });
         return;
       }
+
+      // Enforce workspace ownership. The executionId embedded in the path must belong to
+      // the caller's workspace; otherwise any authenticated user could read another
+      // workspace's artifacts by supplying its executionId (cross-workspace IDOR).
+      const artifactExecutionId = this.parseArtifactExecutionId(gcsPath);
+      if (!artifactExecutionId) {
+        res.status(400).json({ error: 'Invalid path: expected workflow-artifacts/{executionId}/...' });
+        return;
+      }
+      if (!(await this.authorizeExecution(req, res, artifactExecutionId))) return;
 
       const vrBucketName = config.gcs.workflowVRBucketName;
       const storageService = getStorageService(vrBucketName);
@@ -1934,6 +1972,16 @@ export class WorkflowController {
         res.status(400).json({ error: 'Invalid path: must start with workflow-artifacts/' });
         return;
       }
+
+      // Enforce workspace ownership. The executionId embedded in the path must belong to
+      // the caller's workspace; otherwise any authenticated user could read another
+      // workspace's artifacts by supplying its executionId (cross-workspace IDOR).
+      const artifactExecutionId = this.parseArtifactExecutionId(gcsPath);
+      if (!artifactExecutionId) {
+        res.status(400).json({ error: 'Invalid path: expected workflow-artifacts/{executionId}/...' });
+        return;
+      }
+      if (!(await this.authorizeExecution(req, res, artifactExecutionId))) return;
 
       const vrBucketName = config.gcs.workflowVRBucketName;
       const storageService = getStorageService(vrBucketName);


### PR DESCRIPTION
## Summary
Closes a cross-workspace IDOR (finding C-5) in the workflow **artifact** endpoints. Any authenticated user could read another workspace's test artifacts (screenshots, HTML reports, cucumber JSON) by supplying that workspace's `executionId` in the request path.

Affected endpoints:
- `GET /api/workflows/artifacts/view?path=...`
- `GET /api/workflows/artifacts/image?path=...`
- `GET /api/workflows/artifacts/download?path=...`
- `GET /api/workflows/executions/:executionId/test-artifacts`

## Why the existing Prisma tenant ACL did not cover this
The repo already enforces workspace scoping at the DB layer: `DatabaseClient.getInstance()` wraps Prisma with `withAclExtension`, and `WorkflowsACL` / `WorkflowExecutionsACL` / `WorkflowStepsACL` scope every read/write to the caller's `workspaceId`. That closes the IDOR on the workflow **table** reads/creates.

These four endpoints, however, read objects from the **GCS** test-artifact bucket, not Postgres. They took an `executionId` straight from a user-supplied `?path=` / route param and validated only the `workflow-artifacts/` prefix — so the Prisma ACL never saw them and the tenant boundary was not enforced.

## Fix
- Add `parseArtifactExecutionId()` to extract the `executionId` from a `workflow-artifacts/<executionId>/...` path (rejects malformed / `..` traversal paths).
- Before any GCS read, authorize that `executionId` against the caller's workspace via the existing `authorizeExecution()` helper (which resolves through the workspace-scoped Prisma client and returns 404 on a foreign/absent execution).
- `getTestArtifacts` is guarded the same way using its `:executionId` route param.

Behaviour is unchanged for callers requesting artifacts of executions their own workspace owns.

## Test plan
- [ ] Same-workspace artifact view/image/download still returns 200.
- [ ] Cross-workspace `executionId` in `?path=` now returns 404 (was 200).
- [ ] `test-artifacts` list for a foreign execution returns 404.
- [ ] Malformed path (`workflow-artifacts/` only, or with `..`) returns 400.

## Notes / follow-ups (not in this PR)
- `viewArtifact` serves artifact HTML inline (`Content-Type: text/html`, only `X-Frame-Options: SAMEORIGIN`). Consider a `Content-Security-Policy` / `Content-Disposition` hardening pass separately.