### PR TITLE
fix: XYNE-55471 clear both lanes' Zero stores on logout

### DIFF
--- a/apps/dashboard/src/machines/authMachine.ts
+++ b/apps/dashboard/src/machines/authMachine.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import { reactNativeBridge } from '../utils/reactNativeBridge';
 import { mixpanelService, EVENTS, EVENT_PROPERTIES } from '../services/Analytics/mixpanelService';
-import { API_BASE_URL, isTestEnv } from '../config';
+import { API_BASE_URL, isSdlcSurface, isTestEnv } from '../config';
 import { logger } from '../utils/logger';
 import {
   CommunityJoinResultStatus,
@@ -19,7 +19,7 @@ import { indexedDBService } from '../services/indexedDBService';
 import { resetEncryption } from './encryptionMachine';
 import { decryptionCache } from '@xyne/shared';
 import { resetGlobalEncryptionBootstrap } from '@xyne/shared/hooks';
-import { dropZeroDatabases } from '../zero/dropZeroDatabases';
+import { dropAllZeroDatabases, dropZeroDatabases } from '../zero/dropZeroDatabases';
 
 export interface User {
   id: string;
@@ -1338,7 +1338,9 @@ export const authMachine = createMachine(
           /* empty */
         }
 
-        await dropZeroDatabases();
+        // Logout is the one place a cross-lane drop is right: both bundles are going
+        // away. The lane must not take out its host's store, so it only drops its own.
+        await (isSdlcSurface ? dropZeroDatabases() : dropAllZeroDatabases());
         await indexedDBService.dropAllUserDatabases();
       }),
       processOAuthCallback: fromPromise(async () => {

--- a/apps/dashboard/src/zero/dropZeroDatabases.ts
+++ b/apps/dashboard/src/zero/dropZeroDatabases.ts
@@ -1,4 +1,4 @@
-import { dropDatabase } from '@rocicorp/zero';
+import { dropAllDatabases, dropDatabase } from '@rocicorp/zero';
 import { ZERO_STORAGE_KEY } from '../config';
 
 // Zero's dropAllDatabases() deletes every Zero store in the origin, not just this
@@ -68,4 +68,13 @@ export async function dropZeroDatabases(): Promise<void> {
     .filter((name): name is string => !!name && parseLaneKey(name) === key);
 
   await Promise.all(ours.map(name => dropDatabase(name).catch(() => undefined)));
+}
+
+/**
+ * Drops every lane's Zero databases. Correct only at logout, where both bundles
+ * are torn down. Everywhere else use dropZeroDatabases(): deleting the other
+ * lane's store under a live client is what raises IDBNotFoundError.
+ */
+export async function dropAllZeroDatabases(): Promise<void> {
+  await dropAllDatabases().catch(() => undefined);
 }


### PR DESCRIPTION
Stacked on `feature/sdlc-fastlane-release-20260817` (#787).

### The gap

`performLogout` dropped Zero stores **lane-scoped**, so the SDLC lane's store survived logout with the departing user's synced data still on disk:

```ts
await dropZeroDatabases();                       // main lane only
await indexedDBService.dropAllUserDatabases();   // already cross-lane
```

The app's own stores were fine — `DB_PREFIX` (`xyne-state-machine`) has no lane component, so that call already cleared both. It was specifically the lane's Zero store that persisted.

Not cross-user leakage: Zero keys stores as `rep:zero-<userID>-<laneKey>`, so a different user gets a different store. But "log me out of this machine" should not leave the previous user's data behind.

### The change

```ts
// Logout is the one place a cross-lane drop is right: both bundles are going
// away. The lane must not take out its host's store, so it only drops its own.
await (isSdlcSurface ? dropZeroDatabases() : dropAllZeroDatabases());
```

plus a new `dropAllZeroDatabases()` alongside the scoped one, so a single module owns Zero-store deletion and the constraint is documented where it's easy to find.

### Why this is not the escape hatch we removed

The hatch removed in #832 fired on **workspace switch, schema mismatch and re-auth** — moments where the lane keeps running, so deleting its store left a live client broken (`IDBNotFoundError`). Logout is different: both bundles are being torn down.

The asymmetry is deliberate. The parent owns the session and may clear everything; the lane is a guest inside it and must never delete its host's store.

**Every other drop site must stay scoped.** The doc comment on `dropAllZeroDatabases()` says so explicitly, to stop it being reused elsewhere.

### Known trade-off

Logout is a client-side transition (no page navigation), so the frame is still mounted when the drop runs — the frame's Zero client may log one transient `IDBNotFoundError` as it is torn down. Not broken state; the frame is destroyed immediately after. If that shows up in monitoring, the follow-up is a `logout` message on the existing frame bridge so the frame closes its own client first.

### Verification

- `tsc --noEmit`: identical to base — 1 pre-existing error (`@xyne/shared/index`, a build artifact), none in the touched files
- `prettier --check`: clean
- `eslint`: 0 errors (3 pre-existing `Content-Type` warnings at L1396/1446/1547, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)