### PR TITLE
fix: XYNE-56609 make  Outbound webhook url optional in app desk

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1340,6 +1340,7 @@ export const emailChannelPreferenceTable = table("email_channel_preferences")
     workspaceId: string(),
     metricsEnabled: boolean().optional(),
     frtStageNames: string().optional(),
+    appWebhookDeliveryEnabled: boolean(),
   })
   .primaryKey("channelId");
 

--- a/apps/backend/prisma/migrations/20260820120000_add_app_webhook_delivery_preference/migration.sql
+++ b/apps/backend/prisma/migrations/20260820120000_add_app_webhook_delivery_preference/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."email_channel_preferences"
+  ADD COLUMN IF NOT EXISTS "appWebhookDeliveryEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2201,6 +2201,7 @@ model EmailChannelPreference {
   workspaceId            String
   metricsEnabled         Boolean? // Gates the desk metrics dashboard
   frtStageNames          String?  // JSON-serialised string[] of stage names whose first entry stops the FRT clock
+  appWebhookDeliveryEnabled Boolean @default(true) // APP desks only: off means replies are stored without ever calling the app webhook
   @@index([ownerUserId])
   @@index([assigneeUserGroupId])
   @@index([boardId])

--- a/apps/backend/src/services/appDeskService.ts
+++ b/apps/backend/src/services/appDeskService.ts
@@ -67,10 +67,15 @@ class AppDeskService {
       where: { channelId: conversation.channelId },
       select: { appWebhookDeliveryEnabled: true },
     });
-    const webhookDeliveryEnabled = preference?.appWebhookDeliveryEnabled ?? true;
-    const outboundConfigured =
-      webhookDeliveryEnabled &&
-      Boolean(installedApp.webhookUrl?.trim() && installedApp.app?.signingSecret);
+    const outboundConfigured = preference?.appWebhookDeliveryEnabled ?? true;
+    const webhookConfigured = Boolean(
+      installedApp.webhookUrl?.trim() && installedApp.app?.signingSecret,
+    );
+    if (outboundConfigured && !webhookConfigured) {
+      throw new Error(
+        'This desk delivers replies to the app webhook, but the app has no webhook URL configured. Add one, or turn off "Send replies to app webhook" in Desk Settings.',
+      );
+    }
     const signingSecret = installedApp.app?.signingSecret ?? null;
 
     const replier = await this.prisma.user.findUnique({
@@ -118,11 +123,7 @@ class AppDeskService {
       timestamp: new Date().toISOString(),
     };
 
-    const skipReason = !webhookDeliveryEnabled
-      ? 'webhook delivery disabled for channel'
-      : 'no outbound webhook';
-
-    logger.info(`${TAG} ${outboundConfigured ? 'delivering' : `recording (${skipReason})`} DESK_REPLY`, {
+    logger.info(`${TAG} ${outboundConfigured ? 'delivering' : 'recording (webhook delivery disabled)'} DESK_REPLY`, {
       conversationId,
       channelId: conversation.channelId,
       threadId,
@@ -130,7 +131,7 @@ class AppDeskService {
       installedAppId,
       webhookUrl: installedApp?.webhookUrl ?? null,
       outboundConfigured,
-      webhookDeliveryEnabled,
+      webhookConfigured,
       ticketId: ticket?.id,
       replierUserId: userId,
       replierName,
@@ -239,7 +240,7 @@ class AppDeskService {
     }
 
     logger.info(
-      `${TAG} ${outboundConfigured ? 'Reply delivered to app webhook' : `Reply recorded on ticket (${skipReason})`}`,
+      `${TAG} ${outboundConfigured ? 'Reply delivered to app webhook' : 'Reply recorded on ticket (webhook delivery disabled)'}`,
       { conversationId, threadId, externalId: ackExternalId, emailId: email.id },
     );
 

--- a/apps/backend/src/services/appDeskService.ts
+++ b/apps/backend/src/services/appDeskService.ts
@@ -63,9 +63,14 @@ class AppDeskService {
     if (!installedApp) {
       throw new Error(`The app backing this desk no longer exists (install ${installedAppId})`);
     }
-    const outboundConfigured = Boolean(
-      installedApp.webhookUrl?.trim() && installedApp.app?.signingSecret,
-    );
+    const preference = await this.prisma.emailChannelPreference.findUnique({
+      where: { channelId: conversation.channelId },
+      select: { appWebhookDeliveryEnabled: true },
+    });
+    const webhookDeliveryEnabled = preference?.appWebhookDeliveryEnabled ?? true;
+    const outboundConfigured =
+      webhookDeliveryEnabled &&
+      Boolean(installedApp.webhookUrl?.trim() && installedApp.app?.signingSecret);
     const signingSecret = installedApp.app?.signingSecret ?? null;
 
     const replier = await this.prisma.user.findUnique({
@@ -113,7 +118,11 @@ class AppDeskService {
       timestamp: new Date().toISOString(),
     };
 
-    logger.info(`${TAG} ${outboundConfigured ? 'delivering' : 'recording (no outbound webhook)'} DESK_REPLY`, {
+    const skipReason = !webhookDeliveryEnabled
+      ? 'webhook delivery disabled for channel'
+      : 'no outbound webhook';
+
+    logger.info(`${TAG} ${outboundConfigured ? 'delivering' : `recording (${skipReason})`} DESK_REPLY`, {
       conversationId,
       channelId: conversation.channelId,
       threadId,
@@ -121,6 +130,7 @@ class AppDeskService {
       installedAppId,
       webhookUrl: installedApp?.webhookUrl ?? null,
       outboundConfigured,
+      webhookDeliveryEnabled,
       ticketId: ticket?.id,
       replierUserId: userId,
       replierName,
@@ -229,7 +239,7 @@ class AppDeskService {
     }
 
     logger.info(
-      `${TAG} ${outboundConfigured ? 'Reply delivered to app webhook' : 'Reply recorded on ticket (desk is receive-only)'}`,
+      `${TAG} ${outboundConfigured ? 'Reply delivered to app webhook' : `Reply recorded on ticket (${skipReason})`}`,
       { conversationId, threadId, externalId: ackExternalId, emailId: email.id },
     );
 

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -14923,6 +14923,7 @@ export function createMutators(
           autoDraftAgentSlug: z.string().optional().nullable(),
           metricsEnabled: z.boolean().optional(),
           frtStageNames: z.string().optional().nullable(),
+          appWebhookDeliveryEnabled: z.boolean().optional(),
         }),
         async ({
           tx,
@@ -14938,6 +14939,7 @@ export function createMutators(
             autoDraftAgentSlug,
             metricsEnabled,
             frtStageNames,
+            appWebhookDeliveryEnabled,
           },
         }) => {
           const existing = await tx.run(
@@ -14956,6 +14958,7 @@ export function createMutators(
               ...(autoDraftAgentSlug !== undefined ? { autoDraftAgentSlug } : {}),
               ...(metricsEnabled !== undefined ? { metricsEnabled } : {}),
               ...(frtStageNames !== undefined ? { frtStageNames } : {}),
+              ...(appWebhookDeliveryEnabled !== undefined ? { appWebhookDeliveryEnabled } : {}),
             });
           } else {
             const channel = await tx.run(zql.channels.where('id', channelId).one());
@@ -14982,6 +14985,7 @@ export function createMutators(
               priorityClassificationThreshold: 0.5,
               metricsEnabled: metricsEnabled ?? false,
               frtStageNames: frtStageNames ?? null,
+              appWebhookDeliveryEnabled: appWebhookDeliveryEnabled ?? true,
             });
           }
         },

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/InboxTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/InboxTab.tsx
@@ -292,8 +292,7 @@ export const InboxTab: React.FC<InboxTabProps> = ({ channelId, form, signatures 
             <div className='text-desk-label'>Send replies to app webhook</div>
             <div className='text-desk-helper w-full max-w-[500px]'>
               Forward every reply to the app webhook, and accept the reply only once the webhook
-              responds with 200. Turn this off if the app does not consume replies — replies are
-              then stored on the ticket only.
+              responds with 200. Turn this off if the app does not consume replies.
             </div>
           </div>
           <Switch

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/InboxTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/InboxTab.tsx
@@ -59,6 +59,8 @@ export const InboxTab: React.FC<InboxTabProps> = ({ channelId, form, signatures 
     setTwoStepSend,
     autoMergeEmails,
     setAutoMergeEmails,
+    appWebhookDeliveryEnabled,
+    setAppWebhookDeliveryEnabled,
   } = form;
 
   const [ccInputValue, setCcInputValue] = useState('');
@@ -281,6 +283,26 @@ export const InboxTab: React.FC<InboxTabProps> = ({ channelId, form, signatures 
               </div>
             )}
           </div>
+        </div>
+      )}
+
+      {isApp && (
+        <div className='flex items-start justify-between gap-4'>
+          <div className='flex flex-col gap-[4px]'>
+            <div className='text-desk-label'>Send replies to app webhook</div>
+            <div className='text-desk-helper w-full max-w-[500px]'>
+              Forward every reply to the app webhook, and accept the reply only once the webhook
+              responds with 200. Turn this off if the app does not consume replies — replies are
+              then stored on the ticket only.
+            </div>
+          </div>
+          <Switch
+            variant='desk'
+            checked={appWebhookDeliveryEnabled}
+            onCheckedChange={setAppWebhookDeliveryEnabled}
+            disabled={!canManage}
+            aria-label='Toggle sending replies to the app webhook'
+          />
         </div>
       )}
 

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/useDeskSettingsForm.ts
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/useDeskSettingsForm.ts
@@ -200,6 +200,7 @@ export function useDeskSettingsForm(
     autoDraftAgentSlug: emailChannelPreference?.autoDraftAgentSlug ?? null,
     metricsEnabled: emailChannelPreference?.metricsEnabled ?? false,
     frtStageNames: emailChannelPreference?.frtStageNames ?? '[]',
+    appWebhookDeliveryEnabled: emailChannelPreference?.appWebhookDeliveryEnabled ?? true,
   });
   const cls = useDraft({
     enabled: classificationConfig?.enabled ?? false,
@@ -228,6 +229,7 @@ export function useDeskSettingsForm(
   const autoDraftAgentSlug = pref.draft.autoDraftAgentSlug;
   const metricsEnabled = pref.draft.metricsEnabled;
   const frtStageNames = parseFrtStageNames(pref.draft.frtStageNames);
+  const appWebhookDeliveryEnabled = pref.draft.appWebhookDeliveryEnabled;
   const boardId = emailChannelPreference?.boardId ?? null;
   const classificationEnabledDraft = cls.draft.enabled;
   const classificationEnabledSaved = classificationConfig?.enabled ?? false;
@@ -260,6 +262,10 @@ export function useDeskSettingsForm(
   const setMetricsEnabled = (checked: boolean) => {
     if (!canManage) return;
     pref.setField('metricsEnabled', checked);
+  };
+  const setAppWebhookDeliveryEnabled = (checked: boolean) => {
+    if (!canManage) return;
+    pref.setField('appWebhookDeliveryEnabled', checked);
   };
   const setFrtStageNames = (updater: string[] | ((prev: string[]) => string[])) => {
     if (!canManage) return;
@@ -339,6 +345,9 @@ export function useDeskSettingsForm(
       }
       if (d.metricsEnabled !== s.metricsEnabled) {
         patch.metricsEnabled = d.metricsEnabled;
+      }
+      if (d.appWebhookDeliveryEnabled !== s.appWebhookDeliveryEnabled) {
+        patch.appWebhookDeliveryEnabled = d.appWebhookDeliveryEnabled;
       }
       if (d.frtStageNames !== s.frtStageNames) {
         const names = parseFrtStageNames(d.frtStageNames);
@@ -453,6 +462,8 @@ export function useDeskSettingsForm(
     setMetricsEnabled,
     frtStageNames,
     setFrtStageNames,
+    appWebhookDeliveryEnabled,
+    setAppWebhookDeliveryEnabled,
     boardId,
     clawAgents,
     classificationEnabledDraft,

--- a/apps/dashboard/src/components/xyne-desk/SlackThread/SlackComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/SlackThread/SlackComposer.tsx
@@ -7,6 +7,7 @@ import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import { all, createLowlight } from 'lowlight';
 import { ArrowUp, Loader2, Paperclip, X } from 'lucide-react';
 import { toast } from 'sonner';
+import { getApiErrorMessage } from '../../../utils/apiError';
 import type { EmojiClickData } from 'emoji-picker-react';
 import { AutoDraftStatus } from '@xyne/shared';
 import { apiInstance, BASE_URL } from '../../../services/clients/apiClient';
@@ -173,8 +174,8 @@ const SlackComposer = ({
       setAttachments([]);
       lastLoadedDraftRef.current = '';
       deleteDraft();
-    } catch {
-      toast.error('Failed to send message');
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to send message'));
     } finally {
       setSending(false);
     }

--- a/apps/dashboard/src/hooks/useDeskChannelPreferenceAutoSave.ts
+++ b/apps/dashboard/src/hooks/useDeskChannelPreferenceAutoSave.ts
@@ -15,6 +15,7 @@ export type ChannelPreferencePatch = {
   autoDraftAgentSlug?: string | null;
   metricsEnabled?: boolean;
   frtStageNames?: string | null;
+  appWebhookDeliveryEnabled?: boolean;
 };
 
 /**

--- a/apps/dashboard/src/hooks/useEmailChannelPreference.ts
+++ b/apps/dashboard/src/hooks/useEmailChannelPreference.ts
@@ -36,6 +36,7 @@ export function useUpdateEmailChannelPreference() {
       autoDraftAgentSlug,
       metricsEnabled,
       frtStageNames,
+      appWebhookDeliveryEnabled,
     }: {
       channelId: string;
       ownerUserId?: string;
@@ -48,6 +49,7 @@ export function useUpdateEmailChannelPreference() {
       autoDraftAgentSlug?: string | null;
       metricsEnabled?: boolean;
       frtStageNames?: string | null;
+      appWebhookDeliveryEnabled?: boolean;
     }): Promise<void> => {
       zero.mutate(
         mutators.emailChannelPreference.upsert({
@@ -64,6 +66,7 @@ export function useUpdateEmailChannelPreference() {
             : {}),
           ...(metricsEnabled !== undefined ? { metricsEnabled } : {}),
           ...(frtStageNames !== undefined ? { frtStageNames } : {}),
+          ...(appWebhookDeliveryEnabled !== undefined ? { appWebhookDeliveryEnabled } : {}),
         }),
       );
       return Promise.resolve();

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -3927,7 +3927,6 @@ export const SupportTicketDetail = ({
 
   const channelIntegrationInfo = useChannelIntegrationInfo(channelId || null);
   const deskEmail = channelIntegrationInfo.email ?? '';
-  const { outboundConfigured } = channelIntegrationInfo;
 
   useAskAiTicketContext({
     channelId: channelId || null,
@@ -4857,7 +4856,10 @@ export const SupportTicketDetail = ({
                     channelId={channel?.id ?? null}
                     drafts={ticketEmailDrafts}
                     variant={channel?.type === ChannelType.APP ? 'app' : 'slack'}
-                    recordOnly={channel.type === ChannelType.APP && !outboundConfigured}
+                    recordOnly={
+                      channel.type === ChannelType.APP &&
+                      channelPreference?.appWebhookDeliveryEnabled === false
+                    }
                   />
                 ) : null
               ) : channel?.type === ChannelType.EMAIL ? (

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -9474,6 +9474,7 @@ export const mutators = defineMutators({
         autoDraftAgentSlug: z.string().optional().nullable(),
         metricsEnabled: z.boolean().optional(),
         frtStageNames: z.string().optional().nullable(),
+        appWebhookDeliveryEnabled: z.boolean().optional(),
       }),
       async ({
         tx,
@@ -9490,6 +9491,7 @@ export const mutators = defineMutators({
           autoDraftAgentSlug,
           metricsEnabled,
           frtStageNames,
+          appWebhookDeliveryEnabled,
         },
       }) => {
         const existing = await tx.run(
@@ -9508,6 +9510,7 @@ export const mutators = defineMutators({
             ...(autoDraftAgentSlug !== undefined ? { autoDraftAgentSlug } : {}),
             ...(metricsEnabled !== undefined ? { metricsEnabled } : {}),
             ...(frtStageNames !== undefined ? { frtStageNames } : {}),
+            ...(appWebhookDeliveryEnabled !== undefined ? { appWebhookDeliveryEnabled } : {}),
           });
         } else {
           const channel = await tx.run(zql.channels.where('id', channelId).one());
@@ -9533,6 +9536,7 @@ export const mutators = defineMutators({
             priorityClassificationThreshold: 0.5,
             metricsEnabled: metricsEnabled ?? false,
             frtStageNames: frtStageNames ?? null,
+            appWebhookDeliveryEnabled: appWebhookDeliveryEnabled ?? true,
           });
         }
       },

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1614,6 +1614,7 @@ export const emailChannelPreferenceTable = table('email_channel_preferences')
     autoDraftAgentSlug: string().optional(),
     metricsEnabled: boolean().optional(),
     frtStageNames: string().optional(),
+    appWebhookDeliveryEnabled: boolean().optional(),
   })
   .primaryKey('channelId');
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
