### PR TITLE
fix: XYNE-56558 scribe  labels — pill redesign, transcript side panel trigger 

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1464,9 +1464,16 @@ export class CallController {
         }
       }
 
+      // Labels arrive as a mix of already-applied Tag ids and raw text just typed
+      // in the dashboard — resolve creates a real Tag row (method=manual) for any
+      // raw text, so Call.labels only ever holds Tag ids, never bare strings.
+      const resolvedLabels = input.labels
+        ? await noteTakerTranscriptService.resolveLabelsToTagIds(call, input.labels)
+        : undefined;
+
       await repositories.calls.update(call.id, {
         ...(input.title ? { title: input.title } : {}),
-        ...(input.labels ? { labels: [...new Set(input.labels)] } : {}),
+        ...(resolvedLabels ? { labels: resolvedLabels } : {}),
         ...(input.markedItems !== undefined
           ? { markedItems: input.markedItems as Prisma.InputJsonValue[] }
           : {}),

--- a/apps/dashboard/src/components/Chat/TranscriptCitationModal/TranscriptSidePanel.tsx
+++ b/apps/dashboard/src/components/Chat/TranscriptCitationModal/TranscriptSidePanel.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, type ReactElement } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
 import {
   ChevronDown,
   ChevronUp,
@@ -119,13 +120,21 @@ export function TranscriptSidePanel({
     window.setTimeout(() => URL.revokeObjectURL(href), 0);
   }, [transcript]);
 
+  const shouldReduceMotion = useReducedMotion();
+
   return (
-    <aside
+    <motion.aside
       aria-label='Transcript'
       className={cn(
         'flex h-full w-full flex-col overflow-hidden border-l border-border/70 bg-background shadow-2xl',
         className,
       )}
+      initial={{ x: '100%' }}
+      animate={{ x: 0 }}
+      exit={{ x: '100%' }}
+      transition={
+        shouldReduceMotion ? { duration: 0.15 } : { type: 'spring', stiffness: 380, damping: 34 }
+      }
     >
       <header className='flex shrink-0 items-center justify-between gap-2 border-b border-border px-4 py-3'>
         <h2 className='truncate text-base font-semibold text-foreground'>Transcript</h2>
@@ -136,7 +145,7 @@ export function TranscriptSidePanel({
               variant='ghost'
               size='iconSm'
               onClick={() => void handleCopy()}
-              className='text-muted-foreground hover:bg-muted hover:text-foreground'
+              className='text-muted-foreground hover:bg-muted hover:text-foreground rounded-xl'
               aria-label='Copy transcript'
               data-track-category='TranscriptPanel'
               data-track-name='copy_transcript'
@@ -150,7 +159,7 @@ export function TranscriptSidePanel({
               variant='ghost'
               size='iconSm'
               onClick={handleDownload}
-              className='text-muted-foreground hover:bg-muted hover:text-foreground'
+              className='text-muted-foreground hover:bg-muted hover:text-foreground rounded-xl'
               aria-label='Download transcript'
               data-track-category='TranscriptPanel'
               data-track-name='download_transcript'
@@ -164,7 +173,7 @@ export function TranscriptSidePanel({
               variant='ghost'
               size='iconSm'
               onClick={onClose}
-              className='text-muted-foreground hover:bg-muted hover:text-foreground'
+              className='text-muted-foreground hover:bg-muted hover:text-foreground rounded-xl'
               aria-label='Close transcript'
               data-track-category='TranscriptPanel'
               data-track-name='close_transcript'
@@ -176,7 +185,7 @@ export function TranscriptSidePanel({
       </header>
 
       <div className='shrink-0 border-b border-border px-4 py-3'>
-        <div className='flex h-10 items-center gap-1.5 rounded-lg border border-border bg-muted/45 px-3 text-muted-foreground focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20'>
+        <div className='flex h-10 items-center gap-1.5 rounded-xl border border-border bg-muted/45 px-3 text-muted-foreground focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20'>
           <SearchBig size={16} strokeWidth={2.2} className='shrink-0' aria-hidden='true' />
           <input
             type='text'
@@ -295,6 +304,6 @@ export function TranscriptSidePanel({
           </div>
         ) : null}
       </div>
-    </aside>
+    </motion.aside>
   );
 }

--- a/apps/dashboard/src/components/ui/SearchableMultiSelect/SearchableMultiSelect.tsx
+++ b/apps/dashboard/src/components/ui/SearchableMultiSelect/SearchableMultiSelect.tsx
@@ -78,6 +78,7 @@ export function SearchableMultiSelect({
         ? selectedValues.filter(selected => selected !== value)
         : [...selectedValues, value],
     );
+    setSearchValue('');
   };
 
   const handleOpenChange = (open: boolean): void => {

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -3,7 +3,7 @@
  */
 
 import { type ReactElement, useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import axios from 'axios';
 import {
@@ -41,10 +41,11 @@ import {
   File02Text,
   EnvelopeDefault,
   Hashtag,
+  SidebarRightClose,
 } from '@xyne/icons';
 import { Button } from '../../components/ui/Button/Button';
 import { Dialog } from '../../components/ui/Dialog';
-import { Tooltip } from '../../components/ui/Tooltip';
+import { cn, Tooltip } from '../../components/ui/Tooltip';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -841,6 +842,16 @@ export default function RecordingDetailV2Screen(): ReactElement {
     setShowTranscriptPanel(true);
   };
 
+  // Only the toolbar icon button toggles — the waveform pill and "read transcript"
+  // CTA should always open, never surprise-close, an already-open panel.
+  const toggleTranscriptPanel = (): void => {
+    if (showTranscriptPanel) {
+      setShowTranscriptPanel(false);
+      return;
+    }
+    openTranscriptPanel();
+  };
+
   const handleShowSummaryShimmer = (): void => {
     markSummaryRequested(recordingId);
     setSummaryRunNonce(value => value + 1);
@@ -907,7 +918,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
                         recordingService.downloadRecordingBlob(recording.externalId, signal),
                     }
                   : {})}
-                {...(transcriptText ? { onMarkerSelect: handleMarkerSelect } : {})}
+                {...(transcriptText
+                  ? { onMarkerSelect: handleMarkerSelect, onOpenTranscript: openTranscriptPanel }
+                  : {})}
               />
 
               <div className='mb-4 flex items-center justify-between border-b border-border/70 pb-2'>
@@ -1062,16 +1075,26 @@ export default function RecordingDetailV2Screen(): ReactElement {
                   )}
                 </div>
                 {transcriptText ? (
-                  <Tooltip content='Open transcript' side='left'>
+                  <Tooltip
+                    content={!showTranscriptPanel ? 'Open transcript' : 'Close transcript'}
+                    side='left'
+                  >
                     <Button
-                      onClick={openTranscriptPanel}
+                      onClick={toggleTranscriptPanel}
                       variant='ghost'
-                      className='inline-flex size-8 items-center justify-center rounded-xl border border-border/70 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                      aria-label='Open transcript'
+                      className={cn(
+                        'inline-flex size-8 items-center justify-center rounded-xl border border-border/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                        showTranscriptPanel ? 'text-foreground' : 'text-muted-foreground',
+                      )}
+                      aria-label={!showTranscriptPanel ? 'Open transcript' : 'Close transcript'}
                       data-track-category='RecordingDetailV2'
                       data-track-name='open_transcript_panel'
                     >
-                      <SidebarRightOpen className='size-4' aria-hidden='true' variant='Solid' />
+                      {showTranscriptPanel ? (
+                        <SidebarRightClose className='size-4' aria-hidden='true' variant='Solid' />
+                      ) : (
+                        <SidebarRightOpen className='size-4' aria-hidden='true' variant='Solid' />
+                      )}
                     </Button>
                   </Tooltip>
                 ) : null}
@@ -1107,19 +1130,21 @@ export default function RecordingDetailV2Screen(): ReactElement {
       <ResumeRecordingButton recordingExternalId={recording.externalId} />
 
       {/* Transcript side panel */}
-      {showTranscriptPanel && transcriptText && (
-        <TranscriptSidePanel
-          transcript={transcriptText}
-          target={citationRef}
-          openNonce={citationNonce}
-          markedTimestampsSeconds={markedMomentSeconds}
-          onClose={() => {
-            setShowTranscriptPanel(false);
-            setCitationRef(null);
-          }}
-          className='absolute inset-y-0 right-0 z-30 w-full md:w-[560px]'
-        />
-      )}
+      <AnimatePresence>
+        {showTranscriptPanel && transcriptText && (
+          <TranscriptSidePanel
+            transcript={transcriptText}
+            target={citationRef}
+            openNonce={citationNonce}
+            markedTimestampsSeconds={markedMomentSeconds}
+            onClose={() => {
+              setShowTranscriptPanel(false);
+              setCitationRef(null);
+            }}
+            className='absolute inset-y-0 right-0 z-30 w-full md:w-[560px]'
+          />
+        )}
+      </AnimatePresence>
 
       {isOwner && showPostToChannelModal && hasDetailedSummary && (
         <Dialog

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
@@ -17,7 +17,7 @@
  * `onMarkerSelect`, clicking any of the three opens the transcript at that point.
  */
 
-import { useCallback, useEffect, useState, type CSSProperties, type ReactElement } from 'react';
+import { useCallback, useEffect, useState, type ReactElement } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { StopSmall, Spinner, PauseBig, PlayBig, Flag, AlertTriangle } from '@xyne/icons';
 import { Button } from '../../../components/ui/Button/Button';
@@ -38,6 +38,7 @@ interface LiveRecordingControlBarProps {
   onStopped?: () => void;
   onLoadAudio?: (signal: AbortSignal) => Promise<Blob>;
   onMarkerSelect?: (item: MarkedItem) => void;
+  onOpenTranscript?: () => void;
   isAudioPreparing?: boolean;
   /** True once playback is known to be unavailable for this recording. */
   isAudioUnavailable?: boolean;
@@ -52,6 +53,7 @@ export const LiveRecordingControlBar = ({
   onStopped,
   onLoadAudio,
   onMarkerSelect,
+  onOpenTranscript,
   isAudioPreparing = false,
   isAudioUnavailable = false,
 }: LiveRecordingControlBarProps): ReactElement | null => {
@@ -121,6 +123,7 @@ export const LiveRecordingControlBar = ({
         isAudioUnavailable={isAudioUnavailable}
         {...(onLoadAudio ? { onLoadAudio } : {})}
         {...(onMarkerSelect ? { onMarkerSelect } : {})}
+        {...(onOpenTranscript ? { onOpenTranscript } : {})}
       />
     );
   }
@@ -191,7 +194,10 @@ export const LiveRecordingControlBar = ({
         {isPaused ? 'Paused' : 'Live'}
       </span>
 
-      <RecordingVisualizer isPaused={isPaused} />
+      <RecordingVisualizer
+        isAnimated={!isPaused}
+        {...(onOpenTranscript ? { onClick: onOpenTranscript } : {})}
+      />
     </div>
   );
 };
@@ -349,6 +355,8 @@ interface RecordedTimelineBarProps {
   onLoadAudio?: (signal: AbortSignal) => Promise<Blob>;
   /** Supplied once there is a transcript to open at the marker's timestamp. */
   onMarkerSelect?: (item: MarkedItem) => void;
+  /** Supplied once there is a transcript to open — the waveform pill opens it directly. */
+  onOpenTranscript?: () => void;
   /** True while the stitched audio is still on its way. */
   isAudioPreparing?: boolean;
   /** True once playback is known to be unavailable (e.g. older recordings). */
@@ -359,6 +367,7 @@ const RecordedTimelineBar = ({
   recording,
   onLoadAudio,
   onMarkerSelect,
+  onOpenTranscript,
   isAudioPreparing = false,
   isAudioUnavailable = false,
 }: RecordedTimelineBarProps): ReactElement => {
@@ -537,7 +546,10 @@ const RecordedTimelineBar = ({
           {formatElapsedTime(durationMs)}
         </span>
 
-        <RecordingVisualizer isPaused={!isPlaying} />
+        <RecordingVisualizer
+          isAnimated={false}
+          {...(onOpenTranscript ? { onClick: onOpenTranscript } : {})}
+        />
       </div>
 
       {/* Only worth explaining the markers once there are some to explain. */}
@@ -574,24 +586,63 @@ const MarkerLegend = ({ types }: { types: ReadonlySet<MarkedItemType> }): ReactE
 /* Audio visualizer                                                           */
 /* -------------------------------------------------------------------------- */
 
-const RecordingVisualizer = ({ isPaused }: { isPaused: boolean }): ReactElement => (
-  <div className='inline-flex h-7 w-14 items-center justify-center gap-0.5 rounded-lg border border-border px-2'>
-    {Array.from({ length: 4 }, (_, i) => {
-      if (isPaused) {
-        return <div key={i} className='size-1 rounded-full bg-muted-foreground' />;
-      }
+interface RecordingVisualizerProps {
+  /** Bars only wave while the recording itself is live and unpaused — never during playback. */
+  isAnimated: boolean;
+  /** Supplied once there is a transcript to open — makes the pill a button that opens it. */
+  onClick?: () => void;
+}
 
-      const style: CSSProperties = {
-        animation: `recWaveBar 0.55s ease-in-out ${i * 0.08}s infinite alternate`,
-      };
-      return (
-        <div key={i} className='flex h-4 items-center'>
-          <div
-            className='rec-overlay-waveform-bar w-1 rounded-full bg-primary !opacity-100'
-            style={style}
-          />
-        </div>
-      );
-    })}
-  </div>
-);
+const RECORDING_VISUALIZER_REST_HEIGHT = '40%';
+
+const RecordingVisualizer = ({ isAnimated, onClick }: RecordingVisualizerProps): ReactElement => {
+  const shouldReduceMotion = useReducedMotion();
+  const isWaving = isAnimated && !shouldReduceMotion;
+
+  // A single motion value per bar lets it wave on a loop and then settle to a fixed
+  // resting height with one smooth interpolation, instead of snapping between a tall
+  // animated bar and an unrelated static dot.
+  const bars = Array.from({ length: 4 }, (_, i) => (
+    <div key={i} className='flex h-4 items-center'>
+      <motion.div
+        className='w-1.5 rounded-full bg-primary'
+        initial={{ height: isWaving ? '25%' : RECORDING_VISUALIZER_REST_HEIGHT }}
+        animate={
+          isWaving ? { height: ['25%', '100%'] } : { height: RECORDING_VISUALIZER_REST_HEIGHT }
+        }
+        transition={
+          isWaving
+            ? {
+                duration: 0.55,
+                delay: i * 0.08,
+                repeat: Infinity,
+                repeatType: 'mirror',
+                ease: 'easeInOut',
+              }
+            : { duration: 0.3, ease: 'easeOut' }
+        }
+      />
+    </div>
+  ));
+
+  const className =
+    'inline-flex h-7 w-14 items-center justify-center gap-0.5 rounded-lg border border-border px-2';
+
+  if (!onClick) {
+    return <div className={className}>{bars}</div>;
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(className, 'transition-colors hover:border-primary/50')}
+      aria-label='Open transcript'
+      title='Open transcript'
+      data-track-category='RecordingDetailV2'
+      data-track-name='waveform_open_transcript'
+    >
+      {bars}
+    </button>
+  );
+};

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useState } from 'react';
+import { type ReactElement, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
@@ -74,6 +74,7 @@ export const RecordingDetailV2Header = ({
   const [isSavingTitle, setIsSavingTitle] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [isUpdatingTicketLink, setIsUpdatingTicketLink] = useState(false);
+  const labelsUpdateSeqRef = useRef(0);
 
   // Only the creator can rename or relabel; a recording shared with you is read-only.
   const isOwner = recording.createdByUserId === currentUser?.id;
@@ -129,6 +130,7 @@ export const RecordingDetailV2Header = ({
   /** Labels apply optimistically and roll back if the recording rejects the write. */
   const handleLabelsChange = async (labels: string[]): Promise<void> => {
     const previousLabels = recording.labels ?? [];
+    const seq = ++labelsUpdateSeqRef.current;
     onLabelsUpdated(labels);
 
     try {
@@ -136,7 +138,7 @@ export const RecordingDetailV2Header = ({
     } catch (err) {
       logRecordingError('RecordingDetailV2Header.updateLabels', err);
       toast.error('Failed to update labels');
-      onLabelsUpdated(previousLabels);
+      if (labelsUpdateSeqRef.current === seq) onLabelsUpdated(previousLabels);
     }
   };
 
@@ -300,7 +302,7 @@ export const RecordingDetailV2Header = ({
       </div>
 
       {/* Actions row */}
-      <div className='flex items-start'>
+      <div className='flex items-start gap-2'>
         <div className='flex flex-wrap items-center gap-2'>
           {!isLive && recording.detailedSummaryCanvasId && (
             <RecordingTicketLink
@@ -327,7 +329,7 @@ export const RecordingDetailV2Header = ({
                   variant='outline'
                   size='iconSm'
                   onClick={() => setShowShareModal(true)}
-                  className='w-8 h-7 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+                  className='w-7 h-6 rounded-lg text-muted-foreground hover:border-foreground/30 hover:text-foreground'
                   aria-label='Share recording'
                   data-track-category='RecordingDetailV2'
                   data-track-name='share_recording'
@@ -376,7 +378,7 @@ export const RecordingDetailV2Header = ({
               variant='outline'
               size='sm'
               onClick={onAskAI}
-              className='ml-auto h-8 gap-2 rounded-xl w-24 text-[13px] font-medium border-muted-foreground/20'
+              className='ml-auto h-7 gap-2 rounded-lg w-24 text-[13px] font-medium border-muted-foreground/20'
               data-track-category='RecordingDetailV2'
               data-track-name='ask_ai_recording'
             >

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -1,24 +1,19 @@
 import { useMemo, useState, type ReactElement } from 'react';
-import { Check, X } from 'lucide-react';
-import { ChevronDown, ChevronUp, Tag } from '@xyne/icons';
+import { CheckTickSingle, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { TagMethod } from '@xyne/shared';
 import { toast } from 'sonner';
 import { SearchableMultiSelect } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect';
 import type { SearchableMultiSelectOption } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect.types';
 import { Button } from '../../../components/ui/Button/Button';
 import { tagsApi } from '../../../api/tagsApi';
-import { useOverflowFit } from '../../../hooks/useOverflowFit';
 import { useRecordingLabelSuggestions } from '../../../hooks/useRecordingLabelSuggestions';
 import {
   markResolvedRecordingLabelMethod,
   useResolvedRecordingLabels,
 } from '../../../hooks/useResolvedRecordingLabels';
 import { cn } from '../../../utils/classNames';
-import {
-  getRecordingTagDotColor,
-  normalizeRecordingTags,
-  slugifyRecordingLabel,
-} from '../../../utils/recordingUtils';
+import { normalizeRecordingTags, slugifyRecordingLabel } from '../../../utils/recordingUtils';
+import { getTagTheme } from '../../../utils/tagTheme';
 
 export interface RecordingLabelPickerProps {
   labels: string[];
@@ -26,41 +21,50 @@ export interface RecordingLabelPickerProps {
   onChange: (labels: string[]) => void;
 }
 
-const LABEL_STRIP_MAX_WIDTH = 388;
-const LABEL_CHIP_GAP = 6;
 const LABEL_MAX_LENGTH = 40;
+/** Labels beyond this are blocked on add (existing AI suggestions past the cap aren't touched). */
+const MAX_LABELS = 10;
 
-const CHIP_CLASS_NAME =
-  'inline-flex shrink-0 items-center gap-1.5 rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-foreground whitespace-nowrap scrollbar-none data-[theme=midnight]:bg-muted/50';
+const CHIP_BASE_CLASS_NAME =
+  'inline-flex h-6 shrink-0 items-center gap-1.5 rounded-lg pl-2 pr-1.5 text-xs font-medium whitespace-nowrap';
 
-const SUGGESTION_CHIP_CLASS_NAME =
-  'inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-dashed border-muted-foreground/40 px-1.5 h-7 text-xs font-medium text-foreground whitespace-nowrap scrollbar-none';
-
-const READ_ONLY_TRIGGER_CLASS_NAME =
-  'inline-flex h-7 items-center gap-1.5 rounded-lg border bg-background px-2 text-xs font-normal text-foreground shadow-xs';
+const SUGGESTION_CHIP_CLASS_NAME = cn(
+  CHIP_BASE_CLASS_NAME,
+  'border border-dashed border-muted-foreground/40',
+);
 
 const LIST_INHERITS_POPOVER_CLASS_NAME =
   '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
 
-function LabelChip({
+export function LabelChip({
   label,
-  canTruncate = false,
+  onRemove,
 }: {
   label: string;
-  canTruncate?: boolean;
+  onRemove?: () => void;
 }): ReactElement {
+  const theme = getTagTheme(label);
   return (
-    <span className={cn(CHIP_CLASS_NAME, canTruncate && 'min-w-0 shrink')}>
-      <span
-        className={cn('size-1.5 shrink-0 rounded-full', getRecordingTagDotColor(label))}
-        aria-hidden='true'
-      />
-      <span className={cn(canTruncate && 'truncate')}>{label}</span>
+    <span className={cn(CHIP_BASE_CLASS_NAME, theme.bg, theme.text)}>
+      <span className={cn('size-1.5 shrink-0 rounded-full', theme.dot)} aria-hidden='true' />
+      <span>{label}</span>
+      {onRemove && (
+        <button
+          type='button'
+          className='rounded-sm opacity-70 hover:opacity-100'
+          aria-label={`Remove label ${label}`}
+          onClick={onRemove}
+          data-track-category='RecordingDetailV2'
+          data-track-name='remove_recording_label'
+        >
+          <MultipleCrossCancelDefault className='size-3' aria-hidden='true' />
+        </button>
+      )}
     </span>
   );
 }
 
-/** An AI-suggested (unconfirmed) label — tick to keep it (moves into the label box), cross to discard it. */
+/** An AI-suggested (unconfirmed) label — tick to keep it (moves into the confirmed pills), cross to discard it. */
 function SuggestedLabelChip({
   label,
   onConfirm,
@@ -70,32 +74,30 @@ function SuggestedLabelChip({
   onConfirm: () => void;
   onReject: () => void;
 }): ReactElement {
+  const theme = getTagTheme(label);
   return (
-    <span className={SUGGESTION_CHIP_CLASS_NAME}>
-      <span
-        className={cn('size-1.5 shrink-0 rounded-full', getRecordingTagDotColor(label))}
-        aria-hidden='true'
-      />
+    <span className={cn(SUGGESTION_CHIP_CLASS_NAME, 'text-foreground')}>
+      <span className={cn('size-1.5 shrink-0 rounded-full', theme.dot)} aria-hidden='true' />
       <span>{label}</span>
       <button
         type='button'
-        className='rounded-sm text-muted-foreground hover:text-foreground'
+        className='rounded-sm opacity-70 hover:opacity-100'
         aria-label={`Confirm suggested label ${label}`}
         onClick={onConfirm}
         data-track-category='RecordingDetailV2'
         data-track-name='confirm_suggested_label'
       >
-        <Check className='size-3' aria-hidden='true' />
+        <CheckTickSingle className='size-3' aria-hidden='true' />
       </button>
       <button
         type='button'
-        className='rounded-sm text-muted-foreground hover:text-foreground'
+        className='rounded-sm opacity-70 hover:opacity-100'
         aria-label={`Dismiss suggested label ${label}`}
         onClick={onReject}
         data-track-category='RecordingDetailV2'
         data-track-name='reject_suggested_label'
       >
-        <X className='size-3' aria-hidden='true' />
+        <MultipleCrossCancelDefault className='size-3' aria-hidden='true' />
       </button>
     </span>
   );
@@ -111,9 +113,9 @@ export function RecordingLabelPicker({
   const resolvable = useMemo(() => [...labels, ...suggestions], [labels, suggestions]);
   const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(resolvable);
 
-  // Unconfirmed AI suggestions render as standalone pills outside the label box —
+  // Unconfirmed AI suggestions render as standalone pills after the add button —
   // ticking one flips it to `manual` (see handleConfirmSuggestion) so it then falls
-  // into confirmedLabels and appears inside the box on the next render.
+  // into confirmedLabels and appears as a normal pill on the next render.
   const confirmedLabels = useMemo(
     () => (canEdit ? labels.filter(id => resolveMethod(id) !== TagMethod.LLM) : labels),
     [labels, canEdit, resolveMethod],
@@ -136,7 +138,7 @@ export function RecordingLabelPicker({
           label: displayLabel,
           icon: (
             <span
-              className={cn('size-2 shrink-0 rounded-full', getRecordingTagDotColor(displayLabel))}
+              className={cn('size-2 shrink-0 rounded-full', getTagTheme(displayLabel).dot)}
               aria-hidden='true'
             />
           ),
@@ -144,24 +146,27 @@ export function RecordingLabelPicker({
     [labels, suggestions, resolveLabel, resolveMethod],
   );
 
-  const { measureRef, visibleCount } = useOverflowFit<HTMLSpanElement>({
-    itemCount: confirmedLabels.length,
-    containerWidth: LABEL_STRIP_MAX_WIDTH,
-    gap: LABEL_CHIP_GAP,
-    minVisible: 1,
-  });
-
-  const shownCount = Math.min(visibleCount, confirmedLabels.length);
-  const visibleLabels = confirmedLabels.slice(0, shownCount);
-  const overflowCount = confirmedLabels.length - visibleLabels.length;
-
   const handleCreate = (label: string): void => {
+    if (confirmedLabels.length >= MAX_LABELS) {
+      toast.error(`You can add up to ${MAX_LABELS} labels`);
+      return;
+    }
     const slug = slugifyRecordingLabel(label);
     if (!slug) {
       toast.error('Label needs at least one letter or number');
       return;
     }
     onChange(normalizeRecordingTags([...labels, slug]));
+  };
+
+  // `options` already excludes AI-suggested labels (filtered above), so a size increase
+  // here always means a confirmed/manual label is being added.
+  const handleSelectedValuesChange = (values: string[]): void => {
+    if (values.length > labels.length && confirmedLabels.length >= MAX_LABELS) {
+      toast.error(`You can add up to ${MAX_LABELS} labels`);
+      return;
+    }
+    onChange(values);
   };
 
   /** Tick: keep the AI-suggested tag — flips its Tag row to `manual` in place, no labels change needed. */
@@ -180,38 +185,6 @@ export function RecordingLabelPicker({
     onChange(labels.filter(id => id !== labelId));
   };
 
-  const appliedLabels = (
-    <span
-      className='relative flex flex-nowrap items-center gap-1.5 overflow-hidden'
-      style={{ maxWidth: LABEL_STRIP_MAX_WIDTH }}
-    >
-      <span
-        ref={measureRef}
-        aria-hidden='true'
-        className='pointer-events-none invisible absolute left-0 top-0 flex w-max flex-nowrap items-center gap-1.5'
-      >
-        {confirmedLabels.map(label => (
-          <LabelChip key={label} label={resolveLabel(label)} />
-        ))}
-        <span className={cn(CHIP_CLASS_NAME, 'text-muted-foreground')}>
-          +{confirmedLabels.length}
-        </span>
-      </span>
-
-      {visibleLabels.map(label => (
-        <LabelChip key={label} label={resolveLabel(label)} canTruncate />
-      ))}
-      {overflowCount > 0 && (
-        <span
-          className={cn(CHIP_CLASS_NAME, 'text-muted-foreground')}
-          title={confirmedLabels.slice(shownCount).map(resolveLabel).join(', ')}
-        >
-          +{overflowCount}
-        </span>
-      )}
-    </span>
-  );
-
   const suggestionPills =
     canEdit && suggestedLabels.length > 0
       ? suggestedLabels.map(label => (
@@ -227,22 +200,30 @@ export function RecordingLabelPicker({
   if (!canEdit) {
     if (labels.length === 0) return null;
 
-    // Same frame as the owner's trigger — a shared recording's header shouldn't look
-    // like a different screen — but with no chevron and nothing to click.
+    // Same flat pills as the owner's view — a shared recording's header shouldn't
+    // look like a different screen — just no remove/add controls.
     return (
-      <div className={READ_ONLY_TRIGGER_CLASS_NAME} aria-label={`Labels, ${labels.length} applied`}>
-        <Tag className='size-3.5 shrink-0' aria-hidden='true' />
-        {appliedLabels}
-      </div>
+      <>
+        {confirmedLabels.map(label => (
+          <LabelChip key={label} label={resolveLabel(label)} />
+        ))}
+      </>
     );
   }
 
   return (
     <>
+      {confirmedLabels.map(label => (
+        <LabelChip
+          key={label}
+          label={resolveLabel(label)}
+          onRemove={() => onChange(labels.filter(id => id !== label))}
+        />
+      ))}
       <SearchableMultiSelect
         options={options}
         selectedValues={labels}
-        onSelectedValuesChange={onChange}
+        onSelectedValuesChange={handleSelectedValuesChange}
         onCreateOption={handleCreate}
         className={LIST_INHERITS_POPOVER_CLASS_NAME}
         isOpen={isOpen}
@@ -259,27 +240,13 @@ export function RecordingLabelPicker({
             type='button'
             variant='outline'
             size='sm'
-            className={cn(
-              'h-7 gap-1.5 rounded-lg text-xs font-normal ',
-              confirmedLabels.length === 0
-                ? 'border-dashed border-muted-foreground/40 px-3 text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-                : 'px-2',
-            )}
-            aria-label={
-              confirmedLabels.length > 0
-                ? `Labels, ${confirmedLabels.length} applied`
-                : 'Add a label to this recording'
-            }
+            className='h-6 gap-1.5 rounded-lg border-dashed border-muted-foreground/40 pl-2 pr-2.5 text-xs font-medium text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+            aria-label='Add a label'
             data-track-category='RecordingDetailV2'
             data-track-name='open_recording_labels'
           >
-            <Tag className='size-3.5' aria-hidden='true' />
-            {confirmedLabels.length === 0 ? 'Add label' : appliedLabels}
-            {isOpen ? (
-              <ChevronUp className='size-3.5 text-muted-foreground' aria-hidden='true' />
-            ) : (
-              <ChevronDown className='size-3.5 text-muted-foreground' aria-hidden='true' />
-            )}
+            <PlusDefault className='size-3.5' aria-hidden='true' />
+            Label
           </Button>
         }
       />

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -113,12 +113,10 @@ export function RecordingLabelPicker({
   const resolvable = useMemo(() => [...labels, ...suggestions], [labels, suggestions]);
   const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(resolvable);
 
-  // Unconfirmed AI suggestions render as standalone pills after the add button —
-  // ticking one flips it to `manual` (see handleConfirmSuggestion) so it then falls
-  // into confirmedLabels and appears as a normal pill on the next render.
+  // Confirmed labels eg: TagMethod === MANUAL are distinguish b/w the LLM tags and shared public viewable
   const confirmedLabels = useMemo(
-    () => (canEdit ? labels.filter(id => resolveMethod(id) !== TagMethod.LLM) : labels),
-    [labels, canEdit, resolveMethod],
+    () => labels.filter(id => resolveMethod(id) !== TagMethod.LLM),
+    [labels, resolveMethod],
   );
   const suggestedLabels = useMemo(
     () => (canEdit ? labels.filter(id => resolveMethod(id) === TagMethod.LLM) : []),

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingTicketLink.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingTicketLink.tsx
@@ -30,7 +30,7 @@ const TICKET_SEARCH_LIMIT = 20;
 
 /** Matches the header's other pills (date, labels, share). */
 const CHIP_CLASS_NAME =
-  'inline-flex h-7 items-center gap-1.5 rounded-lg border border-border bg-background px-2 text-xs font-normal text-foreground shadow-xs';
+  'inline-flex h-6 items-center gap-1.5 rounded-lg border border-border bg-background px-2 text-xs font-normal text-foreground shadow-xs';
 
 /**
  * Links a recording to exactly one ticket.
@@ -166,7 +166,7 @@ export function RecordingTicketLink({
       disableClientFiltering
       showIndicator={false}
       inputIcon={<LinkChainSlant className='size-3.5' aria-hidden='true' />}
-      inputClassName='h-7 gap-1.5 rounded-lg border border-dashed border-muted-foreground/40 px-3 text-xs font-normal text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+      inputClassName='h-6 gap-1.5 rounded-lg border border-dashed border-muted-foreground/40 px-3 text-xs font-normal text-muted-foreground hover:border-foreground/30 hover:text-foreground'
       testId='recording-ticket-link'
     />
   );

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingLabelFilter.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingLabelFilter.tsx
@@ -4,7 +4,7 @@ import { SearchableMultiSelect } from '../../../components/ui/SearchableMultiSel
 import type { SearchableMultiSelectOption } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect.types';
 import { Button } from '../../../components/ui/Button/Button';
 import { cn } from '../../../utils/classNames';
-import { getRecordingTagDotColor } from '../../../utils/recordingUtils';
+import { getTagDotColor } from '../../../utils/tagTheme';
 
 interface RecordingLabelFilterProps {
   labels: string[];
@@ -37,7 +37,7 @@ export function RecordingLabelFilter({
           label: displayLabel,
           icon: (
             <span
-              className={cn('size-2 shrink-0 rounded-full', getRecordingTagDotColor(displayLabel))}
+              className={cn('size-2 shrink-0 rounded-full', getTagDotColor(displayLabel))}
               aria-hidden='true'
             />
           ),

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -9,7 +9,6 @@ import {
   calculateRecordingElapsedMs,
   formatElapsedTime,
   formatRecordingDuration,
-  getRecordingTagDotColor,
   normalizeRecordingTags,
 } from '../../../utils/recordingUtils';
 import { cn } from '../../../utils/classNames';
@@ -17,6 +16,7 @@ import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { TextShimmer } from '../../../components/ui/ShimmerText';
 import { useRecordingTitleState } from '../../../hooks/useRecordingTitleState';
 import { formatRecordingTimestamp, toRecordingTitleInput } from '../utils/RecordingsV2.utils';
+import { LabelChip } from '../../RecordingDetailV2Screen/components/RecordingLabelPicker';
 
 export interface RecordingsV2PillProps {
   recording: Pick<
@@ -194,19 +194,7 @@ const RecordingsV2Pill = ({
         {visibleTags.length > 0 && (
           <span className='flex flex-wrap items-center gap-1.5'>
             {visibleTags.map(tag => (
-              <span
-                key={tag}
-                className='inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground transition-colors'
-              >
-                <span
-                  className={cn(
-                    'size-1.5 rounded-full',
-                    getRecordingTagDotColor(resolveLabel(tag)),
-                  )}
-                  aria-hidden='true'
-                />
-                <span className='max-w-32 truncate'>{resolveLabel(tag)}</span>
-              </span>
+              <LabelChip key={tag} label={resolveLabel(tag)} />
             ))}
           </span>
         )}

--- a/apps/dashboard/src/utils/recordingUtils.ts
+++ b/apps/dashboard/src/utils/recordingUtils.ts
@@ -168,33 +168,6 @@ export const getSpeakerColor = (name: string): string => {
 };
 
 /**
- * Dot colors for recording labels
- */
-const TAG_DOT_COLORS = [
-  'bg-cyan-600',
-  'bg-yellow-600',
-  'bg-purple-600',
-  'bg-green-600',
-  'bg-pink-600',
-  'bg-blue-600',
-] as const;
-
-/**
- * Assigns the same palette color to a label on every render using a stable string hash.
- *
- * @example
- * getRecordingTagDotColor('customer-call'); // e.g. 'bg-purple-600'
- */
-export const getRecordingTagDotColor = (tag: string): (typeof TAG_DOT_COLORS)[number] => {
-  let hash = 0;
-  for (let index = 0; index < tag.length; index += 1) {
-    hash = tag.charCodeAt(index) + ((hash << 5) - hash);
-  }
-
-  return TAG_DOT_COLORS[Math.abs(hash) % TAG_DOT_COLORS.length] ?? TAG_DOT_COLORS[0];
-};
-
-/**
  * Trims labels and drops blanks and duplicates, preserving order.
  */
 export const normalizeRecordingTags = (tags: string[]): string[] => {

--- a/apps/dashboard/src/utils/tagTheme.ts
+++ b/apps/dashboard/src/utils/tagTheme.ts
@@ -1,0 +1,77 @@
+/**
+ * Deterministic color theme for tag/label chips
+ */
+
+export interface TagTheme {
+  dot: string;
+  bg: string;
+  text: string;
+}
+
+const TAG_THEMES: readonly TagTheme[] = [
+  {
+    dot: 'bg-blue-600 [[data-theme=midnight]_&]:bg-blue-400',
+    bg: 'bg-blue-600/10 [[data-theme=midnight]_&]:bg-blue-400/20',
+    text: 'text-blue-600 [[data-theme=midnight]_&]:text-blue-400',
+  },
+  {
+    dot: 'bg-emerald-700 [[data-theme=midnight]_&]:bg-emerald-400',
+    bg: 'bg-emerald-700/10 [[data-theme=midnight]_&]:bg-emerald-400/20',
+    text: 'text-emerald-700 [[data-theme=midnight]_&]:text-emerald-400',
+  },
+  {
+    dot: 'bg-indigo-600 [[data-theme=midnight]_&]:bg-indigo-400',
+    bg: 'bg-indigo-600/10 [[data-theme=midnight]_&]:bg-indigo-400/20',
+    text: 'text-indigo-600 [[data-theme=midnight]_&]:text-indigo-400',
+  },
+  {
+    dot: 'bg-cyan-600 [[data-theme=midnight]_&]:bg-cyan-400',
+    bg: 'bg-cyan-600/10 [[data-theme=midnight]_&]:bg-cyan-400/20',
+    text: 'text-cyan-600 [[data-theme=midnight]_&]:text-cyan-400',
+  },
+  {
+    dot: 'bg-violet-600 [[data-theme=midnight]_&]:bg-violet-400',
+    bg: 'bg-violet-600/10 [[data-theme=midnight]_&]:bg-violet-400/20',
+    text: 'text-violet-600 [[data-theme=midnight]_&]:text-violet-400',
+  },
+  {
+    dot: 'bg-amber-700 [[data-theme=midnight]_&]:bg-amber-400',
+    bg: 'bg-amber-700/10 [[data-theme=midnight]_&]:bg-amber-400/20',
+    text: 'text-amber-700 [[data-theme=midnight]_&]:text-amber-400',
+  },
+  {
+    dot: 'bg-orange-600 [[data-theme=midnight]_&]:bg-orange-400',
+    bg: 'bg-orange-600/10 [[data-theme=midnight]_&]:bg-orange-400/20',
+    text: 'text-orange-600 [[data-theme=midnight]_&]:text-orange-400',
+  },
+  {
+    dot: 'bg-teal-600 [[data-theme=midnight]_&]:bg-teal-400',
+    bg: 'bg-teal-600/10 [[data-theme=midnight]_&]:bg-teal-400/20',
+    text: 'text-teal-600 [[data-theme=midnight]_&]:text-teal-400',
+  },
+  {
+    dot: 'bg-lime-700 [[data-theme=midnight]_&]:bg-lime-400',
+    bg: 'bg-lime-700/10 [[data-theme=midnight]_&]:bg-lime-400/20',
+    text: 'text-lime-700 [[data-theme=midnight]_&]:text-lime-400',
+  },
+];
+
+function hashTagName(name: string): number {
+  let hash = 0;
+  for (let index = 0; index < name.length; index += 1) {
+    hash = name.charCodeAt(index) + ((hash << 5) - hash);
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * @example
+ * getTagTheme('customer-call'); // { dot: 'bg-indigo-600', bg: '...', text: '...' }
+ */
+export function getTagTheme(name: string): TagTheme {
+  return TAG_THEMES[hashTagName(name) % TAG_THEMES.length]!;
+}
+
+export function getTagDotColor(name: string): string {
+  return getTagTheme(name).dot;
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Label pills reworked: RecordingLabelPicker no longer collapses labels into a +N box — each label is now its own themed, individually-removable pill, followed by a compact + Label add button, followed by AI-suggested pills. (Added a 10-label cap with a toast on overflow.)
- Shared color system: new `utils/tagTheme.ts` 
- Fixed labels being stored as bare strings: callController.updateRecordingTitle now runs incoming labels through noteTakerTranscriptService.resolveLabelsToTagIds before persisting.
- Fix label filtering for shared with me only for TagMethod === MANUAL
-  Waveform onclick triggers Transcript side panel and  animates Transcript side panel

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**