### PR TITLE
fix: don't offer to record a meeting while already recording

### DIFF
--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -620,6 +620,9 @@ export const NotificationHandler: React.FC = () => {
     const isActive = recordingStatus === 'recording' || recordingStatus === 'paused';
     const state = {
       active: isActive,
+      // Sent before the mic is enabled, so the meeting detector can tell our own
+      // recording from a meeting worth offering to record.
+      starting: recordingStatus === 'starting',
       startTime: recordingStartTime ?? undefined,
       paused: recordingStatus === 'paused',
       pauseStartedAt: recordingPauseStartedAt,

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -28,6 +28,7 @@ import {
   resumeRecordingFromOutside,
   setOverlayMinimized,
   setRecordingPillEnabled,
+  setRecordingStarting,
   stopRecording,
   syncRecordingState,
 } from '../services/recording-controller';
@@ -620,6 +621,7 @@ export function setupIpcHandlers(): void {
       event,
       state: {
         active: boolean;
+        starting?: boolean;
         startTime?: number;
         paused?: boolean;
         pauseStartedAt?: number | null;
@@ -628,6 +630,7 @@ export function setupIpcHandlers(): void {
     ) => {
       if (!isMainWindowSender(event)) return;
       markRendererReady();
+      setRecordingStarting(!!state?.starting);
       syncRecordingState(!!state?.active, state?.startTime, {
         paused: !!state?.paused,
         pauseStartedAt: state?.pauseStartedAt ?? null,

--- a/apps/electron/src/services/logger/electron-events.ts
+++ b/apps/electron/src/services/logger/electron-events.ts
@@ -35,6 +35,7 @@ const ElectronEvent = {
     MEETING_APP_IDENTIFIED: 'meeting_app_identified',
     MEETING_POPUP_SHOWN: 'meeting_popup_shown',
     MEETING_POPUP_SKIPPED_LOGGED_OUT: 'meeting_popup_skipped_logged_out',
+    MEETING_POPUP_SKIPPED_RECORDING: 'meeting_popup_skipped_recording',
     MEETING_POPUP_DISMISSED: 'meeting_popup_dismissed',
     MEETING_POPUP_START_RECORDING: 'meeting_popup_start_recording',
     MEETING_POPUP_HIDDEN: 'meeting_popup_hidden',

--- a/apps/electron/src/services/meeting-popup-window.ts
+++ b/apps/electron/src/services/meeting-popup-window.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import log from 'electron-log/main';
 import { Logger } from './logger/Logger';
 import ElectronEvent from './logger/electron-events';
+import { isRecordingInProgress } from './recording-controller';
 
 let popupWindow: BrowserWindow | null = null;
 let autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
@@ -19,6 +20,22 @@ async function isUserLoggedIn(): Promise<boolean> {
 }
 
 export async function showMeetingPopup(meetingData: { app: string; startedAt: string }): Promise<void> {
+  if (popupWindow && !popupWindow.isDestroyed()) {
+    popupWindow.webContents.send('meeting-popup:update', meetingData);
+    resetAutoDismiss();
+    return;
+  }
+
+  if (isRecordingInProgress()) {
+    log.info('[MeetingPopup] Recording already in progress, skipping popup');
+    Logger.info(
+      ElectronEvent.MEETING_POPUP_SKIPPED_RECORDING,
+      { app: meetingData.app },
+      'MeetingDetector',
+    );
+    return;
+  }
+
   // Only show popup if user is logged in to Xyne Spaces
   const loggedIn = await isUserLoggedIn();
   if (!loggedIn) {
@@ -28,13 +45,6 @@ export async function showMeetingPopup(meetingData: { app: string; startedAt: st
       { app: meetingData.app },
       'MeetingDetector',
     );
-    return;
-  }
-
-  if (popupWindow && !popupWindow.isDestroyed()) {
-    // Already showing — just update content
-    popupWindow.webContents.send('meeting-popup:update', meetingData);
-    resetAutoDismiss();
     return;
   }
 

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -26,6 +26,7 @@ export interface RecordingPauseState {
 }
 
 const RENDERER_READY_TIMEOUT_MS = 10_000;
+const STARTING_RECORDING_TIMEOUT_MS = 2 * 60_000;
 const EXTERNAL_START_TIMEOUT_MS = 5 * 60_000;
 const PILL_SYNC_DEBOUNCE_MS = 150;
 const FOCUS_REQUEST_GRACE_MS = 2_000;
@@ -34,6 +35,8 @@ let pillSyncTimer: ReturnType<typeof setTimeout> | null = null;
 let focusRequestTimer: ReturnType<typeof setTimeout> | null = null;
 
 let active = false;
+let startingRecording = false;
+let startingRecordingExpiry: ReturnType<typeof setTimeout> | null = null;
 let startTime: number | null = null;
 let paused = false;
 let pauseStartedAt: number | null = null;
@@ -85,6 +88,9 @@ function watchRendererLifecycle(win: BrowserWindow): void {
   });
   win.webContents.on('render-process-gone', () => {
     rendererReady = false;
+    // syncRecordingState early-returns on inactive -> inactive, so a crash
+    // mid-start would strand the flag.
+    setRecordingStarting(false);
     syncRecordingState(false);
   });
 }
@@ -317,6 +323,30 @@ export function toggleRecording(trigger: RecordingTrigger): void {
   }
 }
 
+// Not folded into syncRecordingState: that early-returns when the recording is
+// inactive and was already inactive, which is exactly what a start looks like.
+export function setRecordingStarting(next: boolean): void {
+  if (startingRecordingExpiry) {
+    clearTimeout(startingRecordingExpiry);
+    startingRecordingExpiry = null;
+  }
+  startingRecording = next;
+  if (!next) return;
+
+  // The renderer is the only thing that clears this, and a hung start never
+  // reports back, so bound it — otherwise one stuck start suppresses the meeting
+  // popup for the rest of the session.
+  startingRecordingExpiry = setTimeout(() => {
+    startingRecordingExpiry = null;
+    startingRecording = false;
+    log.warn('[RecordingController] Recording start was not confirmed by the renderer');
+  }, STARTING_RECORDING_TIMEOUT_MS);
+}
+
+export function isRecordingInProgress(): boolean {
+  return active || startingRecording;
+}
+
 export function syncRecordingState(
   nextActive: boolean,
   nextStartTime?: number,
@@ -331,6 +361,10 @@ export function syncRecordingState(
   pauseStartedAt = nextActive ? (nextPause?.pauseStartedAt ?? null) : null;
   accumulatedPausedMs = nextActive ? (nextPause?.accumulatedPausedMs ?? 0) : 0;
 
+  if (nextActive) {
+    // Via the setter so the watchdog is cleared too, not just the flag.
+    setRecordingStarting(false);
+  }
   if (nextActive && !wasActive) {
     clearExternalStartPending();
   }


### PR DESCRIPTION
## Problem

Starting a Xyne recording enables the microphone. The meeting detector watches the OS microphone (`kAudioDevicePropertyDeviceIsRunningSomewhere`, which is system-wide), so our own recording woke it and popped **"Meeting detected — start recording?"** over a recording that was already running.

## Why `active` alone doesn't fix it

The obvious guard — `if (getRecordingSnapshot().active) return;` — loses a race. The renderer enables the mic partway through starting, well before it tells main the recording is active:

| `recordingStore.ts` | what main sees |
|---|---|
| `:175` `status: 'starting'` | `active: false` |
| **`:196` `setMicrophoneEnabled(true)`** ← mic on, detector fires | `active: false` |
| `:390` `status: 'recording'` | → `active: true` |

`NotificationHandler` only sent `active: recordingStatus === 'recording' \|\| 'paused'`, a boolean, so `'starting'` was indistinguishable from `'idle'` on the wire. Main had no way to know a recording was on its way.

## The fix

Report the starting phase over the existing `recording:state-changed` channel the instant the renderer enters it — which is before any network or LiveKit work, so it *precedes* the mic rather than racing it — and gate the popup on `active || starting`.

Two details worth a reviewer's eye:

- **The flag has its own setter rather than being folded into `syncRecordingState`.** That function early-returns on an `inactive -> inactive` transition, which is exactly what a start looks like, so the flag could never be raised through it.
- **A start that never confirms would otherwise suppress the popup for the whole session.** Neither the API call nor `room.connect()` has a timeout, so a hung start leaves `status: 'starting'` indefinitely. A watchdog bounds the flag, and the renderer-crash path clears it explicitly (`syncRecordingState(false)` early-returns there, so it can't do the job).

The guard sits in `showMeetingPopup()` beside the existing logged-out check, after the "popup already open" branch so a repeat call still refreshes content and resets the auto-dismiss timer.

## Reviewed

This went through an adversarial review across four lenses. Findings that were **disproven**, so they don't need re-litigating:

- The extra `recording-pill:recording-stopped` now emitted at recording start is inert — `syncRecordingState`'s pre-existing `!nextActive && !wasActive` guard swallows it before any mutation.
- The new import does close a require cycle (`meeting-popup-window → recording-controller → window/manager → app/main → meeting-detector`), but it is safe: CommonJS, function-body-only access, and the boot order resolves `window/manager` from cache before it matters. Equivalent to the `window/manager` ↔ `app/main` cycle already in the tree.
- No spoofing surface — the new field is behind the same `isMainWindowSender` gate as the existing ones.
- Every start path passes through `'starting'`; the error path self-heals.

## Known, deliberately out of scope

- `meeting-detector.ts` still latches `currentMeeting` before the popup is suppressed, so detection won't re-evaluate later in the same mic session. Moving the guard into `identifyMeetingApp()` (matching the screen-recording precedent) would change detection semantics, so it's left as a separate call.
- `startRecordingFromOutside()` and `toggleRecording()` still guard on `active` only, so the global shortcut during `'starting'` can begin a second recording. Pre-existing; `isRecordingInProgress()` is the fix when someone wants it.
- `setRecordingStarting` doesn't call `notifyListeners()`, unlike the other mutators — harmless today as no subscriber reads it.

## Testing

`pnpm run typecheck` clean in both apps (dashboard via `--project tsconfig.app.json`), eslint clean, prettier clean. Dashboard lint warnings are pre-existing and outside the changed hunk.

**Not verified:** not exercised in a running app. Worth confirming: start a recording in a meeting app and check no popup appears; and note `apps/electron` has no CI job at all, so four of these five files are ungated.