### PR TITLE
fix: XYNE channel-send attachments through pending framework (backport to release-20260821)

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -30,7 +30,7 @@ import { AgentProgressIndicator } from './AgentProgressIndicator';
 import { useAuth, useAuthContextValues } from '../../../hooks/useAuth';
 import { websocketService } from '../../../services/clients/socketClient';
 import { processMessageForSending, containsSpecialBroadcastMention } from './ChatInput.utils';
-import { saveDraft, useDraft } from '../../../hooks/useDraft';
+import { saveDraft, useDraft, useDraftFromDB } from '../../../hooks/useDraft';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
 import { CreateTicketModal } from '../../Tickets/CreateTicketModal/CreateTicketModal';
@@ -42,7 +42,7 @@ import {
 import type { FocusPosition } from '@tiptap/react';
 import type { MentionResult } from '@xyne/shared';
 import { getSlashCommandArtifactDefinition } from '@xyne/shared';
-import { sendMessage, type ConversationRef } from '@xyne/shared/messages';
+import { sendMessage, type ConversationRef, type PendingAttachment } from '@xyne/shared/messages';
 import { useCanCreateTicket } from '../../../hooks/usePermissions';
 import { mutators } from '../../../zero/mutators';
 import { useShortcutById } from '../../../shortcuts';
@@ -401,6 +401,9 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
     // Subscribe to draft from state machine
     const lookupId = conversationId ?? channelId;
     const draft = useDraft(channelId, conversationId ?? null);
+    // DB-backed draft (with already-uploaded attachments) for the channel
+    // composer; used to carry attachments through the pending-message send.
+    const channelDraftForSend = useDraftFromDB(channelId, conversationId ?? null);
 
     // Load draft for current channel on mount (only if not editing a message)
     const editorValue = React.useMemo(() => {
@@ -813,12 +816,29 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
             // server confirms the write. Failed sends stay queued and surface a
             // retry/delete affordance instead of being restored to the composer.
             const channelRef: ConversationRef = { kind: 'channel', channelId };
+            // Carry the composer's already-uploaded draft attachments through the
+            // pending-message framework so they are stored on the durable pending
+            // entry and promoted (DRAFT -> CHAT) via explicit attachmentIds — on the
+            // immediate send and on any offline auto-retry. The mutator's legacy
+            // draft-scan fallback cannot be relied on here because sendMessage
+            // detaches the draft as part of queueing the message.
+            const pendingAttachments: PendingAttachment[] = (
+              channelDraftForSend?.attachments ?? []
+            ).map(a => ({
+              attachmentId: a.id,
+              originalFilename: a.originalFilename,
+              mimetype: a.mimetype,
+              size: a.size,
+              ...(a.width !== null && { width: a.width }),
+              ...(a.height !== null && { height: a.height }),
+            }));
             sendMessage(zero as Parameters<typeof sendMessage>[0], channelRef, {
               content: processedHtml,
               type: MessageType.USER,
               conversationId: newConversationId,
               messageId: newMessageId,
               timestamp: messageCreatedAt,
+              ...(pendingAttachments.length > 0 && { attachments: pendingAttachments }),
             });
 
             saveDraft(lookupId, '', '');
@@ -877,6 +897,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         context.workspaceId,
         allowThreadBroadcastMentions,
         twinEdit,
+        channelDraftForSend,
         activeArtifactCommand,
       ],
     );

--- a/packages/shared/src/messages/index.ts
+++ b/packages/shared/src/messages/index.ts
@@ -68,6 +68,7 @@ export {
   type PendingStatus,
   type PendingKind,
   type ZeroStateName,
+  type PendingAttachment,
 } from './pending.js';
 
 export { usePendingQueue } from './usePendingQueue.js';

--- a/packages/shared/src/messages/pending.ts
+++ b/packages/shared/src/messages/pending.ts
@@ -164,6 +164,14 @@ export function firePendingMutator(zero: Zero, entry: PendingMessage): void {
   });
 
   let childConversationId: string | undefined = entry.childConversationId;
+  // Replay is hermetic: a queued or retried send carries its own attachment set
+  // on the pending entry, so pass attachmentIds explicitly here (even when empty).
+  // This forces the server mutator down its explicit branch, which links exactly
+  // these ids and leaves any other draft attachments untouched. Do NOT omit it on
+  // the empty case the way sendMessage does on first fire: an omitted attachmentIds
+  // drops the mutator into the legacy draft-scan fallback, which would promote
+  // whatever is in the channel draft *now* (a concurrent, unrelated compose) onto
+  // this replayed message and delete that draft.
   const attachmentIds = entry.attachments?.map(a => a.attachmentId) ?? [];
   let mutation;
   if (entry.kind === 'channel') {
@@ -175,7 +183,7 @@ export function firePendingMutator(zero: Zero, entry: PendingMessage): void {
         messageId: entry.messageId,
         timestamp: fireTimestamp,
         type: entry.type,
-        ...(attachmentIds.length > 0 && { attachmentIds }),
+        attachmentIds,
       }),
     );
   } else {
@@ -186,7 +194,7 @@ export function firePendingMutator(zero: Zero, entry: PendingMessage): void {
         type: entry.type,
         timestamp: fireTimestamp,
         messageId: entry.messageId,
-        ...(attachmentIds.length > 0 && { attachmentIds }),
+        attachmentIds,
         ...(entry.alsoSendToChannel !== undefined && {
           showInChannel: entry.alsoSendToChannel,
         }),

--- a/packages/shared/src/messages/pending.ts
+++ b/packages/shared/src/messages/pending.ts
@@ -175,7 +175,7 @@ export function firePendingMutator(zero: Zero, entry: PendingMessage): void {
         messageId: entry.messageId,
         timestamp: fireTimestamp,
         type: entry.type,
-        attachmentIds,
+        ...(attachmentIds.length > 0 && { attachmentIds }),
       }),
     );
   } else {
@@ -186,7 +186,7 @@ export function firePendingMutator(zero: Zero, entry: PendingMessage): void {
         type: entry.type,
         timestamp: fireTimestamp,
         messageId: entry.messageId,
-        attachmentIds,
+        ...(attachmentIds.length > 0 && { attachmentIds }),
         ...(entry.alsoSendToChannel !== undefined && {
           showInChannel: entry.alsoSendToChannel,
         }),

--- a/packages/shared/src/messages/send.ts
+++ b/packages/shared/src/messages/send.ts
@@ -108,7 +108,7 @@ export function sendMessage(
             messageId,
             timestamp: fireTimestamp,
             type,
-            attachmentIds,
+            ...(attachmentIds.length > 0 && { attachmentIds }),
           }),
         )
       : zero.mutate(
@@ -118,7 +118,7 @@ export function sendMessage(
             type,
             timestamp: fireTimestamp,
             messageId,
-            attachmentIds,
+            ...(attachmentIds.length > 0 && { attachmentIds }),
             ...(payload.alsoSendToChannel !== undefined && {
               showInChannel: payload.alsoSendToChannel,
             }),

--- a/packages/shared/src/messages/send.ts
+++ b/packages/shared/src/messages/send.ts
@@ -97,6 +97,11 @@ export function sendMessage(
   const fireTimestamp = Date.now();
   updatePending(messageId, { mutatorFired: true, timestamp: fireTimestamp });
 
+  // First fire only: when the caller passes no attachments we OMIT attachmentIds
+  // so a send that under-specifies still hits the mutator's legacy draft-scan
+  // fallback for this same compose context. The durable retry path
+  // (firePendingMutator in pending.ts) deliberately does the opposite and always
+  // passes attachmentIds, because a replay must not scavenge live draft state.
   const attachmentIds = attachments.map(a => a.attachmentId);
   const mutation =
     ref.kind === 'channel'


### PR DESCRIPTION
Backport of the channel-send attachment fix onto release-20260821.

Includes two commits:
1. `carry channel-send attachments through pending-message framework` — top-level channel sends routed through the shared pending-message framework (PR #281) stopped attaching files. ChatInput now reads the composer's already-uploaded draft attachments and passes them into sendMessage as PendingAttachment[], stored on the pending entry and promoted via explicit attachmentIds on both immediate send and offline auto-retry.
2. `keep retry hermetic so a resend never scavenges the live channel draft` — firePendingMutator now always passes attachmentIds explicitly (even when empty). Omitting it dropped the server mutator into its legacy draft-scan fallback, so resending a failed no-attachment message would have promoted whatever attachments are in the channel draft *now* (a concurrent compose) onto the replayed message and deleted that draft. Net effect on release-20260821's pending.ts is documentation only, since that branch already passed attachmentIds unconditionally.

Companion to the main-targeted PR #862.