### PR TITLE
fix: cmd k transcript

### DIFF
--- a/apps/backend/src/database/acl/tables/call-participants-acl.ts
+++ b/apps/backend/src/database/acl/tables/call-participants-acl.ts
@@ -41,10 +41,7 @@ export class CallParticipantsACL extends BaseQueryACL<
             ],
           },
         },
-        // Scope on the row's own workspaceId, like getMutateWhere below. Going via
-        // `call.channel` never matches when channelId is null (recordings), which
-        // hid those participant rows from every read.
-        { workspaceId: this.ctx.workspaceId },
+        { call: { channel: { workspaceId: this.ctx.workspaceId } } },
       ],
     }
   }

--- a/apps/backend/src/database/acl/tables/call-participants-acl.ts
+++ b/apps/backend/src/database/acl/tables/call-participants-acl.ts
@@ -41,7 +41,10 @@ export class CallParticipantsACL extends BaseQueryACL<
             ],
           },
         },
-        { call: { channel: { workspaceId: this.ctx.workspaceId } } },
+        // Scope on the row's own workspaceId, like getMutateWhere below. Going via
+        // `call.channel` never matches when channelId is null (recordings), which
+        // hid those participant rows from every read.
+        { workspaceId: this.ctx.workspaceId },
       ],
     }
   }

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -595,14 +595,19 @@ export class YqlBuilder {
       );
     }
 
-    // Chat/Ticket/Transcript attachments: require owner/channelPermissions/isPrivate check
-    if (
-      subApps.some(
-        (s) => s === 'CHAT_ATTACHMENT' || s === 'TICKET_ATTACHMENT' || s === 'TRANSCRIPT'
-      )
-    ) {
+    // Chat/Ticket attachments: require owner/channelPermissions/isPrivate check
+    if (subApps.some((s) => s === 'CHAT_ATTACHMENT' || s === 'TICKET_ATTACHMENT')) {
       subAppConditions.push(
-        `((subApp contains "CHAT_ATTACHMENT" or subApp contains "TICKET_ATTACHMENT" or subApp contains "TRANSCRIPT") and (ownerId contains ${accessUser} or channelPermissions contains ${accessUser} or isPrivate contains "false"))`
+        `((subApp contains "CHAT_ATTACHMENT" or subApp contains "TICKET_ATTACHMENT") and (ownerId contains ${accessUser} or channelPermissions contains ${accessUser} or isPrivate contains "false"))`
+      );
+    }
+
+    // Transcripts also check `permissions` (the call's attendee list). Without it
+    // a channel-less call has only ownerId to match on, so nobody but the creator
+    // can find it.
+    if (subApps.some((s) => s === 'TRANSCRIPT')) {
+      subAppConditions.push(
+        `((subApp contains "TRANSCRIPT") and (ownerId contains ${accessUser} or permissions contains ${accessUser} or channelPermissions contains ${accessUser} or isPrivate contains "false"))`
       );
     }
 
@@ -657,22 +662,21 @@ export class YqlBuilder {
       conditions.push(`(${creators})`);
     }
 
-    // Date filters
+    // Date filters. The file schema's field is `createdAt` (file.sd:92) — there is
+    // no `createdAtTimestamp` here, and naming it makes Vespa reject the query.
     if (filters.createdBefore) {
       const timestamp = parseDateToTimestamp(filters.createdBefore, 'start');
-      if (timestamp) conditions.push(`createdAtTimestamp < ${timestamp}`);
+      if (timestamp) conditions.push(`createdAt < ${timestamp}`);
     }
     if (filters.createdAfter) {
       const timestamp = parseDateToTimestamp(filters.createdAfter, 'end');
-      if (timestamp) conditions.push(`createdAtTimestamp > ${timestamp}`);
+      if (timestamp) conditions.push(`createdAt > ${timestamp}`);
     }
     if (filters.createdOn) {
       const rangeStart = parseDateToTimestamp(filters.createdOn, 'start');
       const rangeEnd = parseDateToTimestamp(filters.createdOn, 'end');
       if (rangeStart && rangeEnd) {
-        conditions.push(
-          `(createdAtTimestamp >= ${rangeStart} and createdAtTimestamp <= ${rangeEnd})`
-        );
+        conditions.push(`(createdAt >= ${rangeStart} and createdAt <= ${rangeEnd})`);
       }
     }
 
@@ -680,9 +684,7 @@ export class YqlBuilder {
     if (filters.createdRange) {
       const timeRange = parseTimeKeyword(filters.createdRange);
       if (timeRange) {
-        conditions.push(
-          `(createdAtTimestamp >= ${timeRange.from} and createdAtTimestamp <= ${timeRange.to})`
-        );
+        conditions.push(`(createdAt >= ${timeRange.from} and createdAt <= ${timeRange.to})`);
       }
     }
     return conditions.join(' and ');
@@ -1240,15 +1242,28 @@ export class YqlBuilder {
       conditions.push(`!(status contains ${params.bind('callStatusExcluded', 'CANCELLED')})`);
     }
 
+    // Time window. `startsAt`/`endsAt` are the SCHEDULED times and are 0 on ad-hoc
+    // calls and recordings, so match the actual start/end too. Additive — anything
+    // that matched before still matches.
     if (Number.isFinite(filters.timeFrom) || Number.isFinite(filters.timeTo)) {
-      const timeConditions: string[] = [];
-      if (Number.isFinite(filters.timeTo)) {
-        timeConditions.push(`startsAtTimestamp < ${Math.trunc(filters.timeTo!)}`);
+      const to = Number.isFinite(filters.timeTo) ? Math.trunc(filters.timeTo!) : null;
+      const from = Number.isFinite(filters.timeFrom) ? Math.trunc(filters.timeFrom!) : null;
+
+      const scheduled: string[] = [];
+      if (to !== null) scheduled.push(`startsAtTimestamp < ${to}`);
+      if (from !== null) scheduled.push(`endsAtTimestamp > ${from}`);
+
+      // No end time = still in progress. Treat it as a point event at its start so
+      // it matches "today" but not every past window.
+      const actual: string[] = [`startedAtTimestamp > 0`];
+      if (to !== null) actual.push(`startedAtTimestamp < ${to}`);
+      if (from !== null) {
+        actual.push(
+          `(endedAtTimestamp > ${from} or (endedAtTimestamp <= 0 and startedAtTimestamp > ${from}))`
+        );
       }
-      if (Number.isFinite(filters.timeFrom)) {
-        timeConditions.push(`endsAtTimestamp > ${Math.trunc(filters.timeFrom!)}`);
-      }
-      conditions.push(`(${timeConditions.join(' and ')})`);
+
+      conditions.push(`((${scheduled.join(' and ')}) or (${actual.join(' and ')}))`);
     }
 
     return conditions.join(' and ');


### PR DESCRIPTION

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
