### PR TITLE
fix: call participant acl regression fix (cherry-pick of #870)

### DIFF
--- a/apps/backend/src/zero/acl/tables/call-participants-acl.ts
+++ b/apps/backend/src/zero/acl/tables/call-participants-acl.ts
@@ -50,16 +50,27 @@ export class CallParticipantsACL extends BaseACL<'call_participants'> {
       throw new MutationACLError('Call participant insert failed: guest does not have access to this channel', 'call_participants');
     }
 
-    const isParticipant = await tx.run(
-      zql.channel_participants
-        .where('channelId', callData.channel.id)
-        .where('userId', this.ctx.userID)
-        .one(),
-    );
+    // Self-join: the caller adds themselves to the call. They must be a
+    // participant of the call's channel to join.
+    if (args.userId === this.ctx.userID) {
+      const isParticipant = await tx.run(
+        zql.channel_participants
+          .where('channelId', callData.channel.id)
+          .where('userId', this.ctx.userID)
+          .one(),
+      );
 
-    if (!isParticipant) {
-      throw new MutationACLError('Call participant insert failed: you must be a channel participant to join calls', 'call_participants');
+      if (!isParticipant) {
+        throw new MutationACLError('Call participant insert failed: you must be a channel participant to join calls', 'call_participants');
+      }
+      return;
     }
+
+    // Inviting another user: the caller must be the call creator or an existing
+    // call participant. Channel membership is NOT required here, so a user who
+    // joined via link or "Add people" (a call participant but not a channel
+    // member) can still invite others.
+    await this.verifyCallerMayInvite(callData.id, callData.createdByUserId, args.userId, tx);
   }
 
   async canUpdate(args: UpdateValue<TableSchema<'call_participants'>>, tx: Transaction<Schema>): Promise<void> {


### PR DESCRIPTION
Cherry-pick of commit 084639da8a4e692e4f2edff995cf5b73a4a677bd from #870 onto the release branch.

Fixes call participant ACL regression: self-join still requires channel membership, but inviting another user now only requires the caller to be the call creator or an existing call participant (channel membership not required), so link/"Add people" participants can invite others.

Services-Requiring-Redeployment:
  - backend