### PR TITLE
fix: presentation by default when invoked from threads

### DIFF
--- a/apps/xyne-claw/src/presentation-catalog.ts
+++ b/apps/xyne-claw/src/presentation-catalog.ts
@@ -1,0 +1,142 @@
+/**
+ * Presentation tools as a Spaces-thread default.
+ *
+ * The presentation tools (post-code-block / post-diff / post-chart / visualize
+ * — see packages/xyne-claw-shared/src/tools/presentation.ts) render the agent's
+ * answer as a CARD inside a Spaces thread. claw-auth's renderUiWidget
+ * (routes/webhook.ts) posts them through /chat/postMessage, so they only mean
+ * anything on a run that has a thread to post into.
+ *
+ * Because they exist for that surface, a thread run gets them regardless of the
+ * agent's `tools.custom` selection — the same "framework default, not per-agent
+ * config" rationale as the plan tools (todo-write / todo-read) in routes/run.ts.
+ * The difference is delivery: plan tools go into the ALWAYS-ACTIVE set, these go
+ * into the lazy CATALOG. The agent sees one index line per tool and pulls the
+ * schema in with `load-tools` at the point of use, so a thread run pays almost
+ * nothing for tools it may never call.
+ *
+ * How the catalog half already works (nothing here changes it):
+ *   - buildToolCatalog tags them with PRESENTATION_CATALOG_SOURCE
+ *   - buildFastModeDirectTools AND buildSubagentTools both skip them, so they
+ *     never reach fastAlwaysActiveToolNames — which is what keeps them lazy
+ *   - routes/run.ts keeps a catalog candidate only if it survived the
+ *     `tools.custom` gate, which is the single thing this module unblocks
+ */
+
+import { isPresentationToolSource, PRESENTATION_CATALOG_SOURCE } from "xyne-claw-shared";
+
+/**
+ * Dispatch event types that mean "a person is talking to this agent in a Spaces
+ * thread right now" — an ALLOWLIST, deliberately.
+ *
+ * claw-auth's /webhook emits exactly three mention event types (webhook.ts):
+ * APP_MENTIONED, DIRECT_MESSAGE and USER_MENTIONED. USER_MENTIONED is absent
+ * here on purpose: claw-auth sets responseMode "approval" for it, and
+ * renderUiWidget DROPS code/diff/chart cards outside "conversation" mode. That
+ * is the digital-twin draft-then-approve flow — it delivers through its own
+ * approval surface, never as thread cards. Offering the tools there would be
+ * worse than withholding them: the widget POST is fire-and-forget, so the tool
+ * reports "Posted to the thread" while nothing ever appears.
+ *
+ * An allowlist and not "channelId is present, minus known exclusions", because
+ * channelId ALONE does not mean Spaces thread. Two other dispatchers forward
+ * one and send no eventType at all:
+ *   - routes/run-stream.ts — the Ask AI composer (a dashboard chat surface)
+ *   - routes/run.ts        — the S2S entry point, whose eventType is
+ *                            caller-supplied and may be omitted
+ * A deny-list predicate lets both through by default; this one cannot.
+ */
+export const THREAD_MENTION_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "APP_MENTIONED",
+  "DIRECT_MESSAGE",
+]);
+
+export interface PresentationCatalogRunContext {
+  /** Set when the run posts into a Spaces channel. Necessary but NOT
+   *  sufficient — see THREAD_MENTION_EVENT_TYPES. */
+  channelId: string | undefined;
+  /** Dispatch event type. Absent on Studio and Ask AI runs. */
+  eventType: string | undefined;
+  conversationId: string | undefined;
+  /** run.ts's isReadOnlyJob, injected so this module stays dependency-light
+   *  and the caller keeps ownership of the scheduled/automation definition. */
+  isScheduledOrAutomationRun: (eventType: string | undefined, conversationId: string | undefined) => boolean;
+}
+
+/**
+ * True when this run should get the presentation catalog for free — i.e. it is
+ * an interactive Spaces thread mention with a channel to post cards into.
+ *
+ * The scheduled/automation check is redundant against the allowlist above (a
+ * scheduled run carries eventType "scheduled"/"automation", not a mention type)
+ * and is kept only to catch a mention-typed dispatch that is really a scheduled
+ * replay — isReadOnlyJob also matches on a `scheduled_` conversationId prefix.
+ */
+export function presentationCatalogDefaultOn(ctx: PresentationCatalogRunContext): boolean {
+  if (!ctx.channelId) return false;
+  if (!ctx.eventType || !THREAD_MENTION_EVENT_TYPES.has(ctx.eventType)) return false;
+  return !ctx.isScheduledOrAutomationRun(ctx.eventType, ctx.conversationId);
+}
+
+/**
+ * True when `tool` is a presentation tool that this run gets for free — i.e.
+ * the `tools.custom` gate in routes/run.ts should let it through even though
+ * the agent never selected it. Returns false when the run isn't a thread run,
+ * so the gate keeps its existing behaviour everywhere else.
+ */
+export function isFreePresentationTool(tool: { source?: string }, defaultOn: boolean): boolean {
+  return defaultOn && isPresentationToolSource(tool.source);
+}
+
+/**
+ * Context primer for a thread run that received the presentation catalog.
+ *
+ * Two jobs, both needed:
+ *
+ *  1. Tell the agent WHY it has these tools. The catalog index
+ *     (renderToolCatalogForPrompt) lists them but says nothing about
+ *     provenance, so an agent whose own tool config never mentioned
+ *     post-chart can read the entry as something it is not entitled to and
+ *     leave it alone. It is entitled to it — because of the SURFACE, not the
+ *     config — and it should be told so plainly.
+ *
+ *  2. Tell it HOW to answer here. A Spaces thread is a chat surface: the reply
+ *     is a message, not a document. Without guidance the common failure is
+ *     posting a card AND repeating its contents in the text, which shows the
+ *     user the same thing twice.
+ *
+ * Returns "" when the run's final catalog has no presentation entries — after
+ * the read-only strips in routes/run.ts a thread run can still end up without
+ * them, and a primer pointing at a catalog that isn't there is worse than
+ * silence.
+ */
+export function buildPresentationPrimer(
+  catalogEntries: ReadonlyArray<{ catalog: string }>,
+): string {
+  const count = catalogEntries.filter((e) => e.catalog === PRESENTATION_CATALOG_SOURCE).length;
+  if (count === 0) return "";
+
+  return [
+    "## Answering in a Spaces Thread",
+    "",
+    "You were invoked by a mention in a Spaces thread, so your answer is delivered as",
+    "chat messages in that thread — not as a document.",
+    "",
+    `Every thread run is given the \`${PRESENTATION_CATALOG_SOURCE}\` catalog. You have it because of WHERE`,
+    "this run came from, not because this agent was configured with those tools, so",
+    "treat them as yours to use. They are not loaded yet: once you know what your",
+    `answer is, call \`load-tools\` with catalog \`${PRESENTATION_CATALOG_SOURCE}\` to pull in the whole set at once.`,
+    "",
+    "How to present the answer:",
+    "- Code the reader will copy or apply (a patch, a config, a query they should run)",
+    "  → post it as a card. A change to an existing file → post it as a diff.",
+    "- Numbers worth comparing — a trend, a breakdown, a ranking → post a chart.",
+    "- Short expressions, names, paths and single values → inline backticks in your",
+    "  reply. Do NOT spend a card on them.",
+    "- After posting a card, do NOT repeat its contents in your text. The user can",
+    "  already see it. Write only what the card cannot say: what it shows and what to",
+    "  do about it.",
+    "- Prose is still the default. A card has to earn its place; a wall of cards does",
+    "  not read as an answer.",
+  ].join("\n");
+}

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -113,6 +113,7 @@ import { buildMemoryWriteTool } from "../memory-write.js";
 import { buildMemoryFileTools } from "../memory-file-tools.js";
 import { buildTwinDeliverTool, buildTwinDeliverMandate, type TwinDeliverRef } from "../twin-deliver.js";
 import { buildProposePlanTool, PROPOSE_PLAN_TOOL_NAME, type ProposePlanRef } from "../propose-plan.js";
+import { presentationCatalogDefaultOn, isFreePresentationTool, buildPresentationPrimer } from "../presentation-catalog.js";
 import { buildProposeAgentTool, type ProposeAgentRef } from "../propose-agent.js";
 import { buildDescribeAgentTool, type DescribeAgentRef } from "../describe-agent.js";
 import { buildEmitBriefTool, EMIT_BRIEF_TOOL_NAME, type EmitBriefRef } from "../daily-brief.js";
@@ -2616,6 +2617,19 @@ async function processTask(
       `Tools: ${subagentTools.length} subagents, ${directTools.length} direct, ${customToolDefs.length} custom, ${parentHoistedTools.length} parent-hoisted, ${kbHoistedTools.length} kb-hoisted${fastModeEnabled ? `, [fast] catalogCandidates=${fastCatalogCandidateItems.length}` : ""}`,
     );
 
+    // Presentation tools (post-code-block / post-diff / post-chart / visualize)
+    // render as cards in the Spaces thread, so a thread run gets them in the
+    // CATALOG regardless of the agent's tools.custom selection. Framework
+    // default, not per-agent config — same rationale as the plan tools below,
+    // but lazy (one index line each) instead of always-active. See
+    // ../presentation-catalog.ts for why these three conditions and no others.
+    const presentationDefaultOn = presentationCatalogDefaultOn({
+      channelId,
+      eventType,
+      conversationId,
+      isScheduledOrAutomationRun,
+    });
+
     // Apply agent-level tool config from DB (agent.config.tools). Reuses the
     // toolsConfigEarly parse we did above for the directPickSuffixes hoist.
     if (toolsConfigEarly) {
@@ -2668,6 +2682,11 @@ async function processTask(
           // Slash-command contracts own their minimum palette. Keep these
           // per-run tools even when the stored Agent.config did not select them.
           if (forcedTaskCommandTools.has(t.name)) return true;
+          // Thread runs get the presentation tools for free. Surviving this
+          // gate is exactly what lets them reach fastCatalogItems below —
+          // they still can't become always-active, because both catalog
+          // builders keep them out of fastAlwaysActiveToolNames.
+          if (isFreePresentationTool(t as { source?: string }, presentationDefaultOn)) return true;
           const toolSelectionKey = (t as { selectionKey?: string }).selectionKey;
           const isAllowedCustom = allowedCustom.has(t.name) || (toolSelectionKey ? allowedCustom.has(toolSelectionKey) : false);
           if (isAllowedCustom) return true;
@@ -3108,7 +3127,7 @@ async function processTask(
         )
       : undefined;
     if (catalogActive) {
-      log(`[catalog] entries=${fastCatalogItems.length} active=0 budget=${fastModeLoadedToolBudget ?? 0} totalCap=${providerToolRequestCap(provider)} fastMode=${fastModeEnabled}`);
+      log(`[catalog] entries=${fastCatalogItems.length} active=0 budget=${fastModeLoadedToolBudget ?? 0} totalCap=${providerToolRequestCap(provider)} fastMode=${fastModeEnabled} presentationDefault=${presentationDefaultOn}`);
     }
 
     const tools = allTools.length > 0 ? allTools : undefined;
@@ -3632,6 +3651,19 @@ async function processTask(
       fullContext = fullContext
         ? `${fullContext}\n\n${fastModeCatalogPrompt}`
         : fastModeCatalogPrompt;
+    }
+    // Reads as an addendum to the catalog index above: WHY this run has the
+    // presentation catalog (the surface, not the agent's tool config) and HOW
+    // to answer on a chat surface. Empty unless presentation entries actually
+    // survived into this run's catalog.
+    const presentationPrimer = presentationDefaultOn
+      ? buildPresentationPrimer(fastCatalogItems.map((item) => item.entry))
+      : "";
+    if (presentationPrimer) {
+      fullContext = fullContext
+        ? `${fullContext}\n\n${presentationPrimer}`
+        : presentationPrimer;
+      log(`[catalog] presentation primer injected (${presentationPrimer.length} chars)`);
     }
     const fastModeSubagentSkills =
       fastModeEnabled && customSubagents && customSubagents.length > 0


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
