### PR TITLE
feat: add recording participants

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1663,6 +1663,7 @@ export const callTable = table("calls")
     instanceDate: number().optional(),
     recordingEnabled: boolean(),
     recordingUrl: string().optional(),
+    recordingParticipants: json<string[]>(),
     transcript: string().optional(),
     aiSummary: string().optional(),
     startedAt: number(),

--- a/apps/backend/prisma/migrations/20260820120000_add_recording_participants/migration.sql
+++ b/apps/backend/prisma/migrations/20260820120000_add_recording_participants/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."calls" ADD COLUMN     "recordingParticipants" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2709,6 +2709,7 @@ model Call {
   instanceDate     DateTime?   // For recurring instances
   recordingEnabled Boolean     @default(false)
   recordingUrl     String?     // GCS path: recordings/{callId}.mp4
+  recordingParticipants String[] @default([])
   transcript       String?     // Call transcript
   aiSummary        String?     // AI-generated summary
   startedAt        DateTime    @default(now())

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -51,6 +51,11 @@ import { canvasAuthService } from '@/services/canvasAuthService';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
 import { readRecordingGoogleDocLinks } from '@/utils/recordingGoogleDocs';
 
+const RecordingParticipantsCommandSchema = z.object({
+  action: z.enum(['add', 'remove']),
+  userId: z.string().min(1).max(64),
+});
+
 const UpdateHeadlessRecordingSchema = z
   .object({
     title: z.string().trim().min(1).max(255).optional(),
@@ -1457,6 +1462,55 @@ export class CallController {
     } catch (error) {
       logger.error('Failed to fetch recording detail:', error);
       res.status(500).json({ success: false, error: 'Failed to fetch recording' });
+    }
+  };
+
+  manageRecordingParticipants = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { callId } = req.params;
+
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    try {
+      const input = RecordingParticipantsCommandSchema.parse(req.body);
+      const call = await repositories.calls.findByExternalId(callId);
+
+      if (
+        !call ||
+        call.callType !== CallType.HEADLESS ||
+        (call.workspaceId !== null && call.workspaceId !== req.user!.workspaceId)
+      ) {
+        res.status(404).json({ success: false, error: 'Recording not found' });
+        return;
+      }
+
+      if (call.createdByUserId !== userId) {
+        res.status(403).json({ success: false, error: 'Access denied' });
+        return;
+      }
+
+      if (input.action === 'add') {
+        const participant = await repositories.users.findById(input.userId);
+        if (
+          !participant ||
+          participant.workspaceId !== req.user!.workspaceId ||
+          participant.leftAt !== null
+        ) {
+          res.status(400).json({ success: false, error: 'User not found in this workspace' });
+          return;
+        }
+        await repositories.calls.addRecordingParticipant(callId, input.userId);
+      } else {
+        await repositories.calls.removeRecordingParticipant(callId, input.userId);
+      }
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('Failed to manage recording participants', { error, callId });
+      res.status(400).json({ success: false, error: 'Failed to update participants' });
     }
   };
 

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -293,6 +293,27 @@ export class CallRepository {
     return rowsUpdated > 0;
   }
 
+  async addRecordingParticipant(externalId: string, userId: string): Promise<boolean> {
+    const rowsUpdated = await DatabaseClient.getInstance().$executeRaw`
+      UPDATE "calls"
+      SET "recordingParticipants" =
+        array_append(COALESCE("recordingParticipants", ARRAY[]::TEXT[]), ${userId})
+      WHERE "externalId" = ${externalId}
+        AND NOT (${userId} = ANY(COALESCE("recordingParticipants", ARRAY[]::TEXT[])))
+    `;
+    return rowsUpdated > 0;
+  }
+
+  async removeRecordingParticipant(externalId: string, userId: string): Promise<boolean> {
+    const rowsUpdated = await DatabaseClient.getInstance().$executeRaw`
+      UPDATE "calls"
+      SET "recordingParticipants" =
+        array_remove(COALESCE("recordingParticipants", ARRAY[]::TEXT[]), ${userId})
+      WHERE "externalId" = ${externalId}
+    `;
+    return rowsUpdated > 0;
+  }
+
   async appendLabels(callId: string, labelIds: string[]): Promise<void> {
     if (labelIds.length === 0) return;
     const lockKey = `call-labels:${callId}`;

--- a/apps/backend/src/database/repositories/noteTakerCallRepository.ts
+++ b/apps/backend/src/database/repositories/noteTakerCallRepository.ts
@@ -52,6 +52,7 @@ export class NoteTakerCallRepository {
         workspaceId,
         createdByUserId: createdBy,
         callType: CallType.HEADLESS,
+        recordingParticipants: [createdBy],
         status: CallStatus.ACTIVE,
         roomLink,
         metadata: metadata as Prisma.InputJsonValue,

--- a/apps/backend/src/routes/calls.ts
+++ b/apps/backend/src/routes/calls.ts
@@ -32,6 +32,7 @@ router.post('/recordings/:callId/export-google-doc', recordingGoogleDocControlle
 router.get('/recordings/:callId/google-doc-compose-context', recordingGoogleDocController.context);
 router.post('/recordings/:callId/sharing', recordingSharingController.manage);
 router.get('/recordings/:callId', callController.getRecordingDetail);
+router.post('/recordings/:callId/participants', callController.manageRecordingParticipants);
 router.patch('/recordings/:callId', callController.updateRecordingTitle);
 router.delete('/recordings/:callId', callController.deleteRecording);
 router.get('/summary-templates', summaryTemplateController.list);

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -4442,6 +4442,7 @@ export function createMutators(
             updatedAt: now,
             labels: [],
             markedItems: [],
+            recordingParticipants: [],
             xyneManaged: false,
             metadata: {
               systemMessageId,

--- a/apps/dashboard/src/hooks/useRecordingParticipants.ts
+++ b/apps/dashboard/src/hooks/useRecordingParticipants.ts
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { toast } from 'sonner';
+import type { User } from '@xyne/shared/machines';
+import { useActiveUsers, useUsersById, useSelf, searchUsers } from './useUsers';
+import { recordingService } from '../services/Recording/recordingService';
+import type { RecordingParticipantShare } from '../services/Recording/recordingService';
+import { getRecordingParticipantIds, logRecordingError } from '../utils/recordingUtils';
+import { getApiErrorMessage } from '../utils/apiError';
+
+interface UseRecordingParticipantsArgs {
+  recordingExternalId: string;
+  createdByUserId: string | undefined;
+  recordingParticipants: readonly string[] | null | undefined;
+  shares: readonly RecordingParticipantShare[] | null | undefined;
+}
+
+export interface UseRecordingParticipantsReturn {
+  self: User | undefined;
+  searchRef: React.RefObject<HTMLInputElement | null>;
+  canManage: boolean;
+  total: number;
+  participants: (User | undefined)[];
+  participantIds: string[];
+  busyIds: ReadonlySet<string>;
+  withAccess: ReadonlySet<string>;
+  accessKnown: boolean;
+  sharesLoaded: boolean;
+  withoutAccess: number;
+  changeParticipant: (action: 'add' | 'remove', userId: string) => void;
+  shareWith: (userId: string) => void;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+  trimmedQuery: string;
+  results: User[];
+  activeIndex: number;
+  onSearchKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  pickResult: (userId: string) => void;
+  highlightResult: (index: number) => void;
+}
+
+export function useRecordingParticipants({
+  recordingExternalId,
+  createdByUserId,
+  recordingParticipants,
+  shares,
+}: UseRecordingParticipantsArgs): UseRecordingParticipantsReturn {
+  const [query, setQuery] = useState('');
+  const [highlighted, setHighlighted] = useState(0);
+  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlyMap<string, 'add' | 'remove'>>(new Map());
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const users = useActiveUsers();
+  const usersById = useUsersById();
+  const self = useSelf();
+
+  const canManage = Boolean(self?.id && createdByUserId && self.id === createdByUserId);
+
+  const serverIds = useMemo(
+    () => getRecordingParticipantIds(createdByUserId, recordingParticipants),
+    [recordingParticipants, createdByUserId],
+  );
+
+  const participantIds = useMemo(() => {
+    if (pending.size === 0) return serverIds;
+    const ids = serverIds.filter(id => pending.get(id) !== 'remove');
+    for (const [id, change] of pending) {
+      if (change === 'add' && !ids.includes(id)) ids.push(id);
+    }
+    return ids;
+  }, [serverIds, pending]);
+
+  useEffect(() => {
+    setPending(current => {
+      const next = new Map(current);
+      for (const [id, change] of current) {
+        if (serverIds.includes(id) === (change === 'add')) next.delete(id);
+      }
+      return next.size === current.size ? current : next;
+    });
+  }, [serverIds]);
+
+  const withAccess = useMemo(() => {
+    const shared = new Set<string>();
+    for (const share of shares ?? []) {
+      if (share.userId) shared.add(share.userId);
+    }
+    if (createdByUserId) shared.add(createdByUserId);
+    return shared;
+  }, [shares, createdByUserId]);
+
+  const accessKnown = !(shares ?? []).some(
+    share => Boolean(share.userGroupId) || Boolean(share.channelId),
+  );
+  const sharesLoaded = shares !== undefined;
+
+  const participants = useMemo(
+    () => participantIds.map(id => usersById.get(id)).filter(Boolean),
+    [participantIds, usersById],
+  );
+
+  const trimmedQuery = query.trim();
+  const results = useMemo(() => {
+    if (!trimmedQuery) return [];
+    const already = new Set(participantIds);
+    return searchUsers(
+      users.filter(user => !already.has(user.id)),
+      trimmedQuery,
+      6,
+    );
+  }, [trimmedQuery, users, participantIds]);
+
+  useEffect(() => setHighlighted(0), [trimmedQuery]);
+  const activeIndex = highlighted < results.length ? highlighted : 0;
+
+  const withBusy = async (userId: string, work: () => Promise<void>): Promise<void> => {
+    setBusyIds(current => new Set(current).add(userId));
+    try {
+      await work();
+    } finally {
+      setBusyIds(current => {
+        const next = new Set(current);
+        next.delete(userId);
+        return next;
+      });
+    }
+  };
+
+  const changeParticipant = (action: 'add' | 'remove', userId: string): void => {
+    setPending(current => new Map(current).set(userId, action));
+    void withBusy(userId, async () => {
+      try {
+        await recordingService.manageRecordingParticipant(recordingExternalId, action, userId);
+      } catch (error) {
+        setPending(current => {
+          const next = new Map(current);
+          next.delete(userId);
+          return next;
+        });
+        logRecordingError('RecordingParticipants.change', error);
+        toast.error(
+          action === 'add' ? 'Could not add participant' : 'Could not remove participant',
+          {
+            description: getApiErrorMessage(error, 'Unable to update participants'),
+          },
+        );
+      }
+    });
+  };
+
+  const shareWith = (userId: string): void => {
+    void withBusy(userId, async () => {
+      try {
+        await recordingService.grantRecordingAccess(recordingExternalId, [
+          { type: 'user', id: userId },
+        ]);
+        toast.success('Recording shared');
+      } catch (error) {
+        logRecordingError('RecordingParticipants.share', error);
+        toast.error('Could not share recording', {
+          description: getApiErrorMessage(error, 'Unable to share this recording'),
+        });
+      }
+    });
+  };
+
+  const total = participantIds.length;
+  const withoutAccess = participantIds.filter(id => !withAccess.has(id)).length;
+
+  const onSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (results.length === 0) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlighted((activeIndex + 1) % results.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlighted((activeIndex - 1 + results.length) % results.length);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const picked = results[activeIndex];
+      if (picked) {
+        setQuery('');
+        changeParticipant('add', picked.id);
+      }
+    }
+  };
+
+  const pickResult = (userId: string): void => {
+    setQuery('');
+    changeParticipant('add', userId);
+  };
+
+  const highlightResult = (index: number): void => setHighlighted(index);
+
+  return {
+    self,
+    searchRef,
+    canManage,
+    total,
+    participants,
+    participantIds,
+    busyIds,
+    withAccess,
+    accessKnown,
+    sharesLoaded,
+    withoutAccess,
+    changeParticipant,
+    shareWith,
+    query,
+    setQuery,
+    trimmedQuery,
+    results,
+    activeIndex,
+    onSearchKeyDown,
+    pickResult,
+    highlightResult,
+  };
+}

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
@@ -160,6 +160,7 @@ function mapVespaCallResultToCall(result: DisplaySearchResult, workspaceId: stri
     instanceDate: null,
     recordingEnabled: false,
     recordingUrl: null,
+    recordingParticipants: [],
     transcript: context?.hasTranscript ? 'available' : undefined,
     aiSummary: null,
     startedAt,

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -422,6 +422,8 @@ export default function RecordingDetailV2Screen(): ReactElement {
         ...prev,
         title: recordingRow.title || prev.title,
         labels: recordingRow.labels ?? prev.labels,
+        recordingParticipants: recordingRow.recordingParticipants ?? prev.recordingParticipants,
+        shares: recordingRow.shares ?? prev.shares,
         linkedTicketId,
         linkedTicketMessageId:
           typeof rawLinkedTicketMessageId === 'string' ? rawLinkedTicketMessageId : null,

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -308,6 +308,8 @@ export const RecordingDetailV2Header = ({
           <RecordingParticipants
             recordingExternalId={recording.externalId}
             createdByUserId={recording.createdByUserId}
+            recordingParticipants={recording.recordingParticipants}
+            shares={recording.shares}
           />
           {!isLive && recording.detailedSummaryCanvasId && (
             <RecordingTicketLink

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../utils/recordingUtils';
 import { getApiErrorMessage } from '../../../utils/apiError';
 import { formatDuration } from '../../../utils/dateUtils';
+import { RecordingParticipants } from './RecordingParticipants';
 import { RecordingLabelPicker } from './RecordingLabelPicker';
 import { RecordingShareModal } from './RecordingShareModal';
 import { RecordingSharedWithAvatars } from './RecordingSharedWithAvatars';
@@ -312,6 +313,10 @@ export const RecordingDetailV2Header = ({
               onChange={(ticketId, ticket) => void handleTicketLinkChange(ticketId, ticket)}
             />
           )}
+          <RecordingParticipants
+            recordingExternalId={recording.externalId}
+            createdByUserId={recording.createdByUserId}
+          />
           <RecordingLabelPicker
             labels={recording.labels ?? []}
             canEdit={recording.createdByUserId === currentUser?.id}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -305,6 +305,10 @@ export const RecordingDetailV2Header = ({
       {/* Actions row */}
       <div className='flex items-start'>
         <div className='flex flex-wrap items-center gap-2'>
+          <RecordingParticipants
+            recordingExternalId={recording.externalId}
+            createdByUserId={recording.createdByUserId}
+          />
           {!isLive && recording.detailedSummaryCanvasId && (
             <RecordingTicketLink
               linkedTicketId={recording.linkedTicketId ?? null}
@@ -313,10 +317,6 @@ export const RecordingDetailV2Header = ({
               onChange={(ticketId, ticket) => void handleTicketLinkChange(ticketId, ticket)}
             />
           )}
-          <RecordingParticipants
-            recordingExternalId={recording.externalId}
-            createdByUserId={recording.createdByUserId}
-          />
           <RecordingLabelPicker
             labels={recording.labels ?? []}
             canEdit={recording.createdByUserId === currentUser?.id}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
@@ -1,0 +1,379 @@
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { Search, Share2, UserPlus, Users, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { queries } from '../../../zero/queries';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useActiveUsers, useUsersById, useSelf, searchUsers } from '../../../hooks/useUsers';
+import { recordingService } from '../../../services/Recording/recordingService';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { getRecordingParticipantIds, logRecordingError } from '../../../utils/recordingUtils';
+import { getApiErrorMessage } from '../../../utils/apiError';
+import Avatar from '../../../components/ui/Avatar/Avatar';
+import AvatarGroup from '../../../components/ui/Avatar/AvatarGroup';
+import { Popover } from '../../../components/ui/Popover/Popover';
+import { Button } from '../../../components/ui/Button/Button';
+import { cn } from '../../../utils/classNames';
+
+interface RecordingParticipantsProps {
+  recordingExternalId: string;
+  createdByUserId: string | undefined;
+}
+
+export function RecordingParticipants({
+  recordingExternalId,
+  createdByUserId,
+}: RecordingParticipantsProps): ReactElement | null {
+  const [query, setQuery] = useState('');
+  const [highlighted, setHighlighted] = useState(0);
+  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlyMap<string, 'add' | 'remove'>>(new Map());
+  const searchRef = useRef<HTMLInputElement>(null);
+  const reduceMotion = useReducedMotion();
+
+  const users = useActiveUsers();
+  const usersById = useUsersById();
+  const self = useSelf();
+  const [recordingRow] = useCachedQuery(
+    queries.oatsRecordingByExternalId({ callId: recordingExternalId }),
+  );
+
+  const canManage = Boolean(self?.id && createdByUserId && self.id === createdByUserId);
+
+  const serverIds = useMemo(
+    () => getRecordingParticipantIds(createdByUserId, recordingRow?.recordingParticipants),
+    [recordingRow, createdByUserId],
+  );
+
+  const participantIds = useMemo(() => {
+    if (pending.size === 0) return serverIds;
+    const ids = serverIds.filter(id => pending.get(id) !== 'remove');
+    for (const [id, change] of pending) {
+      if (change === 'add' && !ids.includes(id)) ids.push(id);
+    }
+    return ids;
+  }, [serverIds, pending]);
+
+  useEffect(() => {
+    setPending(current => {
+      const next = new Map(current);
+      for (const [id, change] of current) {
+        if (serverIds.includes(id) === (change === 'add')) next.delete(id);
+      }
+      return next.size === current.size ? current : next;
+    });
+  }, [serverIds]);
+
+  const withAccess = useMemo(() => {
+    const shared = new Set<string>();
+    for (const share of recordingRow?.shares ?? []) {
+      if (share.userId) shared.add(share.userId);
+    }
+    if (createdByUserId) shared.add(createdByUserId);
+    return shared;
+  }, [recordingRow, createdByUserId]);
+
+  const accessKnown = !(recordingRow?.shares ?? []).some(
+    share => Boolean(share.userGroupId) || Boolean(share.channelId),
+  );
+
+  const participants = useMemo(
+    () => participantIds.map(id => usersById.get(id)).filter(Boolean),
+    [participantIds, usersById],
+  );
+
+  const trimmedQuery = query.trim();
+  const results = useMemo(() => {
+    if (!trimmedQuery) return [];
+    const already = new Set(participantIds);
+    return searchUsers(
+      users.filter(user => !already.has(user.id)),
+      trimmedQuery,
+      6,
+    );
+  }, [trimmedQuery, users, participantIds]);
+
+  useEffect(() => setHighlighted(0), [trimmedQuery]);
+  const activeIndex = highlighted < results.length ? highlighted : 0;
+
+  const withBusy = async (userId: string, work: () => Promise<void>): Promise<void> => {
+    setBusyIds(current => new Set(current).add(userId));
+    try {
+      await work();
+    } finally {
+      setBusyIds(current => {
+        const next = new Set(current);
+        next.delete(userId);
+        return next;
+      });
+    }
+  };
+
+  const changeParticipant = (action: 'add' | 'remove', userId: string): void => {
+    setPending(current => new Map(current).set(userId, action));
+    void withBusy(userId, async () => {
+      try {
+        await recordingService.manageRecordingParticipant(recordingExternalId, action, userId);
+      } catch (error) {
+        setPending(current => {
+          const next = new Map(current);
+          next.delete(userId);
+          return next;
+        });
+        logRecordingError('RecordingParticipants.change', error);
+        toast.error(
+          action === 'add' ? 'Could not add participant' : 'Could not remove participant',
+          {
+            description: getApiErrorMessage(error, 'Unable to update participants'),
+          },
+        );
+      }
+    });
+  };
+
+  const shareWith = (userId: string): void => {
+    void withBusy(userId, async () => {
+      try {
+        await recordingService.grantRecordingAccess(recordingExternalId, [
+          { type: 'user', id: userId },
+        ]);
+        toast.success('Recording shared');
+      } catch (error) {
+        logRecordingError('RecordingParticipants.share', error);
+        toast.error('Could not share recording', {
+          description: getApiErrorMessage(error, 'Unable to share this recording'),
+        });
+      }
+    });
+  };
+
+  const total = participantIds.length;
+  const withoutAccess = participantIds.filter(id => !withAccess.has(id)).length;
+
+  const rowMotion = reduceMotion
+    ? {}
+    : {
+        initial: { opacity: 0, y: 4, filter: 'blur(4px)' },
+        animate: { opacity: 1, y: 0, filter: 'blur(0px)' },
+        exit: {
+          opacity: 0,
+          y: -4,
+          filter: 'blur(4px)',
+          transition: { duration: 0.15, ease: 'easeIn' as const },
+        },
+        transition: { type: 'spring' as const, duration: 0.3, bounce: 0 },
+      };
+
+  const trigger = (
+    <Button
+      type='button'
+      variant='outline'
+      size='sm'
+      className={cn(
+        'h-7 gap-1.5 rounded-lg text-xs font-normal active:scale-[0.96]',
+        total === 0
+          ? 'border-dashed border-muted-foreground/40 px-3 text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+          : 'px-2',
+      )}
+      aria-label={total > 0 ? `Participants, ${total} added` : 'Add participants to this recording'}
+      data-track-category='RecordingDetailV2'
+      data-track-name='open_recording_participants'
+    >
+      {total === 0 ? (
+        <>
+          <UserPlus className='size-3.5' aria-hidden='true' />
+          Add people
+        </>
+      ) : (
+        <>
+          <AvatarGroup userIds={participantIds.slice(0, 3)} size='xs' />
+          <span className='tabular-nums'>{total}</span>
+        </>
+      )}
+    </Button>
+  );
+
+  const emptyState = (
+    <div className='flex flex-col items-center gap-1 px-4 py-7 text-center'>
+      <Users className='size-4 text-muted-foreground' aria-hidden='true' />
+      <p className='text-[13px] text-muted-foreground'>No one added yet</p>
+      {canManage && (
+        <p className='text-[11px] text-muted-foreground/70'>
+          Search above to add the people this recording is about
+        </p>
+      )}
+    </div>
+  );
+
+  return (
+    <Popover
+      trigger={trigger}
+      side='bottom'
+      align='start'
+      sideOffset={6}
+      focusRef={searchRef}
+      className='w-[19rem] overflow-hidden p-0'
+      onEscapeKeyDown={event => {
+        if (!trimmedQuery) return;
+        event.preventDefault();
+        setQuery('');
+      }}
+    >
+      <div className='flex items-center justify-between gap-2 border-b border-border px-3 py-2.5'>
+        <span className='text-[13px] font-medium'>Participants</span>
+        {recordingRow && total > 0 && accessKnown && (
+          <span className='text-[11px] tabular-nums text-muted-foreground'>
+            {withoutAccess === 0
+              ? `all ${total} have access`
+              : `${total - withoutAccess} of ${total} have access`}
+          </span>
+        )}
+      </div>
+
+      {canManage && (
+        <div className='flex items-center gap-2 border-b border-border px-3'>
+          <Search className='size-3.5 shrink-0 text-muted-foreground' aria-hidden='true' />
+          <input
+            ref={searchRef}
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+            onKeyDown={event => {
+              if (results.length === 0) return;
+              if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setHighlighted((activeIndex + 1) % results.length);
+              } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setHighlighted((activeIndex - 1 + results.length) % results.length);
+              } else if (event.key === 'Enter') {
+                event.preventDefault();
+                const picked = results[activeIndex];
+                if (picked) {
+                  setQuery('');
+                  changeParticipant('add', picked.id);
+                }
+              }
+            }}
+            role='combobox'
+            aria-expanded={results.length > 0}
+            aria-controls='recording-participant-results'
+            aria-activedescendant={results[activeIndex]?.id}
+            placeholder='Add someone by name or email'
+            className='h-9 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground'
+            data-track-category='RecordingDetailV2'
+            data-track-name='search_recording_participants'
+          />
+        </div>
+      )}
+
+      {trimmedQuery ? (
+        <div
+          id='recording-participant-results'
+          role='listbox'
+          aria-label='Matching people'
+          className='max-h-60 overflow-y-auto py-1'
+        >
+          {results.length === 0 && (
+            <p className='px-3 py-5 text-center text-[13px] text-muted-foreground'>
+              No one matches “{trimmedQuery}”
+            </p>
+          )}
+          {results.map((user, index) => (
+            <button
+              key={user.id}
+              id={user.id}
+              role='option'
+              aria-selected={index === activeIndex}
+              type='button'
+              disabled={busyIds.has(user.id)}
+              onMouseMove={() => setHighlighted(index)}
+              onClick={() => {
+                setQuery('');
+                changeParticipant('add', user.id);
+              }}
+              className={cn(
+                'flex w-full items-center gap-2.5 px-3 py-2 text-left disabled:opacity-50',
+                index === activeIndex && 'bg-muted',
+              )}
+              data-track-category='RecordingDetailV2'
+              data-track-name='add_recording_participant'
+            >
+              <Avatar userId={user.id} size='rg' showActiveStatus={false} />
+              <span className='min-w-0 flex-1'>
+                <span className='block truncate text-[13px]'>{getUserDisplayName(user)}</span>
+                <span className='block truncate text-[11px] text-muted-foreground'>
+                  {user.email}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className='max-h-60 overflow-y-auto py-1'>
+          {participants.length === 0 && emptyState}
+          <AnimatePresence initial={false}>
+            {participants.map(user => {
+              if (!user) return null;
+              const isSelf = user.id === self?.id;
+              const busy = busyIds.has(user.id);
+              const isOwner = user.id === createdByUserId;
+              return (
+                <motion.div
+                  key={user.id}
+                  layout={!reduceMotion}
+                  {...rowMotion}
+                  className='group flex items-center gap-2.5 px-3 py-2 hover:bg-muted/50'
+                >
+                  <Avatar userId={user.id} size='rg' showActiveStatus={false} />
+                  <div className='min-w-0 flex-1'>
+                    <div className='flex items-center gap-1.5'>
+                      <span className='truncate text-[13px]'>{getUserDisplayName(user)}</span>
+                      {isSelf && !isOwner && (
+                        <span className='shrink-0 text-[11px] text-muted-foreground'>You</span>
+                      )}
+                    </div>
+                    <span className='block truncate text-[11px] text-muted-foreground'>
+                      {isOwner ? 'Owner' : user.email}
+                    </span>
+                  </div>
+                  {canManage && !isOwner && (
+                    <div className='flex shrink-0 items-center gap-0.5'>
+                      {accessKnown && !withAccess.has(user.id) && (
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='sm'
+                          disabled={busy}
+                          onClick={() => shareWith(user.id)}
+                          className='h-7 gap-1 px-2 text-[11px] font-normal text-muted-foreground hover:text-foreground active:scale-[0.96]'
+                          data-track-category='RecordingDetailV2'
+                          data-track-name='share_with_recording_participant'
+                        >
+                          <Share2 className='size-3' aria-hidden='true' />
+                          Share
+                        </Button>
+                      )}
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='iconSm'
+                        disabled={busy}
+                        aria-label={`Remove ${getUserDisplayName(user)}`}
+                        onClick={() => changeParticipant('remove', user.id)}
+                        className='text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 active:scale-[0.96] group-hover:opacity-100'
+                        data-track-category='RecordingDetailV2'
+                        data-track-name='remove_recording_participant'
+                      >
+                        <X className='size-3.5' aria-hidden='true' />
+                      </Button>
+                    </div>
+                  )}
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
+        </div>
+      )}
+    </Popover>
+  );
+}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { Search, Share2, UserPlus, Users, X } from 'lucide-react';
+import { Search, Share2, Users, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { queries } from '../../../zero/queries';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
@@ -150,6 +150,8 @@ export function RecordingParticipants({
   const total = participantIds.length;
   const withoutAccess = participantIds.filter(id => !withAccess.has(id)).length;
 
+  if (total === 0) return null;
+
   const rowMotion = reduceMotion
     ? {}
     : {
@@ -169,27 +171,13 @@ export function RecordingParticipants({
       type='button'
       variant='outline'
       size='sm'
-      className={cn(
-        'h-7 gap-1.5 rounded-lg text-xs font-normal active:scale-[0.96]',
-        total === 0
-          ? 'border-dashed border-muted-foreground/40 px-3 text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-          : 'px-2',
-      )}
-      aria-label={total > 0 ? `Participants, ${total} added` : 'Add participants to this recording'}
+      className='h-7 gap-1.5 rounded-lg px-2 text-xs font-normal active:scale-[0.96]'
+      aria-label={`Participants, ${total} added`}
       data-track-category='RecordingDetailV2'
       data-track-name='open_recording_participants'
     >
-      {total === 0 ? (
-        <>
-          <UserPlus className='size-3.5' aria-hidden='true' />
-          Add people
-        </>
-      ) : (
-        <>
-          <AvatarGroup userIds={participantIds.slice(0, 3)} size='xs' />
-          <span className='tabular-nums'>{total}</span>
-        </>
-      )}
+      <AvatarGroup userIds={participantIds.slice(0, 3)} size='xs' />
+      <span className='tabular-nums'>{total}</span>
     </Button>
   );
 

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
@@ -1,14 +1,9 @@
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { Search, Share2, Users, X } from 'lucide-react';
-import { toast } from 'sonner';
-import { queries } from '../../../zero/queries';
-import { useCachedQuery } from '../../../hooks/useCachedQuery';
-import { useActiveUsers, useUsersById, useSelf, searchUsers } from '../../../hooks/useUsers';
-import { recordingService } from '../../../services/Recording/recordingService';
+import { useRecordingParticipants } from '../../../hooks/useRecordingParticipants';
+import type { RecordingParticipantShare } from '../../../services/Recording/recordingService';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
-import { getRecordingParticipantIds, logRecordingError } from '../../../utils/recordingUtils';
-import { getApiErrorMessage } from '../../../utils/apiError';
 import Avatar from '../../../components/ui/Avatar/Avatar';
 import AvatarGroup from '../../../components/ui/Avatar/AvatarGroup';
 import { Popover } from '../../../components/ui/Popover/Popover';
@@ -18,137 +13,45 @@ import { cn } from '../../../utils/classNames';
 interface RecordingParticipantsProps {
   recordingExternalId: string;
   createdByUserId: string | undefined;
+  recordingParticipants: readonly string[] | null | undefined;
+  shares: readonly RecordingParticipantShare[] | null | undefined;
 }
 
 export function RecordingParticipants({
   recordingExternalId,
   createdByUserId,
+  recordingParticipants,
+  shares,
 }: RecordingParticipantsProps): ReactElement | null {
-  const [query, setQuery] = useState('');
-  const [highlighted, setHighlighted] = useState(0);
-  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
-  const [pending, setPending] = useState<ReadonlyMap<string, 'add' | 'remove'>>(new Map());
-  const searchRef = useRef<HTMLInputElement>(null);
   const reduceMotion = useReducedMotion();
-
-  const users = useActiveUsers();
-  const usersById = useUsersById();
-  const self = useSelf();
-  const [recordingRow] = useCachedQuery(
-    queries.oatsRecordingByExternalId({ callId: recordingExternalId }),
-  );
-
-  const canManage = Boolean(self?.id && createdByUserId && self.id === createdByUserId);
-
-  const serverIds = useMemo(
-    () => getRecordingParticipantIds(createdByUserId, recordingRow?.recordingParticipants),
-    [recordingRow, createdByUserId],
-  );
-
-  const participantIds = useMemo(() => {
-    if (pending.size === 0) return serverIds;
-    const ids = serverIds.filter(id => pending.get(id) !== 'remove');
-    for (const [id, change] of pending) {
-      if (change === 'add' && !ids.includes(id)) ids.push(id);
-    }
-    return ids;
-  }, [serverIds, pending]);
-
-  useEffect(() => {
-    setPending(current => {
-      const next = new Map(current);
-      for (const [id, change] of current) {
-        if (serverIds.includes(id) === (change === 'add')) next.delete(id);
-      }
-      return next.size === current.size ? current : next;
-    });
-  }, [serverIds]);
-
-  const withAccess = useMemo(() => {
-    const shared = new Set<string>();
-    for (const share of recordingRow?.shares ?? []) {
-      if (share.userId) shared.add(share.userId);
-    }
-    if (createdByUserId) shared.add(createdByUserId);
-    return shared;
-  }, [recordingRow, createdByUserId]);
-
-  const accessKnown = !(recordingRow?.shares ?? []).some(
-    share => Boolean(share.userGroupId) || Boolean(share.channelId),
-  );
-
-  const participants = useMemo(
-    () => participantIds.map(id => usersById.get(id)).filter(Boolean),
-    [participantIds, usersById],
-  );
-
-  const trimmedQuery = query.trim();
-  const results = useMemo(() => {
-    if (!trimmedQuery) return [];
-    const already = new Set(participantIds);
-    return searchUsers(
-      users.filter(user => !already.has(user.id)),
-      trimmedQuery,
-      6,
-    );
-  }, [trimmedQuery, users, participantIds]);
-
-  useEffect(() => setHighlighted(0), [trimmedQuery]);
-  const activeIndex = highlighted < results.length ? highlighted : 0;
-
-  const withBusy = async (userId: string, work: () => Promise<void>): Promise<void> => {
-    setBusyIds(current => new Set(current).add(userId));
-    try {
-      await work();
-    } finally {
-      setBusyIds(current => {
-        const next = new Set(current);
-        next.delete(userId);
-        return next;
-      });
-    }
-  };
-
-  const changeParticipant = (action: 'add' | 'remove', userId: string): void => {
-    setPending(current => new Map(current).set(userId, action));
-    void withBusy(userId, async () => {
-      try {
-        await recordingService.manageRecordingParticipant(recordingExternalId, action, userId);
-      } catch (error) {
-        setPending(current => {
-          const next = new Map(current);
-          next.delete(userId);
-          return next;
-        });
-        logRecordingError('RecordingParticipants.change', error);
-        toast.error(
-          action === 'add' ? 'Could not add participant' : 'Could not remove participant',
-          {
-            description: getApiErrorMessage(error, 'Unable to update participants'),
-          },
-        );
-      }
-    });
-  };
-
-  const shareWith = (userId: string): void => {
-    void withBusy(userId, async () => {
-      try {
-        await recordingService.grantRecordingAccess(recordingExternalId, [
-          { type: 'user', id: userId },
-        ]);
-        toast.success('Recording shared');
-      } catch (error) {
-        logRecordingError('RecordingParticipants.share', error);
-        toast.error('Could not share recording', {
-          description: getApiErrorMessage(error, 'Unable to share this recording'),
-        });
-      }
-    });
-  };
-
-  const total = participantIds.length;
-  const withoutAccess = participantIds.filter(id => !withAccess.has(id)).length;
+  const {
+    self,
+    searchRef,
+    canManage,
+    total,
+    participants,
+    participantIds,
+    busyIds,
+    withAccess,
+    accessKnown,
+    sharesLoaded,
+    withoutAccess,
+    changeParticipant,
+    shareWith,
+    query,
+    setQuery,
+    trimmedQuery,
+    results,
+    activeIndex,
+    onSearchKeyDown,
+    pickResult,
+    highlightResult,
+  } = useRecordingParticipants({
+    recordingExternalId,
+    createdByUserId,
+    recordingParticipants,
+    shares,
+  });
 
   if (total === 0) return null;
 
@@ -209,7 +112,7 @@ export function RecordingParticipants({
     >
       <div className='flex items-center justify-between gap-2 border-b border-border px-3 py-2.5'>
         <span className='text-[13px] font-medium'>Participants</span>
-        {recordingRow && total > 0 && accessKnown && (
+        {sharesLoaded && total > 0 && accessKnown && (
           <span className='text-[11px] tabular-nums text-muted-foreground'>
             {withoutAccess === 0
               ? `all ${total} have access`
@@ -225,23 +128,7 @@ export function RecordingParticipants({
             ref={searchRef}
             value={query}
             onChange={event => setQuery(event.target.value)}
-            onKeyDown={event => {
-              if (results.length === 0) return;
-              if (event.key === 'ArrowDown') {
-                event.preventDefault();
-                setHighlighted((activeIndex + 1) % results.length);
-              } else if (event.key === 'ArrowUp') {
-                event.preventDefault();
-                setHighlighted((activeIndex - 1 + results.length) % results.length);
-              } else if (event.key === 'Enter') {
-                event.preventDefault();
-                const picked = results[activeIndex];
-                if (picked) {
-                  setQuery('');
-                  changeParticipant('add', picked.id);
-                }
-              }
-            }}
+            onKeyDown={onSearchKeyDown}
             role='combobox'
             aria-expanded={results.length > 0}
             aria-controls='recording-participant-results'
@@ -274,11 +161,8 @@ export function RecordingParticipants({
               aria-selected={index === activeIndex}
               type='button'
               disabled={busyIds.has(user.id)}
-              onMouseMove={() => setHighlighted(index)}
-              onClick={() => {
-                setQuery('');
-                changeParticipant('add', user.id);
-              }}
+              onMouseMove={() => highlightResult(index)}
+              onClick={() => pickResult(user.id)}
               className={cn(
                 'flex w-full items-center gap-2.5 px-3 py-2 text-left disabled:opacity-50',
                 index === activeIndex && 'bg-muted',

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -33,13 +33,14 @@ import {
   filterRecordingsByLabels,
   filterRecordingsByOwnership,
   findNearestVisibleRecording,
+  formatRecordingParticipants,
   getRecordingDatePresetLabel,
   isRecordingInDatePreset,
   LIST_TAB_CLASS_NAME,
   type RecordingDatePreset,
   type RecordingOwnershipTab,
 } from './utils/RecordingsV2.utils';
-import { normalizeRecordingTags } from '../../utils/recordingUtils';
+import { getRecordingParticipantIds, normalizeRecordingTags } from '../../utils/recordingUtils';
 import { DEFAULT_RECORDING_TITLE, readRecordingCanvasIds } from '@/utils/recordingUtils';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { SummaryTemplatesModal } from '../RecordingDetailV2Screen/components/SummaryTemplatesModal';
@@ -121,9 +122,18 @@ const RecordingsV2Screen = (): ReactElement => {
   }, [handleStartRecording, pendingAutoStart, recordingStatus]);
 
   const availableCreators = useMemo(() => {
-    const creatorIds = new Set(recordings.map(recording => recording.createdByUserId));
-    return users.filter(user => creatorIds.has(user.id));
-  }, [recordings, users]);
+    const ids = new Set<string>();
+    for (const recording of recordings) {
+      for (const id of getRecordingParticipantIds(
+        recording.createdByUserId,
+        recording.recordingParticipants,
+      )) {
+        ids.add(id);
+      }
+    }
+    if (selectedCreatorId) ids.add(selectedCreatorId);
+    return users.filter(user => ids.has(user.id));
+  }, [recordings, users, selectedCreatorId]);
 
   const availableLabels = useMemo(
     () =>
@@ -233,15 +243,9 @@ const RecordingsV2Screen = (): ReactElement => {
     [activeListTab, setActiveListTab],
   );
 
-  const handleCreatorChange = useCallback(
-    (creatorId: string | null): void => {
-      setSelectedCreatorId(creatorId);
-      if (creatorId) {
-        setActiveListTab(creatorId === currentUser?.id ? 'created' : 'shared');
-      }
-    },
-    [currentUser?.id, setActiveListTab],
-  );
+  const handleCreatorChange = useCallback((creatorId: string | null): void => {
+    setSelectedCreatorId(creatorId);
+  }, []);
 
   const handleOpenRecording = useCallback(
     (recordingId: string): void => {
@@ -569,6 +573,14 @@ const RecordingsV2Screen = (): ReactElement => {
                       <RecordingsV2Pill
                         recording={row.recording}
                         creator={usersById.get(row.recording.createdByUserId) ?? null}
+                        participantsLabel={formatRecordingParticipants(
+                          getRecordingParticipantIds(
+                            row.recording.createdByUserId,
+                            row.recording.recordingParticipants,
+                          ),
+                          usersById,
+                          currentUser?.id,
+                        )}
                         tags={row.recording.labels.filter(isManualLabel)}
                         resolveLabel={resolveLabel}
                         onOpen={handleOpenRecording}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingPeopleFilter.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingPeopleFilter.tsx
@@ -94,7 +94,8 @@ export function RecordingPeopleFilter({
         placeholder='People'
         searchPlaceholder='Search people...'
         inputClassName={cn(
-          'h-9 rounded-xl pl-3 pr-7 text-sm font-medium shadow-sm',
+          'h-9 max-w-[9rem] rounded-xl pl-3 pr-7 text-sm font-medium shadow-sm',
+          '[&>span]:min-w-0 [&>span]:overflow-hidden [&>span]:text-ellipsis [&>span]:!whitespace-nowrap',
           selectedUserId && '!border-foreground',
         )}
         onSearchChange={setSearchValue}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -13,7 +13,6 @@ import {
   normalizeRecordingTags,
 } from '../../../utils/recordingUtils';
 import { cn } from '../../../utils/classNames';
-import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { TextShimmer } from '../../../components/ui/ShimmerText';
 import { useRecordingTitleState } from '../../../hooks/useRecordingTitleState';
 import { formatRecordingTimestamp, toRecordingTitleInput } from '../utils/RecordingsV2.utils';
@@ -24,6 +23,7 @@ export interface RecordingsV2PillProps {
     'id' | 'externalId' | 'title' | 'startedAt' | 'endedAt' | 'status' | 'aiSummary' | 'transcript'
   >;
   creator: User | null;
+  participantsLabel: string;
   tags?: string[];
   /** Resolves a tag value (Tag id) to its display text. Defaults to identity. */
   resolveLabel?: (label: string) => string;
@@ -111,6 +111,7 @@ export const RecordingsV2LivePill = ({
 const RecordingsV2Pill = ({
   recording,
   creator,
+  participantsLabel,
   tags = [],
   resolveLabel = (label: string) => label,
   onOpen,
@@ -172,9 +173,7 @@ const RecordingsV2Pill = ({
               </span>
             )}
             <span className='mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground'>
-              <span className='truncate'>
-                {creator ? getUserDisplayName(creator) : 'Unknown creator'}
-              </span>
+              <span className='truncate'>{participantsLabel}</span>
               <span aria-hidden='true'>·</span>
               <span className='shrink-0'>{formatRecordingTimestamp(recording.startedAt)}</span>
             </span>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
@@ -12,8 +12,13 @@ import {
   subWeeks,
 } from 'date-fns';
 import { CallStatus } from '@xyne/shared';
+import type { User } from '@xyne/shared/machines';
 import type { OatsRecordingEntry } from '../../../hooks/usePaginatedOatsRecordings';
-import type { RecordingTitleInput } from '../../../utils/recordingUtils';
+import {
+  getRecordingParticipantIds,
+  type RecordingTitleInput,
+} from '../../../utils/recordingUtils';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 export type RecordingDatePreset =
   | 'all-time'
@@ -220,7 +225,36 @@ export function filterRecordingsByOwnership(
   if (selectedCreatorIds.length === 0) return recordings;
 
   const wanted = new Set(selectedCreatorIds);
-  return recordings.filter(recording => wanted.has(recording.createdByUserId));
+  return recordings.filter(recording =>
+    getRecordingParticipantIds(recording.createdByUserId, recording.recordingParticipants).some(
+      id => wanted.has(id),
+    ),
+  );
+}
+
+export function formatRecordingParticipants(
+  participantIds: string[],
+  usersById: Map<string, User>,
+  currentUserId: string | undefined,
+): string {
+  const names: string[] = [];
+  let includesSelf = false;
+
+  for (const id of participantIds) {
+    if (id === currentUserId) {
+      includesSelf = true;
+      continue;
+    }
+    const user = usersById.get(id);
+    if (user) names.push(getUserDisplayName(user));
+  }
+  if (includesSelf) names.push('you');
+
+  const [first, second, ...rest] = names;
+  if (first === undefined) return 'Unknown creator';
+  if (second === undefined) return includesSelf ? 'Just you' : first;
+  if (rest.length === 0) return `${first} & ${second}`;
+  return `${first}, ${second} & ${rest.length} ${rest.length === 1 ? 'other' : 'others'}`;
 }
 
 /**

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -384,6 +384,14 @@ class RecordingService {
     return response.data;
   }
 
+  async manageRecordingParticipant(
+    callId: string,
+    action: 'add' | 'remove',
+    userId: string,
+  ): Promise<void> {
+    await apiInstance.post(`/calls/recordings/${callId}/participants`, { action, userId });
+  }
+
   async revokeRecordingAccess(
     callId: string,
     targets: RecordingShareTarget[],

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -178,7 +178,15 @@ export interface CitationSegment {
   snippet: string;
 }
 
+export interface RecordingParticipantShare {
+  userId: string | null;
+  userGroupId: string | null;
+  channelId: string | null;
+}
+
 export interface RecordingDetail extends Recording {
+  recordingParticipants?: readonly string[] | null;
+  shares?: readonly RecordingParticipantShare[] | null;
   transcript: string | null;
   identifiedTranscript: string | null;
   hasIdentifiedTranscript: boolean;

--- a/apps/dashboard/src/utils/recordingUtils.ts
+++ b/apps/dashboard/src/utils/recordingUtils.ts
@@ -201,6 +201,15 @@ export const normalizeRecordingTags = (tags: string[]): string[] => {
   return [...new Set(tags.map(tag => tag.trim()).filter(Boolean))];
 };
 
+export const getRecordingParticipantIds = (
+  createdByUserId: string | undefined,
+  stored: readonly string[] | null | undefined,
+): string[] => {
+  const ids = stored ?? [];
+  if (createdByUserId && !ids.includes(createdByUserId)) return [createdByUserId, ...ids];
+  return [...ids];
+};
+
 /** Canonical tag name, or null when the text can't make one — tags must start with a letter. */
 export const slugifyRecordingLabel = (raw: string): string | null => {
   const slug = normalizeTagName(raw);

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1179,6 +1179,7 @@ export const callTable = table('calls')
     instanceDate: number().optional(),
     recordingEnabled: boolean(),
     recordingUrl: string().optional(),
+    recordingParticipants: json<string[]>(),
     transcript: string().optional(),
     aiSummary: string().optional(),
     startedAt: number(),


### PR DESCRIPTION
POT - https://drive.google.com/file/d/11xKOczEc36TYrV9nIbpjMlizv_ljnpeP/view?usp=sharing
updated positioning - 
<img width="998" height="554" alt="Screenshot 2026-08-21 at 12 47 35" src="https://github.com/user-attachments/assets/5c27a7bf-85f2-4bdd-8efe-ad4bf685b855" />
default state - 
<img width="934" height="135" alt="Screenshot 2026-08-21 at 12 47 51" src="https://github.com/user-attachments/assets/2fb2a546-c6ea-4191-b642-1ccd30d9734f" />

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Recordings were only ever attributed to the person who pressed record. If you recorded a call *about* someone else — a 1:1, an interview, a customer call someone else led — the list pill showed your name, and the People filter could only ever find it under you. There was no way to say who a recording is actually about.

This adds an explicit, owner-curated participant set on headless recordings, and threads it through the list, the filter, and the detail header.

**Data model** — new `Call.recordingParticipants` (`TEXT[]`, default `[]`) with its migration, mirrored into both Zero schemas (`packages/shared/src/zero/schema.ts` and the generated backend copy) so the dashboard reads it straight off the synced row with no extra fetch. Note-taker calls seed the array with their creator, so "the owner is a participant" holds from row one; older rows fall back to the creator client-side via `getRecordingParticipantIds`.

**Backend** — one new endpoint, `POST /api/calls/recordings/:callId/participants`, taking an `{ action: 'add' | 'remove', userId }` command. It resolves the call by external id and 404s for anything that isn't a headless recording in the caller's workspace, 403s for anyone who isn't the recording owner, and — on `add` — verifies the target is an active member of the same workspace before touching the row. Writes are `array_append` / `array_remove` in raw SQL, with the append guarded by `NOT (... = ANY(...))`: two clients adding the same person concurrently can't produce a duplicate, and there's no read-modify-write window where a concurrent edit gets lost.

**Recording detail** — a `RecordingParticipants` popover in the header. Search over active workspace users by name or email, keyboard-navigable (arrows / enter, `role="combobox"` + `aria-activedescendant`), owner pinned and non-removable. Mutations are optimistic: a pending add/remove is layered over the synced Zero row, reconciled when the server value catches up, and rolled back with a toast on failure.

Being a participant is *not* the same as having access, so the popover also reports how many participants can actually open the recording and offers a one-click share for those who can't. That count is deliberately hidden when the recording is shared with a group or channel — membership isn't resolvable client-side there, and a wrong number is worse than no number. Non-owners get the read-only view: the list renders, the search box and add/remove controls don't.

**Recordings list** — pills show a participant line ("Alice & you", "Alice, Bob & 2 others") instead of the bare creator name, falling back to the old behaviour when nothing resolves. The People filter is populated from participants rather than creators and matches a recording if *any* participant is selected, so filtering by a colleague surfaces calls they were in but didn't start. The selected user is kept in the option list even when the current result set doesn't contain them, so the filter can always be cleared. Picking someone no longer force-switches the Created / Shared tab — the two dimensions are independent now. The filter trigger is also width-capped and truncates long names so it stops stretching the toolbar.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [x] Adds/modifies a **mutator**
- [x] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [x] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [x] No `Date.now()` / `uuid()` generated inside a mutator
- [x] Optimistic client result matches the server result (no state flash on rebase)
- [x] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [x] Matching Prisma model + migration, client regenerated

The mutator change is a single added field (`recordingParticipants: []`) on the existing `calls.insert` inside the channel-call mutator. There is no corresponding `calls.insert` in the client mutators, so nothing to mirror; no new table, so no new ACL. Participant writes intentionally go through the REST endpoint rather than a mutator — they need an owner check and a workspace-membership check that don't belong in an optimistic client mutation.

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [x] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [x] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [x] Clients regenerated (`db:generate`, `db:common:generate`)
- [x] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [x] Backward compatible with deployed code, or rollout order noted below
- [x] Backfill is idempotent

**Rollout / rollback notes:** additive column with a default, so old code ignores it and new code tolerates its absence. No backfill needed — existing rows get `[]` and the UI falls back to the creator, which is exactly the pre-change behaviour. Rollback is a column drop; nothing else reads it.

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [ ] No API changes
- [x] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

`POST /api/calls/recordings/:callId/participants` → `{ action: 'add' | 'remove', userId }`, returns `{ success: true }`. `401` unauthenticated, `403` non-owner, `404` unknown / non-headless / out-of-workspace recording, `400` invalid body or a target who isn't an active member of the workspace. Purely additive — no existing route or response shape changed.

---

## How did you test it?

Manual verification is still pending — flagging that honestly rather than ticking boxes. Reviewers should focus on:

- Owner vs. non-owner in the detail popover (search + add/remove must be owner-only; the 403 path).
- Two users at once: A adds B, B's list should re-render off the synced Zero row without a flash.
- Filtering by a colleague in the People filter — a recording they were added to but didn't create should appear, and the filter should still clear after the results change.
- Recording shared with a group/channel: the "N of M have access" count should disappear rather than show a wrong number.
- Legacy rows with an empty `recordingParticipants` — pill and popover should fall back to the creator.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no existing suite covers recording participants; endpoint is a thin authz + array-write wrapper -->

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

