### PR TITLE
fix: revert PR #281 (pending-message framework) on release-20260817

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -41,7 +41,6 @@ import {
 } from '../../../services/Analytics/mixpanelService';
 import type { FocusPosition } from '@tiptap/react';
 import type { MentionResult } from '@xyne/shared';
-import { sendMessage, type ConversationRef } from '@xyne/shared/messages';
 import { useCanCreateTicket } from '../../../hooks/usePermissions';
 import { mutators } from '../../../zero/mutators';
 import { useShortcutById } from '../../../shortcuts';
@@ -524,14 +523,11 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
           twinEdit.onApprove(edited);
           return;
         }
-        // Edits and thread replies still require a live connection. New
-        // top-level channel messages are allowed offline: the pending-message
-        // framework queues them and auto-retries on reconnect.
-        if (isOffline && (messageId || conversationId)) {
+        if (isOffline) {
           toast.warning("You're offline", {
             description: messageId
               ? "Edits can't be saved until you reconnect."
-              : "Thread replies can't be sent until you reconnect.",
+              : 'Your message has been saved as a draft. It will be ready to send when you reconnect.',
           });
           throw new Error('offline');
         }
@@ -748,23 +744,28 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
             // Scope the agent-progress spinner to this new conversation right away,
             // before the `conversationId` prop catches up (see pendingConversationId).
             setPendingConversationId(newConversationId);
-            // Route top-level channel sends through the shared pending-message
-            // framework. sendMessage writes a durable pending entry, fires
-            // mutators.conversations.send when Zero is connected (and queues it
-            // for auto-retry when it is not), and clears the entry once the
-            // server confirms the write. Failed sends stay queued and surface a
-            // retry/delete affordance instead of being restored to the composer.
-            const channelRef: ConversationRef = { kind: 'channel', channelId };
-            sendMessage(zero as Parameters<typeof sendMessage>[0], channelRef, {
-              content: processedHtml,
-              type: MessageType.USER,
-              conversationId: newConversationId,
-              messageId: newMessageId,
-              timestamp: messageCreatedAt,
-            });
+            const result = zero.mutate(
+              mutators.conversations.send({
+                channelId,
+                content: processedHtml,
+                type: MessageType.USER,
+                conversationId: newConversationId,
+                messageId: newMessageId,
+                timestamp: messageCreatedAt,
+              }),
+            );
 
             saveDraft(lookupId, '', '');
-            dispatchChatMessageSentEvent(channelId);
+            handleMutationResult(
+              result,
+              restoreDraft,
+              () => dispatchChatMessageSentEvent(channelId),
+              undefined,
+              {
+                channelId,
+                isNewConversation: true,
+              },
+            );
 
             logger.info(Event.MESSAGE_SENT, {
               channelId,

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -36,7 +36,6 @@ import { getDraft } from '../../../hooks/useDraft';
 import { v4 as uuidv4 } from 'uuid';
 import { withProfiler } from '../../../utils/withProfiler';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
-import { usePendingForChannel, buildPendingChannelConversation } from '@xyne/shared/messages';
 import { MessageHoverToolbar } from '../HoverActionsToolbar/MessageHoverToolbar';
 
 export type ChatListProps = {
@@ -301,26 +300,8 @@ const ChatListV4: React.FC<ChatListProps> = ({
   const topVisibleConvIdRef = useRef<string | undefined>(undefined);
   const { isMobile } = usePlatform();
 
-  // Merge durable pending sends (queued while offline, awaiting server
-  // confirmation, or failed) into the render list. Any conversation whose
-  // initial message is still pending is dropped first so Zero's optimistic row
-  // and the pending row never collide on the same key; the pending rows carry
-  // the newest timestamps, so appending sorts them to the tail.
-  const pendingForChannel = usePendingForChannel(channelId);
-  const conversationsWithPending = useMemo(() => {
-    if (pendingForChannel.length === 0) return conversations;
-    const pendingIds = new Set(pendingForChannel.map(p => p.messageId));
-    const base = conversations.filter(
-      c => !c.initialMessageId || !pendingIds.has(c.initialMessageId),
-    );
-    const pendingRows = pendingForChannel.map(
-      p => buildPendingChannelConversation(p) as unknown as Conversation,
-    );
-    return [...base, ...pendingRows];
-  }, [conversations, pendingForChannel]);
-
   const { combinedMessages, itemHeights } = useCombinedMesseges(
-    conversationsWithPending,
+    conversations,
     isMobile,
     newConversationBoundary?.index ?? -1,
   );

--- a/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
@@ -9,13 +9,6 @@ import { useDraft, useDraftFromDB } from '../../../hooks/useDraft';
 import { ChannelScopeType, MessageAttachment } from '@xyne/shared';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
 import { useAuth } from '../../../hooks/useAuth';
-import { useZero } from '../../../hooks/useZero';
-import {
-  usePendingStatusByMessageId,
-  usePendingByMessageId,
-  firePendingMutator,
-  removePending,
-} from '@xyne/shared/messages';
 
 type ChatListItemProps = {
   item: ChatListItemWithSeparator;
@@ -55,10 +48,6 @@ const ChatListItemComponent = ({
   const draft = useDraft(channelId, conversation?.conversationId ?? '');
   const draftFromDB = useDraftFromDB(channelId, conversation?.conversationId ?? '');
   const hasDraftAttachments = draftFromDB?.attachments && draftFromDB.attachments?.length > 0;
-  const zero = useZero();
-  const pendingMessageId = conversation?.initialMessageId ?? '';
-  const pendingStatus = usePendingStatusByMessageId(pendingMessageId);
-  const pendingEntry = usePendingByMessageId(pendingMessageId);
 
   // Render date separator
   if (item.type === 'date-separator') {
@@ -121,29 +110,6 @@ const ChatListItemComponent = ({
         {...(onEmojiPickerOpenChange && { onEmojiPickerOpenChange })}
         {...(linkedConversationId !== null && { linkedConversationId })}
       />
-      {pendingStatus === 'failed' && pendingEntry && (
-        <div className='flex items-center gap-3 pl-12 pt-1 text-xs text-red-500'>
-          <span>Failed to send.</span>
-          <button
-            type='button'
-            data-track-category='PENDING_MESSAGE'
-            data-track-name='retry_failed_send'
-            className='font-medium underline hover:opacity-80'
-            onClick={() => firePendingMutator(zero, pendingEntry)}
-          >
-            Retry
-          </button>
-          <button
-            type='button'
-            data-track-category='PENDING_MESSAGE'
-            data-track-name='delete_failed_send'
-            className='font-medium underline hover:opacity-80'
-            onClick={() => removePending(pendingEntry.messageId)}
-          >
-            Delete
-          </button>
-        </div>
-      )}
     </div>
   );
 };

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -30,7 +30,6 @@ import { useZeroConnectionLogger } from '../services/zeroConnectionLogger';
 import { useCachedQuery } from '../hooks/useCachedQuery';
 import { authRefreshDuration, authRefreshTotal, safeRecordMetric } from '../services/otel';
 import { SharedAuthProvider, HttpClientProvider, ChannelServiceProvider } from '@xyne/shared/hooks';
-import { usePendingQueue } from '@xyne/shared/messages';
 import { axiosHttpClient } from '../services/affinityService';
 import { channelService } from '../services/Chat/channelService';
 
@@ -91,10 +90,6 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
   logger.setZeroClientGroupId(zero.clientGroupID);
 
   useZeroConnectionLogger(state);
-
-  // Durable pending-message queue: reconciles server-confirmed sends and
-  // auto-retries messages queued while the socket was reconnecting.
-  usePendingQueue();
 
   // Connection failure modal state — in-memory only
   const [showModal, setShowModal] = useState(false);


### PR DESCRIPTION
This reverts PR #281 ("feat: reuse shared pending-message framework in dashboard channel sends", squash-merge commit `eec48250df8c1822e2e79531c663d85f07d1daaf`) on the `release-20260817` release branch.

**Reason:** After #281, channel message **attachments are no longer being sent**. Reverting to restore attachment sending on this release.

**Scope:** Clean `git revert` of the squash commit — 4 dashboard files, 23 insertions / 80 deletions (exact inverse of #281):
- apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
- apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
- apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
- apps/dashboard/src/providers/InitialStateLoader.tsx

No merge conflicts. Note: this reverts only on `release-20260817`; `main` still carries #281.