### PR TITLE
fix: XYNE-56552 stop an unselected credential from running the agent

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.ts
@@ -287,10 +287,16 @@ export async function resolveAgentProviderConfigs(
   }
 
   // always-on: the agent's provider wins. Resolve the parent, then the order.
+  // When an order exists but nothing in it has creds, fall back to its FIRST
+  // entry (`primaryParent` maps a credential-less name like `spaces` to the
+  // platform default) — never to a key the user saved but didn't select.
+  // Mirrors agent-chat.ts. Bare-credential fallback: only when no order is set.
   let parent: string | undefined;
-  if (agentProviderOrder.length > 0) parent = agentProviderOrder.find((p) => providerConfigs[p]);
+  if (agentProviderOrder.length > 0) {
+    parent = agentProviderOrder.find((p) => providerConfigs[p]) ?? agentProviderOrder[0];
+  }
   if (!parent && agentLevelProvider && providerConfigs[agentLevelProvider]) parent = agentLevelProvider;
-  if (!parent) parent = Object.keys(providerConfigs)[0];
+  if (!parent && agentProviderOrder.length === 0) parent = Object.keys(providerConfigs)[0];
 
   const providerOrder = agentProviderOrder.length > 0 ? agentProviderOrder : parent ? [parent] : [];
   log.info(`Provider resolution (headless): agent=${agent.id} mode=always-on parent=${parent ?? "spaces"} creds=[${Object.keys(providerConfigs).join(",")}] order=[${providerOrder.join(",")}]`);


### PR DESCRIPTION
An agent whose provider order was [spaces, codex] ran on LiteLLM. The LiteLLM key was saved on the agent but deliberately NOT selected in the order.

resolveAgentProviderConfigs walks the agent's order looking for an entry that has a credential. `spaces` never has one — it IS the platform default — and if the other entries are unconfigured, nothing matches. The last resort then did:

    if (!parent) parent = Object.keys(providerConfigs)[0];

i.e. "use whichever credential is saved on this agent", ignoring the order the user actually chose. Since listByAgent has no ORDER BY, with two stray keys the winner was whichever row Postgres returned first — and editing a credential (which rewrites the row) could silently switch an agent's provider.

The order's first entry is now the fallback, matching agent-chat.ts, which has always resolved it this way:

    parent = agentProviderOrder.find(p => providerConfigs[p]) ?? agentProviderOrder[0];

`primaryParent` below already maps a credential-less name such as `spaces` back to undefined = platform default, which is what the UI promises ("Used when no provider above serves the run"). The bare-credential fallback is kept for agents with no order configured at all.

That divergence is why the v3 chat behaved correctly while dashboard Ask AI did not — same agent, same keys, two resolvers. Unifying them properly also means deciding whether the dashboard path should honour personal user credentials the way chat does; that is a separate change and is NOT done here.

Also log the resolved primary rather than the candidate (the candidate can name a credential-less provider, so the log claimed a provider the run never used), and list saved-but-unselected credentials, so "why is my agent on the platform default when a key exists?" is answerable from the log alone.


