### PR TITLE
fix: change the spaces model + thinking config works

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/model-settings-audit.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/model-settings-audit.ts
@@ -1,0 +1,96 @@
+/**
+ * Audit trail for per-agent model settings (`Agent.config.modelSettings`).
+ *
+ * `modelSettings.model` is the Spaces/platform-default model override: it
+ * decides which model on the shared LiteLLM proxy actually serves the agent's
+ * runs (xyne-claw/src/agent.ts → resolveModel, default LiteLLM branch). Changing
+ * it silently re-points EVERY run of that agent at a different model, so each
+ * edit gets its own audit row with before/after values and the acting user.
+ *
+ * Event type is the existing AGENT_CONFIG_UPDATED — Postgres enums are frozen
+ * (scripts/validate-no-new-enums.sh), so a model change is distinguished by
+ * `metadata.kind = "modelSettings"`, not by a new enum value.
+ *
+ * Called from the PUT /agents/:slug handler, which is the single write path for
+ * every model-settings edit (claw-auth's own console and the Spaces dashboard
+ * both PUT there).
+ */
+import { writeAuditLog } from "./audit.js";
+
+/** The modelSettings keys we track. Mirrors agent-config-validation.ts. */
+export const AUDITED_MODEL_SETTING_KEYS = ["model", "temperature", "maxTokens", "thinkingLevel"] as const;
+export type AuditedModelSettingKey = (typeof AUDITED_MODEL_SETTING_KEYS)[number];
+
+export type ModelSettingsSnapshot = Record<AuditedModelSettingKey, unknown>;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+/** Reads the audited modelSettings keys out of an agent `config` bag. */
+export function readModelSettingsSnapshot(config: unknown): ModelSettingsSnapshot {
+  const ms = asRecord(asRecord(config)?.["modelSettings"]) ?? {};
+  return {
+    model: ms["model"],
+    temperature: ms["temperature"],
+    maxTokens: ms["maxTokens"],
+    thinkingLevel: ms["thinkingLevel"],
+  };
+}
+
+/** Keys whose value differs between two config bags. Empty = nothing to audit. */
+export function diffModelSettings(beforeConfig: unknown, afterConfig: unknown): AuditedModelSettingKey[] {
+  const before = readModelSettingsSnapshot(beforeConfig);
+  const after = readModelSettingsSnapshot(afterConfig);
+  return AUDITED_MODEL_SETTING_KEYS.filter((k) => before[k] !== after[k]);
+}
+
+/** Renders an audited value for the human-readable description. */
+function formatSetting(v: unknown): string {
+  return v === undefined || v === null || v === "" ? "platform default" : String(v);
+}
+
+export interface ModelSettingsAuditArgs {
+  agentId: string;
+  agentName: string;
+  agentSlug: string;
+  orgId: string;
+  /** Verified requester; undefined for non-HTTP/system writes. */
+  actorUserId: string | undefined;
+  beforeConfig: unknown;
+  afterConfig: unknown;
+}
+
+/**
+ * Writes an AGENT_CONFIG_UPDATED row when modelSettings actually changed.
+ * No-ops otherwise, so the high-frequency config writes that don't touch the
+ * model (tools, memory status, scope flips, prompt denorm) don't spam the
+ * audit table.
+ *
+ * Never throws — writeAuditLog swallows its own errors, and a failed audit must
+ * not fail the agent update it observes.
+ */
+export async function auditModelSettingsChange(args: ModelSettingsAuditArgs): Promise<void> {
+  const changed = diffModelSettings(args.beforeConfig, args.afterConfig);
+  if (changed.length === 0) return;
+
+  const before = readModelSettingsSnapshot(args.beforeConfig);
+  const after = readModelSettingsSnapshot(args.afterConfig);
+  const parts = changed.map((k) => `${k}: ${formatSetting(before[k])} → ${formatSetting(after[k])}`);
+
+  await writeAuditLog({
+    ...(args.actorUserId ? { actorUserId: args.actorUserId } : {}),
+    eventType: "AGENT_CONFIG_UPDATED",
+    targetId: args.agentId,
+    description:
+      `Agent "${args.agentName}" (${args.agentSlug}) model settings changed — ${parts.join("; ")}` +
+      (args.actorUserId ? "" : " [no actor — non-HTTP/system write]"),
+    metadata: {
+      kind: "modelSettings",
+      orgId: args.orgId,
+      changed,
+      before: Object.fromEntries(changed.map((k) => [k, before[k] ?? null])),
+      after: Object.fromEntries(changed.map((k) => [k, after[k] ?? null])),
+    },
+  });
+}

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -30,6 +30,7 @@ import { s2sKeyMatches } from "../middleware/require-auth.js";
 import { writeAuditLog } from "../lib/audit.js";
 import { buildAvailableToolsCatalog } from "./tools.js";
 import { validateAgentModelConfig } from "../lib/agent-config-validation.js";
+import { auditModelSettingsChange } from "../lib/model-settings-audit.js";
 import { validateKbGrants } from "../lib/spaces-kb.js";
 import { ORG_SCOPED_SLUGS } from "../lib/org-scoped-slugs.js";
 import { getAdminOrgScope, getOrgNameMap, withOrgLabel } from "../lib/admin-org-scope.js";
@@ -837,9 +838,25 @@ router.put("/:slug", async (req: Request<{ slug: string }>, res: Response) => {
 
     const agent = await agentRepository.update(req.params.slug, existing.orgId, data);
 
-    // Audit general agent edits. Tools/config changes are already captured by
-    // AGENT_CONFIG_UPDATED at the agentRepository.update choke point, so `config`
-    // is deliberately excluded here to avoid a duplicate/overlapping trail.
+    // Model-settings audit — which model actually serves this agent's runs.
+    // Written only when config.modelSettings really changed, so the
+    // high-frequency config writes that don't touch it (tools, memory status,
+    // scope flips) don't spam the audit table.
+    if (normalizedConfig !== undefined) {
+      await auditModelSettingsChange({
+        agentId: existing.id,
+        agentName: existing.name,
+        agentSlug: existing.slug,
+        orgId: existing.orgId,
+        actorUserId: requesterId ?? undefined,
+        beforeConfig: existing.config,
+        afterConfig: normalizedConfig,
+      });
+    }
+
+    // Audit general agent edits. `config` is deliberately excluded here to
+    // avoid a duplicate/overlapping trail — model settings get their own
+    // AGENT_CONFIG_UPDATED row above.
     const changedFields: string[] = [];
     if (data.slug && data.slug !== existing.slug) changedFields.push("slug");
     if (name !== undefined && name.trim() !== existing.name) changedFields.push("name");

--- a/apps/xyne-claw-auth/frontend/src/components/DebugDrawer.tsx
+++ b/apps/xyne-claw-auth/frontend/src/components/DebugDrawer.tsx
@@ -646,8 +646,10 @@ function DebugTimelineSection({
   const streamThinkingChars = typeof data?.streamThinkingChars === "number" ? data.streamThinkingChars as number : undefined;
   const streamTextChars = typeof data?.streamTextChars === "number" ? data.streamTextChars as number : undefined;
   const streamCharsPerSec = typeof data?.streamCharsPerSec === "number" ? data.streamCharsPerSec as number : undefined;
+  const thinkingConfig = isRecord(data?.thinking) ? data.thinking as Record<string, unknown> : null;
+  const thinkingLevel = thinkingConfig ? asString(thinkingConfig.effectiveLevel) : "";
 
-  const headerMeta = [asString(data?.provider), asString(data?.model), toolsUsed.length ? `${toolsUsed.length} tools` : "", `${visibleEvents.length} events`].filter(Boolean).join(" · ");
+  const headerMeta = [asString(data?.provider), asString(data?.model), thinkingLevel ? `thinking ${thinkingLevel}` : "", toolsUsed.length ? `${toolsUsed.length} tools` : "", `${visibleEvents.length} events`].filter(Boolean).join(" · ");
   const TurnIcon = data?.subagentName ? Workflow : MessageSquareText;
   const turnIconColor = data?.subagentName ? "text-cyan-600 dark:text-cyan-400" : "text-xyne-fg-tertiary";
   return (
@@ -668,6 +670,25 @@ function DebugTimelineSection({
           <p className={`text-[12px] leading-relaxed ${data?.providerError ? "text-red-600 dark:text-red-400" : "text-xyne-fg-secondary"}`}>
             {asString(data?.providerError) || asString(data?.question) || asString(data?.task)}
           </p>
+        )}
+
+        {thinkingConfig && (
+          <details className="group/sm" open>
+            <summary className="flex cursor-pointer list-none items-baseline gap-2 py-1">
+              <ChevronDown size={11} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/sm:rotate-0" />
+              <BrainCircuit size={11} className="shrink-0 self-center text-xyne-fg-tertiary" />
+              <span className="text-[12px] font-semibold text-xyne-fg-secondary">Thinking configuration</span>
+            </summary>
+            <div className="ml-1.5 border-l border-xyne-border-subtle pl-4 pt-1.5 pb-1 text-[12px] text-xyne-fg-secondary">
+              <div className="flex flex-wrap gap-x-4 gap-y-1">
+                <span><span className="text-xyne-fg-muted">Requested:</span> {asString(thinkingConfig.requestedLevel)}</span>
+                <span><span className="text-xyne-fg-muted">Effective:</span> {asString(thinkingConfig.effectiveLevel)}</span>
+                <span><span className="text-xyne-fg-muted">Source:</span> {asString(thinkingConfig.source).replaceAll("_", " ")}</span>
+                <span><span className="text-xyne-fg-muted">Reasoning model:</span> {thinkingConfig.modelSupportsReasoning ? "yes" : "no"}</span>
+              </div>
+              {asString(thinkingConfig.wireMode) && <p className="mt-1 font-mono text-[11px] text-xyne-fg-muted">{asString(thinkingConfig.wireMode)}</p>}
+            </div>
+          </details>
         )}
 
         {(tokenUsage || latency || streamGraph.length > 0) && (

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/SpacesDefaultRowV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/SpacesDefaultRowV3.tsx
@@ -10,11 +10,21 @@ import { updateAgent } from "../../../../lib/api";
  *
  * Spaces (the platform LiteLLM proxy) is always available as the terminal
  * fallback and needs no credential, so it's rendered as a permanent row that
- * can't be removed. Its MODEL is the fixed platform default and is NOT
- * editable — only the run params (temperature, thinking level, max output
- * tokens) can be tuned. Persisted at agent.config.modelSettings; applied
- * per-run by the xyne-claw runtime (agent-model-settings.ts). The params apply
- * to whichever provider serves the run (including quota fallbacks).
+ * can't be removed. Its MODEL and run params (temperature, thinking level, max
+ * output tokens) are editable per agent. Persisted at
+ * agent.config.modelSettings; applied per-run by the xyne-claw runtime
+ * (agent-model-settings.ts). The params apply to whichever provider serves the
+ * run (including quota fallbacks).
+ *
+ * The model is a FREE-TEXT field, deliberately not a dropdown: it's whatever
+ * model id the platform LiteLLM proxy exposes, and the proxy's catalogue
+ * changes without a deploy here. Leave it blank to run on the platform default
+ * (LITELLM_MODEL in the claw pod's env). The model only applies when the run is
+ * served by the platform LiteLLM branch — premium providers (Claude, Codex,
+ * Copilot, LiteLLM-own-key) pick their model on their own credential.
+ *
+ * Every change is audited (AGENT_CONFIG_UPDATED, metadata.kind =
+ * "modelSettings") by the PUT /agents/:slug handler in claw-auth.
  *
  * Structured output (config.outputFormat) lives in the Behavior tab, not here —
  * it's an agent-behavior choice, not a model knob.
@@ -33,6 +43,9 @@ const INPUT_CLASS =
   "w-full rounded-lg border border-xyne-border bg-xyne-surface px-3 py-2.5 text-[13px] text-xyne-fg-primary placeholder-xyne-fg-muted focus:border-xyne-border-focus focus:outline-none focus:shadow-[var(--comp-focus-ring)]";
 
 const LABEL_CLASS = "block text-[12px] font-medium text-xyne-fg-secondary mb-1.5";
+
+/** Mirrors the backend clamp in claw-auth's agent-config-validation.ts. */
+const MODEL_MAX_LENGTH = 200;
 
 interface ModelSettings {
   model?: string;
@@ -56,6 +69,12 @@ export function SpacesDefaultRowV3({ agent }: Props) {
   const [savedSettings, setSavedSettings] = useState<ModelSettings>(initial);
 
   const [editing, setEditing] = useState(false);
+  // "default" = no modelSettings.model at all, so the run uses the platform
+  // model from the claw pod's env (LITELLM_MODEL). "custom" = the id typed
+  // below wins. Kept as an explicit choice rather than inferring it from an
+  // empty text box, so "use the platform default" is a deliberate selection.
+  const [modelMode, setModelMode] = useState<"default" | "custom">(initial.model ? "custom" : "default");
+  const [model, setModel] = useState(initial.model ?? "");
   const [temperature, setTemperature] = useState(initial.temperature !== undefined ? String(initial.temperature) : "");
   const [maxTokens, setMaxTokens] = useState(initial.maxTokens !== undefined ? String(initial.maxTokens) : "");
   const [thinkingLevel, setThinkingLevel] = useState(initial.thinkingLevel ?? "");
@@ -67,6 +86,8 @@ export function SpacesDefaultRowV3({ agent }: Props) {
 
   const resetDraft = () => {
     const ms = readSettings();
+    setModelMode(ms.model ? "custom" : "default");
+    setModel(ms.model ?? "");
     setTemperature(ms.temperature !== undefined ? String(ms.temperature) : "");
     setMaxTokens(ms.maxTokens !== undefined ? String(ms.maxTokens) : "");
     setThinkingLevel(ms.thinkingLevel ?? "");
@@ -76,11 +97,20 @@ export function SpacesDefaultRowV3({ agent }: Props) {
     if (saving) return;
 
     const settings: ModelSettings = {};
-    // The Spaces model is fixed (platform default) and not editable here.
-    // Preserve any model value set out-of-band (e.g. via API) rather than
-    // wiping it when params are saved.
-    const existing = readSettings();
-    if (existing.model) settings.model = existing.model;
+    // "default" omits modelSettings.model entirely — that absence is what makes
+    // the runtime fall back to the platform model from env.
+    if (modelMode === "custom") {
+      const trimmedModel = model.trim();
+      if (!trimmedModel) {
+        showSnackbar({ variant: "error", title: 'Enter a model name, or switch to "Platform default"' });
+        return;
+      }
+      if (trimmedModel.length > MODEL_MAX_LENGTH) {
+        showSnackbar({ variant: "error", title: `Model name must be ${MODEL_MAX_LENGTH} characters or fewer` });
+        return;
+      }
+      settings.model = trimmedModel;
+    }
     if (temperatureSet) {
       const t = Number(temperature);
       if (!Number.isFinite(t) || t < 0 || t > 1) {
@@ -180,10 +210,35 @@ export function SpacesDefaultRowV3({ agent }: Props) {
 
       {editing && (
         <div className="mt-3 rounded-xl border border-xyne-border bg-xyne-surface p-4">
-          <div className="mb-3 flex items-center gap-2 text-[12px]">
-            <span className="text-xyne-fg-tertiary">Model</span>
-            <span className="font-mono text-xyne-fg-secondary">{savedSettings.model || "Platform default"}</span>
-            <span className="text-[11px] text-xyne-fg-muted">· fixed, not editable</span>
+          <div className="mb-4">
+            <label className={LABEL_CLASS} htmlFor="spaces-model-source">Model</label>
+            <select
+              id="spaces-model-source"
+              value={modelMode}
+              onChange={(e) => setModelMode(e.target.value === "custom" ? "custom" : "default")}
+              className={INPUT_CLASS}
+            >
+              <option value="default">Platform default (from environment)</option>
+              <option value="custom">Custom model…</option>
+            </select>
+            {modelMode === "custom" && (
+              <input
+                id="spaces-default-model"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="e.g. kimi-latest"
+                spellCheck={false}
+                autoComplete="off"
+                autoFocus
+                maxLength={MODEL_MAX_LENGTH}
+                className={`${INPUT_CLASS} font-mono mt-2`}
+              />
+            )}
+            <p className="mt-1 text-[11px] text-xyne-fg-muted">
+              {modelMode === "custom"
+                ? "Any model id served by the platform LiteLLM proxy. Applies to runs served by Spaces — premium providers keep the model set on their own credential."
+                : "Runs on whichever model the platform is configured with (LITELLM_MODEL). Switch to a custom model to pin this agent to a specific one."}
+            </p>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
@@ -232,8 +287,8 @@ export function SpacesDefaultRowV3({ agent }: Props) {
 
           <p className="mt-3 text-[11px] text-xyne-fg-tertiary">
             Temperature, thinking and max tokens apply to whichever provider serves the run
-            (including quota fallbacks). The Spaces model is the fixed platform default; premium
-            providers pick their model on their credential.
+            (including quota fallbacks). The model applies only to Spaces runs; premium providers
+            pick their model on their credential. Model changes are recorded in the admin audit log.
           </p>
 
           <div className="mt-4 flex items-center gap-2">

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -294,6 +294,19 @@ interface StreamRateSample {
   streamsCollected: number;
 }
 
+interface DebugThinkingConfiguration {
+  /** Value selected by agent model settings / provider config / default policy. */
+  requestedLevel: string;
+  /** Pi's final value after capability clamping for the resolved model. */
+  effectiveLevel: string;
+  /** Where the requested setting came from, so precedence is inspectable. */
+  source: "agent_model_settings" | "provider_credential" | "codex_default" | "server_default" | "temperature_override";
+  /** Whether the resolved Pi model was registered as reasoning-capable. */
+  modelSupportsReasoning: boolean;
+  /** The provider request shape that disables/enables thinking for this model. */
+  wireMode: string;
+}
+
 interface DebugSessionSnapshot {
   schemaVersion: 1;
   conversationId?: string;
@@ -303,6 +316,10 @@ interface DebugSessionSnapshot {
   userName?: string;
   userEmail?: string;
   provider?: string;
+  /** The model resolved for this particular run (not merely the agent default). */
+  model?: string;
+  /** Requested/effective thinking selection and its provider wire representation. */
+  thinking?: DebugThinkingConfiguration;
   startedAt: string;
   finishedAt: string;
   task: string;
@@ -763,6 +780,50 @@ export function contextWindowFor(modelId: string | undefined): number {
     ?? Number(process.env["XYNE_CLAW_DEFAULT_CONTEXT_WINDOW"] ?? 128_000);
 }
 
+/**
+ * Kimi's OpenAI-compatible endpoint does not honor `reasoning_effort: "none"`.
+ * It returns `reasoning_content` unless the request explicitly contains
+ * `thinking: { type: "disabled" }`. In pi-ai's adapter this is the `deepseek`
+ * request shape; its `zai` shape instead emits `enable_thinking: false`, which
+ * Kimi ignores. Keep this narrow: other LiteLLM models such as GLM do honor the
+ * standard `reasoning_effort: "none"` route.
+ */
+function liteLlmThinkingCompat(modelId: string): { thinkingFormat: "deepseek" } | undefined {
+  return /(^|[\/_-])kimi(?:[\/_-]|$)/i.test(modelId)
+    ? { thinkingFormat: "deepseek" }
+    : undefined;
+}
+
+/** Human-readable description of how the thinking level reaches the provider —
+ *  surfaced in the debug snapshot so a "why is it still thinking?" report can be
+ *  answered from the trace instead of by reading adapter source. */
+function describeThinkingWireMode(
+  model: { reasoning: boolean; api: string; compat?: unknown },
+  thinkingLevel: string,
+): string {
+  if (!model.reasoning) return "not sent (model registered without reasoning)";
+  if (model.api !== "openai-completions") return thinkingLevel === "off" ? "provider-native thinking disabled" : "provider-native reasoning";
+
+  const enabled = thinkingLevel !== "off";
+  const thinkingFormat = typeof model.compat === "object" && model.compat !== null
+    && "thinkingFormat" in model.compat
+    && typeof (model.compat as { thinkingFormat?: unknown }).thinkingFormat === "string"
+    ? (model.compat as { thinkingFormat: string }).thinkingFormat
+    : undefined;
+  switch (thinkingFormat) {
+    case "zai":
+      return `thinking: { type: "${enabled ? "enabled" : "disabled"}" }`;
+    case "qwen":
+      return `enable_thinking: ${enabled}`;
+    case "deepseek":
+      return `thinking: { type: "${enabled ? "enabled" : "disabled"}" }`;
+    default:
+      return enabled
+        ? `reasoning_effort: "${thinkingLevel}"`
+        : 'reasoning_effort: "none"';
+  }
+}
+
 export function resolveModel(
   modelRegistry: ModelRegistry,
   provider?: string,
@@ -956,7 +1017,13 @@ export function resolveModel(
   }
 
   // Default: shared LiteLLM proxy
+  // The Spaces grid's default models (including glm-latest) support the
+  // OpenAI-compatible `reasoning_effort` parameter. Marking this model as
+  // non-reasoning used to make pi silently omit the user-selected thinking
+  // level, leaving long server-default reasoning enabled even when an agent
+  // selected "Off". The grid accepts `none` as the explicit off value.
   const litellmModel = overrides?.model ?? LITELLM.model;
+  const litellmCompat = liteLlmThinkingCompat(litellmModel);
   modelRegistry.registerProvider("litellm", {
     baseUrl: LITELLM.url,
     apiKey: overrides?.litellmApiKey || LITELLM.apiKey,
@@ -966,7 +1033,9 @@ export function resolveModel(
       {
         id: litellmModel,
         name: litellmModel,
-        reasoning: false,
+        reasoning: true,
+        thinkingLevelMap: { off: "none" },
+        ...(litellmCompat ? { compat: litellmCompat } : {}),
         input: ["text", "image"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: contextWindowFor(litellmModel),
@@ -2010,6 +2079,13 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   const credEffort = effectiveProviderConfig?.reasoningEffort;
   const credEffortValid =
     credEffort === "low" || credEffort === "medium" || credEffort === "high";
+  let thinkingSource: DebugThinkingConfiguration["source"] = modelSettings?.thinkingLevel
+    ? "agent_model_settings"
+    : credEffortValid
+      ? "provider_credential"
+      : provider === "codex"
+        ? "codex_default"
+        : "server_default";
   let effectiveThinking: SessionThinkingLevel = modelSettings?.thinkingLevel
     ? (modelSettings.thinkingLevel as SessionThinkingLevel)
     : credEffortValid
@@ -2020,6 +2096,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   if (modelSettings?.temperature !== undefined && effectiveThinking !== "off") {
     log.info(`[agent] modelSettings.temperature=${modelSettings.temperature} set — forcing thinkingLevel off (was ${effectiveThinking})`);
     effectiveThinking = "off";
+    thinkingSource = "temperature_override";
   }
   // SECURITY (cross-session read): pi's built-in read/write/grep/find/ls are
   // NOT confined to cwd. `createReadTool(cwd)` uses cwd only as the default base
@@ -2094,6 +2171,18 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     : allCustomTools;
 
   const { session } = await createAgentSession(options);
+  const debugThinking: DebugThinkingConfiguration = {
+    requestedLevel: effectiveThinking,
+    effectiveLevel: session.thinkingLevel,
+    source: thinkingSource,
+    modelSupportsReasoning: model.reasoning,
+    wireMode: describeThinkingWireMode(model, session.thinkingLevel),
+  };
+  log.info(
+    `[agent] Thinking configuration: requested=${debugThinking.requestedLevel} ` +
+    `effective=${debugThinking.effectiveLevel} source=${debugThinking.source} ` +
+    `wire=${debugThinking.wireMode}`,
+  );
 
   if (fastToolController && fastCatalogNameSet.size > 0) {
     const activeSet = new Set(restoredFastActiveToolSet);
@@ -2342,6 +2431,8 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
         ...(userName ? { userName } : {}),
         ...(userEmail ? { userEmail } : {}),
         ...(provider ? { provider } : {}),
+        model: model.id,
+        thinking: debugThinking,
         inProgress: true,
         startedAt: debugStartedIso,
         finishedAt: new Date().toISOString(),
@@ -2463,6 +2554,8 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     ...(progressMeta?.agentSlug ? { agentSlug: progressMeta.agentSlug } : {}),
     userId,
     provider,
+    model: model.id,
+    thinking: debugThinking,
     task,
     context: context ?? null,
     systemPromptOverride: Boolean(systemPromptOverride),
@@ -3407,6 +3500,8 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
         ...(userName ? { userName } : {}),
         ...(userEmail ? { userEmail } : {}),
         ...(provider ? { provider } : {}),
+        model: model.id,
+        thinking: debugThinking,
         startedAt: debugStartedIso,
         finishedAt: new Date().toISOString(),
         task,
@@ -3581,6 +3676,8 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
           ...(userName ? { userName } : {}),
           ...(userEmail ? { userEmail } : {}),
           ...(provider ? { provider } : {}),
+          model: model.id,
+          thinking: debugThinking,
           cancelled: true,
           startedAt: debugStartedIso,
           finishedAt: new Date().toISOString(),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
