### PR TITLE
feat: XYNE-20503 : Adding caching to github ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,26 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
+      # node_modules cache. `cache: pnpm` above only caches the global pnpm
+      # store (downloaded tarballs) — every run still re-links the store into
+      # node_modules, the slow part with node-linker=isolated + 22 workspace
+      # packages. Cache the linked tree too, keyed on the lockfile. With the
+      # isolated linker the virtual store lives in the ROOT node_modules/.pnpm
+      # and each package symlinks into it, so the root tree must be cached or the
+      # symlinks dangle. On a hit `pnpm install` below is a near-instant no-op;
+      # on a lockfile change it falls back to a normal install.
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          # Exact lockfile match only (no restore-keys): never link a fresh
+          # install on top of a stale tree from a different lockfile. A miss
+          # just does a full install from the (cached) store.
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter xyne-spaces-backend...
 
@@ -80,6 +100,17 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
+
+      # See backend job for rationale: cache the linked node_modules tree (root
+      # + per-package for the isolated linker), keyed exactly on the lockfile.
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter xyne-spaces-dashboard...
@@ -129,6 +160,17 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
+      # See backend job for rationale: cache the linked node_modules tree (root
+      # + per-package for the isolated linker), keyed exactly on the lockfile.
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter agentic-framework...
 
@@ -153,6 +195,17 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
+      # See backend job for rationale: cache the linked node_modules tree (root
+      # + per-package for the isolated linker), keyed exactly on the lockfile.
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter xyne-claw...
 
@@ -176,7 +229,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # The gitleaks binary is version-pinned, so cache it per OS/arch/version
+      # instead of re-downloading the release tarball on every run.
+      - name: Cache gitleaks binary
+        id: gl
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/bin/gitleaks
+          key: gitleaks-${{ runner.os }}-${{ runner.arch }}-${{ env.GITLEAKS_VERSION }}
+
       - name: Install gitleaks
+        if: steps.gl.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           # The self-hosted runners differ in OS, so the release asset has to
@@ -195,6 +258,11 @@ jobs:
           mkdir -p "$RUNNER_TEMP/bin"
           curl -sfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_${os}_${arch}.tar.gz" \
             | tar -xz -C "$RUNNER_TEMP/bin" gitleaks
+
+      # Runs on both hit and miss so PATH is set and the binary is verified
+      # regardless of whether the install step above was skipped.
+      - name: Add gitleaks to PATH
+        run: |
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/bin/gitleaks" version
 
@@ -222,11 +290,26 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # The trivy binary is version-pinned, so cache it per OS/arch/version
+      # instead of re-running the install script on every run.
+      - name: Cache Trivy binary
+        id: tv
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/bin/trivy
+          key: trivy-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.TRIVY_VERSION }}
+
       - name: Install Trivy
+        if: steps.tv.outputs.cache-hit != 'true'
         run: |
           mkdir -p "$RUNNER_TEMP/bin"
           curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/v${TRIVY_VERSION}/contrib/install.sh" \
             | sh -s -- -b "$RUNNER_TEMP/bin" "v${TRIVY_VERSION}"
+
+      # Runs on both hit and miss so PATH is set and the binary is verified
+      # regardless of whether the install step above was skipped.
+      - name: Add Trivy to PATH
+        run: |
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/bin/trivy" --version
 
@@ -236,13 +319,25 @@ jobs:
       - name: Pin Trivy cache path
         run: echo "TRIVY_CACHE_DIR=$HOME/.cache/trivy" >> "$GITHUB_ENV"
 
-      # Vulnerability DB (~few hundred MB) changes ~every 6h; cache it per day so
-      # reruns don't re-download. A cache miss just downloads fresh — never fatal.
+      # Vulnerability DB (~few hundred MB) refreshes ~every 6h. Bucket the cache
+      # key on the same 6h cadence: every run inside a window is a true cache hit
+      # (no download), and the first run of a new window pulls only the delta on
+      # top of the previous window's DB (via restore-keys). The old
+      # github.run_id key never matched — it re-fetched every run. Expressions
+      # can't compute time, so the bucket (e.g. 2026-08-20-3) is built in a step.
+      - name: Trivy DB cache bucket (6-hourly)
+        id: tdb
+        # 10# forces base-10: bash reads a leading-zero hour like 08/09 as
+        # invalid octal in $(( )) otherwise, failing the step at 08:00/09:00 UTC.
+        run: echo "key=$(date -u +%Y-%m-%d)-$(( 10#$(date -u +%H) / 6 ))" >> "$GITHUB_OUTPUT"
+
       - name: Cache Trivy DB
         uses: actions/cache@v4
         with:
           path: ~/.cache/trivy
-          key: trivy-db-${{ github.run_id }}
+          key: trivy-db-${{ steps.tdb.outputs.key }}
+          # Newest older DB when this window's cache doesn't exist yet, so Trivy
+          # updates just the delta instead of a full download.
           restore-keys: |
             trivy-db-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,12 @@ jobs:
           # Exact lockfile match only (no restore-keys): never link a fresh
           # install on top of a stale tree from a different lockfile. A miss
           # just does a full install from the (cached) store.
-          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          # Per-job suffix: each job runs a filtered install and thus produces a
+          # DIFFERENT partial tree. Sharing one key made the jobs race for a
+          # single cache slot (first to finish wins, rest skipped), so most jobs
+          # restored a tree missing their packages. Namespacing by job gives each
+          # its own complete cache.
+          key: nm-${{ runner.os }}-backend-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter xyne-spaces-backend...
@@ -110,7 +115,7 @@ jobs:
             node_modules
             apps/*/node_modules
             packages/*/node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: nm-${{ runner.os }}-dashboard-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter xyne-spaces-dashboard...
@@ -169,7 +174,7 @@ jobs:
             node_modules
             apps/*/node_modules
             packages/*/node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: nm-${{ runner.os }}-agentic-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter agentic-framework...
@@ -204,7 +209,7 @@ jobs:
             node_modules
             apps/*/node_modules
             packages/*/node_modules
-          key: nm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: nm-${{ runner.os }}-claw-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install ${{ env.PNPM_FLAGS }} --filter xyne-claw...


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
