### PR TITLE
fix: XYNE-56645 fixes show more button overlay issue for code block

### DIFF
--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -1901,6 +1901,10 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   display: none !important;
 }
 
+[data-message-preview="true"] .message-html-root .xyne-code-block button {
+  display: none !important;
+}
+
 [data-message-preview="true"] .message-html-root a {
   color: var(--link-color) !important;
   text-decoration: underline !important;


### PR DESCRIPTION
Fixes 'show more' button overlay issue for code-block
__Before__: 
<img width="1664" height="645" alt="Screenshot 2026-08-21 at 1 28 26 PM" src="https://github.com/user-attachments/assets/fce4e7fd-725a-4f26-bb44-cdec7b5be418" />
__After__: 
<img width="1670" height="646" alt="Screenshot 2026-08-21 at 2 08 55 PM" src="https://github.com/user-attachments/assets/a191dbcc-52db-4394-88a9-3ffedd7df7a5" />

