### PR TITLE
fix: XYNE-56676 Remove meeting detection feature for recording and calls

### DIFF
--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -13,6 +13,7 @@ import { NativeInboundMessageType, reactNativeBridge } from '../../utils/reactNa
 import { useZero } from '../../hooks/useZero';
 import { callActor } from '../../machines/callMachine';
 import { roomActor } from '../../machines/roomMachine';
+import { useSelector } from '@xstate/react';
 import { CallType } from '@xyne/shared';
 import { setupPresenceListeners, cleanupPresenceListeners } from '../../machines/stateMachine';
 import { queryCacheActor, type Conversation } from '../../machines/queryCacheMachine';
@@ -609,6 +610,21 @@ export const NotificationHandler: React.FC = () => {
     if (!isElectron || !window.electronAPI?.onRecordingSystemSuspend) return;
     return window.electronAPI.onRecordingSystemSuspend(stopRecordingForTeardown);
   }, [isElectron]);
+
+  // Same states useCallJoinOrInitiate treats as "in a call"; `initiating` lands
+  // before the mic is enabled, so main knows the upcoming activation is ours.
+  const isInXyneCall = useSelector(
+    roomActor,
+    s =>
+      s.matches('initiating') ||
+      s.matches('joining') ||
+      s.matches('connecting') ||
+      s.matches('connected'),
+  );
+  useEffect(() => {
+    if (!isElectron) return;
+    window.electronAPI?.ipcSend?.('call:state-changed', isInXyneCall);
+  }, [isElectron, isInXyneCall]);
 
   const recordingStatus = useRecordingStore(ctx => ctx.status);
   const recordingStartTime = useRecordingStore(ctx => ctx.startTime);

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -26,6 +26,7 @@ import {
   focusMainWindow,
   markRendererReady,
   resumeRecordingFromOutside,
+  setCallActive,
   setOverlayMinimized,
   setRecordingPillEnabled,
   setRecordingStarting,
@@ -643,6 +644,11 @@ export function setupIpcHandlers(): void {
     if (!isMainWindowSender(event)) return;
     if (theme !== 'light' && theme !== 'dark') return;
     setRecordingPillTheme(theme);
+  });
+
+  ipcMain.on('call:state-changed', (event, inCall: unknown) => {
+    if (!isMainWindowSender(event)) return;
+    setCallActive(!!inCall);
   });
 
   ipcMain.on('recording:renderer-ready', (event) => {

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -276,6 +276,7 @@ const electronAPI = {
   ipcSend: (channel: string, ...args: unknown[]) => {
     const allowed = [
       'app:theme-changed',
+      'call:state-changed',
       'meeting-popup:content-height',
       'recording-pill:recording-stopped',
       'recording:renderer-ready',

--- a/apps/electron/src/services/meeting-detector.ts
+++ b/apps/electron/src/services/meeting-detector.ts
@@ -5,6 +5,7 @@ import log from 'electron-log/main';
 import { Logger } from './logger/Logger';
 import ElectronEvent from './logger/electron-events';
 import { showMeetingPopup, hideMeetingPopup } from './meeting-popup-window';
+import { isMicOwnedByXyne } from './recording-controller';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -264,6 +265,15 @@ class MeetingDetectorService {
     const active = event.active ?? false;
 
     if (active && !this.currentMeeting) {
+      // A Xyne call or recording is what just turned the mic on. Bail out before
+      // identifying anything — checkProcesses() would otherwise match a Zoom or
+      // Teams that is merely open in the background.
+      if (isMicOwnedByXyne()) {
+        log.info('[MeetingDetector] Xyne call/recording in progress — ignoring mic activation');
+        Logger.info(ElectronEvent.MEETING_POPUP_SKIPPED_RECORDING, { via: 'mic-activation' }, 'MeetingDetector');
+        return;
+      }
+
       log.info('[MeetingDetector] Mic became active — identifying meeting app');
       Logger.info(
         ElectronEvent.MEETING_MIC_ACTIVE,

--- a/apps/electron/src/services/meeting-popup-window.ts
+++ b/apps/electron/src/services/meeting-popup-window.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import log from 'electron-log/main';
 import { Logger } from './logger/Logger';
 import ElectronEvent from './logger/electron-events';
-import { isRecordingInProgress } from './recording-controller';
+import { isMicOwnedByXyne } from './recording-controller';
 
 let popupWindow: BrowserWindow | null = null;
 let autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
@@ -26,7 +26,7 @@ export async function showMeetingPopup(meetingData: { app: string; startedAt: st
     return;
   }
 
-  if (isRecordingInProgress()) {
+  if (isMicOwnedByXyne()) {
     log.info('[MeetingPopup] Recording already in progress, skipping popup');
     Logger.info(
       ElectronEvent.MEETING_POPUP_SKIPPED_RECORDING,

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -86,6 +86,10 @@ function watchRendererLifecycle(win: BrowserWindow): void {
   watchedRenderers.add(win);
   win.webContents.on('did-start-loading', () => {
     rendererReady = false;
+    // A reload tears down the LiveKit connection, so any call is over; the
+    // remounted renderer resends call state either way. Without this a renderer
+    // that hangs mid-reload would strand the flag true and mute detection.
+    callActive = false;
   });
   win.webContents.on('render-process-gone', () => {
     rendererReady = false;
@@ -346,8 +350,8 @@ export function setRecordingStarting(next: boolean): void {
 }
 
 // Calls enable the mic the same way recordings do, so the meeting detector must
-// treat both as ours. The renderer reports call state on every transition and
-// resends it on mount, so a reload self-heals; only a crash needs the reset above.
+// treat both as ours. The renderer reports call state on every transition and on
+// mount; the lifecycle hooks above clear it when the renderer reloads or dies.
 export function setCallActive(next: boolean): void {
   callActive = next;
 }

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -36,6 +36,7 @@ let focusRequestTimer: ReturnType<typeof setTimeout> | null = null;
 
 let active = false;
 let startingRecording = false;
+let callActive = false;
 let startingRecordingExpiry: ReturnType<typeof setTimeout> | null = null;
 let startTime: number | null = null;
 let paused = false;
@@ -91,6 +92,7 @@ function watchRendererLifecycle(win: BrowserWindow): void {
     // syncRecordingState early-returns on inactive -> inactive, so a crash
     // mid-start would strand the flag.
     setRecordingStarting(false);
+    callActive = false;
     syncRecordingState(false);
   });
 }
@@ -343,8 +345,15 @@ export function setRecordingStarting(next: boolean): void {
   }, STARTING_RECORDING_TIMEOUT_MS);
 }
 
-export function isRecordingInProgress(): boolean {
-  return active || startingRecording;
+// Calls enable the mic the same way recordings do, so the meeting detector must
+// treat both as ours. The renderer reports call state on every transition and
+// resends it on mount, so a reload self-heals; only a crash needs the reset above.
+export function setCallActive(next: boolean): void {
+  callActive = next;
+}
+
+export function isMicOwnedByXyne(): boolean {
+  return active || startingRecording || callActive;
 }
 
 export function syncRecordingState(


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
