### PR TITLE
feature: XYNE-17198 add tags backfill stats

### DIFF
--- a/apps/backend/src/queues/messageClassificationQueue.ts
+++ b/apps/backend/src/queues/messageClassificationQueue.ts
@@ -15,6 +15,16 @@ const JOB_NAME = 'classify-message';
 
 export type MessageClassificationJob = { conversationId: string };
 
+/** Clearable states, matching vespa-backfill's clearJobsByState. */
+export const CLASSIFICATION_QUEUE_STATES = [
+  'wait',
+  'active',
+  'delayed',
+  'completed',
+  'failed',
+] as const;
+export type ClassificationQueueState = (typeof CLASSIFICATION_QUEUE_STATES)[number];
+
 /**
  * Off-request LLM classification. Queued so model latency never sits in the send path.
  * Failures are retried twice then dropped — an untagged message is a missing chip.
@@ -121,6 +131,97 @@ class MessageClassificationQueue {
     } catch (error) {
       logger.error('[MessageClassificationQueue] Failed to enqueue', { conversationId, error });
     }
+  }
+
+  /**
+   * Backfill enqueue: same job, no debounce.
+   *
+   * The jobId is shared with enqueueForMessage so a thread already waiting because someone
+   * just replied is not queued twice — that add is skipped and this returns false.
+   *
+   * The finished-job sweep is not optional: Bull keeps completed jobs (removeOnComplete:
+   * 100) and SILENTLY IGNORES an add whose jobId already exists, so without removing the
+   * old one a second backfill run would report success and queue nothing. Backfill jobs
+   * also clear themselves on completion, so they never build up that shadow.
+   *
+   * Returns false when the queue isn't up (feature flag off) or the thread is already
+   * queued, so `enqueued` counts what really landed.
+   */
+  async enqueueBackfill(conversationId: string, delayMs = 0): Promise<boolean> {
+    if (!conversationId || !this.queue) return false;
+    const jobId = `classify:${conversationId}`;
+    try {
+      const existing = await this.queue.getJob(jobId);
+      if (existing) {
+        const state = await existing.getState();
+        // Still pending — leave it alone, it will run.
+        if (state !== 'completed' && state !== 'failed') return false;
+        await existing.remove();
+      }
+
+      await this.queue.add(
+        JOB_NAME,
+        { conversationId },
+        {
+          jobId,
+          removeOnComplete: true,
+          removeOnFail: true,
+          ...(delayMs > 0 ? { delay: delayMs } : {}),
+        },
+      );
+      return true;
+    } catch (error) {
+      logger.error('[MessageClassificationQueue] Backfill enqueue failed', {
+        conversationId,
+        error,
+      });
+      return false;
+    }
+  }
+
+  // ─── Queue control ─────────────────────────────────────────────────────────────
+
+  /** Same shape vespaQueue.getStats returns, so the two admin surfaces read alike. */
+  async getStats() {
+    if (!this.queue) {
+      return { waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0, total: 0 };
+    }
+
+    const [waiting, active, completed, failed, delayed] = await Promise.all([
+      this.queue.getWaitingCount(),
+      this.queue.getActiveCount(),
+      this.queue.getCompletedCount(),
+      this.queue.getFailedCount(),
+      this.queue.getDelayedCount(),
+    ]);
+
+    return {
+      waiting,
+      active,
+      completed,
+      failed,
+      delayed,
+      total: waiting + active + completed + failed + delayed,
+    };
+  }
+
+  /**
+   * Drop jobs in one state, or every state when `state` is 'all'.
+   *
+   * Clearing 'active' does NOT abort a classification already talking to the model; it
+   * only forgets the job, so the run finishes and its write still lands.
+   */
+  async clearJobsByState(state: ClassificationQueueState | 'all'): Promise<boolean> {
+    if (!this.queue) return false;
+    const queue = this.queue;
+
+    if (state === 'all') {
+      await Promise.all(CLASSIFICATION_QUEUE_STATES.map(name => queue.clean(0, name)));
+    } else {
+      await queue.clean(0, state);
+    }
+    logger.warn('[MessageClassificationQueue] Cleared jobs', { state });
+    return true;
   }
 }
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
