### PR TITLE
feat: XYNE-56655 enable the non-creators to share the recordings

### DIFF
--- a/apps/backend/src/services/recordingSharingService.ts
+++ b/apps/backend/src/services/recordingSharingService.ts
@@ -517,12 +517,53 @@ export class RecordingSharingService {
       throw new RecordingSharingError('Recording not found', 404);
     }
     if (call.createdByUserId !== actor.userId) {
-      throw new RecordingSharingError(
-        'Only the recording creator can manage sharing',
-        403,
-      );
+      const hasAccess = await this.hasActiveShare(tx, call.id, actor);
+      if (!hasAccess) {
+        throw new RecordingSharingError(
+          'Only the recording creator or people it is shared with can manage sharing',
+          403,
+        );
+      }
     }
     return call;
+  }
+
+  /**
+   * Mirrors `entityAccessService.hasActiveShare`, but reads through the caller's
+   * transaction so the permission check sees the same snapshot as the write it
+   * guards.
+   */
+  private async hasActiveShare(
+    tx: Prisma.TransactionClient,
+    recordingId: string,
+    actor: RecordingSharingActor,
+  ): Promise<boolean> {
+    const groupMappings = await tx.userGroupMapping.findMany({
+      where: { userId: actor.userId },
+      select: { userGroupId: true },
+    });
+    const channelParticipations = await tx.channelParticipant.findMany({
+      where: { userId: actor.userId },
+      select: { channelId: true },
+    });
+    const userGroupIds = groupMappings.map(mapping => mapping.userGroupId);
+    const channelIds = channelParticipations.map(participation => participation.channelId);
+
+    const share = await tx.entityAccess.findFirst({
+      where: {
+        workspaceId: actor.workspaceId,
+        shareableEntityType: ShareableEntityType.NOTE_TAKER,
+        entityId: recordingId,
+        entityUserAccess: { not: EntityUserAccess.REVOKED },
+        OR: [
+          { userId: actor.userId },
+          ...(userGroupIds.length ? [{ userGroupId: { in: userGroupIds } }] : []),
+          ...(channelIds.length ? [{ channelId: { in: channelIds } }] : []),
+        ],
+      },
+      select: { id: true },
+    });
+    return share !== null;
   }
 
   private async runTransaction<T>(

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -77,6 +77,7 @@ export const RecordingDetailV2Header = ({
 
   // Only the creator can rename or relabel; a recording shared with you is read-only.
   const isOwner = recording.createdByUserId === currentUser?.id;
+  const canShare = !isLive && Boolean(recording.detailedSummaryCanvasId);
   const isGeneratingTitle = titleState?.kind === 'generating';
   const displayTitle =
     titleState && titleState.kind !== 'generating'
@@ -305,7 +306,7 @@ export const RecordingDetailV2Header = ({
           {!isLive && recording.detailedSummaryCanvasId && (
             <RecordingTicketLink
               linkedTicketId={recording.linkedTicketId ?? null}
-              canEdit={isOwner}
+              canEdit={canShare}
               isUpdating={isUpdatingTicketLink}
               onChange={(ticketId, ticket) => void handleTicketLinkChange(ticketId, ticket)}
             />
@@ -315,7 +316,7 @@ export const RecordingDetailV2Header = ({
             canEdit={recording.createdByUserId === currentUser?.id}
             onChange={labels => void handleLabelsChange(labels)}
           />
-          {isOwner && !isLive && recording.detailedSummaryCanvasId && (
+          {canShare && (
             <>
               <RecordingSharedWithAvatars
                 recordingExternalId={recording.externalId}
@@ -354,7 +355,7 @@ export const RecordingDetailV2Header = ({
             </Tooltip>
           )}
 
-          {isOwner && !isLive && showShareModal && recording.detailedSummaryCanvasId && (
+          {canShare && showShareModal && (
             <Dialog
               open={showShareModal}
               onOpenChange={open => !open && setShowShareModal(false)}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
@@ -48,9 +48,6 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
     [locallyRevokedShareIds, recordingRow],
   );
 
-  const isOwner = Boolean(currentUser?.id && currentUser.id === recording.createdByUserId);
-  const canManage = isOwner;
-
   const sharedUserIds = useMemo(
     () => new Set(shares.map(share => share.userId).filter((id): id is string => Boolean(id))),
     [shares],
@@ -69,7 +66,12 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
   // userGroupId/channelId (dynamic membership), not expanded to individual users.
   const options = useMemo(() => {
     const userOptions = activeUsers
-      .filter(u => u.id !== recording.createdByUserId && !sharedUserIds.has(u.id))
+      .filter(
+        u =>
+          u.id !== recording.createdByUserId &&
+          u.id !== currentUser?.id &&
+          !sharedUserIds.has(u.id),
+      )
       .map(u => ({
         label: getUserDisplayName(u),
         subtitle: u.email ?? '',
@@ -104,6 +106,7 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
     sharedUserGroupIds,
     sharedChannelIds,
     recording.createdByUserId,
+    currentUser?.id,
   ]);
 
   const handleShare = async (): Promise<void> => {
@@ -173,14 +176,6 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
       });
     }
   };
-
-  if (!canManage) {
-    return (
-      <div className='p-5 text-sm text-muted-foreground'>
-        Only the recording creator can manage sharing.
-      </div>
-    );
-  }
 
   return (
     <div className='flex flex-col w-full p-5 gap-4'>


### PR DESCRIPTION
…thers

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Enable the non-creators to share the recordings.
POT - https://drive.google.com/file/d/1CCfqUG710nrXyF2tay83A3KplAlbz5QT/view?usp=sharing


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
