### PR TITLE
fix: XYNE-56648 entity view and feedback screen

### DIFF
--- a/apps/backend/prisma/migrations/20260821120000_add_entity_feedback/migration.sql
+++ b/apps/backend/prisma/migrations/20260821120000_add_entity_feedback/migration.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS "non_zero"."entity_feedback" (
+    "workspaceId"    TEXT NOT NULL,
+    "id"             TEXT NOT NULL,
+    "messageId"      TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "entityId"       TEXT NOT NULL,
+    "verdict"        TEXT NOT NULL,
+    "remarks"        TEXT,
+    "createdBy"      TEXT NOT NULL,
+    "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "entity_feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- One verdict per (message, entity, reviewer). Including the reviewer is what
+-- stops two people overwriting each other: re-reviewing upserts your own row,
+-- while a second reviewer adds theirs and the disagreement stays visible.
+CREATE UNIQUE INDEX IF NOT EXISTS "entity_feedback_messageId_entityId_createdBy_key"
+    ON "non_zero"."entity_feedback"("messageId", "entityId", "createdBy");
+CREATE INDEX IF NOT EXISTS "entity_feedback_entityId_idx"
+    ON "non_zero"."entity_feedback"("entityId");
+CREATE INDEX IF NOT EXISTS "entity_feedback_conversationId_idx"
+    ON "non_zero"."entity_feedback"("conversationId");
+-- Reads tally every reviewer's verdict for a message, so this pair is the hot path.
+CREATE INDEX IF NOT EXISTS "entity_feedback_messageId_entityId_idx"
+    ON "non_zero"."entity_feedback"("messageId", "entityId");

--- a/apps/backend/prisma/migrations/20260821120000_add_entity_feedback/migration.sql
+++ b/apps/backend/prisma/migrations/20260821120000_add_entity_feedback/migration.sql
@@ -18,10 +18,9 @@ CREATE TABLE IF NOT EXISTS "non_zero"."entity_feedback" (
 -- while a second reviewer adds theirs and the disagreement stays visible.
 CREATE UNIQUE INDEX IF NOT EXISTS "entity_feedback_messageId_entityId_createdBy_key"
     ON "non_zero"."entity_feedback"("messageId", "entityId", "createdBy");
+-- Reads are `WHERE "workspaceId" = $1 AND "entityId" = $2`; this serves them.
+-- Nothing on (messageId, entityId): a btree on (a,b) is a leading prefix of the unique
+-- index above, so Postgres serves the same lookups from it. Nothing on conversationId
+-- either — no query filters by it.
 CREATE INDEX IF NOT EXISTS "entity_feedback_entityId_idx"
     ON "non_zero"."entity_feedback"("entityId");
-CREATE INDEX IF NOT EXISTS "entity_feedback_conversationId_idx"
-    ON "non_zero"."entity_feedback"("conversationId");
--- Reads tally every reviewer's verdict for a message, so this pair is the hot path.
-CREATE INDEX IF NOT EXISTS "entity_feedback_messageId_entityId_idx"
-    ON "non_zero"."entity_feedback"("messageId", "entityId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4643,7 +4643,8 @@ model Entity {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  aliases EntityAlias[]
+  aliases  EntityAlias[]
+  feedback EntityFeedback[]
 
   @@unique([workspaceId, type, normalizedName])
   @@index([workspaceId, type])
@@ -4816,6 +4817,12 @@ model EntityFeedback {
   /// Denormalized so a thread's feedback can be read without joining messages.
   conversationId String
   entityId       String
+  /// Cascade, matching EntityAlias above: a verdict is about an entity, so it is
+  /// meaningless once that entity is gone. Without it, deleting an entity leaves rows
+  /// pointing at an id that no longer exists — unreachable and only removable by hand.
+  /// relationMode is "prisma", so this is emulated in the client: no database FK and
+  /// no migration.
+  entity         Entity @relation(fields: [entityId], references: [id], onDelete: Cascade)
 
   /// APPROVED | REJECTED
   verdict String
@@ -4827,10 +4834,11 @@ model EntityFeedback {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
+  // Reads are `where: { workspaceId, entityId }`; writes go through the unique key.
+  // No index on (messageId, entityId) — it is a leading prefix of the unique index
+  // below, which serves the same lookups. Nor on conversationId, which has no reader.
   @@unique([messageId, entityId, createdBy])
   @@index([entityId])
-  @@index([conversationId])
-  @@index([messageId, entityId])
   @@map("entity_feedback")
   @@schema("non_zero")
 }

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4797,3 +4797,40 @@ model RadarTeam {
   @@map("radar_teams")
   @@schema("non_zero")
 }
+
+/// Human review of ONE extracted entity on ONE message, by ONE reviewer.
+///
+/// Per-message rather than per-entity because extraction assigns an entity to a
+/// whole thread: the same entity can be right on the message that names it and
+/// wrong on a reply that inherited it.
+///
+/// The unique key includes `createdBy` so reviewers do not overwrite each other —
+/// disagreement between two people is signal, and collapsing it to a single row
+/// would silently discard the earlier verdict along with its attribution. A person
+/// re-reviewing still upserts their own row rather than adding a second one.
+model EntityFeedback {
+  workspaceId String
+  id          String @id @default(cuid())
+
+  messageId String
+  /// Denormalized so a thread's feedback can be read without joining messages.
+  conversationId String
+  entityId       String
+
+  /// APPROVED | REJECTED
+  verdict String
+  /// Free-text reason, captured when a rejection is recorded.
+  remarks String?
+
+  createdBy String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([messageId, entityId, createdBy])
+  @@index([entityId])
+  @@index([conversationId])
+  @@index([messageId, entityId])
+  @@map("entity_feedback")
+  @@schema("non_zero")
+}

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -134,6 +134,7 @@ import dailyBriefRoutes from '@/routes/dailyBrief';
 import userSkillsRoutes from '@/routes/userSkills';
 import scheduledMessageRoutes from '@/routes/scheduledMessages';
 import { tagRoutes, registerDeskEmailTags } from '@/tags';
+import entityRoutes from '@/routes/entities';
 import { tagGenerationPipeline } from '@/tags/pipeline';
 import { automationRoutes, initializeAutomations } from '@/automations';
 import { handleClawCallback } from '@/automations/routes/claw-callback.handler';
@@ -686,6 +687,9 @@ export class App {
 
     // Generic tag routes (auth applied per-route within tagRoutes)
     this.app.use('/api/tags', tagRoutes);
+
+    // Entity registry reads for the Entities page (messages come from /api/vespaSearch)
+    this.app.use('/api/entities', entityRoutes);
 
     // Automations routes (auth required, no ACL — matches /api/calls)
     this.app.use('/api/automations', authMiddleware.authenticate, automationRoutes);

--- a/apps/backend/src/routes/entities.ts
+++ b/apps/backend/src/routes/entities.ts
@@ -95,7 +95,7 @@ router.get('/types', authMiddleware.authenticate, async (req: Request, res: Resp
 });
 
 /**
- * GET /api/entities/:entityId/feedback — every review recorded for this entity.
+ * GET /api/entities/:entityId/feedback — YOUR reviews of this entity.
  *
  * Scoped to one entity rather than paged: the client renders at most a few dozen
  * threads at a time and needs to look feedback up by messageId, so one fetch keyed
@@ -111,7 +111,7 @@ router.get('/:entityId/feedback', authMiddleware.authenticate, async (req: Reque
 
   try {
     const rows = await prisma.entityFeedback.findMany({
-      where: { workspaceId, entityId },
+      where: { workspaceId, entityId, createdBy: userId },
       select: {
         messageId: true,
         conversationId: true,
@@ -122,8 +122,8 @@ router.get('/:entityId/feedback', authMiddleware.authenticate, async (req: Reque
         updatedAt: true,
       },
     });
-    // Every reviewer's rows come back, so the client can show a tally — it needs
-    // the caller's id to pick out which one is the viewer's own verdict.
+    // currentUserId still travels: the client keys its map on it, and returning it
+    // keeps that lookup honest rather than having the client assume every row is its own.
     return res.json({ feedback: rows, currentUserId: userId });
   } catch (error) {
     logger.error('[ENTITIES] list feedback failed:', error);

--- a/apps/backend/src/routes/entities.ts
+++ b/apps/backend/src/routes/entities.ts
@@ -1,0 +1,213 @@
+import { Router, Request, Response } from 'express';
+import { authMiddleware } from '@/middleware/auth';
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+
+/**
+ * Entity registry reads for the Entities page — /api/entities
+ *
+ * Registry only. The MESSAGES behind an entity are a Vespa concern, so the page
+ * calls the shared search endpoint directly:
+ *   GET /api/vespaSearch?filterOnly=true&type=messages&entityId=<id>
+ * That already owns permission scoping, offset/limit paging and the result shape,
+ * so there is deliberately no wrapper for it here.
+ */
+
+const prisma = DatabaseClient.getInstance();
+const router = Router();
+
+const MAX_LIMIT = 100;
+
+/** GET /api/entities?type=&limit=&offset= — the registry, busiest entities first. */
+router.get('/', authMiddleware.authenticate, async (req: Request, res: Response) => {
+  const workspaceId = req.user?.workspaceId;
+  if (!workspaceId) return res.status(401).json({ error: 'Unauthorized' });
+
+  const type = typeof req.query['type'] === 'string' ? req.query['type'] : undefined;
+  const limit = Math.max(1, Math.min(Number(req.query['limit']) || 50, MAX_LIMIT));
+  const offset = Math.max(Number(req.query['offset']) || 0, 0);
+
+  const where = {
+    workspaceId,
+    ...(type ? { type } : {}),
+  };
+
+  try {
+    const [rows, total] = await Promise.all([
+      prisma.entity.findMany({
+        where,
+        orderBy: [{ mentionCount: 'desc' }, { canonicalName: 'asc' }],
+        skip: offset,
+        take: limit,
+        select: {
+          id: true,
+          type: true,
+          canonicalName: true,
+          mentionCount: true,
+          _count: { select: { aliases: true } },
+          // The spellings that resolve to this entity. The client needs them to
+          // highlight a mention: a message's `entitySurfaceForms` is the whole
+          // thread's set with no mapping back to an id, so the only way to know
+          // which span belongs to THIS entity is its alias list.
+          aliases: { select: { surfaceForm: true }, orderBy: { count: 'desc' }, take: 25 },
+        },
+      }),
+      prisma.entity.count({ where }),
+    ]);
+
+    return res.json({
+      entities: rows.map(r => ({
+        id: r.id,
+        type: r.type,
+        canonicalName: r.canonicalName,
+        mentionCount: r.mentionCount,
+        aliasCount: r._count.aliases,
+        aliases: r.aliases.map(a => a.surfaceForm),
+      })),
+      total,
+    });
+  } catch (error) {
+    logger.error('[ENTITIES] list failed:', error);
+    return res.status(500).json({ error: 'Failed to list entities' });
+  }
+});
+
+/** GET /api/entities/types — distinct types in the workspace, for the filter chips. */
+router.get('/types', authMiddleware.authenticate, async (req: Request, res: Response) => {
+  const workspaceId = req.user?.workspaceId;
+  if (!workspaceId) return res.status(401).json({ error: 'Unauthorized' });
+
+  try {
+    // groupBy, not distinct: Prisma does not push `distinct` down to SQL — it emits
+    // `SELECT id, type FROM entities WHERE workspaceId = $1` and deduplicates in the
+    // client, so it reads the workspace's whole entity table on every page load.
+    // groupBy emits a real GROUP BY, served by @@index([workspaceId, type]).
+    const rows = await prisma.entity.groupBy({
+      by: ['type'],
+      where: { workspaceId },
+      orderBy: { type: 'asc' },
+    });
+    return res.json({ types: rows.map(r => r.type) });
+  } catch (error) {
+    logger.error('[ENTITIES] list types failed:', error);
+    return res.status(500).json({ error: 'Failed to list entity types' });
+  }
+});
+
+/**
+ * GET /api/entities/:entityId/feedback — every review recorded for this entity.
+ *
+ * Scoped to one entity rather than paged: the client renders at most a few dozen
+ * threads at a time and needs to look feedback up by messageId, so one fetch keyed
+ * on the entity is cheaper than a lookup per card.
+ */
+router.get('/:entityId/feedback', authMiddleware.authenticate, async (req: Request, res: Response) => {
+  const workspaceId = req.user?.workspaceId;
+  const userId = req.user?.id;
+  if (!workspaceId || !userId) return res.status(401).json({ error: 'Unauthorized' });
+
+  const entityId = req.params['entityId'];
+  if (!entityId) return res.status(400).json({ error: 'entityId is required' });
+
+  try {
+    const rows = await prisma.entityFeedback.findMany({
+      where: { workspaceId, entityId },
+      select: {
+        messageId: true,
+        conversationId: true,
+        entityId: true,
+        verdict: true,
+        remarks: true,
+        createdBy: true,
+        updatedAt: true,
+      },
+    });
+    // Every reviewer's rows come back, so the client can show a tally — it needs
+    // the caller's id to pick out which one is the viewer's own verdict.
+    return res.json({ feedback: rows, currentUserId: userId });
+  } catch (error) {
+    logger.error('[ENTITIES] list feedback failed:', error);
+    return res.status(500).json({ error: 'Failed to load feedback' });
+  }
+});
+
+/**
+ * PUT /api/entities/:entityId/feedback/:messageId — record a review of one entity
+ * on one message.
+ *
+ * Upsert on (messageId, entityId, createdBy): re-reviewing replaces YOUR previous
+ * verdict rather than accumulating rows, while another reviewer's verdict on the
+ * same message is left alone. Approving clears any earlier remark; rejecting
+ * requires one, since the remark is the point of a rejection.
+ */
+router.put(
+  '/:entityId/feedback/:messageId',
+  authMiddleware.authenticate,
+  async (req: Request, res: Response) => {
+    const workspaceId = req.user?.workspaceId;
+    const userId = req.user?.id;
+    if (!workspaceId || !userId) return res.status(401).json({ error: 'Unauthorized' });
+
+    const entityId = req.params['entityId'];
+    const messageId = req.params['messageId'];
+    if (!entityId || !messageId) {
+      return res.status(400).json({ error: 'entityId and messageId are required' });
+    }
+
+    const { verdict, remarks } = req.body as { verdict?: unknown; remarks?: unknown };
+    if (verdict !== 'APPROVED' && verdict !== 'REJECTED') {
+      return res.status(400).json({ error: "verdict must be 'APPROVED' or 'REJECTED'" });
+    }
+    if (verdict === 'REJECTED' && (typeof remarks !== 'string' || !remarks.trim())) {
+      return res.status(400).json({ error: 'remarks is required when rejecting' });
+    }
+
+    const cleanRemarks =
+      verdict === 'REJECTED' ? (remarks as string).trim().slice(0, 1000) : null;
+
+    try {
+      // Both ids come from the URL, so verify they belong to this workspace before
+      // writing — otherwise feedback could be attached to another tenant's message.
+      const [entity, message] = await Promise.all([
+        prisma.entity.findFirst({ where: { id: entityId, workspaceId }, select: { id: true } }),
+        prisma.message.findFirst({
+          where: { messageId, workspaceId },
+          select: { conversationId: true },
+        }),
+      ]);
+      if (!entity) return res.status(404).json({ error: 'Entity not found' });
+      if (!message) return res.status(404).json({ error: 'Message not found' });
+
+      const row = await prisma.entityFeedback.upsert({
+        where: { messageId_entityId_createdBy: { messageId, entityId, createdBy: userId } },
+        create: {
+          workspaceId,
+          messageId,
+          conversationId: message.conversationId,
+          entityId,
+          verdict,
+          remarks: cleanRemarks,
+          createdBy: userId,
+        },
+        // createdBy is part of the key, so it is never reassigned here — a reviewer
+        // only ever edits their own row.
+        update: { verdict, remarks: cleanRemarks },
+        select: {
+          messageId: true,
+          conversationId: true,
+          entityId: true,
+          verdict: true,
+          remarks: true,
+          createdBy: true,
+          updatedAt: true,
+        },
+      });
+      return res.json(row);
+    } catch (error) {
+      logger.error('[ENTITIES] save feedback failed:', error);
+      return res.status(500).json({ error: 'Failed to save feedback' });
+    }
+  },
+);
+
+export default router;

--- a/apps/backend/src/services/entityExtraction/pipeline/stages/buildThreadDocuments.ts
+++ b/apps/backend/src/services/entityExtraction/pipeline/stages/buildThreadDocuments.ts
@@ -30,9 +30,10 @@ export function buildThreadDocument(
   const ticketId = messages.find((m) => m.id.startsWith('ticket:'))?.id.slice('ticket:'.length)
 
   const cleaned = messages
-    .map((m) => ({ id: m.id, text: cleanMessageText(m.text, cfg.minTextLength), ts: m.ts }))
-    .filter((m) => !m.text.drop)
-    .map((m) => ({ id: m.id, text: m.text.text, ts: m.ts }))
+    .map((m) => {
+      const clean = cleanMessageText(m.text, cfg.minTextLength)
+      return { id: m.id, text: clean.drop ? '' : clean.text, ts: m.ts }
+    })
     .sort((a, b) => a.ts - b.ts)
 
   if (cleaned.length === 0) return []
@@ -65,12 +66,14 @@ export function buildThreadDocument(
   }
 
   for (const m of cleaned) {
-    if (chars > 0 && chars + m.text.length > cfg.maxThreadChars) {
+    if (m.text && chars > 0 && chars + m.text.length > cfg.maxThreadChars) {
       flush()
     }
-    part.push(m.text)
+    if (m.text) {
+      part.push(m.text)
+      chars += m.text.length + 1
+    }
     partIds.push(m.id)
-    chars += m.text.length + 1
   }
   flush()
   return docs

--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -205,6 +205,7 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       in: inChannel, // Channel name or ID (renamed to avoid 'in' keyword)
       mentions,        // User ID(s) mentioned in the message (scoped mention search)
       channelMentions, // Channel ID(s) referenced in the message (scoped mention search)
+      entityId,        // Extracted-entity ID(s) the message was tagged with
       mentionHighlights, // Display name(s) of bare mention chips — highlighted in results, not in YQL
       // Unified filters (work for both slack and ticket)
       projectId,   // Project ID(s) - comma-separated
@@ -788,6 +789,11 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
     if (messageActs) {
       options.slack.messageActs = toFilterValues(messageActs, 'messageActs');
     }
+    // Extracted-entity filter — the entity review screen sends this with
+    // filterOnly=true and an empty q to list every message carrying an entity.
+    if (entityId) {
+      options.slack.entityIds = toFilterValues(entityId, 'entityId');
+    }
     // Highlight-only: exact display names to bold in result snippets (kept out of the YQL filter).
     if (mentionHighlights) {
       options.mentionHighlights = mentionHighlights;
@@ -920,16 +926,24 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
 
     const isMailOnlySearch =
       searchApps.length === 1 && searchApps[0].trim().toLowerCase() === 'mail';
-    const mailGroupOffset = isMailOnlySearch
-      ? Math.max(Number(offset) || 0, 0)
-      : 0;
+    // Explicit groupBy=threadId (entity review) pages the same way mail does.
+    //
+    // `&& !isMailOnlySearch` is redundant given the OR below, but it is written out
+    // so the invariant is enforced by the code rather than inferred: a mail-only
+    // search can never enter the new branch. Desk mail therefore behaves exactly as
+    // before — whenever isMailOnlySearch is true, isGroupPaged is true and
+    // groupPageOffset equals the old mailGroupOffset, so all three uses below reduce
+    // to their original expressions.
+    const isThreadGroupedSearch = options.groupBy === 'threadId' && !isMailOnlySearch;
+    const isGroupPaged = isMailOnlySearch || isThreadGroupedSearch;
+    const groupPageOffset = isGroupPaged ? Math.max(Number(offset) || 0, 0) : 0;
 
     // Vespa's top-level offset paginates hits, not grouping buckets. Desk mail
     // results are grouped by threadId, so fetch the ranked group prefix and
     // slice the requested page after parsing the grouping response.
-    if (isMailOnlySearch && mailGroupOffset > 0) {
+    if (isGroupPaged && groupPageOffset > 0) {
       options.offset = 0;
-      options.limit = Math.min(MAX_VESPA_HITS, mailGroupOffset + effectiveLimit);
+      options.limit = Math.min(MAX_VESPA_HITS, groupPageOffset + effectiveLimit);
     }
 
     // Call vespa search
@@ -956,8 +970,8 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       // Grouped result don't have matchFeatures
       // Need to be added explicitly
       // Return grouped results
-      const pageGroups = isMailOnlySearch
-        ? parsedResults.groups.slice(mailGroupOffset, mailGroupOffset + effectiveLimit)
+      const pageGroups = isGroupPaged
+        ? parsedResults.groups.slice(groupPageOffset, groupPageOffset + effectiveLimit)
         : parsedResults.groups;
 
       const groupedResults = await Promise.all(

--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -791,6 +791,7 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
     }
     // Extracted-entity filter — the entity review screen sends this with
     // filterOnly=true and an empty q to list every message carrying an entity.
+    // The builder narrows this to thread roots — one hit per thread. See YqlBuilder.
     if (entityId) {
       options.slack.entityIds = toFilterValues(entityId, 'entityId');
     }
@@ -926,24 +927,16 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
 
     const isMailOnlySearch =
       searchApps.length === 1 && searchApps[0].trim().toLowerCase() === 'mail';
-    // Explicit groupBy=threadId (entity review) pages the same way mail does.
-    //
-    // `&& !isMailOnlySearch` is redundant given the OR below, but it is written out
-    // so the invariant is enforced by the code rather than inferred: a mail-only
-    // search can never enter the new branch. Desk mail therefore behaves exactly as
-    // before — whenever isMailOnlySearch is true, isGroupPaged is true and
-    // groupPageOffset equals the old mailGroupOffset, so all three uses below reduce
-    // to their original expressions.
-    const isThreadGroupedSearch = options.groupBy === 'threadId' && !isMailOnlySearch;
-    const isGroupPaged = isMailOnlySearch || isThreadGroupedSearch;
-    const groupPageOffset = isGroupPaged ? Math.max(Number(offset) || 0, 0) : 0;
+    const mailGroupOffset = isMailOnlySearch
+      ? Math.max(Number(offset) || 0, 0)
+      : 0;
 
     // Vespa's top-level offset paginates hits, not grouping buckets. Desk mail
     // results are grouped by threadId, so fetch the ranked group prefix and
     // slice the requested page after parsing the grouping response.
-    if (isGroupPaged && groupPageOffset > 0) {
+    if (isMailOnlySearch && mailGroupOffset > 0) {
       options.offset = 0;
-      options.limit = Math.min(MAX_VESPA_HITS, groupPageOffset + effectiveLimit);
+      options.limit = Math.min(MAX_VESPA_HITS, mailGroupOffset + effectiveLimit);
     }
 
     // Call vespa search
@@ -970,8 +963,8 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       // Grouped result don't have matchFeatures
       // Need to be added explicitly
       // Return grouped results
-      const pageGroups = isGroupPaged
-        ? parsedResults.groups.slice(groupPageOffset, groupPageOffset + effectiveLimit)
+      const pageGroups = isMailOnlySearch
+        ? parsedResults.groups.slice(mailGroupOffset, mailGroupOffset + effectiveLimit)
         : parsedResults.groups;
 
       const groupedResults = await Promise.all(

--- a/apps/backend/src/services/vespaSearch/resultTransform.ts
+++ b/apps/backend/src/services/vespaSearch/resultTransform.ts
@@ -46,6 +46,12 @@ import { PrismaClient } from '@prisma/client';
        senderId?: string;
        senderName?: string;
        senderEmail?: string;
+       // Extracted entities on this message. The three arrays are deduplicated
+       // independently by the extraction write-back, so they are NOT index-aligned:
+       // entityNames[i] does not necessarily describe entityIds[i].
+       entityIds?: string[];
+       entityNames?: string[];
+       entitySurfaceForms?: string[];
        userId?: string;
        email?: string;
        status?: string;
@@ -543,6 +549,11 @@ import { PrismaClient } from '@prisma/client';
          senderId: doc.userId,
          senderName: doc.username,
          senderEmail: doc.userEmail,
+         ...(doc.entityIds?.length ? { entityIds: doc.entityIds } : {}),
+         ...(doc.entityNames?.length ? { entityNames: doc.entityNames } : {}),
+         ...(doc.entitySurfaceForms?.length
+           ? { entitySurfaceForms: doc.entitySurfaceForms }
+           : {}),
        },
      };
    }

--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -112,6 +112,20 @@ export const vespaSearchQuerySchema = Joi.object({
       'alternatives.types': 'In must be a string or array of channel IDs'
     }),
 
+  // Extracted-entity filter: messages tagged with these entity IDs (Vespa `entityIds` field).
+  // Powers the entity review screen — pair with filterOnly=true and an empty q.
+  entityId: Joi.alternatives()
+    .try(
+      Joi.array().items(Joi.string()),
+      Joi.string().custom((value) => {
+        return value.split(',').map((id: string) => id.trim()).filter(Boolean);
+      })
+    )
+    .optional()
+    .messages({
+      'alternatives.types': 'entityId must be a string or array of entity IDs'
+    }),
+
   // Mention filter (scoped search): messages that mention these user IDs (Vespa `mentions` field)
   mentions: Joi.alternatives()
     .try(

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -229,6 +229,15 @@ export interface VespaChatMessageDocument extends Omit<VespaDocument, 'orgId' | 
   messageActs?: string[];
   /** What kind of thread this is. Set only on the thread's root message. */
   threadType?: string[];
+  /**
+   * Entities the extraction pipeline resolved on this message. Written by
+   * `writeEntitiesToVespa`, which assigns a thread's whole set to every message in
+   * it, and deduplicates the three arrays independently — so they are NOT
+   * index-aligned with each other.
+   */
+  entityIds?: string[];
+  entityNames?: string[];
+  entitySurfaceForms?: string[];
   channelWeightedSet: any,
   userWeightedSet: any,
   channelRef: string;

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -422,11 +422,7 @@ export class YqlBuilder {
       // keeping the highest-relevance hit within each thread.
       yql += ` | all(group(threadId) max(${safeLimit}) order(-max(relevance())) each(max(1) each(output(summary(default)))))`;
     } else if (groupBy && this.shouldGroup(groupBy, schemas, apps)) {
-      // threadId grouping is paged by slicing the group prefix (same approach as the
-      // mail branch above), so the caller raises `limit` to offset+pageSize to reach
-      // deeper pages. Capping it at 50 here would silently stop paging at group 50.
-      const maxGroups = groupBy === 'threadId' ? safeLimit : Math.min(safeLimit, 50);
-      const groupClause = this.buildGroupingClause(groupBy, maxGroups);
+      const groupClause = this.buildGroupingClause(groupBy, Math.min(safeLimit, 50));
       if (groupClause) {
         yql += `| ${groupClause}`;
       }
@@ -831,6 +827,7 @@ export class YqlBuilder {
         .map((id) => `entityIds contains ${params.bind('entityId', id.trim())}`)
         .join(' or ');
       conditions.push(`(${entities})`);
+      conditions.push('isRootMessage = true');
     }
 
     if (filters.createdBefore) {
@@ -1395,10 +1392,6 @@ export class YqlBuilder {
   private static readonly GROUP_FIELD_SCHEMAS: Record<string, VespaSchema[] | 'all'> = {
     senderId: [messageSchema, attachmentSchema],
     userId: [messageSchema, attachmentSchema],
-    // threadId -> chat_message only. Entity extraction resolves per THREAD and
-    // stamps the result on every message in it, so grouping by thread collapses
-    // that fan-out back to one row per conversation.
-    threadId: [messageSchema],
     channelId: [messageSchema, attachmentSchema, ticketSchema, fileSchema, mailSchema],
     docType: 'all',
     threadType: [messageSchema],
@@ -1448,12 +1441,6 @@ export class YqlBuilder {
       case 'docType':
         // Group by document type (messages, channels, attachments, etc.)
         return `all(group(docType) max(10) each(max(10) each(output(summary()))))`;
-
-      case 'threadId':
-        // Group by conversation. A deeper per-group cap than the others: the point
-        // of this grouping is to see a thread's matching messages together, and a
-        // cap of 5 would silently hide most of a long thread.
-        return `all(group(threadId) max(${maxGroups}) each(max(20) each(output(summary()))))`;
 
       case 'senderId':
       case 'userId':

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -57,6 +57,9 @@ export interface SlackFilters {
   // messages that justified a tag. Different questions; both exact attribute filters.
   threadType?: string[];
   messageActs?: string[];
+  // Extracted-entity filter: messages the entity pipeline tagged with these entity ids.
+  // `entityIds` is a fast-search attribute, so this is set membership, not a scan.
+  entityIds?: string[];
   // Date filters
   createdBefore?: string; // Created before date (multiple formats)
   createdAfter?: string; // Created after date (multiple formats)
@@ -419,7 +422,11 @@ export class YqlBuilder {
       // keeping the highest-relevance hit within each thread.
       yql += ` | all(group(threadId) max(${safeLimit}) order(-max(relevance())) each(max(1) each(output(summary(default)))))`;
     } else if (groupBy && this.shouldGroup(groupBy, schemas, apps)) {
-      const groupClause = this.buildGroupingClause(groupBy, Math.min(safeLimit, 50));
+      // threadId grouping is paged by slicing the group prefix (same approach as the
+      // mail branch above), so the caller raises `limit` to offset+pageSize to reach
+      // deeper pages. Capping it at 50 here would silently stop paging at group 50.
+      const maxGroups = groupBy === 'threadId' ? safeLimit : Math.min(safeLimit, 50);
+      const groupClause = this.buildGroupingClause(groupBy, maxGroups);
       if (groupClause) {
         yql += `| ${groupClause}`;
       }
@@ -816,6 +823,14 @@ export class YqlBuilder {
         .map((act) => `messageActs contains ${params.bind('messageActs', act.trim())}`)
         .join(' or ');
       conditions.push(`(${acts})`);
+    }
+
+    // Extracted-entity filter - messages the entity pipeline tagged with these entities
+    if (filters.entityIds && filters.entityIds.length > 0) {
+      const entities = filters.entityIds
+        .map((id) => `entityIds contains ${params.bind('entityId', id.trim())}`)
+        .join(' or ');
+      conditions.push(`(${entities})`);
     }
 
     if (filters.createdBefore) {
@@ -1380,6 +1395,10 @@ export class YqlBuilder {
   private static readonly GROUP_FIELD_SCHEMAS: Record<string, VespaSchema[] | 'all'> = {
     senderId: [messageSchema, attachmentSchema],
     userId: [messageSchema, attachmentSchema],
+    // threadId -> chat_message only. Entity extraction resolves per THREAD and
+    // stamps the result on every message in it, so grouping by thread collapses
+    // that fan-out back to one row per conversation.
+    threadId: [messageSchema],
     channelId: [messageSchema, attachmentSchema, ticketSchema, fileSchema, mailSchema],
     docType: 'all',
     threadType: [messageSchema],
@@ -1429,6 +1448,12 @@ export class YqlBuilder {
       case 'docType':
         // Group by document type (messages, channels, attachments, etc.)
         return `all(group(docType) max(10) each(max(10) each(output(summary()))))`;
+
+      case 'threadId':
+        // Group by conversation. A deeper per-group cap than the others: the point
+        // of this grouping is to see a thread's matching messages together, and a
+        // cap of 5 would silently hide most of a long thread.
+        return `all(group(threadId) max(${maxGroups}) each(max(20) each(output(summary()))))`;
 
       case 'senderId':
       case 'userId':

--- a/apps/dashboard/src/api/entitiesApi.ts
+++ b/apps/dashboard/src/api/entitiesApi.ts
@@ -65,7 +65,7 @@ export const entitiesApi = {
     entityId: string,
   ): Promise<{ feedback: EntityFeedback[]; currentUserId: string }> => {
     const res = await apiInstance.get<{ feedback: EntityFeedback[]; currentUserId: string }>(
-      `/entities/${entityId}/feedback`,
+      `/entities/${encodeURIComponent(entityId)}/feedback`,
     );
     return res.data;
   },
@@ -81,7 +81,7 @@ export const entitiesApi = {
     remarks?: string,
   ): Promise<EntityFeedback> => {
     const res = await apiInstance.put<EntityFeedback>(
-      `/entities/${entityId}/feedback/${messageId}`,
+      `/entities/${encodeURIComponent(entityId)}/feedback/${encodeURIComponent(messageId)}`,
       { verdict, ...(remarks ? { remarks } : {}) },
     );
     return res.data;

--- a/apps/dashboard/src/api/entitiesApi.ts
+++ b/apps/dashboard/src/api/entitiesApi.ts
@@ -1,0 +1,89 @@
+import { apiInstance } from '../services/clients/apiClient';
+
+export type EntityVerdict = 'APPROVED' | 'REJECTED';
+
+/**
+ * A review of one entity on one message.
+ *
+ * Per-message rather than per-entity: extraction assigns an entity to a whole
+ * thread, so the same entity can be right on the message that names it and wrong on
+ * a reply that only inherited it.
+ */
+export interface EntityFeedback {
+  messageId: string;
+  conversationId: string;
+  entityId: string;
+  verdict: EntityVerdict;
+  remarks: string | null;
+  createdBy: string;
+  updatedAt: string;
+}
+
+/** A row in the extraction registry (`non_zero.entities`). */
+export interface EntityListItem {
+  id: string;
+  type: string;
+  canonicalName: string;
+  mentionCount: number;
+  /** Known spellings that resolve to this entity — a high count usually means a messy entity. */
+  aliasCount: number;
+  /**
+   * The actual spellings (capped server-side). Needed to highlight a mention: a
+   * message's `entitySurfaceForms` is the whole thread's set with no mapping back
+   * to an entity id, so this is the only way to know which span is this entity's.
+   */
+  aliases: string[];
+}
+
+/**
+ * Registry and feedback. The messages behind an entity come from the shared search
+ * endpoint, called directly as `GET /api/vespaSearch?entityId=…&groupBy=threadId` —
+ * there is deliberately no wrapper for it here.
+ */
+export const entitiesApi = {
+  listEntities: async (params: {
+    type?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<{ entities: EntityListItem[]; total: number }> => {
+    const res = await apiInstance.get<{ entities: EntityListItem[]; total: number }>('/entities', {
+      params,
+    });
+    return res.data;
+  },
+
+  listTypes: async (): Promise<string[]> => {
+    const res = await apiInstance.get<{ types: string[] }>('/entities/types');
+    return res.data.types;
+  },
+
+  /**
+   * Every review recorded for this entity, by every reviewer. `currentUserId` comes
+   * back so the caller can tell its own verdict apart from other people's.
+   */
+  listFeedback: async (
+    entityId: string,
+  ): Promise<{ feedback: EntityFeedback[]; currentUserId: string }> => {
+    const res = await apiInstance.get<{ feedback: EntityFeedback[]; currentUserId: string }>(
+      `/entities/${entityId}/feedback`,
+    );
+    return res.data;
+  },
+
+  /**
+   * Record a review of this entity on one message. Upserts, so re-reviewing
+   * replaces the previous verdict. `remarks` is required when rejecting.
+   */
+  setFeedback: async (
+    entityId: string,
+    messageId: string,
+    verdict: EntityVerdict,
+    remarks?: string,
+  ): Promise<EntityFeedback> => {
+    const res = await apiInstance.put<EntityFeedback>(
+      `/entities/${entityId}/feedback/${messageId}`,
+      { verdict, ...(remarks ? { remarks } : {}) },
+    );
+    return res.data;
+  },
+};

--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -29,6 +29,7 @@ import {
   ChatChatting,
   Bot,
   RocketShip,
+  Tag,
   type PikaIconProps,
   Tag,
 } from '@xyne/icons';
@@ -116,6 +117,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
   { path: '/product-insights', label: 'Insights', icon: Piechart01, popout: true },
   { path: '/knowledge-base', label: 'Knowledge Base', icon: Notebook, popout: true },
   { path: '/memory', label: 'Context', icon: Database, popout: true },
+  { path: '/entities', label: 'Entities', icon: Tag },
   { path: '/dashboards', label: 'Dashboards', icon: GridDashboard01, popout: true },
   { path: '/listProjects', label: 'List Projects', icon: FolderDefault, popout: true },
   { path: '/releaseManager', label: 'Release Manager', icon: RocketShip, popout: true },

--- a/apps/dashboard/src/components/Entities/EntityList.tsx
+++ b/apps/dashboard/src/components/Entities/EntityList.tsx
@@ -1,0 +1,178 @@
+import { JSX, useEffect, useMemo, useRef, useState } from 'react';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/Select/Select';
+import { cn } from '../../utils/classNames';
+import { entitiesApi, type EntityListItem } from '../../api/entitiesApi';
+
+interface EntityListProps {
+  selectedId: string | null;
+  onSelect: (entity: EntityListItem) => void;
+}
+
+const PAGE_SIZE = 50;
+const ALL_TYPES = '__all__';
+
+/**
+ * Pick a type, then an entity.
+ *
+ * Type is a dropdown rather than a row of chips: the list is workspace-defined and
+ * open-ended, so chips would wrap unpredictably and compete with the entity names
+ * for attention. Type is a filter you set once and forget; the entity is the thing
+ * you actually scan.
+ */
+export const EntityList = ({ selectedId, onSelect }: EntityListProps): JSX.Element => {
+  const [type, setType] = useState<string>(ALL_TYPES);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const { data: types = [] } = useQuery({
+    queryKey: ['entity-types'],
+    queryFn: () => entitiesApi.listTypes(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data, isLoading, isError, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      // Type is part of the key, so changing it starts a fresh list from offset 0
+      // rather than appending to the old one.
+      queryKey: ['entities', type],
+      queryFn: ({ pageParam }) =>
+        entitiesApi.listEntities({
+          ...(type !== ALL_TYPES ? { type } : {}),
+          limit: PAGE_SIZE,
+          offset: pageParam,
+        }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const loaded = allPages.reduce((n, p) => n + p.entities.length, 0);
+        return loaded < lastPage.total ? loaded : undefined;
+      },
+    });
+
+  const entities = useMemo(() => (data?.pages ?? []).flatMap(p => p.entities), [data]);
+  const total = data?.pages?.[0]?.total ?? 0;
+
+  // Paging state via a ref so the observer is created once; re-observing an
+  // already-visible sentinel after every page would fetch the whole list at once.
+  const pagingRef = useRef({ hasNextPage, isFetchingNextPage, fetchNextPage });
+  pagingRef.current = { hasNextPage, isFetchingNextPage, fetchNextPage };
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const root = scrollRef.current;
+    if (!sentinel || !root) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (!entries[0]?.isIntersecting) return;
+        const {
+          hasNextPage: more,
+          isFetchingNextPage: busy,
+          fetchNextPage: next,
+        } = pagingRef.current;
+        if (more && !busy) void next();
+      },
+      { root, threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+    return (): void => observer.disconnect();
+  }, []);
+
+  const resetScroll = (): void => scrollRef.current?.scrollTo({ top: 0 });
+
+  return (
+    <div className='flex flex-col h-full min-h-0 overflow-hidden border-r border-border'>
+      <div className='p-3 border-b border-border shrink-0'>
+        <Select
+          value={type}
+          onValueChange={value => {
+            setType(value);
+            resetScroll();
+          }}
+        >
+          <SelectTrigger size='sm' className='w-full'>
+            <SelectValue placeholder='All types' />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_TYPES}>All types</SelectItem>
+            {types.map(t => (
+              <SelectItem key={t} value={t}>
+                {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div ref={scrollRef} className='flex-1 min-h-0 overflow-y-auto'>
+        {isLoading && entities.length === 0 && (
+          <p className='text-xs text-muted-foreground p-4'>Loading entities…</p>
+        )}
+
+        {/* Distinct from the empty state on purpose: a failed request previously
+            rendered as "nothing extracted", which points the reader at the data
+            when the problem is the request. */}
+        {isError && (
+          <div className='p-4 text-xs'>
+            <p className='text-destructive'>Could not load entities.</p>
+            <p className='text-muted-foreground mt-1 break-words'>
+              {error instanceof Error ? error.message : 'Unknown error'}
+            </p>
+          </div>
+        )}
+
+        {!isLoading && !isError && entities.length === 0 && (
+          <p className='text-xs text-muted-foreground p-4'>
+            {type !== ALL_TYPES
+              ? 'No entities of this type.'
+              : 'No entities have been extracted yet.'}
+          </p>
+        )}
+
+        {entities.map(entity => (
+          <button
+            key={entity.id}
+            type='button'
+            onClick={() => onSelect(entity)}
+            className={cn(
+              'w-full flex items-baseline gap-2 px-3 py-2 text-left border-b border-border/40',
+              'hover:bg-accent/60 transition-colors',
+              selectedId === entity.id && 'bg-accent',
+            )}
+            data-track-category='Entities'
+            data-track-name='SelectEntity'
+          >
+            <span className='flex-1 min-w-0 truncate text-sm'>{entity.canonicalName}</span>
+            {/* Type is only worth repeating per row when the list is unfiltered. */}
+            {type === ALL_TYPES && (
+              <span className='shrink-0 text-[11px] text-muted-foreground'>{entity.type}</span>
+            )}
+            <span className='shrink-0 text-[11px] text-muted-foreground tabular-nums'>
+              {entity.mentionCount}
+            </span>
+          </button>
+        ))}
+
+        {/* Always mounted — the observer is created once on mount. */}
+        <div ref={sentinelRef} className='h-1' aria-hidden='true' />
+
+        {isFetchingNextPage && (
+          <div className='flex items-center justify-center gap-2 p-3 text-xs text-muted-foreground'>
+            <Loader2 className='size-3.5 animate-spin' />
+            Loading more…
+          </div>
+        )}
+      </div>
+
+      {entities.length > 0 && (
+        <div className='px-3 py-1.5 border-t border-border text-[11px] text-muted-foreground shrink-0'>
+          {entities.length} of {total}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EntityList;

--- a/apps/dashboard/src/components/Entities/EntityMessages.tsx
+++ b/apps/dashboard/src/components/Entities/EntityMessages.tsx
@@ -1,0 +1,485 @@
+import { JSX, useEffect, useMemo, useRef, useState } from 'react';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Check, Loader2, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { MessageType } from '@xyne/shared';
+import { apiInstance } from '../../services/clients/apiClient';
+import { SearchResultMessageCard } from '../Chat/SearchResults/SearchResultMessageCard';
+import { SearchResultsContext } from '../Chat/SearchResults/SearchResultsContext';
+import EntityRemarksDialog from './EntityRemarksDialog';
+import { cn } from '../../utils/classNames';
+import type { VespaSearchGroup, VespaSearchResponse } from '../../types/search';
+import {
+  entitiesApi,
+  type EntityFeedback,
+  type EntityListItem,
+  type EntityVerdict,
+} from '../../api/entitiesApi';
+
+/**
+ * What the side panel should show, mirroring SearchResults' own panel state.
+ *
+ * The distinction matters: a conversation WITH replies opens as a thread, while a
+ * standalone message opens its channel context instead. SearchResultMessageCard
+ * already branches on replyCount and calls a different context callback for each,
+ * so collapsing both into one panel kind makes a lone message render as a thread.
+ */
+export type SelectedPanel =
+  | { kind: 'thread'; channelId: string; conversationId: string; matchedMessageId: string | null }
+  | {
+      kind: 'channel';
+      channelId: string;
+      conversationId: string;
+      conversationCreatedAt?: number;
+      matchedMessageId: string | null;
+    };
+
+interface EntityMessagesProps {
+  entity: EntityListItem;
+  onSelectPanel: (panel: SelectedPanel) => void;
+}
+
+/** Threads per page. Grouped responses are paged by slicing the group prefix. */
+const PAGE_SIZE = 20;
+
+/**
+ * Does this message literally name the entity?
+ *
+ * Matched against the entity's ALIAS list from the registry, not its canonical
+ * name: aliases are exactly the spellings that resolve to this entity, including
+ * the fuzzy ones a substring test would miss ("zakpay" resolves to "Zaakpay" but
+ * shares no prefix).
+ */
+const namesEntity = (text: string, entity: EntityListItem): boolean => {
+  const needles = [...new Set([entity.canonicalName, ...entity.aliases])].filter(n => n.length > 1);
+  const lower = text.toLowerCase();
+  return needles.some(n => lower.includes(n.toLowerCase()));
+};
+
+/**
+ * The threads an entity was extracted from.
+ *
+ * Calls `/api/vespaSearch` directly rather than through `searchService.vespaSearch`
+ * for one reason: that helper flattens grouped responses and drops rows with
+ * `relevanceScore > 0`. A filter-only query is unranked and every hit scores 0, so
+ * it would discard the entire result set. Going direct also keeps the request
+ * visible as-is in the network tab.
+ *
+ * Rows are `SearchResultMessageCard`, the same card the full search screen uses.
+ * It reads its click handlers off `SearchResultsContext`, so providing
+ * `onSelectThread` here is all the wiring the side panel needs.
+ *
+ * Paged by `offset`: Vespa's top-level offset paginates hits rather than grouping
+ * buckets, so the backend fetches the group prefix and slices the requested page —
+ * the same mechanism Desk mail uses (vespaSearch/index.ts:921).
+ */
+export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): JSX.Element => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ['entity-threads', entity.id],
+      queryFn: async ({ pageParam }) => {
+        const res = await apiInstance.get<VespaSearchResponse>('/vespaSearch', {
+          params: {
+            q: '',
+            filterOnly: true,
+            apps: 'chat',
+            type: 'messages',
+            entityId: entity.id,
+            groupBy: 'threadId',
+            offset: pageParam,
+            limit: PAGE_SIZE,
+          },
+        });
+        if (!res.data.success) throw new Error(res.data.error || 'Search failed');
+        return res.data.data;
+      },
+      initialPageParam: 0,
+      // totalCount on a grouped response counts MESSAGES, not groups, so it cannot
+      // say when threads run out. A short page is the end-of-results signal.
+      getNextPageParam: (lastPage, allPages) => {
+        const groups = lastPage.groups?.length ?? 0;
+        if (groups < PAGE_SIZE) return undefined;
+        return allPages.reduce((n, p) => n + (p.groups?.length ?? 0), 0);
+      },
+    });
+
+  const totalMessages = data?.pages?.[0]?.totalCount ?? 0;
+
+  // One card per thread, showing its ROOT message. Rendering every message would
+  // mount a ChatBubble per row, and ChatBubble fetches channel shortcuts per
+  // instance (ChatBubble.tsx:198) — one HTTP request each.
+  const rows = useMemo(
+    () =>
+      (data?.pages.flatMap(p => p.groups ?? []) ?? [])
+        .map((group: VespaSearchGroup) => {
+          const root = group.results.find(r => r.searchContext?.isRootMessage) ?? group.results[0];
+          if (!root?.searchContext?.channelId) return null;
+          // Anchor on a message that actually names the entity, so the panel opens
+          // scrolled to the mention rather than the top of the thread.
+          const naming = group.results.find(r => namesEntity(r.context ?? '', entity));
+          return {
+            conversationId: group.groupValue,
+            root,
+            // The card renders `displayMessageId ?? matchedMessageId`, so these must
+            // be passed separately: the ROOT is what the card should show, while the
+            // matched message is only where the side panel scrolls to. Passing the
+            // matched id alone makes the card render a mid-thread reply.
+            displayMessageId: root.searchContext.messageId ?? null,
+            matchedMessageId:
+              naming?.searchContext?.messageId ?? root.searchContext.messageId ?? null,
+          };
+        })
+        .filter((r): r is NonNullable<typeof r> => r !== null),
+    [data, entity],
+  );
+
+  // Latest paging state, read inside the observer callback. Kept in a ref so the
+  // observer is created ONCE: depending on isFetchingNextPage would tear it down and
+  // re-observe after every page, and re-observing an already-visible sentinel fires
+  // immediately — which turns one click into a burst of requests.
+  const pagingRef = useRef({ hasNextPage, isFetchingNextPage, fetchNextPage });
+  pagingRef.current = { hasNextPage, isFetchingNextPage, fetchNextPage };
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const root = scrollRef.current;
+    if (!sentinel || !root) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (!entries[0]?.isIntersecting) return;
+        const {
+          hasNextPage: more,
+          isFetchingNextPage: busy,
+          fetchNextPage: next,
+        } = pagingRef.current;
+        if (more && !busy) void next();
+      },
+      { root, threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+    return (): void => observer.disconnect();
+  }, []);
+
+  const queryClient = useQueryClient();
+  /** The message a rejection is being written for; null when the dialog is closed. */
+  const [rejecting, setRejecting] = useState<{ messageId: string; text: string } | null>(null);
+
+  // One fetch per entity rather than per card: the client only needs to look
+  // feedback up by messageId, and an entity's review set is small.
+  const { data: feedbackData } = useQuery({
+    queryKey: ['entity-feedback', entity.id],
+    queryFn: () => entitiesApi.listFeedback(entity.id),
+  });
+
+  const feedback = useMemo(() => feedbackData?.feedback ?? [], [feedbackData]);
+  const currentUserId = feedbackData?.currentUserId ?? '';
+
+  /**
+   * messageId → every reviewer's verdict on it, with the viewer's own separated out.
+   * Reviewers each get their own row, so a message can carry disagreement; the card
+   * shows your verdict and counts the rest.
+   */
+  const feedbackByMessage = useMemo(() => {
+    const map = new Map<string, { mine?: EntityFeedback; approved: number; rejected: number }>();
+    for (const row of feedback) {
+      const bucket = map.get(row.messageId) ?? { approved: 0, rejected: 0 };
+      if (row.verdict === 'APPROVED') bucket.approved++;
+      else bucket.rejected++;
+      if (row.createdBy === currentUserId) bucket.mine = row;
+      map.set(row.messageId, bucket);
+    }
+    return map;
+  }, [feedback, currentUserId]);
+
+  const feedbackMutation = useMutation({
+    mutationFn: ({
+      messageId,
+      verdict,
+      remarks,
+    }: {
+      messageId: string;
+      verdict: EntityVerdict;
+      remarks?: string;
+    }) => entitiesApi.setFeedback(entity.id, messageId, verdict, remarks),
+    onSuccess: result => {
+      toast.success(
+        result.verdict === 'APPROVED'
+          ? `Approved “${entity.canonicalName}” on this message`
+          : `Rejected “${entity.canonicalName}” on this message`,
+      );
+      setRejecting(null);
+      void queryClient.invalidateQueries({ queryKey: ['entity-feedback', entity.id] });
+    },
+    onError: (error: unknown) => {
+      const message =
+        error && typeof error === 'object' && 'response' in error
+          ? ((error as { response?: { data?: { error?: string } } }).response?.data?.error ??
+            'Failed to save feedback')
+          : 'Failed to save feedback';
+      toast.error(message);
+    },
+  });
+
+  const contextValue = useMemo(
+    () => ({
+      // Conversations WITH replies — open the thread panel.
+      onSelectThread: (thread: {
+        channelId: string;
+        conversationId: string;
+        matchedMessageId?: string | null;
+      }): void =>
+        onSelectPanel({
+          kind: 'thread',
+          channelId: thread.channelId,
+          conversationId: thread.conversationId,
+          matchedMessageId: thread.matchedMessageId ?? null,
+        }),
+      // Standalone messages (replyCount 0) — open channel context, not a thread.
+      onSelectChannelContext: (
+        channelId: string,
+        conversationId: string,
+        conversationCreatedAt?: number,
+        matchedMessageId?: string | null,
+      ): void =>
+        onSelectPanel({
+          kind: 'channel',
+          channelId,
+          conversationId,
+          ...(conversationCreatedAt !== undefined ? { conversationCreatedAt } : {}),
+          matchedMessageId: matchedMessageId ?? null,
+        }),
+    }),
+    [onSelectPanel],
+  );
+
+  return (
+    <div className='flex flex-col h-full min-h-0 overflow-hidden'>
+      {/* Spec: padding 16px 20px 14px, name 17px/600 with tight tracking. */}
+      <div className='px-5 pt-4 pb-3.5 border-b border-border shrink-0'>
+        <h2 className='text-[17px] font-semibold tracking-[-0.01em]'>{entity.canonicalName}</h2>
+        {/*
+          Threads and messages are different units — `rows.length` counts groups,
+          while a grouped response's totalCount counts the messages inside them. The
+          earlier "N of M messages" implied N was a subset of M and looked stuck at
+          the end of the list, so label each count for what it is.
+        */}
+        <p className='text-xs text-muted-foreground mt-0.5'>
+          {entity.type}
+          {rows.length > 0 &&
+            ` · ${rows.length}${hasNextPage ? '+' : ''} thread${rows.length === 1 ? '' : 's'}`}
+          {totalMessages > 0 && ` · ${totalMessages} message${totalMessages === 1 ? '' : 's'}`}
+          {/* Distinct messages, not feedback rows: reviewers each get their own row,
+              so counting rows overstates as soon as two people review one message. */}
+          {feedbackByMessage.size > 0 && ` · ${feedbackByMessage.size} reviewed`}
+        </p>
+      </div>
+
+      {/*
+        The card keeps its own box; only its "Open in home" button
+        (SearchResultMessageCard:305) is hidden — a search-screen affordance that is
+        redundant here, since clicking the card already opens the conversation in the
+        side panel. Scoped so no other screen is affected.
+      */}
+      <style>{`
+        .entity-results [aria-label="Open in home"] { display: none; }
+        /*
+          Card metrics from the design spec: 84px floor, 8px radius, #e7e5e4 border.
+          In the spec the timestamp and the ✓/✕ share one right-hand grid column
+          (space-between, so time on top and buttons at the bottom). The shared card
+          owns its own layout, so the buttons are positioned into that same corner
+          instead — padding-bottom reserves the strip they occupy.
+
+          These live on the CARD, not the wrapper: the wrapper must hug the card
+          exactly, or a short card leaves dead space and the buttons fall outside it.
+        */
+        .entity-results [data-track-name="OPEN_SEARCH_MESSAGE"] {
+          min-height: 84px;
+          /*
+            Only a hairline of breathing room, NOT a reserved strip. In the spec the
+            buttons occupy a grid column beside the content and cost no height at
+            all; padding here to clear them just makes every card taller than the
+            reference. With this small, the 84px floor is what governs a short card
+            — which is exactly the spec's number.
+          */
+          padding-bottom: 6px;
+          border-radius: 8px;
+        }
+      `}</style>
+
+      {/*
+        Block layout with space-y, NOT `flex flex-col`: as flex children the cards
+        pick up the default `flex-shrink: 1` and get squashed to fit the container,
+        clipping their message text mid-line.
+      */}
+      <div
+        ref={scrollRef}
+        // Spec: padding 14px 20px 32px, 10px between cards.
+        className='entity-results flex-1 min-h-0 overflow-y-auto px-5 pt-3.5 pb-8 space-y-2.5'
+      >
+        {isLoading && <p className='text-xs text-muted-foreground p-4'>Loading threads…</p>}
+
+        {isError && (
+          <p className='text-xs text-destructive p-4'>Could not load messages for this entity.</p>
+        )}
+
+        {!isLoading && !isError && rows.length === 0 && (
+          <p className='text-xs text-muted-foreground p-4'>
+            No messages you have access to carry this entity.
+          </p>
+        )}
+
+        <SearchResultsContext.Provider value={contextValue}>
+          {rows.map(row => {
+            // Feedback is keyed on the message the card renders — its thread root.
+            const reviewedId = row.displayMessageId ?? row.matchedMessageId;
+            const bucket = reviewedId ? feedbackByMessage.get(reviewedId) : undefined;
+            const existing = bucket?.mine;
+            // Verdicts from other reviewers on this same message.
+            const othersApproved =
+              (bucket?.approved ?? 0) - (existing?.verdict === 'APPROVED' ? 1 : 0);
+            const othersRejected =
+              (bucket?.rejected ?? 0) - (existing?.verdict === 'REJECTED' ? 1 : 0);
+            const others = othersApproved + othersRejected;
+            const messageText = row.root.context ?? '';
+
+            return (
+              // `relative group/verdict` wraps the shared card so the approve/reject
+              // controls can be overlaid on hover without the card needing new props.
+              // `data-prevent-thread` stops a click on them bubbling into the card's
+              // own handler and opening the side panel.
+              // Fixed height so the list scans as a uniform grid rather than a ragged
+              // stack — message length varies from one line to a paragraph. The card
+              // itself is untouched; the wrapper clips it.
+              // Wrapper hugs the card exactly — no height of its own. Give it one and
+              // a short card leaves dead space beneath, dropping the absolutely
+              // positioned buttons below outside the card's border.
+              <div key={row.conversationId} className='relative'>
+                <SearchResultMessageCard
+                  channelId={row.root.searchContext!.channelId!}
+                  conversationId={row.conversationId}
+                  matchedMessageId={row.matchedMessageId}
+                  {...(row.displayMessageId ? { displayMessageId: row.displayMessageId } : {})}
+                  searchSnippet={row.root.context ?? ''}
+                  searchThread={{
+                    isRootMessage: row.root.searchContext?.isRootMessage ?? true,
+                    replyCount: row.root.searchContext?.replyCount ?? 0,
+                    senderId: row.root.searchContext?.senderId ?? '',
+                    msgType: (row.root.searchContext?.msgType as MessageType) ?? MessageType.USER,
+                    createdAt: row.root.searchContext?.createdAtTimestamp ?? 0,
+                    ...(row.root.searchContext?.threadSenders
+                      ? { threadSenders: row.root.searchContext.threadSenders }
+                      : {}),
+                    ...(row.root.searchContext?.attachmentIds
+                      ? { attachmentIds: row.root.searchContext.attachmentIds }
+                      : {}),
+                  }}
+                />
+
+                {/*
+                Bottom-right of the card, level with the replies indicator on the
+                left — the row the card leaves empty on that side. Always visible,
+                because the colour IS the verdict: hiding them until hover would hide
+                the state along with the control. `data-prevent-thread` stops a click
+                here from also opening the side panel.
+              */}
+                <div
+                  data-prevent-thread
+                  title={
+                    existing?.verdict === 'REJECTED' && existing.remarks
+                      ? existing.remarks
+                      : others > 0
+                        ? `${othersApproved} approved, ${othersRejected} rejected by others`
+                        : undefined
+                  }
+                  className='absolute bottom-3 right-4 z-20 flex items-center gap-[5px]'
+                >
+                  <button
+                    type='button'
+                    title='Correct on this message'
+                    aria-label='Approve this entity on this message'
+                    aria-pressed={existing?.verdict === 'APPROVED'}
+                    disabled={feedbackMutation.isPending || !reviewedId}
+                    onClick={event => {
+                      event.stopPropagation();
+                      if (reviewedId) {
+                        feedbackMutation.mutate({ messageId: reviewedId, verdict: 'APPROVED' });
+                      }
+                    }}
+                    data-track-category='Entities'
+                    data-track-name='ApproveEntityOnMessage'
+                    // Exact palette from the design spec. Dark-mode fallbacks use the
+                    // theme tokens, since the spec is light-only.
+                    className={cn(
+                      'flex size-6 items-center justify-center rounded-[5px] border transition-colors disabled:opacity-50',
+                      existing?.verdict === 'APPROVED'
+                        ? 'border-[#9fd4ba] bg-[#eefaf3] text-[#16794c] dark:border-green-600/60 dark:bg-green-600/15 dark:text-green-500'
+                        : 'border-[#e4e4e7] bg-white text-[#a1a1aa] hover:border-[#16794c] hover:text-[#16794c] dark:border-border dark:bg-background dark:text-muted-foreground',
+                    )}
+                  >
+                    <Check size={13} strokeWidth={2} />
+                  </button>
+                  <button
+                    type='button'
+                    title='Wrong on this message'
+                    aria-label='Reject this entity on this message'
+                    aria-pressed={existing?.verdict === 'REJECTED'}
+                    disabled={feedbackMutation.isPending || !reviewedId}
+                    onClick={event => {
+                      event.stopPropagation();
+                      if (reviewedId) setRejecting({ messageId: reviewedId, text: messageText });
+                    }}
+                    data-track-category='Entities'
+                    data-track-name='RejectEntityOnMessage'
+                    className={cn(
+                      'flex size-6 items-center justify-center rounded-[5px] border transition-colors disabled:opacity-50',
+                      existing?.verdict === 'REJECTED'
+                        ? 'border-[#eeb4ae] bg-[#fdf1f0] text-[#b42318] dark:border-destructive/60 dark:bg-destructive/15 dark:text-destructive'
+                        : 'border-[#e4e4e7] bg-white text-[#a1a1aa] hover:border-[#b42318] hover:text-[#b42318] dark:border-border dark:bg-background dark:text-muted-foreground',
+                    )}
+                  >
+                    <X size={13} strokeWidth={2} />
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </SearchResultsContext.Provider>
+
+        {/* Always mounted: the observer is created once on mount, so a sentinel
+            that unmounts with hasNextPage would leave nothing to observe. */}
+        <div ref={sentinelRef} className='h-1' aria-hidden='true' />
+
+        {isFetchingNextPage && (
+          <div className='flex items-center justify-center gap-2 p-3 text-xs text-muted-foreground'>
+            <Loader2 className='size-3.5 animate-spin' />
+            Loading more threads…
+          </div>
+        )}
+      </div>
+
+      {rejecting && (
+        <EntityRemarksDialog
+          open
+          onOpenChange={next => !next && setRejecting(null)}
+          entity={entity}
+          messageText={rejecting.text}
+          saving={feedbackMutation.isPending}
+          onConfirm={remarks =>
+            feedbackMutation.mutate({
+              messageId: rejecting.messageId,
+              verdict: 'REJECTED',
+              remarks,
+            })
+          }
+        />
+      )}
+    </div>
+  );
+};
+
+export default EntityMessages;

--- a/apps/dashboard/src/components/Entities/EntityMessages.tsx
+++ b/apps/dashboard/src/components/Entities/EntityMessages.tsx
@@ -8,7 +8,8 @@ import { SearchResultMessageCard } from '../Chat/SearchResults/SearchResultMessa
 import { SearchResultsContext } from '../Chat/SearchResults/SearchResultsContext';
 import EntityRemarksDialog from './EntityRemarksDialog';
 import { cn } from '../../utils/classNames';
-import type { VespaSearchGroup, VespaSearchResponse } from '../../types/search';
+import type { VespaSearchResponse } from '../../types/search';
+import { MAX_BACKEND_OFFSET } from '../../hooks/useSearchMetrics';
 import {
   entitiesApi,
   type EntityFeedback,
@@ -39,39 +40,26 @@ interface EntityMessagesProps {
   onSelectPanel: (panel: SelectedPanel) => void;
 }
 
-/** Threads per page. Grouped responses are paged by slicing the group prefix. */
-const PAGE_SIZE = 20;
-
-/**
- * Does this message literally name the entity?
- *
- * Matched against the entity's ALIAS list from the registry, not its canonical
- * name: aliases are exactly the spellings that resolve to this entity, including
- * the fuzzy ones a substring test would miss ("zakpay" resolves to "Zaakpay" but
- * shares no prefix).
- */
-const namesEntity = (text: string, entity: EntityListItem): boolean => {
-  const needles = [...new Set([entity.canonicalName, ...entity.aliases])].filter(n => n.length > 1);
-  const lower = text.toLowerCase();
-  return needles.some(n => lower.includes(n.toLowerCase()));
-};
+/** Threads per page. One hit per thread, so this is a plain Vespa hit offset/limit. */
+const PAGE_SIZE = 25;
 
 /**
  * The threads an entity was extracted from.
  *
+ * One row per THREAD, and the query does that collapsing rather than the client:
+ * filtering by `entityId` makes the backend keep only thread roots, because extraction
+ * stamps a thread's entities on every message in it and the root therefore matches
+ * whatever its replies match. That gives plain Vespa hit paging — no grouping, no
+ * group-prefix re-fetch — and the row's message is always the actual root rather than
+ * whichever hit a grouping clause happened to return.
+ *
  * Calls `/api/vespaSearch` directly rather than through `searchService.vespaSearch`
- * for one reason: that helper flattens grouped responses and drops rows with
- * `relevanceScore > 0`. A filter-only query is unranked and every hit scores 0, so
- * it would discard the entire result set. Going direct also keeps the request
- * visible as-is in the network tab.
+ * because that helper's filter set carries no `entityId`. (Its `relevanceScore > 0`
+ * filter is NOT a reason — that applies only to the grouped branch, and this is flat.)
  *
  * Rows are `SearchResultMessageCard`, the same card the full search screen uses.
  * It reads its click handlers off `SearchResultsContext`, so providing
  * `onSelectThread` here is all the wiring the side panel needs.
- *
- * Paged by `offset`: Vespa's top-level offset paginates hits rather than grouping
- * buckets, so the backend fetches the group prefix and slices the requested page —
- * the same mechanism Desk mail uses (vespaSearch/index.ts:921).
  */
 export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): JSX.Element => {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -88,7 +76,6 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
             apps: 'chat',
             type: 'messages',
             entityId: entity.id,
-            groupBy: 'threadId',
             offset: pageParam,
             limit: PAGE_SIZE,
           },
@@ -97,43 +84,35 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
         return res.data.data;
       },
       initialPageParam: 0,
-      // totalCount on a grouped response counts MESSAGES, not groups, so it cannot
-      // say when threads run out. A short page is the end-of-results signal.
+      // One hit per thread now, so totalCount IS the thread count and gives an exact
+      // end-of-results signal rather than the "short page means done" guess a grouped
+      // response forced.
       getNextPageParam: (lastPage, allPages) => {
-        const groups = lastPage.groups?.length ?? 0;
-        if (groups < PAGE_SIZE) return undefined;
-        return allPages.reduce((n, p) => n + (p.groups?.length ?? 0), 0);
+        const loaded = allPages.reduce((n, p) => n + (p.results?.length ?? 0), 0);
+        if (loaded >= (lastPage.totalCount ?? 0)) return undefined;
+        if (loaded + PAGE_SIZE > MAX_BACKEND_OFFSET) return undefined;
+        return loaded;
       },
     });
 
-  const totalMessages = data?.pages?.[0]?.totalCount ?? 0;
+  const totalThreads = data?.pages?.[0]?.totalCount ?? 0;
 
-  // One card per thread, showing its ROOT message. Rendering every message would
-  // mount a ChatBubble per row, and ChatBubble fetches channel shortcuts per
-  // instance (ChatBubble.tsx:198) — one HTTP request each.
+  // One card per thread. Each hit IS that thread's root, so there is nothing to pick
+  // between — which is what makes the reviewed message deterministic.
   const rows = useMemo(
     () =>
-      (data?.pages.flatMap(p => p.groups ?? []) ?? [])
-        .map((group: VespaSearchGroup) => {
-          const root = group.results.find(r => r.searchContext?.isRootMessage) ?? group.results[0];
-          if (!root?.searchContext?.channelId) return null;
-          // Anchor on a message that actually names the entity, so the panel opens
-          // scrolled to the mention rather than the top of the thread.
-          const naming = group.results.find(r => namesEntity(r.context ?? '', entity));
+      (data?.pages.flatMap(p => p.results ?? []) ?? [])
+        .map(root => {
+          const ctx = root.searchContext;
+          if (!ctx?.channelId || !ctx.conversationId) return null;
           return {
-            conversationId: group.groupValue,
+            conversationId: ctx.conversationId,
             root,
-            // The card renders `displayMessageId ?? matchedMessageId`, so these must
-            // be passed separately: the ROOT is what the card should show, while the
-            // matched message is only where the side panel scrolls to. Passing the
-            // matched id alone makes the card render a mid-thread reply.
-            displayMessageId: root.searchContext.messageId ?? null,
-            matchedMessageId:
-              naming?.searchContext?.messageId ?? root.searchContext.messageId ?? null,
+            messageId: ctx.messageId ?? null,
           };
         })
         .filter((r): r is NonNullable<typeof r> => r !== null),
-    [data, entity],
+    [data],
   );
 
   // Latest paging state, read inside the observer callback. Kept in a ref so the
@@ -180,18 +159,11 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
   const currentUserId = feedbackData?.currentUserId ?? '';
 
   /**
-   * messageId → every reviewer's verdict on it, with the viewer's own separated out.
-   * Reviewers each get their own row, so a message can carry disagreement; the card
-   * shows your verdict and counts the rest.
    */
   const feedbackByMessage = useMemo(() => {
-    const map = new Map<string, { mine?: EntityFeedback; approved: number; rejected: number }>();
+    const map = new Map<string, EntityFeedback>();
     for (const row of feedback) {
-      const bucket = map.get(row.messageId) ?? { approved: 0, rejected: 0 };
-      if (row.verdict === 'APPROVED') bucket.approved++;
-      else bucket.rejected++;
-      if (row.createdBy === currentUserId) bucket.mine = row;
-      map.set(row.messageId, bucket);
+      if (row.createdBy === currentUserId) map.set(row.messageId, row);
     }
     return map;
   }, [feedback, currentUserId]);
@@ -224,6 +196,10 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
       toast.error(message);
     },
   });
+
+  const savingMessageId = feedbackMutation.isPending
+    ? (feedbackMutation.variables?.messageId ?? null)
+    : null;
 
   const contextValue = useMemo(
     () => ({
@@ -263,19 +239,13 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
       <div className='px-5 pt-4 pb-3.5 border-b border-border shrink-0'>
         <h2 className='text-[17px] font-semibold tracking-[-0.01em]'>{entity.canonicalName}</h2>
         {/*
-          Threads and messages are different units — `rows.length` counts groups,
-          while a grouped response's totalCount counts the messages inside them. The
-          earlier "N of M messages" implied N was a subset of M and looked stuck at
-          the end of the list, so label each count for what it is.
-        */}
+         */}
         <p className='text-xs text-muted-foreground mt-0.5'>
           {entity.type}
-          {rows.length > 0 &&
-            ` · ${rows.length}${hasNextPage ? '+' : ''} thread${rows.length === 1 ? '' : 's'}`}
-          {totalMessages > 0 && ` · ${totalMessages} message${totalMessages === 1 ? '' : 's'}`}
-          {/* Distinct messages, not feedback rows: reviewers each get their own row,
-              so counting rows overstates as soon as two people review one message. */}
-          {feedbackByMessage.size > 0 && ` · ${feedbackByMessage.size} reviewed`}
+          {totalThreads > 0 &&
+            ` · ${rows.length} of ${totalThreads} thread${totalThreads === 1 ? '' : 's'}`}
+          {/* Your reviews only — the map holds just your own rows. */}
+          {feedbackByMessage.size > 0 && ` · ${feedbackByMessage.size} reviewed by you`}
         </p>
       </div>
 
@@ -335,35 +305,16 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
 
         <SearchResultsContext.Provider value={contextValue}>
           {rows.map(row => {
-            // Feedback is keyed on the message the card renders — its thread root.
-            const reviewedId = row.displayMessageId ?? row.matchedMessageId;
-            const bucket = reviewedId ? feedbackByMessage.get(reviewedId) : undefined;
-            const existing = bucket?.mine;
-            // Verdicts from other reviewers on this same message.
-            const othersApproved =
-              (bucket?.approved ?? 0) - (existing?.verdict === 'APPROVED' ? 1 : 0);
-            const othersRejected =
-              (bucket?.rejected ?? 0) - (existing?.verdict === 'REJECTED' ? 1 : 0);
-            const others = othersApproved + othersRejected;
+            const reviewedId = row.messageId;
+            const existing = reviewedId ? feedbackByMessage.get(reviewedId) : undefined;
             const messageText = row.root.context ?? '';
 
             return (
-              // `relative group/verdict` wraps the shared card so the approve/reject
-              // controls can be overlaid on hover without the card needing new props.
-              // `data-prevent-thread` stops a click on them bubbling into the card's
-              // own handler and opening the side panel.
-              // Fixed height so the list scans as a uniform grid rather than a ragged
-              // stack — message length varies from one line to a paragraph. The card
-              // itself is untouched; the wrapper clips it.
-              // Wrapper hugs the card exactly — no height of its own. Give it one and
-              // a short card leaves dead space beneath, dropping the absolutely
-              // positioned buttons below outside the card's border.
-              <div key={row.conversationId} className='relative'>
+              <div key={row.messageId ?? row.conversationId} className='relative'>
                 <SearchResultMessageCard
                   channelId={row.root.searchContext!.channelId!}
                   conversationId={row.conversationId}
-                  matchedMessageId={row.matchedMessageId}
-                  {...(row.displayMessageId ? { displayMessageId: row.displayMessageId } : {})}
+                  matchedMessageId={row.messageId}
                   searchSnippet={row.root.context ?? ''}
                   searchThread={{
                     isRootMessage: row.root.searchContext?.isRootMessage ?? true,
@@ -389,13 +340,9 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
               */}
                 <div
                   data-prevent-thread
-                  title={
-                    existing?.verdict === 'REJECTED' && existing.remarks
-                      ? existing.remarks
-                      : others > 0
-                        ? `${othersApproved} approved, ${othersRejected} rejected by others`
-                        : undefined
-                  }
+                  {...(existing?.verdict === 'REJECTED' && existing.remarks
+                    ? { title: existing.remarks }
+                    : {})}
                   className='absolute bottom-3 right-4 z-20 flex items-center gap-[5px]'
                 >
                   <button
@@ -403,7 +350,7 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
                     title='Correct on this message'
                     aria-label='Approve this entity on this message'
                     aria-pressed={existing?.verdict === 'APPROVED'}
-                    disabled={feedbackMutation.isPending || !reviewedId}
+                    disabled={savingMessageId === reviewedId || !reviewedId}
                     onClick={event => {
                       event.stopPropagation();
                       if (reviewedId) {
@@ -428,7 +375,7 @@ export const EntityMessages = ({ entity, onSelectPanel }: EntityMessagesProps): 
                     title='Wrong on this message'
                     aria-label='Reject this entity on this message'
                     aria-pressed={existing?.verdict === 'REJECTED'}
-                    disabled={feedbackMutation.isPending || !reviewedId}
+                    disabled={savingMessageId === reviewedId || !reviewedId}
                     onClick={event => {
                       event.stopPropagation();
                       if (reviewedId) setRejecting({ messageId: reviewedId, text: messageText });

--- a/apps/dashboard/src/components/Entities/EntityRemarksDialog.tsx
+++ b/apps/dashboard/src/components/Entities/EntityRemarksDialog.tsx
@@ -1,0 +1,112 @@
+import { JSX, useState } from 'react';
+import Dialog from '../ui/Dialog';
+import { Button } from '../ui/Button';
+import type { EntityListItem } from '../../api/entitiesApi';
+
+interface EntityRemarksDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entity: EntityListItem;
+  /** The message being reviewed — shown so the reviewer sees what they are judging. */
+  messageText: string;
+  saving: boolean;
+  onConfirm: (remarks: string) => void;
+}
+
+const MAX_REMARKS = 1000;
+
+/**
+ * Captures why an entity was rejected.
+ *
+ * A remark is required rather than optional: a rejection with no reason tells a
+ * later reviewer nothing, and the column exists precisely to carry that reason.
+ *
+ * The Dialog primitive renders `title`/`description` with `className='hidden'` —
+ * they exist for screen readers only — and applies no padding to its content. Both
+ * the visible heading and the padding therefore belong here, matching the house
+ * pattern (StageFormConflictDialog.tsx:205).
+ */
+export const EntityRemarksDialog = ({
+  open,
+  onOpenChange,
+  entity,
+  messageText,
+  saving,
+  onConfirm,
+}: EntityRemarksDialogProps): JSX.Element => {
+  const [remarks, setRemarks] = useState('');
+  const trimmed = remarks.trim();
+
+  const close = (): void => {
+    setRemarks('');
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => (next ? onOpenChange(true) : close())}
+      title='Reject entity'
+      description={`Why is "${entity.canonicalName}" wrong?`}
+      className='max-w-md'
+    >
+      <div className='p-6'>
+        <div className='mb-4'>
+          <h2 className='text-base font-semibold text-foreground'>Reject on this message</h2>
+          <p className='mt-1 text-sm text-muted-foreground'>
+            Why is <span className='font-medium text-foreground'>{entity.canonicalName}</span> wrong
+            here?
+          </p>
+          {messageText && (
+            <p className='mt-2 rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground line-clamp-3'>
+              {messageText}
+            </p>
+          )}
+        </div>
+
+        <textarea
+          value={remarks}
+          onChange={event => setRemarks(event.target.value)}
+          onKeyDown={event => {
+            // Cmd/Ctrl+Enter submits; plain Enter stays a newline, since a remark
+            // is often more than one line.
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter' && trimmed) {
+              event.preventDefault();
+              onConfirm(trimmed);
+            }
+          }}
+          maxLength={MAX_REMARKS}
+          rows={3}
+          autoFocus
+          placeholder='e.g. this is a product name, not a vendor'
+          aria-label='Rejection remarks'
+          data-track-category='Entities'
+          data-track-name='EntityRemarksInput'
+          className='w-full resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:border-ring'
+        />
+
+        <div className='mt-4 flex items-center justify-between gap-3'>
+          <span className='text-xs text-muted-foreground tabular-nums'>
+            {trimmed.length}/{MAX_REMARKS}
+          </span>
+          <div className='flex items-center gap-2'>
+            <Button variant='ghost' size='sm' onClick={close} disabled={saving}>
+              Cancel
+            </Button>
+            <Button
+              variant='destructive'
+              size='sm'
+              onClick={() => onConfirm(trimmed)}
+              loading={saving}
+              disabled={!trimmed}
+            >
+              Reject
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export default EntityRemarksDialog;

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -102,8 +102,8 @@ interface UseSearchMetricsOptions {
 
 const BACKEND_RESULTS_LIMIT = 25;
 // Load-more uses a fixed-size window (constant `limit`, advancing `offset`). Vespa caps the
-// query offset at maxOffset (1000), so stop paginating before `offset` would cross it.
-const MAX_BACKEND_OFFSET = 1000;
+// query offset at maxOffset (1000)
+export const MAX_BACKEND_OFFSET = 1000;
 
 /**
  * Cap on user rows fetched for any Cmd+K user surface (plain-search USERS

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -44,6 +44,7 @@ import { KnowledgeBaseV2Layout } from '../components/knowledgeBaseV2/KnowledgeBa
 import KnowledgeBaseV2Screen from '../components/knowledgeBaseV2/KnowledgeBaseV2Screen';
 import { LegacyKbRedirect } from '../components/knowledgeBaseV2/LegacyKbRedirect';
 import { MemoryScreen } from './MemoryScreen';
+import { EntitiesScreen } from './EntitiesScreen';
 import { FileViewerLayout } from '../components/knowledgeBase/layout/FileViewerLayout';
 import AnalyticsScreen from './AnalyticsScreen/AnalyticsScreen';
 import ProjectsScreen from './ProjectsScreen/ProjectsScreen';
@@ -1524,6 +1525,10 @@ export const router = createBrowserRouter(
                       <MemoryScreen />
                     </ToolbarProtectedRoute>
                   ),
+                },
+                {
+                path: 'entities',
+                element: <EntitiesScreen />,
                 },
                 {
                   path: 'analytics',

--- a/apps/dashboard/src/routes/EntitiesScreen/EntitiesScreen.tsx
+++ b/apps/dashboard/src/routes/EntitiesScreen/EntitiesScreen.tsx
@@ -1,0 +1,84 @@
+import { ReactElement, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ThreadMessages from '../../components/Chat/ThreadPannel';
+import ConversationPanelV2 from '../../components/Chat/ConversationPannel/ConversationPanelV2';
+import EntityList from '../../components/Entities/EntityList';
+import EntityMessages, { type SelectedPanel } from '../../components/Entities/EntityMessages';
+import type { EntityListItem } from '../../api/entitiesApi';
+
+/**
+ * Entity review.
+ *
+ * Three panes: the extraction registry, the threads an entity was found in, and the
+ * conversation itself. The third pane mirrors SearchResultsSidePanel
+ * (SearchResults.tsx:1642) — `ThreadMessages` for a conversation with replies,
+ * `ConversationPanelV2` for a standalone message — so opening something here
+ * behaves exactly as it does on the full search screen.
+ */
+const EntitiesScreen = (): ReactElement => {
+  const [selected, setSelected] = useState<EntityListItem | null>(null);
+  const [panel, setPanel] = useState<SelectedPanel | null>(null);
+  const navigate = useNavigate();
+
+  const selectEntity = (entity: EntityListItem): void => {
+    setSelected(entity);
+    // The open conversation belongs to the previous entity; keeping it would leave
+    // the panel showing something unrelated to the new selection.
+    setPanel(null);
+  };
+
+  return (
+    <div
+      data-testid='entities-page'
+      className='h-full bg-background md:rounded-2xl overflow-hidden shadow-md'
+    >
+      {/* min-h-0 is load-bearing: grid items default to `min-height: auto`, so
+          without it the row grows to fit its content, the panes' overflow-y-auto
+          never gets a bounded height, and nothing can scroll. */}
+      <div
+        className={`grid grid-cols-1 h-full min-h-0 ${
+          panel
+            ? 'md:grid-cols-[280px_minmax(0,1fr)_minmax(0,1.2fr)]'
+            : 'md:grid-cols-[320px_minmax(0,1fr)]'
+        }`}
+      >
+        <EntityList selectedId={selected?.id ?? null} onSelect={selectEntity} />
+
+        {selected ? (
+          <EntityMessages key={selected.id} entity={selected} onSelectPanel={setPanel} />
+        ) : (
+          <div className='hidden md:flex items-center justify-center text-sm text-muted-foreground'>
+            Select an entity to review the threads it was extracted from.
+          </div>
+        )}
+
+        {panel && (
+          <div className='hidden md:flex flex-col min-h-0 border-l border-border'>
+            {panel.kind === 'thread' ? (
+              <ThreadMessages
+                channelId={panel.channelId}
+                conversationId={panel.conversationId}
+                matchedMessageId={panel.matchedMessageId}
+                showChannelLink
+                onChannelLinkClick={() =>
+                  void navigate(`/chat/dir/${panel.channelId}#origin=${panel.conversationId}`)
+                }
+                onClose={() => setPanel(null)}
+              />
+            ) : (
+              <ConversationPanelV2
+                channelId={panel.channelId}
+                previousChannelId={null}
+                linkedConversationIdOverride={panel.conversationId}
+                linkedItemCreatedAtOverride={panel.conversationCreatedAt ?? null}
+                onClose={() => setPanel(null)}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EntitiesScreen;

--- a/apps/dashboard/src/routes/EntitiesScreen/index.tsx
+++ b/apps/dashboard/src/routes/EntitiesScreen/index.tsx
@@ -1,0 +1,1 @@
+export { default as EntitiesScreen } from './EntitiesScreen';


### PR DESCRIPTION
Migration-Changes:
  - New table for entity feedback

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
