### PR TITLE
feat: XYNE-55716 daily brief claw changes for PR #763

### DIFF
--- a/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
@@ -5,6 +5,7 @@ import { prisma } from "../db.js";
 import { redisService } from "../redis.js";
 import { createLogger } from "../logger.js";
 import { DAILY_BRIEF_KIND } from "../repositories/index.js";
+import { formatDayIST } from "../lib/ist-time.js";
 
 const log = createLogger("otel-daily-brief");
 
@@ -22,6 +23,26 @@ const REGEN_USERS_KEY = "daily_brief:regen_users";
 const DEFAULT_REJECTED_USERS_KEY = "daily_brief:default_rejected_users";
 /** Users who ever re-ran a brief they had already regenerated once. */
 const REPEAT_REGEN_USERS_KEY = "daily_brief:repeat_regen_users";
+/** Which control the user switched briefs from. Bounded — never widen without checking cardinality. */
+export type BriefSwitchSource = "history_menu" | "date_picker";
+
+/**
+ * Switching briefs is client state the server never sees on its own (the screen
+ * holds the recent window in memory), so the dashboard beacons it here. Counted
+ * by userId in Redis rather than as a metric label: one series per user would be
+ * unbounded cardinality and PII in a store with no per-series access control.
+ */
+const SWITCH_USERS_KEY = "daily_brief:switch_users";
+/** Switch events, not people — one INCR per switch, globally and per control. */
+const SWITCH_COUNT_KEY = "daily_brief:switches";
+const switchSourceCountKey = (source: BriefSwitchSource): string =>
+  `daily_brief:switches:src:${source}`;
+const switchSourceKey = (source: BriefSwitchSource): string =>
+  `daily_brief:switch_users:src:${source}`;
+/** HyperLogLog per day: a windowed distinct count without one Redis member per user per day. */
+const switchDayKey = (dateBucket: string): string => `daily_brief:switch_users:day:${dateBucket}`;
+const SWITCH_DAY_TTL_SECONDS = 35 * 24 * 60 * 60;
+
 /** Per user per day, so we know which attempt a request is. Two days is plenty. */
 const dayAttemptKey = (userId: string, dateBucket: string): string =>
   `daily_brief:regen:${userId}:${dateBucket}`;
@@ -183,6 +204,37 @@ export async function recordDailyBriefRegeneration(
   }
 }
 
+/** Record that a user switched to a different brief, from a given entry point. */
+export async function recordDailyBriefSwitch(
+  userId: string,
+  source: BriefSwitchSource,
+  dateBucket: string,
+): Promise<void> {
+  try {
+    const redis = redisService.getConnection();
+    const dayKey = switchDayKey(dateBucket);
+    await redis
+      .multi()
+      .incr(SWITCH_COUNT_KEY)
+      .incr(switchSourceCountKey(source))
+      .sadd(SWITCH_USERS_KEY, userId)
+      .sadd(switchSourceKey(source), userId)
+      .pfadd(dayKey, userId)
+      .expire(dayKey, SWITCH_DAY_TTL_SECONDS)
+      .exec();
+  } catch {
+    // metrics must never break a request
+  }
+}
+
+/** The last `days` day-bucket keys, newest first — the union PFCOUNT reads. */
+function switchDayKeysBack(days: number): string[] {
+  const now = Date.now();
+  return Array.from({ length: days }, (_, i) =>
+    switchDayKey(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
+  );
+}
+
 /**
  * Global lifetime totals, re-read on every export tick:
  *   daily_brief_users_total   — users who have at least one brief (generated_content)
@@ -216,27 +268,76 @@ export function registerDailyBriefGauges(): void {
   const repeatRegenGauge = meter.createObservableGauge("daily_brief_repeat_regen_users_total", {
     description: "Users who have re-run a brief they had already regenerated",
   });
+  const switchUsersGauge = meter.createObservableGauge("daily_brief_switch_users_total", {
+    description: "Users who have ever switched to a different brief",
+  });
+  const switchUsersWindowGauge = meter.createObservableGauge("daily_brief_switch_users_window", {
+    description: "Distinct users who switched briefs within a trailing window (HyperLogLog, ~0.81% error)",
+  });
+  const switchUsersSourceGauge = meter.createObservableGauge("daily_brief_switch_users_by_source", {
+    description: "Users who have ever switched briefs, by the control they used",
+  });
+  const switchesGauge = meter.createObservableGauge("daily_brief_switches_total", {
+    description: "Brief switches ever served globally (events, not people)",
+  });
+  const switchesSourceGauge = meter.createObservableGauge("daily_brief_switches_by_source", {
+    description: "Brief switches ever served, by the control used (events, not people)",
+  });
 
   meter.addBatchObservableCallback(
     async (result) => {
       try {
         const where = { kind: DAILY_BRIEF_KIND, generatedAt: { not: null } };
         const redis = redisService.getConnection();
-        const [briefs, users, regenerations, regenUsers, defaultRejected, repeatRegen] =
-          await Promise.all([
-            prisma.generatedContent.count({ where }),
-            prisma.generatedContent.groupBy({ by: ["userId"], where }),
-            redis.get(REGEN_COUNT_KEY).catch(() => null),
-            redis.scard(REGEN_USERS_KEY).catch(() => 0),
-            redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
-            redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
-          ]);
+        const [
+          briefs,
+          users,
+          regenerations,
+          regenUsers,
+          defaultRejected,
+          repeatRegen,
+          switchUsers,
+          switch7d,
+          switch30d,
+          switchHistoryMenu,
+          switchDatePicker,
+          switches,
+          switchesHistoryMenu,
+          switchesDatePicker,
+        ] = await Promise.all([
+          prisma.generatedContent.count({ where }),
+          prisma.generatedContent.groupBy({ by: ["userId"], where }),
+          redis.get(REGEN_COUNT_KEY).catch(() => null),
+          redis.scard(REGEN_USERS_KEY).catch(() => 0),
+          redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
+          redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
+          redis.scard(SWITCH_USERS_KEY).catch(() => 0),
+          redis.pfcount(...switchDayKeysBack(7)).catch(() => 0),
+          redis.pfcount(...switchDayKeysBack(30)).catch(() => 0),
+          redis.scard(switchSourceKey("history_menu")).catch(() => 0),
+          redis.scard(switchSourceKey("date_picker")).catch(() => 0),
+          redis.get(SWITCH_COUNT_KEY).catch(() => null),
+          redis.get(switchSourceCountKey("history_menu")).catch(() => null),
+          redis.get(switchSourceCountKey("date_picker")).catch(() => null),
+        ]);
         result.observe(usersGauge, users.length);
         result.observe(briefsGauge, briefs);
         result.observe(regenerationsGauge, Number(regenerations ?? 0));
         result.observe(regenUsersGauge, regenUsers);
         result.observe(defaultRejectedGauge, defaultRejected);
         result.observe(repeatRegenGauge, repeatRegen);
+        result.observe(switchUsersGauge, switchUsers);
+        result.observe(switchUsersWindowGauge, switch7d, { window: "7d" });
+        result.observe(switchUsersWindowGauge, switch30d, { window: "30d" });
+        result.observe(switchUsersSourceGauge, switchHistoryMenu, { source: "history_menu" });
+        result.observe(switchUsersSourceGauge, switchDatePicker, { source: "date_picker" });
+        result.observe(switchesGauge, Number(switches ?? 0));
+        result.observe(switchesSourceGauge, Number(switchesHistoryMenu ?? 0), {
+          source: "history_menu",
+        });
+        result.observe(switchesSourceGauge, Number(switchesDatePicker ?? 0), {
+          source: "date_picker",
+        });
       } catch (err) {
         // OTel swallows a rejected callback silently — log so a broken read is visible.
         log.warn(`[otel] daily-brief gauges skipped: ${err instanceof Error ? err.message : String(err)}`);
@@ -249,6 +350,11 @@ export function registerDailyBriefGauges(): void {
       regenUsersGauge,
       defaultRejectedGauge,
       repeatRegenGauge,
+      switchUsersGauge,
+      switchUsersWindowGauge,
+      switchUsersSourceGauge,
+      switchesGauge,
+      switchesSourceGauge,
     ],
   );
 }

--- a/apps/xyne-claw-auth/backend/src/repositories/generatedContentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/generatedContentRepository.ts
@@ -29,6 +29,15 @@ export const generatedContentRepository = {
       take: limit,
     }),
 
+  /** Day buckets + status only (no content) — powers the brief date picker. */
+  findDateBuckets: (userId: string, kind: string, limit = 365) =>
+    prisma.generatedContent.findMany({
+      where: { userId, kind },
+      orderBy: [{ dateBucket: "desc" }],
+      take: limit,
+      select: { dateBucket: true, status: true },
+    }),
+
   /** Mark generation as started (idempotent per day) so a fetch can show "generating". */
   markGenerating: (params: {
     userId: string;

--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -16,7 +16,11 @@ import {
   DAILY_BRIEF_SLUG,
   type DailyBriefPayload,
 } from "../services/dailyBrief.js";
-import { recordDailyBriefRegeneration } from "../otel/daily-brief-metrics.js";
+import {
+  recordDailyBriefRegeneration,
+  recordDailyBriefSwitch,
+  type BriefSwitchSource,
+} from "../otel/daily-brief-metrics.js";
 
 const log = createLogger("daily-brief-routes");
 const MAX_INSTRUCTIONS = 8000;
@@ -181,6 +185,90 @@ router.get("/history", async (req: Request, res: Response) => {
   } catch (err) {
     log.error("[daily-brief] get history", err);
     res.status(500).json({ success: false, error: "Failed to load daily brief history" });
+  }
+});
+
+/** GET /dates — every day the user has a brief for, newest first (date + status, no content). */
+router.get("/dates", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    const limitRaw = Number(req.query.limit);
+    const limit = Number.isFinite(limitRaw)
+      ? Math.min(Math.max(Math.trunc(limitRaw), 1), 1000)
+      : 365;
+    const rows = await generatedContentRepository.findDateBuckets(userId, DAILY_BRIEF_KIND, limit);
+    res.json({
+      success: true,
+      data: rows.map((row) => ({ date: row.dateBucket, status: row.status })),
+    });
+  } catch (err) {
+    log.error("[daily-brief] get dates", err);
+    res.status(500).json({ success: false, error: "Failed to load daily brief dates" });
+  }
+});
+
+/** GET /by-date/:date — the stored brief for one YYYY-MM-DD bucket. */
+router.get("/by-date/:date", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    const date = String(req.params.date ?? "");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      res.status(400).json({ success: false, error: "date must be YYYY-MM-DD" });
+      return;
+    }
+    const row = await generatedContentRepository.findForBucket(userId, DAILY_BRIEF_KIND, date);
+    if (!row) {
+      res.json({ success: true, data: { status: "none", date } });
+      return;
+    }
+    res.json({
+      success: true,
+      data: {
+        status: row.status,
+        date: row.dateBucket,
+        content: row.content,
+        data: row.data,
+        agentSlug: row.agentSlug,
+        generatedAt: row.generatedAt,
+        isToday: row.dateBucket === briefDateBucket(),
+      },
+    });
+  } catch (err) {
+    log.error("[daily-brief] get by date", err);
+    res.status(500).json({ success: false, error: "Failed to load daily brief" });
+  }
+});
+
+/**
+ * POST /switched — beacon for "this user switched to another brief". The screen
+ * holds the recent window in memory, so most switches never hit the server and
+ * cannot be inferred from any other route.
+ */
+router.post("/switched", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    // Coerced, not validated: `source` is client-supplied and lands on a metric
+    // label, so an unknown value must collapse into a known one rather than
+    // open the label up to arbitrary cardinality.
+    const body = req.body as { source?: unknown };
+    const source: BriefSwitchSource = body.source === "date_picker" ? "date_picker" : "history_menu";
+    await recordDailyBriefSwitch(userId, source, briefDateBucket());
+    res.status(204).end();
+  } catch (err) {
+    log.error("[daily-brief] post switched", err);
+    res.status(500).json({ success: false, error: "Failed to record brief switch" });
   }
 });
 


### PR DESCRIPTION
Ports the `xyne-claw-auth` slice of #763 (improve metrics, add feature dialog and banner) onto `feature/deploy-xyneclaw`, mirroring the split pattern used by #598 for #465.

### What this contains
Only the claw-auth backend changes needed by #763 — the spaces backend / dashboard / Grafana parts of #763 already merged to `main`.

- `apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts` — record + export brief-switch metrics: distinct switching users (Redis `SADD`), a trailing-window distinct count (HyperLogLog `PFADD`/`PFCOUNT`), and switch-event counters by source control (`history_menu` / `date_picker`). Source is bounded to avoid unbounded metric-label cardinality.
- `apps/xyne-claw-auth/backend/src/repositories/generatedContentRepository.ts` — `findDateBuckets` (date + status, no content) powering the brief date picker.
- `apps/xyne-claw-auth/backend/src/routes/daily-brief.ts` — `GET /dates`, `GET /by-date/:date`, and `POST /switched` (beacon; `source` coerced to a known value before it lands on a metric label).

### Notes
- Reference PRs: #763 (main), #598 (claw side of #465), #465 (main daily-brief feature).
- No new dependencies — `formatDayIST`, `findForBucket`, and `briefDateBucket` already exist on `feature/deploy-xyneclaw` from #598.
- Requires redeploy of: xyne-claw-auth.