### PR TITLE
fix: ask ai calls with transcript

### DIFF
--- a/apps/backend/src/services/vespaSearch/resultTransform.ts
+++ b/apps/backend/src/services/vespaSearch/resultTransform.ts
@@ -568,12 +568,34 @@ import { PrismaClient } from '@prisma/client';
        logger.warn('Invalid createdAt for attachment:', doc.docId, doc.createdAt);
      }
 
+     // The body the hit actually matched on. Vespa ranks `file` docs over their
+     // `chunks` (for subApp=TRANSCRIPT those chunks ARE the call transcript), so
+     // echoing fileName here made every content match come back with no content
+     // — callers could see THAT a transcript matched but never WHAT was said.
+     const chunkContent = pickBestChunk(hit, doc);
+
+     // TRANSCRIPT docs are keyed by the internal call id, but the call APIs
+     // (…/download-transcript, recording detail) are keyed by externalId, which
+     // only exists inside the doc's metadata JSON. Surface both so a caller can
+     // go from a search hit to the full transcript without a second lookup.
+     let callId: string | undefined;
+     let externalId: string | undefined;
+     if (doc.subApp?.toUpperCase() === 'TRANSCRIPT' && doc.metadata) {
+       try {
+         const parsed = JSON.parse(doc.metadata) as { callId?: string; externalId?: string };
+         callId = parsed.callId;
+         externalId = parsed.externalId;
+       } catch (error) {
+         logger.warn('Failed to parse metadata for transcript:', doc.docId);
+       }
+     }
+
      return {
        id: doc.docId,
        type: 'attachment',
        title: doc.fileName,
        subtitle: doc.description,
-       context: doc.fileName,
+       context: chunkContent || doc.description || doc.fileName,
        relevanceScore: hit.relevance,
        avatar: doc.ownerId,
        metadata: {
@@ -592,10 +614,51 @@ import { PrismaClient } from '@prisma/client';
          callType: doc.callType,
          fileSize: doc.fileSize,
          mimeType: doc.mimeType,
+         ...(callId ? { callId } : {}),
+         ...(externalId ? { externalId } : {}),
        },
      };
    }
    
+/**
+ * Pick the chunk a `file` hit actually matched on.
+ *
+ * Vespa's `chunk_scores` match-feature is the authoritative signal, but it is
+ * only present when the deployed rank profile publishes it. Fall back to the
+ * chunk carrying the most `<hi>` highlights (the same heuristic transformMail
+ * uses), then to the first chunk. Never substring the result — that could cut a
+ * `<hi>` tag in half; the dashboard's SearchSnippetRenderer windows it instead.
+ */
+function pickBestChunk(hit: VespaSearchHit, doc: VespaFileDocument): string {
+  const chunks = doc.chunks;
+  if (!chunks || chunks.length === 0) return '';
+
+  const chunkScores = (hit.fields as any)?.matchfeatures?.chunk_scores;
+  if (chunkScores?.cells && typeof chunkScores.cells === 'object') {
+    let maxScore = -Infinity;
+    let bestIndex = 0;
+    for (const [idx, score] of Object.entries(chunkScores.cells)) {
+      if (typeof score === 'number' && score > maxScore) {
+        maxScore = score;
+        bestIndex = parseInt(idx, 10);
+      }
+    }
+    if (bestIndex >= 0 && bestIndex < chunks.length) return chunks[bestIndex] || '';
+  }
+
+  let best = '';
+  let bestCount = 0;
+  for (const c of chunks) {
+    if (typeof c !== 'string') continue;
+    const count = (c.match(/<hi>/g) || []).length;
+    if (count > bestCount) {
+      bestCount = count;
+      best = c;
+    }
+  }
+  return best || chunks[0] || '';
+}
+
 /**
  * Transform collection document (knowledge base file)
  */

--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -433,6 +433,9 @@ const buildClawCitationTooltip = (citation: ClawCitation | null): string => {
   if (citation.kind === 'canvas') {
     return citation.label ? `Canvas — ${citation.label}` : 'Canvas';
   }
+  if (citation.kind === 'recording') {
+    return citation.label ? `Recording — ${citation.label}` : 'Recording';
+  }
   if (citation.kind === 'external') {
     return citation.label || citation.url || 'External link';
   }

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPickerPanel.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPickerPanel.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback, useMemo, useRef } from 'react';
 import GlobalCommandMenu from '../../../GlobalCommandMenu/GlobalCommandMenu';
 import type { ContextItem } from '../../ThreadContextPanel/ThreadContextPanel.types';
 import { TabType } from '../../ChatDirectory/ChannelCommandMenu.types';
+import type { CanvasRole } from '../utils/XyneAITypes';
 
 // ─── Exported Types ───────────────────────────────────────────────────────────
 
@@ -27,6 +28,14 @@ export interface SelectedCanvas {
    * attachment id for dedupe and is not what the canvas route accepts.
    */
   canvasId?: string;
+  /**
+   * What this canvas IS, when the attaching screen knows. A recording attaches two
+   * canvases that look identical from their row alone — the machine-written summary
+   * and the human's own notes — and the agent has to weigh them very differently.
+   * Undefined for a canvas the user picked by hand; the agent then treats it as a
+   * plain document.
+   */
+  canvasRole?: CanvasRole;
 }
 
 /**
@@ -64,6 +73,8 @@ export interface AttachedContextItem {
   id: string;
   title: string;
   threadId?: string;
+  /** Canvas items only — see SelectedCanvas.canvasRole. */
+  canvasRole?: CanvasRole;
   // For activity items
   eventName?: string;
   eventCategory?: string;
@@ -99,6 +110,7 @@ export function toAttachedContext(selections: ContextSelections): AttachedContex
       type: 'canvas',
       id: canvas.id,
       title: canvas.title,
+      ...(canvas.canvasRole ? { canvasRole: canvas.canvasRole } : {}),
     });
   }
 

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
@@ -137,6 +137,9 @@ const buildClawCitationTooltip = (citation: ClawCitation | null): string => {
   if (citation.kind === 'canvas') {
     return citation.label ? `Canvas — ${citation.label}` : 'Canvas';
   }
+  if (citation.kind === 'recording') {
+    return citation.label ? `Recording — ${citation.label}` : 'Recording';
+  }
   if (citation.kind === 'external') {
     return citation.label || citation.url || 'External link';
   }

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
@@ -10,9 +10,18 @@ export interface SelectedChannel {
   isPrivate: boolean;
 }
 
+/**
+ * What a canvas IS, for screens that attach one on the user's behalf.
+ * `call-notes` = the human's own notes taken during the call; `call-summary` =
+ * the AI-generated summary of it. The two are easy to confuse from the row
+ * alone but carry very different authority, so the role travels with the item.
+ */
+export type CanvasRole = 'call-notes' | 'call-summary';
+
 export interface SelectedCanvas {
   id: string;
   title: string;
+  canvasRole?: CanvasRole;
 }
 
 export interface SelectedTicket {

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
@@ -118,7 +118,7 @@ export interface StoredMessage {
  */
 export interface ClawCitation {
   label?: string;
-  kind: 'thread' | 'canvas' | 'ticket' | 'external' | 'collection-item';
+  kind: 'thread' | 'canvas' | 'ticket' | 'external' | 'collection-item' | 'recording';
   channelId?: string;
   conversationId?: string;
   messageId?: string;
@@ -126,6 +126,9 @@ export interface ClawCitation {
   channelType?: string;
   channelKind?: string;
   canvasId?: string;
+  /** For kind="recording": the call's externalId — the `/recordings/:id` segment.
+   *  Note-taker recordings have no channel or thread, so this is their only link. */
+  recordingId?: string;
   ticketId?: string;
   xyneId?: string;
   mailId?: string;

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/utils/clawCitationUrl.ts
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/utils/clawCitationUrl.ts
@@ -73,6 +73,13 @@ export function buildClawCitationUrl(citation: ClawCitation): string | null {
     return `/chat/canvas/${citation.canvasId}`;
   }
 
+  // Note-taker recordings have no channel and no thread, so they can't be cited
+  // as one. `recordingId` is the call's externalId — the segment the
+  // `recordings/:recordingId` route reads.
+  if (citation.kind === 'recording' && citation.recordingId) {
+    return `/recordings/${citation.recordingId}`;
+  }
+
   if (
     citation.kind === 'ticket' &&
     citation.ticketId &&
@@ -144,6 +151,7 @@ export function getClawCitationLabel(citation: ClawCitation): string {
     return citation.channelName ? `Thread in #${citation.channelName}` : 'Spaces thread';
   }
   if (citation.kind === 'canvas') return 'Canvas';
+  if (citation.kind === 'recording') return 'Recording';
   if (citation.kind === 'ticket') return `Ticket ${citation.ticketId || ''}`.trim();
   if (citation.kind === 'external') return 'Source link';
   if (citation.kind === 'collection-item') return citation.fileName || 'Knowledge base file';

--- a/apps/dashboard/src/components/ui/MessageBubble/ThreadCitationChip.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/ThreadCitationChip.tsx
@@ -97,6 +97,9 @@ function buildTooltip(citation: ClawCitation | null, fallback: string): string {
   if (citation.kind === 'canvas') {
     return citation.label ? `Canvas — ${citation.label}` : 'Canvas';
   }
+  if (citation.kind === 'recording') {
+    return citation.label ? `Recording — ${citation.label}` : 'Recording';
+  }
   if (citation.kind === 'external') {
     return citation.label || citation.url || 'External link';
   }

--- a/apps/dashboard/src/machines/xyneAIMachine.ts
+++ b/apps/dashboard/src/machines/xyneAIMachine.ts
@@ -1,6 +1,7 @@
 import { logger, Event as LogEvent } from '../utils/logger';
 import { setup, createActor, assign } from 'xstate';
 import { RefObject } from 'react';
+import type { CanvasRole } from '../components/Chat/XyneAISidebar/utils/XyneAITypes';
 
 // Available XyneAI states
 export type XyneAIState = 'closed' | 'open';
@@ -70,7 +71,10 @@ export interface CanvasSelectionContext {
  * context that it sends to the Claw API.
  */
 export interface AskAIInitialContextSelections {
-  canvases: Array<{ id: string; title: string; canvasId?: string }>;
+  /** `canvasRole` marks what an auto-attached canvas IS (a recording attaches
+   *  both its AI summary and the user's own notes) so the agent can weigh them
+   *  differently. Must stay declared here or the role is dropped in transit. */
+  canvases: Array<{ id: string; title: string; canvasId?: string; canvasRole?: CanvasRole }>;
   tickets?: Array<{ id: string; title: string; xyneId?: string; status?: string }>;
   recordings: Array<{
     id: string;

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -661,6 +661,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
     if (!recording) return;
     const attachmentIds = (message?.attachments ?? []).map((att: { id: string }) => att.id);
     const hasThreadContext = !!recording.conversationId || attachmentIds.length > 0;
+    // Both canvases are attached with an explicit role: from the row alone the
+    // agent cannot tell the machine-written summary from the user's own notes,
+    // and it must weigh them differently.
     const canvasSelections = [
       ...(recording.detailedSummaryCanvasId
         ? [
@@ -668,6 +671,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
               id: recording.detailedSummaryCanvasId,
               canvasId: recording.detailedSummaryCanvasId,
               title: `${recording.title || 'Recording'} summary`,
+              canvasRole: 'call-summary' as const,
             },
           ]
         : []),
@@ -677,6 +681,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
               id: notesCanvasId,
               canvasId: notesCanvasId,
               title: `${recording.title || 'Recording'} notes`,
+              canvasRole: 'call-notes' as const,
             },
           ]
         : []),

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -40,7 +40,7 @@ import {
   type RecordingOwnershipTab,
 } from './utils/RecordingsV2.utils';
 import { normalizeRecordingTags } from '../../utils/recordingUtils';
-import { DEFAULT_RECORDING_TITLE } from '@/utils/recordingUtils';
+import { DEFAULT_RECORDING_TITLE, readRecordingCanvasIds } from '@/utils/recordingUtils';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { SummaryTemplatesModal } from '../RecordingDetailV2Screen/components/SummaryTemplatesModal';
 import { useSummaryTemplates } from '../../hooks/useSummaryTemplates';
@@ -249,13 +249,45 @@ const RecordingsV2Screen = (): ReactElement => {
   }, []);
 
   const handleConfirmAskAIContext = useCallback((selected: OatsRecordingEntry[]): void => {
+    // Attach each recording's documents alongside the recording itself, the same
+    // way the detail screen does — otherwise Ask AI opened from the list gets only
+    // the call and has to rediscover the summary and the user's notes. Each canvas
+    // carries its role, because from the row alone the machine-written summary and
+    // the human's notes are indistinguishable.
+    const canvases = selected.flatMap(recording => {
+      const title = recording.title || DEFAULT_RECORDING_TITLE;
+      const { summaryCanvasId, notesCanvasId } = readRecordingCanvasIds(recording.metadata);
+      return [
+        ...(summaryCanvasId
+          ? [
+              {
+                id: summaryCanvasId,
+                canvasId: summaryCanvasId,
+                title: `${title} summary`,
+                canvasRole: 'call-summary' as const,
+              },
+            ]
+          : []),
+        ...(notesCanvasId && notesCanvasId !== summaryCanvasId
+          ? [
+              {
+                id: notesCanvasId,
+                canvasId: notesCanvasId,
+                title: `${title} notes`,
+                canvasRole: 'call-notes' as const,
+              },
+            ]
+          : []),
+      ];
+    });
+
     xyneAIActor.send({
       type: 'OPEN',
       contextType: 'general',
       threadInfo: null,
       startFreshChat: true,
       initialContextSelections: {
-        canvases: [],
+        canvases,
         recordings: selected.map(recording => ({
           id: recording.id,
           title: recording.title || DEFAULT_RECORDING_TITLE,

--- a/apps/dashboard/src/utils/recordingUtils.ts
+++ b/apps/dashboard/src/utils/recordingUtils.ts
@@ -251,3 +251,23 @@ export const STT_MODEL_LABELS: Record<string, string> = {
 export const STT_MODELS = ['google', 'azure', 'deepgram'] as const;
 
 export type SttModel = (typeof STT_MODELS)[number];
+
+/**
+ * Pull a recording's two document ids out of `Call.metadata`.
+ *
+ * Neither has a column of its own: the note-taker webhook stamps `notesCanvasId`
+ * (older rows carry `notesCanvasViewAccessId` instead) and the summary pipeline
+ * stamps `detailedSummaryCanvasId`. Both are absent for recordings created before
+ * those canvases existed, so every caller must handle nulls.
+ */
+export const readRecordingCanvasIds = (
+  metadata: unknown,
+): { summaryCanvasId: string | null; notesCanvasId: string | null } => {
+  const meta = (metadata ?? null) as Record<string, unknown> | null;
+  const rawSummary = meta?.['detailedSummaryCanvasId'];
+  const rawNotes = meta?.['notesCanvasId'] ?? meta?.['notesCanvasViewAccessId'];
+  return {
+    summaryCanvasId: typeof rawSummary === 'string' && rawSummary ? rawSummary : null,
+    notesCanvasId: typeof rawNotes === 'string' && rawNotes ? rawNotes : null,
+  };
+};


### PR DESCRIPTION
POT https://drive.google.com/file/d/1v9Z4L0-YIw0KcR83ZNpFFcHIkH_AJMXs/view?usp=sharing
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
