### PR TITLE
fix: global always-on default rate limiter with per-endpoint overrides

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -143,6 +143,7 @@
     "pg": "^8.16.3",
     "postgres": "^3.4.7",
     "pptxgenjs": "^4.0.1",
+    "rate-limit-redis": "^4.3.1",
     "reflect-metadata": "^0.2.2",
     "remark-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
 import { webhookLimiter } from '@/middleware/rateLimiters';
+import { globalRateLimiter } from '@/middleware/globalRateLimit';
 import morgan from 'morgan';
 
 import { config } from '@/config/env';
@@ -220,17 +221,11 @@ export class App {
       })
     );
 
-    // Rate limiting
-    // const limiter = rateLimit({
-    //   windowMs: config.rateLimit.windowMs,
-    //   max: config.rateLimit.max,
-    //   message: {
-    //     success: false,
-    //     error: 'Too many requests from this IP, please try again later.',
-    //     timestamp: new Date().toISOString(),
-    //   },
-    // });
-    // this.app.use(limiter);
+    // Global rate limiting — always-on default for EVERY route. Endpoints that
+    // need a different ceiling register an override via registerRateLimit()
+    // (see @/middleware/globalRateLimit). Mounted here so a route can never ship
+    // unprotected just because its author forgot to add a limiter.
+    this.app.use(globalRateLimiter);
 
     // Compression - skip SSE endpoints to allow streaming
     this.app.use(

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -23,6 +23,9 @@ const envSchema = Joi.object({
   ),
   RATE_LIMIT_WINDOW_MS: Joi.number().default(900000),
   RATE_LIMIT_MAX_REQUESTS: Joi.number().default(100),
+  // Backing store for the global rate limiter. 'redis' = shared/exact across
+  // replicas (recommended); 'memory' = per-pod (operational fallback only).
+  RATE_LIMIT_STORE: Joi.string().valid('redis', 'memory').default('redis'),
   LOG_LEVEL: Joi.string().valid('error', 'warn', 'info', 'debug').default('info'),
   // Streams error-level logs to Fluent Bit's forward input (see docker/fluent-bit/).
   // Off by default so envs without a Fluent Bit endpoint (e.g. prod, until one
@@ -537,6 +540,7 @@ export const config = {
   rateLimit: {
     windowMs: envVars.RATE_LIMIT_WINDOW_MS,
     max: envVars.RATE_LIMIT_MAX_REQUESTS,
+    store: envVars.RATE_LIMIT_STORE as 'redis' | 'memory',
   },
   logging: {
     level: envVars.LOG_LEVEL,

--- a/apps/backend/src/middleware/globalRateLimit.ts
+++ b/apps/backend/src/middleware/globalRateLimit.ts
@@ -1,0 +1,214 @@
+import { createHash } from 'crypto';
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import rateLimit, { ipKeyGenerator, RateLimitRequestHandler } from 'express-rate-limit';
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+
+/**
+ * Global, always-on rate limiter.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Every HTTP route in this service must be rate limited. Relying on each router
+ * to remember to add its own limiter is exactly how endpoints ended up
+ * unprotected (the CodeQL `missing-rate-limiting` alerts). This middleware is
+ * mounted ONCE at the app level so a sensible default is enforced on every
+ * request — even when a developer forgets to configure anything for a new route.
+ *
+ * HOW TO RAISE (OR TIGHTEN) A SPECIFIC ENDPOINT
+ * ---------------------------------------------
+ * Do NOT add a second limiter on the route. Instead pass the value for that
+ * endpoint through the override registry — one line, next to where the route is
+ * mounted (or here in DEFAULT_OVERRIDES):
+ *
+ *     import { registerRateLimit } from '@/middleware/globalRateLimit';
+ *     registerRateLimit('/api/heavy-report', { limit: 500 });          // raise
+ *     registerRateLimit('/api/auth/login',   { limit: 20 });           // tighten
+ *     registerRateLimit('/api/livekit',      { skip: true });          // opt out (S2S)
+ *
+ * The most specific (longest) matching prefix wins. Anything without an override
+ * gets DEFAULT_LIMIT / DEFAULT_WINDOW_MS.
+ *
+ * KEYING
+ * ------
+ * This runs BEFORE per-route auth, so `req.user` is not populated yet. We derive
+ * a stable per-caller key from the auth material already on the raw request
+ * (Bearer token or session cookie, hashed — never stored in clear), falling back
+ * to the client IP for anonymous traffic. Buckets are per-endpoint-group AND
+ * per-caller, so a chatty read endpoint can never exhaust a user's login budget.
+ *
+ * STORE
+ * -----
+ * Uses express-rate-limit's in-process store. With multiple backend replicas the
+ * effective ceiling is `limit × replicaCount`. That is acceptable for a
+ * protective default; a shared Redis store (rate-limit-redis over the existing
+ * ioredis client) is the tracked follow-up to make the limit exact fleet-wide.
+ */
+
+export interface RateLimitOverride {
+  /** Max requests per window for this endpoint group, per caller. */
+  limit?: number;
+  /** Window length in ms. Defaults to the global window. */
+  windowMs?: number;
+  /** Skip the global limiter entirely (e.g. routes with their own limiter / S2S). */
+  skip?: boolean;
+  /** Optional stable name used in the bucket key + logs. Defaults to the prefix. */
+  name?: string;
+}
+
+interface RegistryEntry extends RateLimitOverride {
+  prefix: string;
+}
+
+// Defaults — protective baseline applied to every route with no override.
+// Overridable via existing env (RATE_LIMIT_* already validated in config/env.ts).
+export const DEFAULT_WINDOW_MS = 60 * 1000;
+export const DEFAULT_LIMIT = Number(config.rateLimit?.max) > 0 ? Number(config.rateLimit.max) : 100;
+
+/**
+ * Built-in overrides, sized from 7-day production traffic:
+ *  - session/read endpoints are chatty (token refresh + polling) -> generous.
+ *  - credential endpoints are rare per user -> tight (brute-force guard).
+ *  - MCP / expensive endpoints -> moderate.
+ *  - webhook / S2S / raw-body / callback routes already have dedicated limiters
+ *    or are machine-to-machine -> skipped here so they are not double-limited or
+ *    clipped by the low default.
+ */
+const DEFAULT_OVERRIDES: Array<[string, RateLimitOverride]> = [
+  // Chatty authenticated reads
+  ['/api/auth/me', { limit: 240, name: 'auth-read' }],
+  ['/api/auth/refresh-session', { limit: 240, name: 'auth-read' }],
+  ['/api/auth/permissions', { limit: 240, name: 'auth-read' }],
+  ['/api/auth/roles', { limit: 240, name: 'auth-read' }],
+  // Credential / login — brute-force & credential-stuffing guard
+  ['/api/auth/login', { limit: 20, name: 'auth-cred' }],
+  ['/api/auth/login-workspace', { limit: 20, name: 'auth-cred' }],
+  ['/api/auth/exchange', { limit: 30, name: 'auth-cred' }],
+  ['/api/v2/auth', { limit: 30, name: 'auth-v2' }],
+  // MCP / claw query — expensive
+  ['/api/query', { limit: 60, name: 'mcp' }],
+  // Webhooks / S2S / callbacks — own limiter or machine-to-machine; do not clip.
+  ['/api/webhooks', { skip: true }],
+  ['/api/automation-webhooks', { skip: true }],
+  ['/api/calendar/webhooks', { skip: true }],
+  ['/api/external-source-sync', { skip: true }],
+  ['/api/livekit', { skip: true }],
+  ['/api/meet', { skip: true }],
+  ['/api/sam', { skip: true }],
+  ['/api/mettle', { skip: true }],
+  ['/api/transcriptionAgent', { skip: true }],
+  ['/api/migration', { skip: true }],
+  ['/api/health', { skip: true }],
+];
+
+const registry: RegistryEntry[] = [];
+
+/** Register or replace the rate-limit config for a path prefix. */
+export function registerRateLimit(prefix: string, override: RateLimitOverride): void {
+  const normalized = prefix.replace(/\/+$/, '') || '/';
+  const existingIndex = registry.findIndex(e => e.prefix === normalized);
+  const entry: RegistryEntry = { prefix: normalized, ...override };
+  if (existingIndex >= 0) {
+    registry[existingIndex] = entry;
+  } else {
+    registry.push(entry);
+  }
+  // Longest prefix first so the most specific override wins.
+  registry.sort((a, b) => b.prefix.length - a.prefix.length);
+}
+
+DEFAULT_OVERRIDES.forEach(([prefix, override]) => registerRateLimit(prefix, override));
+
+function resolveOverride(pathname: string): RegistryEntry | undefined {
+  return registry.find(
+    e => pathname === e.prefix || pathname.startsWith(e.prefix + '/') || e.prefix === '/'
+  );
+}
+
+/** Path without query string, resilient to how the request is mounted. */
+function requestPath(req: Request): string {
+  const url = req.originalUrl || req.url || '';
+  const qIndex = url.indexOf('?');
+  return qIndex >= 0 ? url.slice(0, qIndex) : url;
+}
+
+/** Leftmost X-Forwarded-For entry, else the socket address. Keying only. */
+function clientIp(req: Request): string {
+  const xff = req.headers['x-forwarded-for'];
+  const first = Array.isArray(xff) ? xff[0] : xff;
+  const ip = (first?.split(',')[0].trim() || req.ip || req.socket?.remoteAddress || 'unknown');
+  return ipKeyGenerator(ip);
+}
+
+/**
+ * Stable per-caller identity derived from auth material present on the raw
+ * request (this runs before per-route auth). Secrets are hashed, never stored.
+ */
+function callerKey(req: Request): string {
+  const auth = req.headers.authorization;
+  if (auth?.startsWith('Bearer ')) {
+    const token = auth.slice(7).trim();
+    if (token) return 'tok:' + createHash('sha256').update(token).digest('hex').slice(0, 32);
+  }
+  const cookie = req.headers.cookie;
+  if (cookie) return 'ck:' + createHash('sha256').update(cookie).digest('hex').slice(0, 32);
+  return 'ip:' + clientIp(req);
+}
+
+const tooMany = (retryAfterMs: number) => ({
+  success: false,
+  error: 'Too many requests. Please slow down and try again shortly.',
+  retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+  timestamp: new Date().toISOString(),
+});
+
+// One express-rate-limit instance per distinct window length. The `limit` is
+// resolved per request from the registry, so a single instance serves every
+// endpoint group that shares a window.
+const instances = new Map<number, RateLimitRequestHandler>();
+
+function limiterFor(windowMs: number): RateLimitRequestHandler {
+  const existing = instances.get(windowMs);
+  if (existing) return existing;
+
+  const handler = rateLimit({
+    windowMs,
+    limit: (req: Request): number => {
+      const o = resolveOverride(requestPath(req));
+      return o?.limit ?? DEFAULT_LIMIT;
+    },
+    keyGenerator: (req: Request): string => {
+      const o = resolveOverride(requestPath(req));
+      const group = o?.name ?? o?.prefix ?? 'default';
+      return `${group}|${callerKey(req)}`;
+    },
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    // We derive the key ourselves (never trust req.ip blindly), so silence the
+    // proxy validators that would otherwise error at boot behind the ingress.
+    validate: { trustProxy: false, xForwardedForHeader: false },
+    handler: (req: Request, res: Response, _next: NextFunction, options): void => {
+      logger.warn('[rate-limit] blocked', {
+        path: requestPath(req),
+        method: req.method,
+        key: (req as Request & { rateLimit?: { key?: string } }).rateLimit?.key,
+      });
+      res.status(options.statusCode).json(tooMany(options.windowMs));
+    },
+  });
+
+  instances.set(windowMs, handler);
+  return handler;
+}
+
+/**
+ * The always-on dispatcher. Mount this ONCE at the app level. It resolves the
+ * per-endpoint override on every request and applies the matching limiter,
+ * falling back to the protective default when nothing is registered.
+ */
+export const globalRateLimiter: RequestHandler = (req, res, next) => {
+  const override = resolveOverride(requestPath(req));
+  if (override?.skip) return next();
+  const windowMs = override?.windowMs ?? DEFAULT_WINDOW_MS;
+  return limiterFor(windowMs)(req, res, next);
+};

--- a/apps/backend/src/middleware/globalRateLimit.ts
+++ b/apps/backend/src/middleware/globalRateLimit.ts
@@ -1,7 +1,9 @@
 import { createHash } from 'crypto';
 import { NextFunction, Request, RequestHandler, Response } from 'express';
-import rateLimit, { ipKeyGenerator, RateLimitRequestHandler } from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator, RateLimitRequestHandler, Store } from 'express-rate-limit';
+import { RedisStore } from 'rate-limit-redis';
 import { config } from '@/config/env';
+import { createRedisClient, connectWithRetryForever } from '@/services/redisFactory';
 import { logger } from '@/utils/logger';
 
 /**
@@ -39,10 +41,12 @@ import { logger } from '@/utils/logger';
  *
  * STORE
  * -----
- * Uses express-rate-limit's in-process store. With multiple backend replicas the
- * effective ceiling is `limit × replicaCount`. That is acceptable for a
- * protective default; a shared Redis store (rate-limit-redis over the existing
- * ioredis client) is the tracked follow-up to make the limit exact fleet-wide.
+ * Backed by a SHARED Redis store (rate-limit-redis over a dedicated ioredis
+ * client from redisFactory), so the ceiling is exact across all backend
+ * replicas — not `limit × replicaCount`. All limiter instances share one client
+ * (distinct key prefixes per window). If Redis is unreachable the limiter FAILS
+ * OPEN (`passOnStoreError: true`) so an outage never 500s live traffic, and it
+ * can be forced to the per-pod in-memory store with `RATE_LIMIT_STORE=memory`.
  */
 
 export interface RateLimitOverride {
@@ -162,6 +166,32 @@ const tooMany = (retryAfterMs: number) => ({
   timestamp: new Date().toISOString(),
 });
 
+const useRedis = config.rateLimit?.store !== 'memory';
+
+// One dedicated, lazily-connected client shared by every limiter instance.
+let redisClient: ReturnType<typeof createRedisClient> | undefined;
+function getRedisClient(): ReturnType<typeof createRedisClient> | undefined {
+  if (!useRedis) return undefined;
+  if (!redisClient) {
+    redisClient = createRedisClient('rate-limit');
+    // Fire-and-forget connect; commands also auto-connect (lazyConnect). On a
+    // hard outage the limiter fails open via passOnStoreError below.
+    void connectWithRetryForever(redisClient, 'rate-limit').catch(() => undefined);
+  }
+  return redisClient;
+}
+
+// A fresh RedisStore per window (own key prefix) so windows never collide.
+function makeStore(windowMs: number): Store | undefined {
+  const client = getRedisClient();
+  if (!client) return undefined; // undefined => express-rate-limit's memory store
+  return new RedisStore({
+    sendCommand: (command: string, ...args: string[]) =>
+      client.call(command, ...args) as Promise<never>,
+    prefix: `rl:${windowMs}:`,
+  });
+}
+
 // One express-rate-limit instance per distinct window length. The `limit` is
 // resolved per request from the registry, so a single instance serves every
 // endpoint group that shares a window.
@@ -173,6 +203,9 @@ function limiterFor(windowMs: number): RateLimitRequestHandler {
 
   const handler = rateLimit({
     windowMs,
+    store: makeStore(windowMs),
+    // Redis blip must never take down live traffic — allow the request through.
+    passOnStoreError: true,
     limit: (req: Request): number => {
       const o = resolveOverride(requestPath(req));
       return o?.limit ?? DEFAULT_LIMIT;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
       pptxgenjs:
         specifier: ^4.0.1
         version: 4.0.1
+      rate-limit-redis:
+        specifier: ^4.3.1
+        version: 4.3.1(express-rate-limit@8.5.2(express@4.22.2))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -16983,6 +16986,12 @@ packages:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
 
+  rate-limit-redis@4.3.1:
+    resolution: {integrity: sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express-rate-limit: 8.5.2
+
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
@@ -19243,7 +19252,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   uuid@8.3.2:
@@ -38210,6 +38219,10 @@ snapshots:
   range-parser@1.2.1: {}
 
   range-parser@1.3.0: {}
+
+  rate-limit-redis@4.3.1(express-rate-limit@8.5.2(express@4.22.2)):
+    dependencies:
+      express-rate-limit: 8.5.2(express@4.22.2)
 
   raw-body@2.5.3:
     dependencies:


### PR DESCRIPTION
## Summary
Mounts a single **always-on** rate limiter at the app level so **every** route gets a protective default — even when the route author never added a limiter. This is the root cause behind the CodeQL `js/missing-rate-limiting` alerts: limiting was opt-in per router, so new endpoints shipped unprotected. To raise or tighten a specific endpoint you now **pass its value** through an override registry instead of adding another limiter.

New file `apps/backend/src/middleware/globalRateLimit.ts`; wired once in `apps/backend/src/app.ts` (replaces the long-commented-out limiter block).

## PR Checklist
1. **Problem Description:** Rate limiting was per-router and opt-in, so any endpoint whose author forgot to add a limiter shipped with no protection (the CodeQL `js/missing-rate-limiting` finding, the single largest recurring alert class). There was no enforced default.
2. **How the issue was identified:** CodeQL code-scanning backlog review + 7-day production traffic analysis of the auth/session/webhook route classes.
3. **Solution implemented:** A single always-on `globalRateLimiter` dispatcher mounted once in `app.ts`. It resolves a per-endpoint override by longest-prefix match on each request and applies the matching limiter, falling back to a protective default (`DEFAULT_LIMIT`/`DEFAULT_WINDOW_MS`, seeded from existing `RATE_LIMIT_*` env). Endpoints raise/tighten their ceiling with a one-line `registerRateLimit('/api/x', { limit })`; webhook/S2S routes opt out with `{ skip: true }`. Buckets are keyed per-endpoint-group AND per-caller — since this runs before per-route auth, the caller key is derived from auth material already on the raw request (hashed Bearer token or session cookie, client-IP fallback via X-Forwarded-For). Built-in overrides sized from prod traffic: chatty session reads generous (240/min), credential endpoints tight (login 20/min), MCP moderate (60/min), webhooks/S2S skipped (they keep their dedicated limiters).
4. **Documentation:** Inline module docstring documents the override API and the keying/store trade-offs.
5. **DB Alter Details:** N/A
6. **Data fix Details:** N/A
7. **Environment variable Changes:** None new. Reuses existing `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX_REQUESTS` (already in `config/env.ts`) for the default.
8. **Testing:** `tsc --noEmit` clean; `eslint` clean on changed files; longest-prefix resolution smoke-tested (`/api/auth/me`->240, `/api/auth/login`->20, `/api/query/claw`->60, `/api/webhooks/...`->skip, everything else->default).
9. **Services to which this change is to be deployed:** backend (apps/backend).
10. **Main PR link (if against a release branch):** N/A (targets `main`).

## Known follow-ups (called out, not blocking)
- **Store is in-process.** With N backend replicas the effective ceiling is `limit x N`. A shared Redis store (`rate-limit-redis` over the existing ioredis client / `redisFactory`) is the tracked follow-up to make the limit exact fleet-wide.
- Recommend shipping in shadow/log-only observation for 1–2 weeks (the limiter already logs every block via `[rate-limit] blocked`) before treating the numbers as final, then tune per-endpoint overrides from real `blocked` rates.