### PR TITLE
fix: XYNE-56550 stop agent clones from carrying credentials and privi…

### DIFF
--- a/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
@@ -157,7 +157,9 @@ export const agentRepository = {
    * The clone is meant to be a WORKING replica, so everything that defines
    * what the agent is and does comes across —
    *   1. systemPrompt   (also seeded as prompt version v1)
-   *   2. description / color / modelId / delegationTier / enabled
+   *   2. description / color / modelId / enabled — a paused agent yields a
+   *                        paused copy, so cloning never silently puts a
+   *                        withdrawn agent back in service
    *   3. config          — the ENTIRE json blob. This is the one that matters:
    *                        `config.tools` is the real tool palette every read
    *                        path uses (mcp.ts parseToolsConfig, the agent-config
@@ -167,9 +169,17 @@ export const agentRepository = {
    *   4. tools           — AgentTool rows, including each tool's `permission`
    *   5. skills          — AgentSkill junction links
    *   6. knowledge base  — kbScope + every AgentCollection grant
-   *   7. MCP connections — including the encrypted credential blobs
+   *   7. MCP connections — ONLY when the cloner already owns the source, since
+   *                        the rows carry credential blobs (see below)
    *
    * Everything past that point stays OUT, each for its own reason:
+   *   • MCP connections when cloning SOMEONE ELSE's agent — the row's encrypted
+   *     credentials are decrypted per-agent at tool-execution time, so a copy
+   *     is a standing grant on the source owner's third-party account that
+   *     survives share revocation and deletion of the source connection.
+   *   • `delegationTier` — admin-only on the update route ("Only claw admins
+   *     can change delegationTier") and not settable on create, so copying it
+   *     would make cloning the one non-admin path to an elevated tier.
    *   • Spaces app identity (`spacesAppId` is @unique, plus `spacesAppToken` /
    *     `signingSecret`) and SurfaceAgent registrations — these are WHO the
    *     agent is on an external surface. A copy would receive the source's
@@ -224,7 +234,6 @@ export const agentRepository = {
           description: source.description,
           color: source.color,
           modelId: source.modelId,
-          delegationTier: source.delegationTier,
           enabled: source.enabled,
           kbScope: source.kbScope,
           config: source.config as Prisma.InputJsonValue,
@@ -264,11 +273,18 @@ export const agentRepository = {
         });
       }
 
-      // MCP instances, credential blobs included. Ciphertext is copied as-is:
-      // same deployment, same CONFIG.encryptionKey, so no re-encryption is
-      // needed. `createdByUserId` keeps pointing at whoever actually pasted the
-      // secret — that is what the audit trail is for.
-      if (source.mcpConnections.length > 0) {
+      // MCP instances — SELF-CLONES ONLY. The row carries the credential blob
+      // (encryptedCreds/iv/authTag is NOT NULL, so there is no credential-less
+      // copy to make), and the runtime decrypts it per-agent, meaning the
+      // clone's tool calls authenticate as whoever pasted the secret. Copying
+      // that to an agent owned by SOMEONE ELSE hands them a standing grant on
+      // the source owner's third-party account which outlives both revoking
+      // their share and deleting the connection on the source — nothing ever
+      // rotates or back-references a copied blob. When the cloner is already
+      // the owner no trust boundary is crossed, so their own credentials
+      // travel and cloning your own agent still produces a working replica.
+      const selfClone = source.ownerUserId !== null && source.ownerUserId === newOwnerId;
+      if (selfClone && source.mcpConnections.length > 0) {
         await tx.agentMcpConnection.createMany({
           data: source.mcpConnections.map((c) => ({
             agentId: clone.id,

--- a/apps/xyne-claw-auth/frontend/src/components/SubagentDetailPage.tsx
+++ b/apps/xyne-claw-auth/frontend/src/components/SubagentDetailPage.tsx
@@ -122,7 +122,7 @@ export function SubagentDetailPage({ userId, isAdmin, mode }: Props) {
     setLoading(true);
     setError(null);
     try {
-      const [avail, sks] = await Promise.all([getAvailableTools(), listSkills()]);
+      const [avail, sks] = await Promise.all([getAvailableTools(), listSkills(userId)]);
       setAvailable(avail);
       setSkills(sks);
       if (mode === "edit") {

--- a/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
@@ -119,6 +119,20 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
   const [availableModels, setAvailableModels] = useState<ClaudeModelInfo[]>([]);
   const [availableTools, setAvailableTools] = useState<AvailableTools | null>(null);
   const [availableSkills, setAvailableSkills] = useState<Skill[]>([]);
+  // Skills the agent already has, hydrated by the agent payload itself. Kept
+  // separately because listSkills() only ever returns global skills plus the
+  // VIEWER's own — a personal skill belonging to someone else (which is exactly
+  // what a cloned agent carries) is absent from that list, and the skill pills
+  // render off the palette, so without this the attached skill shows as nothing.
+  const [attachedSkills, setAttachedSkills] = useState<Skill[]>([]);
+  /** Skill palette for the Knowledge card: everything the viewer may pick from,
+   *  plus any already-attached skill the listing doesn't include. */
+  const skillPalette = useMemo(() => {
+    const byId = new Map(availableSkills.map((sk) => [sk.id, sk]));
+    for (const sk of attachedSkills) if (!byId.has(sk.id)) byId.set(sk.id, sk);
+    return [...byId.values()];
+  }, [availableSkills, attachedSkills]);
+
   /** User's per-provider credentials. Used to gray-out unconfigured providers
       in the Provider dropdown — Spaces is always available, every other
       provider is enabled only when the user has set up credentials. */
@@ -276,6 +290,9 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
         setPrompt(agentData.systemPrompt ?? agentData.description ?? "");
         setDraftTools(extractToolsFromConfig(agentData.config));
         setDraftSkillIds((agentData.skills ?? []).map((s) => s.skillId));
+        setAttachedSkills(
+          (agentData.skills ?? []).map((s) => ({ id: s.skillId, ...s.skill }) as Skill),
+        );
         setDraftKbResources((agentData.collections ?? []).map((c) => ({ collectionId: c.collectionId, fileId: c.fileId })));
         setDraftKbScope(agentData.kbScope === "USER" ? "USER" : "COLLECTIONS");
         setDraftProvider(provider);
@@ -1019,7 +1036,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
             onRemoveDelegationConfigEntry={handleRemoveDelegationConfigEntry}
             draftSkillIds={draftSkillIds}
             onToggleSkill={toggleSkill}
-            availableSkills={availableSkills}
+            availableSkills={skillPalette}
             draftKbResources={draftKbResources}
             onDraftKbResourcesChange={setDraftKbResources}
             draftKbScope={draftKbScope}
@@ -1175,6 +1192,8 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
         onOpenChange={setCloneDialogOpen}
         sourceName={agent.name}
         needsApproval={!permissions?.canEdit}
+        isOwnAgent={agent.ownerUserId === userId}
+        sourceEnabled={agent.enabled}
         submitting={cloning}
         onConfirm={(name) => void doClone(name)}
       />

--- a/apps/xyne-claw-auth/frontend/src/v3/components/SkillPickerDialog.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/SkillPickerDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { Dialog } from "./ui/Dialog";
 import { Button } from "./ui/Button";
@@ -27,14 +27,22 @@ export function SkillPickerDialog({ open, onOpenChange, userId, selectedIds, onA
     if (open) setSelected(new Set(selectedIds));
   }, [open, selectedIds]);
 
+  // Cache the listing per userId rather than "once ever": the previous guard
+  // (skills.length > 0) meant a userId arriving after the first fetch could
+  // never refresh the list, so the viewer's personal skills stayed missing for
+  // the component's lifetime — the exact bug passing userId is meant to fix.
+  const fetchedFor = useRef<string | null>(null);
   useEffect(() => {
-    if (!open || skills.length > 0) return;
+    if (!open) return;
+    const key = userId ?? "";
+    if (fetchedFor.current === key) return;
+    fetchedFor.current = key;
     setLoading(true);
     listSkills(userId)
       .then(setSkills)
-      .catch(() => {})
+      .catch(() => { fetchedFor.current = null; })
       .finally(() => setLoading(false));
-  }, [open, skills.length, userId]);
+  }, [open, userId]);
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailHeader.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailHeader.tsx
@@ -274,8 +274,8 @@ export function AgentDetailHeader({
             forceExpanded={cloning}
             title={
               cloneNeedsApproval
-                ? "Send a clone request to this agent's owner. A clone copies its prompt, tools, skills, knowledge base and integrations."
-                : "Create your own copy — prompt, tools, skills, knowledge base and integrations — in a new personal agent."
+                ? "Send a clone request to this agent's owner. A clone copies its prompt, tools, skills and knowledge-base grants — not their saved credentials."
+                : "Create your own copy — prompt, tools, skills and knowledge base — in a new personal agent."
             }
           />
         )}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/CloneAgentDialog.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/CloneAgentDialog.tsx
@@ -1,8 +1,11 @@
 /**
  * CloneAgentDialog — prompts for the new agent's name before cloning.
  *
- * A clone is a full copy — prompt, tools, skills, knowledge base and
- * integrations — into a new personal agent. Owners/contributors/admins get an
+ * A clone copies the prompt, tools, skills, behaviour settings and
+ * knowledge-base grants into a new personal agent. Saved integration
+ * credentials come across only when you already own the source — cloning
+ * someone else's agent never copies their credentials, so the copy describes
+ * itself differently in those two cases. Owners/contributors/admins get an
  * instant copy; everyone else raises an approval request (the chosen name is
  * carried through and applied when the owner approves). The parent owns the
  * actual clone call + navigation.
@@ -21,6 +24,12 @@ interface CloneAgentDialogProps {
   sourceName: string;
   /** True when the viewer can't edit → cloning raises an approval request. */
   needsApproval: boolean;
+  /** True when the viewer already owns the source, the only case where its
+   *  saved integration credentials travel with the copy. */
+  isOwnAgent: boolean;
+  /** Source's enabled state — mirrored onto the copy, so a paused source makes
+   *  a paused copy and the dialog has to say so or the copy looks broken. */
+  sourceEnabled: boolean;
   /** In-flight flag from the parent (disables inputs + button). */
   submitting: boolean;
   /** Called with the chosen name when the user confirms. */
@@ -34,6 +43,8 @@ export function CloneAgentDialog({
   onOpenChange,
   sourceName,
   needsApproval,
+  isOwnAgent,
+  sourceEnabled,
   submitting,
   onConfirm,
 }: CloneAgentDialogProps) {
@@ -99,7 +110,9 @@ export function CloneAgentDialog({
       description={
         needsApproval
           ? "You'll send a request to this agent's owner. Your chosen name is used when they approve."
-          : "Creates your own copy — prompt, tools, skills, knowledge base and integrations all come across. Its Spaces identity, sharing and provider keys do not."
+          : isOwnAgent
+            ? "Creates your own copy — prompt, tools, skills, knowledge base and your integrations all come across. Its Spaces identity and sharing do not."
+            : "Creates your own copy — prompt, tools, skills and knowledge-base grants come across. You'll connect your own credentials for its integrations."
       }
       maxWidth={520}
       footer={
@@ -162,7 +175,9 @@ export function CloneAgentDialog({
         <div className="mt-1 flex items-start gap-2 rounded-lg border border-xyne-border-subtle px-3 py-2 text-[11px] text-xyne-fg-tertiary">
           <CopyIcon size={12} className="mt-[1px] shrink-0" />
           <span>
-            The copy starts with no model selected — you'll pick one before its first run.
+            {sourceEnabled
+              ? "The copy starts with no model selected — you'll pick one before its first run."
+              : "This agent is paused, so your copy starts paused too — enable it when you're ready."}
           </span>
         </div>
       </div>

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/CloneRequestsTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/CloneRequestsTab.tsx
@@ -77,7 +77,7 @@ export function CloneRequestsTab({
                     onClick={() => onResolve(req, "approve")}
                     disabled={busyId !== null}
                     className="inline-flex items-center gap-1 rounded-md bg-xyne-accent px-2.5 py-1 text-[12px] font-medium text-white disabled:opacity-50"
-                    title="Approve — creates a copy for the requester"
+                    title="Approve — gives the requester a personal copy with this agent's prompt, tools, skills, behaviour and knowledge-base grants. Your integration credentials are not shared."
                   >
                     <CheckIcon size={14} weight="bold" />
                     Approve

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -827,7 +827,7 @@ export function buildCloneApprovalFlow(
     .setTitle('Clone Request')
     .addText(
       'intro',
-      `*${context.requesterName}* wants to clone your agent *${context.agentName}*.\n\nA clone copies only the system prompt, tools, and skills into a new personal agent they own. Your app registration, credentials, and knowledge-base grants are NOT shared.${link}`,
+      `*${context.requesterName}* wants to clone your agent *${context.agentName}*.\n\nApproving gives them a personal copy carrying its prompt, tools, skills, behaviour settings and knowledge-base grants. Your app registration and your saved integration credentials are NOT shared — they will have to connect their own.${link}`,
     )
     .addDivider('d1')
     .addRow('actions', [


### PR DESCRIPTION


https://github.com/user-attachments/assets/1e1807da-a363-4e03-aff8-a023e1012b7c


Follow-up to #788. Making the clone a full copy also made it copy trust-bearing state across a user boundary. Four issues, all closed here:

1. MCP credentials. AgentMcpConnection rows carry the credential blob (the columns are NOT NULL, so there is no credential-less copy), and the runtime decrypts them per-agent — so a copy let the clone's owner act as whoever pasted the secret, and it outlived both revoking their share and deleting the connection on the source. Connections now travel only on a SELF-clone, where no trust boundary is crossed; cloning someone else's agent leaves them to connect their own.

2. delegationTier is admin-gated on update ("Only claw admins can change delegationTier") and not settable on create, so copying it made cloning the one non-admin path to orchestrator tier — which grants callable access to every global agent without the per-pair approved grants standard tier needs. No longer copied.

3. enabled is now mirrored onto the copy, so cloning a paused agent yields a paused copy instead of silently putting a withdrawn agent back in service. Cloning a disabled agent stays allowed (it always was, and GET /agents/:slug already exposes the full config to any org viewer, so blocking it bought little) — but the copy no longer arrives live, and the dialog says why it is paused rather than leaving the requester with a copy that refuses to run.

4. The Spaces clone-approval DM still told owners "credentials, and knowledge-base grants are NOT shared" while the approval path copied both — consent collected on a false statement. That text, the owner-side Approve tooltip and the requester-side dialog/tooltip now describe what actually happens, and the dialog distinguishes self-clones from cloning others.

Also closes two gaps in #788's skills fix: attached skills render from the palette, which lists only global skills plus the VIEWER's own, so a personal skill belonging to the source owner (exactly what a clone carries) showed as nothing — the agent's own hydrated skill rows are now merged into the palette. And SubagentDetailPage still called listSkills() bare. The skill picker's "fetch once" guard is now keyed on userId so a late-arriving id refetches.




