### PR TITLE
Fix: XYNE-56555 fixing and adding canvas features

### DIFF
--- a/apps/dashboard/src/components/Canvas/Canvas.types.ts
+++ b/apps/dashboard/src/components/Canvas/Canvas.types.ts
@@ -35,6 +35,8 @@ export interface CanvasEditorProps {
   initialCommentThreadId?: string | undefined;
   /** Emits the number of open comment threads already loaded by the editor highlight query. */
   onOpenCommentCountChange?: (count: number) => void;
+  /** Mirrors the comments panel open state so the host header can mark its button as active. */
+  onCommentsOpenChange?: (open: boolean) => void;
   /** Auto-focus the editor on mount */
   autoFocus?: boolean;
   /** Optional preloaded canvas participants to avoid duplicate query */

--- a/apps/dashboard/src/components/Canvas/CanvasCommentsPanel/CanvasCommentsPanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCommentsPanel/CanvasCommentsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   ArrowRight,
   Check,
@@ -31,7 +31,6 @@ import Avatar from '../../ui/Avatar/Avatar';
 import Button from '../../ui/Button';
 import { InputBox } from '../../ui/InputBox';
 import type { MentionResult } from '../../ui/InputBox';
-import { Tooltip } from '../../ui/Tooltip';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -39,6 +38,7 @@ import {
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
 import { formatRelativeCommentTime } from '../canvasCommentTime';
+import { useCanvasCommentRail } from '../useCanvasCommentRail';
 
 type UserLite = {
   id: string;
@@ -91,9 +91,16 @@ interface CanvasCommentsPanelProps {
   activeBlockId: string | null;
   activeThreadId?: string | null | undefined;
   activeAnchor?: CanvasCommentAnchor | null | undefined;
+  /**
+   * Thread ids whose anchor mark is still in the document, or null while that is unknown.
+   * A thread whose commented text was deleted drops off the list until an undo restores it.
+   */
+  anchoredThreadIds?: Set<string> | null | undefined;
   editable: boolean;
+  /** Canvas editor container, used to align each thread with the text it annotates. */
+  anchorContainerRef?: React.RefObject<HTMLDivElement | null> | undefined;
   onClose: () => void;
-  onSelectBlock: (blockId: string) => void;
+  onSelectBlock: (blockId: string, threadId?: string) => void;
   onBeforeCreateThread?: ((threadId: string, anchor: CanvasCommentAnchor) => boolean) | undefined;
   onCreateThreadCreated?: (() => void) | undefined;
   onCreateThreadFailed?: ((anchor: CanvasCommentAnchor) => void) | undefined;
@@ -112,14 +119,24 @@ interface CanvasCommentComposerProps {
   onSubmit: (payload: { body: string; mentionedUserIds: string[] }) => void;
 }
 
+interface CanvasCommentBodyProps {
+  body: string;
+  mentionedUserIds: string[];
+  users: UserLite[];
+  isDeleted: boolean;
+  containerClassName?: string | undefined;
+  className?: string | undefined;
+}
+
 interface CanvasCommentThreadSectionProps {
   thread: CanvasCommentThread;
+  isActive: boolean;
   editable: boolean;
   channelId?: string | undefined;
   currentUserId?: string | undefined;
   allUsers: UserLite[];
   editingCommentId: string | null;
-  onSelectBlock: (blockId: string) => void;
+  onSelectBlock: (blockId: string, threadId?: string) => void;
   onSetThreadStatus: (threadId: string, status: CanvasCommentThreadStatus) => void;
   onSetEditingCommentId: (commentId: string | null) => void;
   onDeleteComment: (commentId: string) => void;
@@ -129,6 +146,9 @@ interface CanvasCommentThreadSectionProps {
     payload: { body: string; mentionedUserIds: string[] },
   ) => void;
 }
+
+// Written out in full so Tailwind's class scanner can see it.
+const COLLAPSED_COMMENT_CLAMP_CLASS = 'overflow-hidden line-clamp-4';
 
 const getDisplayName = (user?: UserLite | null): string =>
   user?.displayName || user?.name || user?.email || 'Unknown';
@@ -217,6 +237,62 @@ const renderCommentBody = (
 
   return nodes.length > 0 ? nodes : [body];
 };
+
+function CanvasCommentBody({
+  body,
+  mentionedUserIds,
+  users,
+  isDeleted,
+  containerClassName,
+  className,
+}: CanvasCommentBodyProps): React.JSX.Element {
+  const bodyRef = useRef<HTMLParagraphElement | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+
+  useLayoutEffect(() => {
+    const node = bodyRef.current;
+    // While expanded the clamp is off, so overflow can no longer be measured —
+    // keep the last collapsed measurement so "Show less" stays available.
+    if (!node || isExpanded) return;
+
+    const measure = (): void => {
+      setIsClamped(node.scrollHeight - node.clientHeight > 1);
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return (): void => observer.disconnect();
+  }, [body, isDeleted, isExpanded]);
+
+  return (
+    <div className={cn('flex flex-col items-start', containerClassName)}>
+      <p
+        ref={bodyRef}
+        className={cn(
+          'w-full whitespace-pre-wrap break-words [text-wrap:pretty]',
+          !isExpanded && COLLAPSED_COMMENT_CLAMP_CLASS,
+          className,
+        )}
+      >
+        {isDeleted ? 'Comment deleted' : renderCommentBody(body, mentionedUserIds, users)}
+      </p>
+      {!isDeleted && isClamped && (
+        <button
+          type='button'
+          onClick={() => setIsExpanded(previous => !previous)}
+          className='py-1 text-[12px] font-bold text-foreground'
+          data-track-category='CANVAS'
+          data-track-name='comment_body_toggle_expand'
+        >
+          {isExpanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
+    </div>
+  );
+}
 
 function CanvasCommentComposer({
   id,
@@ -337,6 +413,7 @@ function CanvasCommentComposer({
 
 function CanvasCommentThreadSection({
   thread,
+  isActive,
   editable,
   channelId,
   currentUserId,
@@ -370,8 +447,12 @@ function CanvasCommentThreadSection({
   return (
     <section
       className={cn(
-        'flex flex-col gap-2 rounded-xl border border-border p-3 transition-colors',
-        isResolved ? 'bg-muted/40' : 'bg-background',
+        'group flex flex-col gap-2 rounded-md border border-border p-2 transition-colors',
+        isActive
+          ? 'border-emerald-300/70 bg-emerald-50 dark:border-emerald-500/35 dark:bg-emerald-500/10'
+          : isResolved
+            ? 'bg-muted/40 hover:bg-accent'
+            : 'bg-background hover:bg-accent',
       )}
     >
       {expandedComments.map((comment, index) => {
@@ -459,7 +540,7 @@ function CanvasCommentThreadSection({
             {isInitialComment && thread.anchorText && (
               <div className='flex min-w-0 gap-2'>
                 <span className='w-[2px] shrink-0 rounded-sm bg-[#e5a93d]' aria-hidden='true' />
-                <span className='min-w-0 flex-1 whitespace-pre-wrap break-words text-[12.5px] leading-[1.5] text-muted-foreground'>
+                <span className='line-clamp-3 min-w-0 flex-1 overflow-hidden whitespace-pre-wrap break-words text-[12.5px] leading-[1.5] text-muted-foreground'>
                   {thread.anchorText}
                 </span>
               </div>
@@ -482,23 +563,19 @@ function CanvasCommentThreadSection({
                 }
               />
             ) : (
-              <p
+              <CanvasCommentBody
+                body={comment.body}
+                mentionedUserIds={parseMentionedUserIds(comment.mentionedUserIds)}
+                users={allUsers}
+                isDeleted={isDeleted}
+                containerClassName={isReply ? 'pl-7' : undefined}
                 className={cn(
-                  'whitespace-pre-wrap break-words [text-wrap:pretty]',
                   isReply
-                    ? 'pl-7 text-[13px] leading-[1.55] text-muted-foreground'
+                    ? 'text-[13px] leading-[1.55] text-muted-foreground'
                     : 'text-[13.5px] leading-[1.6] text-foreground',
                   isDeleted && 'italic text-muted-foreground',
                 )}
-              >
-                {isDeleted
-                  ? 'Comment deleted'
-                  : renderCommentBody(
-                      comment.body,
-                      parseMentionedUserIds(comment.mentionedUserIds),
-                      allUsers,
-                    )}
-              </p>
+              />
             )}
           </div>
         );
@@ -508,7 +585,7 @@ function CanvasCommentThreadSection({
         <Button
           variant='outline'
           size='sm'
-          onClick={() => onSelectBlock(thread.blockId)}
+          onClick={() => onSelectBlock(thread.blockId, thread.id)}
           className='h-[26px] gap-1.5 rounded-[7px] px-2.5 text-xs font-medium'
         >
           <ArrowRight className='size-3.5' />
@@ -547,8 +624,11 @@ export function CanvasCommentsPanel({
   canvasTitle,
   channelId,
   activeBlockId,
+  activeThreadId,
   activeAnchor,
+  anchoredThreadIds,
   editable,
+  anchorContainerRef,
   onClose,
   onSelectBlock,
   onBeforeCreateThread,
@@ -564,12 +644,20 @@ export function CanvasCommentsPanel({
     enabled: Boolean(canvasId),
   }) as unknown as [CanvasCommentThread[]];
 
+  // A thread lives as long as the text it annotates: the editor drops its id from this set when
+  // the anchor is deleted and puts it back on undo.
+  const anchoredThreads = useMemo(
+    () =>
+      anchoredThreadIds ? threads.filter(thread => anchoredThreadIds.has(thread.id)) : threads,
+    [anchoredThreadIds, threads],
+  );
+
   const orderedThreads = useMemo(() => {
-    return [...threads].sort((a, b) => {
+    return [...anchoredThreads].sort((a, b) => {
       if (a.status !== b.status) return a.status === CanvasCommentThreadStatus.OPEN ? -1 : 1;
       return b.createdAt - a.createdAt;
     });
-  }, [threads]);
+  }, [anchoredThreads]);
 
   const visibleThreads = useMemo(
     () =>
@@ -586,10 +674,15 @@ export function CanvasCommentsPanel({
     thread => thread.status === CanvasCommentThreadStatus.RESOLVED,
   ).length;
 
-  const threadCountLabel =
-    orderedThreads.length === 0
-      ? 'No comments on this canvas yet'
-      : `${openCount} open · ${resolvedCount} resolved`;
+  const railScrollRef = useRef<HTMLDivElement | null>(null);
+  const railTrackRef = useRef<HTMLDivElement | null>(null);
+  const rail = useCanvasCommentRail({
+    anchorContainerRef,
+    railScrollRef,
+    railTrackRef,
+    threads: visibleThreads,
+    enabled: Boolean(anchorContainerRef),
+  });
 
   const filterTabs: { value: CanvasCommentThreadFilter; label: string; count: number }[] = [
     { value: 'ALL', label: 'All', count: orderedThreads.length },
@@ -741,43 +834,23 @@ export function CanvasCommentsPanel({
 
   return (
     <motion.aside
-      className='relative z-40 flex h-full w-[390px] max-w-[86%] shrink-0 flex-col rounded-tl-[18px] border-l border-t border-input bg-background shadow-[-16px_0_44px_hsl(var(--foreground)/0.09)]'
+      className='absolute inset-y-0 right-0 z-20 flex w-full shrink-0 flex-col border-l border-border bg-background shadow-xl md:relative md:z-auto md:w-80 md:shadow-none'
       initial={{ x: 14, opacity: 0 }}
       animate={{ x: 0, opacity: 1 }}
       exit={{ x: 12, opacity: 0, transition: { duration: 0.15, ease: 'easeIn' } }}
       transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
     >
-      <motion.div
-        className='flex items-start justify-between gap-2 px-4 pb-3 pt-4'
-        initial={{ opacity: 0, y: 8, filter: 'blur(4px)' }}
-        animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
-        transition={{ duration: 0.3, delay: 0.05, ease: [0.4, 0, 0.2, 1] }}
-      >
-        <div className='min-w-0 flex-1'>
-          <h2 className='truncate text-[14.5px] font-bold leading-5 text-foreground'>
-            Comment activity
-          </h2>
-          <p className='mt-1 text-xs text-muted-foreground'>{threadCountLabel}</p>
+      <div className='flex h-14 shrink-0 items-center justify-between border-b border-border px-4'>
+        <div className='flex items-center gap-2 text-sm font-semibold text-foreground'>
+          <MessageSquare size={16} />
+          Comments
         </div>
-        <Tooltip content='Close comments'>
-          <Button
-            variant='ghost'
-            size='iconSm'
-            onClick={onClose}
-            aria-label='Close comments'
-            className='size-7 shrink-0 text-muted-foreground'
-          >
-            <X className='size-4' />
-          </Button>
-        </Tooltip>
-      </motion.div>
+        <Button variant='ghost' size='iconSm' onClick={onClose} aria-label='Close comments'>
+          <X size={16} />
+        </Button>
+      </div>
 
-      <motion.div
-        className='flex items-center gap-1 px-4 pb-3'
-        initial={{ opacity: 0, y: 8, filter: 'blur(4px)' }}
-        animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
-        transition={{ duration: 0.3, delay: 0.11, ease: [0.4, 0, 0.2, 1] }}
-      >
+      <div className='flex shrink-0 items-center gap-1 border-b border-border px-3 py-2'>
         {filterTabs.map(tab => (
           <button
             key={tab.value}
@@ -796,16 +869,23 @@ export function CanvasCommentsPanel({
             {tab.label} {tab.count}
           </button>
         ))}
-      </motion.div>
+      </div>
 
-      <motion.div
-        className='thin-scrollbar flex-1 overflow-y-auto px-4 pb-5'
-        initial={{ opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.3, delay: 0.17, ease: [0.4, 0, 0.2, 1] }}
+      <div
+        ref={railScrollRef}
+        className={cn(
+          'thin-scrollbar min-h-0 flex-1 overflow-y-auto px-3 pt-3',
+          rail.isAligned ? 'relative' : 'pb-6',
+        )}
       >
         {editable && selectedTextAnchor && (
-          <div className='mb-3 rounded-xl border border-border bg-background p-3'>
+          <div
+            className={cn(
+              'rounded-md border border-border bg-background p-2',
+              // Overlaid while aligned so the composer cannot push the rail off its anchors.
+              rail.isAligned ? 'absolute inset-x-3 top-3 z-10 shadow-sm' : 'mb-2',
+            )}
+          >
             <p className='mb-2 truncate text-[11px] font-semibold uppercase tracking-wide text-muted-foreground'>
               New comment on selected text
             </p>
@@ -827,44 +907,49 @@ export function CanvasCommentsPanel({
         )}
 
         {visibleThreads.length === 0 ? (
-          <div className='flex flex-col items-center justify-center gap-2 px-3 py-10 text-center'>
-            <MessageSquare className='size-[26px] stroke-[1.5] text-muted-foreground/50' />
-            <p className='text-[13px] font-medium text-foreground'>
-              {threadStatusFilter === 'ALL'
-                ? 'No comments'
-                : threadStatusFilter === CanvasCommentThreadStatus.RESOLVED
-                  ? 'No resolved comments'
-                  : 'No open comments'}
-            </p>
-            <p className='text-xs text-muted-foreground'>
-              {threadStatusFilter === 'ALL'
-                ? 'Select text and start a thread.'
-                : threadStatusFilter === CanvasCommentThreadStatus.RESOLVED
-                  ? 'Resolved threads will appear here.'
-                  : 'Select text and start a thread.'}
-            </p>
+          <div className='flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground'>
+            {threadStatusFilter === 'ALL'
+              ? 'No comments yet'
+              : threadStatusFilter === CanvasCommentThreadStatus.RESOLVED
+                ? 'No resolved comments'
+                : 'No open comments'}
           </div>
         ) : (
-          <div className='space-y-2'>
+          <div
+            ref={railTrackRef}
+            className={rail.isAligned ? 'relative' : 'space-y-2'}
+            style={rail.isAligned ? { height: rail.trackHeight } : undefined}
+          >
             {visibleThreads.map(thread => (
-              <CanvasCommentThreadSection
+              <div
                 key={thread.id}
-                thread={thread}
-                editable={editable}
-                channelId={channelId}
-                currentUserId={user?.id}
-                allUsers={allUsers}
-                editingCommentId={editingCommentId}
-                onSelectBlock={onSelectBlock}
-                onSetThreadStatus={setThreadStatus}
-                onSetEditingCommentId={setEditingCommentId}
-                onDeleteComment={deleteComment}
-                onUpdateComment={updateComment}
-              />
+                ref={
+                  rail.isAligned
+                    ? (element): void => rail.registerCard(thread.id, element)
+                    : undefined
+                }
+                className={rail.isAligned ? 'absolute inset-x-0' : undefined}
+                style={rail.isAligned ? { top: rail.cardTops[thread.id] ?? 0 } : undefined}
+              >
+                <CanvasCommentThreadSection
+                  thread={thread}
+                  isActive={activeThreadId === thread.id}
+                  editable={editable}
+                  channelId={channelId}
+                  currentUserId={user?.id}
+                  allUsers={allUsers}
+                  editingCommentId={editingCommentId}
+                  onSelectBlock={onSelectBlock}
+                  onSetThreadStatus={setThreadStatus}
+                  onSetEditingCommentId={setEditingCommentId}
+                  onDeleteComment={deleteComment}
+                  onUpdateComment={updateComment}
+                />
+              </div>
             ))}
           </div>
         )}
-      </motion.div>
+      </div>
     </motion.aside>
   );
 }

--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -137,6 +137,7 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       initialBlockIdToFocus,
       initialCommentThreadId,
       onOpenCommentCountChange,
+      onCommentsOpenChange,
       autoFocus,
       canvasParticipants: preloadedParticipants,
       canvasCreatedBy,
@@ -399,6 +400,7 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       activeCommentBlockId,
       activeCommentThreadId,
       activeCommentAnchor,
+      anchoredCommentThreadIds,
       refreshCommentHighlights,
       openCommentsForCurrentBlock,
       focusCommentBlock,
@@ -414,6 +416,11 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       initialCommentThreadId,
       onOpenCommentCountChange,
     });
+
+    // The panel lives in here, so the header above has no other way to tell that it is open.
+    useEffect(() => {
+      onCommentsOpenChange?.(isCommentsOpen);
+    }, [isCommentsOpen, onCommentsOpenChange]);
 
     // Expose presentation and comment drawer methods via ref
     useImperativeHandle(
@@ -615,7 +622,9 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
                 activeBlockId={activeCommentBlockId}
                 activeThreadId={activeCommentThreadId}
                 activeAnchor={activeCommentAnchor}
+                anchoredThreadIds={anchoredCommentThreadIds}
                 editable={editable}
+                anchorContainerRef={containerRef}
                 onClose={() => setIsCommentsOpen(false)}
                 onSelectBlock={focusCommentBlock}
                 onBeforeCreateThread={applyCommentAnchorStyle}

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -10,10 +10,11 @@ import { CanvasEditor } from '../CanvasEditor/CanvasEditor';
 import { CanvasList } from '../CanvasList';
 import { CanvasShareModal } from '../CanvasShareModal';
 import {
-  CanvasVersionDiffPanel,
+  CanvasVersionDiffLegend,
   CanvasVersionHistory,
   type CanvasVersionRecord,
 } from '../CanvasVersionHistory';
+import { buildCanvasVersionDiffContent } from '../../../utils/canvasVersionDiffContent';
 import { toast } from 'sonner';
 import { Button } from '../../ui/Button';
 import {
@@ -27,6 +28,7 @@ import {
 } from '../../ui/dropdown-menu';
 import { Dialog } from '../../ui/Dialog';
 import { Popover } from '../../ui/Popover';
+import { Switch } from '../../ui/Switch';
 import Input from '../../ui/Input';
 import AvatarGroup from '../../ui/Avatar/AvatarGroup';
 import {
@@ -85,6 +87,7 @@ import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useCurrentUserGroupIds } from '../../../hooks/useUserGroup';
 import { logger, Event } from '../../../utils/logger';
 import { apiInstance } from '../../../services/clients/apiClient';
+import { useSelector } from '@xstate/react';
 import { xyneAIActor, type CanvasInfo } from '../../../machines/xyneAIMachine';
 import { useAllVisibleChannels } from '@xyne/shared/hooks';
 import { usePersistedCanvasPreferences } from '../../../hooks/usePersistedCanvasPreferences';
@@ -208,10 +211,13 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
   }, [selectedCanvas?.id]);
   const [isCreating, setIsCreating] = useState(false);
   const [currentTitle, setCurrentTitle] = useState('Untitled Canvas');
+  const [isRenamingTitle, setIsRenamingTitle] = useState(false);
   const [currentContent, setCurrentContent] = useState<PartialBlock[] | undefined>(undefined);
   const [isSaving, setIsSaving] = useState(false);
   const [showSendConfirmation, setShowSendConfirmation] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
+  // Owned by the editor; mirrored here so the header can mark its comments button as active.
+  const [isCommentsPanelOpen, setIsCommentsPanelOpen] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const [isApproved, setIsApproved] = useState(false);
   const [selectedTheme, setSelectedTheme] = useState('white');
@@ -224,7 +230,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
   } = usePersistedCanvasPreferences();
   const [showVersionHistory, setShowVersionHistory] = useState(false);
   const [previewVersion, setPreviewVersion] = useState<CanvasVersionRecord | null>(null);
-  const [showVersionDiff, setShowVersionDiff] = useState(false);
+  const [showVersionDiff, setShowVersionDiff] = useState(true);
   const [restoringVersionId, setRestoringVersionId] = useState<string | undefined>(undefined);
   const [renamingVersionId, setRenamingVersionId] = useState<string | undefined>(undefined);
 
@@ -927,7 +933,9 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     }
     previewVersionRef.current = version;
     setPreviewVersion(version);
-    setShowVersionDiff(false);
+    // Opening a version shows its changes highlighted straight away; the toggle turns the
+    // highlighting off to read the version plain.
+    setShowVersionDiff(true);
   }, []);
 
   const handleBackToCurrentVersion = useCallback((): void => {
@@ -1060,9 +1068,6 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
 
   const currentContentForVersionCompare =
     latestContentRef.current || currentContent || selectedCanvas?.content || [];
-  const displayedContent = previewVersion
-    ? (normalizeCanvasContent(previewVersion.content) as PartialBlock[])
-    : currentContent || selectedCanvas?.content || [];
   const isPreviewSameAsCurrent = previewVersion
     ? stableStringifyCanvasContent(previewVersion.content) ===
       stableStringifyCanvasContent(currentContentForVersionCompare)
@@ -1071,6 +1076,15 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     ? createCanvasContentTextDiff(currentContentForVersionCompare, previewVersion.content)
     : [];
   const hasVersionDiff = versionDiffParts.some(isVisibleCanvasContentDiffPart);
+  // When on, the preview renders the version document with its changes highlighted inline.
+  const isVersionDiffVisible = Boolean(previewVersion) && showVersionDiff && hasVersionDiff;
+  const previewContent =
+    previewVersion && isVersionDiffVisible
+      ? buildCanvasVersionDiffContent(currentContentForVersionCompare, previewVersion.content)
+      : previewVersion
+        ? (normalizeCanvasContent(previewVersion.content) as PartialBlock[])
+        : null;
+  const displayedContent = previewContent ?? currentContent ?? selectedCanvas?.content ?? [];
   const previewUpdatedAtText = previewVersion
     ? new Date(previewVersion.updatedAt).toLocaleString(undefined, {
         month: 'short',
@@ -1204,9 +1218,18 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     return rows;
   }, [allUsers, selectedCanvas, user?.id, user?.name, visibleChannels]);
 
-  // Shared metrics for the header's 28px icon buttons.
-  const headerIconButtonClass =
-    'relative flex size-7 shrink-0 items-center justify-center rounded-lg text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
+  // Ask AI shares one global sidebar, so its button reads that machine rather than local state.
+  const isAskAIOpen = useSelector(xyneAIActor, snapshot => snapshot.matches('open'));
+
+  // Shared metrics for the header's 28px icon buttons. A button whose surface is currently
+  // showing keeps the hover fill and drops the icon back to full strength, so the row says
+  // which panel is open. Radix triggers (popover, dropdown) flip data-state themselves.
+  const headerIconButtonClass = (isActive = false): string =>
+    cn(
+      'relative flex size-7 shrink-0 items-center justify-center rounded-lg text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+      'data-[state=open]:bg-accent data-[state=open]:[&_svg]:opacity-100',
+      isActive && 'bg-accent [&_svg]:opacity-100',
+    );
 
   return (
     <div className='relative h-full bg-muted flex' data-component='CanvasScreen'>
@@ -1241,7 +1264,14 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                       <ArrowLeft size={16} />
                     </Button>
 
-                    <div className='flex min-w-0 flex-1 items-center gap-2 px-3 py-1'>
+                    <div
+                      className={cn(
+                        'flex min-w-0 flex-1 items-center gap-2 rounded-md border px-3 py-1 transition-colors',
+                        isRenamingTitle
+                          ? 'border-primary/40 bg-background ring-2 ring-primary/10'
+                          : 'border-transparent',
+                      )}
+                    >
                       {canvasPanelContext?.leftHeaderSlot}
                       <FileText size={16} className='shrink-0 text-foreground' />
                       <Input
@@ -1256,8 +1286,20 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                           titleRef.current = newTitle;
                         }}
                         readOnly={!canEdit}
+                        onFocus={() => {
+                          if (canEdit) setIsRenamingTitle(true);
+                        }}
                         onBlur={() => {
+                          setIsRenamingTitle(false);
                           handleTitleSave();
+                        }}
+                        onKeyDown={event => {
+                          // Blur rather than save directly, so onBlur remains the single
+                          // save path and the name cannot be committed twice.
+                          if (event.key === 'Enter') {
+                            event.preventDefault();
+                            event.currentTarget.blur();
+                          }
                         }}
                         className={cn(
                           'h-auto min-w-0 flex-1 border-none bg-transparent px-0 py-0 text-base font-semibold text-foreground shadow-none focus:ring-0 focus-visible:border-none focus-visible:ring-0',
@@ -1308,7 +1350,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                           trigger={
                             <button
                               type='button'
-                              className='flex shrink-0 items-center justify-center rounded-lg py-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                              className='flex shrink-0 items-center justify-center rounded-lg px-1 py-2 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-accent'
                               aria-label='Canvas details'
                               data-testid='canvas-details-button'
                               data-track-category='CANVAS'
@@ -1348,8 +1390,9 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                         <button
                           type='button'
                           onClick={() => editorRef.current?.toggleComments()}
-                          className={headerIconButtonClass}
+                          className={headerIconButtonClass(isCommentsPanelOpen)}
                           title='Comments'
+                          aria-pressed={isCommentsPanelOpen}
                           aria-label='Open comment activity'
                           data-testid='canvas-comments-button'
                           data-track-category='CANVAS'
@@ -1368,7 +1411,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                         <button
                           type='button'
                           onClick={() => setShowShareModal(true)}
-                          className={headerIconButtonClass}
+                          className={headerIconButtonClass(showShareModal)}
                           title='Share'
                           aria-label='Share'
                           data-testid='canvas-share-button'
@@ -1383,7 +1426,10 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                           <button
                             type='button'
                             onClick={handleOpenRecordingNotes}
-                            className={`${headerIconButtonClass} bg-muted text-muted-foreground hover:bg-border hover:text-foreground`}
+                            className={cn(
+                              headerIconButtonClass(),
+                              'bg-muted text-muted-foreground hover:bg-border hover:text-foreground',
+                            )}
                             title='Open recording notes'
                             aria-label='Open recording notes'
                             data-track-category='CANVAS'
@@ -1399,11 +1445,12 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
 
                         {/* Icon button group */}
                         <div className='flex items-center gap-1'>
+                          {/* Ask AI */}
                           {showAskAiAction && (
                             <button
                               type='button'
                               onClick={handleAskAI}
-                              className={headerIconButtonClass}
+                              className={headerIconButtonClass(isAskAIOpen)}
                               title='Ask AI'
                               aria-label='Ask AI'
                               data-track-category='CANVAS'
@@ -1423,7 +1470,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                             <DropdownMenuTrigger asChild>
                               <button
                                 type='button'
-                                className={headerIconButtonClass}
+                                className={headerIconButtonClass()}
                                 title='More options'
                                 aria-label='More options'
                                 data-testid='canvas-more-menu-button'
@@ -1614,6 +1661,9 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                   <span className='font-medium text-foreground'>{previewUpdatedAtText}</span>
                 </div>
                 <div className='flex items-center gap-2'>
+                  {isVersionDiffVisible && (
+                    <CanvasVersionDiffLegend className='mr-1 hidden sm:flex' />
+                  )}
                   <Button
                     variant='secondary'
                     size='sm'
@@ -1624,17 +1674,15 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                     Back to current
                   </Button>
                   {hasVersionDiff && (
-                    <Button
-                      variant={showVersionDiff ? 'default' : 'secondary'}
-                      size='sm'
-                      onClick={() => setShowVersionDiff(prev => !prev)}
-                      data-track-category='CANVAS'
-                      data-track-name='TOGGLE_VERSION_DIFF'
-                      aria-pressed={showVersionDiff}
-                    >
+                    <div className='flex items-center gap-2 text-sm text-muted-foreground'>
                       <GitCompare size={14} />
-                      Diff
-                    </Button>
+                      <span>Diff</span>
+                      <Switch
+                        checked={showVersionDiff}
+                        onCheckedChange={setShowVersionDiff}
+                        aria-label='Highlight changes against the current canvas'
+                      />
+                    </div>
                   )}
                   {canEdit && !isPreviewSameAsCurrent && (
                     <Button
@@ -1653,10 +1701,6 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
               </div>
             )}
 
-            {previewVersion && showVersionDiff && hasVersionDiff && (
-              <CanvasVersionDiffPanel parts={versionDiffParts} />
-            )}
-
             {/* Canvas Editor */}
             <div ref={canvasContentRef} className='flex-1 overflow-hidden'>
               {isCreating && !selectedCanvas ? (
@@ -1668,7 +1712,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                 </div>
               ) : previewVersion ? (
                 <CanvasEditor
-                  key={`preview-${previewVersion.id}`}
+                  key={`preview-${previewVersion.id}-${isVersionDiffVisible ? 'diff' : 'plain'}`}
                   ref={editorRef}
                   content={displayedContent}
                   editable={false}
@@ -1679,6 +1723,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                   initialBlockIdToFocus={blockIdFromUrl}
                   initialCommentThreadId={commentThreadIdFromUrl}
                   onOpenCommentCountChange={setOpenCommentCount}
+                  onCommentsOpenChange={setIsCommentsPanelOpen}
                   canvasParticipants={canvasParticipants}
                   canvasCreatedBy={selectedCanvas?.createdBy}
                   currentUserRole={selectedCanvas?.accessLevel ?? null}
@@ -1704,6 +1749,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                   initialBlockIdToFocus={blockIdFromUrl}
                   initialCommentThreadId={commentThreadIdFromUrl}
                   onOpenCommentCountChange={setOpenCommentCount}
+                  onCommentsOpenChange={setIsCommentsPanelOpen}
                   autoFocus={!skipAutoFocus}
                   canvasParticipants={canvasParticipants}
                   canvasCreatedBy={selectedCanvas.createdBy}
@@ -1726,6 +1772,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                   initialBlockIdToFocus={blockIdFromUrl}
                   initialCommentThreadId={commentThreadIdFromUrl}
                   onOpenCommentCountChange={setOpenCommentCount}
+                  onCommentsOpenChange={setIsCommentsPanelOpen}
                   autoFocus={!skipAutoFocus}
                   canvasParticipants={canvasParticipants}
                   canvasCreatedBy={selectedCanvas?.createdBy}

--- a/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
@@ -173,6 +173,7 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
     setOpenCommentCount(0);
   }, [canvas?.id]);
   const [currentTitle, setCurrentTitle] = useState('Untitled Canvas');
+  const [isRenamingTitle, setIsRenamingTitle] = useState(false);
   const titleRef = useRef('Untitled Canvas'); // Track title synchronously to avoid race conditions
   const [currentContent, setCurrentContent] = useState<PartialBlock[] | undefined>(undefined);
   const [isSaving, setIsSaving] = useState(false);
@@ -1019,12 +1020,26 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
               titleRef.current = newTitle;
             }}
             readOnly={!canEdit}
+            onFocus={() => {
+              if (canEdit) setIsRenamingTitle(true);
+            }}
             onBlur={() => {
+              setIsRenamingTitle(false);
               handleTitleSave();
             }}
-            className={`text-base md:text-xl font-semibold flex-1 border-none shadow-none focus:ring-0 focus-visible:ring-0 focus-visible:border-none px-2 py-1 h-auto rounded min-w-0 ${
-              canEdit ? 'hover:bg-accent' : 'cursor-default'
-            }`}
+            onKeyDown={event => {
+              // Blur rather than save directly, so onBlur remains the single save path
+              // and the name cannot be committed twice.
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                event.currentTarget.blur();
+              }
+            }}
+            className={`text-base md:text-xl font-semibold flex-1 shadow-none focus:ring-0 focus-visible:ring-0 px-2 py-1 h-auto rounded min-w-0 transition-colors ${
+              isRenamingTitle
+                ? 'border border-primary/40 bg-background ring-2 ring-primary/10 focus-visible:border-primary/40'
+                : 'border-none focus-visible:border-none'
+            } ${canEdit ? 'hover:bg-accent' : 'cursor-default'}`}
             placeholder='Untitled Canvas'
             data-testid='canvas-title-input'
             data-track-category='CANVAS'

--- a/apps/dashboard/src/components/Canvas/CanvasVersionHistory/CanvasVersionDiffLegend.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasVersionHistory/CanvasVersionDiffLegend.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+import { cn } from '../../../utils/classNames';
+
+interface CanvasVersionDiffLegendProps {
+  className?: string;
+}
+
+/**
+ * Explains the inline highlighting used by the version preview while diff mode is on.
+ * The diff itself is rendered inside the document, so this is the only chrome it needs.
+ */
+export const CanvasVersionDiffLegend = ({
+  className,
+}: CanvasVersionDiffLegendProps): ReactElement => (
+  <div className={cn('flex flex-wrap items-center gap-3 text-xs text-muted-foreground', className)}>
+    <span className='inline-flex items-center gap-1'>
+      <span className='h-2 w-2 rounded-sm bg-emerald-300' />
+      In this version
+    </span>
+    <span className='inline-flex items-center gap-1'>
+      <span className='h-2 w-2 rounded-sm bg-red-300' />
+      Only in current
+    </span>
+  </div>
+);

--- a/apps/dashboard/src/components/Canvas/CanvasVersionHistory/CanvasVersionHistory.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasVersionHistory/CanvasVersionHistory.tsx
@@ -144,7 +144,7 @@ export const CanvasVersionHistory = ({
                         className='min-w-0 flex-1 text-left'
                         onClick={() => {
                           onPreview(version);
-                          onClose();
+                          //onClose();
                         }}
                         data-track-category='CANVAS'
                         data-track-name='Preview_Canvas_Version'

--- a/apps/dashboard/src/components/Canvas/CanvasVersionHistory/index.ts
+++ b/apps/dashboard/src/components/Canvas/CanvasVersionHistory/index.ts
@@ -1,3 +1,4 @@
 export { CanvasVersionDiffPanel } from './CanvasVersionDiffPanel';
+export { CanvasVersionDiffLegend } from './CanvasVersionDiffLegend';
 export { CanvasVersionHistory } from './CanvasVersionHistory';
 export type { CanvasVersionRecord } from './CanvasVersionHistory';

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -128,6 +128,8 @@ interface CollaborativeCanvasEditorProps {
   initialCommentThreadId?: string | undefined;
   /** Emits the number of open comment threads already loaded by the editor highlight query. */
   onOpenCommentCountChange?: (count: number) => void;
+  /** Mirrors the comments panel open state so the host header can mark its button as active. */
+  onCommentsOpenChange?: (open: boolean) => void;
   /** Auto-focus the editor on mount */
   autoFocus?: boolean;
   /** Recording summaries render generated body copy muted; local edits mark touched blocks foreground. */
@@ -160,6 +162,7 @@ export const CollaborativeCanvasEditor = forwardRef<
       initialBlockIdToFocus,
       initialCommentThreadId,
       onOpenCommentCountChange,
+      onCommentsOpenChange,
       autoFocus,
       trackEditedRecordingSummaryBlocks = false,
       canvasParticipants: preloadedParticipants,
@@ -548,6 +551,7 @@ export const CollaborativeCanvasEditor = forwardRef<
       activeCommentBlockId,
       activeCommentThreadId,
       activeCommentAnchor,
+      anchoredCommentThreadIds,
       refreshCommentHighlights,
       openCommentsForCurrentBlock,
       focusCommentBlock,
@@ -564,6 +568,11 @@ export const CollaborativeCanvasEditor = forwardRef<
       onOpenCommentCountChange,
       ready: isEditorReady,
     });
+
+    // The panel lives in here, so the header above has no other way to tell that it is open.
+    useEffect(() => {
+      onCommentsOpenChange?.(isCommentsOpen);
+    }, [isCommentsOpen, onCommentsOpenChange]);
 
     // Expose presentation and comment drawer methods via ref
     useImperativeHandle(
@@ -804,7 +813,9 @@ export const CollaborativeCanvasEditor = forwardRef<
                 activeBlockId={activeCommentBlockId}
                 activeThreadId={activeCommentThreadId}
                 activeAnchor={activeCommentAnchor}
+                anchoredThreadIds={anchoredCommentThreadIds}
                 editable={editable && !isReadOnly}
+                anchorContainerRef={containerRef}
                 onClose={() => setIsCommentsOpen(false)}
                 onSelectBlock={focusCommentBlock}
                 onBeforeCreateThread={applyCommentAnchorStyle}

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentAnchors.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentAnchors.ts
@@ -1,0 +1,228 @@
+import type {
+  BlockNoteEditor,
+  BlockSchema,
+  InlineContentSchema,
+  StyleSchema,
+} from '@blocknote/core';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+type CanvasEditorLike = BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>;
+
+/** Style spec registered in `canvasSchema`; the mark carries the thread id. */
+const COMMENT_THREAD_STYLE = 'canvasCommentThread';
+
+/** BlockNote stores a `propSchema: 'string'` style value under this mark attribute. */
+const COMMENT_THREAD_STYLE_VALUE_ATTR = 'stringValue';
+
+/** One scan per burst of typing instead of one per keystroke. */
+const SCAN_DEBOUNCE_MS = 150;
+
+/**
+ * The document can arrive after mount (initial load, first collaborative sync) without a
+ * further change event, so the first scan is retried across that window.
+ */
+const SCAN_RETRY_DELAYS_MS = [100, 400, 900];
+
+/**
+ * How long a document with no text must stay quiet before it is believed to be genuinely empty
+ * rather than still loading. Comfortably longer than a collaborative sync takes to land, and it
+ * restarts on every document change — see `useCanvasCommentAnchors`.
+ */
+const EMPTY_DOCUMENT_SETTLE_MS = 2500;
+
+interface ProseMirrorMarkLike {
+  type: { name: string };
+  attrs: Record<string, unknown>;
+}
+
+interface ProseMirrorNodeLike {
+  isText: boolean;
+  text?: string | undefined;
+  marks: readonly ProseMirrorMarkLike[];
+  descendants: (callback: (node: ProseMirrorNodeLike) => void) => void;
+}
+
+interface CanvasCommentAnchorScan {
+  anchoredThreadIds: Set<string>;
+  /** Whether the document held any text at all — see `useCanvasCommentAnchors`. */
+  hasText: boolean;
+}
+
+const getEditorDocument = (editor: CanvasEditorLike | null): ProseMirrorNodeLike | null => {
+  if (!editor) return null;
+  try {
+    return (
+      (editor as unknown as { _tiptapEditor?: { state?: { doc?: ProseMirrorNodeLike } } })
+        ._tiptapEditor?.state?.doc ?? null
+    );
+  } catch {
+    return null;
+  }
+};
+
+const isSameThreadIdSet = (a: Set<string>, b: Set<string>): boolean =>
+  a.size === b.size && [...a].every(threadId => b.has(threadId));
+
+/**
+ * Walks the document for comment anchor marks. Returns null when there is no document to read.
+ */
+export const scanCanvasCommentAnchors = (
+  editor: CanvasEditorLike | null,
+): CanvasCommentAnchorScan | null => {
+  const doc = getEditorDocument(editor);
+  if (!doc) return null;
+
+  const anchoredThreadIds = new Set<string>();
+  let hasText = false;
+
+  try {
+    doc.descendants(node => {
+      if (!hasText && node.isText && node.text && node.text.trim().length > 0) {
+        hasText = true;
+      }
+      node.marks.forEach(mark => {
+        if (mark.type.name !== COMMENT_THREAD_STYLE) return;
+        const threadId = mark.attrs[COMMENT_THREAD_STYLE_VALUE_ATTR];
+        if (typeof threadId === 'string' && threadId.length > 0) {
+          anchoredThreadIds.add(threadId);
+        }
+      });
+    });
+  } catch {
+    return null;
+  }
+
+  return { anchoredThreadIds, hasText };
+};
+
+interface UseCanvasCommentAnchorsOptions {
+  canvasId?: string | undefined;
+  containerRef: RefObject<HTMLElement | null>;
+  getEditor: () => CanvasEditorLike | null;
+  enabled?: boolean;
+  /** Bumped by the editors on every document change, including undo and redo. */
+  refreshKey?: unknown;
+}
+
+export interface CanvasCommentAnchors {
+  /**
+   * Thread ids whose anchor mark is still in the document, or `null` while that cannot be known
+   * yet. Callers treat `null` as "show everything".
+   */
+  anchoredThreadIds: Set<string> | null;
+  /**
+   * Records an anchor the caller just wrote into the document, so a brand new thread is never
+   * hidden for the one debounce window before the next scan sees its mark.
+   */
+  trackAnchoredThreadId: (threadId: string) => void;
+}
+
+/**
+ * Tracks which comment threads still have their anchor in the document.
+ *
+ * The anchor mark lives in the document itself, so deleting the commented text takes the mark
+ * with it and undo puts it back. Deriving comment visibility from the mark therefore gives a
+ * comment exactly the lifetime of the text it annotates — including undo — without a second
+ * source of truth that could disagree with the document.
+ */
+export const useCanvasCommentAnchors = ({
+  canvasId,
+  containerRef,
+  getEditor,
+  enabled = true,
+  refreshKey,
+}: UseCanvasCommentAnchorsOptions): CanvasCommentAnchors => {
+  const [anchoredThreadIds, setAnchoredThreadIds] = useState<Set<string> | null>(null);
+
+  /**
+   * An editor that has not loaded its content yet is indistinguishable from one whose text was
+   * all deleted: both scan as zero anchors. Text in the document settles that immediately and
+   * for good — the flag stays set, so later emptying the whole canvas still drops its comments.
+   * A document that has never held text is only trusted after the settle period below, so a slow
+   * load never wipes every comment on screen.
+   */
+  const hasHeldTextRef = useRef(false);
+  const getEditorRef = useRef(getEditor);
+  getEditorRef.current = getEditor;
+
+  useEffect(() => {
+    hasHeldTextRef.current = false;
+    setAnchoredThreadIds(null);
+  }, [canvasId]);
+
+  const trackAnchoredThreadId = useCallback((threadId: string): void => {
+    setAnchoredThreadIds(current => {
+      if (!current || current.has(threadId)) return current;
+      const next = new Set(current);
+      next.add(threadId);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') {
+      setAnchoredThreadIds(null);
+      return;
+    }
+
+    // Reset on every document change, so the deadline means "quiet for this long", not "this
+    // long after mount". Emptying the canvas therefore settles once the user stops deleting.
+    let hasSettled = false;
+
+    const scan = (): void => {
+      const scanned = scanCanvasCommentAnchors(getEditorRef.current());
+      if (!scanned) return;
+      if (scanned.hasText) hasHeldTextRef.current = true;
+      if (!hasHeldTextRef.current && !hasSettled) return;
+
+      setAnchoredThreadIds(current =>
+        current && isSameThreadIdSet(current, scanned.anchoredThreadIds)
+          ? current
+          : scanned.anchoredThreadIds,
+      );
+    };
+
+    const settleTimeout = window.setTimeout(() => {
+      hasSettled = true;
+      scan();
+    }, EMPTY_DOCUMENT_SETTLE_MS);
+
+    let debounceTimeout: number | null = null;
+    const scheduleScan = (): void => {
+      if (debounceTimeout !== null) window.clearTimeout(debounceTimeout);
+      debounceTimeout = window.setTimeout(() => {
+        debounceTimeout = null;
+        scan();
+      }, SCAN_DEBOUNCE_MS);
+    };
+
+    scheduleScan();
+    const retryTimeouts = SCAN_RETRY_DELAYS_MS.map(delay => window.setTimeout(scan, delay));
+
+    // A remote collaborator's edit reaches the document without a local change event, so watch
+    // the rendered anchors too rather than relying on the editor's onChange alone.
+    const container = containerRef.current;
+    const observer =
+      container && typeof MutationObserver !== 'undefined'
+        ? new MutationObserver(scheduleScan)
+        : null;
+    if (observer && container) {
+      observer.observe(container, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ['data-canvas-comment-thread-id'],
+      });
+    }
+
+    return () => {
+      if (debounceTimeout !== null) window.clearTimeout(debounceTimeout);
+      window.clearTimeout(settleTimeout);
+      retryTimeouts.forEach(timeout => window.clearTimeout(timeout));
+      observer?.disconnect();
+    };
+  }, [containerRef, enabled, refreshKey]);
+
+  return { anchoredThreadIds, trackAnchoredThreadId };
+};

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 
 import { scrollToHeading } from '../../utils/canvasUtils';
 import type { CanvasCommentAnchor } from './CanvasCommentsPanel/CanvasCommentsPanel';
+import { useCanvasCommentAnchors } from './useCanvasCommentAnchors';
 import {
   useCanvasCommentHighlights,
   type CanvasCommentHighlightThread,
@@ -47,6 +48,9 @@ interface TiptapEditorLike {
   };
   commands: {
     setTextSelection: (range: { from: number; to: number }) => boolean;
+  };
+  view?: {
+    posAtDOM: (node: Node, offset: number) => number;
   };
 }
 
@@ -108,6 +112,40 @@ const getCommentThreadRect = (
   );
 };
 
+/**
+ * Puts the caret at the first character of the commented text rather than at the top of its
+ * block, by mapping the rendered anchor back to a document position. Returns false when the
+ * anchor is not rendered, so the caller can fall back to the block.
+ */
+const focusCommentAnchorStart = (
+  editor: CanvasEditorLike,
+  container: HTMLElement | null,
+  threadId: string,
+): boolean => {
+  if (!container) return false;
+
+  const anchorElement = container.querySelector<HTMLElement>(
+    `[data-canvas-comment-thread-id="${escapeSelectorValue(threadId)}"]`,
+  );
+  if (!anchorElement) return false;
+
+  const tiptapEditor = getTiptapEditor(editor);
+  const view = tiptapEditor?.view;
+  if (!tiptapEditor || !view) return false;
+
+  try {
+    const position = view.posAtDOM(anchorElement, 0);
+    if (typeof position !== 'number' || Number.isNaN(position) || position < 0) return false;
+
+    tiptapEditor.commands.setTextSelection({ from: position, to: position });
+    (editor as unknown as { focus?: () => void }).focus?.();
+    anchorElement.scrollIntoView({ block: 'center' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const INLINE_COMMENT_INTERACTIVE_SELECTOR = [
   '[data-canvas-inline-comment-thread="true"]',
   '[data-overlay-portal]',
@@ -142,7 +180,7 @@ export function useCanvasCommentEditorBridge({
 
   const handleCommentAnchorClick = useCallback(
     (thread: CanvasCommentHighlightThread, rect?: DOMRect): void => {
-      setIsCommentsOpen(false);
+      // The panel stays open — clicking an anchor selects a thread, it does not dismiss the list.
       setActiveCommentBlockId(thread.blockId);
       setActiveCommentThreadId(thread.id);
       setActiveCommentAnchor(null);
@@ -157,16 +195,36 @@ export function useCanvasCommentEditorBridge({
     [],
   );
 
+  // The anchor mark is part of the document, so it dies with the text it wraps and comes back
+  // with an undo. Everything that shows a comment follows this set rather than the thread rows.
+  const { anchoredThreadIds: anchoredCommentThreadIds, trackAnchoredThreadId } =
+    useCanvasCommentAnchors({
+      canvasId,
+      containerRef,
+      getEditor,
+      enabled: ready && Boolean(canvasId),
+      refreshKey: commentHighlightVersion,
+    });
+
   useCanvasCommentHighlights({
     canvasId,
     containerRef,
     enabled: ready && Boolean(canvasId),
     refreshKey: commentHighlightVersion,
     activeThreadId: activeCommentThreadId,
+    anchoredThreadIds: anchoredCommentThreadIds,
     onAnchorClick: handleCommentAnchorClick,
     onOpenCountChange: onOpenCommentCountChange,
     onThreadsChange: setCommentThreads,
   });
+
+  // A card left open over text that just got deleted has nothing to point at.
+  useEffect(() => {
+    if (!anchoredCommentThreadIds || !activeCommentThreadId) return;
+    if (anchoredCommentThreadIds.has(activeCommentThreadId)) return;
+    setInlineCommentThread(null);
+    setActiveCommentThreadId(null);
+  }, [activeCommentThreadId, anchoredCommentThreadIds]);
 
   useEffect(() => {
     setInlineCommentThread(current => {
@@ -183,24 +241,42 @@ export function useCanvasCommentEditorBridge({
   useEffect(() => {
     if (!inlineCommentThread) return;
 
+    // Both paths must also drop the active thread. Its badge is hidden with
+    // `pointer-events: none` while active, so leaving the id set after the card closes would
+    // leave an invisible, unclickable badge behind and the next click would do nothing.
+    const dismissInlineThread = (): void => {
+      setInlineCommentThread(null);
+      setActiveCommentThreadId(null);
+    };
+
     const handlePointerDown = (event: PointerEvent): void => {
       const target = event.target;
       if (!(target instanceof Element)) return;
       if (target.closest(INLINE_COMMENT_INTERACTIVE_SELECTOR)) return;
-      setInlineCommentThread(null);
+      dismissInlineThread();
     };
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
-        setInlineCommentThread(null);
+        dismissInlineThread();
       }
+    };
+
+    // Scrolling the document dismisses the card, but scrolling inside it (a long thread)
+    // must not. Capture phase is required — scroll events do not bubble.
+    const handleScroll = (event: Event): void => {
+      const target = event.target;
+      if (target instanceof Element && target.closest(INLINE_COMMENT_INTERACTIVE_SELECTOR)) return;
+      dismissInlineThread();
     };
 
     document.addEventListener('pointerdown', handlePointerDown);
     document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('scroll', handleScroll, true);
     return () => {
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('scroll', handleScroll, true);
     };
   }, [inlineCommentThread]);
 
@@ -305,13 +381,16 @@ export function useCanvasCommentEditorBridge({
           from: anchor.selectionTo,
           to: anchor.selectionTo,
         });
+        // Claim the anchor now: the thread row lands before the next scan reads the mark, and
+        // without this the brand new comment would blink out for that window.
+        trackAnchoredThreadId(threadId);
         refreshCommentHighlights();
         return true;
       } catch {
         return false;
       }
     },
-    [getEditor, refreshCommentHighlights],
+    [getEditor, refreshCommentHighlights, trackAnchoredThreadId],
   );
 
   const removeCommentAnchorStyle = useCallback(
@@ -373,12 +452,16 @@ export function useCanvasCommentEditorBridge({
   }, [containerRef, getCurrentBlockId, getCurrentCommentAnchor, getEditor]);
 
   const focusCommentBlock = useCallback(
-    (blockId: string): void => {
+    (blockId: string, threadId?: string): void => {
       setActiveCommentBlockId(blockId);
-      setActiveCommentThreadId(null);
+      setActiveCommentThreadId(threadId ?? null);
       setActiveCommentAnchor(null);
       const editor = getEditor();
       if (!editor) return;
+
+      // Prefer the commented text itself; fall back to the block when it is not rendered.
+      if (threadId && focusCommentAnchorStart(editor, containerRef.current, threadId)) return;
+
       try {
         editor.setTextCursorPosition(blockId, 'start');
         (editor as unknown as { focus?: () => void }).focus?.();
@@ -407,6 +490,7 @@ export function useCanvasCommentEditorBridge({
     activeCommentBlockId,
     activeCommentThreadId,
     activeCommentAnchor,
+    anchoredCommentThreadIds,
     refreshCommentHighlights,
     openCommentsForCurrentBlock,
     focusCommentBlock,

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentHighlights.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentHighlights.ts
@@ -19,6 +19,12 @@ interface UseCanvasCommentHighlightsOptions {
   enabled?: boolean;
   refreshKey?: unknown;
   activeThreadId?: string | null | undefined;
+  /**
+   * Thread ids whose anchor mark is still in the document, or null while that is unknown.
+   * A thread outside the set had its commented text deleted, so it gets no highlight and no
+   * badge until an undo brings the anchor back.
+   */
+  anchoredThreadIds?: Set<string> | null | undefined;
   onAnchorClick?: ((thread: CanvasCommentHighlightThread, rect?: DOMRect) => void) | undefined;
   onOpenCountChange?: ((count: number) => void) | undefined;
   onThreadsChange?: ((threads: CanvasCommentHighlightThread[]) => void) | undefined;
@@ -172,6 +178,7 @@ export const useCanvasCommentHighlights = ({
   enabled = true,
   refreshKey,
   activeThreadId,
+  anchoredThreadIds,
   onAnchorClick,
   onOpenCountChange,
   onThreadsChange,
@@ -182,9 +189,14 @@ export const useCanvasCommentHighlights = ({
       enabled: enabled && Boolean(canvasId),
     },
   ) as unknown as [CanvasCommentHighlightThread[]];
+  const anchoredThreads = useMemo(
+    () =>
+      anchoredThreadIds ? threads.filter(thread => anchoredThreadIds.has(thread.id)) : threads,
+    [anchoredThreadIds, threads],
+  );
   const openThreads = useMemo(
-    () => threads.filter(thread => thread.status === CanvasCommentThreadStatus.OPEN),
-    [threads],
+    () => anchoredThreads.filter(thread => thread.status === CanvasCommentThreadStatus.OPEN),
+    [anchoredThreads],
   );
   const openThreadIds = useMemo(() => new Set(openThreads.map(thread => thread.id)), [openThreads]);
   const threadBadgeData = useMemo(
@@ -225,8 +237,8 @@ export const useCanvasCommentHighlights = ({
     }
 
     onOpenCountChange?.(openThreads.length);
-    onThreadsChange?.(threads);
-  }, [canvasId, enabled, onOpenCountChange, onThreadsChange, openThreads.length, threads]);
+    onThreadsChange?.(anchoredThreads);
+  }, [anchoredThreads, canvasId, enabled, onOpenCountChange, onThreadsChange, openThreads.length]);
 
   useEffect(() => {
     if (!enabled || !canvasId || typeof window === 'undefined') return;

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentRail.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentRail.ts
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+
+/** Vertical breathing room between two cards that would otherwise overlap. */
+const CARD_GAP = 8;
+/** Used until a card has been measured, so the first paint is roughly right. */
+const ESTIMATED_CARD_HEIGHT = 132;
+/** Below this width the panel covers the document, so aligning to it is meaningless. */
+const ALIGNED_VIEWPORT_QUERY = '(min-width: 768px)';
+/** Space kept under the last card so it never sits flush against the panel edge. */
+const RAIL_BOTTOM_SPACE = 24;
+
+export interface CanvasCommentRailThread {
+  id: string;
+  blockId: string;
+}
+
+interface UseCanvasCommentRailOptions {
+  /** The canvas editor container; the rail measures anchors inside its scroller. */
+  anchorContainerRef?: RefObject<HTMLElement | null> | undefined;
+  /** The panel's own scroll container, kept in step with the document. */
+  railScrollRef: RefObject<HTMLElement | null>;
+  /**
+   * The track the cards are absolutely positioned in. Its origin is compared against the
+   * document's so the panel's own chrome — header, filter strip, padding — cannot shift every
+   * card down by a constant amount.
+   */
+  railTrackRef: RefObject<HTMLElement | null>;
+  threads: CanvasCommentRailThread[];
+  enabled: boolean;
+}
+
+export interface CanvasCommentRail {
+  /** False when anchors cannot be measured — the caller falls back to a plain list. */
+  isAligned: boolean;
+  /** Height of the rail track: tall enough for the document and for every card. */
+  trackHeight: number;
+  /** Final top offset per thread, after resolving overlaps. */
+  cardTops: Record<string, number>;
+  registerCard: (threadId: string, element: HTMLElement | null) => void;
+}
+
+const escapeSelectorValue = (value: string): string =>
+  typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+    ? CSS.escape(value)
+    : value.replace(/["\\]/g, '\\$&');
+
+const areOffsetsEqual = (a: Record<string, number>, b: Record<string, number>): boolean => {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  // Sub-pixel jitter from layout should not trigger a re-render.
+  return aKeys.every(key => key in b && Math.abs((a[key] ?? 0) - (b[key] ?? 0)) < 0.5);
+};
+
+/**
+ * Positions comment cards beside the text they annotate, the way Google Docs does: each card
+ * starts at its anchor's vertical offset, and cards that would overlap are pushed down. The
+ * rail spans the document's scroll range, and the two columns scroll together — dragging
+ * either one moves the other.
+ */
+export const useCanvasCommentRail = ({
+  anchorContainerRef,
+  railScrollRef,
+  railTrackRef,
+  threads,
+  enabled,
+}: UseCanvasCommentRailOptions): CanvasCommentRail => {
+  const [anchorTops, setAnchorTops] = useState<Record<string, number>>({});
+  const [cardHeights, setCardHeights] = useState<Record<string, number>>({});
+  /** Track height needed for the rail to travel as far as the document can scroll. */
+  const [documentTrackHeight, setDocumentTrackHeight] = useState(0);
+  const [isWideViewport, setIsWideViewport] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(ALIGNED_VIEWPORT_QUERY).matches,
+  );
+
+  const cardElementsRef = useRef<Map<string, HTMLElement>>(new Map());
+  const cardObserverRef = useRef<ResizeObserver | null>(null);
+
+  // Threads arrive as a fresh array on every query update; key on content so the measuring
+  // effect only restarts when the set of anchors actually changes.
+  const threadsKey = threads.map(thread => `${thread.id}:${thread.blockId}`).join('|');
+  const threadsRef = useRef(threads);
+  threadsRef.current = threads;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const query = window.matchMedia(ALIGNED_VIEWPORT_QUERY);
+    const handleChange = (): void => setIsWideViewport(query.matches);
+    handleChange();
+    query.addEventListener('change', handleChange);
+    return () => query.removeEventListener('change', handleChange);
+  }, []);
+
+  const isAlignmentActive = enabled && isWideViewport;
+
+  useEffect(() => {
+    if (!isAlignmentActive || typeof window === 'undefined') return;
+
+    const container = anchorContainerRef?.current;
+    if (!container) return;
+
+    const scrollContainer = container.querySelector<HTMLElement>('.thin-scrollbar') ?? container;
+
+    const measure = (): void => {
+      const trackElement = railTrackRef.current;
+      const railElement = railScrollRef.current;
+      if (!trackElement || !railElement) return;
+
+      const scrollRect = scrollContainer.getBoundingClientRect();
+      const trackRect = trackElement.getBoundingClientRect();
+
+      // Anchor offsets are in the document's coordinate space, but the cards live in the track,
+      // which starts lower — below the panel's header and filter strip, and without the editor's
+      // top padding. Without this correction every card is off by that constant.
+      //
+      // Both terms are taken at scroll 0 so the delta cannot drift as either column scrolls:
+      // a scroll container's own box does not move (only its content does), while the track is
+      // content, so its rect has already been displaced by -scrollTop and has to add it back.
+      const documentContainerTop = scrollRect.top;
+      const trackOriginTop = trackRect.top + railElement.scrollTop;
+      const originDelta = documentContainerTop - trackOriginTop;
+
+      const nextAnchorTops: Record<string, number> = {};
+
+      threadsRef.current.forEach(thread => {
+        const anchorElement =
+          scrollContainer.querySelector<HTMLElement>(
+            `[data-canvas-comment-thread-id="${escapeSelectorValue(thread.id)}"]`,
+          ) ??
+          scrollContainer.querySelector<HTMLElement>(
+            `[data-id="${escapeSelectorValue(thread.blockId)}"]`,
+          );
+        if (!anchorElement) return;
+
+        // getClientRects()[0] is the first line of a wrapped anchor; getBoundingClientRect
+        // returns the union box, which drags the card down to the middle of a multi-line run.
+        const anchorRect =
+          anchorElement.getClientRects()[0] ?? anchorElement.getBoundingClientRect();
+        const documentOffset = anchorRect.top - scrollRect.top + scrollContainer.scrollTop;
+        nextAnchorTops[thread.id] = Math.max(0, documentOffset + originDelta);
+      });
+
+      setAnchorTops(current =>
+        areOffsetsEqual(current, nextAnchorTops) ? current : nextAnchorTops,
+      );
+
+      // How much scroll travel the rail needs to keep step with the document. The cards alone
+      // cannot supply it: a filter that leaves one card standing collapses the track, and the
+      // rail then clamps at scrollTop 0 while the canvas scrolls out from under that card.
+      const railRect = railElement.getBoundingClientRect();
+      const trackOffsetWithinRail = trackRect.top + railElement.scrollTop - railRect.top;
+      const documentScrollRange = Math.max(
+        0,
+        scrollContainer.scrollHeight - scrollContainer.clientHeight,
+      );
+      const nextDocumentTrackHeight = Math.max(
+        0,
+        documentScrollRange + railElement.clientHeight - trackOffsetWithinRail,
+      );
+      setDocumentTrackHeight(current =>
+        Math.abs(current - nextDocumentTrackHeight) < 1 ? current : nextDocumentTrackHeight,
+      );
+    };
+
+    let pendingAnimationFrame: number | null = null;
+    const scheduleMeasure = (): void => {
+      if (pendingAnimationFrame !== null) return;
+      pendingAnimationFrame = window.requestAnimationFrame(() => {
+        pendingAnimationFrame = null;
+        measure();
+      });
+    };
+
+    scheduleMeasure();
+    // The editor paints its content in stages; re-measure until it settles.
+    const retryTimeouts = [100, 300, 800].map(delay => window.setTimeout(scheduleMeasure, delay));
+
+    scrollContainer.addEventListener('scroll', scheduleMeasure, { passive: true });
+    // The panel scrolls on its own, so its scroll moves the track and the origins must be
+    // re-read — the offsets themselves are scroll-invariant, this only keeps them accurate.
+    const railScrollElement = railScrollRef.current;
+    railScrollElement?.addEventListener('scroll', scheduleMeasure, { passive: true });
+    window.addEventListener('resize', scheduleMeasure);
+
+    const observedEditor = scrollContainer.querySelector<HTMLElement>('.bn-editor');
+    const mutationObserver =
+      observedEditor && typeof MutationObserver !== 'undefined'
+        ? new MutationObserver(scheduleMeasure)
+        : null;
+    if (mutationObserver && observedEditor) {
+      mutationObserver.observe(observedEditor, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ['data-id', 'data-canvas-comment-thread-id'],
+      });
+    }
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleMeasure) : null;
+    resizeObserver?.observe(scrollContainer);
+
+    return () => {
+      if (pendingAnimationFrame !== null) window.cancelAnimationFrame(pendingAnimationFrame);
+      retryTimeouts.forEach(timeout => window.clearTimeout(timeout));
+      scrollContainer.removeEventListener('scroll', scheduleMeasure);
+      railScrollElement?.removeEventListener('scroll', scheduleMeasure);
+      window.removeEventListener('resize', scheduleMeasure);
+      mutationObserver?.disconnect();
+      resizeObserver?.disconnect();
+    };
+  }, [anchorContainerRef, isAlignmentActive, railScrollRef, railTrackRef, threadsKey]);
+
+  /**
+   * Scrolling the canvas carries the panel with it, so cards stay beside their paragraphs.
+   * The link is deliberately one-way: the panel remains its own scroll container, so comments
+   * can be browsed without dragging the document along. The next canvas scroll re-levels them.
+   */
+  useEffect(() => {
+    if (!isAlignmentActive || typeof window === 'undefined') return;
+
+    const container = anchorContainerRef?.current;
+    const railElement = railScrollRef.current;
+    if (!container || !railElement) return;
+
+    const documentElement = container.querySelector<HTMLElement>('.thin-scrollbar') ?? container;
+
+    const handleDocumentScroll = (): void => {
+      const target = documentElement.scrollTop;
+      if (Math.abs(railElement.scrollTop - target) < 1) return;
+      railElement.scrollTop = target;
+    };
+
+    documentElement.addEventListener('scroll', handleDocumentScroll, { passive: true });
+    return () => documentElement.removeEventListener('scroll', handleDocumentScroll);
+  }, [anchorContainerRef, isAlignmentActive, railScrollRef]);
+
+  const getCardObserver = useCallback((): ResizeObserver | null => {
+    if (typeof ResizeObserver === 'undefined') return null;
+    if (!cardObserverRef.current) {
+      cardObserverRef.current = new ResizeObserver(entries => {
+        setCardHeights(current => {
+          let next = current;
+          entries.forEach(entry => {
+            const threadId = (entry.target as HTMLElement).dataset['canvasCommentCardThreadId'];
+            if (!threadId) return;
+            const height = entry.contentRect.height;
+            if (Math.abs((current[threadId] ?? 0) - height) < 0.5) return;
+            if (next === current) next = { ...current };
+            next[threadId] = height;
+          });
+          return next;
+        });
+      });
+    }
+    return cardObserverRef.current;
+  }, []);
+
+  const registerCard = useCallback(
+    (threadId: string, element: HTMLElement | null): void => {
+      const observer = getCardObserver();
+      const elements = cardElementsRef.current;
+      const previous = elements.get(threadId);
+
+      if (previous && previous !== element) {
+        observer?.unobserve(previous);
+        elements.delete(threadId);
+      }
+
+      if (element) {
+        element.dataset['canvasCommentCardThreadId'] = threadId;
+        elements.set(threadId, element);
+        observer?.observe(element);
+      }
+    },
+    [getCardObserver],
+  );
+
+  useEffect(
+    () => () => {
+      cardObserverRef.current?.disconnect();
+      cardObserverRef.current = null;
+      cardElementsRef.current.clear();
+    },
+    [],
+  );
+
+  const { cardTops, contentBottom } = useMemo(() => {
+    const ordered = [...threads]
+      .filter(thread => anchorTops[thread.id] !== undefined)
+      .sort((a, b) => (anchorTops[a.id] ?? 0) - (anchorTops[b.id] ?? 0));
+
+    const tops: Record<string, number> = {};
+    let previousBottom = Number.NEGATIVE_INFINITY;
+    let lowestBottom = 0;
+
+    ordered.forEach(thread => {
+      const top = Math.max(anchorTops[thread.id] ?? 0, previousBottom + CARD_GAP);
+      tops[thread.id] = top;
+      previousBottom = top + (cardHeights[thread.id] ?? ESTIMATED_CARD_HEIGHT);
+      lowestBottom = previousBottom;
+    });
+
+    return { cardTops: tops, contentBottom: lowestBottom };
+  }, [anchorTops, cardHeights, threads]);
+
+  return {
+    isAligned: isAlignmentActive && Object.keys(cardTops).length > 0,
+    // Sized to the cards, but floored at the document's scroll range so both columns always
+    // have the same travel — otherwise a filter showing a single card leaves the panel with no
+    // scroll range, pinning that card while the canvas scrolls away beneath its anchor. Never
+    // capped by the document height either, so a stack pushed past the document's end still
+    // scrolls fully into view.
+    trackHeight: Math.max(contentBottom + RAIL_BOTTOM_SPACE, documentTrackHeight),
+    cardTops,
+    registerCard,
+  };
+};

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -525,6 +525,14 @@ const XyneAISidebar = ({
         // Add new selections to existing ones
         if (newSelections.length > 0) {
           setActiveSelectionInfos(prev => [...prev, ...newSelections]);
+
+          // Drop the selected text into the composer so it can be edited or sent as-is.
+          // Replaces whatever was there — a new selection starts a new prompt.
+          const selectedText = newSelections
+            .map(selection => selection.text)
+            .filter(Boolean)
+            .join('\n\n');
+          if (selectedText) setInputValue(selectedText);
         }
       }
     };

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
@@ -949,6 +949,10 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
       }
     };
 
+    // Last text this editor reported to the parent, used to tell the parent's echo of the
+    // user's own typing apart from a deliberate write coming back down.
+    const lastReportedTextRef = useRef(inputValue);
+
     // TipTap editor setup
     const editor = useEditor({
       extensions: [
@@ -983,6 +987,7 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
       content: '',
       onUpdate: ({ editor }) => {
         const text = editor.getText();
+        lastReportedTextRef.current = text;
         onInputChange(text);
       },
       editorProps: {
@@ -1145,12 +1150,19 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
 
     // Sync inputValue changes from parent to editor (skip during voice recording)
     useEffect(() => {
-      if (editor && !editor.isFocused) {
-        const currentText = editor.getText();
-        if (currentText !== inputValue) {
-          editor.commands.setContent(inputValue);
-        }
-      }
+      if (!editor) return;
+
+      const currentText = editor.getText();
+      if (currentText === inputValue) return;
+
+      // Only echoes of the user's own typing are ignored — comparing against the last text
+      // this editor reported upward. Anything else is a deliberate write from the parent
+      // (Ask AI seeding a selection, a cleared composer) and must land even while focused,
+      // which the previous plain `!editor.isFocused` check silently dropped.
+      if (inputValue === lastReportedTextRef.current) return;
+
+      lastReportedTextRef.current = inputValue;
+      editor.commands.setContent(inputValue);
     }, [inputValue, editor]);
 
     // Clear editor content and attachments when inputValue is empty (after submit)

--- a/apps/dashboard/src/utils/canvasVersionDiffContent.ts
+++ b/apps/dashboard/src/utils/canvasVersionDiffContent.ts
@@ -1,0 +1,400 @@
+import type { PartialBlock } from '@blocknote/core';
+import { diffArrays, diffWordsWithSpace } from 'diff';
+import { normalizeCanvasContent } from './canvasVersioning';
+
+/**
+ * Builds the document shown by the read-only version preview while diff mode is on.
+ *
+ * The result is the selected version's document — same blocks, same types, same inline
+ * formatting — with text that exists only in that version highlighted green, and text
+ * that exists only in the current canvas re-inserted inline in red strikethrough. The
+ * diff therefore reads as the document itself rather than as a separate list of hunks.
+ *
+ * Highlighting uses BlockNote's built-in `backgroundColor` / `strike` styles, so no
+ * schema or editor change is needed to render it.
+ */
+
+type UnknownRecord = Record<string, unknown>;
+
+const ADDED_STYLES: UnknownRecord = { backgroundColor: 'green' };
+const REMOVED_STYLES: UnknownRecord = { backgroundColor: 'red', strike: true };
+
+/** Separates the parts of a block alignment key so unrelated fields cannot collide. */
+const KEY_SEPARATOR = '\u0000';
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * A block's inline content flattened into a character-addressable stream.
+ * Text segments carry their original styles (and link) so slices can be re-emitted with
+ * the formatting they had; atoms are non-text inline content (mentions, citations) which
+ * contribute no characters but must keep their position.
+ */
+type TextSegment = {
+  kind: 'text';
+  text: string;
+  styles: UnknownRecord;
+  href?: string;
+  start: number;
+  end: number;
+};
+
+type AtomSegment = { kind: 'atom'; node: unknown; start: number };
+
+type InlineSegment = TextSegment | AtomSegment;
+
+const collectInlineSegments = (
+  content: unknown,
+  segments: InlineSegment[],
+  offset: number,
+  href?: string,
+): number => {
+  const linkStyles = href ? { href } : {};
+
+  if (typeof content === 'string') {
+    if (!content) return offset;
+    segments.push({
+      kind: 'text',
+      text: content,
+      styles: {},
+      start: offset,
+      end: offset + content.length,
+      ...linkStyles,
+    });
+    return offset + content.length;
+  }
+
+  if (!Array.isArray(content)) return offset;
+
+  let cursor = offset;
+  for (const item of content) {
+    if (!isRecord(item)) {
+      segments.push({ kind: 'atom', node: item, start: cursor });
+      continue;
+    }
+
+    if (item['type'] === 'text' && typeof item['text'] === 'string') {
+      const text = item['text'];
+      if (!text) continue;
+      segments.push({
+        kind: 'text',
+        text,
+        styles: isRecord(item['styles']) ? item['styles'] : {},
+        start: cursor,
+        end: cursor + text.length,
+        ...linkStyles,
+      });
+      cursor += text.length;
+      continue;
+    }
+
+    // Links wrap their own inline content: flatten it so link text takes part in the diff.
+    if (item['type'] === 'link' && typeof item['href'] === 'string') {
+      const next = collectInlineSegments(item['content'], segments, cursor, item['href']);
+      if (next === cursor) segments.push({ kind: 'atom', node: item, start: cursor });
+      cursor = next;
+      continue;
+    }
+
+    segments.push({ kind: 'atom', node: item, start: cursor });
+  }
+
+  return cursor;
+};
+
+/** Returns null when the block's content is not an inline stream (tables, images, files). */
+const getInlineSegments = (block: UnknownRecord): InlineSegment[] | null => {
+  const content = block['content'];
+  if (typeof content !== 'string' && !Array.isArray(content)) return null;
+
+  const segments: InlineSegment[] = [];
+  collectInlineSegments(content, segments, 0);
+  return segments;
+};
+
+const segmentsToText = (segments: InlineSegment[]): string =>
+  segments.reduce((text, segment) => (segment.kind === 'text' ? text + segment.text : text), '');
+
+const getBlockChildren = (block: UnknownRecord): UnknownRecord[] =>
+  Array.isArray(block['children']) ? block['children'].filter(isRecord) : [];
+
+/**
+ * Blocks are aligned on type + own text, so a block whose text is untouched keeps its
+ * identity even when neighbouring blocks were inserted or deleted around it.
+ */
+const getBlockKey = (block: UnknownRecord): string => {
+  const type = typeof block['type'] === 'string' ? block['type'] : 'paragraph';
+  const segments = getInlineSegments(block);
+  if (segments) return `${type}${KEY_SEPARATOR}${segmentsToText(segments)}`;
+
+  // Non-text blocks have nothing to word-diff, so they compare whole.
+  return [
+    type,
+    JSON.stringify(block['content'] ?? null),
+    JSON.stringify(block['props'] ?? null),
+  ].join(KEY_SEPARATOR);
+};
+
+/** Emits `[from, to)` of the version's inline stream, keeping original formatting. */
+const pushSegmentSlice = (
+  target: unknown[],
+  segments: InlineSegment[],
+  from: number,
+  to: number,
+  extraStyles: UnknownRecord,
+): void => {
+  for (const segment of segments) {
+    if (segment.kind === 'atom') {
+      if (segment.start >= from && segment.start < to) target.push(segment.node);
+      continue;
+    }
+
+    const start = Math.max(from, segment.start);
+    const end = Math.min(to, segment.end);
+    if (end <= start) continue;
+
+    const textNode: UnknownRecord = {
+      type: 'text',
+      text: segment.text.slice(start - segment.start, end - segment.start),
+      styles: { ...segment.styles, ...extraStyles },
+    };
+
+    target.push(
+      segment.href ? { type: 'link', href: segment.href, content: [textNode] } : textNode,
+    );
+  }
+};
+
+/**
+ * Word-diffs one block's text against its counterpart and rebuilds the version block's
+ * inline content with added text highlighted and removed text spliced back in.
+ * Returns null when the block cannot be diffed inline.
+ */
+const buildInlineDiffContent = (
+  currentBlock: UnknownRecord,
+  versionBlock: UnknownRecord,
+): unknown[] | null => {
+  const segments = getInlineSegments(versionBlock);
+  if (!segments) return null;
+
+  const currentSegments = getInlineSegments(currentBlock);
+  const currentText = currentSegments ? segmentsToText(currentSegments) : '';
+  const versionText = segmentsToText(segments);
+
+  const content: unknown[] = [];
+  let cursor = 0;
+
+  // `added` is text only in the version, `removed` is text only in the current canvas.
+  for (const change of diffWordsWithSpace(currentText, versionText)) {
+    if (!change.value) continue;
+
+    if (change.removed) {
+      content.push({ type: 'text', text: change.value, styles: { ...REMOVED_STYLES } });
+      continue;
+    }
+
+    const next = cursor + change.value.length;
+    pushSegmentSlice(content, segments, cursor, next, change.added ? ADDED_STYLES : {});
+    cursor = next;
+  }
+
+  // Flush atoms sitting at the very end of the block, which no slice above can reach.
+  pushSegmentSlice(content, segments, cursor, versionText.length + 1, {});
+
+  return content;
+};
+
+const markInlineItem = (item: unknown, extraStyles: UnknownRecord): unknown => {
+  if (!isRecord(item)) return item;
+
+  if (item['type'] === 'text' && typeof item['text'] === 'string') {
+    const styles = isRecord(item['styles']) ? item['styles'] : {};
+    return { ...item, styles: { ...styles, ...extraStyles } };
+  }
+
+  if (Array.isArray(item['content'])) {
+    return { ...item, content: item['content'].map(child => markInlineItem(child, extraStyles)) };
+  }
+
+  return item;
+};
+
+const markTableCell = (cell: unknown, extraStyles: UnknownRecord): unknown => {
+  if (Array.isArray(cell)) return cell.map(item => markInlineItem(item, extraStyles));
+  if (isRecord(cell) && 'content' in cell) {
+    return { ...cell, content: markInlineContent(cell['content'], extraStyles) };
+  }
+  return cell;
+};
+
+function markInlineContent(content: unknown, extraStyles: UnknownRecord): unknown {
+  if (typeof content === 'string') {
+    return content ? [{ type: 'text', text: content, styles: { ...extraStyles } }] : content;
+  }
+
+  if (Array.isArray(content)) {
+    return content.map(item => markInlineItem(item, extraStyles));
+  }
+
+  // Table content: { type: 'tableContent', rows: [{ cells: [...] }] }
+  if (isRecord(content) && Array.isArray(content['rows'])) {
+    return {
+      ...content,
+      rows: (content['rows'] as unknown[]).map(row =>
+        isRecord(row) && Array.isArray(row['cells'])
+          ? {
+              ...row,
+              cells: (row['cells'] as unknown[]).map(cell => markTableCell(cell, extraStyles)),
+            }
+          : row,
+      ),
+    };
+  }
+
+  return content;
+}
+
+/**
+ * Applies one diff style to every piece of text in a block and its children.
+ * `dropId` is set for blocks lifted from the current canvas so their ids cannot collide
+ * with the version blocks they are rendered next to.
+ */
+const markBlock = (
+  block: UnknownRecord,
+  extraStyles: UnknownRecord,
+  dropId: boolean,
+): UnknownRecord => {
+  const marked: UnknownRecord = { ...block };
+
+  if ('content' in block) marked['content'] = markInlineContent(block['content'], extraStyles);
+
+  const children = getBlockChildren(block);
+  if (children.length > 0) {
+    marked['children'] = children.map(child => markBlock(child, extraStyles, dropId));
+  }
+
+  if (dropId) delete marked['id'];
+
+  return marked;
+};
+
+const mergeUnchangedBlock = (
+  currentBlock: UnknownRecord | undefined,
+  versionBlock: UnknownRecord,
+): UnknownRecord => {
+  const currentChildren = currentBlock ? getBlockChildren(currentBlock) : [];
+  const versionChildren = getBlockChildren(versionBlock);
+  if (currentChildren.length === 0 && versionChildren.length === 0) return versionBlock;
+
+  return { ...versionBlock, children: diffBlockLists(currentChildren, versionChildren) };
+};
+
+const buildModifiedBlocks = (
+  currentBlock: UnknownRecord | undefined,
+  versionBlock: UnknownRecord,
+): UnknownRecord[] => {
+  if (!currentBlock) return [markBlock(versionBlock, ADDED_STYLES, false)];
+
+  const inlineContent = buildInlineDiffContent(currentBlock, versionBlock);
+  // Nothing to word-diff (image, table, file...): show the old and the new side by side.
+  if (!inlineContent) {
+    return [
+      markBlock(currentBlock, REMOVED_STYLES, true),
+      markBlock(versionBlock, ADDED_STYLES, false),
+    ];
+  }
+
+  const merged: UnknownRecord = { ...versionBlock, content: inlineContent };
+  const currentChildren = getBlockChildren(currentBlock);
+  const versionChildren = getBlockChildren(versionBlock);
+  if (currentChildren.length > 0 || versionChildren.length > 0) {
+    merged['children'] = diffBlockLists(currentChildren, versionChildren);
+  }
+
+  return [merged];
+};
+
+function diffBlockLists(
+  currentBlocks: UnknownRecord[],
+  versionBlocks: UnknownRecord[],
+): UnknownRecord[] {
+  const changes = diffArrays(currentBlocks.map(getBlockKey), versionBlocks.map(getBlockKey));
+  const result: UnknownRecord[] = [];
+  let currentIndex = 0;
+  let versionIndex = 0;
+
+  const takeCurrent = (): UnknownRecord | undefined => currentBlocks[currentIndex++];
+  const takeVersion = (): UnknownRecord | undefined => versionBlocks[versionIndex++];
+
+  for (let index = 0; index < changes.length; index += 1) {
+    const change = changes[index];
+    if (!change) continue;
+
+    const count = change.count ?? change.value.length;
+
+    if (!change.added && !change.removed) {
+      for (let offset = 0; offset < count; offset += 1) {
+        const currentBlock = takeCurrent();
+        const versionBlock = takeVersion();
+        if (versionBlock) result.push(mergeUnchangedBlock(currentBlock, versionBlock));
+      }
+      continue;
+    }
+
+    if (change.removed) {
+      // A removed run followed by an added run is an edit: pair the blocks up so their
+      // text is diffed in place instead of rendering the block twice.
+      const nextChange = changes[index + 1];
+      const addedCount =
+        nextChange && nextChange.added ? (nextChange.count ?? nextChange.value.length) : 0;
+      const pairedCount = Math.min(count, addedCount);
+
+      for (let offset = 0; offset < pairedCount; offset += 1) {
+        const currentBlock = takeCurrent();
+        const versionBlock = takeVersion();
+        if (versionBlock) result.push(...buildModifiedBlocks(currentBlock, versionBlock));
+      }
+
+      for (let offset = pairedCount; offset < count; offset += 1) {
+        const currentBlock = takeCurrent();
+        if (currentBlock) result.push(markBlock(currentBlock, REMOVED_STYLES, true));
+      }
+
+      if (nextChange && nextChange.added) {
+        for (let offset = pairedCount; offset < addedCount; offset += 1) {
+          const versionBlock = takeVersion();
+          if (versionBlock) result.push(markBlock(versionBlock, ADDED_STYLES, false));
+        }
+        index += 1;
+      }
+
+      continue;
+    }
+
+    for (let offset = 0; offset < count; offset += 1) {
+      const versionBlock = takeVersion();
+      if (versionBlock) result.push(markBlock(versionBlock, ADDED_STYLES, false));
+    }
+  }
+
+  return result;
+}
+
+const toBlockList = (content: unknown): UnknownRecord[] =>
+  Array.isArray(content) ? content.filter(isRecord) : [];
+
+/**
+ * Produces the version document annotated with its differences against the current canvas.
+ * Both inputs are normalized (and therefore deep-cloned) so the caller's content is never
+ * mutated by the rebuild.
+ */
+export const buildCanvasVersionDiffContent = (
+  currentContent: unknown,
+  versionContent: unknown,
+): PartialBlock[] => {
+  const currentBlocks = toBlockList(normalizeCanvasContent(currentContent));
+  const versionBlocks = toBlockList(normalizeCanvasContent(versionContent));
+
+  return diffBlockLists(currentBlocks, versionBlocks) as unknown as PartialBlock[];
+};


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
Link : https://drive.google.com/file/d/1r2GEyV8qAv7G7fE7x2mD1a3m1nZc89Ai/view?usp=sharing

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
