### PR TITLE
feat: XYNE-56649 make ticket role assignments editable

### DIFF
--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -6549,6 +6549,58 @@ export function createMutators(
           }
         },
       ),
+      // Re-point an existing role assignment (Manager / Reviewer / QA / any
+      // custom role) at a different user, or clear the slot. Authoritative
+      // server counterpart of the shared client mutator
+      // (packages/shared/src/zero/mutators.ts → ticket.reassignRole) — KEEP IN
+      // SYNC. Authorization is enforced by TicketAssignmentsACL; the
+      // ticket_assignments side-effect (fired on the wrapped tx.mutate write)
+      // creates the activity + notification. createdBy is stamped with the actor
+      // so the notification is attributed to whoever performed the reassignment.
+      reassignRole: defineMutator(
+        z.object({
+          id: z.string(),
+          userId: z.string().nullable(),
+        }),
+        async ({ tx, args: { id, userId } }) => {
+          const assignment = await tx.run(zql.ticket_assignments.where('id', id).one());
+          if (!assignment) throw new Error('Ticket assignment not found');
+
+          const previousUserId = assignment.userId;
+
+          if (userId === null) {
+            await tx.mutate.ticket_assignments.delete({ id });
+          } else {
+            await tx.mutate.ticket_assignments.update({
+              id,
+              userId,
+              createdBy: authData.sub,
+            });
+          }
+
+          // Role assignments count toward per-user workload (see
+          // ticketAssignmentService persist -> syncUserWorkload), so keep both
+          // the user losing the slot and the user gaining it in sync.
+          const ticket = await tx.run(zql.tickets.where('id', assignment.ticketId).one());
+          if (ticket?.userGroupId && ticket.boardId) {
+            const usersToSync = [
+              ...new Set([previousUserId, userId].filter(Boolean) as string[]),
+            ];
+            for (const uid of usersToSync) {
+              asyncTasks.push(async () => {
+                try {
+                  await syncUserWorkload(uid, ticket.userGroupId!, ticket.boardId!, authData.sub);
+                } catch (error) {
+                  logger.error(
+                    `[Workload Sync] Failed for user ${uid} in role reassignment:`,
+                    error,
+                  );
+                }
+              });
+            }
+          }
+        },
+      ),
     },
     ticketStageEta: {
       update: defineMutator(

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -688,7 +688,10 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
   // assigned users. `role` may be undefined if the backend hasn't been
   // updated yet — fall back to a generic label in that case.
   const roleGroups = useMemo(() => {
-    const groups = new Map<string, { label: string; userIds: string[] }>();
+    const groups = new Map<
+      string,
+      { label: string; entries: { assignmentId: string; userId: string }[] }
+    >();
     for (const a of ticketAssignments) {
       const userId = a.userId;
       if (!userId) continue;
@@ -698,11 +701,14 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
         (a.roleId && (a as { role?: { name?: string } | null }).role?.name) ||
         a.userResponsibility ||
         'Role';
+      // Keep the assignment row id alongside each user so the role can be
+      // reassigned in place (the row is keyed by its own id, not by userId).
+      const entry = { assignmentId: a.id, userId };
       const existing = groups.get(key);
       if (existing) {
-        existing.userIds.push(userId);
+        existing.entries.push(entry);
       } else {
-        groups.set(key, { label, userIds: [userId] });
+        groups.set(key, { label, entries: [entry] });
       }
     }
     return Array.from(groups.values());
@@ -2042,6 +2048,25 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     );
   };
 
+  // Reassign (or clear) a role slot on the ticket. Each role assignment row is
+  // addressed by its own id, so changing the user re-points that single slot
+  // without touching the ticket's primary assignee.
+  const handleRoleReassign = (assignmentId: string, userId: string | null): void => {
+    void (async (): Promise<void> => {
+      try {
+        const result = await zero.mutate(
+          mutators.ticket.reassignRole({ id: assignmentId, userId }),
+        ).server;
+        if (result.type === 'error') {
+          toast.error(result.error.message || 'Failed to update role assignment');
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(message || 'Failed to update role assignment');
+      }
+    })();
+  };
+
   const handleTicketTypeChange = (type: string): void => {
     void applyTicketUpdate(
       {
@@ -3306,30 +3331,24 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
             {roleGroups.map(group => (
               <TicketKeyValuePair
                 key={group.label}
-                ticketKey={group.userIds.length > 1 ? `${group.label}s` : group.label}
+                ticketKey={group.entries.length > 1 ? `${group.label}s` : group.label}
                 value={
                   <div
                     className={
-                      group.userIds.length > 1 ? 'flex flex-col gap-2' : 'flex items-center gap-2'
+                      group.entries.length > 1 ? 'flex flex-col gap-2' : 'flex items-center gap-2'
                     }
                   >
-                    {group.userIds.map(userId => {
-                      const user = users?.find(
-                        (u: { id: string; name: string; displayName?: string | null }) =>
-                          u.id === userId,
-                      );
-                      return (
-                        <div key={userId} className='flex items-center gap-2'>
-                          <UserAvatar
-                            userId={userId}
-                            size={AvatarSize.SM}
-                            shape={AvatarShape.CIRCULAR}
-                            showActiveStatus={false}
-                          />
-                          {getUserDisplayName(user) || 'Unknown'}
-                        </div>
-                      );
-                    })}
+                    {group.entries.map(entry => (
+                      <UserSelector
+                        key={entry.assignmentId}
+                        selectedUserId={entry.userId}
+                        onUserSelect={newUserId =>
+                          handleRoleReassign(entry.assignmentId, newUserId)
+                        }
+                        channelId={ticket.channelId ?? undefined}
+                        noBorder={true}
+                      />
+                    ))}
                   </div>
                 }
               />

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -4201,6 +4201,34 @@ export const mutators = defineMutators({
         await updateTicketMdFromZero(tx, zql, ticketId);
       },
     ),
+    // Re-point an existing role assignment (Manager / Reviewer / QA / any custom
+    // role) at a different user, or clear the slot. The assignment row is keyed
+    // by its own id; membership on the ticket's channel is the authorization
+    // boundary (enforced by TicketAssignmentsACL). createdBy is stamped with the
+    // acting user so the ticket_assignments side-effect attributes the resulting
+    // activity + notification to whoever performed the reassignment.
+    reassignRole: defineMutator(
+      z.object({
+        id: z.string(),
+        userId: z.string().nullable(),
+      }),
+      async ({ tx, ctx, args: { id, userId } }) => {
+        const assignment = await tx.run(zql.ticket_assignments.where('id', id).one());
+        if (!assignment) throw new Error('Ticket assignment not found');
+
+        if (userId === null) {
+          await tx.mutate.ticket_assignments.delete({ id });
+        } else {
+          await tx.mutate.ticket_assignments.update({
+            id,
+            userId,
+            createdBy: ctx.userID,
+          });
+        }
+
+        await updateTicketMdFromZero(tx, zql, assignment.ticketId);
+      },
+    ),
   },
   ticketStageEta: {
     update: defineMutator(


### PR DESCRIPTION
## Summary
Ticket role assignments (Manager, Reviewer, QA, and any custom roles) were rendered read-only on the ticket details panel. This PR makes each role slot editable so any member of the ticket's channel can reassign or clear it, matching the existing primary-assignee UX.

1. Problem Description:
When a ticket has roles assigned (manager, reviewer, qa, etc.), those role assignments were displayed as static avatar + name and could not be changed from the UI. Only the primary assignee was editable.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Enhancement requested in XYNE-56649. Confirmed by inspecting `TicketDetails.tsx`, where role groups were rendered read-only (UserAvatar + display name) while the primary Assignee row used an editable `UserSelector`.

3. Explain the solution implemented in the PR:
- Added a `ticket.reassignRole` Zero mutator (`packages/shared/src/zero/mutators.ts`) that re-points a single `ticket_assignments` row (addressed by its own id) at a new user, or deletes the row when cleared. It stamps `createdBy` with the acting user so the existing `ticket_assignments` side-effect attributes the activity + notification to whoever performed the reassignment. Authorization is enforced by the existing `TicketAssignmentsACL` (channel-membership boundary; already supports update/delete).
- In `TicketDetails.tsx`, extended `roleGroups` to carry each assignment's row id, added a `handleRoleReassign` handler, and replaced the read-only role rendering with the same `UserSelector` used for the primary assignee (per role slot).

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
None — reuses the existing `ticket_assignments` table, ACL, and side-effect handler. No schema change.

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
None

8. Testing (how it was tested; screenshots/links):
- `pnpm --filter @xyne/shared build` passes.
- Dashboard `tsc --noEmit` (tsconfig.app.json) passes.
- Manual UI verification of reassign/clear pending reviewer sign-off.

9. Services to which this change is to be deployed:
dashboard (frontend) + shared package (Zero mutators used by backend/zero-cache).

10. Main PR link (if this PR is raised against a release branch):
N/A — raised against main.

Ticket: XYNE-56649