### PR TITLE
fix: XYNE-56181 restore cmd+K on every back, and give the results pag…

### DIFF
--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft } from '@xyne/icons';
 import { ResizableGroup, Panel, Separator } from '../../ui/Resizable/Resizable';
 import {
   FileText,
@@ -174,6 +175,7 @@ function buildSelectedMentions(
 
 const SearchResults = (): ReactElement => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   const { isMobile } = usePlatform();
   const [selectedPanel, setSelectedPanel] = useState<SidePanelState>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -769,8 +771,24 @@ const SearchResults = (): ReactElement => {
   const resultsColumn = (
     <div className='relative flex flex-col h-full min-h-0'>
       <div className='shrink-0 px-4'>
-        <div className='pt-4'>
-          <SearchQueryInput query={query} onSubmit={handleQuerySubmit} isSearching={isLoading} />
+        <div className='pt-4 flex items-center gap-2'>
+          {/* This page is only ever arrived at from somewhere — the cmd+K palette, or a
+              link out of it — and it is the one screen that renders no AppNavigator, so it
+              had no in-app way back at all. Going back lands on the palette's own history
+              entry, which reopens cmd+K with the search still in it. */}
+          <button
+            type='button'
+            aria-label='Back'
+            onClick={() => void navigate(-1)}
+            className='size-7 shrink-0 flex items-center justify-center rounded-[10px] border border-transparent transition-colors text-sidebar-secondary-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent'
+            data-track-category='SEARCH_RESULTS'
+            data-track-name='GO_BACK'
+          >
+            <ArrowLeft size={16} />
+          </button>
+          <div className='flex-1 min-w-0'>
+            <SearchQueryInput query={query} onSubmit={handleQuerySubmit} isSearching={isLoading} />
+          </div>
         </div>
         <div className='mt-3'>
           <SearchFilterBar filters={filters} onFiltersChange={handleFiltersChange} />

--- a/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
+++ b/apps/dashboard/src/hooks/useHistoryBackedOverlay.ts
@@ -95,6 +95,13 @@ export function useHistoryBackedOverlay<TPayload = unknown>({
       return;
     }
 
+    // Standing anywhere but our entry ends the "already restored this one" guard below.
+    // That guard only exists to stop a close-in-place from immediately re-restoring, and
+    // react-router hands an entry the SAME `location.key` every time it is popped back to
+    // — so without this reset the guard never lifts and an entry can be restored exactly
+    // once per session. Leaving the entry is what makes the next return a fresh visit.
+    if (!isOverlayEntry) restoredKeyRef.current = null;
+
     if (open && !pushedRef.current) {
       pushedRef.current = true;
       navigatingRef.current = false;


### PR DESCRIPTION


https://github.com/user-attachments/assets/4be32199-057f-45f8-aab8-1f4f8efc775b



## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-56181. Two related fixes to the cmd+K → back → "my search is still there" flow.

**1. The restore only ever fired once per history entry.** `useHistoryBackedOverlay` sets
`restoredKeyRef = location.key` when it restores the palette and never clears it. React Router
hands an entry the *same* `location.key` every time it is popped back to, so the guard never
lifted: the first back from a chat reopened cmd+K with the search in it, and every back after
that landed you on a bare page with the palette shut — even though the entry still carried the
payload. Fix is to clear the ref whenever we're standing anywhere but our own entry; leaving is
what makes the next return a fresh visit. The guard's actual purpose (stopping a close-in-place
from immediately re-restoring) still holds, because the entry stays current in that case.

**2. The full-screen results page had no back affordance at all.** It's the one screen that
renders no `AppNavigator`, so the restore was reachable only via the browser/trackpad gesture,
never from inside the app. Added a back arrow inline before the query input.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Manually in the browser, plus a scripted Playwright walkthrough that asserts each step and
records itself — attached. Five assertions, all green:

| # | Check | Result |
|---|---|---|
| 1 | Opening cmd+K pushes a history entry (marker on `location.state`, same URL) | idx 0 → 1 |
| 2 | Open a chat from a result → back → palette reopens with the query | reopened "incidents" |
| 3 | **Do it again** → back → reopens again | reopened again ← the bug |
| 4 | Results page renders a back arrow | present (`SEARCH_RESULTS/GO_BACK`) |
| 5 | That arrow reopens cmd+K with the query | reopened "incidents" |

Before the fix, #3 failed: same entry key, marker and payload both still on the entry, palette
closed. Verified by reading `window.history.state` directly rather than trusting the screenshot,
since the URL is unchanged when the palette opens.

Also checked I didn't break what the guard was for: Escape on a restored palette does **not**
spring it back open, a fresh open + Escape still pops its own entry (stack left as found), and
the results-page round trip still restores.

**Known, unchanged by this PR:** the top-bar back arrow is not clickable while the palette is
open — the modal sets `body { pointer-events: none }`. Clicking there still closes the palette,
but via click-outside dismissal, not the arrow. Pre-existing; worth a follow-up.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — the bug is history-stack behaviour across real navigations
      (`location.key` reuse on pop), which the current suite has no harness for. Covered by the
      attached self-asserting Playwright script instead; happy to land that as a spec if wanted.

### Manual

**Users**
- [x] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

*(Not exercised — the change is client-side history/overlay state with no server or ACL surface.)*

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (backend :3001 + dashboard :5173)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — n/a, Zero untouched

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [x] Large / realistic data volume (291-result query)
- [ ] Empty state
- [ ] Error paths

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes — **could not run locally**: it dies on the corepack pnpm
      version pin (`configured to use 10.15.0 … current pnpm is v11.21.0`), which is
      pre-existing and unrelated to this diff. `packages/shared` and `packages/icons` do build
      clean via `pnpm exec tsc` directly. Relying on CI here.
- [ ] Backend `typecheck` + `build` pass — not run; no backend files touched.
- [x] Dashboard `typecheck` passes (`tsc --noEmit -p tsconfig.app.json`, clean)
- [x] eslint clean on both changed files (0 errors; 1 pre-existing
      `explicit-function-return-type` warning already on `useHistoryBackedOverlay.ts`)
- [ ] Dashboard `build` — not run locally.
- [x] Formatting clean (`prettier --check` on both files)
- [x] No new deps
- [x] Commit follows `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [ ] Docs / guidelines updated — n/a, no documented behaviour changed
- [x] No debug logging or commented-out code left behind