### PR TITLE
fix: remove unread mentions hover opacity

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/UnreadMentionsPill.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/UnreadMentionsPill.tsx
@@ -86,7 +86,7 @@ const UnreadMentionsPill = ({
   return (
     <button
       type='button'
-      className='pointer-events-auto flex shrink-0 items-center gap-1.5 rounded-full bg-sidebar-primary px-3 py-1 text-xs font-medium text-sidebar-primary-foreground shadow-md transition-colors hover:opacity-90'
+      className='pointer-events-auto flex shrink-0 items-center gap-1.5 rounded-full bg-sidebar-primary px-3 py-1 text-xs font-medium text-sidebar-primary-foreground shadow-md'
       onClick={() => target.scrollIntoView({ block: 'start', behavior: 'smooth' })}
       data-track-category='CHAT_SIDEBAR'
       data-track-name='JUMP_TO_UNREAD_MENTION'


### PR DESCRIPTION
1. Problem Description:
The ChatDirectory unread mentions jump pill reduced opacity on hover, making underlying sidebar text visible through the pill.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in Spaces thread by Harsh Sharma.

3. Explain the solution implemented in the PR:
Removed the `hover:opacity-90` hover state from `UnreadMentionsPill` so the pill remains fully opaque while hovered.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
Ran `pnpm --dir apps/dashboard exec eslint src/components/Chat/ChatDirectory/UnreadMentionsPill.tsx` successfully.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A