### PR TITLE
fix: codeql fixes

### DIFF
--- a/apps/backend/src/automations/routes/automation.routes.ts
+++ b/apps/backend/src/automations/routes/automation.routes.ts
@@ -150,7 +150,7 @@ router.post(
       return;
     }
     try {
-      const files = (req.files as Express.Multer.File[] | undefined) ?? [];
+      const files: Express.Multer.File[] = Array.isArray(req.files) ? req.files : [];
       const stepId = typeof req.body?.stepId === 'string' ? req.body.stepId : '';
       const attachments = await storeAutomationTemplates({
         files,

--- a/apps/backend/src/controllers/analyticsController.ts
+++ b/apps/backend/src/controllers/analyticsController.ts
@@ -2,6 +2,15 @@ import { Request, Response } from 'express';
 import { AnalyticsRepository, AnalyticsFilters } from '@/database/repositories/analyticsRepository';
 import { logger } from '@/utils/logger';
 
+/**
+ * Returns the query param only when it is a single string. Repeated params
+ * (`?timeRange=a&timeRange=b`) arrive as arrays and are treated as absent.
+ */
+function queryString(req: Request, key: string): string | undefined {
+  const value = req.query[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
 export class AnalyticsController {
   private analyticsRepository = new AnalyticsRepository();
 
@@ -10,9 +19,9 @@ export class AnalyticsController {
     extraFilters: Partial<AnalyticsFilters> = {}
   ): AnalyticsFilters {
     return {
-      timeRange: req.query.timeRange as string,
-      startDate: req.query.startDate as string,
-      endDate: req.query.endDate as string,
+      timeRange: queryString(req, 'timeRange'),
+      startDate: queryString(req, 'startDate'),
+      endDate: queryString(req, 'endDate'),
       ...extraFilters,
       workspaceId: req.user!.workspaceId!
     };

--- a/apps/backend/src/controllers/meetCallbackController.ts
+++ b/apps/backend/src/controllers/meetCallbackController.ts
@@ -64,11 +64,16 @@ export class MeetCallbackController {
       }
       const payload = validationResult.data;
 
-      // Extract identifiers from query params
-      const xyneTicketId = req.query.xyneTicketId as string;
-      const workspaceId = req.query.workspaceId as string;
-      const threadId = req.query.threadId as string;
-      const meetCode = req.query.meetCode as string;
+      // Extract identifiers from query params. A repeated param (`?meetCode=a&meetCode=b`)
+      // arrives as an array; only accept single string values.
+      const queryString = (key: string): string | undefined => {
+        const value = req.query[key];
+        return typeof value === 'string' ? value : undefined;
+      };
+      const xyneTicketId = queryString('xyneTicketId');
+      const workspaceId = queryString('workspaceId');
+      const threadId = queryString('threadId');
+      const meetCode = queryString('meetCode');
 
       logger.info('[MeetCallbackController] Received callback from SAM', {
         xyneTicketId,

--- a/apps/backend/src/database/repositories/analyticsRepository.ts
+++ b/apps/backend/src/database/repositories/analyticsRepository.ts
@@ -153,7 +153,8 @@ export function getDateFilter(filters: AnalyticsFilters): Date | { gte: Date; lt
   }
 
   // Handle date range in format "YYYY-MM-DD_YYYY-MM-DD" from frontend calendar
-  const timeRange = filters.timeRange || '7d';
+  const timeRange =
+    typeof filters.timeRange === 'string' && filters.timeRange ? filters.timeRange : '7d';
   if (timeRange.includes('_')) {
     const [startDateStr, endDateStr] = timeRange.split('_');
     const startDate = new Date(startDateStr);

--- a/apps/backend/src/git-providers/bitbucket/apis.ts
+++ b/apps/backend/src/git-providers/bitbucket/apis.ts
@@ -255,7 +255,7 @@ export class BitbucketManager {
     description: string
   ) {
     try {
-      const buildStatusUrl = `${config.bitbucket.baseUrl}/rest/build-status/1.0/commits/${commitHash}`;
+      const buildStatusUrl = `${config.bitbucket.baseUrl}/rest/build-status/1.0/commits/${encodeURIComponent(commitHash)}`;
       const payload = {
         state,
         key,

--- a/apps/backend/src/routes/calendarWebhooks.ts
+++ b/apps/backend/src/routes/calendarWebhooks.ts
@@ -198,7 +198,8 @@ router.post('/microsoft-calendar', async (req: Request, res: Response) => {
       } catch (parseErr) {
         logger.error(`${MICROSOFT_TAG} Failed to parse Buffer payload`, {
           error: parseErr instanceof Error ? parseErr.message : String(parseErr),
-          preview: payload.slice(0, 100).toString('hex'),
+          // First 100 bytes as hex (200 hex chars) of the raw Buffer body.
+          preview: payload.toString('hex').slice(0, 200),
         });
         res.status(202).send('Accepted');
         return;

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -1287,7 +1287,7 @@ export async function downloadClawAttachment(
   contentDisposition: string | null;
   contentLength: string | null;
 }> {
-  const url = `${getClawBaseUrl()}/claw/api/v1/agent-chat/attachments/${attachmentId}/download`;
+  const url = `${getClawBaseUrl()}/claw/api/v1/agent-chat/attachments/${encodeURIComponent(attachmentId)}/download`;
   logger.info(`[ClawAgentService] Downloading attachment: ${attachmentId}`);
 
   const response = await fetch(url, {

--- a/apps/backend/src/services/meetLinkService.ts
+++ b/apps/backend/src/services/meetLinkService.ts
@@ -141,7 +141,7 @@ async function withRetry<T>(
  * Includes retry logic with exponential backoff for transient failures
  */
 export async function sendMeetMetadataToSam(metadata: MeetLinkMetadata): Promise<boolean> {
-  const endpoint = `${config.sam.baseUrl}/sam/s2s/meet/${metadata.meetCode}/meta`;
+  const endpoint = `${config.sam.baseUrl}/sam/s2s/meet/${encodeURIComponent(metadata.meetCode)}/meta`;
 
   // Generate notification URL with query params for callback identification (including workspaceId)
   const notificationUrl = generateNotificationUrl(

--- a/apps/backend/src/services/pulseService.ts
+++ b/apps/backend/src/services/pulseService.ts
@@ -117,7 +117,7 @@ export class PulseService {
   async fetchOrgLeadData(orgId: string): Promise<PulseProduct[]> {
     const { apiUrl } = config.pulse;
     try {
-      const response = await fetch(`${apiUrl}/curie/s2s/organization/lead/data/${orgId}`, {
+      const response = await fetch(`${apiUrl}/curie/s2s/organization/lead/data/${encodeURIComponent(orgId)}`, {
         method: 'POST',
         headers: this.headersNoBody,
         // No body — same pattern as fetchOrgList

--- a/apps/backend/src/services/release/repoInspector.ts
+++ b/apps/backend/src/services/release/repoInspector.ts
@@ -40,10 +40,13 @@ export async function testRepoConnection(opts: {
     const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
     if (token) headers.Authorization = `Bearer ${token}`;
 
-    const resp = await fetch(`${apiUrl}/repos/${parsed.owner}/${parsed.repo}`, {
-      headers,
-      signal: AbortSignal.timeout(API_TIMEOUT_MS),
-    });
+    const resp = await fetch(
+      `${apiUrl}/repos/${encodeURIComponent(parsed.owner)}/${encodeURIComponent(parsed.repo)}`,
+      {
+        headers,
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      },
+    );
     if (resp.ok) {
       const json = (await resp.json()) as { full_name: string; default_branch: string };
       return {
@@ -84,7 +87,7 @@ export async function testRepoConnection(opts: {
       headers.Authorization = `Basic ${basic}`;
     }
     const resp = await fetch(
-      `${baseUrl}/projects/${parsed.projectKey}/repos/${parsed.repoSlug}`,
+      `${baseUrl}/projects/${encodeURIComponent(parsed.projectKey)}/repos/${encodeURIComponent(parsed.repoSlug)}`,
       { headers, signal: AbortSignal.timeout(API_TIMEOUT_MS) },
     );
     if (resp.ok) {

--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -264,6 +264,12 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       res.status(403).json({ success: false, error: 'Forbidden: workspace context required' });
       return;
     }
+    // `q` is used as a string all the way down to YqlBuilder; a repeated query
+    // param (`?q=a&q=b`) arrives as an array, so reject anything that isn't a string.
+    if (q !== undefined && typeof q !== 'string') {
+      res.status(400).json({ success: false, error: 'Query parameter "q" must be a string' });
+      return;
+    }
 
     // ── Chunk-level KB drill-in (additive, opt-in) ─────────────────────────
     //

--- a/apps/backend/src/services/vespaSearch/schemaHandler.ts
+++ b/apps/backend/src/services/vespaSearch/schemaHandler.ts
@@ -11,9 +11,17 @@ if (!process.env['VESPA_CONFIG_SERVER_URL']) {
   logger.warn('[schemaHandler] VESPA_CONFIG_SERVER_URL is not set — falling back to http://127.0.0.1:19071');
 }
 
+// Vespa schema names are plain identifiers; anything else is not a schema we
+// serve and must not be interpolated into the config-server path.
+const SCHEMA_NAME_PATTERN = /^[A-Za-z0-9_]+$/;
+
 export const schemaHandler = async (req: Request, res: Response): Promise<void> => {
-  const schemaName = req.query['schema'] as string;
-  const url = `${SCHEMA_BASE_URL}/${schemaName}.sd`;
+  const schemaName = req.query['schema'];
+  if (typeof schemaName !== 'string' || !SCHEMA_NAME_PATTERN.test(schemaName)) {
+    res.status(400).send('Invalid schema name');
+    return;
+  }
+  const url = `${SCHEMA_BASE_URL}/${encodeURIComponent(schemaName)}.sd`;
 
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });

--- a/apps/backend/src/vespa/src/client/vespaClient.ts
+++ b/apps/backend/src/vespa/src/client/vespaClient.ts
@@ -163,7 +163,7 @@ class VespaClient {
       // Clean document fields to remove Unicode replacement characters before insertion
       const cleanedDocument = cleanDocumentFields(document);
 
-      const url = `${this.feedEndpoint}/document/v1/${options.namespace}/${options.schema}/docid/${document.docId}`;
+      const url = `${this.feedEndpoint}/document/v1/${options.namespace}/${options.schema}/docid/${encodeURIComponent(document.docId)}`;
       const response = await this.fetchWithRetry(url, {
         method: 'POST',
         headers: {
@@ -191,7 +191,7 @@ class VespaClient {
 
   async getDocument(options: VespaConfigValues & { docId: string }): Promise<any> {
     const { docId, namespace, schema } = options;
-    const url = `${this.feedEndpoint}/document/v1/${namespace}/${schema}/docid/${docId}`;
+    const url = `${this.feedEndpoint}/document/v1/${namespace}/${schema}/docid/${encodeURIComponent(docId)}`;
     try {
       const response = await this.fetchWithRetry(url, {
         method: 'GET',
@@ -228,7 +228,7 @@ class VespaClient {
     const { docId, namespace, schema, create } = options;
     // create=true upserts: Vespa builds the doc from these assign ops when it
     // doesn't exist yet, instead of silently no-oping the partial update.
-    const url = `${this.feedEndpoint}/document/v1/${namespace}/${schema}/docid/${docId}${
+    const url = `${this.feedEndpoint}/document/v1/${namespace}/${schema}/docid/${encodeURIComponent(docId)}${
       create ? '?create=true' : ''
     }`;
 
@@ -272,7 +272,7 @@ class VespaClient {
 
   async deleteDocument(options: VespaConfigValues & { docId: string }): Promise<void> {
     const { docId, namespace, schema } = options;
-    const url = `${this.feedEndpoint}/document/v1/${namespace}/${schema}/docid/${docId}`;
+    const url = `${this.feedEndpoint}/document/v1/${namespace}/${schema}/docid/${encodeURIComponent(docId)}`;
 
     try {
       const response = await this.fetchWithRetry(url, {

--- a/apps/electron/src/services/agent-auth.ts
+++ b/apps/electron/src/services/agent-auth.ts
@@ -1088,10 +1088,9 @@ class AgentAuthService {
           const filePath = path.join(downloadDir, filename);
 
           // Download attachment using the attachment download endpoint
-          const downloadUrl = `${config.BACKEND_URL}/api/attachments/${attachment.id}/download`;
-          log.info(`[AgentAuth] Downloading attachment: ${filename} from ${downloadUrl}`);
+          log.info(`[AgentAuth] Downloading attachment: ${filename} (id=${attachment.id})`);
 
-          await this.downloadAttachmentToFile(downloadUrl, filePath, accessToken);
+          await this.downloadAttachmentToFile(String(attachment.id), filePath, accessToken);
 
           const stats = await fs.promises.stat(filePath);
           downloadedFiles.push({
@@ -1186,13 +1185,19 @@ class AgentAuthService {
   }
 
   /**
-   * Download an attachment file using Electron's net module
+   * Download an attachment file using Electron's net module.
+   *
+   * Takes the attachment id rather than a URL: the request always goes to the
+   * configured backend (config.BACKEND_URL), and the id — which comes from a
+   * backend response — is only ever a percent-encoded path segment, so it can
+   * never change the host or scheme of the request.
    */
   private async downloadAttachmentToFile(
-    url: string,
+    attachmentId: string,
     filePath: string,
     accessToken: string
   ): Promise<void> {
+    const url = `${config.BACKEND_URL}/api/attachments/${encodeURIComponent(attachmentId)}/download`;
     return new Promise((resolve, reject) => {
       const request = net.request({
         url,

--- a/apps/xyne-claw-auth/backend/src/lib/oauth-state.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/oauth-state.ts
@@ -53,6 +53,12 @@ export class OAuthStateError extends Error {
 }
 
 export function verifyOAuthState(state: string): VerifiedState {
+  // `state` comes straight from the provider callback's query/body, so it can be an
+  // array (`?state=a&state=b`) at runtime despite the declared type. Reject anything
+  // that isn't a single string before doing string operations on it.
+  if (typeof state !== "string") {
+    throw new OAuthStateError("malformed");
+  }
   const dot = state.lastIndexOf(".");
   if (dot <= 0 || dot === state.length - 1) {
     throw new OAuthStateError("malformed");

--- a/apps/xyne-claw-auth/backend/src/lib/url-guard.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/url-guard.ts
@@ -1,0 +1,108 @@
+/**
+ * Outbound-URL guards (SSRF). Every `fetch` whose target host or scheme can be
+ * influenced by request data — a body field, a query/param, a DB column that a
+ * route wrote from a body — must derive its URL from one of these helpers
+ * rather than from the raw string.
+ *
+ * Three shapes are supported:
+ *   - `rebaseOnTrustedOrigin`: the caller may pick a path on one of OUR
+ *     origins (internal result/progress callbacks). Scheme/host/port always
+ *     come from the trusted origin string; only path + query are carried over.
+ *   - `requireHost`: the URL must live on a known provider host
+ *     (e.g. Slack's `hooks.slack.com`).
+ *   - `resolveProviderBaseUrl`: a user-configured base URL for an
+ *     OpenAI/Anthropic-compatible proxy. Mirrors the external-callback policy
+ *     in surfaces/external-api/const.ts: plain http(s), never cloud metadata
+ *     or link-local addresses.
+ *
+ * Callers that follow `fetch` with a user-influenced target should also pass
+ * `redirect: "manual"` so a 3xx cannot bounce the request somewhere else.
+ */
+
+export const HTTP_PROTOCOLS: ReadonlySet<string> = new Set(["http:", "https:"]);
+
+/** Cloud metadata endpoints by name… */
+const BLOCKED_HOSTNAMES: ReadonlySet<string> = new Set([
+  "metadata.google.internal",
+  "instance-data",
+  "fd00:ec2::254",
+]);
+/** …and by link-local address. */
+const LINK_LOCAL_IPV4_RE = /^169\.254\.\d{1,3}\.\d{1,3}$/;
+
+export class OutboundUrlError extends Error {
+  override readonly name = "OutboundUrlError";
+}
+
+/** Parse `raw` as an absolute http(s) URL without userinfo; null for anything else. */
+export function parseHttpUrl(raw: unknown): URL | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (!HTTP_PROTOCOLS.has(parsed.protocol)) return null;
+  // `https://user@host/` is never a legitimate shape for these targets and is
+  // a classic way to make a URL read as one host while pointing at another.
+  if (parsed.username || parsed.password) return null;
+  return parsed;
+}
+
+/** Lower-cased hostname with IPv6 brackets removed. */
+export function hostnameOf(url: URL): string {
+  return url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+}
+
+/** False for cloud-metadata names and link-local IPv4 literals. */
+export function isAllowedOutboundHost(url: URL): boolean {
+  const hostname = hostnameOf(url);
+  if (BLOCKED_HOSTNAMES.has(hostname)) return false;
+  if (LINK_LOCAL_IPV4_RE.test(hostname)) return false;
+  return true;
+}
+
+/**
+ * Rebuild `raw` on top of whichever of `trustedOrigins` it matches. The
+ * returned URL takes scheme, host and port from the trusted origin string and
+ * only path + query from `raw`; null when `raw` is not on a trusted origin.
+ */
+export function rebaseOnTrustedOrigin(raw: unknown, trustedOrigins: readonly string[]): URL | null {
+  const candidate = parseHttpUrl(raw);
+  if (!candidate) return null;
+  for (const trusted of trustedOrigins) {
+    const base = parseHttpUrl(trusted);
+    if (!base || base.origin !== candidate.origin) continue;
+    return new URL(`${candidate.pathname}${candidate.search}`, base.origin);
+  }
+  return null;
+}
+
+/**
+ * Accept `raw` only when it is an http(s) URL whose hostname is one of
+ * `allowedHosts` (exact, case-insensitive). Returns the parsed URL or null.
+ */
+export function requireHost(raw: unknown, allowedHosts: ReadonlySet<string>): URL | null {
+  const parsed = parseHttpUrl(raw);
+  if (!parsed) return null;
+  return allowedHosts.has(hostnameOf(parsed)) ? parsed : null;
+}
+
+/**
+ * Resolve a user-configured provider base URL. Empty/undefined falls back to
+ * `fallback` (a constant or config value). The result has no trailing slash so
+ * callers can append `/v1/models` etc. Throws OutboundUrlError on a URL that
+ * is not plain http(s) or targets a blocked host.
+ */
+export function resolveProviderBaseUrl(raw: string | null | undefined, fallback: string): string {
+  const candidate = (raw ?? "").trim() || fallback;
+  const parsed = parseHttpUrl(candidate);
+  if (!parsed) {
+    throw new OutboundUrlError("baseUrl must be an absolute http(s) URL");
+  }
+  if (!isAllowedOutboundHost(parsed)) {
+    throw new OutboundUrlError("baseUrl targets a host that is not allowed");
+  }
+  return parsed.href.replace(/\/+$/, "");
+}

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/bitbucket-list-prs.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/bitbucket-list-prs.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { describe, expect, it, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { handleListPullRequests } from "./bitbucket.js";
 
 const CREDS = { username: "u", token: "t", baseUrl: "https://bitbucket.example.net" };
+
+// The base URL is validated before any request (see resolveBitbucketBase);
+// the fake host does not resolve, so trust it via the operator allowlist.
+beforeAll(() => vi.stubEnv("BITBUCKET_ALLOWED_HOSTS", "bitbucket.example.net"));
+afterAll(() => vi.unstubAllEnvs());
 
 interface FakePr { id: number; toRef?: string }
 

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/bitbucket.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/bitbucket.ts
@@ -1,6 +1,84 @@
 import type { StdioMcpAdapter, McpToolInfo } from "../types.js";
 import type { Citation } from "xyne-claw-shared";
 import { prefixChunk } from "./grafana.js";
+import { assertOutboundUrlAllowed, parseHostAllowlist } from "../url-guard.js";
+
+const DEFAULT_BITBUCKET_BASE_URL = "https://bitbucket.juspay.net";
+
+/**
+ * Resolve and validate the Bitbucket Server base URL for a connection.
+ *
+ * `credentials.baseUrl` is a free-text credential field: it is written by
+ * POST /:userId/connections straight from the request body and only checked
+ * for "non-empty string". Every local Bitbucket tool then builds REST URLs
+ * on it, so without validation any authenticated user could aim this
+ * service's Basic-auth requests at loopback / cluster-internal / metadata
+ * hosts. Validate ONCE per tool call (scheme, host allowlist or public
+ * address) and build every request from the returned URL object.
+ *
+ * BITBUCKET_ALLOWED_HOSTS (comma-separated) pins the accepted hosts; hosts
+ * on it skip the address check so an on-prem server on a private range
+ * still works when an operator has explicitly trusted it.
+ */
+export async function resolveBitbucketBase(credentials: Record<string, unknown>): Promise<URL> {
+  const raw = typeof credentials["baseUrl"] === "string" ? credentials["baseUrl"].trim() : "";
+  return assertOutboundUrlAllowed(raw || DEFAULT_BITBUCKET_BASE_URL, {
+    allowedHosts: parseHostAllowlist(process.env["BITBUCKET_ALLOWED_HOSTS"]),
+    label: "Bitbucket base URL",
+  });
+}
+
+/** `https://host[/context]` without a trailing slash — the shape the citation builders take. */
+function bitbucketSiteUrl(base: URL): string {
+  return base.origin + base.pathname.replace(/\/+$/, "");
+}
+
+/**
+ * Build a `/rest/api/1.0/...` URL on a validated base. Caller-supplied values
+ * only ever become individual, percent-encoded PATH segments (plus an
+ * optional query string) on the validated origin; they can never reach the
+ * scheme or host. Dot segments are refused outright because the URL parser
+ * would otherwise collapse `..` back up the path.
+ */
+export function bitbucketApiUrl(
+  base: URL,
+  segments: ReadonlyArray<string | number>,
+  query?: URLSearchParams,
+): string {
+  const encoded = segments.map((seg) => {
+    const s = String(seg);
+    if (s === "" || s === "." || s === "..") {
+      throw new Error(`Bitbucket API path segment ${JSON.stringify(s)} is not allowed`);
+    }
+    return encodeURIComponent(s);
+  });
+  const url = new URL(base.origin);
+  url.pathname = `${base.pathname.replace(/\/+$/, "")}/rest/api/1.0/${encoded.join("/")}`;
+  if (query) url.search = query.toString();
+  return url.href;
+}
+
+/**
+ * Bitbucket Server project keys are `[A-Za-z0-9_]` (personal projects are
+ * `~username`), repo slugs are `[a-z0-9._-]`. Anything else is not a valid
+ * identifier and would only ever be a path-shaping attempt.
+ */
+const BB_IDENT_RE = /^~?[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function requireBitbucketIdent(tool: string, name: string, value: unknown): string {
+  if (typeof value !== "string" || !BB_IDENT_RE.test(value.trim())) {
+    throw new Error(`${tool}: ${name} must be a valid Bitbucket identifier`);
+  }
+  return value.trim();
+}
+
+function requireBitbucketPrId(tool: string, value: unknown): string {
+  const s = typeof value === "number" ? String(value) : typeof value === "string" ? value.trim() : "";
+  if (!/^\d{1,12}$/.test(s)) {
+    throw new Error(`${tool}: prId must be a pull request number`);
+  }
+  return s;
+}
 
 export const bitbucketAdapter: StdioMcpAdapter = {
   transport: "stdio",
@@ -224,11 +302,9 @@ export async function handleUploadPrScreenshot(
 ): Promise<{ content: string; citations?: Citation[] }> {
   const username = credentials["username"] as string;
   const token = credentials["token"] as string;
-  const baseUrl = ((credentials["baseUrl"] as string) || "https://bitbucket.juspay.net").replace(/\/+$/, "");
-
-  const projectKey = params["projectKey"] as string;
-  const repoSlug = params["repoSlug"] as string;
-  const prId = params["prId"] as string;
+  const projectKey = requireBitbucketIdent("upload-pr-screenshot", "projectKey", params["projectKey"]);
+  const repoSlug = requireBitbucketIdent("upload-pr-screenshot", "repoSlug", params["repoSlug"]);
+  const prId = requireBitbucketPrId("upload-pr-screenshot", params["prId"]);
   const fileData = params["fileData"] as string | undefined;
   const explicitFileName = params["fileName"] as string | undefined;
   const mimeType = (params["mimeType"] as string | undefined) || "image/png";
@@ -247,9 +323,11 @@ export async function handleUploadPrScreenshot(
   const caption = (params["caption"] as string) || fileName;
 
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
+  const base = await resolveBitbucketBase(credentials);
+  const siteUrl = bitbucketSiteUrl(base);
 
   // Upload as repo attachment — Bitbucket Server returns attachment metadata with links
-  const uploadUrl = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/attachments`;
+  const uploadUrl = bitbucketApiUrl(base, ["projects", projectKey, "repos", repoSlug, "attachments"]);
 
   const boundary = "----XyneUpload" + Date.now();
   const bodyParts = [
@@ -289,10 +367,10 @@ export async function handleUploadPrScreenshot(
   }
 
   // The URL from the API may be relative — make it absolute
-  const fullUrl = attachmentUrl.startsWith("http") ? attachmentUrl : `${baseUrl}${attachmentUrl}`;
+  const fullUrl = attachmentUrl.startsWith("http") ? attachmentUrl : `${siteUrl}${attachmentUrl}`;
 
   // Add a PR comment with the embedded image
-  const commentUrl = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/pull-requests/${prId}/comments`;
+  const commentUrl = bitbucketApiUrl(base, ["projects", projectKey, "repos", repoSlug, "pull-requests", prId, "comments"]);
   const commentBody = `![${caption}](${fullUrl})\n\n**${caption}**`;
 
   const commentRes = await fetch(commentUrl, {
@@ -305,7 +383,7 @@ export async function handleUploadPrScreenshot(
   });
 
   const citations: Citation[] = [
-    { kind: "external", url: prUrl(baseUrl, projectKey, repoSlug, prId), chunkIndex: 1, label: `Bitbucket PR #${prId}` },
+    { kind: "external", url: prUrl(siteUrl, projectKey, repoSlug, prId), chunkIndex: 1, label: `Bitbucket PR #${prId}` },
   ];
 
   if (!commentRes.ok) {
@@ -443,18 +521,17 @@ export async function handleGetPrComments(
 ): Promise<{ content: string; citations?: Citation[] }> {
   const username = credentials["username"] as string;
   const token = credentials["token"] as string;
-  const baseUrl = ((credentials["baseUrl"] as string) || "https://bitbucket.juspay.net").replace(/\/+$/, "");
-
-  const projectKey = params["projectKey"] as string;
-  const repoSlug = params["repoSlug"] as string;
-  const prId = params["prId"] as string;
+  if (!params["projectKey"] || !params["repoSlug"] || !params["prId"]) {
+    throw new Error("get-pr-comments: projectKey, repoSlug, and prId are required");
+  }
+  const projectKey = requireBitbucketIdent("get-pr-comments", "projectKey", params["projectKey"]);
+  const repoSlug = requireBitbucketIdent("get-pr-comments", "repoSlug", params["repoSlug"]);
+  const prId = requireBitbucketPrId("get-pr-comments", params["prId"]);
   const maxComments = typeof params["maxComments"] === "number" ? (params["maxComments"] as number) : 500;
   const includeDeleted = params["includeDeleted"] === true;
 
-  if (!projectKey || !repoSlug || !prId) {
-    throw new Error("get-pr-comments: projectKey, repoSlug, and prId are required");
-  }
-
+  const base = await resolveBitbucketBase(credentials);
+  const siteUrl = bitbucketSiteUrl(base);
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
   const pageSize = 100;
   const out: FlatComment[] = [];
@@ -463,9 +540,11 @@ export async function handleGetPrComments(
   const maxPages = 200; // hard ceiling — 20k activities is plenty even for huge PRs
 
   while (out.length < maxComments && pagesWalked < maxPages) {
-    const url =
-      `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}` +
-      `/pull-requests/${prId}/activities?start=${start}&limit=${pageSize}`;
+    const url = bitbucketApiUrl(
+      base,
+      ["projects", projectKey, "repos", repoSlug, "pull-requests", prId, "activities"],
+      new URLSearchParams({ start: String(start), limit: String(pageSize) }),
+    );
 
     const res = await fetch(url, {
       method: "GET",
@@ -509,7 +588,7 @@ export async function handleGetPrComments(
     2,
   );
   const citations: Citation[] = [
-    { kind: "external", url: prUrl(baseUrl, projectKey, repoSlug, prId), chunkIndex: 1, label: `Bitbucket PR #${prId} comments` },
+    { kind: "external", url: prUrl(siteUrl, projectKey, repoSlug, prId), chunkIndex: 1, label: `Bitbucket PR #${prId} comments` },
   ];
   return { content: prefixChunk(1, content), citations };
 }
@@ -539,16 +618,13 @@ export async function handleGetPrTemplate(
 ): Promise<{ content: string; citations?: Citation[] }> {
   const username = credentials["username"] as string;
   const token = credentials["token"] as string;
-  const baseUrl = ((credentials["baseUrl"] as string) || "https://bitbucket.juspay.net").replace(/\/+$/, "");
-
-  const projectKey = params["projectKey"] as string;
-  const repoSlug = params["repoSlug"] as string;
-  const at = (params["at"] as string | undefined)?.trim() || undefined;
-  const explicitPath = (params["path"] as string | undefined)?.trim() || undefined;
-
-  if (!projectKey || !repoSlug) {
+  if (!params["projectKey"] || !params["repoSlug"]) {
     throw new Error("get-pr-template: projectKey and repoSlug are required");
   }
+  const projectKey = requireBitbucketIdent("get-pr-template", "projectKey", params["projectKey"]);
+  const repoSlug = requireBitbucketIdent("get-pr-template", "repoSlug", params["repoSlug"]);
+  const at = (params["at"] as string | undefined)?.trim() || undefined;
+  const explicitPath = (params["path"] as string | undefined)?.trim() || undefined;
   // Guard the caller-supplied path: encodeURIComponent does NOT encode ".", so a ".." segment
   // would survive as real path traversal. Reject absolute paths and any ".." / empty segment.
   if (
@@ -558,15 +634,20 @@ export async function handleGetPrTemplate(
     throw new Error("get-pr-template: path must be a relative repo path with no '..' or empty segments");
   }
 
+  const base = await resolveBitbucketBase(credentials);
+  const siteUrl = bitbucketSiteUrl(base);
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
   const candidates = explicitPath ? [explicitPath] : DEFAULT_PR_TEMPLATE_PATHS;
   const tried: string[] = [];
 
   for (const path of candidates) {
-    // Encode each path segment to prevent traversal / stray query chars leaking into the URL.
-    const encodedPath = path.split("/").map(encodeURIComponent).join("/");
-    let url = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/raw/${encodedPath}`;
-    if (at) url += `?at=${encodeURIComponent(at)}`;
+    // Each path segment becomes its own percent-encoded URL segment, so traversal /
+    // stray query chars can't leak into the URL.
+    const url = bitbucketApiUrl(
+      base,
+      ["projects", projectKey, "repos", repoSlug, "raw", ...path.split("/")],
+      at ? new URLSearchParams({ at }) : undefined,
+    );
 
     tried.push(path);
     const res = await fetch(url, {
@@ -587,7 +668,7 @@ export async function handleGetPrTemplate(
     const content = await res.text();
     const body = JSON.stringify({ found: true, path, at: at ?? null, content, triedPaths: tried }, null, 2);
     const citations: Citation[] = [
-      { kind: "external", url: fileUrl(baseUrl, projectKey, repoSlug, path, at), chunkIndex: 1, label: `Bitbucket file ${path}` },
+      { kind: "external", url: fileUrl(siteUrl, projectKey, repoSlug, path, at), chunkIndex: 1, label: `Bitbucket file ${path}` },
     ];
     return { content: prefixChunk(1, body), citations };
   }
@@ -650,13 +731,11 @@ export async function handleListPullRequests(
 ): Promise<{ content: string; citations?: Citation[] }> {
   const username = credentials["username"] as string;
   const token = credentials["token"] as string;
-  const baseUrl = ((credentials["baseUrl"] as string) || "https://bitbucket.juspay.net").replace(/\/+$/, "");
-
-  const projectKey = params["projectKey"] as string;
-  const repoSlug = params["repoSlug"] as string;
-  if (!projectKey || !repoSlug) {
+  if (!params["projectKey"] || !params["repoSlug"]) {
     throw new Error("list-pull-requests: projectKey and repoSlug are required");
   }
+  const projectKey = requireBitbucketIdent("list-pull-requests", "projectKey", params["projectKey"]);
+  const repoSlug = requireBitbucketIdent("list-pull-requests", "repoSlug", params["repoSlug"]);
 
   const state = ((params["state"] as string) || "MERGED").toUpperCase();
   const order = ((params["order"] as string) || "NEWEST").toUpperCase();
@@ -665,6 +744,7 @@ export async function handleListPullRequests(
   const targetBranchRaw = typeof params["targetBranch"] === "string" ? (params["targetBranch"] as string).trim() : "";
   const target = targetBranchRaw ? normalizeBranchRef(targetBranchRaw) : null;
 
+  const base = await resolveBitbucketBase(credentials);
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
   const pageSize = 100;
   const collected: BbPullRequest[] = [];
@@ -689,7 +769,7 @@ export async function handleListPullRequests(
       qs.set("direction", "INCOMING");
     }
 
-    const url = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/pull-requests?${qs.toString()}`;
+    const url = bitbucketApiUrl(base, ["projects", projectKey, "repos", repoSlug, "pull-requests"], qs);
     const res = await fetch(url, {
       method: "GET",
       headers: { Authorization: authHeader, Accept: "application/json" },

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/github.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/github.ts
@@ -102,6 +102,18 @@ const IMAGE_MIME = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"
 const MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 
 const GITHUB_API_VERSION = "2026-03-10";
+const GITHUB_API_ORIGIN = "https://api.github.com";
+
+/**
+ * Build an api.github.com URL. The origin is fixed; every caller-supplied
+ * part (owner, repo, PR number) is its own percent-encoded path segment, so
+ * tool-call arguments can shape the path but never the scheme or host.
+ */
+function githubApiUrl(...segments: Array<string | number>): string {
+  const url = new URL(GITHUB_API_ORIGIN);
+  url.pathname = "/" + segments.map((s) => encodeURIComponent(String(s))).join("/");
+  return url.href;
+}
 
 /**
  * GitHub renders a player for a video URL on its OWN bare line; the `![]()`
@@ -182,7 +194,7 @@ export async function handleUploadPrAttachment(
   };
 
   // The upload endpoint keys off the numeric repository id, not owner/name.
-  const lookupRes = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+  const lookupRes = await fetch(githubApiUrl("repos", owner, repo), {
     headers: { ...auth, Accept: "application/vnd.github+json" },
     signal: AbortSignal.timeout(20_000),
   });
@@ -247,15 +259,12 @@ export async function handleUploadPrAttachment(
   }
 
   // PR/issue comments share the issues endpoint on GitHub.
-  const commentRes = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments`,
-    {
-      method: "POST",
-      headers: { ...auth, Accept: "application/vnd.github+json", "Content-Type": "application/json" },
-      body: JSON.stringify({ body: markdown }),
-      signal: AbortSignal.timeout(30_000),
-    },
-  );
+  const commentRes = await fetch(githubApiUrl("repos", owner, repo, "issues", prNumber, "comments"), {
+    method: "POST",
+    headers: { ...auth, Accept: "application/vnd.github+json", "Content-Type": "application/json" },
+    body: JSON.stringify({ body: markdown }),
+    signal: AbortSignal.timeout(30_000),
+  });
 
   const citations: Citation[] = [
     { kind: "external", url: prUrl(owner, repo, prNumber), chunkIndex: 1, label: `GitHub PR #${prNumber}` },

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const lookupMock = vi.fn();
+vi.mock("node:dns/promises", () => ({ lookup: (...args: unknown[]) => lookupMock(...args) }));
+
+const { handleWebfetch } = await import("./webfetch.js");
+
+const PUBLIC = [{ address: "93.184.216.34", family: 4 }];
+const PRIVATE = [{ address: "10.0.0.9", family: 4 }];
+
+function htmlResponse(body: string): Response {
+  return new Response(body, { status: 200, headers: { "content-type": "text/html" } });
+}
+
+function redirectResponse(status: number, location: string): Response {
+  return new Response(null, { status, headers: { location } });
+}
+
+afterEach(() => {
+  lookupMock.mockReset();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("handleWebfetch SSRF fence", () => {
+  it("refuses loopback / metadata / private-resolving hosts before any request", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    lookupMock.mockResolvedValue(PRIVATE);
+
+    expect(await handleWebfetch({ url: "http://127.0.0.1:3003/health" })).toMatch(/^Error: .*private, loopback/);
+    expect(await handleWebfetch({ url: "http://169.254.169.254/latest/meta-data/" })).toMatch(/^Error: /);
+    expect(await handleWebfetch({ url: "http://localhost:8080/" })).toMatch(/^Error: .*internal-only/);
+    expect(await handleWebfetch({ url: "https://intranet.example.com/" })).toMatch(/^Error: .*resolves to private/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches the validated URL with redirect: manual and converts the page", async () => {
+    lookupMock.mockResolvedValue(PUBLIC);
+    const fetchSpy = vi.fn(async () => htmlResponse("<html><body><article><h1>Hi</h1><p>body text here</p></article></body></html>"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const out = await handleWebfetch({ url: "https://example.com/page" });
+    expect(out).toContain("Hi");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(calledUrl).toBe("https://example.com/page");
+    expect(init.redirect).toBe("manual");
+  });
+
+  it("follows a redirect to another public host, re-validating the hop", async () => {
+    lookupMock.mockResolvedValue(PUBLIC);
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(302, "https://cdn.example.org/final"))
+      .mockResolvedValueOnce(htmlResponse("<p>landed</p>"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const out = await handleWebfetch({ url: "https://example.com/start" });
+    expect(out).toContain("landed");
+    expect(fetchSpy.mock.calls.map((c) => c[0])).toEqual(["https://example.com/start", "https://cdn.example.org/final"]);
+    expect(lookupMock.mock.calls.map((c) => c[0])).toEqual(["example.com", "cdn.example.org"]);
+  });
+
+  it("resolves a relative Location against the current hop", async () => {
+    lookupMock.mockResolvedValue(PUBLIC);
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(301, "/moved"))
+      .mockResolvedValueOnce(htmlResponse("<p>moved</p>"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await handleWebfetch({ url: "https://example.com/old" });
+    expect(fetchSpy.mock.calls[1]?.[0]).toBe("https://example.com/moved");
+  });
+
+  it("stops at a redirect into a private / metadata address", async () => {
+    lookupMock.mockResolvedValue(PUBLIC);
+    const fetchSpy = vi.fn().mockResolvedValueOnce(redirectResponse(302, "http://169.254.169.254/latest/meta-data/"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const out = await handleWebfetch({ url: "https://example.com/open-redirect" });
+    expect(out).toMatch(/^Error: Webfetch failed: .*169\.254\.169\.254/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after too many redirects", async () => {
+    lookupMock.mockResolvedValue(PUBLIC);
+    const fetchSpy = vi.fn(async () => redirectResponse(302, "https://example.com/again"));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const out = await handleWebfetch({ url: "https://example.com/loop" });
+    expect(out).toMatch(/too many redirects/);
+    expect(fetchSpy).toHaveBeenCalledTimes(6); // initial + 5 hops
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/webfetch.ts
@@ -20,6 +20,7 @@ import { Readability } from "@mozilla/readability";
 import { parseHTML } from "linkedom";
 import TurndownService from "turndown";
 import type { McpToolInfo } from "../types.js";
+import { assertOutboundUrlAllowed, OutboundUrlBlockedError } from "../url-guard.js";
 
 import { createLogger } from "../../logger.js";
 const log = createLogger("webfetch");
@@ -49,6 +50,12 @@ const DOWNLOAD_MAX_BYTES = 5 * 1024 * 1024;
 const HIGH_LIMIT_DOWNLOAD_MAX_BYTES = 25 * 1024 * 1024;
 const MAX_QUERY_FRAGMENT_CHARS = 128;
 const MAX_PARAM_VALUE_CHARS = 50;
+// Redirects are followed by hand so every hop goes through the same SSRF
+// guard as the original URL: a public page 302-ing to 169.254.169.254 or
+// http://localhost:... must be stopped, and `redirect: "follow"` would have
+// silently followed it.
+const MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 // Run of base64 / base64url alphabet that's long enough to fit a meaningful
 // payload (32 chars ≈ 24 bytes binary — small token/header territory).
 const BASE64_RUN_RE = /[A-Za-z0-9+/_=-]{32,}/;
@@ -128,6 +135,31 @@ async function readBodyCapped(response: Response, maxBytes: number): Promise<{ t
   return { text: new TextDecoder("utf-8", { fatal: false }).decode(buf), hitCap };
 }
 
+/**
+ * GET `target`, following up to MAX_REDIRECTS hops manually and re-running
+ * the outbound-URL guard on each Location before connecting to it. Only the
+ * validated URL object's `href` is ever handed to fetch.
+ */
+async function fetchWithGuardedRedirects(
+  target: URL,
+  init: { headers: Record<string, string>; signal: AbortSignal },
+): Promise<Response> {
+  let current = target;
+  for (let hop = 0; ; hop++) {
+    const response = await fetch(current.href, { ...init, redirect: "manual" });
+    if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+    const location = response.headers.get("location");
+    await response.body?.cancel().catch(() => undefined);
+    if (!location) return response; // 3xx without Location: hand back as-is (caller reports !ok)
+    if (hop >= MAX_REDIRECTS) {
+      throw new Error(`too many redirects (more than ${MAX_REDIRECTS})`);
+    }
+    const next = new URL(location, current); // Location may be relative
+    current = await assertOutboundUrlAllowed(next, { label: "redirect target" });
+  }
+}
+
 export async function handleWebfetch(
   params: Record<string, unknown>,
   opts?: { highLimit?: boolean },
@@ -173,15 +205,27 @@ export async function handleWebfetch(
     return `Error: URL contains a ${base64Match[0].length}-char base64-shaped run in the query string — this pattern looks like an exfiltration payload and is blocked. If this is a legitimate URL, ask the user for it directly instead of constructing it from data in your context.`;
   }
 
+  // SSRF fence: the URL is caller-supplied by design, so the host must resolve
+  // to a public address (no loopback / RFC1918 / link-local / metadata /
+  // cluster DNS). From here on only `target` (the validated URL object) is
+  // used to build the request, never the raw `url` string.
+  let target: URL;
   try {
-    const response = await fetch(url, {
+    target = await assertOutboundUrlAllowed(parsed);
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    log.warn(`[webfetch] REJECT url=${url.slice(0, 200)} reason=${reason}`);
+    return `Error: ${reason}. webfetch only reaches public hosts.`;
+  }
+
+  try {
+    const response = await fetchWithGuardedRedirects(target, {
       signal: AbortSignal.timeout(fetchTimeoutMs),
       headers: {
         "User-Agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
         Accept: "text/html, text/plain;q=0.9, */*;q=0.1",
       },
-      redirect: "follow",
     });
 
     if (!response.ok) {
@@ -237,6 +281,9 @@ export async function handleWebfetch(
     }
     return markdown;
   } catch (e) {
+    if (e instanceof OutboundUrlBlockedError) {
+      log.warn(`[webfetch] REJECT redirect from url=${url.slice(0, 200)} reason=${e.message}`);
+    }
     return `Error: Webfetch failed: ${e instanceof Error ? e.message : String(e)}`;
   }
 }

--- a/apps/xyne-claw-auth/backend/src/mcp/bitbucket-throttle.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/bitbucket-throttle.ts
@@ -19,6 +19,7 @@
  */
 import { callTool } from "./runner.js";
 import type { McpCallResult } from "./types.js";
+import { bitbucketApiUrl, resolveBitbucketBase } from "./adapters/bitbucket.js";
 
 const MAX_CONCURRENT_PER_USER = Number(process.env["BITBUCKET_MAX_CONCURRENCY"] ?? 2);
 const MIN_INTERVAL_MS = Number(process.env["BITBUCKET_MIN_INTERVAL_MS"] ?? 300);
@@ -75,12 +76,16 @@ async function probeBitbucketStatus(
   const m = errorMsg.match(/pull request (\d+) in ([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)/);
   if (!m) return null;
   const [, prId, project, repo] = m;
+  if (!prId || !project || !repo) return null;
   const username = credentials["username"] as string | undefined;
   const token = credentials["token"] as string | undefined;
   if (!username || !token) return null;
-  const baseUrl = ((credentials["baseUrl"] as string) || "https://bitbucket.juspay.net").replace(/\/+$/, "");
-  const url = `${baseUrl}/rest/api/1.0/projects/${project}/repos/${repo}/pull-requests/${prId}`;
   try {
+    // Same validated base + segment-encoded path builder as the local
+    // bitbucket tools: the connection's baseUrl is caller-written, so it is
+    // checked (scheme / allowlist / public address) before any request.
+    const base = await resolveBitbucketBase(credentials);
+    const url = bitbucketApiUrl(base, ["projects", project, "repos", repo, "pull-requests", prId]);
     const res = await fetch(url, {
       method: "GET",
       headers: { Authorization: "Basic " + Buffer.from(`${username}:${token}`).toString("base64") },

--- a/apps/xyne-claw-auth/backend/src/mcp/url-guard.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/url-guard.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const lookupMock = vi.fn();
+vi.mock("node:dns/promises", () => ({ lookup: (...args: unknown[]) => lookupMock(...args) }));
+
+const { assertOutboundUrlAllowed, isBlockedAddress, parseHostAllowlist } = await import("./url-guard.js");
+
+afterEach(() => {
+  lookupMock.mockReset();
+  vi.unstubAllEnvs();
+});
+
+describe("isBlockedAddress", () => {
+  it.each([
+    "127.0.0.1",
+    "127.8.8.8",
+    "10.1.2.3",
+    "172.16.0.1",
+    "172.31.255.254",
+    "192.168.1.1",
+    "169.254.169.254",
+    "100.64.0.1",
+    "0.0.0.0",
+    "224.0.0.1",
+    "::1",
+    "::",
+    "fe80::1",
+    "fd00::1",
+    "::ffff:127.0.0.1",
+    "::ffff:7f00:1",
+    "::ffff:10.0.0.1",
+    "64:ff9b::7f00:1",
+  ])("blocks %s", (addr) => {
+    expect(isBlockedAddress(addr)).toBe(true);
+  });
+
+  it.each(["8.8.8.8", "1.1.1.1", "43.204.132.146", "2606:4700:4700::1111", "::ffff:8.8.8.8"])(
+    "allows public %s",
+    (addr) => {
+      expect(isBlockedAddress(addr)).toBe(false);
+    },
+  );
+});
+
+describe("assertOutboundUrlAllowed", () => {
+  it("rejects non-http(s) schemes and malformed URLs without resolving", async () => {
+    await expect(assertOutboundUrlAllowed("file:///etc/passwd")).rejects.toThrow(/http or https/);
+    await expect(assertOutboundUrlAllowed("gopher://example.com")).rejects.toThrow(/http or https/);
+    await expect(assertOutboundUrlAllowed("not a url")).rejects.toThrow(/valid absolute URL/);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "http://127.0.0.1:3003/internal",
+    "http://[::1]/",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://10.0.0.5/",
+    "http://2130706433/", // decimal form of 127.0.0.1, normalised by the URL parser
+    "http://0x7f.0.0.1/",
+  ])("rejects IP literal %s without resolving", async (u) => {
+    await expect(assertOutboundUrlAllowed(u)).rejects.toThrow(/private, loopback or link-local/);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "http://localhost:8080/",
+    "http://api.localhost/",
+    "http://metadata.google.internal/computeMetadata/v1/",
+    "http://vespa.svc.cluster.local:8080/",
+    "http://printer.local/",
+  ])("rejects internal-only hostname %s without resolving", async (u) => {
+    await expect(assertOutboundUrlAllowed(u)).rejects.toThrow(/internal-only/);
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a public-looking hostname that resolves to a private address", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }, { address: "10.0.0.9", family: 4 }]);
+    await expect(assertOutboundUrlAllowed("https://evil.example.com/x")).rejects.toThrow(/resolves to private/);
+  });
+
+  it("fails closed when the hostname does not resolve", async () => {
+    lookupMock.mockRejectedValue(new Error("ENOTFOUND"));
+    await expect(assertOutboundUrlAllowed("https://nope.example.net/")).rejects.toThrow(/DNS resolution failed/);
+    lookupMock.mockResolvedValue([]);
+    await expect(assertOutboundUrlAllowed("https://nope.example.net/")).rejects.toThrow(/does not resolve/);
+  });
+
+  it("returns the parsed URL for a host that resolves only to public addresses", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const u = await assertOutboundUrlAllowed("https://example.com/a/b?c=1");
+    expect(u).toBeInstanceOf(URL);
+    expect(u.origin).toBe("https://example.com");
+    expect(lookupMock).toHaveBeenCalledWith("example.com", { all: true });
+  });
+
+  it("rejects URLs with embedded credentials", async () => {
+    await expect(assertOutboundUrlAllowed("https://user:pw@example.com/")).rejects.toThrow(/embed credentials/);
+  });
+
+  it("with an allowlist, accepts only listed hosts and skips resolution for them", async () => {
+    const allowedHosts = parseHostAllowlist(" Bitbucket.Example.net, other.example.org ");
+    expect(allowedHosts).toEqual(["bitbucket.example.net", "other.example.org"]);
+    const u = await assertOutboundUrlAllowed("https://bitbucket.example.net/rest", { allowedHosts });
+    expect(u.hostname).toBe("bitbucket.example.net");
+    expect(lookupMock).not.toHaveBeenCalled();
+    await expect(assertOutboundUrlAllowed("https://example.com/", { allowedHosts })).rejects.toThrow(/allowlist/);
+    // Even a listed host cannot smuggle a different scheme.
+    await expect(assertOutboundUrlAllowed("ftp://bitbucket.example.net/", { allowedHosts })).rejects.toThrow(/http or https/);
+  });
+
+  it("MCP_OUTBOUND_ALLOW_PRIVATE_HOSTS=true skips the address check (local dev only)", async () => {
+    vi.stubEnv("MCP_OUTBOUND_ALLOW_PRIVATE_HOSTS", "true");
+    const u = await assertOutboundUrlAllowed("http://localhost:3000/");
+    expect(u.hostname).toBe("localhost");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/mcp/url-guard.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/url-guard.ts
@@ -1,0 +1,198 @@
+/**
+ * Outbound-URL guard for MCP adapters that make HTTP requests from this
+ * process to a host that is NOT a compile-time constant:
+ *
+ *   - webfetch: fetches an arbitrary caller-supplied URL by design.
+ *   - bitbucket: the API base URL is a per-connection credential field
+ *     (`credentials.baseUrl`, written by POST /:userId/connections from the
+ *     request body), so any authenticated user can point it anywhere.
+ *
+ * Without a fence either path lets a caller aim this service at loopback,
+ * RFC1918 ranges, link-local / cloud-metadata (169.254.169.254) or the
+ * cluster's internal DNS — classic SSRF. The guard resolves hostnames via the
+ * same resolver `fetch` uses and refuses anything that lands on a private,
+ * loopback, link-local, multicast or reserved address.
+ *
+ * Escape hatches (both opt-in, both off by default):
+ *   - MCP_OUTBOUND_ALLOW_PRIVATE_HOSTS=true  — local development only; skips
+ *     the address check entirely.
+ *   - per-integration host allowlists (e.g. BITBUCKET_ALLOWED_HOSTS) — an
+ *     operator-trusted host list; hosts on it are accepted without the
+ *     address check so an on-prem server on a private range still works.
+ *
+ * Limitation: a DNS answer can change between this check and the connect
+ * (rebinding). Pinning the resolved address would need a custom dispatcher;
+ * callers MUST at least re-validate every redirect hop (see webfetch).
+ */
+import { lookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
+
+export class OutboundUrlBlockedError extends Error {
+  override readonly name = "OutboundUrlBlockedError";
+  readonly host: string;
+  constructor(host: string, reason: string) {
+    super(`Refusing to connect to ${host || "(empty host)"}: ${reason}`);
+    this.host = host;
+  }
+}
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+const blockedV4 = new BlockList();
+blockedV4.addRange("0.0.0.0", "0.255.255.255"); // "this" network
+blockedV4.addRange("10.0.0.0", "10.255.255.255"); // RFC1918
+blockedV4.addRange("100.64.0.0", "100.127.255.255"); // CGNAT
+blockedV4.addRange("127.0.0.0", "127.255.255.255"); // loopback
+blockedV4.addRange("169.254.0.0", "169.254.255.255"); // link-local / cloud metadata
+blockedV4.addRange("172.16.0.0", "172.31.255.255"); // RFC1918
+blockedV4.addRange("192.0.0.0", "192.0.0.255"); // IETF protocol assignments
+blockedV4.addRange("192.0.2.0", "192.0.2.255"); // TEST-NET-1
+blockedV4.addRange("192.168.0.0", "192.168.255.255"); // RFC1918
+blockedV4.addRange("198.18.0.0", "198.19.255.255"); // benchmarking
+blockedV4.addRange("198.51.100.0", "198.51.100.255"); // TEST-NET-2
+blockedV4.addRange("203.0.113.0", "203.0.113.255"); // TEST-NET-3
+blockedV4.addRange("224.0.0.0", "239.255.255.255"); // multicast
+blockedV4.addRange("240.0.0.0", "255.255.255.255"); // reserved + broadcast
+
+const blockedV6 = new BlockList();
+blockedV6.addAddress("::", "ipv6"); // unspecified
+blockedV6.addAddress("::1", "ipv6"); // loopback
+blockedV6.addSubnet("fc00::", 7, "ipv6"); // unique local
+blockedV6.addSubnet("fe80::", 10, "ipv6"); // link-local
+blockedV6.addSubnet("ff00::", 8, "ipv6"); // multicast
+blockedV6.addSubnet("2001:db8::", 32, "ipv6"); // documentation
+blockedV6.addSubnet("64:ff9b::", 96, "ipv6"); // NAT64 (wraps IPv4, checked below)
+
+/** Hostnames that name internal-only things regardless of what they resolve to. */
+function isBlockedHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/\.$/, "");
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h.endsWith(".local")) return true; // mDNS + *.svc.cluster.local
+  if (h.endsWith(".internal")) return true; // metadata.google.internal, *.internal cloud DNS
+  if (h === "metadata" || h === "instance-data") return true; // cloud metadata aliases
+  return false;
+}
+
+/** True when `addr` (a literal IPv4/IPv6 address) is private, loopback, link-local, etc. */
+export function isBlockedAddress(addr: string): boolean {
+  const bare = addr.replace(/^\[|\]$/g, "").replace(/%.*$/, "");
+  const kind = isIP(bare);
+  if (kind === 4) return blockedV4.check(bare);
+  if (kind === 6) {
+    // BlockList matches IPv4-mapped (::ffff:a.b.c.d) against the v4 rules itself.
+    if (blockedV4.check(bare, "ipv6")) return true;
+    if (blockedV6.check(bare, "ipv6")) return true;
+    // NAT64 embeds an IPv4 address in the low 32 bits; unwrap and re-check.
+    const nat64 = /^64:ff9b::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(bare);
+    if (nat64) {
+      const hi = parseInt(nat64[1]!, 16);
+      const lo = parseInt(nat64[2]!, 16);
+      return blockedV4.check(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`);
+    }
+    return false;
+  }
+  // Not an IP literal at all — caller should have resolved it first.
+  return true;
+}
+
+function allowPrivateHosts(): boolean {
+  return process.env["MCP_OUTBOUND_ALLOW_PRIVATE_HOSTS"] === "true";
+}
+
+/**
+ * Resolve `hostname` and throw unless every address it maps to is public.
+ * IP literals are checked directly. Fails CLOSED on resolver errors: a host
+ * that does not resolve here would not connect either, and failing open
+ * would turn a flaky resolver into a bypass.
+ */
+export async function assertPublicHost(hostname: string): Promise<void> {
+  const host = hostname.trim().replace(/^\[|\]$/g, "");
+  if (!host) throw new OutboundUrlBlockedError(host, "empty host");
+  if (allowPrivateHosts()) return;
+
+  if (isBlockedHostname(host)) {
+    throw new OutboundUrlBlockedError(host, "hostname is internal-only");
+  }
+
+  if (isIP(host) !== 0) {
+    if (isBlockedAddress(host)) {
+      throw new OutboundUrlBlockedError(host, "private, loopback or link-local address");
+    }
+    return;
+  }
+
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(host, { all: true });
+  } catch (err) {
+    throw new OutboundUrlBlockedError(
+      host,
+      `DNS resolution failed (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  if (addresses.length === 0) {
+    throw new OutboundUrlBlockedError(host, "hostname does not resolve");
+  }
+  for (const { address } of addresses) {
+    if (isBlockedAddress(address)) {
+      throw new OutboundUrlBlockedError(host, `resolves to private, loopback or link-local address ${address}`);
+    }
+  }
+}
+
+/** Parse a comma/whitespace-separated host allowlist from an env var value. */
+export function parseHostAllowlist(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(/[\s,]+/)
+    .map((h) => h.trim().toLowerCase().replace(/\.$/, ""))
+    .filter((h) => h.length > 0);
+}
+
+export interface OutboundUrlOptions {
+  /**
+   * Operator-trusted hostnames. When non-empty the URL's host MUST be on this
+   * list and the address check is skipped (on-prem servers on private ranges
+   * are the point of the list). When empty, the address check applies.
+   */
+  allowedHosts?: readonly string[];
+  /** Used in error messages, e.g. "Bitbucket base URL". Defaults to "URL". */
+  label?: string;
+}
+
+/**
+ * Validate an outbound request target: well-formed, http(s), and a host that
+ * is either on the allowlist or resolves only to public addresses. Returns
+ * the parsed URL; callers must build the request from IT (`.origin`,
+ * `.href`), never from the raw input string.
+ */
+export async function assertOutboundUrlAllowed(
+  input: string | URL,
+  opts: OutboundUrlOptions = {},
+): Promise<URL> {
+  const label = opts.label ?? "URL";
+  let parsed: URL;
+  try {
+    parsed = input instanceof URL ? input : new URL(input);
+  } catch {
+    throw new OutboundUrlBlockedError(String(input).slice(0, 200), `${label} is not a valid absolute URL`);
+  }
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new OutboundUrlBlockedError(parsed.hostname, `${label} must use http or https (got ${parsed.protocol})`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new OutboundUrlBlockedError(parsed.hostname, `${label} must not embed credentials`);
+  }
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (!hostname) throw new OutboundUrlBlockedError(hostname, `${label} has no host`);
+
+  const allowedHosts = opts.allowedHosts ?? [];
+  if (allowedHosts.length > 0) {
+    if (!allowedHosts.includes(hostname.replace(/\.$/, ""))) {
+      throw new OutboundUrlBlockedError(hostname, `${label} host is not on the configured allowlist`);
+    }
+    return parsed;
+  }
+
+  await assertPublicHost(hostname);
+  return parsed;
+}

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -1271,11 +1271,16 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
     // the same row that was pre-created here. Without it, the cross-pod
     // callback would create a NEW row and the pre-created placeholder would
     // dangle in "running" forever.
-    const callbackUrl = `${CONFIG.internalUrl}/claw/api/v1/internal/agent-chat/${slug}/chat/${conversationId}/callback?callbackId=${callbackId}&assistantMessageId=${assistantMsg.id}`;
+    //
+    // slug (req.params) and conversationId (req.body) are caller-controlled, so
+    // they are percent-encoded into the path: the host is always
+    // CONFIG.internalUrl and request data can only name a path segment.
+    const callbackPathBase = `${CONFIG.internalUrl}/claw/api/v1/internal/agent-chat/${encodeURIComponent(slug)}/chat/${encodeURIComponent(conversationId)}`;
+    const callbackUrl = `${callbackPathBase}/callback?callbackId=${encodeURIComponent(callbackId)}&assistantMessageId=${encodeURIComponent(assistantMsg.id)}`;
     // assistantMessageId also threaded here so the /progress webhook (which may
     // land on another pod) can debounce-persist partial assistant content onto
     // the pre-created placeholder row — so a reload mid-run shows the answer-so-far.
-    const progressUrl = `${CONFIG.internalUrl}/claw/api/v1/internal/agent-chat/${slug}/chat/${conversationId}/progress?callbackId=${callbackId}&assistantMessageId=${assistantMsg.id}`;
+    const progressUrl = `${callbackPathBase}/progress?callbackId=${encodeURIComponent(callbackId)}&assistantMessageId=${encodeURIComponent(assistantMsg.id)}`;
 
     // Resolve provider + credentials with the same 3-layer chain as webhook:
     //   1. user's personal provider (userAgentConfig + userProviderCredentials)
@@ -2999,7 +3004,7 @@ async function runAgentChatViaSse(
           const sid = capturedSessionId ?? (consumeResult.result["sessionId"] as string | undefined) ?? "";
           const callbackBody = { ...consumeResult.result, sessionId: sid };
           try {
-            const cbRes = await fetch(`${callbackUrl}`, {
+            const cbRes = await fetch(callbackUrl, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -3019,7 +3024,7 @@ async function runAgentChatViaSse(
           // outer await resultPromise unblocks and the user sees an error
           // instead of the 30-min safety-net timeout.
           try {
-            await fetch(`${callbackUrl}`, {
+            await fetch(callbackUrl, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -3044,7 +3049,7 @@ async function runAgentChatViaSse(
         // We already returned success to the outer handler — push a synthetic
         // failed /callback so the resultPromise unblocks instead of timing out.
         try {
-          await fetch(`${callbackUrl}`, {
+          await fetch(callbackUrl, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -7,6 +7,7 @@ import { validateSubagentInput, ValidationError as SubagentValidationError } fro
 import { getSubagentDefinition, buildCloneApprovalFlow } from "xyne-claw-shared";
 import { spacesAppFetch } from "../lib/spaces-api.js";
 import { getWorkspaceIdForUser } from "../lib/spaces-db.js";
+import { OutboundUrlError, resolveProviderBaseUrl } from "../lib/url-guard.js";
 import { prisma } from "../db.js";
 import { CONFIG } from "../config.js";
 import { encrypt, decrypt } from "../crypto.js";
@@ -2813,7 +2814,9 @@ export interface ClaudeModelInfo {
 }
 
 export async function fetchAnthropicModels(apiKey: string, baseUrl?: string, authType?: string): Promise<ClaudeModelInfo[]> {
-  const root = (baseUrl?.trim() || ANTHROPIC_BASE_URL).replace(/\/+$/, "");
+  // baseUrl is caller-configured (request body, or a credential row written
+  // from one) — validate it before it becomes the request host.
+  const root = resolveProviderBaseUrl(baseUrl, ANTHROPIC_BASE_URL);
   // Anthropic OAuth tokens (Pro/Max via `claude setup-token`) authenticate
   // with Authorization: Bearer + anthropic-beta=oauth-2025-04-20. The API
   // key path (Console keys) uses x-api-key. Sending the OAuth token as
@@ -2832,6 +2835,7 @@ export async function fetchAnthropicModels(apiKey: string, baseUrl?: string, aut
   const res = await fetch(`${root}/v1/models`, {
     method: "GET",
     headers,
+    redirect: "manual",
     signal: AbortSignal.timeout(10_000),
   });
 
@@ -4026,10 +4030,22 @@ router.post(
         if (!baseUrl) baseUrl = cred.baseUrl ?? "";
       }
 
-      const root = (baseUrl || CONFIG.litellmBaseUrl).replace(/\/+$/, "");
+      // baseUrl is caller-configured (body, or a credential row written from
+      // one) — validate it before it becomes the request host.
+      let root: string;
+      try {
+        root = resolveProviderBaseUrl(baseUrl, CONFIG.litellmBaseUrl);
+      } catch (err) {
+        if (err instanceof OutboundUrlError) {
+          res.status(400).json({ success: false, error: err.message });
+          return;
+        }
+        throw err;
+      }
       log.info(`[agents] litellm/models fetching ${root}/v1/models (keyLen=${apiKey.length}, source=${typedKey ? "typed" : "saved-cred"})`);
       const upstream = await fetch(`${root}/v1/models`, {
         headers: { Authorization: `Bearer ${apiKey}`, "User-Agent": "xyne-claw-auth" },
+        redirect: "manual",
         signal: AbortSignal.timeout(20_000),
       });
       if (!upstream.ok) {

--- a/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
@@ -40,14 +40,35 @@ function getEgnyteCredentials(): { clientId: string; clientSecret: string } {
   return { clientId, clientSecret };
 }
 
+/** A single DNS label: the tenant part of `<tenant>.egnyte.com`. */
+const EGNYTE_TENANT_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+const EGNYTE_HOST_SUFFIX = ".egnyte.com";
+
+/**
+ * Build the domain-scoped Egnyte OAuth endpoint. `domain` reaches us via the
+ * signed OAuth state (and, on refresh, the stored credential), so it is
+ * checked here to be a bare tenant label: the resulting host is always
+ * `<tenant>.egnyte.com` over https and can never name another origin.
+ */
+function egnyteOAuthEndpoint(domain: string): string {
+  if (!EGNYTE_TENANT_RE.test(domain)) {
+    throw new Error("Invalid Egnyte domain: expected the tenant label of <tenant>.egnyte.com");
+  }
+  const endpoint = new URL(`https://${domain}${EGNYTE_HOST_SUFFIX}/puboauth/token`);
+  if (endpoint.protocol !== "https:" || !endpoint.hostname.endsWith(EGNYTE_HOST_SUFFIX)) {
+    throw new Error("Invalid Egnyte domain");
+  }
+  return endpoint.href;
+}
+
 /** Egnyte auth endpoint — domain-scoped. */
 function egnyteAuthUrl(domain: string): string {
-  return `https://${domain}.egnyte.com/puboauth/token`;
+  return egnyteOAuthEndpoint(domain);
 }
 
 /** Egnyte token endpoint — domain-scoped (same path as auth, POST). */
 function egnyteTokenUrl(domain: string): string {
-  return `https://${domain}.egnyte.com/puboauth/token`;
+  return egnyteOAuthEndpoint(domain);
 }
 
 /** Default browser-callback URI. */

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -50,7 +50,7 @@ import {
 } from "../middleware/require-auth.js";
 import { handleRunCompletion, handleRunHandoff } from "../queue/run-recovery-worker.js";
 import { getDmChannelForUserAndApp, getSpacesAuthForUser, getWorkspaceIdForUser } from "../lib/spaces-db.js";
-import { isAllowedExternalCallbackUrl, isInternalCallbackOrigin, type ExternalResultCallbackConfig } from "../surfaces/external-api/delivery.js";
+import { isAllowedExternalCallbackUrl, isInternalCallbackOrigin, resolveInternalCallbackUrl, type ExternalResultCallbackConfig } from "../surfaces/external-api/delivery.js";
 import type { VerifiedCliToken } from "../lib/cli-tokens.js";
 import { agentScopeAllows, canPostToChannels, sanitizeExternalRunBody } from "../lib/service-tokens.js";
 import { encryptSurfaceSecret } from "../lib/surface-resolver.js";
@@ -879,6 +879,14 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
     }
     if (callbackUrl && !isInternalCallbackOrigin(callbackUrl) && !isAllowedExternalCallbackUrl(callbackUrl)) {
       res.status(400).json({ success: false, error: "callbackUrl is not an allowed target" });
+      return;
+    }
+    // progressUrl is an internal-only sink: every producer (webhook.ts,
+    // agent-chat.ts, run-stream.ts, queue workers, Slack dispatch) builds it
+    // from CONFIG.internalUrl, and progress POSTs carry x-s2s-key. Never let
+    // a caller point them at a foreign origin.
+    if (progressUrl !== undefined && (typeof progressUrl !== "string" || !isInternalCallbackOrigin(progressUrl))) {
+      res.status(400).json({ success: false, error: "progressUrl must target an internal origin" });
       return;
     }
     if (callbackSecret !== undefined && (typeof callbackSecret !== "string" || callbackSecret.length > 256)) {
@@ -1743,10 +1751,13 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
             // callback — synthesizing failure here raced that and mislabeled
             // ~47 live runs/day as "sse stream broken" (prod 2026-07-09).
             log.warn(`[run] proxy: pass-through stream lost; run continues headless (session=${sessionId})`);
+            // effectiveCallbackUrl, not the raw body value: an external
+            // callback is relayed via the injected internal /webhook/result,
+            // and these POSTs carry x-s2s-key + x-session-token.
             armHeadlessFinalizeCheck({
               sessionId,
               sessionToken,
-              callbackUrl,
+              callbackUrl: effectiveCallbackUrl,
               conversationId: typeof conversationId === "string" ? conversationId : undefined,
               agentSlug: typeof agentSlug === "string" ? agentSlug : undefined,
               eventType,
@@ -1754,7 +1765,7 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
             });
           } else {
             await postBrokenSseTerminalCallback({
-              callbackUrl,
+              callbackUrl: effectiveCallbackUrl,
               sessionId,
               sessionToken,
               conversationId: typeof conversationId === "string" ? conversationId : undefined,
@@ -2565,7 +2576,12 @@ async function postBrokenSseTerminalCallback(opts: {
   }
 
   try {
-    const cbRes = await fetch(opts.callbackUrl, {
+    // The callback carries x-s2s-key + x-session-token, so it may only go to
+    // an origin we own; scheme/host/port come from config, the caller's URL
+    // contributes path + query.
+    const target = resolveInternalCallbackUrl(opts.callbackUrl);
+    if (!target) throw new Error("callbackUrl is not an internal origin");
+    const cbRes = await fetch(target.href, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -2573,6 +2589,7 @@ async function postBrokenSseTerminalCallback(opts: {
         ...(opts.sessionToken ? { "x-session-token": opts.sessionToken } : {}),
       },
       body: JSON.stringify(body),
+      redirect: "manual",
       signal: AbortSignal.timeout(15_000),
     });
     if (!cbRes.ok) {
@@ -2644,13 +2661,22 @@ async function runBridgeForProbeResponse(opts: BridgeForProbeOpts): Promise<void
 
   // Serial dispatch via consumeAlreadyOpenStream's awaited handlers means
   // these POSTs land at progressUrl in the exact order claw emitted them.
+  //
+  // Both sinks carry x-s2s-key, so they are resolved onto an origin we own
+  // (scheme/host/port from config; the caller's URL contributes path + query).
+  // /run already rejected foreign origins at ingress; this is the last line.
+  const progressTarget = progressUrl ? resolveInternalCallbackUrl(progressUrl) : null;
+  if (progressUrl && !progressTarget) {
+    log.warn(`[run] proxy: progressUrl is not an internal origin — progress events dropped (session=${sessionId})`);
+  }
   const postProgress = async (body: Record<string, unknown>): Promise<void> => {
-    if (!progressUrl) return;
+    if (!progressTarget) return;
     try {
-      await fetch(progressUrl, {
+      await fetch(progressTarget.href, {
         method: "POST",
         headers: sharedHeaders,
         body: JSON.stringify({ ...convFallback, ...body }),
+        redirect: "manual",
         signal: AbortSignal.timeout(15_000),
       });
     } catch (err) {
@@ -2715,9 +2741,12 @@ async function runBridgeForProbeResponse(opts: BridgeForProbeOpts): Promise<void
         // latency, reasoning, provider, model, etc., and stripping any of
         // those breaks downstream consumers silently (Control Center finalize,
         // digital-twin suffix, etc.).
-        await fetch(callbackUrl, {
+        const callbackTarget = resolveInternalCallbackUrl(callbackUrl);
+        if (!callbackTarget) throw new Error("callbackUrl is not an internal origin");
+        await fetch(callbackTarget.href, {
           method: "POST",
           headers: callbackHeaders,
+          redirect: "manual",
           body: JSON.stringify({
             ...convFallback,
             ...result.result,

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -35,6 +35,7 @@ import {
 } from "../lib/agent-card.js";
 import { getValidClaudeBearer } from "../lib/claude-oauth-refresh.js";
 import { getValidCodexBearer } from "../lib/codex-oauth-refresh.js";
+import { rebaseOnTrustedOrigin } from "../lib/url-guard.js";
 import { resolveAgentProviderConfigs, resolveSubagentProviderMode, KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget } from "../lib/agent-provider-config.js";
 import { expandSpacesMentions, resolveUnboundMentions } from "../lib/mention-transform.js";
 import { shouldTwinRespond, recordTwinSilence, FAIL_CLOSED } from "../services/twinRespondGate.js";
@@ -2818,13 +2819,23 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         );
 
         const sources: Array<{ label: string; url: string; headers?: Record<string, string> }> = [];
-        if (att.fileUrl && /^https?:\/\//i.test(att.fileUrl)) {
-          sources.push({ label: "fileUrl", url: att.fileUrl });
+        // `fileUrl` is whatever the webhook body says it is. Only fetch it when
+        // it sits on a Spaces origin we already trust — scheme/host/port are
+        // taken from config, the body contributes path + query only. Anything
+        // else falls through to the authenticated download routes below.
+        const trustedFileUrl = att.fileUrl
+          ? rebaseOnTrustedOrigin(att.fileUrl, [CONFIG.spacesInternalUrl, CONFIG.spacesBackendUrl, CONFIG.spacesAppUrl])
+          : null;
+        if (trustedFileUrl) {
+          sources.push({ label: "fileUrl", url: trustedFileUrl.href });
+        } else if (att.fileUrl && /^https?:\/\//i.test(att.fileUrl)) {
+          log.warn(`Attachment ${att.attachmentId}: fileUrl is not on a Spaces origin — skipping direct fetch`);
         }
+        const encodedAttachmentId = encodeURIComponent(att.attachmentId);
         if (userSpacesToken) {
           sources.push({
             label: "user-token",
-            url: `${CONFIG.spacesInternalUrl}/api/attachments/${att.attachmentId}/download`,
+            url: `${CONFIG.spacesInternalUrl}/api/attachments/${encodedAttachmentId}/download`,
             headers: {
               Authorization: `Bearer ${userSpacesToken}`,
               ...(userSpacesWorkspaceId ? { "x-workspace-id": userSpacesWorkspaceId } : {}),
@@ -2834,12 +2845,12 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         }
         sources.push({
           label: "apps-route",
-          url: `${CONFIG.spacesInternalUrl}/api/apps/attachments/${att.attachmentId}/download`,
+          url: `${CONFIG.spacesInternalUrl}/api/apps/attachments/${encodedAttachmentId}/download`,
           headers: { Authorization: `Bearer ${agent.appToken}` },
         });
         sources.push({
           label: "user-route",
-          url: `${CONFIG.spacesInternalUrl}/api/attachments/${att.attachmentId}/download`,
+          url: `${CONFIG.spacesInternalUrl}/api/attachments/${encodedAttachmentId}/download`,
           headers: { Authorization: `Bearer ${agent.appToken}` },
         });
 
@@ -2848,6 +2859,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         for (const src of sources) {
           try {
             const dlRes = await fetch(src.url, {
+              redirect: "manual",
               signal: AbortSignal.timeout(15_000),
               ...(src.headers ? { headers: src.headers } : {}),
             });

--- a/apps/xyne-claw-auth/backend/src/surfaces/external-api/delivery.ts
+++ b/apps/xyne-claw-auth/backend/src/surfaces/external-api/delivery.ts
@@ -1,6 +1,7 @@
 import { CONFIG } from "../../config.js";
 import { createLogger } from "../../logger.js";
 import { decryptSurfaceSecret } from "../../lib/surface-resolver.js";
+import { hostnameOf, parseHttpUrl, rebaseOnTrustedOrigin } from "../../lib/url-guard.js";
 import { postExternalCallback } from "./api.js";
 import {
   RETRY_DELAYS_MS,
@@ -40,31 +41,44 @@ function parseUrl(value: string): URL | null {
   }
 }
 
-/** True only for callback origins owned by claw-auth/claw itself. */
-export function isInternalCallbackOrigin(
-  callbackUrl: string,
-  config: CallbackOriginConfig = {
+function defaultCallbackOriginConfig(): CallbackOriginConfig {
+  return {
     selfUrl: CONFIG.selfUrl,
     internalUrl: CONFIG.internalUrl,
     xyneClawUrl: CONFIG.xyneClawUrl,
     ...(process.env["NODE_ENV"] ? { nodeEnv: process.env["NODE_ENV"] } : {}),
-  },
-): boolean {
-  const candidate = parseUrl(callbackUrl);
-  if (!candidate) return false;
+  };
+}
 
-  const knownOrigins = [config.selfUrl, config.internalUrl, config.xyneClawUrl]
-    .filter((value): value is string => typeof value === "string" && value.length > 0)
-    .map(parseUrl)
-    .filter((value): value is URL => value !== null)
-    .map((value) => value.origin);
-  if (knownOrigins.includes(candidate.origin)) return true;
+/**
+ * Resolve a caller-supplied callback/progress URL to one we will actually
+ * POST to. Only origins owned by claw-auth/claw itself qualify; the returned
+ * URL takes scheme/host/port from the configured origin and carries over only
+ * the caller's path + query. Null for any other target.
+ */
+export function resolveInternalCallbackUrl(
+  callbackUrl: string,
+  config: CallbackOriginConfig = defaultCallbackOriginConfig(),
+): URL | null {
+  const knownOrigins = [config.selfUrl, config.internalUrl, config.xyneClawUrl].filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  const rebased = rebaseOnTrustedOrigin(callbackUrl, knownOrigins);
+  if (rebased) return rebased;
 
   if (config.nodeEnv === "development") {
-    const hostname = candidate.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-    return DEV_LOCAL_HOSTNAMES.has(hostname);
+    const candidate = parseHttpUrl(callbackUrl);
+    if (candidate && DEV_LOCAL_HOSTNAMES.has(hostnameOf(candidate))) return candidate;
   }
-  return false;
+  return null;
+}
+
+/** True only for callback origins owned by claw-auth/claw itself. */
+export function isInternalCallbackOrigin(
+  callbackUrl: string,
+  config: CallbackOriginConfig = defaultCallbackOriginConfig(),
+): boolean {
+  return resolveInternalCallbackUrl(callbackUrl, config) !== null;
 }
 
 /** Validate the deliberately narrow SSRF policy for external result delivery. */

--- a/apps/xyne-claw-auth/backend/src/surfaces/slack/api.ts
+++ b/apps/xyne-claw-auth/backend/src/surfaces/slack/api.ts
@@ -8,9 +8,13 @@
  */
 import { WebClient, type WebClientOptions } from "@slack/web-api";
 import { createLogger } from "../../logger.js";
+import { requireHost } from "../../lib/url-guard.js";
 import { RESPONSE_URL_RETRY_DELAY_MS, SLACK_API_MAX_RETRIES, SLACK_API_TIMEOUT_MS } from "./const.js";
 
 const log = createLogger("slack-api");
+
+/** Slack only ever issues response_urls on this host. */
+const RESPONSE_URL_HOSTS: ReadonlySet<string> = new Set(["hooks.slack.com"]);
 
 const clientOptions: WebClientOptions = {
   timeout: SLACK_API_TIMEOUT_MS,
@@ -52,6 +56,15 @@ export async function postResponseUrl(
   responseUrl: string,
   message: { text: string; responseType?: "ephemeral" | "in_channel" },
 ): Promise<boolean> {
+  // The response_url arrives in the slash-command body. Slack signs that body,
+  // but the URL is still request data: only accept Slack's own webhook host
+  // over https, and never follow a redirect off it.
+  const target = requireHost(responseUrl, RESPONSE_URL_HOSTS);
+  if (!target || target.protocol !== "https:") {
+    log.warn("[slack-api] response_url rejected: not a hooks.slack.com https URL");
+    return false;
+  }
+
   const body = JSON.stringify({
     response_type: message.responseType ?? "ephemeral",
     text: message.text,
@@ -60,10 +73,11 @@ export async function postResponseUrl(
   for (let attempt = 1; attempt <= SLACK_API_MAX_RETRIES; attempt += 1) {
     try {
       // eslint-disable-next-line no-restricted-globals -- documented response_url exemption
-      const response = await fetch(responseUrl, {
+      const response = await fetch(target.href, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body,
+        redirect: "manual",
         signal: AbortSignal.timeout(SLACK_API_TIMEOUT_MS),
       });
       if (response.ok) return true;

--- a/apps/xyne-claw/src/config.ts
+++ b/apps/xyne-claw/src/config.ts
@@ -1,3 +1,5 @@
+import { rebuildUrlOnTrustedOrigin } from "./lib/url-guard.js";
+
 export const SERVER = {
   port: Number(process.env["XYNE_CLAW_PORT"] ?? 3002),
   s2sKey: process.env["XYNE_CLAW_S2S_KEY"] ?? "",
@@ -30,6 +32,34 @@ export function isAllowedCallbackUrl(raw: string | undefined | null): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Resolve a caller-supplied callback/progress URL into the URL we will
+ * actually POST to, or undefined if it is not on the allowlist.
+ *
+ * This is the form every outbound callback/progress fetch must use. Unlike
+ * `isAllowedCallbackUrl` (a yes/no check), it returns a URL rebuilt from the
+ * matching allowlist origin plus the caller's (re-encoded) path and query, so
+ * the host and scheme that reach `fetch` come from our configuration rather
+ * than from the request body. Apply it once at the edge (the /run handler) and
+ * pass the result downstream.
+ */
+export function resolveAllowedCallbackUrl(raw: string | undefined | null): string | undefined {
+  if (!raw) return undefined;
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return undefined;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return undefined;
+  for (const allowedOrigin of ALLOWED_CALLBACK_ORIGINS) {
+    if (allowedOrigin === u.origin) {
+      return rebuildUrlOnTrustedOrigin(u, allowedOrigin);
+    }
+  }
+  return undefined;
 }
 
 export const PATHS = {

--- a/apps/xyne-claw/src/lib/url-guard.ts
+++ b/apps/xyne-claw/src/lib/url-guard.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers for turning a caller-supplied URL into one we are willing to fetch.
+ *
+ * The SSRF fences in this service (callback/progress URLs from the /run body,
+ * signed download URLs for attachment ingest) all validate the *origin* of a
+ * caller-supplied URL against an allowlist. Validation alone is not enough,
+ * though: the value that reaches `fetch` must be assembled from parts we
+ * control, not the caller's string, so a check-vs-use mismatch can't creep in
+ * and so static analysis (CodeQL js/request-forgery) can see that the host and
+ * scheme never derive from request data.
+ *
+ * `rebuildUrlOnTrustedOrigin` does exactly that: the origin comes from the
+ * allowlist entry that matched (never from the parsed URL), every path segment
+ * is re-encoded with `encodeURIComponent`, and the query is carried over
+ * verbatim after a literal `?` — query data can't influence the host.
+ */
+
+/**
+ * RFC 3986 "unreserved-only" percent-encoding of a single path segment.
+ * `encodeURIComponent` leaves `!'()*` bare; GCS/S3 signed-URL canonical paths
+ * encode them, so match that form to keep signatures valid after the rebuild.
+ */
+function encodePathSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/**
+ * Rebuild `parsed` on top of `trustedOrigin` (a `scheme://host[:port]` string
+ * taken from configuration, NOT from the caller).
+ *
+ * Path segments are decoded then re-encoded so an already-encoded signed URL
+ * round-trips byte-for-byte (`%2F` stays `%2F`, `a%20b` stays `a%20b`); a
+ * segment with a malformed percent-escape is rejected by returning undefined.
+ */
+export function rebuildUrlOnTrustedOrigin(parsed: URL, trustedOrigin: string): string | undefined {
+  const segments: string[] = [];
+  for (const raw of parsed.pathname.split("/")) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(raw);
+    } catch {
+      return undefined;
+    }
+    segments.push(encodePathSegment(decoded));
+  }
+  const path = segments.join("/");
+  const origin = trustedOrigin.replace(/\/+$/, "");
+  if (parsed.search.length > 1) {
+    return `${origin}${path}?${parsed.search.slice(1)}`;
+  }
+  return `${origin}${path}`;
+}

--- a/apps/xyne-claw/src/routes/attachments.ts
+++ b/apps/xyne-claw/src/routes/attachments.ts
@@ -24,6 +24,8 @@ import type { Request, Response } from "express";
 import { validateS2SKey } from "../middleware/auth.js";
 import { ingestAttachments, type AttachmentInput } from "../attachment-ingest.js";
 import { createLogger } from "../logger.js";
+import { GCS, STORAGE } from "../config.js";
+import { rebuildUrlOnTrustedOrigin } from "../lib/url-guard.js";
 
 const log = createLogger("attachments-ingest");
 const URL_ATTACHMENT_DOWNLOAD_TIMEOUT_MS = Number(process.env["ATTACHMENT_URL_DOWNLOAD_TIMEOUT_MS"] ?? 120_000);
@@ -36,21 +38,55 @@ const URL_ATTACHMENT_MAX_BYTES = Number(process.env["ATTACHMENT_URL_MAX_BYTES"] 
  * but that alone is not a boundary: any bug or compromise upstream would turn
  * this pod into a fetch proxy for the cluster's internal network — including the
  * GCP metadata server (169.254.169.254), which would hand out this pod's own
- * service-account credentials. The URL is only ever a storage signed URL, so
- * restrict it to storage hosts and https by construction rather than trusting
- * the caller. Extra hosts (fake-gcs in dev, a custom S3 endpoint) come from
- * ATTACHMENT_URL_ALLOWED_HOSTS as a comma-separated list.
+ * service-account credentials. The URL is only ever a storage signed URL for
+ * this deployment's own bucket, so restrict it to exactly those storage hosts
+ * and to https by construction rather than trusting the caller.
+ *
+ * The fetched URL is REBUILT from the allowlist entry that matched (plus the
+ * caller's re-encoded path and query), so the host/scheme handed to `fetch`
+ * come from our configuration, not from the request body.
+ *
+ * Hosts are matched exactly (hostname, or host:port). The public-cloud hosts
+ * are derived from the same STORAGE/GCS config claw-auth signs with, covering
+ * both path-style and virtual-hosted signed URLs. Extra hosts (fake-gcs in
+ * dev, a custom S3 endpoint) come from ATTACHMENT_URL_ALLOWED_HOSTS as a
+ * comma-separated list; only those explicitly configured hosts may use http.
  */
-const URL_ATTACHMENT_ALLOWED_HOSTS = new Set(
+function hostOfUrl(raw: string): string | undefined {
+  try {
+    return new URL(raw).host.toLowerCase() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const URL_ATTACHMENT_CONFIGURED_HOSTS: ReadonlySet<string> = new Set(
   [
-    "storage.googleapis.com",
-    ...(process.env["ATTACHMENT_URL_ALLOWED_HOSTS"] ?? "")
-      .split(",")
-      .map((h) => h.trim().toLowerCase())
-      .filter(Boolean),
-  ],
+    ...(STORAGE.s3Endpoint ? [hostOfUrl(STORAGE.s3Endpoint)] : []),
+    ...(GCS.fakeHost ? [hostOfUrl(GCS.fakeHost)] : []),
+    ...(process.env["ATTACHMENT_URL_ALLOWED_HOSTS"] ?? "").split(","),
+  ]
+    .map((h) => h?.trim().toLowerCase())
+    .filter((h): h is string => !!h),
 );
 
+const URL_ATTACHMENT_ALLOWED_HOSTS: ReadonlySet<string> = new Set(
+  [
+    // GCS: path-style (the @google-cloud/storage default) and virtual-hosted.
+    "storage.googleapis.com",
+    ...(GCS.bucketName ? [`${GCS.bucketName}.storage.googleapis.com`] : []),
+    // S3: virtual-hosted (the SDK default) and path-style.
+    ...(STORAGE.s3BucketName ? [`${STORAGE.s3BucketName}.s3.${STORAGE.s3Region}.amazonaws.com`] : []),
+    `s3.${STORAGE.s3Region}.amazonaws.com`,
+    ...URL_ATTACHMENT_CONFIGURED_HOSTS,
+  ].map((h) => h.toLowerCase()),
+);
+
+/**
+ * Validate a caller-supplied download URL and return the URL we will actually
+ * fetch: same path and query, but the scheme and host are taken from the
+ * allowlist entry that matched rather than from the caller's string.
+ */
 function assertDownloadableUrl(raw: string, fileName: string): URL {
   let parsed: URL;
   try {
@@ -58,20 +94,43 @@ function assertDownloadableUrl(raw: string, fileName: string): URL {
   } catch {
     throw new IngestBadRequest(`Attachment "${fileName}": malformed download URL`);
   }
-  // http:// is allowed ONLY for an explicitly configured host (dev fake-gcs);
-  // everything else must be https so the bytes aren't readable in transit.
-  const host = parsed.hostname.toLowerCase();
-  const allowed = URL_ATTACHMENT_ALLOWED_HOSTS.has(host)
-    || [...URL_ATTACHMENT_ALLOWED_HOSTS].some((h) => host.endsWith(`.${h}`));
-  if (!allowed) {
-    throw new IngestBadRequest(
-      `Attachment "${fileName}": download host "${host}" is not an allowed storage host`,
-    );
-  }
-  if (parsed.protocol !== "https:" && !URL_ATTACHMENT_ALLOWED_HOSTS.has(host)) {
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
     throw new IngestBadRequest(`Attachment "${fileName}": download URL must use https`);
   }
-  return parsed;
+  const hostname = parsed.hostname.toLowerCase();
+  const hostWithPort = parsed.host.toLowerCase();
+  // Prefer a host:port entry; fall back to a bare-hostname entry, in which case
+  // the (numeric) port from the URL is carried over.
+  let matchedHost: string | undefined;
+  let portSuffix = "";
+  for (const allowed of URL_ATTACHMENT_ALLOWED_HOSTS) {
+    if (allowed === hostWithPort) {
+      matchedHost = allowed;
+      portSuffix = "";
+      break;
+    }
+    if (allowed === hostname && matchedHost === undefined) {
+      matchedHost = allowed;
+      portSuffix = parsed.port ? `:${Number.parseInt(parsed.port, 10)}` : "";
+    }
+  }
+  if (matchedHost === undefined) {
+    throw new IngestBadRequest(
+      `Attachment "${fileName}": download host "${hostname}" is not an allowed storage host`,
+    );
+  }
+  // http:// is allowed ONLY for an explicitly configured host (dev fake-gcs,
+  // custom S3 endpoint); everything else must be https so the bytes aren't
+  // readable in transit.
+  const scheme = parsed.protocol === "https:" ? "https:" : "http:";
+  if (scheme === "http:" && !URL_ATTACHMENT_CONFIGURED_HOSTS.has(matchedHost)) {
+    throw new IngestBadRequest(`Attachment "${fileName}": download URL must use https`);
+  }
+  const rebuilt = rebuildUrlOnTrustedOrigin(parsed, `${scheme}//${matchedHost}${portSuffix}`);
+  if (!rebuilt) {
+    throw new IngestBadRequest(`Attachment "${fileName}": malformed download URL`);
+  }
+  return new URL(rebuilt);
 }
 
 export const attachmentsRouter = Router();

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -106,7 +106,7 @@ import {
   isReadOnlyJob as isScheduledOrAutomationRun,
   type SetupStep,
 } from "xyne-claw-shared";
-import { SERVER, PATHS, LITELLM, isAllowedCallbackUrl } from "../config.js";
+import { SERVER, PATHS, LITELLM, isAllowedCallbackUrl, resolveAllowedCallbackUrl } from "../config.js";
 import { judgeChainContinuation } from "../chain-judge.js";
 import { isDigitalTwinAgent, listSubsystemTaxonomy, fetchAgentPromptFiles } from "../memory.js";
 import { buildMemorySearchTool } from "../memory-search.js";
@@ -411,7 +411,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     conversationId,
     piSessionConversationId,
     spacesConversationId,
-    callbackUrl,
+    callbackUrl: rawCallbackUrl,
     systemPrompt,
     agentConfig,
     agentSlug,
@@ -426,7 +426,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     subagentProviders,
     subagentProviderMode,
     providerConfigs,
-    progressUrl,
+    progressUrl: rawProgressUrl,
     attachments,
     recordingRefs,
     contextFiles,
@@ -584,6 +584,26 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     generateFollowUpSuggestions?: boolean;
   };
   const experiment = normalizeExperimentContext(rawExperiment);
+
+  // SSRF fence for the caller-supplied callback/progress URLs. Resolve them
+  // ONCE here, at the edge, into URLs rebuilt on the allowlisted claw-auth
+  // origin (see resolveAllowedCallbackUrl). Every downstream POST — progress
+  // events in agent.ts / subagent-tools.ts, the final result in sendCallback —
+  // then targets a URL whose host and scheme come from our config, never from
+  // the request body. A callbackUrl off the allowlist is rejected up front:
+  // the run's result could never be delivered, so running it would only burn
+  // the budget. A progressUrl off the allowlist is dropped (run proceeds
+  // without live progress), matching the previous behavior.
+  const callbackUrl = resolveAllowedCallbackUrl(rawCallbackUrl);
+  if (typeof rawCallbackUrl === "string" && rawCallbackUrl.trim().length > 0 && !callbackUrl) {
+    clog.error(`[run] Rejecting /run: callbackUrl is not on the allowlisted claw-auth origin: ${rawCallbackUrl}`);
+    res.status(400).json({ success: false, error: "callbackUrl must target the claw-auth origin" });
+    return;
+  }
+  const progressUrl = resolveAllowedCallbackUrl(rawProgressUrl);
+  if (typeof rawProgressUrl === "string" && rawProgressUrl.trim().length > 0 && !progressUrl) {
+    clog.warn(`[run] Ignoring non-allowlisted progressUrl: ${rawProgressUrl}`);
+  }
 
   // [AUTODBG] claw-side receipt of every /run forward (esp. automations). Confirms
   // the request crossed claw-auth → claw and which session id it arrived under

--- a/packages/xyne-claw-mcp/src/index.ts
+++ b/packages/xyne-claw-mcp/src/index.ts
@@ -349,9 +349,18 @@ function sleep(ms: number): Promise<void> {
  * server is a subprocess of the CLI), so this works on the user's machine. */
 function openBrowser(url: string): boolean {
 	try {
-		const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
-		const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
-		execFileSync(cmd, args, { stdio: "ignore" });
+		// The URL comes from the server's device-login response. Only ever hand a
+		// well-formed http(s) URL to the OS opener — never a bare string.
+		const parsed = new URL(url);
+		if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return false;
+		const href = parsed.href;
+		if (process.platform === "win32") {
+			// Launch the default browser directly; do not route through cmd.exe
+			// (`cmd /c start`), where `&`, `|`, `^`, `%VAR%` etc. would be interpreted.
+			execFileSync("rundll32", ["url.dll,FileProtocolHandler", href], { stdio: "ignore" });
+		} else {
+			execFileSync(process.platform === "darwin" ? "open" : "xdg-open", [href], { stdio: "ignore" });
+		}
 		return true;
 	} catch {
 		return false;

--- a/packages/xyne-claw-pi-plugin/index.ts
+++ b/packages/xyne-claw-pi-plugin/index.ts
@@ -338,9 +338,18 @@ function sleep(ms: number): Promise<void> {
 
 function openBrowser(url: string): boolean {
 	try {
-		const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
-		const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
-		execFileSync(cmd, args, { stdio: "ignore" });
+		// The URL comes from the server's device-login response. Only ever hand a
+		// well-formed http(s) URL to the OS opener — never a bare string.
+		const parsed = new URL(url);
+		if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return false;
+		const href = parsed.href;
+		if (process.platform === "win32") {
+			// Launch the default browser directly; do not route through cmd.exe
+			// (`cmd /c start`), where `&`, `|`, `^`, `%VAR%` etc. would be interpreted.
+			execFileSync("rundll32", ["url.dll,FileProtocolHandler", href], { stdio: "ignore" });
+		} else {
+			execFileSync(process.platform === "darwin" ? "open" : "xdg-open", [href], { stdio: "ignore" });
+		}
 		return true;
 	} catch {
 		return false;


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
