### PR TITLE
feat: warn before a workspace switch or refresh stops an active recording

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -23,6 +23,7 @@ import Wallpaper from './components/Wallpaper/Wallpaper';
 import { initializeTelemetry } from './services/otel/init';
 import { KeyboardProvider } from './contexts/KeyboardContext';
 import { SwitchLoadingOverlay } from './components/SwitchLoadingOverlay/SwitchLoadingOverlay';
+import { RecordingInterruptGuard } from './components/Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 import { TRUSTED_ORIGINS } from '@xyne/shared';
 import { DEFAULT_WORKSPACE_ID } from './config';
 import {
@@ -110,6 +111,7 @@ const App = (): ReactElement => {
                       <RouterProvider router={router}></RouterProvider>
                     </main>
                     <SwitchLoadingOverlay />
+                    <RecordingInterruptGuard />
                     <Toaster
                       position='top-right'
                       richColors

--- a/apps/dashboard/src/components/AppSidebar/WorkspaceSwitcher.tsx
+++ b/apps/dashboard/src/components/AppSidebar/WorkspaceSwitcher.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../machines/authMachine';
 import { queryClient } from '../../services/clients/queryClient';
 import { useCanCreateWorkspace } from '../../hooks/usePermissions';
+import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 type CreateWorkspaceType = (typeof WorkspaceType)[keyof typeof WorkspaceType];
 
@@ -192,6 +193,7 @@ export const WorkspaceSwitcher: React.FC = () => {
       setIsOpen(false);
       return;
     }
+    if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
     setSwitching(targetWorkspaceId);
     try {
       // NEW: Call switch-workspace API instead of logout
@@ -229,6 +231,7 @@ export const WorkspaceSwitcher: React.FC = () => {
   const handleCreate = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
     if (!workspaceName.trim()) return;
+    if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
     setCreating(true);
     setError(null);
     try {

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -612,6 +612,11 @@ export const NotificationHandler: React.FC = () => {
     return window.electronAPI.onRecordingSystemSuspend(stopRecordingForTeardown);
   }, [isElectron]);
 
+  useEffect(() => {
+    if (!isElectron || !window.electronAPI?.onRecordingStopForTeardown) return;
+    return window.electronAPI.onRecordingStopForTeardown(stopRecordingForTeardown);
+  }, [isElectron]);
+
   const recordingStatus = useRecordingStore(ctx => ctx.status);
   const recordingStartTime = useRecordingStore(ctx => ctx.startTime);
   const recordingPauseStartedAt = useRecordingStore(ctx => ctx.pauseStartedAt);

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -23,6 +23,7 @@ import {
   useRecordingStore,
 } from '../../hooks/useRecordingStore';
 import { sendSosAlertEvent } from '../../stores/sosAlertStore';
+import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 // Singleton: a fresh Audio element PER NOTIFICATION leaked native listener
 // registrations and media elements — heap analysis showed "JS event
@@ -139,6 +140,7 @@ export const NotificationHandler: React.FC = () => {
       const currentWorkspaceId = activeWorkspaceIdRef.current;
 
       if (targetWorkspaceId && targetWorkspaceId !== currentWorkspaceId) {
+        if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
         try {
           await axios.post(
             `${API_BASE_URL}/auth/switch-workspace`,

--- a/apps/dashboard/src/components/Recording/RecordingInterruptGuard/RecordingInterruptGuard.tsx
+++ b/apps/dashboard/src/components/Recording/RecordingInterruptGuard/RecordingInterruptGuard.tsx
@@ -1,0 +1,218 @@
+import { ReactElement, useEffect, useRef, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ConnectionState, RoomEvent } from 'livekit-client';
+import { Dialog } from '../../ui/Dialog/Dialog';
+import { Button } from '../../ui/Button/Button';
+import { recordingStore } from '../../../stores/recordingStore';
+import { calculateRecordingElapsedMs, formatElapsedTime } from '../../../utils/recordingUtils';
+import {
+  getRecordingStatus,
+  stopRecordingForTeardown,
+  useRecordingStore,
+} from '../../../hooks/useRecordingStore';
+
+const DISCONNECT_TIMEOUT_MS = 3000;
+
+export type RecordingInterruptReason = 'workspaceSwitch' | 'reload';
+
+const COPY: Record<RecordingInterruptReason, { title: string; body: string; proceed: string }> = {
+  workspaceSwitch: {
+    title: 'Switching workspace will stop your recording',
+    body: 'Switching reloads the app, which ends this recording. Everything captured so far is saved to your recordings.',
+    proceed: 'Stop and switch',
+  },
+  reload: {
+    title: 'Reloading will stop your recording',
+    body: 'Reloading ends this recording. Everything captured so far is saved to your recordings.',
+    proceed: 'Stop and reload',
+  },
+};
+
+let openGuard:
+  | ((reason: RecordingInterruptReason, resolve: (proceed: boolean) => void) => void)
+  | null = null;
+
+export function isRecordingInterruptible(): boolean {
+  const status = getRecordingStatus();
+  return status === 'starting' || status === 'recording' || status === 'paused';
+}
+
+export async function confirmRecordingInterrupt(
+  reason: RecordingInterruptReason,
+): Promise<boolean> {
+  if (!isRecordingInterruptible()) return true;
+
+  const open = openGuard;
+  if (!open) return true;
+
+  return new Promise<boolean>(resolve => open(reason, resolve));
+}
+
+async function stopActiveRecording(): Promise<void> {
+  const { room } = recordingStore.getSnapshot().context;
+  stopRecordingForTeardown();
+
+  if (!room || room.state === ConnectionState.Disconnected) return;
+
+  await new Promise<void>(resolve => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const finish = (): void => {
+      if (timer) clearTimeout(timer);
+      room.off(RoomEvent.Disconnected, finish);
+      resolve();
+    };
+    timer = setTimeout(finish, DISCONNECT_TIMEOUT_MS);
+    room.on(RoomEvent.Disconnected, finish);
+  });
+}
+
+function StatusDot({ status }: { status: string }): ReactElement {
+  if (status === 'paused') {
+    return <span className='inline-flex size-2 rounded-full bg-amber-500' />;
+  }
+  if (status === 'starting') {
+    return <span className='inline-flex size-2 animate-pulse rounded-full bg-blue-500' />;
+  }
+  return (
+    <span className='relative inline-flex size-2'>
+      <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75' />
+      <span className='relative inline-flex size-2 rounded-full bg-red-500' />
+    </span>
+  );
+}
+
+export function RecordingInterruptGuard(): ReactElement | null {
+  const resolverRef = useRef<((proceed: boolean) => void) | null>(null);
+  const [reason, setReason] = useState<RecordingInterruptReason | null>(null);
+  const [stopping, setStopping] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const reduceMotion = useReducedMotion();
+
+  const status = useRecordingStore(ctx => ctx.status);
+  const startTime = useRecordingStore(ctx => ctx.startTime);
+  const pauseStartedAt = useRecordingStore(ctx => ctx.pauseStartedAt);
+  const accumulatedPausedMs = useRecordingStore(ctx => ctx.accumulatedPausedMs);
+
+  useEffect(() => {
+    openGuard = (nextReason, resolve): void => {
+      if (resolverRef.current) {
+        resolve(false);
+        return;
+      }
+      resolverRef.current = resolve;
+      setNow(Date.now());
+      setReason(nextReason);
+    };
+    return (): void => {
+      openGuard = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!reason || status !== 'recording') return undefined;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return (): void => clearInterval(id);
+  }, [reason, status]);
+
+  if (!reason) return null;
+
+  const copy = COPY[reason];
+  const isPaused = status === 'paused';
+  const elapsed = formatElapsedTime(
+    calculateRecordingElapsedMs(startTime, pauseStartedAt, accumulatedPausedMs, now),
+  );
+
+  const settle = (proceed: boolean): void => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setReason(null);
+    setStopping(false);
+    resolve?.(proceed);
+  };
+
+  const handleStop = (): void => {
+    setStopping(true);
+    void stopActiveRecording().then(() => settle(true));
+  };
+
+  const enter = (index: number): Record<string, unknown> =>
+    reduceMotion
+      ? {}
+      : {
+          initial: { opacity: 0, y: 4 },
+          animate: { opacity: 1, y: 0 },
+          transition: { type: 'spring', duration: 0.3, bounce: 0, delay: 0.04 * index },
+        };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open): void => {
+        if (!open) settle(false);
+      }}
+      title={copy.title}
+      description={copy.body}
+      testId='recording-interrupt-guard'
+      className='max-w-[460px] overflow-hidden rounded-xl'
+    >
+      <div className='px-5 pb-5 pt-5'>
+        <motion.div
+          {...enter(0)}
+          className='inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/50 py-1 pl-2.5 pr-3'
+        >
+          <StatusDot status={status} />
+          <span className='text-[11px] font-medium uppercase tracking-wider text-muted-foreground'>
+            {status === 'starting' ? 'Starting' : isPaused ? 'Paused' : 'Recording'}
+          </span>
+          {status !== 'starting' && (
+            <span className='text-[11px] font-semibold tabular-nums text-foreground'>
+              {elapsed}
+            </span>
+          )}
+        </motion.div>
+
+        <motion.h2
+          {...enter(1)}
+          className='mt-3.5 text-balance text-[17px] font-semibold leading-snug tracking-[-0.01em] text-foreground'
+        >
+          {copy.title}
+        </motion.h2>
+
+        <motion.p
+          {...enter(2)}
+          className='mt-2 text-pretty text-[13px] leading-relaxed text-muted-foreground'
+        >
+          {copy.body}
+        </motion.p>
+      </div>
+
+      <motion.div
+        {...enter(3)}
+        className='flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/30 px-5 py-3.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between'
+      >
+        <Button
+          variant='ghost'
+          onClick={(): void => settle(false)}
+          disabled={stopping}
+          className='w-full shrink-0 active:scale-[0.96] sm:w-auto'
+          data-testid='recording-interrupt-keep'
+        >
+          Keep recording
+        </Button>
+
+        <div className='flex flex-col gap-2 sm:flex-row sm:items-center'>
+          <Button
+            variant='destructive'
+            onClick={handleStop}
+            loading={stopping}
+            disabled={stopping}
+            className='w-full shrink-0 active:scale-[0.96] sm:w-auto'
+            data-testid='recording-interrupt-stop'
+          >
+            {stopping ? 'Stopping' : copy.proceed}
+          </Button>
+        </div>
+      </motion.div>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/components/SosAlert/SosAlertBanner.tsx
+++ b/apps/dashboard/src/components/SosAlert/SosAlertBanner.tsx
@@ -8,6 +8,7 @@ import { API_BASE_URL } from '../../config';
 import { queryClient } from '../../services/clients/queryClient';
 import { websocketService } from '../../services/clients/socketClient';
 import { sendSosAlertEvent, useSosAlertStore, type SosAlert } from '../../stores/sosAlertStore';
+import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 // Singleton audio element (same leak-avoidance pattern as NotificationHandler).
 let sirenAudio: HTMLAudioElement | null = null;
@@ -141,6 +142,7 @@ export const SosAlertBanner: React.FC = () => {
         alert.actionUrl || (alert.workspaceId ? `/${alert.workspaceId}/chat` : '/chat');
 
       if (alert.workspaceId && alert.workspaceId !== activeWorkspaceId) {
+        if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
         try {
           await axios.post(
             `${API_BASE_URL}/auth/switch-workspace`,

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -114,6 +114,11 @@ import RecordingDetailRoute from './RecordingDetailRoute/RecordingDetailRoute';
 import { RecordingOverlay } from '../components/Recording/RecordingOverlay/RecordingOverlay';
 import { useRecordingVersion } from '../hooks/useRecordingVersion';
 import { stopRecordingForTeardown } from '../hooks/useRecordingStore';
+import { isElectronApp } from '../utils/electronApp';
+import {
+  confirmRecordingInterrupt,
+  isRecordingInterruptible,
+} from '../components/Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 import { NoteTakerOverlayHost } from './RecordingsV2Screen/components/NoteTakerOverlayHost';
 import FormScreen from './FormScreen/FormScreen';
 import ScheduledMessageScreen from './ScheduledMessageScreen/ScheduledMessageScreen';
@@ -351,6 +356,35 @@ const AppRoot = (): ReactElement => {
     window.addEventListener('pagehide', stopRecordingForTeardown);
     return (): void => {
       window.removeEventListener('pagehide', stopRecordingForTeardown);
+    };
+  }, []);
+
+  useEffect(() => {
+    const warnBeforeUnload = (event: BeforeUnloadEvent): void => {
+      if (isElectronApp()) return;
+      if (!isRecordingInterruptible()) return;
+      event.preventDefault();
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    return (): void => {
+      window.removeEventListener('beforeunload', warnBeforeUnload);
+    };
+  }, []);
+
+  useEffect(() => {
+    const interceptReload = (event: KeyboardEvent): void => {
+      if (isElectronApp()) return;
+      const isReloadCombo = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'r';
+      if (!isReloadCombo && event.key !== 'F5') return;
+      if (!isRecordingInterruptible()) return;
+      event.preventDefault();
+      void confirmRecordingInterrupt('reload').then(proceed => {
+        if (proceed) window.location.reload();
+      });
+    };
+    window.addEventListener('keydown', interceptReload, true);
+    return (): void => {
+      window.removeEventListener('keydown', interceptReload, true);
     };
   }, []);
   useShortcutById('global.openShortcutsHelp', () => setIsShortcutsModalOpen(prev => !prev));

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -29,6 +29,24 @@ let transcriptIdCounter = 0;
 // stop first so its callback cannot be mistaken for a server-side failure.
 const intentionallyDisconnectedRooms = new WeakSet<Room>();
 
+const PAGE_UNLOAD_GRACE_MS = 5000;
+let pageUnloading = false;
+let pageUnloadingReset: ReturnType<typeof setTimeout> | null = null;
+
+if (typeof window !== 'undefined') {
+  const markPageUnloading = (): void => {
+    pageUnloading = true;
+    if (pageUnloadingReset) clearTimeout(pageUnloadingReset);
+    pageUnloadingReset = setTimeout(() => {
+      pageUnloading = false;
+      pageUnloadingReset = null;
+    }, PAGE_UNLOAD_GRACE_MS);
+  };
+  for (const event of ['beforeunload', 'pagehide', 'freeze']) {
+    window.addEventListener(event, markPageUnloading);
+  }
+}
+
 export interface TranscriptEntry {
   id: number;
   speaker: string;
@@ -290,6 +308,7 @@ export const recordingStore = createStore({
 
       const handleRoomDisconnected = (): void => {
         if (intentionallyDisconnectedRooms.delete(room)) return;
+        if (pageUnloading) return;
 
         const current = recordingStore.getSnapshot().context;
         if (current.room !== room || !ACTIVE_STATUSES.has(current.status)) return;
@@ -308,6 +327,7 @@ export const recordingStore = createStore({
         try {
           const data = JSON.parse(metadata) as { recordingStartFailure?: unknown };
           if (data.recordingStartFailure !== true) return;
+          if (pageUnloading) return;
 
           const current = recordingStore.getSnapshot().context;
           if (current.room !== room || !ACTIVE_STATUSES.has(current.status)) return;

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -100,6 +100,7 @@ export interface ElectronAPI {
   ) => Promise<{ saved: boolean; filePath?: string }>;
   onWindowModeChanged: (callback: (data: { compact: boolean }) => void) => () => void;
   onRecordingSystemSuspend: (callback: () => void) => () => void;
+  onRecordingStopForTeardown?: (callback: () => void) => () => void;
   onRecordingResumeRequest?: (callback: () => void) => () => void;
   onRecordingPauseRequest?: (callback: () => void) => () => void;
   onLog: (callback: (message: { data?: unknown[] }) => void) => () => void;

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -168,6 +168,12 @@ const electronAPI = {
     return () => ipcRenderer.removeListener('recording:system-suspend', listener);
   },
 
+  onRecordingStopForTeardown: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('recording:stop-for-teardown', listener);
+    return () => ipcRenderer.removeListener('recording:stop-for-teardown', listener);
+  },
+
   onRecordingResumeRequest: (callback: () => void) => {
     const listener = () => callback();
     ipcRenderer.on('recording:resume-requested', listener);

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -299,6 +299,30 @@ export function stopRecording(trigger: RecordingTrigger): void {
   log.info(`[RecordingController] Stop requested from ${trigger}`);
 }
 
+export async function stopRecordingForReload(timeoutMs = 3000): Promise<void> {
+  if (!isRecordingInProgress()) return;
+
+  const mainWindow = getMainWindow();
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+
+  mainWindow.webContents.send('recording:stop-for-teardown');
+  log.info('[RecordingController] Stop requested before reload');
+
+  await new Promise<void>(resolve => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let unsubscribe: (() => void) | null = null;
+    const finish = (): void => {
+      if (timer) clearTimeout(timer);
+      unsubscribe?.();
+      resolve();
+    };
+    unsubscribe = onRecordingStateChange(() => {
+      if (!isRecordingInProgress()) finish();
+    });
+    timer = setTimeout(finish, timeoutMs);
+  });
+}
+
 export function pauseRecordingFromOutside(trigger: RecordingTrigger): void {
   if (!active || paused) return;
   const mainWindow = getMainWindow();

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -16,7 +16,7 @@ import { EnrollmentEvent } from '../services/logger/enrollment-events';
 import { handleCertificateError, isCertificateError } from '../services/certificate-error-handler';
 import { dashboardLoad, enrollmentSkipped, mtlsFrontendLoaded } from '../services/enrollmentMetrics';
 import { safeRecordMetric } from '../services/telemetry';
-import { isRecordingInProgress } from '../services/recording-controller';
+import { isRecordingInProgress, stopRecordingForReload } from '../services/recording-controller';
 import type { Counter } from '@opentelemetry/api';
 
 async function confirmReloadWhileRecording(window: BrowserWindow): Promise<boolean> {
@@ -33,7 +33,10 @@ async function confirmReloadWhileRecording(window: BrowserWindow): Promise<boole
     detail: 'Everything captured so far is saved to your recordings.',
   });
 
-  return response === 1;
+  if (response !== 1) return false;
+
+  await stopRecordingForReload();
+  return true;
 }
 
 let mainWindow: BrowserWindow | null = null;

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, shell, Menu, MenuItem, app } from 'electron';
+import { BrowserWindow, shell, Menu, MenuItem, app, dialog } from 'electron';
 import path from 'path';
 import log from 'electron-log/main';
 import { config } from '../app/config';
@@ -16,7 +16,25 @@ import { EnrollmentEvent } from '../services/logger/enrollment-events';
 import { handleCertificateError, isCertificateError } from '../services/certificate-error-handler';
 import { dashboardLoad, enrollmentSkipped, mtlsFrontendLoaded } from '../services/enrollmentMetrics';
 import { safeRecordMetric } from '../services/telemetry';
+import { isRecordingInProgress } from '../services/recording-controller';
 import type { Counter } from '@opentelemetry/api';
+
+async function confirmReloadWhileRecording(window: BrowserWindow): Promise<boolean> {
+  if (!isRecordingInProgress()) return true;
+
+  const { response } = await dialog.showMessageBox(window, {
+    type: 'warning',
+    buttons: ['Keep recording', 'Reload anyway'],
+    defaultId: 0,
+    cancelId: 0,
+    noLink: true,
+    title: 'Recording in progress',
+    message: 'Reloading will stop your recording.',
+    detail: 'Everything captured so far is saved to your recordings.',
+  });
+
+  return response === 1;
+}
 
 let mainWindow: BrowserWindow | null = null;
 let isCompactMode = false;
@@ -255,6 +273,7 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
       try {
         if (mainWindow) {
           isReloading = true;
+          if (!(await confirmReloadWhileRecording(mainWindow))) return;
           // Clear cache before reloading for a true hard refresh
           await mainWindow.webContents.session.clearCache();
           await loadApp(mainWindow);
@@ -275,6 +294,7 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
       try {
         if (mainWindow) {
           isReloading = true;
+          if (!(await confirmReloadWhileRecording(mainWindow))) return;
           await loadUrl(mainWindow, mainWindow.webContents.getURL());
         }
       } catch (error) {


### PR DESCRIPTION
POT -

## Problem

Switching workspace and refreshing both tear down the page. That destroys the in-memory LiveKit `Room` held in `recordingStore`, so an in-progress recording ends with no warning at all. On the backend side, `noteTakerCallRepository.handleParticipantLeave` ends the call the instant the participant disconnects — there is no grace period — so the recording is genuinely over, not merely interrupted.

None of these paths go through the React Router history stack (`window.location.href` for workspace switch, main-process `loadApp()` for Electron reload), so `useBlocker` would not guard any of them.

## What this does

Adds a confirmation guard on the **user-initiated** paths:

| Path | Desktop | Web |
| --- | --- | --- |
| Workspace switch (×4 call sites) | modal | modal |
| `Cmd/Ctrl+R`, `Cmd+Shift+R`, `F5` | native dialog | modal |
| Reload button, tab close, address bar | n/a | browser `beforeunload` prompt |

The four switch call sites are the sidebar switcher, workspace create, cross-workspace notification click, and the SOS alert banner.

Electron's reload is confirmed with `dialog.showMessageBox` in the main process because `before-input-event` intercepts the keystroke before the renderer ever sees it — matching the existing consent-dialog pattern in `ipc/handlers.ts`. Web intercepts the keystroke in the renderer so browser users get the same modal; `beforeunload` stays as the backstop for the paths no keystroke handler can catch.

## Notes

- **Stopping now awaits the room disconnect** (3s cap) before navigating. The existing `pagehide` teardown fires `room.disconnect()` unawaited, which lands the recording in the backend's 30s crash-reconciliation path and yields a truncated transcript. Deliberately stopping should finalize cleanly.
- The guard short-circuits to a no-op when nothing is recording, so the common path is unaffected.
- `beforeunload` is skipped under Electron — it would surface as `will-prevent-unload`, which nothing handles, and would silently swallow reloads.
- No pause option. Pausing would only cancel the navigation, leaving you to come back and stop anyway; and a recording cannot survive the reload without a much larger backend change (`RecordingStatus` has no `PAUSED`, LiveKit egress is start/stop only).

## Not covered

Automatic reloads still end recordings silently and are out of scope here — most notably `ui-updater.ts`, which applies a staged UI update on window **blur**, so alt-tabbing during a recording can reload the app. Worth a follow-up.

## Testing

`typecheck`, `eslint` (0 errors), and `prettier --check` pass for both `apps/dashboard` and `apps/electron`. The Electron native dialog and the web keystroke path need a manual pass — neither is reachable from typecheck.
