### PR TITLE
fix: allow any Spaces user to approve an agent plan

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -1901,11 +1901,13 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       const planUserId = priorCtx.senderId;
       const serverTodos = activePlan.todos;
 
-      // Only the user the server recorded for this plan can approve/reject it.
-      if (!callerUserId || callerUserId !== planUserId) {
-        log.error(`[flow-action] plan-approval: unauthorized — caller ${callerUserId ?? "(none)"} != plan owner ${planUserId}`);
+      if (!callerUserId) {
+        log.error(`[flow-action] plan-approval: unauthorized — no callerUserId (plan owner ${planUserId})`);
         res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
         return;
+      }
+      if (callerUserId !== planUserId) {
+        log.info(`[flow-action] plan-approval: decided by ${callerUserId} on behalf of plan owner ${planUserId}`);
       }
 
       // ── Reject ────────────────────────────────────────────────────────────
@@ -2056,7 +2058,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
             approved.map((t, i) => `${i + 1}. ${t.title}`).join("\n");
           const fastModeEnabled = await resolveFastMode(planConversationId, planAgentSlug, agent.config);
           const dispatchPayload: Record<string, unknown> = {
-            userId: planUserId,
+            userId: callerUserId,
             task,
             conversationId: planConversationId,
             ...(planChannelId ? { channelId: planChannelId } : {}),


### PR DESCRIPTION
## Problem

Clicking **Approve** on an agent plan card returned `403 Unauthorized` every time, for every user, when the plan came from an automation.

The plan-approval branch in `flow-action.ts` required the approver to be the person who requested the plan:

```js
const planUserId = priorCtx.senderId;
if (!callerUserId || callerUserId !== planUserId) → 403
```

`priorCtx.senderId` is the Spaces sender of the mention that started the run. When an automation posts `@Xyne Doctor …`, that sender is the **Automations bot** (`send-message.step.ts` resolves it via `getAutomationsBotUserId`; automations are explicitly forbidden from posting as a human). So the only account permitted to approve was a bot, which never clicks a button — the card was permanently undecidable and every human was, by definition, "not the requester".

Spaces surfaced the upstream 403 as `App backend error 403` via `flowController.ts`, which made it look like a Spaces error.

## Changes

**1. Drop the owner-equality check.** Any Spaces user served the card can decide it; still fails closed on a missing `callerUserId`.

This does not weaken the route. `/action` is mounted behind `requireStrictS2S` + `verifySpacesSignature`, which re-run the per-agent HMAC over the raw bytes so — in the existing comment's words — *"context.userId is bound to a payload Spaces actually signed."* Identity is proven by the platform check, not by ownership.

**2. Dispatch Turn 2 as the approver** (`callerUserId`) rather than the recorded requester.

Required for the fix to actually work. A bot requester has `authProvider: API_KEY` and no login session, so `getSpacesAuthForUser` returns null and `resolveAppTokenForAppUser` misses (a Spaces system bot is no agent's app user). Turn 2 would run with **no Spaces token** and the agent could not read or update the ticket it was approved to work on. Identical id when a human requested the plan.

Also added an `info` log when approver ≠ requester so the automation path is traceable.

## Behaviour change

Previously only the person who mentioned the agent could approve its plan. Now any user in the thread can. That is intentional — but it is a widening, and the point worth reviewing.

## Testing

`tsc --noEmit` clean on `apps/xyne-claw-auth/backend`. gitleaks, tenant-key guard, schema-migration validation, change-analysis, enum guard and dashboard lint all pass. No existing tests cover the plan-approval branch.

Still to verify by hand:
- automation-created ticket → agent proposes a plan → human approves → card flips to executing **and `spaces-update-ticket` succeeds** (the token half is reasoned from `mcp/runner.ts`, not yet observed)
- regression: a human-mentioned plan is still approvable and still shows the correct "Approved by"