### PR TITLE
fix: XYNE-56551 adding husky and ci check to avoid default case in acls

### DIFF
--- a/apps/backend/src/database/acl/acl-factory.ts
+++ b/apps/backend/src/database/acl/acl-factory.ts
@@ -499,7 +499,7 @@ export class ACLFactory {
       return new BaseQueryACL(ctx, prisma)
     case 'entityAlias':
       return new BaseQueryACL(ctx, prisma)
-    default:
+    case 'deskAutoLabelRuleReference':
       return new BaseQueryACL(ctx, prisma)
     }
   }

--- a/scripts/validate-workspace-id.sh
+++ b/scripts/validate-workspace-id.sh
@@ -15,12 +15,30 @@
 # Escape hatch: a model that is intentionally global/cross-tenant (e.g. a shared
 # lookup table) can opt out by placing `// workspace-check:ignore` on the line
 # directly above `model X {`.
+#
+# No-Default-ACL Guard
+#
+# The ACL factory switches (see ACL_FACTORY_PATHS below) must enumerate every
+# table with an explicit `case`. A `default:` branch returning BaseQueryACL /
+# BaseACL lets a brand-new table silently inherit generic base-class scoping
+# without the author — or any reviewer — ever making a deliberate access
+# decision for that table. There is no escape hatch for this one: remove the
+# `default:` branch and add an explicit `case` per table (a purpose-built ACL
+# class, or an explicit BaseQueryACL/UnscopedACL choice).
 
 set -e
 
 SCHEMA_PATHS=(
     "apps/backend/prisma/schema.prisma"
     "apps/xyne-claw-auth/backend/prisma/schema.prisma"
+)
+
+# ACL factory switches that must enumerate every table explicitly — a `default:`
+# branch in any of these files is a blocking failure.
+ACL_FACTORY_PATHS=(
+    "apps/backend/src/database/acl/acl-factory.ts"
+    "apps/backend/src/zero/acl/core/acl-factory.ts"
+    "packages/shared/src/zero/acl/core/query-acl-factory.ts"
 )
 
 if [ -t 1 ]; then
@@ -154,13 +172,74 @@ validate_workspace_id() {
     return 0
 }
 
+# Staged (or working-tree fallback) content of an arbitrary file, so the check
+# matches what would actually be committed.
+get_file_content() {
+    local file="$1"
+    git show ":$file" 2>/dev/null || cat "$file" 2>/dev/null || echo ""
+}
+
+# No-Default-ACL guard: the factory switches must list every table with an
+# explicit `case`. A `default:` branch returning a base ACL means a new table
+# gets generic scoping without anyone deliberately choosing its access rules.
+validate_no_default_acl() {
+    local has_errors=false
+
+    for factory_file in "${ACL_FACTORY_PATHS[@]}"; do
+        if [ ! -f "$factory_file" ]; then
+            log_warning "$factory_file not found — skipping its default-branch check."
+            continue
+        fi
+
+        local matches
+        matches=$(get_file_content "$factory_file" | grep -nE '^[[:space:]]*default[[:space:]]*:' || true)
+
+        if [ -n "$matches" ]; then
+            has_errors=true
+            log_error "$factory_file has a 'default:' branch in the ACL factory switch:"
+            while IFS= read -r match; do
+                echo "    ${match}"
+            done <<< "$matches"
+        fi
+    done
+
+    if [ "$has_errors" = true ]; then
+        echo ""
+        echo "ACL factory switches must enumerate every table explicitly:"
+        echo "  Remove the 'default:' branch and add an explicit 'case' for each table"
+        echo "  (a purpose-built ACL class, or an explicit BaseQueryACL/UnscopedACL choice),"
+        echo "  so every table's access rule is a deliberate, reviewable decision."
+        echo ""
+        return 1
+    fi
+
+    log_success "No 'default:' branch found in ACL factory switches."
+    return 0
+}
+
 # Skip validation if HUSKY=0 (for automated commits)
 if [ "${HUSKY:-}" = "0" ]; then
-    log_info "HUSKY=0 detected, skipping workspaceId validation"
+    log_info "HUSKY=0 detected, skipping workspaceId/ACL-factory validation"
     exit 0
 fi
 
-if ! validate_workspace_id; then
+failed_guards=()
+
+log_info "━━━ Guard 1/2: tenant-key (workspaceId/orgId) on new models ━━━"
+validate_workspace_id || failed_guards+=("workspaceId/orgId tenant-key check")
+
+echo ""
+log_info "━━━ Guard 2/2: no 'default:' branch in ACL factory switches ━━━"
+validate_no_default_acl || failed_guards+=("no-default-ACL check")
+
+if [ ${#failed_guards[@]} -gt 0 ]; then
+    echo ""
+    log_error "Guard(s) failed:"
+    for guard in "${failed_guards[@]}"; do
+        echo "  ❌ $guard"
+    done
+    echo ""
+    echo "See the detailed error output above for each failed guard."
     exit 1
 fi
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
