### PR TITLE
fix: XYNE-56611 xyne desk metrics — filter search, AND/OR logic, scro…

### DIFF
--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -160,22 +160,20 @@ export class DeskMetricsRepository {
     // Cohort: active tickets created in range, optionally scoped by the selected filters.
     let customFieldExists: Prisma.Sql = Prisma.sql``;
     if (customFieldFilter && customFieldFilter.keys.length > 0) {
-      // Value conditions — OR across keys that have values/terms selected
-      const valueConditions: Prisma.Sql[] = [];
+      // One EXISTS per field, AND'd together — values within a field are OR'd, different fields are AND'd
+      const perKeyExists: Prisma.Sql[] = [];
       for (const key of customFieldFilter.keys) {
         const kf = customFieldFilter.perKeyFilters?.[key];
         const hasValues = kf?.values && kf.values.length > 0;
         const hasTerms = kf?.textTerms && kf.textTerms.length > 0;
-        if (!hasValues && !hasTerms) continue;
         const fieldNameMatch = Prisma.sql`COALESCE(gf."fieldName", ff."fieldName") = ${key}`;
         const fieldCol = Prisma.sql`COALESCE(fev."actualFieldValue"#>>'{}', NULLIF(fev."fieldValue", ''))`;
-        let valueCondition: Prisma.Sql;
+        let valueCondition: Prisma.Sql | undefined;
         if (hasTerms) {
-          // OR across all text terms within this field
           valueCondition = kf!
             .textTerms!.map((t) => Prisma.sql`${fieldCol} ILIKE ${'%' + t + '%'}`)
             .reduce((or, c, i) => (i === 0 ? c : Prisma.sql`${or} OR ${c}`));
-        } else {
+        } else if (hasValues) {
           valueCondition = Prisma.sql`(
             ${fieldCol} IN (${Prisma.join(kf!.values!)})
             OR (
@@ -187,22 +185,19 @@ export class DeskMetricsRepository {
             )
           )`;
         }
-        valueConditions.push(Prisma.sql`(${fieldNameMatch} AND (${valueCondition}))`);
-      }
-      // Single EXISTS: field-level pre-filter (fieldName IN keys) + optional value-level AND
-      const valueClause =
-        valueConditions.length > 0
-          ? Prisma.sql`AND (${valueConditions.reduce((or, c, i) => (i === 0 ? c : Prisma.sql`${or} OR ${c}`))})`
-          : Prisma.sql``;
-      customFieldExists = Prisma.sql`AND EXISTS (
+        perKeyExists.push(Prisma.sql`AND EXISTS (
           SELECT 1 FROM "public"."form_entity_values" fev
           LEFT JOIN "public"."global_fields" gf ON gf.id = fev."fieldId"
           LEFT JOIN "public"."form_fields" ff ON ff.id = fev."fieldId"
           WHERE fev."entityId" = ta."ticketId"
             AND fev."entityType" = 'TICKET'
-            AND COALESCE(gf."fieldName", ff."fieldName") IN (${Prisma.join(customFieldFilter.keys)})
-            ${valueClause}
-        )`;
+            AND ${fieldNameMatch}
+            ${valueCondition !== undefined ? Prisma.sql`AND (${valueCondition})` : Prisma.sql``}
+        )`);
+      }
+      if (perKeyExists.length > 0) {
+        customFieldExists = perKeyExists.reduce((acc, c) => Prisma.sql`${acc} ${c}`);
+      }
     }
 
     // Tag filter: parse "category:tag" composite values (format used by GeneratedTagsSubmenu)

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/DynamicFieldSubmenu/DynamicFieldSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/DynamicFieldSubmenu/DynamicFieldSubmenu.tsx
@@ -112,7 +112,11 @@ export const DynamicFieldSubmenu = ({
             </div>
           )}
         </div>
-        <div className='max-h-80 overflow-y-auto p-1'>
+        <div
+          className='max-h-80 overflow-y-auto p-1'
+          onWheel={e => e.stopPropagation()}
+          onTouchMove={e => e.stopPropagation()}
+        >
           {filteredOptions.length > 0 ? (
             <div className='space-y-0.5'>
               {filteredOptions.map(option => {

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/PrioritySubmenu/PrioritySubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/PrioritySubmenu/PrioritySubmenu.tsx
@@ -41,7 +41,11 @@ export const PrioritySubmenu = ({
 
   return (
     <div className='w-56 bg-background border border-border rounded-lg shadow-lg overflow-hidden'>
-      <div className='py-1.5 px-1 flex flex-col gap-1 max-h-80 overflow-y-auto'>
+      <div
+        className='py-1.5 px-1 flex flex-col gap-1 max-h-80 overflow-y-auto'
+        onWheel={e => e.stopPropagation()}
+        onTouchMove={e => e.stopPropagation()}
+      >
         {prioritiesToShow.length > 0 ? (
           prioritiesToShow.map(([priority, config]) => {
             const isSelected = selectedPriorities.includes(priority as TicketPriority);

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/StagesSubmenu/StagesSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/StagesSubmenu/StagesSubmenu.tsx
@@ -87,7 +87,13 @@ export const StagesSubmenu = ({
           />
         </div>
       </div>
-      <div className='max-h-80 overflow-y-auto p-1' role='listbox' aria-multiselectable='true'>
+      <div
+        className='max-h-80 overflow-y-auto p-1'
+        role='listbox'
+        aria-multiselectable='true'
+        onWheel={e => e.stopPropagation()}
+        onTouchMove={e => e.stopPropagation()}
+      >
         {isLoading ? (
           <div className='p-8 text-center text-sm text-muted-foreground' aria-live='polite'>
             Loading status…

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/UserGroupSubmenu/UserGroupSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/UserGroupSubmenu/UserGroupSubmenu.tsx
@@ -101,7 +101,11 @@ export const UserGroupSubmenu = ({
 
       {/* Selected Groups */}
       {selectedGroupsData.length > 0 && (
-        <div className='p-3 border-b border-border max-h-40 overflow-y-auto'>
+        <div
+          className='p-3 border-b border-border max-h-40 overflow-y-auto'
+          onWheel={e => e.stopPropagation()}
+          onTouchMove={e => e.stopPropagation()}
+        >
           <div className='text-xs font-medium text-muted-foreground mb-2'>Selected</div>
           <div className='space-y-1'>
             {selectedGroupsData.map((group: UserGroup) => (
@@ -137,7 +141,11 @@ export const UserGroupSubmenu = ({
       )}
 
       {/* Available Groups */}
-      <div className='max-h-64 overflow-y-auto'>
+      <div
+        className='max-h-64 overflow-y-auto'
+        onWheel={e => e.stopPropagation()}
+        onTouchMove={e => e.stopPropagation()}
+      >
         {!allUserGroups || allUserGroups.length === 0 ? (
           <div className='p-4 text-center text-sm text-muted-foreground'>
             Loading user groups...

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/UserSubmenu/UserSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/UserSubmenu/UserSubmenu.tsx
@@ -321,7 +321,12 @@ export const UserSubmenu = ({
       </div>
       {rows.length > 0 ? (
         isVirtualized ? (
-          <div role='listbox' aria-multiselectable='true'>
+          <div
+            role='listbox'
+            aria-multiselectable='true'
+            onWheel={e => e.stopPropagation()}
+            onTouchMove={e => e.stopPropagation()}
+          >
             <Virtuoso
               data={rows}
               // Row-height estimate so the scroll range is right before rows measure.
@@ -335,7 +340,13 @@ export const UserSubmenu = ({
             />
           </div>
         ) : (
-          <div className='max-h-80 overflow-y-auto p-1' role='listbox' aria-multiselectable='true'>
+          <div
+            className='max-h-80 overflow-y-auto p-1'
+            role='listbox'
+            aria-multiselectable='true'
+            onWheel={e => e.stopPropagation()}
+            onTouchMove={e => e.stopPropagation()}
+          >
             <div className='space-y-0.5'>{rows.map(item => renderRow(item))}</div>
           </div>
         )

--- a/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDashboard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDashboard.tsx
@@ -115,7 +115,11 @@ const TagsInCategorySubmenu = ({
       <div className='border-b border-border px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground'>
         {category}
       </div>
-      <div className='max-h-72 overflow-y-auto p-1'>
+      <div
+        className='max-h-72 overflow-y-auto p-1'
+        onWheel={e => e.stopPropagation()}
+        onTouchMove={e => e.stopPropagation()}
+      >
         {availableTags.length === 0 ? (
           <div className='p-6 text-center text-sm text-muted-foreground'>No tags available</div>
         ) : (
@@ -945,6 +949,11 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
   const [assigneePopoverOpen, setAssigneePopoverOpen] = useState(false);
   const [customFieldPopoverOpen, setCustomFieldPopoverOpen] = useState(false);
   const [activeSubmenu, setActiveSubmenu] = useState<string | null>(null);
+  const [filterSearch, setFilterSearch] = useState('');
+  // Stable tag list per category: grows as tags are seen, never shrinks.
+  // Prevents mutually-exclusive tags (e.g. sentiment) from disappearing when
+  // selecting one tag filters the cohort and the API stops returning the others.
+  const [stableTagsInCategory, setStableTagsInCategory] = useState<string[]>([]);
 
   useEffect(() => {
     setCustomFieldPopoverOpen(false);
@@ -1038,6 +1047,20 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
     selectedUserGroupIds,
     selectedTagValues,
   );
+
+  useEffect(() => {
+    if (selectedTagCategory === null) {
+      setStableTagsInCategory([]);
+      return;
+    }
+    const fresh = (data?.tagBreakdown ?? [])
+      .filter(tb => tb.tagCategory === selectedTagCategory)
+      .map(tb => `${tb.tagCategory}:${tb.tag}`);
+    setStableTagsInCategory(prev => {
+      const prevForCategory = prev.filter(k => k.startsWith(`${selectedTagCategory}:`));
+      return [...new Set([...prevForCategory, ...fresh])];
+    });
+  }, [selectedTagCategory, data?.tagBreakdown]);
 
   const availableCustomFields = useMemo(() => {
     const fields = new Map<string, DeskMetricsCustomFieldDefinition>();
@@ -1477,12 +1500,15 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                     open={customFieldPopoverOpen}
                     onOpenChange={nextOpen => {
                       setCustomFieldPopoverOpen(nextOpen);
-                      if (!nextOpen) setActiveSubmenu(null);
+                      if (!nextOpen) {
+                        setActiveSubmenu(null);
+                        setFilterSearch('');
+                      }
                     }}
                     align='start'
                     sideOffset={6}
                     collisionPadding={12}
-                    className='max-h-[400px] w-56 overflow-y-auto rounded-lg border border-border bg-background p-0 shadow-lg'
+                    className='w-56 rounded-lg border border-border bg-background p-0 shadow-lg'
                     onInteractOutside={event => {
                       const target = event.target;
                       if (
@@ -1507,300 +1533,235 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                       </button>
                     }
                   >
-                    <div className='py-1'>
-                      <PopoverPrimitive.Root
-                        open={activeSubmenu === '__priority'}
-                        onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? '__priority' : null)}
+                    <>
+                      <div className='flex items-center gap-2 border-b border-border px-2 py-1.5'>
+                        <Search size={14} className='shrink-0 text-muted-foreground' />
+                        <input
+                          type='text'
+                          value={filterSearch}
+                          onChange={e => setFilterSearch(e.target.value)}
+                          onKeyDown={e => e.stopPropagation()}
+                          placeholder='Search filters…'
+                          className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
+                          data-track-category='DeskMetrics'
+                          data-track-name='SearchFilters'
+                        />
+                      </div>
+                      <div
+                        className='max-h-[360px] overflow-y-auto py-1'
+                        onWheel={e => e.stopPropagation()}
+                        onTouchMove={e => e.stopPropagation()}
                       >
-                        <PopoverPrimitive.Trigger asChild>
-                          <button
-                            type='button'
-                            className={cn(
-                              'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
-                              activeSubmenu === '__priority' && 'bg-muted font-medium',
-                            )}
-                            data-track-category='DeskMetrics'
-                            data-track-name='OpenPriorityFilterSubmenu'
+                        {(!filterSearch || 'priority'.includes(filterSearch.toLowerCase())) && (
+                          <PopoverPrimitive.Root
+                            open={activeSubmenu === '__priority'}
+                            onOpenChange={nextOpen =>
+                              setActiveSubmenu(nextOpen ? '__priority' : null)
+                            }
                           >
-                            <div className='flex min-w-0 items-center gap-3'>
-                              <BarChart4 size={16} className='shrink-0' />
-                              <span>Priority</span>
-                              {selectedPriorities.length > 0 && (
-                                <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
-                              )}
-                            </div>
-                            <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
-                          </button>
-                        </PopoverPrimitive.Trigger>
-                        <PopoverPrimitive.Portal>
-                          <PopoverPrimitive.Content
-                            side='right'
-                            align='start'
-                            sideOffset={4}
-                            collisionPadding={12}
-                            className='z-[70] outline-none'
-                            data-custom-field-submenu='true'
-                            onOpenAutoFocus={event => event.preventDefault()}
+                            <PopoverPrimitive.Trigger asChild>
+                              <button
+                                type='button'
+                                className={cn(
+                                  'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                                  activeSubmenu === '__priority' && 'bg-muted font-medium',
+                                )}
+                                data-track-category='DeskMetrics'
+                                data-track-name='OpenPriorityFilterSubmenu'
+                              >
+                                <div className='flex min-w-0 items-center gap-3'>
+                                  <BarChart4 size={16} className='shrink-0' />
+                                  <span>Priority</span>
+                                  {selectedPriorities.length > 0 && (
+                                    <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
+                                  )}
+                                </div>
+                                <ChevronRight
+                                  size={16}
+                                  className='shrink-0 text-muted-foreground'
+                                />
+                              </button>
+                            </PopoverPrimitive.Trigger>
+                            <PopoverPrimitive.Portal>
+                              <PopoverPrimitive.Content
+                                side='right'
+                                align='start'
+                                sideOffset={4}
+                                collisionPadding={12}
+                                className='z-[70] outline-none'
+                                data-custom-field-submenu='true'
+                                onOpenAutoFocus={event => event.preventDefault()}
+                              >
+                                <PrioritySubmenu
+                                  selectedPriorities={selectedPriorities}
+                                  onChange={setSelectedPriorities}
+                                />
+                              </PopoverPrimitive.Content>
+                            </PopoverPrimitive.Portal>
+                          </PopoverPrimitive.Root>
+                        )}
+                        {(!filterSearch || 'user groups'.includes(filterSearch.toLowerCase())) && (
+                          <PopoverPrimitive.Root
+                            open={activeSubmenu === '__userGroups'}
+                            onOpenChange={nextOpen =>
+                              setActiveSubmenu(nextOpen ? '__userGroups' : null)
+                            }
                           >
-                            <PrioritySubmenu
-                              selectedPriorities={selectedPriorities}
-                              onChange={setSelectedPriorities}
-                            />
-                          </PopoverPrimitive.Content>
-                        </PopoverPrimitive.Portal>
-                      </PopoverPrimitive.Root>
-
-                      <PopoverPrimitive.Root
-                        open={activeSubmenu === '__userGroups'}
-                        onOpenChange={nextOpen =>
-                          setActiveSubmenu(nextOpen ? '__userGroups' : null)
-                        }
-                      >
-                        <PopoverPrimitive.Trigger asChild>
-                          <button
-                            type='button'
-                            className={cn(
-                              'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
-                              activeSubmenu === '__userGroups' && 'bg-muted font-medium',
-                            )}
-                            data-track-category='DeskMetrics'
-                            data-track-name='OpenUserGroupFilterSubmenu'
+                            <PopoverPrimitive.Trigger asChild>
+                              <button
+                                type='button'
+                                className={cn(
+                                  'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                                  activeSubmenu === '__userGroups' && 'bg-muted font-medium',
+                                )}
+                                data-track-category='DeskMetrics'
+                                data-track-name='OpenUserGroupFilterSubmenu'
+                              >
+                                <div className='flex min-w-0 items-center gap-3'>
+                                  <Users size={16} className='shrink-0' />
+                                  <span>User Groups</span>
+                                  {selectedUserGroupIds.length > 0 && (
+                                    <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
+                                  )}
+                                </div>
+                                <ChevronRight
+                                  size={16}
+                                  className='shrink-0 text-muted-foreground'
+                                />
+                              </button>
+                            </PopoverPrimitive.Trigger>
+                            <PopoverPrimitive.Portal>
+                              <PopoverPrimitive.Content
+                                side='right'
+                                align='start'
+                                sideOffset={4}
+                                collisionPadding={12}
+                                className='z-[70] outline-none'
+                                data-custom-field-submenu='true'
+                                onOpenAutoFocus={event => event.preventDefault()}
+                              >
+                                <UserGroupSubmenu
+                                  selectedGroups={selectedUserGroupIds}
+                                  onChange={setSelectedUserGroupIds}
+                                  onClose={() => setActiveSubmenu(null)}
+                                />
+                              </PopoverPrimitive.Content>
+                            </PopoverPrimitive.Portal>
+                          </PopoverPrimitive.Root>
+                        )}
+                        {(!filterSearch || 'tag category'.includes(filterSearch.toLowerCase())) && (
+                          <PopoverPrimitive.Root
+                            open={activeSubmenu === '__tagCategory'}
+                            onOpenChange={nextOpen =>
+                              setActiveSubmenu(nextOpen ? '__tagCategory' : null)
+                            }
                           >
-                            <div className='flex min-w-0 items-center gap-3'>
-                              <Users size={16} className='shrink-0' />
-                              <span>User Groups</span>
-                              {selectedUserGroupIds.length > 0 && (
-                                <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
-                              )}
-                            </div>
-                            <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
-                          </button>
-                        </PopoverPrimitive.Trigger>
-                        <PopoverPrimitive.Portal>
-                          <PopoverPrimitive.Content
-                            side='right'
-                            align='start'
-                            sideOffset={4}
-                            collisionPadding={12}
-                            className='z-[70] outline-none'
-                            data-custom-field-submenu='true'
-                            onOpenAutoFocus={event => event.preventDefault()}
-                          >
-                            <UserGroupSubmenu
-                              selectedGroups={selectedUserGroupIds}
-                              onChange={setSelectedUserGroupIds}
-                              onClose={() => setActiveSubmenu(null)}
-                            />
-                          </PopoverPrimitive.Content>
-                        </PopoverPrimitive.Portal>
-                      </PopoverPrimitive.Root>
-
-                      {/* Tag Category (single-select) */}
-                      <PopoverPrimitive.Root
-                        open={activeSubmenu === '__tagCategory'}
-                        onOpenChange={nextOpen =>
-                          setActiveSubmenu(nextOpen ? '__tagCategory' : null)
-                        }
-                      >
-                        <PopoverPrimitive.Trigger asChild>
-                          <button
-                            type='button'
-                            className={cn(
-                              'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
-                              activeSubmenu === '__tagCategory' && 'bg-muted font-medium',
-                            )}
-                            data-track-category='DeskMetrics'
-                            data-track-name='OpenTagCategorySubmenu'
-                          >
-                            <div className='flex min-w-0 items-center gap-3'>
-                              <Tag size={16} className='shrink-0' />
-                              <span>Tag Category</span>
-                              {selectedTagCategory !== null && (
-                                <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
-                              )}
-                            </div>
-                            <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
-                          </button>
-                        </PopoverPrimitive.Trigger>
-                        <PopoverPrimitive.Portal>
-                          <PopoverPrimitive.Content
-                            side='right'
-                            align='start'
-                            sideOffset={4}
-                            collisionPadding={12}
-                            className='z-[70] outline-none'
-                            data-custom-field-submenu='true'
-                            onOpenAutoFocus={event => event.preventDefault()}
-                          >
-                            <div className='w-56 rounded-[10px] border border-border bg-background shadow-lg'>
-                              <div className='border-b border-border px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground'>
-                                Select Category
-                              </div>
-                              <div className='max-h-72 overflow-y-auto p-1'>
-                                {(data?.tagCategories ?? []).length === 0 ? (
-                                  <div className='p-6 text-center text-sm text-muted-foreground'>
-                                    No categories
+                            <PopoverPrimitive.Trigger asChild>
+                              <button
+                                type='button'
+                                className={cn(
+                                  'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                                  activeSubmenu === '__tagCategory' && 'bg-muted font-medium',
+                                )}
+                                data-track-category='DeskMetrics'
+                                data-track-name='OpenTagCategorySubmenu'
+                              >
+                                <div className='flex min-w-0 items-center gap-3'>
+                                  <Tag size={16} className='shrink-0' />
+                                  <span>Tag Category</span>
+                                  {selectedTagCategory !== null && (
+                                    <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
+                                  )}
+                                </div>
+                                <ChevronRight
+                                  size={16}
+                                  className='shrink-0 text-muted-foreground'
+                                />
+                              </button>
+                            </PopoverPrimitive.Trigger>
+                            <PopoverPrimitive.Portal>
+                              <PopoverPrimitive.Content
+                                side='right'
+                                align='start'
+                                sideOffset={4}
+                                collisionPadding={12}
+                                className='z-[70] outline-none'
+                                data-custom-field-submenu='true'
+                                onOpenAutoFocus={event => event.preventDefault()}
+                              >
+                                <div className='w-56 rounded-[10px] border border-border bg-background shadow-lg'>
+                                  <div className='border-b border-border px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground'>
+                                    Select Category
                                   </div>
-                                ) : (
-                                  <div className='space-y-0.5'>
-                                    {(data?.tagCategories ?? []).map(tc => (
-                                      <button
-                                        key={tc.tagCategory}
-                                        type='button'
-                                        onClick={() => {
-                                          setSelectedTagCategory(
-                                            selectedTagCategory === tc.tagCategory
-                                              ? null
-                                              : tc.tagCategory,
-                                          );
-                                          setActiveSubmenu(null);
-                                        }}
-                                        data-track-category='DeskMetrics'
-                                        data-track-name='SelectTagCategory'
-                                        className={cn(
-                                          'flex w-full items-center justify-between rounded-[6px] px-3 py-2 text-sm transition-colors',
-                                          selectedTagCategory === tc.tagCategory
-                                            ? 'bg-accent text-accent-foreground'
-                                            : 'text-foreground hover:bg-muted',
-                                        )}
-                                      >
-                                        <span className='truncate'>{tc.tagCategory}</span>
-                                        <span className='ml-2 shrink-0 text-xs text-muted-foreground'>
-                                          {tc.count}
-                                        </span>
-                                      </button>
-                                    ))}
+                                  <div
+                                    className='max-h-72 overflow-y-auto p-1'
+                                    onWheel={e => e.stopPropagation()}
+                                    onTouchMove={e => e.stopPropagation()}
+                                  >
+                                    {(data?.tagCategories ?? []).length === 0 ? (
+                                      <div className='p-6 text-center text-sm text-muted-foreground'>
+                                        No categories
+                                      </div>
+                                    ) : (
+                                      <div className='space-y-0.5'>
+                                        {(data?.tagCategories ?? []).map(tc => (
+                                          <button
+                                            key={tc.tagCategory}
+                                            type='button'
+                                            onClick={() => {
+                                              setSelectedTagCategory(
+                                                selectedTagCategory === tc.tagCategory
+                                                  ? null
+                                                  : tc.tagCategory,
+                                              );
+                                              setActiveSubmenu(null);
+                                            }}
+                                            data-track-category='DeskMetrics'
+                                            data-track-name='SelectTagCategory'
+                                            className={cn(
+                                              'flex w-full items-center justify-between rounded-[6px] px-3 py-2 text-sm transition-colors',
+                                              selectedTagCategory === tc.tagCategory
+                                                ? 'bg-accent text-accent-foreground'
+                                                : 'text-foreground hover:bg-muted',
+                                            )}
+                                          >
+                                            <span className='truncate'>{tc.tagCategory}</span>
+                                            <span className='ml-2 shrink-0 text-xs text-muted-foreground'>
+                                              {tc.count}
+                                            </span>
+                                          </button>
+                                        ))}
+                                      </div>
+                                    )}
                                   </div>
-                                )}
-                              </div>
-                            </div>
-                          </PopoverPrimitive.Content>
-                        </PopoverPrimitive.Portal>
-                      </PopoverPrimitive.Root>
-
-                      {/* Tags within selected category */}
-                      {selectedTagCategory !== null && (
-                        <PopoverPrimitive.Root
-                          open={activeSubmenu === '__tags'}
-                          onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? '__tags' : null)}
-                        >
-                          <PopoverPrimitive.Trigger asChild>
-                            <button
-                              type='button'
-                              className={cn(
-                                'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
-                                activeSubmenu === '__tags' && 'bg-muted font-medium',
-                              )}
-                              data-track-category='DeskMetrics'
-                              data-track-name='OpenTagsSubmenu'
-                            >
-                              <div className='flex min-w-0 items-center gap-3'>
-                                <Tag size={16} className='shrink-0' />
-                                <span>Tags</span>
-                                {selectedTagValues.length > 0 && (
-                                  <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
-                                )}
-                              </div>
-                              <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
-                            </button>
-                          </PopoverPrimitive.Trigger>
-                          <PopoverPrimitive.Portal>
-                            <PopoverPrimitive.Content
-                              side='right'
-                              align='start'
-                              sideOffset={4}
-                              collisionPadding={12}
-                              className='z-[70] outline-none'
-                              data-custom-field-submenu='true'
-                              onOpenAutoFocus={event => event.preventDefault()}
-                            >
-                              <TagsInCategorySubmenu
-                                availableTags={(data?.tagBreakdown ?? [])
-                                  .filter(tb => tb.tagCategory === selectedTagCategory)
-                                  .map(tb => `${tb.tagCategory}:${tb.tag}`)}
-                                category={selectedTagCategory}
-                                selectedTags={selectedTagValues}
-                                onChange={setSelectedTagValues}
-                              />
-                            </PopoverPrimitive.Content>
-                          </PopoverPrimitive.Portal>
-                        </PopoverPrimitive.Root>
-                      )}
-
-                      {!isMultiDesk && stageOptions.length > 0 && (
-                        <PopoverPrimitive.Root
-                          open={activeSubmenu === '__stages'}
-                          onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? '__stages' : null)}
-                        >
-                          <PopoverPrimitive.Trigger asChild>
-                            <button
-                              type='button'
-                              className={cn(
-                                'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
-                                activeSubmenu === '__stages' && 'bg-muted font-medium',
-                              )}
-                              data-track-category='DeskMetrics'
-                              data-track-name='OpenStageFilterSubmenu'
-                            >
-                              <div className='flex min-w-0 items-center gap-3'>
-                                <Circle size={16} className='shrink-0' />
-                                <span>Stages</span>
-                                {selectedStageNames.length > 0 && (
-                                  <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
-                                )}
-                              </div>
-                              <ChevronRight size={16} className='shrink-0 text-muted-foreground' />
-                            </button>
-                          </PopoverPrimitive.Trigger>
-                          <PopoverPrimitive.Portal>
-                            <PopoverPrimitive.Content
-                              side='right'
-                              align='start'
-                              sideOffset={4}
-                              collisionPadding={12}
-                              className='z-[70] outline-none'
-                              data-custom-field-submenu='true'
-                              onOpenAutoFocus={event => event.preventDefault()}
-                            >
-                              <StagesSubmenu
-                                selectedStages={selectedStageNames}
-                                onChange={setSelectedStageNames}
-                                availableStages={[...stageOptions]}
-                              />
-                            </PopoverPrimitive.Content>
-                          </PopoverPrimitive.Portal>
-                        </PopoverPrimitive.Root>
-                      )}
-                      {!isMultiDesk &&
-                        availableCustomFields.map(definition => {
-                          const key = definition.fieldName;
-                          const FieldIcon = getIconForFieldType(definition.fieldType);
-                          const isOpen = activeSubmenu === key;
-                          const isActive = activeCustomFieldKeys.includes(key);
-
-                          return (
+                                </div>
+                              </PopoverPrimitive.Content>
+                            </PopoverPrimitive.Portal>
+                          </PopoverPrimitive.Root>
+                        )}
+                        {/* Tags within selected category */}
+                        {selectedTagCategory !== null &&
+                          (!filterSearch || 'tags'.includes(filterSearch.toLowerCase())) && (
                             <PopoverPrimitive.Root
-                              key={key}
-                              open={isOpen}
-                              onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? key : null)}
+                              open={activeSubmenu === '__tags'}
+                              onOpenChange={nextOpen =>
+                                setActiveSubmenu(nextOpen ? '__tags' : null)
+                              }
                             >
                               <PopoverPrimitive.Trigger asChild>
                                 <button
                                   type='button'
                                   className={cn(
                                     'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
-                                    isOpen && 'bg-muted font-medium',
+                                    activeSubmenu === '__tags' && 'bg-muted font-medium',
                                   )}
                                   data-track-category='DeskMetrics'
-                                  data-track-name='OpenCustomFieldFilterSubmenu'
-                                  data-track-metadata={JSON.stringify({ fieldName: key })}
+                                  data-track-name='OpenTagsSubmenu'
                                 >
                                   <div className='flex min-w-0 items-center gap-3'>
-                                    <FieldIcon className='h-4 w-4 shrink-0' />
-                                    <span className='truncate' title={key}>
-                                      {key}
-                                    </span>
-                                    {isActive && (
+                                    <Tag size={16} className='shrink-0' />
+                                    <span>Tags</span>
+                                    {selectedTagValues.length > 0 && (
                                       <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
                                     )}
                                   </div>
@@ -1820,24 +1781,142 @@ export const DeskMetricsDashboard: React.FC<DeskMetricsDashboardProps> = ({
                                   data-custom-field-submenu='true'
                                   onOpenAutoFocus={event => event.preventDefault()}
                                 >
-                                  <DynamicFieldSubmenu
-                                    fieldId={definition.id}
-                                    fieldName={key}
-                                    fieldType={definition.fieldType}
-                                    fieldEnum={parseFieldOptionValues(definition.fieldEnum)}
-                                    selectedValue={selectedCustomFieldValues[key] ?? []}
-                                    onChange={value => {
-                                      if (!Array.isArray(value)) return;
-                                      updateCustomFieldValues(key, value);
-                                    }}
-                                    onClose={() => setActiveSubmenu(null)}
+                                  <TagsInCategorySubmenu
+                                    availableTags={stableTagsInCategory}
+                                    category={selectedTagCategory}
+                                    selectedTags={selectedTagValues}
+                                    onChange={setSelectedTagValues}
                                   />
                                 </PopoverPrimitive.Content>
                               </PopoverPrimitive.Portal>
                             </PopoverPrimitive.Root>
-                          );
-                        })}
-                    </div>
+                          )}
+
+                        {!isMultiDesk &&
+                          stageOptions.length > 0 &&
+                          (!filterSearch || 'stages'.includes(filterSearch.toLowerCase())) && (
+                            <PopoverPrimitive.Root
+                              open={activeSubmenu === '__stages'}
+                              onOpenChange={nextOpen =>
+                                setActiveSubmenu(nextOpen ? '__stages' : null)
+                              }
+                            >
+                              <PopoverPrimitive.Trigger asChild>
+                                <button
+                                  type='button'
+                                  className={cn(
+                                    'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                                    activeSubmenu === '__stages' && 'bg-muted font-medium',
+                                  )}
+                                  data-track-category='DeskMetrics'
+                                  data-track-name='OpenStageFilterSubmenu'
+                                >
+                                  <div className='flex min-w-0 items-center gap-3'>
+                                    <Circle size={16} className='shrink-0' />
+                                    <span>Stages</span>
+                                    {selectedStageNames.length > 0 && (
+                                      <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
+                                    )}
+                                  </div>
+                                  <ChevronRight
+                                    size={16}
+                                    className='shrink-0 text-muted-foreground'
+                                  />
+                                </button>
+                              </PopoverPrimitive.Trigger>
+                              <PopoverPrimitive.Portal>
+                                <PopoverPrimitive.Content
+                                  side='right'
+                                  align='start'
+                                  sideOffset={4}
+                                  collisionPadding={12}
+                                  className='z-[70] outline-none'
+                                  data-custom-field-submenu='true'
+                                  onOpenAutoFocus={event => event.preventDefault()}
+                                >
+                                  <StagesSubmenu
+                                    selectedStages={selectedStageNames}
+                                    onChange={setSelectedStageNames}
+                                    availableStages={[...stageOptions]}
+                                  />
+                                </PopoverPrimitive.Content>
+                              </PopoverPrimitive.Portal>
+                            </PopoverPrimitive.Root>
+                          )}
+                        {!isMultiDesk &&
+                          availableCustomFields
+                            .filter(
+                              def =>
+                                !filterSearch ||
+                                def.fieldName.toLowerCase().includes(filterSearch.toLowerCase()),
+                            )
+                            .map(definition => {
+                              const key = definition.fieldName;
+                              const FieldIcon = getIconForFieldType(definition.fieldType);
+                              const isOpen = activeSubmenu === key;
+                              const isActive = activeCustomFieldKeys.includes(key);
+
+                              return (
+                                <PopoverPrimitive.Root
+                                  key={key}
+                                  open={isOpen}
+                                  onOpenChange={nextOpen => setActiveSubmenu(nextOpen ? key : null)}
+                                >
+                                  <PopoverPrimitive.Trigger asChild>
+                                    <button
+                                      type='button'
+                                      className={cn(
+                                        'flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-muted',
+                                        isOpen && 'bg-muted font-medium',
+                                      )}
+                                      data-track-category='DeskMetrics'
+                                      data-track-name='OpenCustomFieldFilterSubmenu'
+                                      data-track-metadata={JSON.stringify({ fieldName: key })}
+                                    >
+                                      <div className='flex min-w-0 items-center gap-3'>
+                                        <FieldIcon className='h-4 w-4 shrink-0' />
+                                        <span className='truncate' title={key}>
+                                          {key}
+                                        </span>
+                                        {isActive && (
+                                          <span className='h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500' />
+                                        )}
+                                      </div>
+                                      <ChevronRight
+                                        size={16}
+                                        className='shrink-0 text-muted-foreground'
+                                      />
+                                    </button>
+                                  </PopoverPrimitive.Trigger>
+                                  <PopoverPrimitive.Portal>
+                                    <PopoverPrimitive.Content
+                                      side='right'
+                                      align='start'
+                                      sideOffset={4}
+                                      collisionPadding={12}
+                                      className='z-[70] outline-none'
+                                      data-custom-field-submenu='true'
+                                      onOpenAutoFocus={event => event.preventDefault()}
+                                    >
+                                      <DynamicFieldSubmenu
+                                        fieldId={definition.id}
+                                        fieldName={key}
+                                        fieldType={definition.fieldType}
+                                        fieldEnum={parseFieldOptionValues(definition.fieldEnum)}
+                                        selectedValue={selectedCustomFieldValues[key] ?? []}
+                                        onChange={value => {
+                                          if (!Array.isArray(value)) return;
+                                          updateCustomFieldValues(key, value);
+                                        }}
+                                        onClose={() => setActiveSubmenu(null)}
+                                      />
+                                    </PopoverPrimitive.Content>
+                                  </PopoverPrimitive.Portal>
+                                </PopoverPrimitive.Root>
+                              );
+                            })}
+                      </div>
+                    </>
                   </Popover>
 
                   {hasAnyFiltersActive && (


### PR DESCRIPTION
…ll fix, stable tags

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
