### PR TITLE
feat: XYNE-56610 digital twin response ui

### DIFF
--- a/apps/dashboard/src/components/Chat/DraftsPanel/TwinDraftsPanel.tsx
+++ b/apps/dashboard/src/components/Chat/DraftsPanel/TwinDraftsPanel.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Sparkles } from 'lucide-react';
+import { PencilEditAi } from '@xyne/icons';
 import { Virtuoso } from 'react-virtuoso';
 import { useSelector } from '@xstate/react';
 import { stateMachineActor } from '../../../machines/stateMachine';
@@ -45,7 +45,7 @@ const TwinDraftRow = ({ draft }: { draft: TwinDraftItem }): ReactElement => {
       recipientName={displayName}
       contentPreview={
         <span className='inline-flex items-center gap-1.5'>
-          <Sparkles size={12} className='shrink-0 text-muted-foreground' />
+          <PencilEditAi size={12} className='shrink-0 text-muted-foreground' />
           {preview}
         </span>
       }
@@ -70,7 +70,7 @@ const TwinDraftsPanel = (): ReactElement => {
       <div className='flex-1 overflow-y-auto p-6'>
         {items.length === 0 ? (
           <div className='flex flex-col items-center justify-center h-full p-8 text-center'>
-            <Sparkles className='text-muted-foreground mb-4' size={48} />
+            <PencilEditAi className='text-muted-foreground mb-4' size={48} />
             <p className='text-muted-foreground text-lg font-medium mb-2'>No twin drafts</p>
             <p className='text-muted-foreground text-sm max-w-md'>
               Replies the Digital Twin drafts for you, awaiting your approval, will appear here

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/ThreadAssistDock.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/ThreadAssistDock.tsx
@@ -1,24 +1,32 @@
 import { ReactElement, ReactNode, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  Loader2,
-  CornerDownLeft,
-  Hash,
-  AtSign,
-  ChevronUp,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
+  Spinner,
+  ArrowTurnDownLeft,
+  Hashtag,
+  AtMark,
+  ChevronBigUp,
+  ChevronBigLeft,
+  ChevronBigRight,
   ArrowUp,
   ArrowLeft,
-  Pencil,
-  MessageSquareX,
-} from 'lucide-react';
+  PencilEditAi,
+  PencilEraserEditLine,
+  ChatCancel,
+} from '@xyne/icons';
 import { Button } from '../../ui/Button';
+import { Tooltip } from '../../ui/Tooltip';
 import { XyneAIStar } from '../../icons/xyne-ai';
 import { cn } from '../../../utils/classNames';
 import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
 import { createMarkdownComponents } from '../../../utils/markdownComponents';
+import {
+  buildClawCitationToolNumbers,
+  linkifyAndGroupClawCitations,
+  stripCitationMarks,
+} from '../../ui/TipTapExtensions/CitationMark';
+import { registerClawIcons } from '../XyneAISidebar/utils/clawCitationUrl';
+import type { ToolInvocation } from '../XyneAISidebar/utils/XyneAITypes';
 import type { TwinReplyDraftView, PostedTarget } from './twinReplyDraftApi';
 import type { AssistTab } from './useThreadAssist';
 
@@ -113,6 +121,9 @@ export function ThreadAssistDock({
   const headerName = selectedSource?.name ?? selectedDraft?.senderName;
   const editing = !!onEditBack;
   const bodyOpen = !collapsed && !editing;
+  const fused = attached && !bodyOpen;
+  const mutedHeader = collapsed && !editing;
+  const ease = 'duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]';
 
   return (
     <motion.div
@@ -120,37 +131,43 @@ export function ThreadAssistDock({
       initial='initial'
       animate='animate'
       exit='exit'
-      className={attached ? '-mb-3' : undefined}
+      className={cn('transition-[margin]', ease, attached && (fused ? '-mb-3' : 'mb-2'))}
     >
       <div
         className={cn(
-          'overflow-hidden border border-input bg-card',
-          attached ? 'rounded-t-2xl border-b-0' : 'rounded-2xl',
+          'overflow-hidden border border-border bg-background',
+          'transition-[box-shadow,border-color]',
+          ease,
+          fused
+            ? 'rounded-t-xl border-b-transparent shadow-none'
+            : 'rounded-xl shadow-[0_-5px_17px_0_rgba(0,0,0,0.06)]',
         )}
       >
-        {editing ? (
-          <EditHeader senderName={headerName} onBack={onEditBack} />
-        ) : collapsed ? (
-          <CollapsedBar
-            hasReply={hasReply}
-            replyCount={replyCount}
-            senderNames={senderNames}
-            recapLabel={hasRecap ? 'Thread recap' : 'Suggested reply'}
-            onExpand={onToggleCollapse}
-          />
-        ) : (
-          <ExpandedHeader
-            tab={tab}
-            hasRecap={hasRecap}
-            hasReply={hasReply}
-            replyCount={replyCount}
-            active={active}
-            senderName={headerName}
-            onGoTo={goTo}
-            onTabChange={onTabChange}
-            onCollapse={onToggleCollapse}
-          />
-        )}
+        <div className={cn('transition-colors', ease, mutedHeader ? 'bg-muted' : 'bg-transparent')}>
+          {editing ? (
+            <EditHeader senderName={headerName} onBack={onEditBack} />
+          ) : collapsed ? (
+            <CollapsedBar
+              hasReply={hasReply}
+              replyCount={replyCount}
+              senderNames={senderNames}
+              recapLabel={hasRecap ? 'Thread recap' : 'Suggested reply'}
+              onExpand={onToggleCollapse}
+            />
+          ) : (
+            <ExpandedHeader
+              tab={tab}
+              hasRecap={hasRecap}
+              hasReply={hasReply}
+              replyCount={replyCount}
+              active={active}
+              senderName={headerName}
+              onGoTo={goTo}
+              onTabChange={onTabChange}
+              onCollapse={onToggleCollapse}
+            />
+          )}
+        </div>
 
         <AnimatePresence initial={false}>
           {bodyOpen && (
@@ -162,7 +179,7 @@ export function ThreadAssistDock({
               transition={{ height: bodySpring, opacity: { duration: 0.15 } }}
               className='overflow-hidden'
             >
-              <div className='px-3.5 pb-3 pt-2'>
+              <div className='px-3.5 pb-4 pt-2.5'>
                 {tab === 'recap' ? (
                   <RecapPane content={recap.content} loading={recap.loading} />
                 ) : selectedDraft ? (
@@ -206,7 +223,7 @@ function EditHeader({
   onBack: () => void;
 }): ReactElement {
   return (
-    <div className='relative flex h-[42px] select-none items-center gap-1.5 px-2 pb-3'>
+    <div className='relative flex select-none items-center gap-1.5 px-3.5 pb-5 pt-2'>
       <button
         type='button'
         onClick={onBack}
@@ -215,10 +232,10 @@ function EditHeader({
         data-track-name='edit-back'
         className='absolute inset-0 cursor-pointer transition-colors hover:bg-muted/20'
       />
-      <span className='pointer-events-none relative flex h-7 w-7 shrink-0 items-center justify-center text-muted-foreground'>
+      <span className='pointer-events-none relative flex h-[22px] w-4 shrink-0 items-center justify-center text-muted-foreground'>
         <ArrowLeft size={16} />
       </span>
-      <span className='pointer-events-none relative flex min-w-0 items-center gap-1.5 text-[13px] font-medium text-foreground'>
+      <span className='pointer-events-none relative flex min-w-0 items-center gap-1.5 text-sm font-semibold leading-[22px] tracking-[-0.1px] text-foreground'>
         <span className='flex shrink-0'>
           <XyneAIStar size={14} />
         </span>
@@ -253,23 +270,21 @@ function CollapsedBar({
         aria-label='Expand AI replies'
         data-track-category='twin-dock'
         data-track-name='expand'
-        className='flex h-[42px] w-full select-none items-center gap-2 bg-muted/60 px-3 pb-3 text-left transition-colors hover:bg-muted'
+        className='flex w-full select-none items-center gap-1.5 px-3.5 pb-5 pt-2 text-left transition-colors hover:bg-foreground/[0.04]'
       >
-        <span className='flex shrink-0'>
-          <XyneAIStar size={14} />
-        </span>
-        <span className='shrink-0 text-[13px] font-semibold text-foreground'>
-          {replyCount === 1 ? '1 AI reply ready' : `${replyCount} AI replies ready`}
+        <span className='flex shrink-0 items-center gap-1'>
+          <span className='flex h-4 w-4 items-center justify-center text-[color:var(--mention-color)]'>
+            <PencilEditAi size={12} />
+          </span>
+          <span className='text-sm font-semibold leading-[22px] tracking-[-0.1px] text-[color:var(--mention-color)]'>
+            {replyCount === 1 ? '1 AI reply ready' : `${replyCount} AI replies ready`}
+          </span>
         </span>
         {senderNames.length > 0 && (
-          <>
-            <AvatarCluster names={senderNames} />
-            <span className='min-w-0 truncate text-[13px] text-muted-foreground'>
-              {senderNames.join(', ')}
-            </span>
-          </>
+          <span className='min-w-0 truncate text-[13px] font-medium leading-[22px] tracking-[-0.1px] text-foreground/60'>
+            {senderNames.join(', ')}
+          </span>
         )}
-        <ChevronUp size={15} className='ml-auto shrink-0 text-muted-foreground' />
       </button>
     );
   }
@@ -279,10 +294,12 @@ function CollapsedBar({
       aria-label='Expand'
       data-track-category='twin-dock'
       data-track-name='expand'
-      className='flex h-[42px] w-full select-none items-center gap-2.5 bg-muted/60 px-3 pb-3 text-left transition-colors hover:bg-muted'
+      className='flex w-full select-none items-center gap-2.5 px-3.5 pb-5 pt-2 text-left transition-colors hover:bg-foreground/[0.04]'
     >
-      <span className='text-xs font-semibold text-foreground'>{recapLabel}</span>
-      <ChevronUp size={15} className='ml-auto text-muted-foreground' />
+      <span className='text-sm font-semibold leading-[22px] tracking-[-0.1px] text-foreground'>
+        {recapLabel}
+      </span>
+      <ChevronBigUp size={15} className='ml-auto text-muted-foreground' />
     </button>
   );
 }
@@ -310,7 +327,7 @@ function ExpandedHeader({
 }): ReactElement {
   const showToggle = hasRecap && hasReply;
   return (
-    <div className='relative flex h-9 select-none items-center gap-2 border-b border-border/60 px-3'>
+    <div className='relative flex select-none items-center gap-2 px-3.5 pb-1.5 pt-2'>
       <button
         type='button'
         onClick={onCollapse}
@@ -330,11 +347,11 @@ function ExpandedHeader({
           <HeaderTab active={tab === 'recap'} onClick={() => onTabChange('recap')} label='Recap' />
         </div>
       ) : tab === 'recap' ? (
-        <span className='pointer-events-none relative text-[13px] font-semibold text-foreground'>
+        <span className='pointer-events-none relative text-sm font-semibold leading-[22px] text-foreground'>
           Thread recap
         </span>
       ) : (
-        <span className='pointer-events-none relative flex min-w-0 items-center gap-1.5 text-[13px] font-semibold text-foreground'>
+        <span className='pointer-events-none relative flex min-w-0 items-center gap-2 text-sm font-semibold leading-[22px] text-[color:var(--mention-color)]'>
           <span className='flex shrink-0'>
             <XyneAIStar size={14} />
           </span>
@@ -344,11 +361,10 @@ function ExpandedHeader({
         </span>
       )}
 
-      <div className='pointer-events-none relative ml-auto flex items-center gap-1.5'>
+      <div className='pointer-events-none relative ml-auto flex items-center'>
         {tab === 'reply' && replyCount > 1 && (
           <Pager active={active} total={replyCount} onGoTo={onGoTo} />
         )}
-        <ChevronDown size={16} className='text-muted-foreground' />
       </div>
     </div>
   );
@@ -371,7 +387,7 @@ function HeaderTab({
       data-track-category='twin-dock'
       data-track-name={`tab-${label.toLowerCase()}`}
       className={cn(
-        'pointer-events-auto flex h-7 items-center gap-1.5 rounded-full px-2.5 text-xs transition-colors',
+        'pointer-events-auto flex h-[22px] items-center gap-1.5 rounded-full px-2.5 text-xs transition-colors',
         active
           ? 'bg-muted font-semibold text-foreground'
           : 'font-medium text-muted-foreground hover:bg-muted/50',
@@ -380,16 +396,6 @@ function HeaderTab({
       {icon && <span className='flex shrink-0'>{icon}</span>}
       {label}
     </button>
-  );
-}
-
-function AvatarCluster({ names }: { names: string[] }): ReactElement {
-  return (
-    <div className='flex shrink-0 -space-x-1.5'>
-      {names.slice(0, 3).map((n, i) => (
-        <SourceAvatar key={`${n}-${i}`} name={n} size={16} />
-      ))}
-    </div>
   );
 }
 
@@ -403,34 +409,38 @@ function Pager({
   onGoTo: (index: number) => void;
 }): ReactElement {
   const btn =
-    'pointer-events-auto flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground';
+    'pointer-events-auto flex h-4 w-4 items-center justify-center text-muted-foreground transition-colors hover:text-foreground';
   return (
-    <div className='flex items-center'>
-      <button
-        onClick={() => onGoTo((active - 1 + total) % total)}
-        aria-label='Previous draft'
-        data-track-category='twin-dock'
-        data-track-name='pager-prev'
-        className={btn}
-      >
-        <ChevronLeft size={14} />
-      </button>
+    <div className='flex items-center gap-1.5'>
+      <Tooltip content='Previous draft' side='top'>
+        <button
+          onClick={() => onGoTo((active - 1 + total) % total)}
+          aria-label='Previous draft'
+          data-track-category='twin-dock'
+          data-track-name='pager-prev'
+          className={btn}
+        >
+          <ChevronBigLeft size={16} />
+        </button>
+      </Tooltip>
       <span
         role='status'
         aria-live='polite'
-        className='min-w-[34px] text-center text-[11px] tabular-nums text-muted-foreground'
+        className='text-[13px] font-semibold leading-[1.2] tabular-nums tracking-[-0.1px] text-foreground/60'
       >
-        {active + 1} / {total}
+        {active + 1}/{total}
       </span>
-      <button
-        onClick={() => onGoTo((active + 1) % total)}
-        aria-label='Next draft'
-        data-track-category='twin-dock'
-        data-track-name='pager-next'
-        className={btn}
-      >
-        <ChevronRight size={14} />
-      </button>
+      <Tooltip content='Next draft' side='top'>
+        <button
+          onClick={() => onGoTo((active + 1) % total)}
+          aria-label='Next draft'
+          data-track-category='twin-dock'
+          data-track-name='pager-next'
+          className={btn}
+        >
+          <ChevronBigRight size={16} />
+        </button>
+      </Tooltip>
     </div>
   );
 }
@@ -454,15 +464,20 @@ function avatarColor(name: string): string {
 function SourceAvatar({
   name,
   size = 16,
+  className,
 }: {
   name?: string | undefined;
   size?: number;
+  className?: string;
 }): ReactElement {
   const label = (name ?? '').trim();
   const initial = (label[0] ?? '?').toUpperCase();
   return (
     <span
-      className='inline-flex shrink-0 items-center justify-center rounded-full font-semibold uppercase leading-none text-white'
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center rounded-full font-semibold uppercase leading-none text-white',
+        className,
+      )}
       style={{
         width: size,
         height: size,
@@ -490,7 +505,7 @@ function RecapPane({
           <MarkdownMessageRenderer content={content} markdownComponents={markdownComponents} />
         ) : loading ? (
           <span className='flex items-center gap-2'>
-            <Loader2 size={14} className='animate-spin' /> Generating summary…
+            <Spinner size={14} className='animate-spin' /> Generating summary…
           </span>
         ) : (
           <span>No summary available for this thread yet.</span>
@@ -512,7 +527,7 @@ function destinationInfo(draft: TwinReplyDraftView): {
   switch (draft.destinationKind) {
     case 'origin_channel':
       return {
-        icon: <Hash size={12} />,
+        icon: <Hashtag size={12} />,
         verb: 'post',
         where: (
           <>
@@ -522,7 +537,7 @@ function destinationInfo(draft: TwinReplyDraftView): {
       };
     case 'channel':
       return {
-        icon: <Hash size={12} />,
+        icon: <Hashtag size={12} />,
         verb: 'post',
         where: (
           <>
@@ -532,7 +547,7 @@ function destinationInfo(draft: TwinReplyDraftView): {
       };
     case 'thread':
       return {
-        icon: <CornerDownLeft size={12} />,
+        icon: <ArrowTurnDownLeft size={12} />,
         verb: 'post',
         where: (
           <>
@@ -550,7 +565,7 @@ function destinationInfo(draft: TwinReplyDraftView): {
       };
     case 'dm_sender':
       return {
-        icon: <AtSign size={12} />,
+        icon: <AtMark size={12} />,
         verb: 'send',
         where: (
           <>
@@ -560,7 +575,7 @@ function destinationInfo(draft: TwinReplyDraftView): {
       };
     case 'dm':
       return {
-        icon: <AtSign size={12} />,
+        icon: <AtMark size={12} />,
         verb: 'send',
         where: (
           <>
@@ -571,7 +586,7 @@ function destinationInfo(draft: TwinReplyDraftView): {
     case 'origin_thread':
     default:
       return {
-        icon: <CornerDownLeft size={12} />,
+        icon: <ArrowTurnDownLeft size={12} />,
         verb: 'reply',
         where: (
           <>
@@ -600,25 +615,73 @@ function SourcePreview({ source }: { source: TwinSourceInfo }): ReactElement | n
             }
           : undefined
       }
-      title={clickable ? 'Jump to message' : undefined}
+      aria-label={clickable ? 'Jump to message' : undefined}
       data-track-category='twin-dock'
       data-track-name='jump-to-source'
       className={cn(
-        'group flex w-full min-w-0 items-center gap-1.5 py-0.5 text-[11px] text-muted-foreground/60',
+        'group flex w-full min-w-0 items-center gap-2 rounded-md border-[0.4px] border-border/60 bg-muted py-2 pl-2 pr-2.5',
         clickable && 'cursor-pointer',
       )}
     >
-      <SourceAvatar name={source.name} size={14} />
-      {source.name && (
-        <span className='max-w-[45%] shrink-0 truncate font-medium text-muted-foreground/80'>
-          {source.name}
+      <span className='w-[3px] shrink-0 self-stretch rounded-[2px] bg-[color:var(--mention-color)]' />
+      <SourceAvatar name={source.name} size={18} className='rounded' />
+      <div className='flex min-w-0 flex-1 items-center gap-1.5'>
+        {source.name && (
+          <span className='max-w-[45%] shrink-0 truncate text-[13px] font-bold leading-[1.2] tracking-[-0.1px] text-foreground/90'>
+            {source.name}:
+          </span>
+        )}
+        <span
+          className={cn(
+            'min-w-0 flex-1 truncate text-sm font-normal text-foreground/60',
+            clickable && 'group-hover:underline',
+          )}
+        >
+          {source.text}
         </span>
-      )}
-      <span className={cn('min-w-0 flex-1 truncate', clickable && 'group-hover:underline')}>
-        {source.text}
-      </span>
+      </div>
     </div>
   );
+}
+
+function DraftBody({ draft }: { draft: TwinReplyDraftView }): ReactElement {
+  const message = draft.message ?? '';
+
+  const clawCitationCtx = useMemo(() => {
+    const clawCitations = draft.clawCitations as ToolInvocation[] | undefined;
+    if (!clawCitations?.length) return undefined;
+    registerClawIcons(draft.clawCitationIcons);
+    const toolNumbers = buildClawCitationToolNumbers(message);
+    if (toolNumbers.size === 0) return undefined;
+    return { toolInvocations: clawCitations, toolNumbers };
+  }, [draft.clawCitations, draft.clawCitationIcons, message]);
+
+  const content = useMemo(() => {
+    if (message.indexOf('clf-') === -1) return message;
+    const linkified = clawCitationCtx
+      ? linkifyAndGroupClawCitations(message, clawCitationCtx.toolNumbers)
+      : message;
+    return stripCitationMarks(linkified);
+  }, [message, clawCitationCtx]);
+
+  const markdownComponents = useMemo(
+    () => createMarkdownComponents(`twin-draft-${draft.id}`, clawCitationCtx),
+    [draft.id, clawCitationCtx],
+  );
+
+  return (
+    <div className='bot-markdown-content max-h-[220px] overflow-y-auto px-1 text-sm leading-[22px] text-foreground'>
+      <MarkdownMessageRenderer content={content} markdownComponents={markdownComponents} />
+    </div>
+  );
+}
+
+function provenanceLabel(draft: TwinReplyDraftView): string | null {
+  const cites = draft.clawCitations as ToolInvocation[] | undefined;
+  if (!cites?.length) return null;
+  const total = cites.reduce((acc, c) => acc + (c.citations?.length ?? 0), 0);
+  if (total === 0) return null;
+  return `Derived from ${total} source${total > 1 ? 's' : ''}...`;
 }
 
 function ReplyCard({
@@ -666,6 +729,14 @@ function ReplyCard({
     );
   }
 
+  const provenance = provenanceLabel(draft);
+  const footerNote: ReactNode = provenance ?? (
+    <span className='inline-flex items-center gap-1'>
+      {hasReply && dest.icon}
+      {intent}
+    </span>
+  );
+
   const beginEdit = (): void => {
     if (onBeginEdit) {
       onBeginEdit();
@@ -681,20 +752,12 @@ function ReplyCard({
   };
 
   return (
-    <div className='flex flex-col gap-1.5'>
-      <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground/60'>
-        {hasReply && dest.icon}
-        <span>{intent}</span>
-        <span className='ml-auto shrink-0'>Only you can see this</span>
-      </div>
-
-      <div className='flex min-h-[22px] items-center'>
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-3.5'>
         {source ? <SourcePreview source={source} /> : null}
-      </div>
 
-      <div className='mt-0.5 h-[76px] overflow-y-auto rounded-md border border-dashed border-border bg-muted/30 px-3 py-2'>
         {hasReact && !hasReply ? (
-          <div className='flex h-full items-center gap-2.5'>
+          <div className='flex items-center gap-2.5 px-1'>
             <span className='flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-xl'>
               {draft.emoji}
             </span>
@@ -709,50 +772,69 @@ function ReplyCard({
             onChange={e => setEditText(e.target.value)}
             data-track-category='twin-dock'
             data-track-name='edit-draft'
-            className='h-full w-full resize-none rounded bg-background px-2 py-1.5 text-sm text-foreground outline-none ring-1 ring-border focus:ring-foreground/40'
+            className='h-[120px] w-full resize-none rounded-md bg-background px-2 py-1.5 text-sm leading-[22px] text-foreground outline-none ring-1 ring-border focus:ring-foreground/40'
           />
         ) : (
-          <div className='whitespace-pre-wrap text-sm text-foreground'>{draft.message}</div>
+          <DraftBody draft={draft} />
         )}
       </div>
 
-      <div className='flex items-center gap-1'>
-        {draft.reasoning && (
-          <button
-            onClick={onOpenReasoning}
-            aria-label='Why this reply'
-            data-track-category='twin-dock'
-            data-track-name='open-reasoning'
-            className='flex h-8 items-center gap-1 rounded-md px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-          >
-            Why?
-          </button>
-        )}
-        <div className='ml-auto flex items-center gap-1'>
-          <Button
-            size='iconSm'
-            variant='ghost'
-            onClick={() => void decline()}
-            disabled={loading}
-            aria-label='Reject'
-            className='text-muted-foreground hover:text-foreground'
-          >
-            <MessageSquareX size={17} />
-          </Button>
-          {hasReply && (
-            <Button
-              size='iconSm'
-              variant='ghost'
-              onClick={editing ? () => setEditing(false) : beginEdit}
-              disabled={loading}
-              aria-label={editing ? 'Cancel edit' : 'Edit'}
-              className='text-muted-foreground hover:text-foreground'
+      <div className='flex items-center gap-8 px-1'>
+        {draft.reasoning ? (
+          <Tooltip content='See why this reply was drafted' side='top' align='start'>
+            <button
+              onClick={onOpenReasoning}
+              aria-label='See why this reply was drafted'
+              data-track-category='twin-dock'
+              data-track-name='open-reasoning'
+              className='min-w-0 flex-1 truncate text-left text-xs font-medium text-foreground/40 transition-colors hover:text-foreground'
             >
-              <Pencil size={16} />
-            </Button>
-          )}
-          <Button size='sm' onClick={() => void send()} disabled={loading} loading={loading}>
-            {!loading && <ArrowUp size={15} />}
+              {footerNote}
+            </button>
+          </Tooltip>
+        ) : (
+          <span className='min-w-0 flex-1 truncate text-xs font-medium text-foreground/40'>
+            {footerNote}
+          </span>
+        )}
+
+        <div className='flex shrink-0 items-center gap-2'>
+          <div className='flex items-center'>
+            <Tooltip content='Discard draft' side='top'>
+              <button
+                onClick={() => void decline()}
+                disabled={loading}
+                aria-label='Discard draft'
+                data-track-category='twin-dock'
+                data-track-name='decline'
+                className='flex items-center justify-center px-[9px] py-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50'
+              >
+                <ChatCancel size={14} />
+              </button>
+            </Tooltip>
+            {hasReply && (
+              <Tooltip content={editing ? 'Cancel edit' : 'Edit draft'} side='top'>
+                <button
+                  onClick={editing ? () => setEditing(false) : beginEdit}
+                  disabled={loading}
+                  aria-label={editing ? 'Cancel edit' : 'Edit draft'}
+                  data-track-category='twin-dock'
+                  data-track-name='edit'
+                  className='flex items-center justify-center px-[9px] py-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50'
+                >
+                  <PencilEraserEditLine size={14} />
+                </button>
+              </Tooltip>
+            )}
+          </div>
+          <Button
+            size='sm'
+            onClick={() => void send()}
+            disabled={loading}
+            loading={loading}
+            className='h-7 gap-1 rounded-lg px-[9px] text-[13px] font-medium'
+          >
+            {!loading && <ArrowUp size={14} className='size-3.5' />}
             {hasReact && !hasReply ? 'Send reaction' : editing ? 'Send edited' : 'Send'}
           </Button>
         </div>

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinDraftIndicator.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinDraftIndicator.tsx
@@ -1,6 +1,7 @@
-import { Sparkles } from 'lucide-react';
+import { PencilEditAi } from '@xyne/icons';
 import type { ReactElement } from 'react';
 import { cn } from '../../../utils/classNames';
+import { Tooltip } from '../../ui/Tooltip';
 import { useTwinDraftBadge } from './TwinDraftBadgeContext';
 
 export function TwinDraftIndicator({
@@ -15,15 +16,19 @@ export function TwinDraftIndicator({
 
   const label = badge.action === 'react' ? 'Twin reaction' : 'Twin draft';
   return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground',
-        className,
-      )}
-      title='The Digital Twin drafted a response for you — open the thread to review it'
+    <Tooltip
+      content='The Digital Twin drafted a response for you — open the thread to review it'
+      side='top'
     >
-      <Sparkles size={9} className='shrink-0' />
-      {label}
-    </span>
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 rounded-full border border-border bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground',
+          className,
+        )}
+      >
+        <PencilEditAi size={9} className='shrink-0' />
+        {label}
+      </span>
+    </Tooltip>
   );
 }

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinReasoningDrawer.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/TwinReasoningDrawer.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useEffect, useMemo, useState } from 'react';
-import { Sparkles, Bug, X } from 'lucide-react';
+import { PencilEditAi, Bug, MultipleCrossCancelDefault } from '@xyne/icons';
 import { cn } from '../../../utils/classNames';
+import { Tooltip } from '../../ui/Tooltip';
 import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
 import { createMarkdownComponents } from '../../../utils/markdownComponents';
 import {
@@ -47,7 +48,7 @@ export function TwinReasoningDrawer({
           <TabButton
             active={tab === 'reasoning'}
             onClick={() => setTab('reasoning')}
-            icon={<Sparkles size={13} />}
+            icon={<PencilEditAi size={13} />}
             label='Reasoning'
           />
           <TabButton
@@ -57,15 +58,17 @@ export function TwinReasoningDrawer({
             label='Debug'
           />
         </div>
-        <button
-          onClick={onClose}
-          aria-label='Close'
-          data-track-category='twin-reasoning'
-          data-track-name='close'
-          className='ml-auto flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-        >
-          <X size={16} />
-        </button>
+        <Tooltip content='Close' side='bottom'>
+          <button
+            onClick={onClose}
+            aria-label='Close'
+            data-track-category='twin-reasoning'
+            data-track-name='close'
+            className='ml-auto flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+          >
+            <MultipleCrossCancelDefault size={16} />
+          </button>
+        </Tooltip>
       </div>
 
       {tab === 'reasoning' ? (
@@ -155,7 +158,7 @@ function ReasoningBody({
   return (
     <>
       <div className='mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground'>
-        <Sparkles size={12} /> Why this reply
+        <PencilEditAi size={12} /> Why this reply
       </div>
       <div className='text-sm leading-relaxed text-foreground'>
         <MarkdownMessageRenderer


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
XYNE-56610 — rebuilds the Digital Twin suggested-reply dock (ThreadAssistDock) to the Figma designs for the edit, send, citations and card-expansion flows, in light and dark.

Layout — the container now takes the design's two shapes: fused to the composer when collapsed, detached card (12px radius, shadow) when open. Collapsed bar, expanded header, source-quote block and footer restyled to spec; header padding, horizontal padding and line box unified across all three states so collapse/expand no longer shifts its contents.

Body — was a fixed 76px plain-text box; now renders markdown through MarkdownMessageRenderer, so bullets, bold and mentions appear as designed. Inline claw citations resolve in the draft body, not only in the reasoning drawer.

Footer — replaces the Why? button with the design's provenance line, which doubles as the reasoning-drawer trigger. Where a draft has no citations it falls back to the destination summary, so cross-channel and DM targets stay visible — the design drops the old intent row, and without this variants that post somewhere other than the origin thread become indistinguishable.

Icons — migrated the twin surfaces from lucide-react to @xyne/icons, using the components the designs name (ChevronBigLeft/Right, ChatCancel, PencilEraserEditLine, PencilEditAi). This also fixes the Send arrow rendering at 16px instead of 14px: Button's [&_svg:not([class*="size-"])]:size-4 was overriding the icon's width/height attributes.

Theming — card is bg-background, exact in both themes (bg-card resolved to #22232A against the design's #1a1a1f in dark). Secondary text is text-foreground/60|40, matching the design's alpha-on-foreground values (text-muted-foreground drifted to #B1B4B9 vs #94969C).

Motion — shadow, background, margin and border-colour share one easing so the collapsed↔expanded change resolves as a single movement.

Tooltips added to the discard, edit and pager controls.

Two calls worth a reviewer's eye: the dark frame specifies #3b82f6 for the header, but that node is an un-overridden Figma instance while every local text node in the same frame got a dark value — I used --mention-color (#88c2ff dark), which is what the design uses for the mention chip inside that card. And the provenance line reads "Derived from N sources" rather than the design's "2 docs and 3 conversations", since clawCitations doesn't reliably distinguish the two.



## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
