### PR TITLE
fix: XYNE-55471 clear both lanes' Zero stores on logout

### DIFF
--- a/apps/dashboard/src/machines/authMachine.ts
+++ b/apps/dashboard/src/machines/authMachine.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import { reactNativeBridge } from '../utils/reactNativeBridge';
 import { mixpanelService, EVENTS, EVENT_PROPERTIES } from '../services/Analytics/mixpanelService';
-import { API_BASE_URL, isTestEnv } from '../config';
+import { API_BASE_URL, isSdlcSurface, isTestEnv } from '../config';
 import { logger } from '../utils/logger';
 import {
   CommunityJoinResultStatus,
@@ -19,7 +19,7 @@ import { indexedDBService } from '../services/indexedDBService';
 import { resetEncryption } from './encryptionMachine';
 import { decryptionCache } from '@xyne/shared';
 import { resetGlobalEncryptionBootstrap } from '@xyne/shared/hooks';
-import { dropZeroDatabases } from '../zero/dropZeroDatabases';
+import { dropAllZeroDatabases, dropZeroDatabases } from '../zero/dropZeroDatabases';
 
 export interface User {
   id: string;
@@ -1338,7 +1338,9 @@ export const authMachine = createMachine(
           /* empty */
         }
 
-        await dropZeroDatabases();
+        // Logout is the one place a cross-lane drop is right: both bundles are going
+        // away. The lane must not take out its host's store, so it only drops its own.
+        await (isSdlcSurface ? dropZeroDatabases() : dropAllZeroDatabases());
         await indexedDBService.dropAllUserDatabases();
       }),
       processOAuthCallback: fromPromise(async () => {

--- a/apps/dashboard/src/zero/dropZeroDatabases.ts
+++ b/apps/dashboard/src/zero/dropZeroDatabases.ts
@@ -1,4 +1,4 @@
-import { dropDatabase } from '@rocicorp/zero';
+import { dropAllDatabases, dropDatabase } from '@rocicorp/zero';
 import { ZERO_STORAGE_KEY } from '../config';
 
 // Zero's dropAllDatabases() deletes every Zero store in the origin, not just this
@@ -68,4 +68,13 @@ export async function dropZeroDatabases(): Promise<void> {
     .filter((name): name is string => !!name && parseLaneKey(name) === key);
 
   await Promise.all(ours.map(name => dropDatabase(name).catch(() => undefined)));
+}
+
+/**
+ * Drops every lane's Zero databases. Correct only at logout, where both bundles
+ * are torn down. Everywhere else use dropZeroDatabases(): deleting the other
+ * lane's store under a live client is what raises IDBNotFoundError.
+ */
+export async function dropAllZeroDatabases(): Promise<void> {
+  await dropAllDatabases().catch(() => undefined);
 }


### PR DESCRIPTION
Main-side counterpart of #836. Stacked on `feature/sdlc-scoped-zero-storage` (#761).

Cherry-picked from `feature/sdlc-logout-drop-all-lanes-release-20260817` — the two branches have identical structure here, so it applied without conflict.

### The gap

`performLogout` dropped Zero stores **lane-scoped**, so the SDLC lane's store survived logout with the departing user's synced data still on disk. The app's own stores were already cleared for both lanes (`DB_PREFIX` has no lane component); it was specifically the lane's Zero store that persisted.

Not cross-user leakage — Zero keys stores as `rep:zero-<userID>-<laneKey>` — but "log me out of this machine" should not leave the previous user's data behind.

### The change

```ts
// Logout is the one place a cross-lane drop is right: both bundles are going
// away. The lane must not take out its host's store, so it only drops its own.
await (isSdlcSurface ? dropZeroDatabases() : dropAllZeroDatabases());
```

The asymmetry is deliberate: the parent owns the session and may clear everything; the lane is a guest and must never delete its host's store.

### Why this is not the escape hatch we removed

That hatch fired on **workspace switch, schema mismatch and re-auth**, where the lane keeps running — deleting its store left a live client broken (`IDBNotFoundError`). Logout is different: both bundles are torn down. **Every other drop site must stay scoped**, and the doc comment on `dropAllZeroDatabases()` says so to prevent reuse.

### Known trade-off

Logout is a client-side transition, so the frame is still mounted when the drop runs and may log one transient `IDBNotFoundError` as it is destroyed. Not broken state. If it shows up in monitoring, the follow-up is a `logout` message on the existing frame bridge.

### Verification

- `prettier --check`: clean
- `eslint`: 0 errors (3 pre-existing `Content-Type` warnings, unrelated)
- typecheck verified identical-to-base on the 0817 branch carrying the same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)