### PR TITLE
fix: XYNE-56550 clone agents with their full configuration

### DIFF
--- a/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
@@ -154,16 +154,36 @@ export const agentRepository = {
   /**
    * Clone an agent into a NEW personal agent owned by `newOwnerId`.
    *
-   * Deliberately narrow copy scope (product decision): only the three fields
-   * that define the agent's *behaviour* are carried over —
-   *   1. systemPrompt (also seeded as prompt version v1)
-   *   2. tools        (AgentTool rows, including each tool's `permission`)
-   *   3. skills       (AgentSkill junction links)
-   * Everything else resets to defaults: no description, default color,
-   * empty modelId/config, COLLECTIONS kbScope with NO KB grants, no Spaces
-   * app identity / signing secret, no shares, no provider credentials, no MCP
-   * connections. This is an allow-list copy — we NEVER spread the source row,
-   * so a future secret-bearing column can't silently leak into clones.
+   * The clone is meant to be a WORKING replica, so everything that defines
+   * what the agent is and does comes across —
+   *   1. systemPrompt   (also seeded as prompt version v1)
+   *   2. description / color / modelId / delegationTier / enabled
+   *   3. config          — the ENTIRE json blob. This is the one that matters:
+   *                        `config.tools` is the real tool palette every read
+   *                        path uses (mcp.ts parseToolsConfig, the agent-config
+   *                        editor), so a clone without it runs tool-less.
+   *                        Carries subagents, skillTriggers, planMode,
+   *                        promptInjection, sandbox repos, outputFormat, …
+   *   4. tools           — AgentTool rows, including each tool's `permission`
+   *   5. skills          — AgentSkill junction links
+   *   6. knowledge base  — kbScope + every AgentCollection grant
+   *   7. MCP connections — including the encrypted credential blobs
+   *
+   * Everything past that point stays OUT, each for its own reason:
+   *   • Spaces app identity (`spacesAppId` is @unique, plus `spacesAppToken` /
+   *     `signingSecret`) and SurfaceAgent registrations — these are WHO the
+   *     agent is on an external surface. A copy would receive the source's
+   *     webhooks and sign as it.
+   *   • `scope` / `isDefault` / `ownerUserId` / `orgId` — the clone is a
+   *     PERSONAL agent belonging to the caller; inheriting `scope: "global"`
+   *     would publish it org-wide on creation.
+   *   • AgentShare rows — the source's ACL. Copying would hand third parties
+   *     access to someone else's brand-new private agent.
+   *   • Provider credentials, A2A delegation grants, prompt-version history and
+   *     per-user agent config — left to the clone's owner to (re)establish.
+   *
+   * Still an explicit allow-list — we never spread the source row, so a future
+   * secret-bearing column can't silently leak into clones.
    *
    * Returns the fully-hydrated clone (tools + skills + collections), or null
    * if the source agent no longer exists.
@@ -175,7 +195,12 @@ export const agentRepository = {
   ) => {
     const source = await prisma.agent.findUnique({
       where: { id: sourceId },
-      include: { tools: true, skills: true },
+      include: {
+        tools: true,
+        skills: true,
+        collections: true,
+        mcpConnections: true,
+      },
     });
     if (!source) return null;
 
@@ -196,6 +221,13 @@ export const agentRepository = {
           slug,
           name,
           systemPrompt,
+          description: source.description,
+          color: source.color,
+          modelId: source.modelId,
+          delegationTier: source.delegationTier,
+          enabled: source.enabled,
+          kbScope: source.kbScope,
+          config: source.config as Prisma.InputJsonValue,
           scope: "personal",
           owner: { connect: { id: newOwnerId } },
           ...(owner?.orgId ? { org: { connect: { id: owner.orgId } } } : {}),
@@ -218,8 +250,43 @@ export const agentRepository = {
         });
       }
 
+      // KB grants. Safe to copy verbatim: stored grants are only ever an
+      // ALLOW-LIST, intersected at runtime with the tree spaces returns for the
+      // CALLING user (kb-handlers.ts fileAllowed/collectionAllowed), so a grant
+      // can never widen what the clone's owner may read — only narrow it.
+      if (source.collections.length > 0) {
+        await tx.agentCollection.createMany({
+          data: source.collections.map((c) => ({
+            agentId: clone.id,
+            collectionId: c.collectionId,
+            fileId: c.fileId,
+          })),
+        });
+      }
+
+      // MCP instances, credential blobs included. Ciphertext is copied as-is:
+      // same deployment, same CONFIG.encryptionKey, so no re-encryption is
+      // needed. `createdByUserId` keeps pointing at whoever actually pasted the
+      // secret — that is what the audit trail is for.
+      if (source.mcpConnections.length > 0) {
+        await tx.agentMcpConnection.createMany({
+          data: source.mcpConnections.map((c) => ({
+            agentId: clone.id,
+            mcpServerId: c.mcpServerId,
+            slug: c.slug,
+            displayName: c.displayName,
+            encryptedCreds: c.encryptedCreds,
+            iv: c.iv,
+            authTag: c.authTag,
+            createdByUserId: c.createdByUserId,
+          })),
+        });
+      }
+
       // Seed prompt history so the clone's version list isn't empty and the
-      // denormalized active-pointer fields are consistent with a real row.
+      // denormalized active-pointer fields are consistent with a real row. The
+      // source's own history stays with the source — the clone's lineage starts
+      // here, and the note records where it came from.
       const pv = await tx.agentPromptVersion.create({
         data: {
           agentId: clone.id,

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -1645,8 +1645,10 @@ router.post("/requests/:requestId/reject", requireClawAdmin, async (req: Request
 });
 
 // ── Agent cloning ─────────────────────────────────────────────────────────────
-// Clone copies ONLY the source agent's system prompt, tools, and skills into a
-// new personal agent owned by the caller (see agentRepository.cloneAgentForUser).
+// Clone copies the source agent's prompt, config (tools/subagents/behaviour),
+// tools, skills, KB grants and MCP connections into a new PERSONAL agent owned
+// by the caller. Spaces app identity, shares, provider credentials, delegation
+// grants and prompt history stay behind (see agentRepository.cloneAgentForUser).
 // Owners / contributors / admins clone instantly; everyone else raises a
 // "clone" AgentRequest that the SOURCE agent's owner reviews — surfaced both on
 // this frontend (GET /clone-requests/incoming) and, best-effort, as an

--- a/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
@@ -323,7 +323,10 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
 
   useEffect(() => {
     getAvailableTools().then(setAvailableTools).catch(() => {});
-    listSkills().then(setAvailableSkills).catch(() => {});
+    // Pass userId: without it the API falls back to scope='global' only, so a
+    // personal skill attached to this agent renders as nothing at all — and a
+    // cloned agent looks like its skills were never copied.
+    listSkills(userId).then(setAvailableSkills).catch(() => {});
     listProviderCredentials(userId).then(setProviderCredentials).catch(() => {});
     listSandboxRepos().then(setSandboxRepoOptions).catch(() => {});
     listSbxGitRepos().then(setSbxGitRepoOptions).catch(() => {});
@@ -860,8 +863,9 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
   /**
    * Clone the current agent. Owners/contributors/admins get an instant copy
    * (server returns cloned=true) and we navigate to the new agent so they can
-   * pick a model before first run — the clone intentionally carries no model.
-   * Everyone else raises an approval request routed to the owner (cloned=false).
+   * pick a model before first run — provider/model is per-user config and does
+   * not travel with the clone. Everyone else raises an approval request routed
+   * to the owner (cloned=false).
    */
   const doClone = useCallback(async (name: string) => {
     if (!agent || cloning) return;
@@ -1098,6 +1102,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       <SkillPickerDialog
         open={skillPickerOpen}
         onOpenChange={setSkillPickerOpen}
+        userId={userId}
         selectedIds={draftSkillIds}
         onApply={(ids) => setDraftSkillIds(ids)}
       />

--- a/apps/xyne-claw-auth/frontend/src/v3/components/SkillPickerDialog.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/SkillPickerDialog.tsx
@@ -8,13 +8,16 @@ import { listSkills, type Skill } from "../../lib/api";
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Viewer's id — without it the listing is global-scope only and the viewer's
+   *  own personal skills are invisible here. */
+  userId?: string;
   /** Currently-selected skill IDs (controlled). */
   selectedIds: string[];
   /** Called with the full new selection when the user clicks Apply. */
   onApply: (nextIds: string[]) => void;
 }
 
-export function SkillPickerDialog({ open, onOpenChange, selectedIds, onApply }: Props) {
+export function SkillPickerDialog({ open, onOpenChange, userId, selectedIds, onApply }: Props) {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState("");
@@ -27,11 +30,11 @@ export function SkillPickerDialog({ open, onOpenChange, selectedIds, onApply }: 
   useEffect(() => {
     if (!open || skills.length > 0) return;
     setLoading(true);
-    listSkills()
+    listSkills(userId)
       .then(setSkills)
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [open, skills.length]);
+  }, [open, skills.length, userId]);
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailHeader.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailHeader.tsx
@@ -274,8 +274,8 @@ export function AgentDetailHeader({
             forceExpanded={cloning}
             title={
               cloneNeedsApproval
-                ? "Send a clone request to this agent's owner. A clone copies only the system prompt, tools, and skills."
-                : "Create your own copy — copies the system prompt, tools, and skills into a new personal agent."
+                ? "Send a clone request to this agent's owner. A clone copies its prompt, tools, skills, knowledge base and integrations."
+                : "Create your own copy — prompt, tools, skills, knowledge base and integrations — in a new personal agent."
             }
           />
         )}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/CloneAgentDialog.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/CloneAgentDialog.tsx
@@ -1,10 +1,11 @@
 /**
  * CloneAgentDialog — prompts for the new agent's name before cloning.
  *
- * A clone copies only the system prompt, tools, and skills into a new personal
- * agent. Owners/contributors/admins get an instant copy; everyone else raises
- * an approval request (the chosen name is carried through and applied when the
- * owner approves). The parent owns the actual clone call + navigation.
+ * A clone is a full copy — prompt, tools, skills, knowledge base and
+ * integrations — into a new personal agent. Owners/contributors/admins get an
+ * instant copy; everyone else raises an approval request (the chosen name is
+ * carried through and applied when the owner approves). The parent owns the
+ * actual clone call + navigation.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -98,7 +99,7 @@ export function CloneAgentDialog({
       description={
         needsApproval
           ? "You'll send a request to this agent's owner. Your chosen name is used when they approve."
-          : "Creates your own copy — the system prompt, tools, and skills. Credentials and knowledge-base grants are not copied."
+          : "Creates your own copy — prompt, tools, skills, knowledge base and integrations all come across. Its Spaces identity, sharing and provider keys do not."
       }
       maxWidth={520}
       footer={


### PR DESCRIPTION


https://github.com/user-attachments/assets/f11ce6ae-92f2-4799-b9ea-c32dd45a6748

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

**XYNE-56550** — Cloning an agent produced a copy with an empty tool palette.

`cloneAgentForUser` copied the `agent_tools` junction rows — a legacy surface
nothing reads at runtime — while resetting `config` to `{}`. But `config.tools`
is the palette every read path actually uses (`mcp.ts` `parseToolsConfig`, the
agent-config editor), so the copy came out with **0 of 277** tools where the
source had 38 selected. Knowledge-base grants and MCP connections were dropped
for the same reason.

The clone now carries over:

| | |
|---|---|
| `config` (whole blob) | tools, subagents, `skillTriggers`, `planMode`, `promptInjection`, sandbox repos, `outputFormat`, verification flags |
| agent fields | `description`, `color`, `modelId`, `delegationTier`, `enabled`, `kbScope` |
| relations | `AgentTool` (+ permissions), `AgentSkill`, `AgentCollection` (KB grants), `AgentMcpConnection` (incl. encrypted credential blobs) |

Deliberately **not** copied, each documented inline: Spaces app identity +
`SurfaceAgent` rows (`spacesAppId` is `@unique`; a copy would receive the
source's webhooks and sign as it), `scope`/`isDefault`/owner/org (the clone is a
personal agent — inheriting `scope: "global"` would publish it org-wide),
`AgentShare` rows (the source's ACL), and provider credentials / delegation
grants / prompt history / per-user config.

Copying KB grants is safe: stored grants are only ever an allow-list,
intersected at runtime with the tree Spaces returns for the **calling** user
(`kb-handlers.ts` `fileAllowed`/`collectionAllowed`), so a grant can only narrow
what the clone's owner reads, never widen it.

Also fixes a related display bug: `listSkills()` in the v3 agent detail page and
skill picker was called without `userId`, so the API fell back to
`scope='global'` only and a personal skill attached to an agent rendered as
nothing — which made correctly-copied skills look dropped too.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

No Prisma changes: every column and table the clone now copies already existed.

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots

`POST /agents/:slug/clone` keeps the same request shape, response shape, status
codes and auth. Fields that previously came back empty (`config`, `kbScope`,
`description`, `color`, `modelId`) are now populated — no consumer change needed.

---

## How did you test it?

Reproduced the bug first, then verified the fix end-to-end in the Claw UI at
`localhost:5174` against claw-auth `:3003` and spaces `:3001`, driven by a
scripted Playwright walk-through with hard assertions (recording attached, 59s).

**Before:** cloning **Ask AI** (38 tools selected) gave a copy showing
`Tools 0 of 277`, `config.tools` absent, `skillTriggers` 0, 0 KB grants.

**After** — source vs copy, each verified on its own card in the UI:

| Item | Source → Copy |
|---|---|
| Name, colour & description | `#f59e0b` + description → identical |
| Persona — system prompt | 13,257 chars → 13,257 |
| Tools — `config.tools` palette | 38 selected → 38 |
| Subagents | spaces/artifacts/google → same 3 |
| Knowledge — skills | 8 → 8 (+ 6 `AgentTool` rows) |
| Contextual responses (`skillTriggers`) | 2 → 2 |
| Behaviour — plan mode + reminder | ON + reminder → ON + reminder |
| Knowledge Base — scope + grants | `USER` · 2 grants → `USER` · 2 |
| Connections — MCP + credentials | Amplitude Prod → same, ciphertext byte-identical |

A separate run also cloned a copy **twice** to confirm nothing degrades on a
second hop, and both demo agents were deleted through the UI afterwards
(agent count back to 11, no fixtures left).

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test` <!-- not run: apps/backend untouched -->
- [x] Claw tests — ran the `xyne-claw-auth` backend suite (`npx vitest run`):
      **424 passed / 15 failed**. All 15 failures are pre-existing and unrelated
      (`mention-transform`, `verify-spaces-signature`, `run.cli-bearer`,
      `skills.skill-update`, `external-api/delivery`) — re-ran the same 5 files
      at `HEAD~1` and got the identical 16 failed / 42 passed, so this change
      moves nothing.
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — no automated test committed (test file intentionally
      not added per review direction). Verified instead by a scripted UI
      walk-through with 9 hard assertions; the driver lives outside the repo and
      can be committed as a suite if you want it.

### Manual

**Users**
- [x] Single user
- [ ] Two users at once
- [x] Different roles or permission levels — as a non-owner the button correctly
      offers the **clone request** path ("Send a clone request to this agent's
      owner"); the instant clone was exercised as `CLAW_ADMIN`. The
      owner-approval path calls the same repository function but was **not**
      run end-to-end.
- [ ] Different workspaces / spaces

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev — services started individually (claw-auth backend, spaces
      backend, claw-auth UI), not via `dev:all`
- [ ] Test mode / Sandbox / Prod-like / Docker compose / Electron

**Sync & resilience**
- N/A — no Zero involvement.

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme — both themes were seen incidentally
      (screenshots dark, recording light); narrow viewport not tested
- [x] Empty state — cloning a seeded agent with no KB grants and no MCP
      connections produces the same empty state, no errors
- [ ] Large / realistic data volume
- [ ] Error paths

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes — not run; no shared package touched. Note
      that `packages/storage`'s prepare/build currently fails on a corepack pnpm
      version pin (10.15.0 vs 11.21.0), pre-existing and unrelated.
- [ ] Backend `typecheck` + `build` pass — N/A (`apps/backend` untouched).
      For the package actually changed: `xyne-claw-auth/backend` `tsc --noEmit`
      reports **zero** errors in the files touched; the file's remaining errors
      are pre-existing, from a stale generated Prisma client missing the
      `Experiment*` models.
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass — N/A
      (`apps/dashboard` untouched). `xyne-claw-auth/frontend` `tsc -b` is clean
      and `vite build` succeeds.
- [ ] Formatting clean in the packages I touched — no formatter configured for
      this package; changes follow surrounding style
- [x] New deps added with `pnpm --filter <pkg> add <dep>` — N/A, no new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or
      `feature/*` — `fix: XYNE-56550 clone agents with their full configuration`
      on `fix/clone-agent-full-copy`
- [x] Docs / guidelines updated where behaviour changed — rewrote the
      `cloneAgentForUser` doc block, the route comment, and the user-facing copy
      in the clone dialog, header tooltip and success toast, which all still
      claimed "only the system prompt, tools, and skills"
- [x] No debug logging or commented-out code left behind
[XYNE56550clonewalkthrough.webm](https://github.com/user-attachments/assets/7f7cbf0a-60e1-4c22-a812-9e9a3d154645)
