### PR TITLE
feature: XYNE-17198 add prefetch

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/vespa-search-areas.ts
@@ -226,6 +226,13 @@ export const SEARCH_AREAS: Record<string, SearchArea> = {
     timestampField: "createdAt",
     fields: [
       strField("channelId", "The channel's own id.", ["in"], "docId"),
+      // Name → id resolution. Mapped to `channelName_fuzzy`, NOT the bare
+      // `channelName`: the latter is `attribute | summary` with no index, so a
+      // `contains` on it is a whole-value exact match and "#xyne-spaces" would
+      // only ever match a channel called exactly that. `channelName_fuzzy` is
+      // `input channelName | index` with 3-gram matching + bm25 — built for
+      // exactly this lookup, and it survives partial names and typos.
+      strField("channelName", "Channel name — partial, case-insensitive (3-gram fuzzy index).", ["contains", "in"], "channelName_fuzzy"),
       strField("scopeType", "Channel scope: DEFAULT (regular channel), DM, GROUP_DM, TICKET, DOCUMENT.", ["in", "nin"]),
       strField("visibility", "Channel visibility: PUBLIC or PRIVATE.", ["in"]),
       strField("projectId", "Project the channel belongs to.", ["in", "contains"]),
@@ -364,6 +371,10 @@ export const SEARCH_AREAS: Record<string, SearchArea> = {
     timestampField: "createdAt",
     fields: [
       strField("email", "User email.", ["contains"]),
+      // `name_fuzzy` is `input name | index | attribute` with 3-gram + bm25 —
+      // partial names and misspellings resolve, which a plain attribute match
+      // would not.
+      strField("name", "User name — partial (3-gram fuzzy index).", ["contains", "in"], "name_fuzzy"),
       strField("status", "User status (e.g. ACTIVE).", ["in"]),
       dateField("createdDate", "User creation date (dd/mm/yy, IST).", "createdAt"),
     ],
@@ -391,6 +402,12 @@ export const SEARCH_AREAS: Record<string, SearchArea> = {
     aclSchemaKey: null,
     timestampField: "createdAt",
     fields: [
+      // `project.name` is `index | attribute | summary` with bm25, so `contains`
+      // is a real tokenised match. `projectId` mirrors the channel area's
+      // docId mapping so a project resolved by name can be re-queried by id
+      // (and a channel row's `projectId` can be followed back to its project).
+      strField("projectId", "The project's own id.", ["in"], "docId"),
+      strField("name", "Project name.", ["contains", "in"]),
       strField("createdBy", "Creator user id.", ["contains"]),
       dateField("createdDate", "Project creation date (dd/mm/yy, IST).", "createdAt"),
     ],

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -4446,8 +4446,9 @@ const spacesScheduleCall: ToolDef = {
 const spacesWhoami: ToolDef = {
   name: "spaces-whoami",
   description:
-    "Returns the current user's Spaces profile — userId, name, email and workspaceId of the User " +
-    "Call this first to get the userId needed for filtering other tools (e.g. assignedTo, from, createdBy).",
+    "Returns the current user's Spaces profile — userId, name, email and workspaceId. " +
+    "If the userId and name are ALREADY in your system prompt, so do not call this just to read them; " +
+    "use it only when you need the workspaceId or want to confirm the profile.",
   inputSchema: { type: "object", properties: {} },
   async handler(_args, ctx) {
     try {
@@ -6438,6 +6439,33 @@ const spacesVespaSchema: ToolDef = {
   },
 };
 
+/**
+ * Entity ids for the DIRECT-VESPA tools only.
+ *
+ * A `channel` / `project` lookup returns a NAME, but every follow-up query
+ * needs the ID — and `formatSearchResult` prints one only for people hits
+ * (`userId:`). Project rows are also non-routable, so they carry no citation
+ * chip either: the model got a name it could not turn into a filter, and had to
+ * re-resolve it through another tool.
+ *
+ * Deliberately NOT inside `formatSearchResult`: that renderer is shared with
+ * spaces-search / spaces-search-v2, and this is only wanted on the structured
+ * Vespa path where the ids feed straight back into `filters`.
+ *
+ * Ids come from searchContext (vespa-direct's transformHit); a project doc is
+ * keyed by its own id, so `r.id` is the fallback there.
+ */
+function directEntityIdLines(r: SearchResult): string {
+  const sc = r.searchContext ?? {};
+  const lines: string[] = [];
+  if (sc["channelId"] && (r.type === "chat_container" || r.type === "channel")) {
+    lines.push(`  channelId: ${sc["channelId"]}`);
+  }
+  if (sc["projectId"]) lines.push(`  projectId: ${sc["projectId"]}`);
+  else if (r.type === "project" && r.id) lines.push(`  projectId: ${r.id}`);
+  return lines.length > 0 ? `\n${lines.join("\n")}` : "";
+}
+
 // Shared renderer for the direct-Vespa tools (spaces-vespa-query raw YQL and
 // spaces-vespa-search structured). Builds a routable Citation per result row —
 // mirrors spaces-search's harvest() so hits render as CLICKABLE chips instead of
@@ -6616,7 +6644,7 @@ async function renderDirectResult(
       for (const r of group.results) {
         chunkIndex += 1;
         const cited = harvest(r, chunkIndex);
-        parts.push(formatSearchResult(r, cited ? chunkIndex : null));
+        parts.push(formatSearchResult(r, cited ? chunkIndex : null) + directEntityIdLines(r));
       }
       parts.push("");
     }
@@ -6628,7 +6656,7 @@ async function renderDirectResult(
   const rendered = results
     .map((r, idx) => {
       const cited = harvest(r, idx + 1);
-      return formatSearchResult(r, cited ? idx + 1 : null);
+      return formatSearchResult(r, cited ? idx + 1 : null) + directEntityIdLines(r);
     })
     .join("\n\n");
   return finalize(
@@ -6753,7 +6781,7 @@ const spacesVespaQuery: ToolDef = {
           ? (args["rankInputs"] as Record<string, unknown>)
           : undefined;
 
-      const workspaceId = await getWorkspaceIdForUser(ctx.userId);
+      const { userId: aclUserId, workspaceId } = await directVespaIdentity(ctx.userId);
       if (!workspaceId) {
         log.error(
           `[xyne-spaces-tools] workspaceId is required; refusing raw Vespa query userId=${ctx.userId}`,
@@ -6764,7 +6792,7 @@ const spacesVespaQuery: ToolDef = {
       const data = await queryDirect(
         yql,
         query,
-        ctx.userId,
+        aclUserId,
         hits,
         offset,
         CONFIG.vespaQueryEndpoint,
@@ -6778,6 +6806,43 @@ const spacesVespaQuery: ToolDef = {
     }
   },
 };
+
+/**
+ * Caller identity for the DIRECT-VESPA tools, with a LOCAL-ONLY override.
+ *
+ * These tools do not go through the MCP credentials path: they read
+ * `ctx.userId` (the Spaces user id on the claw session) and resolve the tenant
+ * with `getWorkspaceIdForUser`, a lookup against the local Spaces DB. Locally
+ * that pins every query to whichever seeded user your Spaces instance
+ * authenticates as, so a query cannot be aimed at another tenant — which is
+ * exactly what you need when the Vespa endpoint is port-forwarded to a
+ * different environment and the local ids match nothing in that index.
+ *
+ * Scope is deliberately narrow: ONLY the ACL + workspace guards of the direct
+ * Vespa tools. The gateway-backed tools keep the real session identity, so
+ * they continue to work against local data instead of failing on an identity
+ * that has no local Spaces session.
+ *
+ * HARD-GATED on `!CONFIG.isProduction` — an override here would otherwise run
+ * one user's queries under another user's ACL.
+ */
+async function directVespaIdentity(
+  ctxUserId: string,
+): Promise<{ userId: string; workspaceId: string | null }> {
+  const devUser = CONFIG.isProduction ? "" : (process.env["XYNE_SPACES_DEV_USER_ID"] ?? "").trim();
+  const devWorkspace = CONFIG.isProduction ? "" : (process.env["XYNE_SPACES_DEV_WORKSPACE_ID"] ?? "").trim();
+  const userId = devUser || ctxUserId;
+  // Skip the Spaces-DB lookup when the workspace is pinned: an overridden user
+  // id generally has no row in the LOCAL Spaces DB, so the lookup would return
+  // null and the tool would refuse the query.
+  const workspaceId = devWorkspace || (await getWorkspaceIdForUser(userId));
+  if (devUser || devWorkspace) {
+    log.warn(
+      `[xyne-spaces-tools] DEV vespa identity override: user ${ctxUserId} -> ${userId}, workspace -> ${workspaceId}`,
+    );
+  }
+  return { userId, workspaceId };
+}
 
 // ── spaces-vespa-search ──────────────────────────────────────────────────────
 
@@ -6939,7 +7004,7 @@ const spacesVespaSearch: ToolDef = {
       // Tenant scope — every direct-Vespa query is confined to the caller's
       // workspace, resolved from the user record (public.users). Refuse to run
       // unscoped rather than risk crossing tenants.
-      const workspaceId = await getWorkspaceIdForUser(ctx.userId);
+      const { userId: aclUserId, workspaceId } = await directVespaIdentity(ctx.userId);
       if (!workspaceId)
         return err("Could not resolve your workspaceId — cannot run a workspace-scoped search.");
 
@@ -6960,14 +7025,14 @@ const spacesVespaSearch: ToolDef = {
           ...(rankProfile ? { rankProfile } : {}),
           hits,
         },
-        ctx.userId,
+        aclUserId,
         workspaceId,
       );
 
       const data = await queryDirect(
         built.yql,
         built.query,
-        ctx.userId,
+        aclUserId,
         hits,
         offset,
         CONFIG.vespaQueryEndpoint,
@@ -7566,7 +7631,7 @@ const spacesCorpusScan: ToolDef = {
         bucket,
       });
 
-      const workspaceId = await getWorkspaceIdForUser(ctx.userId);
+      const { userId: aclUserId, workspaceId } = await directVespaIdentity(ctx.userId);
       if (!workspaceId)
         return err("Could not resolve your workspaceId — cannot run a workspace-scoped scan.");
 
@@ -7583,7 +7648,7 @@ const spacesCorpusScan: ToolDef = {
         const res = await queryDirect(
           yql,
           query,
-          ctx.userId,
+          aclUserId,
           0,
           0,
           CONFIG.vespaQueryEndpoint,
@@ -7727,7 +7792,7 @@ const spacesEvidencePack: ToolDef = {
       });
       const { scan, topic, perBucket } = validated;
 
-      const workspaceId = await getWorkspaceIdForUser(ctx.userId);
+      const { userId: aclUserId, workspaceId } = await directVespaIdentity(ctx.userId);
       if (!workspaceId) return err("Could not resolve your workspaceId — cannot run a workspace-scoped extraction.");
 
       const debugPayloads: Array<{ stage: string; yql: string; vespaParams: Record<string, unknown> }> = [];
@@ -7737,7 +7802,7 @@ const spacesEvidencePack: ToolDef = {
       // finite and the coverage note honest.
       const censusYql = buildCorpusScanYql(scan, { withTerm: true });
       const termBucketCounts = await Promise.all(scan.terms.map(async term => {
-        const res = await queryDirect(censusYql, termToQuery(term), ctx.userId, 0, 0, CONFIG.vespaQueryEndpoint, "unranked", undefined, workspaceId);
+        const res = await queryDirect(censusYql, termToQuery(term), aclUserId, 0, 0, CONFIG.vespaQueryEndpoint, "unranked", undefined, workspaceId);
         const executed = res.data.debug?.payloads?.[0];
         debugPayloads.push({ stage: `evidence-pack census: "${term}"`, yql: executed?.yql ?? censusYql, vespaParams: executed?.vespaParams ?? {} });
         const buckets: Record<number, number> = {};
@@ -7766,7 +7831,7 @@ const spacesEvidencePack: ToolDef = {
 
       const rowsNested = await Promise.all(fetchList.map(async ({ term, bucketKey }) => {
         const yql = buildPackFetchYql(scan, bucketRange(bucketKey, scan.bucket));
-        const res = await queryDirect(yql, termToQuery(term), ctx.userId, perBucket, 0, CONFIG.vespaQueryEndpoint, "unranked", undefined, workspaceId, true);
+        const res = await queryDirect(yql, termToQuery(term), aclUserId, perBucket, 0, CONFIG.vespaQueryEndpoint, "unranked", undefined, workspaceId, true);
         const executed = res.data.debug?.payloads?.[0];
         debugPayloads.push({ stage: `evidence-pack fetch: "${term}" @ ${bucketKey}`, yql: executed?.yql ?? yql, vespaParams: executed?.vespaParams ?? {} });
         const results = (!res.data.grouped ? res.data.results : []) ?? [];

--- a/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/AgentDetailPageV3.tsx
@@ -157,6 +157,11 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
   // "Run autonomously" button (the `pendingGoalSuggestion` payload). Default
   // false so existing agents are unchanged.
   const [draftSuggestGoal, setDraftSuggestGoal] = useState(false);
+  // Query prefetch opt-in (agent.config.prefetchContext). When on, xyne-claw
+  // resolves the entities named in the question (channels, projects, people)
+  // BEFORE the first model turn and attaches the ids to the prompt, so the
+  // agent does not spend turns looking them up.
+  const [draftPrefetchContext, setDraftPrefetchContext] = useState(false);
   // Per-agent opt-OUT: post the live plan/TODO card (from the todo-write tool)
   // into the Spaces thread. Default true (post) so existing agents are
   // unchanged; turning it off sets agent.config.postTodos=false, which
@@ -288,6 +293,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
         setDraftResearchAgentProductId((agentData.config as { product_id?: string | null; RESEARCH_AGENT_PRODUCT_ID?: string | null }).product_id ?? (agentData.config as { RESEARCH_AGENT_PRODUCT_ID?: string | null }).RESEARCH_AGENT_PRODUCT_ID ?? "");
         setDraftResearchAgentRepositoryId((agentData.config as { repository_id?: string | null; RESEARCH_AGENT_REPOSITORY_ID?: string | null }).repository_id ?? (agentData.config as { RESEARCH_AGENT_REPOSITORY_ID?: string | null }).RESEARCH_AGENT_REPOSITORY_ID ?? "");
         setDraftSuggestGoal((agentData.config as { suggestGoal?: boolean }).suggestGoal === true);
+        setDraftPrefetchContext((agentData.config as { prefetchContext?: boolean }).prefetchContext === true);
         setDraftPostTodos((agentData.config as { postTodos?: boolean }).postTodos !== false);
         setDraftAutoGoal((agentData.config as { autoGoal?: boolean }).autoGoal === true);
         setDraftPlanMode((agentData.config as { planMode?: boolean }).planMode === true);
@@ -391,6 +397,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
     const baseResearchAgentProductId = (agent.config as { product_id?: string | null; RESEARCH_AGENT_PRODUCT_ID?: string | null }).product_id ?? (agent.config as { RESEARCH_AGENT_PRODUCT_ID?: string | null }).RESEARCH_AGENT_PRODUCT_ID ?? "";
     const baseResearchAgentRepositoryId = (agent.config as { repository_id?: string | null; RESEARCH_AGENT_REPOSITORY_ID?: string | null }).repository_id ?? (agent.config as { RESEARCH_AGENT_REPOSITORY_ID?: string | null }).RESEARCH_AGENT_REPOSITORY_ID ?? "";
     const baseSuggestGoal = (agent.config as { suggestGoal?: boolean }).suggestGoal === true;
+    const basePrefetchContext = (agent.config as { prefetchContext?: boolean }).prefetchContext === true;
     const basePostTodos = (agent.config as { postTodos?: boolean }).postTodos !== false;
     const baseAutoGoal = (agent.config as { autoGoal?: boolean }).autoGoal === true;
     const basePlanMode = (agent.config as { planMode?: boolean }).planMode === true;
@@ -433,6 +440,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       draftResearchAgentProductId !== baseResearchAgentProductId ||
       draftResearchAgentRepositoryId !== baseResearchAgentRepositoryId ||
       draftSuggestGoal !== baseSuggestGoal ||
+      draftPrefetchContext !== basePrefetchContext ||
       draftPostTodos !== basePostTodos ||
       draftAutoGoal !== baseAutoGoal ||
       draftPlanMode !== basePlanMode ||
@@ -450,7 +458,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       draftOutputRequireTools !== baseOutputRequireTools ||
       triggersChanged
     );
-  }, [agent, config, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers]);
+  }, [agent, config, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPrefetchContext, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers]);
 
   /* ── handlers ──────────────────────────────────────────────────── */
 
@@ -518,6 +526,11 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
       nextConfig.repository_id = draftResearchAgentRepositoryId || null;
       delete nextConfig.RESEARCH_AGENT_PRODUCT_ID;
       delete nextConfig.RESEARCH_AGENT_REPOSITORY_ID;
+      if (draftPrefetchContext) {
+        nextConfig.prefetchContext = true;
+      } else {
+        delete nextConfig.prefetchContext;
+      }
       if (draftSuggestGoal) {
         nextConfig.suggestGoal = true;
       } else {
@@ -658,7 +671,7 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
     } finally {
       setSavingConfig(false);
     }
-  }, [agent, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers, config, savingConfig, dirty, userId, showSnackbar]);
+  }, [agent, draftName, draftDescription, prompt, draftTools, draftSkillIds, draftKbResources, draftKbScope, draftProvider, draftModel, draftPromptInjection, draftSandboxRepo, draftForceReadOnlySandbox, draftSbxGitRepos, draftResearchAgentProductId, draftResearchAgentRepositoryId, draftSuggestGoal, draftPrefetchContext, draftPostTodos, draftAutoGoal, draftPlanMode, draftPlanModePrompt, draftVerifyResponses, draftCitationReflection, draftAutoToolCitations, draftVerifyResponseCriteria, draftOutputFormatEnabled, draftOutputType, draftOutputSchema, draftOutputTemplate, draftOutputRequireTools, skillTriggers, config, savingConfig, dirty, userId, showSnackbar]);
 
   const persistToolsConfig = useCallback(async (nextTools: AgentToolSelection): Promise<Agent> => {
     if (!agent) throw new Error("Agent not loaded");
@@ -1040,6 +1053,8 @@ export function AgentDetailPageV3({ userId, isAdmin }: Props) {
             researchAgentRepositoryOptions={researchAgentRepositoryOptions}
             draftSuggestGoal={draftSuggestGoal}
             onDraftSuggestGoalChange={setDraftSuggestGoal}
+            draftPrefetchContext={draftPrefetchContext}
+            onDraftPrefetchContextChange={setDraftPrefetchContext}
             draftPostTodos={draftPostTodos}
             onDraftPostTodosChange={setDraftPostTodos}
             draftVerifyResponses={draftVerifyResponses}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailLeftColumn.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailLeftColumn.tsx
@@ -1530,6 +1530,10 @@ interface Props {
   // a one-click "Run autonomously" button at the end of multi-turn planning.
   draftSuggestGoal: boolean;
   onDraftSuggestGoalChange: (v: boolean) => void;
+  /** Query prefetch opt-in (agent.config.prefetchContext). Resolves the
+   *  entities named in a question to ids before the agent's first turn. */
+  draftPrefetchContext: boolean;
+  onDraftPrefetchContextChange: (v: boolean) => void;
   // Post TODOs to Spaces opt-OUT (agent.config.postTodos). Default ON: the
   // live plan/TODO card from the todo-write tool is posted into the thread.
   // Turning it OFF sets postTodos=false, suppressing the card at claw-auth's
@@ -1717,6 +1721,8 @@ export function AgentDetailLeftColumn({
   researchAgentRepositoryOptions,
   draftSuggestGoal,
   onDraftSuggestGoalChange,
+  draftPrefetchContext,
+  onDraftPrefetchContextChange,
   draftPostTodos,
   onDraftPostTodosChange,
   draftVerifyResponses,
@@ -2556,7 +2562,7 @@ export function AgentDetailLeftColumn({
         label="Behaviour"
         tech="rules & autonomy"
         subtitle="extra rules applied on every turn"
-        summary={behaviorCount > 0 || draftSuggestGoal || draftAutoGoal || draftPlanMode || !draftPostTodos ? "Customised" : "Defaults"}
+        summary={behaviorCount > 0 || draftSuggestGoal || draftPrefetchContext || draftAutoGoal || draftPlanMode || !draftPostTodos ? "Customised" : "Defaults"}
         open={activeTab === "behavior"}
         onToggle={() => toggleSection("behavior")}
       />
@@ -2742,6 +2748,39 @@ export function AgentDetailLeftColumn({
           existing agents). Display when canEdit OR when already on, so
           read-only viewers see the current setting on agents that have it
           enabled. */}
+      {/* Prefetch context — opt-IN switch (agent.config.prefetchContext). Before
+          the first model turn, a cheap model extracts the names the question
+          mentions and the platform resolves each one against channels,
+          projects and people in parallel, then attaches the ids to the prompt.
+          Measured motivation: runs were spending whole turns (15-25s each)
+          re-deriving a user id already in the request payload and mapping
+          channel/project names to ids. Off by default. */}
+      {(canEdit || draftPrefetchContext) && (
+        <div className="rounded-xl border border-xyne-border bg-xyne-surface p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-xyne-fg-tertiary">Prefetch Context</div>
+              <p className="text-[12px] leading-relaxed text-xyne-fg-secondary">
+                Resolve the channels, projects and people a question names before the agent&apos;s first turn, and hand it the ids up front.
+                {" "}
+                <span className="text-xyne-fg-tertiary">Best for search and reporting agents that otherwise burn turns looking up ids. Results are attached as a hint the agent still verifies.</span>
+              </p>
+            </div>
+            <label className="flex shrink-0 items-center gap-2 select-none">
+              <input
+                type="checkbox"
+                checked={draftPrefetchContext}
+                onChange={(e) => onDraftPrefetchContextChange(e.target.checked)}
+                disabled={!canEdit}
+                className="h-4 w-4 cursor-pointer accent-xyne-accent disabled:cursor-not-allowed disabled:opacity-60"
+                aria-label="Enable Prefetch Context"
+              />
+              <span className="text-[12px] text-xyne-fg-primary">{draftPrefetchContext ? "On" : "Off"}</span>
+            </label>
+          </div>
+        </div>
+      )}
+
       {(canEdit || draftSuggestGoal) && (
         <div className="rounded-xl border border-xyne-border bg-xyne-surface p-4">
           <div className="flex items-start justify-between gap-4">

--- a/apps/xyne-claw/src/prefetch.ts
+++ b/apps/xyne-claw/src/prefetch.ts
@@ -1,0 +1,597 @@
+/**
+ * Query prefetch — resolve entities BEFORE the model's first turn.
+ *
+ * Measured motivation (debug-session analysis, 2026-08-19, agent `ask-ai`):
+ * two runs of the same question spent whole turns discovering things the
+ * platform can look up deterministically —
+ *   - `spaces-whoami` returned the SAME id already present in the run payload,
+ *   - channel / project lookups just mapped a name to an id,
+ *   - each of those cost a full LLM round trip (15-25s at the measured 23-27
+ *     tok/s), because emitting any tool call ends the assistant turn.
+ *
+ * So: extract the entities named in the query with ONE cheap model call, resolve
+ * them with plain tool calls in parallel, and hand the answers to the model as
+ * part of its first user message.
+ *
+ * Design rules this file follows, in order of importance:
+ *   1. NEVER fail the run. Every step is timeout-bounded and swallowed; the
+ *      worst outcome is no block at all, i.e. today's behaviour.
+ *   2. Resolve, don't decide. When several channels match, attach them ALL with
+ *      their ids and let the big model pick. A wrong pick made here is invisible
+ *      to the model and unrecoverable; an extra 40 tokens is not.
+ *   3. Bounded output. Digest only — ids, names, counts. Dumping result bodies
+ *      here would recreate the context bloat that forces compaction.
+ *   4. Hint, not truth. The block is labelled as prefetched and unverified, so
+ *      the model re-checks rather than anchoring on it.
+ */
+
+import { LITELLM } from "./config.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("prefetch");
+
+/** The extractor is a hint generator, not a gate — if it is slow we ship without it. */
+const EXTRACT_TIMEOUT_MS = Number(process.env["XYNE_CLAW_PREFETCH_EXTRACT_TIMEOUT_MS"] ?? 6_000);
+/** Resolvers run in parallel, so this is the wall-clock ceiling for ALL of them. */
+const RESOLVE_TIMEOUT_MS = Number(process.env["XYNE_CLAW_PREFETCH_RESOLVE_TIMEOUT_MS"] ?? 5_000);
+/**
+ * Per-resolver line budget, spent in whole rows (see `digest`).
+ *
+ * A clean channel row is ~5-6 lines (header, description, the detail line, and
+ * the ids), so 12 bought exactly TWO rows — and a `Channels matching "x"` that
+ * really matched 8 showed the model a quarter of them. `scrub` took ~40% of the
+ * old volume out of each row, so this buys ~4 rows now instead of 2, at roughly
+ * the character cost the noisy 2-row version used to have.
+ *
+ * Bounded above by RESOLVER_LIMIT (nothing beyond 10 rows is fetched) and by
+ * MAX_BLOCK_CHARS, which still governs the block as a whole: a run with two
+ * populated sections lands near 3k of the 4k cap.
+ */
+const MAX_LINES_PER_RESOLVER = 24;
+/** Hard cap on the whole block, so a pathological resolver can never bloat turn 1. */
+const MAX_BLOCK_CHARS = 4_000;
+/** Asked of the resolvers themselves, so a broad name match never ships 100 rows across the wire. */
+const RESOLVER_LIMIT = 10;
+/** Each entity fans out to every resolver, so this bounds the fan-out at MAX_ENTITIES x 3. */
+const MAX_ENTITIES = 3;
+/** Second-hop lookups (channel→project, project→channels). One hop, never recursive. */
+const MAX_HOPS = 2;
+
+/** Which resolver produced a section — drives the graph hops below. */
+type ResolvedKind = "channels" | "projects" | "people";
+
+interface ResolvedSection {
+  kind: ResolvedKind;
+  heading: string;
+  body: string | null;
+}
+
+/**
+ * A second-hop result, tagged by which lookup produced it. Both hops for a
+ * project run in one round, so the round's results are a mixed bag that has to
+ * be sorted back out by tag.
+ */
+type HopResult =
+  | { hop: "channels"; projectId: string; body: string | null }
+  | { hop: "name"; projectId: string; name: string | null };
+
+/**
+ * What the extractor pulls out of the raw question. Everything is optional:
+ * a conversational message legitimately yields empty lists, and that is the
+ * signal to skip prefetch entirely.
+ */
+export interface PrefetchSpec {
+  /** `conversational` means "no retrieval needed" — we then attach nothing but identity. */
+  intent: "sweep" | "lookup" | "count" | "conversational";
+  /**
+   * Names the question mentions — NOT typed as channel/project/person.
+   *
+   * The extractor has never seen this workspace, so asking it whether
+   * "xyne-spaces" is a channel or a project is asking it to guess. It cannot
+   * know, and a wrong guess silently drops a resolver. So it only reports the
+   * names; every name is fanned out to EVERY resolver and the lookups decide.
+   * A row coming back from the `project` search area IS the proof it is a project.
+   */
+  entities: string[];
+}
+
+/**
+ * Minimal structural shape of a live tool. We deliberately do NOT import pi's
+ * `ToolDefinition`: prefetch only ever needs the name and the execute closure,
+ * and a structural type keeps this module independent of the SDK version.
+ */
+export interface ExecutableTool {
+  name: string;
+  execute(toolCallId: string, params: unknown): Promise<unknown>;
+}
+
+export interface PrefetchIdentity {
+  userId: string;
+  userName?: string | undefined;
+  userEmail?: string | undefined;
+}
+
+const EXTRACT_TOOL = {
+  type: "function",
+  function: {
+    name: "record_query_entities",
+    description: "Record the entities named in the user's question so the platform can resolve their ids up front.",
+    parameters: {
+      type: "object",
+      properties: {
+        intent: {
+          type: "string",
+          enum: ["sweep", "lookup", "count", "conversational"],
+          description:
+            "sweep = exhaustive list ('what all', 'everything'); lookup = find specific items; count = how many; conversational = no data retrieval needed.",
+        },
+        entities: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Names of things the question mentions — a team, product, channel, project, repo, or person. Do NOT say what kind of thing each one is; the platform resolves that. Strip a leading '#'. Empty when the question names nothing.",
+        },
+      },
+      required: ["intent", "entities"],
+      additionalProperties: false,
+    },
+  },
+} as const;
+
+const EXTRACT_SYSTEM_PROMPT = `Extract the named entities from a question asked inside Xyne Spaces (a workplace chat/ticketing platform).
+
+Rules:
+- List ONLY the names the question actually mentions. Never infer, expand, or add related things.
+- Do NOT try to say whether a name is a channel, a project, or a person. You have not seen this workspace and cannot know — the platform looks each one up. Just report the name.
+- Strip a leading '#'.
+- If the question mentions nothing and needs no data (a greeting, a thank-you, a question about you), use intent "conversational" with an empty list.
+- Classify intent by the ask, not the topic: "what all X" / "list every X" is sweep; "how many" is count; finding specific items is lookup.
+
+Call record_query_entities exactly once.`;
+
+function asString(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function asStringList(v: unknown, max = 5): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const item of v) {
+    const s = asString(item).replace(/^#/, "");
+    // Single characters and pathological lengths are never real entity names;
+    // they only cost a resolver call that returns the whole workspace.
+    if (s.length < 2 || s.length > 120) continue;
+    if (!out.includes(s)) out.push(s);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+/**
+ * Fire the extractor. Call this as EARLY as possible in the request handler —
+ * it needs nothing but the task text, so it can overlap the MCP tool listing and
+ * session restore instead of adding its latency in front of turn 1.
+ *
+ * Never rejects: a failure resolves to null and prefetch degrades to
+ * identity-only.
+ */
+export function startPrefetchExtraction(task: string): Promise<PrefetchSpec | null> {
+  if (!LITELLM.apiKey || !task.trim()) return Promise.resolve(null);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), EXTRACT_TIMEOUT_MS);
+
+  return (async (): Promise<PrefetchSpec | null> => {
+    try {
+      const res = await fetch(`${LITELLM.url.replace(/\/$/, "")}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${LITELLM.apiKey}` },
+        signal: controller.signal,
+        body: JSON.stringify({
+          model: LITELLM.fastModel,
+          messages: [
+            { role: "system", content: EXTRACT_SYSTEM_PROMPT },
+            { role: "user", content: task.slice(0, 2_000) },
+          ],
+          tools: [EXTRACT_TOOL],
+          tool_choice: { type: "function", function: { name: "record_query_entities" } },
+          temperature: 0,
+        }),
+      });
+      if (!res.ok) {
+        log.warn(`[prefetch] extractor HTTP ${res.status} — skipping prefetch`);
+        return null;
+      }
+      const body = (await res.json()) as {
+        choices?: Array<{ message?: { tool_calls?: Array<{ function?: { arguments?: string } }> } }>;
+      };
+      const raw = body.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments;
+      if (!raw) {
+        log.warn("[prefetch] extractor returned no tool call — skipping prefetch");
+        return null;
+      }
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const intent = asString(parsed["intent"]);
+      const spec: PrefetchSpec = {
+        intent:
+          intent === "sweep" || intent === "lookup" || intent === "count" || intent === "conversational"
+            ? intent
+            : "lookup",
+        // Capped low on purpose: each name fans out to every resolver, so the
+        // call count is entities x resolvers.
+        entities: asStringList(parsed["entities"], MAX_ENTITIES),
+      };
+      log.info(`[prefetch] extracted intent=${spec.intent} entities=[${spec.entities.join(", ")}]`);
+      return spec;
+    } catch (err) {
+      // AbortError included: a slow extractor is a skipped optimisation, not an error.
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`[prefetch] extractor failed (${msg}) — skipping prefetch`);
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  })();
+}
+
+/** Pull the plain text out of a tool result without assuming the exact envelope. */
+function toolResultText(result: unknown): string {
+  const r = result as { content?: Array<{ type?: string; text?: string }> } | undefined;
+  if (!r?.content) return "";
+  return r.content
+    .filter((c) => c?.type === "text" && typeof c.text === "string")
+    .map((c) => c.text as string)
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Strip the parts of a rendered tool result that are noise INSIDE a prefetch
+ * block, BEFORE `digest()` applies its cap.
+ *
+ * The resolvers share a renderer built for a tool result the model asked for
+ * and reads on its own terms: it emits citation tokens for the frontend, echoes
+ * the YQL it ran, and heads the list with a row count. In a prefetch block none
+ * of that survives contact with reality —
+ *   - `[clf-prefetch#N]` is a citation handle that resolves to NOTHING (prefetch
+ *     registers no citation), so leaving it in invites the model to cite a chip
+ *     that renders dead;
+ *   - the echoed YQL is debugging output for a human, and it is long: the two
+ *     EMPTY resolvers in the measured run spent ~700 chars on it between them;
+ *   - `score: 0.000` is what a structured filter query always returns (nothing
+ *     ranked it), i.e. a confidence signal that is false rather than absent;
+ *   - the renderer prints `channelId` from both searchContext and metadata, so
+ *     every channel row carries it twice.
+ *
+ * The point is not the tokens — the block is only ~3.8% of turn 1. It is that
+ * MAX_LINES_PER_RESOLVER is a LINE budget, not a row budget: every noise line
+ * displaces a real result. Measured on the run of 2026-08-20, a channel search
+ * that matched 8 channels showed the model 2, because 6 of its 12 lines were
+ * spent on the above.
+ */
+export function scrub(text: string): string {
+  const out: string[] = [];
+  let lastCreatedBy: string | null = null;
+  for (const raw of text.split("\n")) {
+    if (/^\s*\[Executed YQL/.test(raw)) continue;
+    if (/^\s*Found \d+ result\(s\):\s*$/.test(raw)) continue;
+
+    let line = raw.replace(/\[clf-[^\]\s]*#[\d#-]+\]\s*/g, "");
+    line = line.replace(/\s*·\s*score:\s*0\.000\s*$/, "");
+    if (!line.trim()) continue;
+
+    // `Owner:` restating the `createdBy:` directly above it — the renderer
+    // fills both from the same field for channel rows.
+    const created = line.match(/^\s*createdBy:\s*(\S+)\s*$/);
+    if (created) lastCreatedBy = created[1] ?? null;
+    else {
+      const owner = line.match(/^\s*Owner:\s*(\S+)\s*$/);
+      if (owner && owner[1] === lastCreatedBy) continue;
+      if (!owner) lastCreatedBy = null;
+    }
+
+    // Consecutive exact repeats (the doubled `channelId:`).
+    if (out.length > 0 && out[out.length - 1]!.trim() === line.trim()) continue;
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+/**
+ * Trim a resolver result to the few ROWS the model needs to disambiguate.
+ *
+ * Row-aware, not line-aware, for two reasons the line version got wrong:
+ *   - it cut mid-row, so the last channel in a block could arrive without the
+ *     `channelId:` line that is the entire reason for prefetching it. A row the
+ *     model cannot act on is worse than a row it never saw;
+ *   - its "… N more" counted LINES, so a search matching 8 channels that showed
+ *     2 reported "12 more" — a number that corresponds to nothing the model can
+ *     ask for. It now counts results, which is what "query the tool directly"
+ *     would return.
+ */
+export function digest(text: string): string | null {
+  if (!text) return null;
+  const lines = text
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return null;
+
+  // A row is an unindented `[type] …` header plus the indented detail lines
+  // beneath it. Text with no header at all (`No results found.`) collapses to a
+  // single row and is kept whole.
+  const rows: string[][] = [];
+  for (const line of lines) {
+    if (rows.length === 0 || /^\[/.test(line)) rows.push([line]);
+    else rows[rows.length - 1]!.push(line);
+  }
+
+  const kept: string[][] = [];
+  let used = 0;
+  for (const row of rows) {
+    // The first row goes in whatever its length: better one oversized row than
+    // an empty section.
+    if (kept.length > 0 && used + row.length > MAX_LINES_PER_RESOLVER) break;
+    kept.push(row);
+    used += row.length;
+  }
+
+  const omitted = rows.length - kept.length;
+  const body = kept.flat().join("\n");
+  return omitted > 0
+    ? `${body}\n… ${omitted} more result${omitted === 1 ? "" : "s"} (query the tool directly)`
+    : body;
+}
+
+/**
+ * Pull a project's NAME out of a rendered `project` row.
+ *
+ * `formatSearchResult` renders a project hit as `[project] <name> — <subtitle>`
+ * (the leading `[clf-…#N]` token is absent because project rows are
+ * non-routable), so the name is everything after the type tag and before the
+ * em-dash subtitle separator. Null when the lookup missed, which keeps the
+ * caller on its id-only fallback.
+ */
+export function parseProjectName(text: string | null): string | null {
+  if (!text) return null;
+  for (const line of text.split("\n")) {
+    const m = line.match(/\[project\]\s+(.+?)\s*$/);
+    if (!m) continue;
+    const name = (m[1] ?? "").split(" — ")[0]?.trim();
+    if (name) return name;
+  }
+  return null;
+}
+
+/**
+ * Annotate every `projectId: <id>` line whose project we resolved a name for.
+ *
+ * A channel row prints its owning project as a bare id, which is unreadable on
+ * its own — the model either ignores it or spends a turn resolving it. We
+ * already fetch the name for the hop heading, so stamping it inline here is
+ * free.
+ */
+export function annotateProjectIds(text: string, names: Map<string, string>): string {
+  if (names.size === 0) return text;
+  return text.replace(/^(\s*projectId:\s*)([A-Za-z0-9_-]{6,})\s*$/gm, (line, prefix: string, id: string) => {
+    const name = names.get(id);
+    return name ? `${prefix}${id} (${name})` : line;
+  });
+}
+
+/**
+ * Run one resolver. `undefined` when the tool is not mounted for this agent —
+ * which is normal and must not be logged as an error.
+ */
+async function runResolver(
+  tool: ExecutableTool | undefined,
+  params: unknown,
+  label: string,
+): Promise<string | null> {
+  if (!tool) return null;
+  try {
+    const text = toolResultText(await tool.execute("prefetch", params));
+    return digest(scrub(text));
+  } catch (err) {
+    log.warn(`[prefetch] ${label} resolver failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+}
+
+/** Tools are mounted under a server-prefixed name (`Xyne_Spaces__spaces-vespa-search`). */
+function findTool(tools: ExecutableTool[], bareName: string): ExecutableTool | undefined {
+  return tools.find((t) => t.name === bareName || t.name.endsWith(`__${bareName}`));
+}
+
+/**
+ * Resolve the spec against live tools and render the block appended to the
+ * model's first user message. Returns null when there is nothing worth saying.
+ *
+ * Identity is emitted even with no spec: it is free (already in the run payload)
+ * and removes the `spaces-whoami` round trip on its own.
+ */
+export async function buildPrefetchBlock(opts: {
+  spec: PrefetchSpec | null;
+  tools: ExecutableTool[];
+  identity: PrefetchIdentity;
+}): Promise<string | null> {
+  const { spec, tools, identity } = opts;
+  const sections: string[] = [];
+
+  const who = [
+    `- You are: ${identity.userName ?? "unknown"}`,
+    identity.userEmail ? ` <${identity.userEmail}>` : "",
+    ` — Spaces user id \`${identity.userId}\``,
+  ].join("");
+  sections.push(who);
+
+  // Conversational questions need no lookups; doing them anyway spends latency
+  // and invites the model to anchor on irrelevant rows.
+  if (spec && spec.intent !== "conversational") {
+    // ONE budget for every round, so adding the hop below can never push the
+    // first turn out. Each round races the time that is actually left.
+    const deadline = Date.now() + RESOLVE_TIMEOUT_MS;
+    const raceRemaining = async <T>(jobs: Array<Promise<T>>): Promise<PromiseSettledResult<T>[]> => {
+      const left = deadline - Date.now();
+      if (left <= 0 || jobs.length === 0) return [];
+      return Promise.race([
+        Promise.allSettled(jobs),
+        new Promise<PromiseSettledResult<T>[]>((r) => setTimeout(() => r([]), left)),
+      ]);
+    };
+
+    // Every name against every resolver. Only the ones that return rows make it
+    // into the block, so the block is self-labelling: the section heading says
+    // what the thing turned out to BE, and nothing had to guess up front.
+    // All three resolvers are Vespa, using STRUCTURED name filters rather than
+    // free-text `query`: a filter is a deterministic match on the name field,
+    // where `query` would be ranked retrieval whose top hit is not guaranteed
+    // to be the entity meant. Channel and user names map to 3-gram fuzzy
+    // indexes server-side, so partial names and typos still resolve.
+    // `searchArea` is singular, hence one call per area.
+    const resolvers: Array<{
+      kind: ResolvedKind;
+      area: string;
+      filters: (name: string) => Record<string, unknown>;
+      label: (n: string) => string;
+    }> = [
+      { kind: "channels", area: "channel", filters: (n) => ({ channelName: { contains: n } }), label: (n) => `Channels matching "${n}"` },
+      { kind: "projects", area: "project", filters: (n) => ({ name: { contains: n } }), label: (n) => `Projects matching "${n}"` },
+      { kind: "people", area: "user", filters: (n) => ({ name: { contains: n } }), label: (n) => `People matching "${n}"` },
+    ];
+    const vespa = findTool(tools, "spaces-vespa-search");
+
+    const round1: Array<Promise<ResolvedSection>> = [];
+    for (const name of spec.entities) {
+      for (const r of resolvers) {
+        round1.push(
+          runResolver(
+            vespa,
+            { searchArea: r.area, filters: r.filters(name), hits: RESOLVER_LIMIT },
+            `spaces-vespa-search(${r.area})`,
+          ).then((body) => ({ kind: r.kind, heading: r.label(name), body })),
+        );
+      }
+    }
+
+    const settled1 = await raceRemaining(round1);
+    if (settled1.length === 0 && round1.length > 0) {
+      log.warn(`[prefetch] resolvers exceeded ${RESOLVE_TIMEOUT_MS}ms — shipping identity only`);
+    }
+    const found = settled1
+      .filter((r): r is PromiseFulfilledResult<ResolvedSection> => r.status === "fulfilled")
+      .map((r) => r.value)
+      .filter((v) => v.body);
+
+    // ── Graph hop: project → its name + its channels (one level, never recursive) ────
+    // The user names ONE thing; the answer usually needs its neighbours. Run 2
+    // spent separate turns discovering the project id AND the channel ids for
+    // a single named entity.
+    //
+    // Two lookups per project, fired in the SAME round so they cost one
+    // round trip, not two:
+    //   - channels in the project — Vespa's `channel` area takes a `projectId`
+    //     filter, an exact structured match rather than the naming-convention
+    //     guess that searching by name would be;
+    //   - the project's own row, purely for its NAME. A channel row prints
+    //     `projectId:` as a bare id and nothing else, so without this every
+    //     mention of the project — the hop heading included — was an opaque
+    //     cuid the model had to spend a turn resolving. The `project` area maps
+    //     `projectId` onto `docId`, and that field only accepts `in`.
+    const hops: Array<Promise<HopResult>> = [];
+    const projectIds: string[] = [];
+    for (const section of found) {
+      if (!section.body) continue;
+      for (const m of section.body.matchAll(/^\s*projectId:\s*([A-Za-z0-9_-]{6,})\s*$/gm)) {
+        const id = (m[1] ?? "").trim();
+        if (projectIds.includes(id)) continue;
+        projectIds.push(id);
+        if (projectIds.length >= MAX_HOPS) break;
+      }
+      if (projectIds.length >= MAX_HOPS) break;
+    }
+    for (const projectId of projectIds) {
+      hops.push(
+        runResolver(
+          vespa,
+          {
+            searchArea: "channel",
+            filters: { projectId: { contains: projectId } },
+            hits: RESOLVER_LIMIT,
+            sort: { by: "lastActiveDate", dir: "desc" },
+          },
+          "spaces-vespa-search(channel by project)",
+        ).then((body) => ({ hop: "channels" as const, projectId, body })),
+      );
+      hops.push(
+        runResolver(
+          vespa,
+          { searchArea: "project", filters: { projectId: { in: [projectId] } }, hits: 1 },
+          "spaces-vespa-search(project by id)",
+        ).then((body) => ({ hop: "name" as const, projectId, name: parseProjectName(body) })),
+      );
+    }
+
+    // Names are collected before any heading is rendered, so a name that
+    // arrives inside the budget always reaches BOTH the heading and the inline
+    // `projectId:` lines; one that does not simply leaves the id-only text.
+    const projectNames = new Map<string, string>();
+    if (hops.length > 0) {
+      log.info(`[prefetch] hop project→channels+name for ${projectIds.length} project(s)`);
+      const channelHops: Array<{ projectId: string; body: string }> = [];
+      for (const r of await raceRemaining(hops)) {
+        if (r.status !== "fulfilled") continue;
+        const v = r.value;
+        if (v.hop === "name") {
+          if (v.name) projectNames.set(v.projectId, v.name);
+        } else if (v.body) {
+          channelHops.push({ projectId: v.projectId, body: v.body });
+        }
+      }
+      for (const { projectId, body } of channelHops) {
+        const name = projectNames.get(projectId);
+        found.push({
+          kind: "channels",
+          heading: `Channels in project ${name ? `"${name}" (${projectId})` : projectId} (most recently active first)`,
+          body,
+        });
+      }
+    }
+
+    for (const section of found) {
+      sections.push(`- ${section.heading}:\n${indent(annotateProjectIds(section.body as string, projectNames))}`);
+    }
+  }
+
+  // Identity alone is worth emitting (it deletes the whoami turn), but say so
+  // in the log so a run with a failed extractor is distinguishable from one
+  // where the question simply named nothing.
+  if (sections.length === 1) log.info("[prefetch] identity-only block");
+
+  const block = [
+    "## Resolved context (prefetched — treat as a hint, verify before relying on it)",
+    ...sections,
+  ].join("\n");
+
+  if (block.length > MAX_BLOCK_CHARS) {
+    log.warn(`[prefetch] block ${block.length} chars exceeds cap — truncating`);
+    // Cut on a line boundary. A raw slice can land mid-id and hand the model a
+    // half-written `channelId:` that looks real and resolves to nothing.
+    const cut = block.slice(0, MAX_BLOCK_CHARS);
+    const lastBreak = cut.lastIndexOf("\n");
+    return `${lastBreak > 0 ? cut.slice(0, lastBreak) : cut}\n… (truncated)`;
+  }
+  return block;
+}
+
+function indent(text: string): string {
+  return text
+    .split("\n")
+    .map((l) => `    ${l}`)
+    .join("\n");
+}
+
+/** `agentConfig.prefetchContext` — off unless explicitly enabled. */
+export function prefetchEnabled(agentConfig: Record<string, unknown> | undefined): boolean {
+  return agentConfig?.["prefetchContext"] === true || agentConfig?.["prefetchContext"] === "true";
+}

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -140,6 +140,12 @@ import {
   resolveTaskCommandMode,
 } from "../task-commands.js";
 import { createLogger } from "../logger.js";
+import {
+  buildPrefetchBlock,
+  prefetchEnabled,
+  startPrefetchExtraction,
+  type ExecutableTool,
+} from "../prefetch.js";
 
 const clog = createLogger("run");
 const XYNE_CLAW_PACKAGE_DIR = fileURLToPath(new URL("../../", import.meta.url));
@@ -1446,6 +1452,14 @@ async function processTask(
   shouldGenerateFollowUpSuggestions?: boolean,
   lateFollowUpCallbackUrl?: string,
 ): Promise<void> {
+  // Query prefetch (opt-in, `agentConfig.prefetchContext`). Fired at the TOP of
+  // the run so the fast-model extractor overlaps the expensive setup that
+  // follows — session restore and the MCP tool listing — instead of adding its
+  // latency in front of the first turn. It is awaited far below, once the tool
+  // palette exists and the resolvers can run. Never rejects; see prefetch.ts.
+  const prefetchSpecPromise = prefetchEnabled(agentConfig)
+    ? startPrefetchExtraction(task)
+    : null;
   let mcpCleanup: (() => Promise<void>) | undefined;
   // Absolute paths of raw recordings staged into a CALLER-OWNED cwd. Ephemeral
   // workspaces are deleted whole in the finally, but a persistent cwd survives
@@ -3512,6 +3526,33 @@ async function processTask(
       fullContext = fullContext
         ? `${fullContext}\n\n${idLines.join("\n")}`
         : idLines.join("\n");
+    }
+
+    // Resolve the prefetch spec now that the tool palette is final: the
+    // resolvers ARE the agent's own Spaces tools, invoked through the same
+    // `execute` closure the model would use, so ACL and permissions come along
+    // for free and there is no second auth path to keep in sync.
+    if (prefetchSpecPromise) {
+      const prefetchStartedAt = Date.now();
+      try {
+        const block = await buildPrefetchBlock({
+          spec: await prefetchSpecPromise,
+          tools: allTools as unknown as ExecutableTool[],
+          identity: {
+            userId,
+            ...(userName ? { userName } : {}),
+            ...(userEmail ? { userEmail } : {}),
+          },
+        });
+        if (block) {
+          fullContext = fullContext ? `${fullContext}\n\n${block}` : block;
+          log(`[prefetch] attached ${block.length} chars in ${Date.now() - prefetchStartedAt}ms`);
+        }
+      } catch (err) {
+        // Belt-and-braces: prefetch.ts already swallows everything, but a
+        // prefetch failure must never be the reason a run does not happen.
+        log(`[prefetch] skipped: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
 
     // Key sessions by user + conversationId + agentSlug so each caller gets an isolated sandbox per thread.


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
