### PR TITLE
fix: use encodeHtmlAttr for flow JSON escaping in data-flow-json attributes

### DIFF
--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -262,7 +262,7 @@ export class ChatController {
           return;
         }
 
-        const escapedJSON = JSON.stringify(flowResult.data).replace(/"/g, '&quot;');
+        const escapedJSON = encodeHtmlAttr(JSON.stringify(flowResult.data));
         // Inner text = notification/preview fallback (shown when the widget
         // isn't rendered). Prefer flow.data.fallbackText, then the flow title,
         // else a generic label — never worse than the old hardcoded "Flow JSON".
@@ -363,7 +363,7 @@ export class ChatController {
           return;
         }
         const flowId = (flowResult.data.screenId) ?? crypto.randomUUID();
-        const escapedJSON = JSON.stringify(flowResult.data).replace(/"/g, '&quot;');
+        const escapedJSON = encodeHtmlAttr(JSON.stringify(flowResult.data));
         // Inner text = notification/preview fallback (see postMessage above).
         const fbRaw = (flowResult.data.data as Record<string, unknown> | undefined)?.['fallbackText'];
         const flowFallback = encodeHtmlAttr(

--- a/apps/backend/src/apps/controllers/incomingWebhookController.ts
+++ b/apps/backend/src/apps/controllers/incomingWebhookController.ts
@@ -13,6 +13,7 @@ import { resolveSlackMessageParts } from '@/integrations/adapters/slack-webhook-
 import { MessageType, AppIncomingWebhookAction, AppIncomingWebhookType } from '@xyne/shared';
 import { config } from '@/config/env';
 import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
+import { encodeHtmlAttr } from '@/utils/contentUtils';
 import {
   buildSentinelRawFallbackMessage,
   buildSentinelRawFallbackTicketDescription,
@@ -433,7 +434,7 @@ class IncomingWebhookController {
       return null;
     }
 
-    const escapedJSON = JSON.stringify(result.data).replace(/"/g, '&quot;');
+    const escapedJSON = encodeHtmlAttr(JSON.stringify(result.data));
     return `<div data-flow-json="${escapedJSON}">Flow JSON</div>`;
   }
 

--- a/apps/backend/src/apps/platform-adapters/slack/request-transformers/chat.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/request-transformers/chat.ts
@@ -5,6 +5,7 @@ import {
 	resolveSlackText,
 } from "@/integrations/adapters/slack-webhook-tickets/utils/slackUtils";
 import { config } from "@/config/env";
+import { encodeHtmlAttr } from "@/utils/contentUtils";
 import type { TransformContext } from "../../types";
 import type {
 	SlackChatPostMessageRequest,
@@ -49,7 +50,7 @@ async function processContent(
 		}, botToken, workspaceId);
 
 		if (flowJSON) {
-			const escapedJSON = JSON.stringify(flowJSON).replace(/"/g, "&quot;");
+			const escapedJSON = encodeHtmlAttr(JSON.stringify(flowJSON));
 			return {
 				content: `<div data-flow-json="${escapedJSON}">Flow JSON</div>`,
 				isMarkdown: false,

--- a/apps/backend/src/utils/urlUtils.ts
+++ b/apps/backend/src/utils/urlUtils.ts
@@ -160,7 +160,10 @@ function extractFlowJsonLinks(content: string): string[] {
     const json = attrMatch[1]
       .replace(/&quot;/g, '"')
       .replace(/&#10;/g, '\n')
-      .replace(/&#13;/g, '\r');
+      .replace(/&#13;/g, '\r')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
     const flow = JSON.parse(json) as { components?: unknown[] };
 
     const links = new Set<string>();

--- a/packages/xyne-claw-shared/src/flow/flow-text.ts
+++ b/packages/xyne-claw-shared/src/flow/flow-text.ts
@@ -36,6 +36,9 @@ export function parseFlowJsonComponents(content: string): FlowComponent[] | null
       .replace(/&quot;/g, '"')
       .replace(/&#10;/g, "\n")
       .replace(/&#13;/g, "\r")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
       // Repair stray backslashes that are NOT valid JSON escape sequences.
       // Slack mrkdwn leaves fragments like "\1" / "\6" in the content, which
       // are invalid JSON escapes; without this, JSON.parse aborts the ENTIRE


### PR DESCRIPTION
## Summary

Agent capability cards (and any flow JSON messages containing `&quot;` entities) fail to render in the dashboard. The `JSON.parse` step in `RenderMessageWithHTML.tsx` throws a SyntaxError because the browser decodes `&quot;` → `"` inside the `data-flow-json` attribute value.

## Root Cause

The flow JSON encoding at 4 creation sites used `.replace(/"/g, '&quot;')` which only escapes `"` but NOT `&`. When the JSON content contains literal `&quot;` strings (e.g. from skill descriptions in agent system prompts like `corpus-question-router-test`, `corpus-question-router`, `corpus-self-verify`), the browser's HTML parser resolves `&quot;` → `"` inside the attribute value, injecting unescaped double quotes into the JSON string and breaking `JSON.parse`.

**Example:** A flow JSON value like `"Contains &quot;how many&quot; keywords"` gets encoded as `...&quot;Contains &quot;how many&quot; keywords&quot;...`. The browser decodes ALL `&quot;` entities (including the ones that were literal text), producing `"Contains "how many" keywords"` — invalid JSON.

## Fix

Replace the naive `.replace(/"/g, '&quot;')` with the existing `encodeHtmlAttr()` utility (`apps/backend/src/utils/contentUtils.ts`) which escapes `&` → `&amp;` FIRST, then `"` → `&quot;`, `'` → `&#39;`, `<` → `&lt;`, `>` → `&gt;`. With `&` escaped first, literal `&quot;` in the JSON becomes `&amp;quot;` — the browser decodes `&amp;` → `&` but leaves `quot;` as literal text, preserving the original `&quot;` string in the parsed attribute value.

Also add `&lt;`, `&gt;`, `&amp;` decoding to 2 incomplete parser sites that only decoded `&quot;`, `&#10;`, `&#13;`.

## Changes

### Creation sites (4 — replace naive escaping with `encodeHtmlAttr`):
1. `apps/backend/src/apps/controllers/chatController.ts:265` — `postMessage`: `encodeHtmlAttr(JSON.stringify(flowResult.data))` (import already present)
2. `apps/backend/src/apps/controllers/chatController.ts:366` — `updateMessage`: same (import already present)
3. `apps/backend/src/apps/controllers/incomingWebhookController.ts:437` — `encodeFlowContent`: same + added `import { encodeHtmlAttr } from '@/utils/contentUtils'`
4. `apps/backend/src/apps/platform-adapters/slack/request-transformers/chat.ts:53` — `processContent`: same + added import

### Parser sites (2 — add missing `&lt;`, `&gt;`, `&amp;` decoding, `&amp;` LAST):
5. `packages/xyne-claw-shared/src/flow/flow-text.ts:39` — `parseFlowJsonComponents`: added `.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&")`
6. `apps/backend/src/utils/urlUtils.ts:163` — `extractFlowJsonLinks`: same 3 decodes added

## Backward Compatibility

Old messages encoded without `&` escaping still parse correctly with the updated decoders because:
- Literal `&` in old attributes has no `&amp;` to decode (`.replace(/&amp;/g, '&')` is a no-op)
- The `&amp;` decode is applied LAST in the chain, so it doesn't double-decode `&amp;quot;` → `&quot;` → `"`

## Test Cases

| TC | Description | Result |
|----|-------------|--------|
| TC1 | Old encoding with `&quot;` fails JSON.parse | PASS (proves bug exists) |
| TC2 | New encodeHtmlAttr preserves `&quot;` strings | PASS (fix works) |
| TC3 | Simple flow JSON without special chars (backward compat) | PASS |
| TC4 | Flow JSON with `<`, `>`, `&` characters | PASS |
| TC5 | End-to-end API: flow message with `&quot` stored with correct `&amp;quot;` encoding | PASS |

## Typecheck

- Backend: `npx tsc --noEmit` ✅
- Dashboard: `npx tsc --noEmit --project tsconfig.app.json` ✅