### PR TITLE
fix: onboarding regression — pass userId to hasCompletedOnboarding

### DIFF
--- a/apps/backend/prisma/migrations/20260820180000_backfill_email_on_questionnaire_responses/migration.sql
+++ b/apps/backend/prisma/migrations/20260820180000_backfill_email_on_questionnaire_responses/migration.sql
@@ -1,0 +1,28 @@
+-- Backfill email on existing questionnaire_responses rows that have email = NULL.
+-- Joins to users to get the email, picks one survivor per (email, questionnaireType)
+-- group (most recently updated), and skips any group that already has an email
+-- set (so the unique (email, questionnaireType) index is never violated).
+WITH candidates AS (
+  SELECT qr."id", lower(trim(u."email")) AS email, qr."questionnaireType", qr."updatedAt"
+  FROM "non_zero"."questionnaire_responses" qr
+  JOIN "non_zero"."users" u ON u."id" = qr."userId"
+  WHERE qr."email" IS NULL AND u."email" IS NOT NULL
+),
+already_set AS (
+  SELECT DISTINCT lower(trim("email")) AS email, "questionnaireType"
+  FROM "non_zero"."questionnaire_responses" WHERE "email" IS NOT NULL
+),
+ranked AS (
+  SELECT c."id", c.email, c."questionnaireType",
+         ROW_NUMBER() OVER (
+           PARTITION BY c.email, c."questionnaireType"
+           ORDER BY c."updatedAt" DESC NULLS LAST, c."id" DESC
+         ) AS rn
+  FROM candidates c
+  WHERE NOT EXISTS (SELECT 1 FROM already_set a
+                    WHERE a.email = c.email AND a."questionnaireType" = c."questionnaireType")
+)
+UPDATE "non_zero"."questionnaire_responses" qr
+SET "email" = r.email
+FROM ranked r
+WHERE qr."id" = r."id" AND r.rn = 1;

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -2146,7 +2146,7 @@ export class AuthV2Controller {
           maxAge: 30 * 24 * 60 * 60 * 1000,
         });
 
-        const isNewUser = !(await this.userService.hasCompletedOnboarding(userData.email));
+        const isNewUser = !(await this.userService.hasCompletedOnboarding(userData.email, workspaceUser.id));
 
         setOnboardingCookie(res, isNewUser, {
           secure: isProduction,
@@ -2291,7 +2291,7 @@ export class AuthV2Controller {
         res.cookie('user_session_id', newSessionId, { ...cookieBase, maxAge: config.session.expiryDays * 24 * 60 * 60 * 1000 });
       }
       res.cookie('xyne_last_workspace', targetWorkspaceId, { ...cookieBase, maxAge: 30 * 24 * 60 * 60 * 1000 });
-      const isNewUser = !(await this.userService.hasCompletedOnboarding(fullUser.email));
+      const isNewUser = !(await this.userService.hasCompletedOnboarding(fullUser.email, workspaceUser.id));
       setOnboardingCookie(res, isNewUser, {
         secure: isProduction,
         sameSite: 'strict' as const,

--- a/apps/backend/src/services/communityWorkspaceService.ts
+++ b/apps/backend/src/services/communityWorkspaceService.ts
@@ -331,8 +331,6 @@ export class CommunityWorkspaceService {
         });
       }
 
-      const hasCompletedOnboarding = await this.userService.hasCompletedOnboarding(email);
-
       let workspaceUser = await tx.user.findUnique({
         where: {
           email_workspaceId: {
@@ -341,6 +339,8 @@ export class CommunityWorkspaceService {
           },
         },
       });
+
+      const hasCompletedOnboarding = await this.userService.hasCompletedOnboarding(email, workspaceUser?.id);
 
       const isNewUser = !hasCompletedOnboarding;
       if (workspaceUser) {

--- a/apps/backend/src/services/userService.ts
+++ b/apps/backend/src/services/userService.ts
@@ -53,13 +53,16 @@ export class UserService {
     this.prisma = DatabaseClient.getInstance();
   }
 
-  async hasCompletedOnboarding(email: string): Promise<boolean> {
+  async hasCompletedOnboarding(email: string, userId?: string): Promise<boolean> {
     const normalizedEmail = email.toLowerCase().trim();
     return await runAsSystem(async () => {
       const onboardingResponse = await this.prisma.questionnaireResponse.findFirst({
         where: {
           questionnaireType: 'onboarding',
-          email: normalizedEmail,
+          OR: [
+            { email: normalizedEmail },
+            ...(userId ? [{ userId }] : []),
+          ],
         },
         select: { id: true },
       });
@@ -798,7 +801,7 @@ export class UserService {
       }
 
       const normalizedAuthProvider = (userData.authProvider?.toUpperCase() as AuthProvider) || AuthProvider.GOOGLE;
-      const hasCompletedOnboarding = await this.hasCompletedOnboarding(userData.email);
+      const hasCompletedOnboarding = await this.hasCompletedOnboarding(userData.email, workspaceUser?.id);
 
       if (workspaceUser) {
         workspaceUser = await this.prisma.user.update({


### PR DESCRIPTION
## Bug
After PR #555 (merged 2026-08-20), existing users who logout and login back in pre-prod are sent to the onboarding screen.

## Root Cause
PR #555 made onboarding detection **person-level** (keyed by `email`) instead of workspace-level (keyed by `userId`). The migration ran successfully (column exists, queries succeed), but it added `email` as **nullable with no backfill** — so every pre-existing onboarding row has `email = NULL`. The new `hasCompletedOnboarding(email)` queries `where: { questionnaireType: 'onboarding', email: normalizedEmail }` → no match on NULL-email rows → `isNewUser = true` → onboarding screen for existing users.

## Fix

### Part 1 — Code: pass `userId` as a fallback
Added optional `userId` param to `hasCompletedOnboarding` with an `OR` clause so it matches existing rows by `userId` even when `email` is NULL:

```ts
async hasCompletedOnboarding(email: string, userId?: string): Promise<boolean> {
  // ...
  where: {
    questionnaireType: 'onboarding',
    OR: [
      { email: normalizedEmail },
      ...(userId ? [{ userId }] : []),
    ],
  },
}
```

Updated 4 of 5 call sites to pass `userId`:
- `userService.ts:804` — `createOrGetWorkspaceUser` (returning-user login — the reported bug scenario)
- `authV2Controller.ts:2149` — CREATE-WORKSPACE-PENDING flow
- `authV2Controller.ts:2294` — CREATE-WORKSPACE-AUTH flow
- `communityWorkspaceService.ts:334` — community workspace join (reordered lookup before call)

Left 1 call site unchanged (`userService.ts:1038` — `createOrganizationWithUser`) where `userId` is not available yet (user not created).

### Part 2 — Backfill migration
New file: `apps/backend/prisma/migrations/20260820180000_backfill_email_on_questionnaire_responses/migration.sql`

Populates `email` on existing NULL rows by joining to `users.email`, picking one survivor per `(email, questionnaireType)` group to respect the unique index.

## Testing
- TypeScript typecheck passes (`tsc --noEmit` in apps/backend)
- No schema.prisma change needed (email column already modelled as String? in PR #555)

## Backfill queries for manual execution in pre-prod/prod
```sql
-- Diagnostic: count NULL-email onboarding rows
SELECT count(*) FROM "non_zero"."questionnaire_responses" WHERE "email" IS NULL;

-- Backfill (same as migration.sql)
WITH candidates AS (
  SELECT qr."id", lower(trim(u."email")) AS email, qr."questionnaireType", qr."updatedAt"
  FROM "non_zero"."questionnaire_responses" qr
  JOIN "non_zero"."users" u ON u."id" = qr."userId"
  WHERE qr."email" IS NULL AND u."email" IS NOT NULL
),
already_set AS (
  SELECT DISTINCT lower(trim("email")) AS email, "questionnaireType"
  FROM "non_zero"."questionnaire_responses" WHERE "email" IS NOT NULL
),
ranked AS (
  SELECT c."id", c.email, c."questionnaireType",
         ROW_NUMBER() OVER (
           PARTITION BY c.email, c."questionnaireType"
           ORDER BY c."updatedAt" DESC NULLS LAST, c."id" DESC
         ) AS rn
  FROM candidates c
  WHERE NOT EXISTS (SELECT 1 FROM already_set a
                    WHERE a.email = c.email AND a."questionnaireType" = c."questionnaireType")
)
UPDATE "non_zero"."questionnaire_responses" qr
SET "email" = r.email
FROM ranked r
WHERE qr."id" = r."id" AND r.rn = 1;
```