### PR TITLE
Fix/xyne 56181 popup search only

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -45,6 +45,7 @@ import Badge from '../../ui/Badge';
 import { DisplaySearchResult } from '../../../types/search';
 import {
   TabType,
+  TAB_TO_DOC_TYPE,
   MentionType,
   type MentionData,
   ChannelCommandMenuProps,
@@ -1098,8 +1099,12 @@ const ChannelCommandMenu = ({
     }
 
     onOpenChange(false);
+    // Land on the tab the user was already filtering by — Messages stays on Messages,
+    // Files on Files, and so on. Tabs with no results-page docType (and plain All) fall
+    // through to undefined, which leaves the page on its own default.
+    const docType = TAB_TO_DOC_TYPE[activeTab as keyof typeof TAB_TO_DOC_TYPE];
     void navigate(
-      `/search-results?${buildSearchParams(searchText, selectedMentions, usersById, allChannels).toString()}`,
+      `/search-results?${buildSearchParams(searchText, selectedMentions, usersById, allChannels, docType).toString()}`,
     );
   };
 

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.types.ts
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.types.ts
@@ -96,6 +96,25 @@ export const DOC_TYPE_TO_TAB = Object.fromEntries(
 ) as Record<SearchResultsDocType, TabType>;
 
 /**
+ * Palette TabType -> results-page docType, so "Show detailed results for" lands on the
+ * tab the user was already looking at.
+ *
+ * Deliberately NOT an inversion of DOC_TYPE_TO_TAB: 'all' and 'channels' both map to
+ * TabType.ALL, so inverting is lossy — it would drop 'channels' and make TabType.ALL
+ * ambiguous. Only the palette's own tabs appear here; TabType also carries CANVAS/CALL/
+ * RECORDING, which are not tabs in the palette, hence Partial.
+ */
+export const TAB_TO_DOC_TYPE = {
+  [TabType.ALL]: 'all',
+  [TabType.MESSAGES]: 'messages',
+  [TabType.USERS]: 'people',
+  [TabType.CHANNELS]: 'channels',
+  [TabType.ATTACHMENTS]: 'files',
+  [TabType.TICKETS]: 'tickets',
+  [TabType.DESK]: 'desk',
+} as const satisfies Partial<Record<TabType, SearchResultsDocType>>;
+
+/**
  * Backend-result group key -> results-page docType — derived by inverting each
  * registry entry's `groupKeys`.
  */

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -13,7 +13,6 @@ import {
   ChevronLeft,
   ChevronRight,
   Calendar,
-  Search,
   Monitor,
   Smartphone,
   LayoutGrid,
@@ -80,7 +79,6 @@ const NAV_ITEMS: NavItem[] = [
     desktopOnly: true,
   },
   { id: 'launch', label: 'Launch', icon: <Zap className='size-4' />, desktopOnly: true },
-  { id: 'search', label: 'Search', icon: <Search className='size-4' /> },
   {
     id: 'toolbar',
     label: 'Toolbar',
@@ -923,32 +921,6 @@ const DeveloperSection: FC<{ state: PreferencesState }> = ({ state }) => {
   );
 };
 
-// ─── Search ─────────────────────────────────────────────────────────────────
-const SearchSection: FC<{ state: PreferencesState }> = ({ state }) => (
-  <div className='space-y-4'>
-    <SectionHeader
-      title='Search'
-      subtitle='Choose how search opens when you click the search bar or press ⌘K'
-    />
-    <div className='p-3 rounded-lg border border-border bg-muted/30 space-y-3'>
-      <RadioGroup
-        value={state.searchMode}
-        onChange={value => state.setSearchMode(value as 'popup' | 'screen')}
-      >
-        <Radio value='popup' subtext='Opens a floating modal — fast navigation and inline results'>
-          Quick search popup
-        </Radio>
-        <Radio
-          value='screen'
-          subtext='Opens the search results page with filters for type, sender, channel, and sort'
-        >
-          Full search screen
-        </Radio>
-      </RadioGroup>
-    </div>
-  </div>
-);
-
 // ─── Toolbar ────────────────────────────────────────────────────────────────
 const ToolbarSection: FC<{ state: PreferencesState }> = () => {
   const items = useVisibleNavigationItems();
@@ -1002,7 +974,6 @@ const SECTIONS: Record<PreferenceSection, FC<{ state: PreferencesState }>> = {
   calls: CallsSection,
   messaging: MessagingSection,
   launch: LaunchSection,
-  search: SearchSection,
   toolbar: ToolbarSection,
   calendar: CalendarSection,
   password: PasswordSection as FC<{ state: PreferencesState }>,

--- a/apps/dashboard/src/components/Settings/Preferences/index.ts
+++ b/apps/dashboard/src/components/Settings/Preferences/index.ts
@@ -8,7 +8,6 @@ export type PreferenceSection =
   | 'calls'
   | 'messaging'
   | 'launch'
-  | 'search'
   | 'toolbar'
   | 'calendar'
   | 'password'

--- a/apps/dashboard/src/hooks/usePreferencesState.ts
+++ b/apps/dashboard/src/hooks/usePreferencesState.ts
@@ -47,7 +47,7 @@ export function usePreferencesState(enabled: boolean) {
   const { defaultFormattingToolbarOpen, setDefaultFormattingToolbarOpen } =
     useDefaultFormattingToolbarOpen();
   const { showThreadTags, setShowThreadTags } = useShowThreadTags();
-  const { searchMode, setSearchMode } = useSearchMode();
+  const { searchMode } = useSearchMode();
   const { showClawDashboard, setShowClawDashboard } = useClawDashboardVisibility();
   const { allowThreadBroadcastMentions, setAllowThreadBroadcastMentions } =
     useThreadBroadcastMentions();
@@ -145,7 +145,6 @@ export function usePreferencesState(enabled: boolean) {
     setShowThreadTags,
     setEnterSendsMessage,
     searchMode,
-    setSearchMode,
     showClawDashboard,
     setShowClawDashboard,
     allowThreadBroadcastMentions,

--- a/apps/dashboard/src/hooks/useSearchMode.ts
+++ b/apps/dashboard/src/hooks/useSearchMode.ts
@@ -11,19 +11,14 @@ const subscribe = (listener: () => void): (() => void) => {
   return () => listeners.delete(listener);
 };
 
-const getSnapshot = (): SearchMode =>
-  (localStorage.getItem(SEARCH_MODE_KEY) as SearchMode | null) ?? 'popup';
+// The quick-search popup is the only supported mode. Read nothing from storage: a
+// `screen` value written by an older build (the setting used to be user-facing) would
+// otherwise keep routing people to the full-screen palette forever, with no UI left to
+// turn it back off. Forcing it here rather than at each call site means every
+// `searchMode === 'screen'` branch in the tree evaluates false from one place.
+const getSnapshot = (): SearchMode => 'popup';
 
-export const useSearchMode = (): {
-  searchMode: SearchMode;
-  setSearchMode: (mode: SearchMode) => void;
-} => {
+export const useSearchMode = (): { searchMode: SearchMode } => {
   const searchMode = useSyncExternalStore(subscribe, getSnapshot);
-
-  const setSearchMode = (mode: SearchMode): void => {
-    localStorage.setItem(SEARCH_MODE_KEY, mode);
-    listeners.forEach(l => l());
-  };
-
-  return { searchMode, setSearchMode };
+  return { searchMode };
 };


### PR DESCRIPTION


https://github.com/user-attachments/assets/f50a17ed-c010-4c94-9298-0a09be2b0180


https://github.com/user-attachments/assets/e3946ec3-4ca0-4e5f-84cd-d5f1577fd737



## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-56181. Two independent search changes, one commit each.

**1. `6bf7c4a57` — the quick-search popup becomes the only search mode.**
The full-screen palette was a user-facing preference; the popup is the mode we want
everyone on. Deleting the setting alone isn't enough: a `screen` value written by the
current build is still sitting in people's `localStorage`, and with the radio gone there'd
be no UI left to turn it back off — they'd keep getting the full-screen palette forever.
So it's forced at the single source of truth: `getSnapshot` returns `'popup'`
unconditionally and reads nothing from storage, which makes all seven
`searchMode === 'screen'` branches in the tree evaluate false from one place instead of
needing each call site patched. The setter goes with it, along with the Preferences
section, its nav entry, and the `'search'` member of `PreferenceSection`.

⚠️ **Reviewer note:** this deliberately *ignores* existing `xyne:search-mode` values rather
than migrating them. That's the point of the change, but it does mean the key is now inert.

**2. `6c04964fb` — "Show detailed results for" keeps the tab you were on.**
Filtering the palette to Files and then asking for full results threw that choice away.
Now Messages stays on Messages, likewise People / Channels / Files / Tickets / Desk. The
plumbing already existed — `buildSearchParams` takes a docType (the "See N more" links use
it), `goToSearchResults` just never supplied one. The missing piece was the palette-tab →
docType mapping, added next to the other derived maps in the registry file.
`TAB_TO_DOC_TYPE` is spelled out rather than derived by inverting `DOC_TYPE_TO_TAB`,
because that inversion is lossy: `'all'` and `'channels'` both map to `TabType.ALL`, so it
would drop `'channels'` and leave `TabType.ALL` ambiguous.

The full results page itself is untouched — `/search-results` opens exactly as before.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

*(No env vars, URLs or feature flags. The only config-shaped thing is the `xyne:search-mode`
localStorage key, now ignored — called out in the Description.)*

## API Contract

- [x] No API changes

---

## How did you test it?

Two scripted Playwright walkthroughs, each of which asserts every step and fails the run on
any mismatch — recordings attached. Both printed `RESULT: PASS`.

**Popup-only** — the run *seeds* `localStorage['xyne:search-mode'] = 'screen'` first, so it
proves the override actually holds rather than just showing an absent setting:

| Check | Result |
|---|---|
| localStorage forced to `screen` | `screen` |
| App still reports mode | `popup` |
| ⌘K renders the popup (tabs visible, not full width) | 4 tabs, 768px wide |
| Preferences has no Search section | nav goes Calls → Messaging → Launch |
| "Show detailed results" still reaches the page | opened `/search-results` |

**Tab carry-through** — walks all six tabs, asserting the resulting URL each time:
`Messages→tab=messages`, `People→tab=people`, `Channels→tab=channels`, `Files→tab=files`,
`Tickets→tab=tickets`, `Desk→tab=desk`.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — both behaviours are palette-state + URL-param assertions across
      real navigations, which the current suite has no harness for. Covered by the two
      self-asserting Playwright scripts above; happy to land them as specs if wanted.

### Manual

**Users**
- [x] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

*(Not exercised — client-only UI state, no server or ACL surface.)*

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev — backend `:3001` + dashboard `:5173` (started individually, not `dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — n/a, Zero untouched

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [x] Empty state — Tickets and Desk returned no matches for the test query; the tab still
      carried through correctly (the palette renders no `cmdk-list` at all in that case)
- [x] Large / realistic data volume (291-result query, ~2k indexed docs)
- [ ] Error paths

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing — two commits, one concern each
- [ ] `pnpm run build:shared` passes — **cannot run locally**: dies on the corepack pnpm
      version pin (`configured to use 10.15.0 … current pnpm is v11.21.0`), pre-existing and
      unrelated to this diff. Relying on CI.
- [ ] Backend `typecheck` + `build` pass — not run; no backend files touched
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` — **lint and typecheck pass clean
      across the whole app**; `build` not run locally
- [x] Formatting clean (`prettier --check` on all six files)
- [x] No new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [ ] Docs / guidelines updated — n/a
- [x] No debug logging or commented-out code left behind — but see below