### PR TITLE
feat: XYNE-56557 Create Google doc list for recordi

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -48,6 +48,7 @@ import { noteTakerTranscriptService } from '@/services/noteTakerTranscriptServic
 import { summaryTemplateService } from '@/services/summaryTemplateService';
 import { canvasAuthService } from '@/services/canvasAuthService';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
+import { readRecordingGoogleDocLinks } from '@/utils/recordingGoogleDocs';
 
 const UpdateHeadlessRecordingSchema = z
   .object({
@@ -1407,6 +1408,8 @@ export class CallController {
             typeof callMetadata?.linkedTicketMessageId === 'string'
               ? callMetadata.linkedTicketMessageId
               : null,
+          // Google Docs exported from this recording's summary, newest first.
+          googleDocs: readRecordingGoogleDocLinks(call.metadata),
           citationSegments,
           hasRecording: !!uploadedRecording,
         },

--- a/apps/backend/src/controllers/recordingGoogleDocController.ts
+++ b/apps/backend/src/controllers/recordingGoogleDocController.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import { Prisma } from '@prisma/client';
 import { google } from 'googleapis';
 import z from 'zod';
 import { db } from '@/database/client';
@@ -8,6 +9,12 @@ import { decrypt, encrypt } from '@/services/encryptionService';
 import { convertBlockNoteToMarkdown } from '@/services/canvasService';
 import { GoogleDocsApiError, googleDocsService } from '@/services/googleDocsService';
 import { readFromYSweet } from '@/utils/ysweetUtils';
+import {
+  appendRecordingGoogleDocLink,
+  readRecordingGoogleDocLinks,
+  recordingGoogleDocUrl,
+  type RecordingGoogleDocLink,
+} from '@/utils/recordingGoogleDocs';
 import { markdownToPlainText } from '@/utils/markdownToPlainText';
 import { logger } from '@/utils/logger';
 
@@ -15,6 +22,11 @@ const RECORDING_DOC_SOURCE_TYPE = 'google-recording-doc';
 const HEADLESS_CALL_TYPE = 'HEADLESS';
 const RecordingGoogleDocParamsSchema = z.object({
   callId: z.string().trim().min(1, 'Recording ID is required'),
+});
+
+/** The export modal lets the owner rename the doc before it is created. */
+const RecordingGoogleDocExportBodySchema = z.object({
+  title: z.string().trim().min(1).max(240).optional(),
 });
 
 function recordingTitle(value: string | null): string {
@@ -61,6 +73,37 @@ async function readDetailedSummary(
   const storedBlocks = Array.isArray(canvas.content) ? canvas.content : [];
   const blocks = ySweetBlocks.length > 0 ? ySweetBlocks : storedBlocks;
   return blocks.length > 0 ? convertBlockNoteToMarkdown(blocks) : null;
+}
+
+/**
+ * Appends a created doc to `calls.metadata.googleDocs`.
+ *
+ * Metadata is re-read here rather than reused from the request-scoped call row:
+ * summary generation and ticket linking write to the same JSON blob, and the
+ * export can take several seconds, so a stale copy would silently drop their keys.
+ */
+async function recordCreatedGoogleDoc(
+  callId: string,
+  link: RecordingGoogleDocLink,
+): Promise<void> {
+  const current = await db.call.findUnique({ where: { id: callId }, select: { metadata: true } });
+  const metadata =
+    current?.metadata && typeof current.metadata === 'object' && !Array.isArray(current.metadata)
+      ? (current.metadata as Prisma.InputJsonObject)
+      : {};
+
+  await db.call.update({
+    where: { id: callId },
+    data: {
+      metadata: {
+        ...metadata,
+        googleDocs: appendRecordingGoogleDocLink(
+          readRecordingGoogleDocLinks(current?.metadata ?? null),
+          link,
+        ),
+      } as Prisma.InputJsonValue,
+    },
+  });
 }
 
 export class RecordingGoogleDocController {
@@ -111,6 +154,10 @@ export class RecordingGoogleDocController {
         success: true,
         canExport,
         summary: summary ? markdownToPlainText(summary) : null,
+        // Docs already exported from this recording, newest first — the preview
+        // modal lists them so a second export is a deliberate choice, not a
+        // duplicate someone makes because the earlier doc is out of sight.
+        documents: readRecordingGoogleDocLinks(call.metadata),
         unavailableReason: 'Connect Google Docs to create a document from this recording.',
       });
     } catch (error) {
@@ -184,7 +231,12 @@ export class RecordingGoogleDocController {
         return;
       }
 
-      const title = recordingTitle(call.title);
+      const parsedBody = RecordingGoogleDocExportBodySchema.safeParse(req.body ?? {});
+      if (!parsedBody.success) {
+        res.status(400).json({ success: false, error: 'Document title is invalid' });
+        return;
+      }
+      const title = recordingTitle(parsedBody.data.title ?? call.title);
       const content = markdownToPlainText(summary).slice(0, 900_000);
       let documentId: string;
       try {
@@ -218,10 +270,28 @@ export class RecordingGoogleDocController {
         return;
       }
 
+      const document: RecordingGoogleDocLink = {
+        documentId,
+        title,
+        url: recordingGoogleDocUrl(documentId),
+        createdAt: new Date().toISOString(),
+        createdByUserId: userId,
+      };
+      // Best effort: the doc exists either way, so a metadata write failure must not
+      // fail the export — it only costs this doc its place in the recording's list.
+      await recordCreatedGoogleDoc(call.id, document).catch((error) => {
+        logger.error('[RecordingGoogleDoc] Failed to record created document on the call', {
+          callId,
+          documentId,
+          error,
+        });
+      });
+
       res.json({
         success: true,
         documentId,
-        documentUrl: `https://docs.google.com/document/d/${documentId}/edit`,
+        documentUrl: document.url,
+        document,
       });
     } catch (error) {
       logger.error('[RecordingGoogleDoc] Failed to export recording', { callId, userId, error });

--- a/apps/backend/src/utils/recordingGoogleDocs.ts
+++ b/apps/backend/src/utils/recordingGoogleDocs.ts
@@ -1,0 +1,72 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * A Google Doc created from a recording's summary.
+ *
+ * Stored on `calls.metadata.googleDocs` because the Docs API hands back the
+ * document id exactly once — at creation time. Persisting it is the only way the
+ * recording screen can list every doc that was ever exported from a recording.
+ */
+// A type alias rather than an interface on purpose: only aliases carry an implicit
+// index signature, which is what lets these entries be written straight into a
+// Prisma JSON column without an `unknown` cast.
+export type RecordingGoogleDocLink = {
+  documentId: string;
+  title: string;
+  url: string;
+  /** ISO timestamp of when the doc was created. */
+  createdAt: string;
+  createdByUserId: string;
+};
+
+/** Keeps the metadata blob bounded — this is a recent-history list, not an archive. */
+const MAX_RECORDING_GOOGLE_DOCS = 50;
+
+const DEFAULT_DOC_TITLE = 'Untitled document';
+
+export const recordingGoogleDocUrl = (documentId: string): string =>
+  `https://docs.google.com/document/d/${documentId}/edit`;
+
+function toGoogleDocLink(value: unknown): RecordingGoogleDocLink | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const entry = value as Record<string, unknown>;
+  const documentId = typeof entry.documentId === 'string' ? entry.documentId.trim() : '';
+  if (!documentId) return null;
+
+  const title = typeof entry.title === 'string' ? entry.title.trim() : '';
+  const url = typeof entry.url === 'string' ? entry.url.trim() : '';
+  return {
+    documentId,
+    title: title || DEFAULT_DOC_TITLE,
+    url: url || recordingGoogleDocUrl(documentId),
+    createdAt: typeof entry.createdAt === 'string' ? entry.createdAt : '',
+    createdByUserId: typeof entry.createdByUserId === 'string' ? entry.createdByUserId : '',
+  };
+}
+
+/**
+ * Reads the exported-docs list off `calls.metadata`, dropping malformed entries so a
+ * hand-edited or legacy metadata blob can never break the recording detail response.
+ */
+export function readRecordingGoogleDocLinks(
+  metadata: Prisma.JsonValue | null | undefined,
+): RecordingGoogleDocLink[] {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return [];
+  const raw = (metadata as Record<string, unknown>).googleDocs;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    const link = toGoogleDocLink(entry);
+    return link ? [link] : [];
+  });
+}
+
+/** Newest first, deduped by document id, capped at {@link MAX_RECORDING_GOOGLE_DOCS}. */
+export function appendRecordingGoogleDocLink(
+  existing: RecordingGoogleDocLink[],
+  link: RecordingGoogleDocLink,
+): RecordingGoogleDocLink[] {
+  return [link, ...existing.filter((entry) => entry.documentId !== link.documentId)].slice(
+    0,
+    MAX_RECORDING_GOOGLE_DOCS,
+  );
+}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -69,6 +69,10 @@ import { SummaryGenerationPanel } from './components/SummaryGenerationPill/Summa
 import { PostRecordingToChannelModal } from './components/PostRecordingToChannelModal';
 import { PostRecordingToEmailModal } from './components/PostRecordingToEmailModal';
 import { GoogleDocPreviewModal } from './components/GoogleDocPreviewModal';
+import {
+  RecordingGoogleDocsList,
+  parseRecordingGoogleDocLinks,
+} from './components/RecordingGoogleDocsList';
 import { CollaborativeCanvasEditor } from '../../components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
@@ -171,7 +175,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
   // panel is opened from the toolbar with no particular moment in mind.
   const [citationRef, setCitationRef] = useState<TranscriptPanelTarget | null>(null);
 
-  const exportGoogleDoc = async (): Promise<void> => {
+  const exportGoogleDoc = async (documentTitle?: string): Promise<void> => {
     if (!recording || isExportingGoogleDoc) return;
 
     // Opening synchronously keeps this user-initiated navigation from being blocked by browsers.
@@ -180,11 +184,31 @@ export default function RecordingDetailV2Screen(): ReactElement {
 
     setIsExportingGoogleDoc(true);
     try {
-      const { documentUrl } = await recordingService.exportGoogleDoc(recording.externalId);
+      const { documentUrl, document: createdDocument } = await recordingService.exportGoogleDoc(
+        recording.externalId,
+        documentTitle,
+      );
       if (documentWindow) {
         documentWindow.location.assign(documentUrl);
       } else {
         window.open(documentUrl, '_blank', 'noopener,noreferrer');
+      }
+      // Zero replays the metadata write too, but only after the row round-trips —
+      // the list should show the doc the moment its tab opens.
+      if (createdDocument) {
+        setRecording(prev =>
+          prev
+            ? {
+                ...prev,
+                googleDocs: [
+                  createdDocument,
+                  ...(prev.googleDocs ?? []).filter(
+                    entry => entry.documentId !== createdDocument.documentId,
+                  ),
+                ],
+              }
+            : prev,
+        );
       }
       toast.success('Google Doc created');
       setShowGoogleDocPreviewModal(false);
@@ -390,6 +414,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
       const rawDetailedSummaryCanvasId = metadata?.['detailedSummaryCanvasId'];
       const rawDetailedSummaryReady = metadata?.['detailedSummaryReady'];
       const rawNotesCanvasId = metadata?.['notesCanvasId'] ?? metadata?.['notesCanvasViewAccessId'];
+      const googleDocs = parseRecordingGoogleDocLinks(metadata?.['googleDocs']);
       const next: RecordingDetail = {
         ...prev,
         title: recordingRow.title || prev.title,
@@ -407,6 +432,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
             : prev.detailedSummaryReady,
         notesCanvasId:
           prev.notesCanvasId ?? (typeof rawNotesCanvasId === 'string' ? rawNotesCanvasId : null),
+        // An empty list here means metadata hasn't carried the key yet (older
+        // recording, or the export write is still in flight) — keep what we have.
+        googleDocs: googleDocs.length > 0 ? googleDocs : (prev.googleDocs ?? []),
         markedItems: recordingRow.markedItems ?? prev.markedItems,
         summaryTemplateId: recordingRow.summaryTemplateId ?? prev.summaryTemplateId ?? null,
         aiSummary: recordingRow.aiSummary ?? prev.aiSummary,
@@ -1048,6 +1076,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
                   onReadTranscript={transcriptText ? openTranscriptPanel : undefined}
                 />
               )}
+              {/* Owner-only: the docs live in the owner's Drive, so these links are
+                  dead ends for anyone the recording was merely shared with. */}
+              {isOwner ? <RecordingGoogleDocsList documents={recording.googleDocs ?? []} /> : null}
             </section>
           )}
         </div>
@@ -1109,7 +1140,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
           onOpenChange={open => !open && setShowGoogleDocPreviewModal(false)}
           title='Preview Google Doc'
           description='Review the recording summary before creating a Google Doc.'
-          className='max-w-[760px] overflow-hidden rounded-xl p-0'
+          className='max-w-[720px] overflow-hidden rounded-[18px] p-0'
           testId='google-doc-preview-dialog'
         >
           <GoogleDocPreviewModal

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/GoogleDocPreviewModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/GoogleDocPreviewModal.tsx
@@ -1,17 +1,56 @@
-import { type ReactElement, useEffect, useState } from 'react';
-import { FileText, LockKeyhole, X } from 'lucide-react';
+import { type MouseEvent, type ReactElement, useEffect, useState } from 'react';
+import {
+  Check,
+  ChevronDown,
+  ExternalLink,
+  File as FileIcon,
+  Link as LinkIcon,
+  LockKeyhole,
+  Plus,
+  SquareArrowOutUpRight,
+  X,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '../../../components/ui/Button/Button';
+import Input from '../../../components/ui/Input/Input';
 import {
   recordingService,
   type RecordingDetail,
   type RecordingGoogleDocComposeContext,
+  type RecordingGoogleDocLink,
 } from '../../../services/Recording/recordingService';
+import { formatDate, formatThreadTimestamp } from '../../../utils/dateUtils';
+import { openLink } from '../../../utils/openLink';
+
+/** Newest first, deduped by document id. */
+function mergeGoogleDocLinks(
+  ...lists: Array<RecordingGoogleDocLink[] | undefined>
+): RecordingGoogleDocLink[] {
+  const byId = new Map<string, RecordingGoogleDocLink>();
+  for (const link of lists.flatMap(list => list ?? [])) {
+    if (!byId.has(link.documentId)) byId.set(link.documentId, link);
+  }
+  return [...byId.values()].sort(
+    (a, b) => (Date.parse(b.createdAt) || 0) - (Date.parse(a.createdAt) || 0),
+  );
+}
+
+/** Legacy/hand-edited metadata can carry an unparseable timestamp — show nothing rather than throw. */
+function formatDocTimestamp(createdAt: string, style: 'date' | 'relative'): string | null {
+  const timestamp = Date.parse(createdAt);
+  if (Number.isNaN(timestamp)) return null;
+  return style === 'date' ? formatDate(timestamp) : formatThreadTimestamp(timestamp);
+}
+
+const LABEL_CLASS = 'text-[11px] font-semibold uppercase tracking-[0.4px] text-muted-foreground';
+
+const CONNECT_PROMPT = 'Connect Google Docs to create a document from this recording.';
 
 interface GoogleDocPreviewModalProps {
   recording: RecordingDetail;
   onClose: () => void;
-  onExport: () => Promise<void>;
+  /** Creates the doc; `title` names it. Rejects so this modal can surface the reason. */
+  onExport: (title?: string) => Promise<void>;
   isExporting: boolean;
 }
 
@@ -24,6 +63,8 @@ export function GoogleDocPreviewModal({
   const [context, setContext] = useState<RecordingGoogleDocComposeContext | null>(null);
   const [contextError, setContextError] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
+  const [title, setTitle] = useState(() => recording.title?.trim() || 'Untitled Recording');
+  const [earlierOpen, setEarlierOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -69,7 +110,7 @@ export function GoogleDocPreviewModal({
 
   const createGoogleDoc = async (): Promise<void> => {
     try {
-      await onExport();
+      await onExport(title.trim() || undefined);
     } catch (error) {
       const message =
         (error as { response?: { data?: { error?: string } } })?.response?.data?.error ||
@@ -78,92 +119,240 @@ export function GoogleDocPreviewModal({
         canExport: false,
         unavailableReason: message,
         summary: context?.summary ?? null,
+        documents: context?.documents ?? [],
       });
     }
   };
 
-  const title = recording.title?.trim() || 'Untitled Recording';
+  const openDoc = (event: MouseEvent<HTMLAnchorElement>, url: string): void => {
+    event.preventDefault();
+    openLink(url, event);
+  };
+
+  const copyDocLink = async (url: string): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('Link copied');
+    } catch {
+      toast.error('Could not copy the link');
+    }
+  };
+
   const summary = context?.summary?.replace(/\[clf-\d+\]/gi, '').trim();
+  // The recording row carries a doc the moment it is created, so it can be ahead
+  // of the fetched context when this modal is reopened right after an export.
+  const documents = mergeGoogleDocLinks(recording.googleDocs, context?.documents);
+  const [latestDoc, ...earlierDocs] = documents;
+  const isTitleEmpty = title.trim().length === 0;
+  // Either the account was never connected, or the export just came back saying the
+  // Docs scope is missing. Both leave nothing to create, so the footer becomes the
+  // connect step instead of showing a create button that cannot succeed.
+  const needsConnection = !!context && !context.canExport;
 
   return (
     <div
       className='flex max-h-[88vh] w-full flex-col bg-background'
       data-testid='google-doc-preview-modal'
     >
-      <header className='flex items-start justify-between gap-4 border-b border-border px-6 py-5 sm:px-8'>
-        <div className='flex items-start gap-3'>
-          <div className='mt-0.5 flex size-10 items-center justify-center rounded-lg border border-border bg-muted/50 text-muted-foreground'>
-            <FileText className='size-5' aria-hidden='true' />
-          </div>
-          <div>
-            <h2 className='text-lg font-semibold leading-6 text-foreground'>Preview Google Doc</h2>
-            <p className='mt-0.5 text-sm text-muted-foreground'>
-              Review the recording summary before creating the document.
-            </p>
-          </div>
+      <header className='flex flex-shrink-0 items-start gap-3 border-b border-border px-5 py-4'>
+        <span className='flex size-[34px] shrink-0 items-center justify-center rounded-[9px] border border-border bg-background text-[#1a73e8] dark:text-[#8ab4f8]'>
+          <FileIcon className='size-[18px]' aria-hidden='true' />
+        </span>
+        <div className='min-w-0 flex-1 pt-px'>
+          <h2 className='text-[15.5px] font-semibold leading-6 tracking-[-0.01em] text-foreground'>
+            Export to Google Doc
+          </h2>
+          <p className='mt-0.5 text-[12.5px] text-muted-foreground'>
+            Review the recording summary before creating the document.
+          </p>
         </div>
         <button
           type='button'
           onClick={onClose}
           disabled={isExporting || isConnecting}
-          className='-mr-1 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50'
+          className='inline-flex size-[30px] shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50'
           aria-label='Close Google Docs preview'
           data-track-category='RecordingDetailV2'
           data-track-name='close_google_doc_preview'
         >
-          <X className='size-5' aria-hidden='true' />
+          <X className='size-[15px]' aria-hidden='true' />
         </button>
       </header>
 
-      <div className='min-h-0 flex-1 overflow-y-auto px-6 py-5 sm:px-8'>
-        <p className='text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
-          Document title
-        </p>
-        <h3 className='mt-1 text-base font-semibold text-foreground'>{title}</h3>
-        <div className='mt-5 rounded-lg border border-border bg-muted/20 p-4'>
-          <p className='mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
-            Summary
-          </p>
-          <div className='max-h-[42vh] overflow-y-auto whitespace-pre-wrap text-sm leading-6 text-foreground'>
-            {context ? summary || 'No summary is available to export.' : 'Preparing preview…'}
+      <div className='min-h-0 flex-1 overflow-y-auto px-5 py-[18px]'>
+        {latestDoc ? (
+          <div
+            className='mb-5 flex items-center gap-3 rounded-[13px] border border-emerald-300/70 bg-emerald-50 p-3.5 dark:border-emerald-500/40 dark:bg-emerald-950/25'
+            data-testid='google-doc-latest-export'
+          >
+            <span className='inline-flex size-8 shrink-0 items-center justify-center rounded-[9px] border border-emerald-300/70 bg-background text-status-success dark:border-emerald-500/40'>
+              <Check className='size-4' aria-hidden='true' />
+            </span>
+            <div className='min-w-0 flex-1'>
+              <div className='flex items-center gap-[7px]'>
+                <span className='truncate text-[13.5px] font-semibold text-foreground'>
+                  {latestDoc.title}
+                </span>
+                <span className='shrink-0 rounded-full border border-emerald-300/70 px-[7px] py-0.5 text-[9.5px] font-medium uppercase tracking-[0.3px] text-status-success dark:border-emerald-500/40'>
+                  Latest
+                </span>
+              </div>
+              <p className='mt-[3px] text-[11.5px] text-muted-foreground'>
+                {formatDocTimestamp(latestDoc.createdAt, 'relative')
+                  ? `Already exported ${formatDocTimestamp(latestDoc.createdAt, 'relative')} · Google Docs`
+                  : 'Already exported to Google Docs'}
+              </p>
+            </div>
+            <button
+              type='button'
+              onClick={() => void copyDocLink(latestDoc.url)}
+              title='Copy link'
+              aria-label='Copy document link'
+              className='inline-flex size-[30px] shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground hover:border-muted-foreground/60 hover:text-foreground'
+              data-track-category='RecordingDetailV2'
+              data-track-name='copy_recording_google_doc_link'
+            >
+              <LinkIcon className='size-[15px]' aria-hidden='true' />
+            </button>
+            <a
+              href={latestDoc.url}
+              target='_blank'
+              rel='noopener noreferrer'
+              onClick={event => openDoc(event, latestDoc.url)}
+              className='inline-flex shrink-0 items-center gap-[7px] rounded-[9px] bg-foreground px-3 py-2 text-[12.5px] font-semibold text-background hover:opacity-90'
+              data-track-category='RecordingDetailV2'
+              data-track-name='open_recording_google_doc'
+            >
+              Open doc
+              <SquareArrowOutUpRight className='size-3.5' aria-hidden='true' />
+            </a>
           </div>
+        ) : null}
+
+        {earlierDocs.length > 0 ? (
+          <div className='mb-5'>
+            <button
+              type='button'
+              onClick={() => setEarlierOpen(open => !open)}
+              className={`flex items-center gap-1.5 pb-2 ${LABEL_CLASS} hover:text-foreground`}
+              aria-expanded={earlierOpen}
+              data-track-category='RecordingDetailV2'
+              data-track-name='toggle_earlier_google_doc_exports'
+            >
+              <ChevronDown
+                className={`size-3 shrink-0 transition-transform ${earlierOpen ? '' : '-rotate-90'}`}
+                aria-hidden='true'
+              />
+              <span>Earlier exports · {earlierDocs.length}</span>
+            </button>
+            {earlierOpen ? (
+              <ul className='divide-y divide-border/70 overflow-hidden rounded-xl border border-border'>
+                {earlierDocs.map(doc => (
+                  <li key={doc.documentId} className='flex items-center gap-[11px] px-3 py-2.5'>
+                    <span className='inline-flex size-[26px] shrink-0 items-center justify-center rounded-[7px] border border-border bg-muted/40'>
+                      <FileIcon className='size-3.5 text-muted-foreground' aria-hidden='true' />
+                    </span>
+                    <span className='min-w-0 flex-1 truncate text-[13px] text-foreground'>
+                      {doc.title}
+                    </span>
+                    {formatDocTimestamp(doc.createdAt, 'date') ? (
+                      <span className='shrink-0 font-mono text-[11px] text-muted-foreground'>
+                        {formatDocTimestamp(doc.createdAt, 'date')}
+                      </span>
+                    ) : null}
+                    <a
+                      href={doc.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      onClick={event => openDoc(event, doc.url)}
+                      className='inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted'
+                      data-track-category='RecordingDetailV2'
+                      data-track-name='open_recording_google_doc'
+                    >
+                      Open
+                      <ExternalLink className='size-3' aria-hidden='true' />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        ) : null}
+
+        <label className={`mb-[7px] block ${LABEL_CLASS}`} htmlFor='google-doc-title'>
+          Document title
+        </label>
+        <Input
+          id='google-doc-title'
+          variant='flat'
+          value={title}
+          onChange={event => setTitle(event.target.value)}
+          maxLength={240}
+          aria-invalid={isTitleEmpty}
+          className='h-auto py-2.5 text-sm font-semibold tracking-[-0.01em]'
+          data-testid='google-doc-title-input'
+        />
+
+        <p className={`mb-[7px] mt-[18px] ${LABEL_CLASS}`}>Summary preview</p>
+        <div className='max-h-[320px] overflow-y-auto whitespace-pre-wrap text-[13px] leading-[1.6] text-foreground'>
+          {context ? summary || 'No summary is available to export.' : 'Preparing preview…'}
         </div>
 
         {contextError ? <p className='mt-4 text-sm text-destructive'>{contextError}</p> : null}
-        {context && !context.canExport ? (
-          <div className='mt-4 flex gap-2 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-3 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/30 dark:text-amber-100'>
-            <LockKeyhole className='mt-0.5 size-4 shrink-0' aria-hidden='true' />
-            <div className='flex min-w-0 flex-1 flex-wrap items-center justify-between gap-3'>
-              <p>{context.unavailableReason}</p>
-              <Button
-                size='sm'
-                variant='outline'
-                onClick={() => void connectGoogleDoc()}
-                disabled={isConnecting}
-                loading={isConnecting}
-                data-track-category='RecordingDetailV2'
-                data-track-name='recording_google_doc_connect_calendar'
-              >
-                Connect Google Docs
-              </Button>
-            </div>
-          </div>
-        ) : null}
       </div>
 
-      <footer className='flex items-center justify-end gap-2 border-t border-border px-6 py-4 sm:px-8'>
-        <Button variant='outline' onClick={onClose} disabled={isExporting || isConnecting}>
-          Cancel
-        </Button>
-        <Button
-          onClick={() => void createGoogleDoc()}
-          disabled={!context?.canExport || !!contextError || isConnecting}
-          loading={isExporting}
-          data-track-category='RecordingDetailV2'
-          data-track-name='create_recording_google_doc'
-        >
-          Create Google Doc
-        </Button>
+      <footer className='flex flex-shrink-0 items-center gap-3 border-t border-border bg-muted/30 px-[18px] py-3'>
+        {needsConnection ? (
+          <>
+            <p className='flex min-w-0 flex-1 items-start gap-2 text-[11.5px] text-amber-700 dark:text-amber-200'>
+              <LockKeyhole className='mt-px size-3.5 shrink-0' aria-hidden='true' />
+              <span>{context?.unavailableReason ?? CONNECT_PROMPT}</span>
+            </p>
+            <Button
+              className='bg-foreground text-background hover:bg-foreground/90'
+              onClick={() => void connectGoogleDoc()}
+              disabled={isConnecting}
+              loading={isConnecting}
+              data-track-category='RecordingDetailV2'
+              data-track-name='recording_google_doc_connect_calendar'
+            >
+              Connect Google Docs
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className='min-w-0 flex-1 text-[11.5px] text-muted-foreground'>
+              {latestDoc
+                ? 'A new doc is created as a separate copy — the existing one stays as it is.'
+                : null}
+            </p>
+            <Button variant='outline' onClick={onClose} disabled={isExporting}>
+              Cancel
+            </Button>
+            <Button
+              variant={latestDoc ? 'outline' : 'default'}
+              // The design's create action is the inverted (foreground) button, not the
+              // red primary — `default` only carries the size/shape here.
+              className={
+                latestDoc ? undefined : 'bg-foreground text-background hover:bg-foreground/90'
+              }
+              onClick={() => void createGoogleDoc()}
+              disabled={!context?.canExport || !!contextError || isTitleEmpty}
+              loading={isExporting}
+              data-track-category='RecordingDetailV2'
+              data-track-name='create_recording_google_doc'
+            >
+              {latestDoc ? (
+                <>
+                  <Plus className='size-[15px]' aria-hidden='true' />
+                  Create another doc
+                </>
+              ) : (
+                'Create Google Doc'
+              )}
+            </Button>
+          </>
+        )}
       </footer>
     </div>
   );

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingGoogleDocsList.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingGoogleDocsList.tsx
@@ -1,0 +1,110 @@
+import type { MouseEvent, ReactElement } from 'react';
+// Same two glyphs the export modal uses, so a doc row reads the same in both places.
+import { ExternalLink, File as FileIcon } from 'lucide-react';
+import type { RecordingGoogleDocLink } from '../../../services/Recording/recordingService';
+import { formatDate } from '../../../utils/dateUtils';
+import { openLink } from '../../../utils/openLink';
+
+interface RecordingGoogleDocsListProps {
+  /** Docs exported from this recording, newest first. */
+  documents: RecordingGoogleDocLink[];
+  /** Section label. Defaults to 'Google Docs'. */
+  heading?: string;
+}
+
+const GOOGLE_DOC_URL = (documentId: string): string =>
+  `https://docs.google.com/document/d/${documentId}/edit`;
+
+/**
+ * Reads the doc list out of a raw `calls.metadata` blob.
+ *
+ * The screen also receives this recording live over Zero, where metadata arrives
+ * as untyped JSON, so the same list has to be re-derived there — malformed or
+ * partial entries are dropped rather than rendered as a broken row.
+ */
+export function parseRecordingGoogleDocLinks(value: unknown): RecordingGoogleDocLink[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap(entry => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+    const raw = entry as Record<string, unknown>;
+    const documentId = typeof raw['documentId'] === 'string' ? raw['documentId'].trim() : '';
+    if (!documentId) return [];
+    const title = typeof raw['title'] === 'string' ? raw['title'].trim() : '';
+    const url = typeof raw['url'] === 'string' ? raw['url'].trim() : '';
+    return [
+      {
+        documentId,
+        title: title || 'Untitled document',
+        url: url || GOOGLE_DOC_URL(documentId),
+        createdAt: typeof raw['createdAt'] === 'string' ? raw['createdAt'] : '',
+        createdByUserId: typeof raw['createdByUserId'] === 'string' ? raw['createdByUserId'] : '',
+      },
+    ];
+  });
+}
+
+/** Legacy/hand-edited metadata can carry an unparseable timestamp — show no date rather than throw. */
+function formatCreatedAt(createdAt: string): string | null {
+  const timestamp = Date.parse(createdAt);
+  return Number.isNaN(timestamp) ? null : formatDate(timestamp);
+}
+
+/**
+ * Lists the Google Docs created from this recording's summary.
+ *
+ * The Docs API returns a document id only at creation time, so these come from
+ * `calls.metadata.googleDocs` — without that list, an exported doc is reachable
+ * only from whichever tab happened to be open when it was created.
+ *
+ * Clicks go through `openLink` rather than the browser's default navigation so
+ * Electron honours the user's in-app / system-browser preference; the `href` is
+ * still real, keeping hover previews and "copy link address" working.
+ */
+export function RecordingGoogleDocsList({
+  documents,
+  heading = 'Google Docs',
+}: RecordingGoogleDocsListProps): ReactElement | null {
+  if (documents.length === 0) return null;
+
+  const handleOpen = (event: MouseEvent<HTMLAnchorElement>, url: string): void => {
+    event.preventDefault();
+    openLink(url, event);
+  };
+
+  return (
+    <section className='mt-6' data-testid='recording-google-docs-list'>
+      <h3 className='text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
+        {heading}
+      </h3>
+      <ul className='mt-2 divide-y divide-border/70 rounded-lg border border-border/70'>
+        {documents.map(doc => (
+          <li key={doc.documentId}>
+            <a
+              href={doc.url}
+              target='_blank'
+              rel='noopener noreferrer'
+              onClick={event => handleOpen(event, doc.url)}
+              className='group flex items-center gap-2.5 px-3 py-2.5 text-sm transition-colors hover:bg-muted/50'
+              data-track-category='RecordingDetailV2'
+              data-track-name='open_recording_google_doc'
+            >
+              <FileIcon className='size-4 shrink-0 text-muted-foreground' aria-hidden='true' />
+              <span className='min-w-0 flex-1 truncate font-medium text-foreground group-hover:underline'>
+                {doc.title}
+              </span>
+              {formatCreatedAt(doc.createdAt) ? (
+                <span className='shrink-0 text-xs text-muted-foreground'>
+                  {formatCreatedAt(doc.createdAt)}
+                </span>
+              ) : null}
+              <ExternalLink
+                className='size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100'
+                aria-hidden='true'
+              />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -136,15 +136,28 @@ export interface RegenerateRecordingSummaryResult {
   detailedSummaryReady: boolean;
 }
 
+/** A Google Doc created from this recording's summary, as stored on call metadata. */
+export interface RecordingGoogleDocLink {
+  documentId: string;
+  title: string;
+  url: string;
+  /** ISO timestamp of when the doc was created. */
+  createdAt: string;
+  createdByUserId: string;
+}
+
 export interface ExportRecordingGoogleDocResult {
   documentId: string;
   documentUrl: string;
+  document: RecordingGoogleDocLink;
 }
 
 export interface RecordingGoogleDocComposeContext {
   canExport: boolean;
   unavailableReason?: string;
   summary: string | null;
+  /** Docs already exported from this recording, newest first. */
+  documents?: RecordingGoogleDocLink[];
 }
 
 interface GoogleRecordingDocConnectionResponse {
@@ -178,6 +191,8 @@ export interface RecordingDetail extends Recording {
   detailedSummaryCanvasId: string | null;
   detailedSummaryReady: boolean | null;
   citationSegments: CitationSegment[];
+  /** Google Docs exported from this recording, newest first. Absent on legacy responses. */
+  googleDocs?: RecordingGoogleDocLink[];
   hasRecording?: boolean;
   linkedTicketId?: string | null;
   linkedTicketMessageId?: string | null;
@@ -328,9 +343,11 @@ class RecordingService {
     return response.data;
   }
 
-  async exportGoogleDoc(callId: string): Promise<ExportRecordingGoogleDocResult> {
+  /** `title` names the new doc; omitted, the backend falls back to the recording title. */
+  async exportGoogleDoc(callId: string, title?: string): Promise<ExportRecordingGoogleDocResult> {
     const response = await apiInstance.post<{ success: true } & ExportRecordingGoogleDocResult>(
       `/calls/recordings/${callId}/export-google-doc`,
+      title ? { title } : {},
     );
     return response.data;
   }


### PR DESCRIPTION


https://github.com/user-attachments/assets/29380b7a-c815-404b-a161-497302e84dcb



Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
