### PR TITLE
feature: teach agents to reuse subagent session_id for related follow-ups

### DIFF
--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -612,6 +612,7 @@ const PARENT_PARALLELISM_PREAMBLE = [
   "- If you genuinely need multiple subagent calls, fire them in the SAME assistant turn (per the parallelism rule above) — never one-at-a-time across turns.",
   "- For a narrow, factual lookup, check whether a direct (non-`[Subagent ...]`) tool can answer it before reaching for the subagent.",
   "- **Background.** If a subagent call exposes a `run_in_background` option, set it when the work is slow AND independent of your immediate next step: you get an instant acknowledgement and keep working, and its result is delivered back to you automatically before you finish. Do NOT wait or poll for it. Use blocking (leave it unset) when you need the result to decide your very next move.",
+  "- **Reuse the session for RELATED follow-ups.** When a subagent result ends with a `_Follow-up:_ ... session_id: \"...\"` footer, that handle resumes the SAME child session with its full prior context. If your next question builds on that run (a refinement, a drill-down, \"now check X in the same repo\"), pass that exact `session_id` back instead of re-asking cold — the subagent skips re-deriving context it already has, which cuts redundant internal tool calls and latency on the follow-up. Omit `session_id` (fresh session) for an UNRELATED question, and never pass a `session_id` that a DIFFERENT subagent returned.",
   "",
   "---",
   "",


### PR DESCRIPTION
## What
Adds one bullet to `PARENT_PARALLELISM_PREAMBLE` in `apps/xyne-claw/src/agent.ts` — the tool-use preamble prepended to every parent agent's persona — codifying the `session_id` follow-up pattern as the preferred mode for RELATED follow-ups.

## Why
The session-resume capability already shipped on this deploy branch (`subagent-tools.ts`: the `session_id` param on every subagent tool + the `_Follow-up:_ … session_id: "…"` footer appended to each subagent result). But agents were only told about it at those two touchpoints; the main preamble never taught them to use it proactively. Resuming a subagent session reloads the child pi session with full prior context, so on a related follow-up the subagent skips re-deriving context — fewer redundant internal tool calls and lower follow-up latency.

## Scope / risk
- Prompt-text only: one bullet added, no code-path change. 1 file, +1 line.
- Keeps existing guardrails: fresh session for unrelated questions; never pass a session_id across different subagents.