### PR TITLE
fix: XYNE-55471 strip the router basename before reading the workspace id

### DIFF
--- a/apps/dashboard/src/services/clients/apiClient.ts
+++ b/apps/dashboard/src/services/clients/apiClient.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosE
 import { v4 as uuidv4 } from 'uuid';
 import { reactNativeBridge } from '../../utils/reactNativeBridge';
 import { mixpanelService, EVENTS, EVENT_PROPERTIES } from '../Analytics/mixpanelService';
-import { API_BASE_URL } from '../../config';
+import { API_BASE_URL, APP_BASE_PATH } from '../../config';
 import { logger, Logger } from '../../utils/logger';
 import {
   httpRequestDuration,
@@ -106,7 +106,11 @@ apiConfig.interceptors.request.use(
 
       // X-Workspace-Id for multi-workspace. Main routes are /:workspaceId/...; standalone
       // /newWindow/* windows carry it as a query param (then fall back to lastActiveWorkspaceId).
-      const firstPathSegment = window.location.pathname.match(/^\/([^/]+)/)?.[1];
+      // The lane serves under the /sdlc-app basename, whose segment would otherwise
+      // read as the workspace id. APP_BASE_PATH is '' in the main bundle.
+      const path = window.location.pathname;
+      const appPath = path.startsWith(APP_BASE_PATH) ? path.slice(APP_BASE_PATH.length) : path;
+      const firstPathSegment = appPath.match(/^\/([^/]+)/)?.[1];
       let workspaceId: string | undefined = firstPathSegment;
       if (firstPathSegment === 'newWindow') {
         const search = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Main-side counterpart of #841. Cherry-picked cleanly.

### Root cause

`apiClient.ts` derived the workspace id from raw `window.location.pathname`, assuming routes are `/:workspaceId/...`. The SDLC lane serves under the `/sdlc-app` basename, so it sent `x-workspace-id: sdlc-app` instead of the workspace uuid.

Auth itself succeeded (`/sdlc-api/auth/validate` → 200), but every workspace-scoped endpoint 401'd. That tripped the global 401 handler, which cleared the auth cookies and navigated to `/auth` — so the framed lane rendered the login screen and looped.

### Fix

Strip `APP_BASE_PATH` before taking the first segment. `APP_BASE_PATH` is `''` for the main bundle, so the guard short-circuits and main behaviour is unchanged.

react-router already strips the basename for routing, so `useParams()` was correct; this interceptor reads `window.location` directly and is the only place deriving a workspace id that way (`AppSidebar.tsx:179` splits similarly but uses `useLocation()`).

### Verified

- `prettier --check`: clean
- `eslint`: 0 errors
- typecheck verified identical-to-base on #841, which carries the same commit
- logic checked across main/lane × `{ws}` / `auth` / `newWindow` / bare-basename paths

### Follow-up, not in this PR

`clearAuthTokens()` clears cookies with `path=/` — origin-wide, not frame-scoped — so a genuine 401 inside the frame still logs the parent out. Same class as the Zero `dropAllDatabases()` issue. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)