### PR TITLE
feat: XYNE-55471 deploy the SDLC surface as an independent lane

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,6 +1,10 @@
 # Server Configuration
 NODE_ENV=development
 PORT=3001
+# Extra leading path prefix this instance also answers on, in addition to /api.
+# Set to /sdlc-api on the SDLC lane's backend so the edge can route the two lanes
+# apart on a static prefix without needing rewrite support. Empty = today's behaviour.
+API_PATH_PREFIX=
 HOST=0.0.0.0
 # Set to a positive integer to enforce a member cap per organization; leave unset for no limit
 # ORG_MEMBER_LIMIT=10

--- a/apps/backend/.env.sdlc
+++ b/apps/backend/.env.sdlc
@@ -1,0 +1,11 @@
+# SDLC fast lane — backend instance. Loaded by `dotenv -e .env.sdlc -e .env.local`,
+# where the FIRST file wins, so .env.local supplies database, redis and secrets.
+# No secrets here: this file is tracked. See docs/sdlc-fast-lane.md.
+
+PORT=3011
+
+# The SDLC bundle calls /sdlc-api/*; app.ts maps it onto /api so the edge never
+# has to rewrite.
+API_PATH_PREFIX=/sdlc-api
+
+# No worker here — a second consumer would double-process the shared queues.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,6 +19,7 @@
     "start:api": "NODE_ENV=production tsx --enable-source-maps dist/index.js",
     "start:worker": "NODE_ENV=production tsx --enable-source-maps dist/worker.js",
     "dev": "dotenv -e .env.local -- sh -c 'NODE_ENV=development CHOKIDAR_USEPOLLING=true tsx watch src/index.ts'",
+    "dev:sdlc": "dotenv -e .env.sdlc -e .env.local -- sh -c 'NODE_ENV=development CHOKIDAR_USEPOLLING=true tsx watch src/index.ts'",
     "dev:api": "NODE_ENV=development tsx watch src/index.ts",
     "dev:worker": "dotenv -e .env.local -- sh -c 'NODE_ENV=development tsx watch src/worker.ts'",
     "dev:test": "dotenv -e .env.local -- sh -c 'NODE_ENV=test tsx src/index.ts'",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -206,6 +206,22 @@ export class App {
   }
 
   private initializeMiddlewares(): void {
+
+    const apiPathPrefix = config.apiPathPrefix;
+    if (apiPathPrefix) {
+      this.app.use((req: Request, _res: Response, next: express.NextFunction): void => {
+        const url = req.url;
+        const isPrefixed =
+          url === apiPathPrefix ||
+          url.startsWith(`${apiPathPrefix}/`) ||
+          url.startsWith(`${apiPathPrefix}?`);
+        if (isPrefixed) {
+          req.url = `/api${url.slice(apiPathPrefix.length)}`;
+        }
+        next();
+      });
+    }
+
     // Security middleware
     this.app.use(helmet());
 

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -16,6 +16,9 @@ const envSchema = Joi.object({
   USE_MOCK_ANALYSIS: Joi.boolean().default(false),
   USE_MOCK_BUILD: Joi.boolean().default(false),
   PORT: Joi.number().default(3001),
+
+  // This is for making the backend API available under a prefix path (e.g. /api/v1) for reverse proxy setups. Empty string means no prefix.
+  API_PATH_PREFIX: Joi.string().allow('').default(''),
   HOST: Joi.string().default('localhost'),
   CORS_ORIGIN: Joi.string().default('http://localhost:3000'),
   ALLOWED_MEDIA_ORIGINS: Joi.string().default(
@@ -525,6 +528,10 @@ export const config = {
   // Email of the Digital Twin app's bot user (empty = twin delivery disabled).
   digitalTwinAppEmail: envVars.DIGITAL_TWIN_APP_EMAIL as string,
   port: envVars.PORT,
+  // Normalized to '/sdlc-api' form, or ''.
+  apiPathPrefix: (envVars.API_PATH_PREFIX as string)
+    ? `/${(envVars.API_PATH_PREFIX as string).trim().replace(/^\/+|\/+$/g, '')}`
+    : '',
   host: envVars.HOST,
   cors: {
     origin: envVars.CORS_ORIGIN.split(',')

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -51,3 +51,15 @@ VITE_SEARCH_VERSION = v1.0
 VITE_ELECTRON_BACKEND_URL=
 VITE_ELECTRON_ZERO_BACKEND_URL=
 VITE_SHAREABLE_ORIGIN=
+
+# --- SDLC fast lane ---------------------------------------------------------
+# Set only in the SDLC bundle's build; empty here keeps the main bundle unchanged.
+# Real values live in .env.sdlc. See docs/sdlc-fast-lane.md.
+VITE_XYNE_SURFACE=
+VITE_APP_BASE_PATH=
+# Replaces API_BASE_URL. Not VITE_API_BASE_URL above, which is the backend origin.
+VITE_API_BASE_OVERRIDE=
+VITE_ZERO_PATH=
+VITE_ZERO_STORAGE_KEY=
+VITE_SDLC_APP_BASE_PATH=
+VITE_DEV_PORT=

--- a/apps/dashboard/.env.sdlc
+++ b/apps/dashboard/.env.sdlc
@@ -1,0 +1,20 @@
+# SDLC fast lane — dashboard bundle. Loaded by `vite --mode sdlc`.
+# No secrets: this file is tracked. Machine overrides go in .env.sdlc.local.
+# See docs/sdlc-fast-lane.md.
+
+# Hides the app chrome so the bundle renders as a bare panel in the iframe.
+VITE_XYNE_SURFACE=sdlc
+
+# Router basename + Vite asset base. Trailing slash required.
+VITE_APP_BASE_PATH=/sdlc-app/
+
+# Replaces API_BASE_URL. Not VITE_API_BASE_URL — that means the backend origin.
+VITE_API_BASE_OVERRIDE=/sdlc-api
+
+VITE_ZERO_PATH=/sdlc-zero
+
+# MUST differ from the main bundle's, or the two Zero clients share one store.
+VITE_ZERO_STORAGE_KEY=sdlc
+
+# Dev only. Reached via http://localhost:5173/sdlc-app/, which proxies here.
+VITE_DEV_PORT=5175

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -48,7 +48,27 @@ ENV REACT_APP_SOURCE_COMMIT=$SOURCE_COMMIT
 
 # Accept build argument for API URL
 ENV VITE_API_URL=https://spaces.xyne.juspay.net/api
-ENV VITE_ZERO_SERVER=https://spaces.xyne.juspay.net/zero
+
+# --- Deployment lane -------------------------------------------------------
+# Defaults build the main bundle. The SDLC image adds:
+#   --build-arg BUILD_SCRIPT=build:sdlc --build-arg STATIC_SUBDIR=sdlc-app
+# Everything else comes from .env.sdlc via `vite build --mode sdlc`, including
+# VITE_ZERO_PATH.
+#
+# VITE_ZERO_SERVER is deliberately NOT set here. config.ts reads it when present,
+# and baking an absolute URL made it win over the serving host — a bundle on
+# app.spaces.xyne.juspay.net opened wss://spaces.xyne.juspay.net/zero. Unset, the
+# URL derives from whatever host serves the bundle. Local dev, sandbox and the
+# test compose file still set it themselves via their own .env files.
+ARG BUILD_SCRIPT=build
+
+# Only read by the main bundle; defaults to /sdlc-app in config.ts.
+ARG SDLC_APP_BASE_PATH=""
+ENV VITE_SDLC_APP_BASE_PATH=${SDLC_APP_BASE_PATH}
+
+# Subdirectory the assets are stored under, matching the base path they were
+# built with, so the edge needs no rewriting. Empty for the main bundle.
+ARG STATIC_SUBDIR=""
 
 # Mixpanel token (public client-side analytics; injected at build time)
 ARG VITE_MIXPANEL_TOKEN=""
@@ -65,7 +85,7 @@ ENV VITE_DEFAULT_WORKSPACE_ID=6642623f-cca7-43ad-9a6b-5e49c33226b4
 
 # Build the Vite React app with increased memory
 ENV NODE_OPTIONS="--max-old-space-size=8192"
-RUN pnpm --filter xyne-spaces-dashboard run build
+RUN pnpm --filter xyne-spaces-dashboard run ${BUILD_SCRIPT}
 
 # Create ZIP of the built assets for Electron OTA updates
 # The ZIP will be served at /releases/dashboard.zip
@@ -86,9 +106,12 @@ RUN addgroup --system --gid 1001 frontend && \
 # Copy nginx configuration as template for envsubst
 COPY --chown=frontend:frontend apps/dashboard/nginx.conf /etc/nginx/nginx.conf.template
 
+# Re-declare in the runner stage: ARGs do not cross stage boundaries.
+ARG STATIC_SUBDIR=""
+
 # Only the built assets cross into the runner, so the builder's workspace layout
 # does not matter here — no node_modules or symlinks are carried over.
-COPY --from=builder --chown=frontend:frontend /repo/apps/dashboard/dist /usr/share/nginx/html
+COPY --from=builder --chown=frontend:frontend /repo/apps/dashboard/dist /usr/share/nginx/html/${STATIC_SUBDIR}
 
 # Copy releases folder with dashboard.zip for Electron OTA updates
 COPY --from=builder --chown=frontend:frontend /repo/apps/dashboard/releases /usr/share/nginx/html/releases

--- a/apps/dashboard/nginx.conf
+++ b/apps/dashboard/nginx.conf
@@ -110,6 +110,22 @@ http {
 
         # LiveKit API endpoints (twirp RPC)
 
+        # SDLC lane SPA. Present only in the SDLC image (STATIC_SUBDIR=sdlc-app);
+        # in the main image the directory does not exist and these 404.
+        location = /sdlc-app/index.html {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            etag off;
+            if_modified_since off;
+            add_header Last-Modified "";
+        }
+
+        # Falls back to the SDLC bundle's own index.html, never the main one's.
+        location /sdlc-app/ {
+            try_files $uri $uri/ /sdlc-app/index.html;
+        }
+
         # Explicitly disable cache for index.html (SPA entry point)
         location = /index.html {
             add_header Cache-Control "no-cache, no-store, must-revalidate";

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -5,10 +5,12 @@
   "description": "Xyne Spaces - Workflow Automation Dashboard",
   "scripts": {
     "dev": "vite",
+    "dev:sdlc": "vite --mode sdlc",
     "dev:test": "vite --mode test",
     "claw:test": "VITE_SANDBOX_TEST_MODE=true vite --mode test",
     "dev:prod": "vite --mode prod-local",
     "build": "tsc --noEmit && vite build",
+    "build:sdlc": "tsc --noEmit && vite build --mode sdlc",
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:errors-only": "eslint . --quiet",

--- a/apps/dashboard/src/config.ts
+++ b/apps/dashboard/src/config.ts
@@ -25,9 +25,16 @@ const ELECTRON_BACKEND_ZERO_URL = isProd
 const isDockerTestEnv = isTestEnv && !isSandboxLocal;
 const backendPort = isLocalhost ? ':3001' : isDockerTestEnv ? ':5173' : '';
 
-export const API_BASE_URL = isElectronBundled
-  ? `${ELECTRON_BACKEND_URL}/api`
-  : `${protocol}://${hostname}${backendPort}/api`;
+// Replaces API_BASE_URL wholesale; the SDLC lane builds with '/sdlc-api'.
+// NOT named VITE_API_BASE_URL — that already means the backend origin with no
+// '/api' suffix, used as a vite proxy target.
+const apiBaseOverride = (import.meta.env['VITE_API_BASE_OVERRIDE'] as string | undefined) || '';
+
+export const API_BASE_URL =
+  apiBaseOverride ||
+  (isElectronBundled
+    ? `${ELECTRON_BACKEND_URL}/api`
+    : `${protocol}://${hostname}${backendPort}/api`);
 
 const zeroServerPort = isLocalhost ? ':4848' : isTestEnv ? ':4848' : '';
 export const APPS_PUBLIC_BASE_URL = isLocalhost
@@ -36,9 +43,17 @@ export const APPS_PUBLIC_BASE_URL = isLocalhost
     ? 'https://spaces.sandbox.xyne.juspay.net/api/apps'
     : 'https://spaces.xyne.juspay.net/api/apps';
 
-export const VITE_ZERO_SERVER = isElectronBundled
-  ? `${ELECTRON_BACKEND_ZERO_URL}/zero`
-  : `${protocol}://${hostname}${zeroServerPort}/zero`;
+// SDLC lane: same-origin path to its own zero-cache. Everything else derives from
+// the serving host. VITE_ZERO_SERVER is deliberately not read here — it is used
+// server-side (vite preview's /zero proxy, sandbox's traefik rule), and reading it
+// client-side let a baked absolute URL pin every host to one origin.
+const laneZeroPath = (import.meta.env['VITE_ZERO_PATH'] as string | undefined) || '';
+
+export const VITE_ZERO_SERVER = laneZeroPath
+  ? `${window.location.origin}${laneZeroPath}`
+  : isElectronBundled
+    ? `${ELECTRON_BACKEND_ZERO_URL}/zero`
+    : `${protocol}://${hostname}${zeroServerPort}/zero`;
 
 // OpenTelemetry
 const otelHost = isDockerTestEnv ? 'otel-collector' : hostname;
@@ -85,3 +100,28 @@ export const ENABLE_SUMMARY_ACTION_BUTTON: boolean =
 // Set VITE_DEFAULT_WORKSPACE_ID in .env.local to the default workspace ID.
 export const DEFAULT_WORKSPACE_ID: string =
   (import.meta.env['VITE_DEFAULT_WORKSPACE_ID'] as string) ?? '';
+
+// Deployment lane. The same source builds a second 'sdlc' bundle served at
+// '/sdlc-app/' with its own backend and zero-cache. Inert when VITE_XYNE_SURFACE
+// is unset. See docs/sdlc-fast-lane.md.
+
+export type XyneSurface = 'main' | 'sdlc';
+
+export const XYNE_SURFACE: XyneSurface =
+  (import.meta.env['VITE_XYNE_SURFACE'] as string) === 'sdlc' ? 'sdlc' : 'main';
+
+export const isSdlcSurface = XYNE_SURFACE === 'sdlc';
+
+// Router basename; vite.config.ts reads the same var for `base`. No trailing
+// slash, which is what react-router expects.
+export const APP_BASE_PATH: string = (
+  (import.meta.env['VITE_APP_BASE_PATH'] as string) || '/'
+).replace(/\/+$/, '');
+
+// Where the main bundle points its iframe.
+export const SDLC_APP_BASE_PATH: string =
+  (import.meta.env['VITE_SDLC_APP_BASE_PATH'] as string) || '/sdlc-app';
+
+// Gives this bundle its own Zero IndexedDB so two clients on one origin do not
+// share a store. Empty = single lane, unchanged behaviour.
+export const ZERO_STORAGE_KEY: string = (import.meta.env['VITE_ZERO_STORAGE_KEY'] as string) || '';

--- a/apps/dashboard/src/machines/authMachine.ts
+++ b/apps/dashboard/src/machines/authMachine.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import { reactNativeBridge } from '../utils/reactNativeBridge';
 import { mixpanelService, EVENTS, EVENT_PROPERTIES } from '../services/Analytics/mixpanelService';
-import { API_BASE_URL, isTestEnv } from '../config';
+import { API_BASE_URL, isSdlcSurface, isTestEnv } from '../config';
 import { logger } from '../utils/logger';
 import {
   CommunityJoinResultStatus,
@@ -19,7 +19,7 @@ import { indexedDBService } from '../services/indexedDBService';
 import { resetEncryption } from './encryptionMachine';
 import { decryptionCache } from '@xyne/shared';
 import { resetGlobalEncryptionBootstrap } from '@xyne/shared/hooks';
-import { dropAllDatabases } from '@rocicorp/zero';
+import { dropAllZeroDatabases, dropZeroDatabases } from '../zero/dropZeroDatabases';
 
 export interface User {
   id: string;
@@ -1338,7 +1338,9 @@ export const authMachine = createMachine(
           /* empty */
         }
 
-        await dropAllDatabases();
+        // Logout is the one place a cross-lane drop is right: both bundles are going
+        // away. The lane must not take out its host's store, so it only drops its own.
+        await (isSdlcSurface ? dropZeroDatabases() : dropAllZeroDatabases());
         await indexedDBService.dropAllUserDatabases();
       }),
       processOAuthCallback: fromPromise(async () => {

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -23,7 +23,7 @@ import { API_BASE_URL } from '../config';
 import { v4 as uuidv4 } from 'uuid';
 import { mixpanelService } from '../services/Analytics/mixpanelService';
 import { EVENTS, EVENT_PROPERTIES } from '../services/Analytics/mixpanel.types';
-import { dropAllDatabases } from '@rocicorp/zero';
+import { dropZeroDatabases } from '../zero/dropZeroDatabases';
 import { clearAuthTokens } from '../services/clients/apiClient';
 import { logger, Event as LoggerEvent } from '../utils/logger';
 import { useZeroConnectionLogger } from '../services/zeroConnectionLogger';
@@ -213,8 +213,8 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
         sessionDuration: Date.now() - (window.performance?.timing?.navigationStart || 0),
       });
 
-      // Clear Zero's local databases
-      void dropAllDatabases();
+      // Clear this lane's Zero local databases
+      void dropZeroDatabases();
 
       // Clear all cookies and auth tokens (handles Electron + Web)
       clearAuthTokens();

--- a/apps/dashboard/src/providers/ZeroProvider.tsx
+++ b/apps/dashboard/src/providers/ZeroProvider.tsx
@@ -1,10 +1,11 @@
 import { ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
 import { ZeroProvider as ZeroReactProvider } from '@rocicorp/zero/react';
-import { dropAllDatabases, UpdateNeededReason, Zero } from '@rocicorp/zero';
+import { UpdateNeededReason, Zero } from '@rocicorp/zero';
 import { useAuth } from './AuthProvider';
 import { mutators } from '../zero/mutators';
 import { schema } from '@xyne/shared';
-import { VITE_ZERO_SERVER } from '../config';
+import { VITE_ZERO_SERVER, ZERO_STORAGE_KEY } from '../config';
+import { dropZeroDatabases, rememberZeroLane } from '../zero/dropZeroDatabases';
 import { createBatchViewUpdatesWithMetrics } from '../services/otel';
 import { useSelector } from '@xstate/react';
 import { stateMachineActor } from '../machines/stateMachine';
@@ -35,7 +36,7 @@ const ZeroProvider: React.FC<ZeroProviderProps> = ({ children }): ReactElement |
       if (reason.type === 'SchemaVersionNotSupported' || reason.type === 'VersionNotSupported') {
         isRefreshing.current = true;
         try {
-          await dropAllDatabases();
+          await dropZeroDatabases();
         } catch {
           // Ignore errors during drop
         }
@@ -57,10 +58,11 @@ const ZeroProvider: React.FC<ZeroProviderProps> = ({ children }): ReactElement |
     prevWorkspaceIdRef.current = currentWorkspaceId;
 
     const initZero = async (): Promise<void> => {
-      // If workspaceId changed, drop all local databases to prevent stale cross-workspace cache
+      // If workspaceId changed, drop this lane's local databases to prevent stale
+      // cross-workspace cache. Scoped so a sibling bundle on the same origin keeps its own.
       if (prevWorkspaceId !== undefined && prevWorkspaceId !== currentWorkspaceId) {
         try {
-          await dropAllDatabases();
+          await dropZeroDatabases();
         } catch {
           // Ignore errors during drop
         }
@@ -70,6 +72,8 @@ const ZeroProvider: React.FC<ZeroProviderProps> = ({ children }): ReactElement |
         userID: user.id,
         auth: authFunction,
         server: VITE_ZERO_SERVER,
+        // Empty in single-lane builds, which keeps the storage name unchanged.
+        ...(ZERO_STORAGE_KEY ? { storageKey: ZERO_STORAGE_KEY } : {}),
         pingTimeoutMs: 10000,
         schema,
         mutators: mutators,
@@ -88,6 +92,10 @@ const ZeroProvider: React.FC<ZeroProviderProps> = ({ children }): ReactElement |
         },
         onClientStateNotFound: handleClientStateNotFound,
       });
+
+      // Cache which lane this document's Zero storage belongs to, so a later
+      // logout can scope its drop after the client has been torn down.
+      rememberZeroLane(zeroObj.idbName);
 
       setZero(prev => {
         void prev?.close();

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -49,6 +49,11 @@ import UserGroupsScreen from './UserGroupsScreen/UserGroupsScreen';
 import ProjectDetailScreen from './ProjectDetailScreen/ProjectDetailScreen';
 import SdlcScreen from './SdlcScreen/SdlcScreen';
 import { SdlcDebuggerPanel } from './SdlcScreen/SdlcDebuggerPanel';
+import { APP_BASE_PATH, isSdlcSurface } from '../config';
+import SdlcFrameHost from './SdlcScreen/SdlcFrameHost';
+import SdlcFrameViewport from './SdlcScreen/SdlcFrameViewport';
+import { SdlcFrameProvider } from './SdlcScreen/SdlcFrameContext';
+import { useSdlcFrameBridge } from './SdlcScreen/useSdlcFrameBridge';
 import ReleaseDetailScreen from './ReleaseDetailScreen/ReleaseDetailScreen';
 
 import KanbanBoardScreen from './KanbanBoardScreen/KanbanBoardScreen';
@@ -424,7 +429,11 @@ const AppRoot = (): ReactElement => {
   const xyneAIAutoSendNonce = useSelector(xyneAIActor, state => state.context.autoSendNonce);
   const isSdlcDebuggerOpen = useExternalDebuggerStore(state => state.target !== null);
   const { isMobile } = usePlatform();
-  const isInPanelWebview = useIsInPanelWebview();
+  // No-op outside the SDLC bundle's framed instance.
+  useSdlcFrameBridge();
+
+  // The SDLC bundle wants the same chromeless layout as the browser panel.
+  const isInPanelWebview = useIsInPanelWebview() || isSdlcSurface;
 
   // Get current location to check if we're on onboarding
   const location = useLocation();
@@ -601,298 +610,305 @@ const AppRoot = (): ReactElement => {
                 <SlashCommandArtifactSideEffectProvider>
                   {!isInPanelWebview && <SlashCommandArtifactBanner />}
                   <EditProvider>
-                    {shouldShowMobileHeader && externalId && (
-                      <MobileCallHeader
-                        participants={participants}
-                        activeCalls={activeCalls}
-                        externalId={externalId}
-                        isMicEnabled={isMicEnabled}
-                        onToggleMic={() => roomActor.send({ type: 'TOGGLE_MIC' })}
-                        onDisconnect={() => roomActor.send({ type: 'DISCONNECT' })}
-                        onExpand={() => roomActor.send({ type: 'TOGGLE_VIEW' })}
-                      />
-                    )}
-                    {isInPanelWebview ? (
-                      // Inside the browser-panel webview — render only the route
-                      // content. No GlobalTopBar / AppSidebar / right panels /
-                      // ChatDirectory; see useIsInPanelWebview and the doc there.
-                      <main className='flex-1 h-screen'>
-                        <EditWarningModal />
-                        <Outlet />
-                      </main>
-                    ) : isOnboarding ? (
-                      // Onboarding screen - full width without sidebar
-                      <main
-                        className={`flex-1 h-screen ${shouldShowMobileHeader ? 'pt-[60px]' : ''}`}
-                      >
-                        <EditWarningModal />
-                        <Outlet />
-                      </main>
-                    ) : showXyneAIPanel ||
-                      showSdlcDebuggerPanel ||
-                      browserPanelState === 'open' ||
-                      webviewState === 'closed' ||
-                      webviewState === 'idle' ? (
-                      <div className='flex flex-col h-screen'>
-                        <ResizableGroup
-                          orientation='horizontal'
-                          className='flex-1 no-scrollbar overflow-auto'
-                          autoSaveId='app-root-browser'
-                          panelIds={
-                            showSdlcDebuggerPanel
-                              ? ['app-root-left', 'app-root-sdlc-debugger']
-                              : showXyneAIPanel
-                                ? ['app-root-left', 'app-root-xyneai']
-                                : showBrowserPanel
-                                  ? ['app-root-left', 'app-root-browser']
-                                  : ['app-root-left']
-                          }
+                    {/* Above the layout branches, so leaving /sdlc hides the frame
+                      rather than destroying it. */}
+                    <SdlcFrameProvider>
+                      {!isSdlcSurface && <SdlcFrameHost />}
+                      {shouldShowMobileHeader && externalId && (
+                        <MobileCallHeader
+                          participants={participants}
+                          activeCalls={activeCalls}
+                          externalId={externalId}
+                          isMicEnabled={isMicEnabled}
+                          onToggleMic={() => roomActor.send({ type: 'TOGGLE_MIC' })}
+                          onDisconnect={() => roomActor.send({ type: 'DISCONNECT' })}
+                          onExpand={() => roomActor.send({ type: 'TOGGLE_VIEW' })}
+                        />
+                      )}
+                      {isInPanelWebview ? (
+                        // Inside the browser-panel webview — render only the route
+                        // content. No GlobalTopBar / AppSidebar / right panels /
+                        // ChatDirectory; see useIsInPanelWebview and the doc there.
+                        <main className='flex-1 h-screen'>
+                          <EditWarningModal />
+                          <Outlet />
+                        </main>
+                      ) : isOnboarding ? (
+                        // Onboarding screen - full width without sidebar
+                        <main
+                          className={`flex-1 h-screen ${shouldShowMobileHeader ? 'pt-[60px]' : ''}`}
                         >
-                          <Panel
-                            id='app-root-left'
-                            panelRef={browserPanelLeftRef}
-                            defaultSize={
-                              showXyneAIPanel
-                                ? `${100 - XYNE_AI_PANEL_DEFAULT_SIZE}%`
-                                : showSdlcDebuggerPanel || showBrowserPanel
-                                  ? '65%'
-                                  : '100%'
+                          <EditWarningModal />
+                          <Outlet />
+                        </main>
+                      ) : showXyneAIPanel ||
+                        showSdlcDebuggerPanel ||
+                        browserPanelState === 'open' ||
+                        webviewState === 'closed' ||
+                        webviewState === 'idle' ? (
+                        <div className='flex flex-col h-screen'>
+                          <ResizableGroup
+                            orientation='horizontal'
+                            className='flex-1 no-scrollbar overflow-auto'
+                            autoSaveId='app-root-browser'
+                            panelIds={
+                              showSdlcDebuggerPanel
+                                ? ['app-root-left', 'app-root-sdlc-debugger']
+                                : showXyneAIPanel
+                                  ? ['app-root-left', 'app-root-xyneai']
+                                  : showBrowserPanel
+                                    ? ['app-root-left', 'app-root-browser']
+                                    : ['app-root-left']
                             }
                           >
-                            <div
-                              className={`flex h-full ${shouldShowMobileHeader ? 'pt-[60px]' : ''}`}
+                            <Panel
+                              id='app-root-left'
+                              panelRef={browserPanelLeftRef}
+                              defaultSize={
+                                showXyneAIPanel
+                                  ? `${100 - XYNE_AI_PANEL_DEFAULT_SIZE}%`
+                                  : showSdlcDebuggerPanel || showBrowserPanel
+                                    ? '65%'
+                                    : '100%'
+                              }
                             >
-                              <AppSidebar />
-                              <main className='flex-1 no-scrollbar overflow-auto'>
-                                <EditWarningModal />
-                                <Outlet />
-                              </main>
-                            </div>
-                          </Panel>
-                          {showSdlcDebuggerPanel ? (
-                            <>
-                              <Separator className='w-[2px] transition-colors cursor-col-resize flex items-center justify-center group'>
-                                <div
-                                  id='panel-resize-divider'
-                                  className='w-[2px] h-full bg-transparent group-hover:bg-primary group-active:bg-primary'
-                                ></div>
-                              </Separator>
-                              <Panel
-                                id='app-root-sdlc-debugger'
-                                defaultSize='35%'
-                                minSize='30%'
-                                maxSize='55%'
+                              <div
+                                className={`flex h-full ${shouldShowMobileHeader ? 'pt-[60px]' : ''}`}
                               >
-                                <SdlcDebuggerPanel />
-                              </Panel>
-                            </>
-                          ) : showXyneAIPanel ? (
-                            <>
-                              <Separator className='w-[2px] transition-colors cursor-col-resize flex items-center justify-center group'>
-                                <div
-                                  id='panel-resize-divider'
-                                  className='w-[2px] h-full bg-transparent group-hover:bg-primary group-active:bg-primary'
-                                ></div>
-                              </Separator>
-                              <Panel
-                                id='app-root-xyneai'
-                                panelRef={xyneAIRightPanelRef}
-                                defaultSize={`${XYNE_AI_PANEL_DEFAULT_SIZE}%`}
-                                maxSize={isXyneDebuggerOpen ? '55%' : '50%'}
-                                minSize={isXyneDebuggerOpen ? `${XYNE_AI_PANEL_MIN_SIZE}%` : '25%'}
-                              >
-                                <XyneAISidebarZIndexShell>
-                                  <XyneAISidebar
-                                    channelId={xyneAIChannelId}
-                                    threadInfo={xyneAIThreadInfo}
-                                    startFreshChat={xyneAIStartFreshChat}
-                                    canvasInfo={xyneAICanvasInfo}
-                                    initialContextSelections={xyneAIInitialContextSelections}
-                                    contextOpenNonce={xyneAIContextOpenNonce}
-                                    kbCollectionId={xyneAIKbCollectionId ?? ''}
-                                    kbChannelId={xyneAIKbChannelId ?? ''}
-                                    kbDocId={xyneAIKbDocId ?? ''}
-                                    kbDocName={xyneAIKbDocName ?? ''}
-                                    kbOpenNonce={xyneAIKbOpenNonce}
-                                    researchContext={xyneAIResearchContext}
-                                    initialQuery={xyneAIInitialQuery ?? undefined}
-                                    autoSendNonce={xyneAIAutoSendNonce}
-                                    onDebuggerOpenChange={setIsXyneDebuggerOpen}
-                                  />
-                                </XyneAISidebarZIndexShell>
-                              </Panel>
-                            </>
-                          ) : (
-                            showBrowserPanel && (
+                                <AppSidebar />
+                                <main className='flex-1 no-scrollbar overflow-auto'>
+                                  <EditWarningModal />
+                                  <Outlet />
+                                </main>
+                              </div>
+                            </Panel>
+                            {showSdlcDebuggerPanel ? (
                               <>
-                                <Separator className='w-1 hover:bg-sidebar-divider active:bg-sidebar-divider transition-colors duration-200 cursor-col-resize flex items-center justify-center group'>
-                                  <div className='w-0.5 h-8 bg-transparent group-hover:bg-sidebar-divider group-active:bg-sidebar-divider transition-colors duration-200 rounded-full'></div>
+                                <Separator className='w-[2px] transition-colors cursor-col-resize flex items-center justify-center group'>
+                                  <div
+                                    id='panel-resize-divider'
+                                    className='w-[2px] h-full bg-transparent group-hover:bg-primary group-active:bg-primary'
+                                  ></div>
                                 </Separator>
                                 <Panel
-                                  id='app-root-browser'
-                                  panelRef={browserPanelRightRef}
+                                  id='app-root-sdlc-debugger'
                                   defaultSize='35%'
-                                  maxSize='50%'
+                                  minSize='30%'
+                                  maxSize='55%'
                                 >
-                                  <div className='h-full'>
-                                    <BrowserPanel />
-                                  </div>
+                                  <SdlcDebuggerPanel />
                                 </Panel>
                               </>
-                            )
-                          )}
-                        </ResizableGroup>
-                      </div>
-                    ) : (
-                      // WebView is open - show panel layout with WebView
-                      <div className='flex flex-col h-screen'>
-                        <ResizableGroup
-                          orientation='horizontal'
-                          className='flex-1 overflow-hidden'
-                          autoSaveId='app-root'
-                        >
-                          <Panel id='app-root-left' panelRef={leftPanelRef} defaultSize='50%'>
-                            <div
-                              className={`flex h-full ${shouldShowMobileHeader ? 'pt-[60px]' : ''}`}
-                            >
-                              <AppSidebar />
-                              <main className='flex-1 no-scrollbar overflow-auto'>
-                                <EditWarningModal />
-                                <Outlet />
-                              </main>
-                            </div>
-                          </Panel>
-                          <Separator className='w-2 hover:bg-sidebar-divider active:bg-sidebar-divider transition-colors duration-200 cursor-col-resize flex items-center justify-center group'>
-                            <div className='w-0.5 h-8 bg-transparent group-hover:bg-sidebar-divider group-active:bg-sidebar-divider transition-colors duration-200 rounded-full'></div>
-                          </Separator>
-                          <Panel id='app-root-webview' panelRef={rightPanelRef} defaultSize='50%'>
-                            <WebView />
-                          </Panel>
-                        </ResizableGroup>
-                      </div>
-                    )}
-                    {/* Global overlays and IPC handlers — skipped in the panel
+                            ) : showXyneAIPanel ? (
+                              <>
+                                <Separator className='w-[2px] transition-colors cursor-col-resize flex items-center justify-center group'>
+                                  <div
+                                    id='panel-resize-divider'
+                                    className='w-[2px] h-full bg-transparent group-hover:bg-primary group-active:bg-primary'
+                                  ></div>
+                                </Separator>
+                                <Panel
+                                  id='app-root-xyneai'
+                                  panelRef={xyneAIRightPanelRef}
+                                  defaultSize={`${XYNE_AI_PANEL_DEFAULT_SIZE}%`}
+                                  maxSize={isXyneDebuggerOpen ? '55%' : '50%'}
+                                  minSize={
+                                    isXyneDebuggerOpen ? `${XYNE_AI_PANEL_MIN_SIZE}%` : '25%'
+                                  }
+                                >
+                                  <XyneAISidebarZIndexShell>
+                                    <XyneAISidebar
+                                      channelId={xyneAIChannelId}
+                                      threadInfo={xyneAIThreadInfo}
+                                      startFreshChat={xyneAIStartFreshChat}
+                                      canvasInfo={xyneAICanvasInfo}
+                                      initialContextSelections={xyneAIInitialContextSelections}
+                                      contextOpenNonce={xyneAIContextOpenNonce}
+                                      kbCollectionId={xyneAIKbCollectionId ?? ''}
+                                      kbChannelId={xyneAIKbChannelId ?? ''}
+                                      kbDocId={xyneAIKbDocId ?? ''}
+                                      kbDocName={xyneAIKbDocName ?? ''}
+                                      kbOpenNonce={xyneAIKbOpenNonce}
+                                      researchContext={xyneAIResearchContext}
+                                      initialQuery={xyneAIInitialQuery ?? undefined}
+                                      autoSendNonce={xyneAIAutoSendNonce}
+                                      onDebuggerOpenChange={setIsXyneDebuggerOpen}
+                                    />
+                                  </XyneAISidebarZIndexShell>
+                                </Panel>
+                              </>
+                            ) : (
+                              showBrowserPanel && (
+                                <>
+                                  <Separator className='w-1 hover:bg-sidebar-divider active:bg-sidebar-divider transition-colors duration-200 cursor-col-resize flex items-center justify-center group'>
+                                    <div className='w-0.5 h-8 bg-transparent group-hover:bg-sidebar-divider group-active:bg-sidebar-divider transition-colors duration-200 rounded-full'></div>
+                                  </Separator>
+                                  <Panel
+                                    id='app-root-browser'
+                                    panelRef={browserPanelRightRef}
+                                    defaultSize='35%'
+                                    maxSize='50%'
+                                  >
+                                    <div className='h-full'>
+                                      <BrowserPanel />
+                                    </div>
+                                  </Panel>
+                                </>
+                              )
+                            )}
+                          </ResizableGroup>
+                        </div>
+                      ) : (
+                        // WebView is open - show panel layout with WebView
+                        <div className='flex flex-col h-screen'>
+                          <ResizableGroup
+                            orientation='horizontal'
+                            className='flex-1 overflow-hidden'
+                            autoSaveId='app-root'
+                          >
+                            <Panel id='app-root-left' panelRef={leftPanelRef} defaultSize='50%'>
+                              <div
+                                className={`flex h-full ${shouldShowMobileHeader ? 'pt-[60px]' : ''}`}
+                              >
+                                <AppSidebar />
+                                <main className='flex-1 no-scrollbar overflow-auto'>
+                                  <EditWarningModal />
+                                  <Outlet />
+                                </main>
+                              </div>
+                            </Panel>
+                            <Separator className='w-2 hover:bg-sidebar-divider active:bg-sidebar-divider transition-colors duration-200 cursor-col-resize flex items-center justify-center group'>
+                              <div className='w-0.5 h-8 bg-transparent group-hover:bg-sidebar-divider group-active:bg-sidebar-divider transition-colors duration-200 rounded-full'></div>
+                            </Separator>
+                            <Panel id='app-root-webview' panelRef={rightPanelRef} defaultSize='50%'>
+                              <WebView />
+                            </Panel>
+                          </ResizableGroup>
+                        </div>
+                      )}
+                      {/* Global overlays and IPC handlers — skipped in the panel
                     webview (we don't want nested CMDK, nested browser panel,
                     duplicated call UIs, etc. inside the embedded view).
                     AttachmentGalleryModal stays because it's triggered by
                     attachments inside the conversation itself. */}
-                    {!isInPanelWebview && (
-                      <>
-                        <IncomingCallModal />
-                        {import.meta.env.DEV &&
-                          new URLSearchParams(window.location.search).has('devIncomingCall') && (
-                            <IncomingCallDevHarness />
+                      {!isInPanelWebview && (
+                        <>
+                          <IncomingCallModal />
+                          {import.meta.env.DEV &&
+                            new URLSearchParams(window.location.search).has('devIncomingCall') && (
+                              <IncomingCallDevHarness />
+                            )}
+                          <GlobalCallOverlay />
+                          {recordingVersion === 'v2' ? (
+                            <NoteTakerOverlayHost />
+                          ) : (
+                            <RecordingOverlay />
                           )}
-                        <GlobalCallOverlay />
-                        {recordingVersion === 'v2' ? (
-                          <NoteTakerOverlayHost />
-                        ) : (
-                          <RecordingOverlay />
-                        )}
-                        <GlobalUploadProgress />
-                        <NotificationHandler />
-                        <ElectronBadgeSync />
-                        <ElectronUpdateNudge />
-                        <SosAlertBanner />
-                        <CallFromRecentsHandler />
-                        <CloudAgentFloatingHost />
-                        <BrowserPanelHandler />
-                        <GlobalCommandMenu />
-                        <ShortcutsHelpModal
-                          isOpen={isShortcutsModalOpen}
-                          onClose={() => setIsShortcutsModalOpen(false)}
-                        />
-                      </>
-                    )}
-                    <AttachmentGalleryModal />
-                    <ThreadCitationModal />
-                    <TranscriptCitationModal />
-                    <AttachmentCitationPreview />
-                    <ErrorReportModal
-                      isOpen={isErrorReportOpen}
-                      onClose={() => setIsErrorReportOpen(false)}
-                      pendingRecording={pendingRecording}
-                      pendingRecordingFilePath={pendingRecordingFilePath}
-                      onSourceSelected={(source: ScreenSource, withMic: boolean) =>
-                        void startRecording(source, withMic)
-                      }
-                      onSubmitSuccess={() => {
-                        setPendingRecording(null);
-                        setPendingRecordingFilePath(null);
-                      }}
-                      onDiscard={() => {
-                        setPendingRecording(null);
-                        setPendingRecordingFilePath(null);
-                      }}
-                    />
+                          <GlobalUploadProgress />
+                          <NotificationHandler />
+                          <ElectronBadgeSync />
+                          <ElectronUpdateNudge />
+                          <SosAlertBanner />
+                          <CallFromRecentsHandler />
+                          <CloudAgentFloatingHost />
+                          <BrowserPanelHandler />
+                          <GlobalCommandMenu />
+                          <ShortcutsHelpModal
+                            isOpen={isShortcutsModalOpen}
+                            onClose={() => setIsShortcutsModalOpen(false)}
+                          />
+                        </>
+                      )}
+                      <AttachmentGalleryModal />
+                      <ThreadCitationModal />
+                      <TranscriptCitationModal />
+                      <AttachmentCitationPreview />
+                      <ErrorReportModal
+                        isOpen={isErrorReportOpen}
+                        onClose={() => setIsErrorReportOpen(false)}
+                        pendingRecording={pendingRecording}
+                        pendingRecordingFilePath={pendingRecordingFilePath}
+                        onSourceSelected={(source: ScreenSource, withMic: boolean) =>
+                          void startRecording(source, withMic)
+                        }
+                        onSubmitSuccess={() => {
+                          setPendingRecording(null);
+                          setPendingRecordingFilePath(null);
+                        }}
+                        onDiscard={() => {
+                          setPendingRecording(null);
+                          setPendingRecordingFilePath(null);
+                        }}
+                      />
 
-                    {!isXyneAIDrawerOpen && hasXyneAIStreaming && (
-                      <div className='hidden' aria-hidden='true'>
-                        <XyneAISidebar
-                          channelId={xyneAIChannelId}
-                          threadInfo={xyneAIThreadInfo}
-                          startFreshChat={xyneAIStartFreshChat}
-                          canvasInfo={xyneAICanvasInfo}
-                          initialContextSelections={xyneAIInitialContextSelections}
-                          contextOpenNonce={xyneAIContextOpenNonce}
-                          kbCollectionId={xyneAIKbCollectionId ?? ''}
-                          kbChannelId={xyneAIKbChannelId ?? ''}
-                          kbDocId={xyneAIKbDocId ?? ''}
-                          kbDocName={xyneAIKbDocName ?? ''}
-                          kbOpenNonce={xyneAIKbOpenNonce}
-                          researchContext={xyneAIResearchContext}
-                          initialQuery={xyneAIInitialQuery ?? undefined}
-                          autoSendNonce={xyneAIAutoSendNonce}
-                          onDebuggerOpenChange={setIsXyneDebuggerOpen}
-                          visible={false}
-                        />
-                      </div>
-                    )}
-                    {/* XyneAI Mobile Drawer */}
-                    {isMobile && !isInPanelWebview && !isOnAIPage && (
-                      <Drawer
-                        open={isXyneAIDrawerOpen}
-                        onOpenChange={open => {
-                          // Don't allow closing during AI onboarding
-                          if (!open && isAIOnboardingActive()) return;
-                          xyneAIActor.send({ type: open ? 'OPEN' : 'CLOSE' });
-                        }}
-                        title='Xyne AI'
-                        description='Ask questions about your channel'
-                      >
-                        <XyneAISidebar
-                          channelId={xyneAIChannelId}
-                          threadInfo={xyneAIThreadInfo}
-                          startFreshChat={xyneAIStartFreshChat}
-                          canvasInfo={xyneAICanvasInfo}
-                          initialContextSelections={xyneAIInitialContextSelections}
-                          contextOpenNonce={xyneAIContextOpenNonce}
-                          kbCollectionId={xyneAIKbCollectionId ?? ''}
-                          kbChannelId={xyneAIKbChannelId ?? ''}
-                          kbDocId={xyneAIKbDocId ?? ''}
-                          kbDocName={xyneAIKbDocName ?? ''}
-                          kbOpenNonce={xyneAIKbOpenNonce}
-                          researchContext={xyneAIResearchContext}
-                          initialQuery={xyneAIInitialQuery ?? undefined}
-                          autoSendNonce={xyneAIAutoSendNonce}
-                          onDebuggerOpenChange={setIsXyneDebuggerOpen}
-                        />
-                      </Drawer>
-                    )}
-                    {isMobile && !isInPanelWebview && (
-                      <Drawer
-                        open={isSdlcDebuggerOpen}
-                        onOpenChange={open => {
-                          if (!open) useExternalDebuggerStore.getState().close();
-                        }}
-                        title='Debugger'
-                        description='Inspect this SDLC run'
-                      >
-                        <div className='h-[85vh]'>
-                          <SdlcDebuggerPanel />
+                      {!isXyneAIDrawerOpen && hasXyneAIStreaming && (
+                        <div className='hidden' aria-hidden='true'>
+                          <XyneAISidebar
+                            channelId={xyneAIChannelId}
+                            threadInfo={xyneAIThreadInfo}
+                            startFreshChat={xyneAIStartFreshChat}
+                            canvasInfo={xyneAICanvasInfo}
+                            initialContextSelections={xyneAIInitialContextSelections}
+                            contextOpenNonce={xyneAIContextOpenNonce}
+                            kbCollectionId={xyneAIKbCollectionId ?? ''}
+                            kbChannelId={xyneAIKbChannelId ?? ''}
+                            kbDocId={xyneAIKbDocId ?? ''}
+                            kbDocName={xyneAIKbDocName ?? ''}
+                            kbOpenNonce={xyneAIKbOpenNonce}
+                            researchContext={xyneAIResearchContext}
+                            initialQuery={xyneAIInitialQuery ?? undefined}
+                            autoSendNonce={xyneAIAutoSendNonce}
+                            onDebuggerOpenChange={setIsXyneDebuggerOpen}
+                            visible={false}
+                          />
                         </div>
-                      </Drawer>
-                    )}
+                      )}
+                      {/* XyneAI Mobile Drawer */}
+                      {isMobile && !isInPanelWebview && !isOnAIPage && (
+                        <Drawer
+                          open={isXyneAIDrawerOpen}
+                          onOpenChange={open => {
+                            // Don't allow closing during AI onboarding
+                            if (!open && isAIOnboardingActive()) return;
+                            xyneAIActor.send({ type: open ? 'OPEN' : 'CLOSE' });
+                          }}
+                          title='Xyne AI'
+                          description='Ask questions about your channel'
+                        >
+                          <XyneAISidebar
+                            channelId={xyneAIChannelId}
+                            threadInfo={xyneAIThreadInfo}
+                            startFreshChat={xyneAIStartFreshChat}
+                            canvasInfo={xyneAICanvasInfo}
+                            initialContextSelections={xyneAIInitialContextSelections}
+                            contextOpenNonce={xyneAIContextOpenNonce}
+                            kbCollectionId={xyneAIKbCollectionId ?? ''}
+                            kbChannelId={xyneAIKbChannelId ?? ''}
+                            kbDocId={xyneAIKbDocId ?? ''}
+                            kbDocName={xyneAIKbDocName ?? ''}
+                            kbOpenNonce={xyneAIKbOpenNonce}
+                            researchContext={xyneAIResearchContext}
+                            initialQuery={xyneAIInitialQuery ?? undefined}
+                            autoSendNonce={xyneAIAutoSendNonce}
+                            onDebuggerOpenChange={setIsXyneDebuggerOpen}
+                          />
+                        </Drawer>
+                      )}
+                      {isMobile && !isInPanelWebview && (
+                        <Drawer
+                          open={isSdlcDebuggerOpen}
+                          onOpenChange={open => {
+                            if (!open) useExternalDebuggerStore.getState().close();
+                          }}
+                          title='Debugger'
+                          description='Inspect this SDLC run'
+                        >
+                          <div className='h-[85vh]'>
+                            <SdlcDebuggerPanel />
+                          </div>
+                        </Drawer>
+                      )}
+                    </SdlcFrameProvider>
                   </EditProvider>
                 </SlashCommandArtifactSideEffectProvider>
               </AIOnboardingProvider>
@@ -904,839 +920,847 @@ const AppRoot = (): ReactElement => {
   );
 };
 
-export const router = createBrowserRouter([
-  {
-    element: <ProtectedRoute />,
-    errorElement: <RouterErrorFallback />,
-    children: [
-      {
-        path: '/newWindow/claw',
-        element: <ClawOverlay />,
-      },
-    ],
-  },
-  {
-    element: <SplashScreen />,
-    errorElement: <RouterErrorFallback />,
-    children: [
-      {
-        path: '/',
-        element: <ProtectedRoute />,
-        children: [
-          {
-            index: true,
-            element: <WorkspaceRedirect />,
-          },
-          {
-            path: ':workspaceId',
-            element: <AppRoot />,
-            children: [
-              {
-                index: true,
-                element: <HomeScreen />,
-              },
-              {
-                path: 'ai',
-                children: [
-                  { index: true, element: <Navigate to='chat/new' replace /> },
-                  { path: 'chat/new', element: <AIScreen /> },
-                  { path: 'daily-brief', element: <AIDailyBriefScreen /> },
-                  { path: 'daily-brief/:briefDate', element: <AIDailyBriefScreen /> },
-                  { path: 'library', element: <AILibraryScreen /> },
-                  {
-                    path: 'admin',
-                    element: (
-                      <RequireClawAdmin>
-                        <AIAdminScreen />
-                      </RequireClawAdmin>
-                    ),
-                  },
-                  { path: 'library/agent/create', element: <AIAgentCreateScreen /> },
-                  { path: 'library/subagent/create', element: <AISubagentCreateScreen /> },
-                  { path: 'library/skill/create', element: <AISkillCreateScreen /> },
-                  { path: 'library/agent/:slug/edit', element: <AIAgentEditScreen /> },
-                  { path: 'library/agent/:slug', element: <AIAgentDetailScreen /> },
-                  { path: 'library/subagent/:name/edit', element: <AISubagentEditScreen /> },
-                  { path: 'library/subagent/:name', element: <AISubagentDetailScreen /> },
-                  { path: 'library/skill/:slug', element: <AISkillDetailScreen /> },
-                  { path: 'library/mcp/:type', element: <AIMcpDetailScreen /> },
-                  { path: 'knowledge', element: <AIKnowledgeScreen /> },
-                  {
-                    path: 'organization',
-                    element: (
-                      <RequireOrgManager>
-                        <AIOrganizationScreen />
-                      </RequireOrgManager>
-                    ),
-                  },
-                  {
-                    element: <AISectionLayout />,
-                    children: [
-                      {
-                        path: 'digital-twin',
-                        element: <ClawDigitalTwinScreen />,
-                        children: [
-                          { index: true, element: <DigitalTwinMemoriesTab /> },
-                          { path: 'hot', element: <DigitalTwinHotTab /> },
-                          { path: 'proposals', element: <DigitalTwinProposalsTab /> },
-                          { path: 'recall', element: <DigitalTwinRecallTab /> },
-                          { path: 'graph', element: <DigitalTwinGraphTab /> },
-                          { path: 'metrics', element: <ClawDigitalTwinMetricsScreen /> },
-                          { path: 'settings', element: <DigitalTwinSettingsTab /> },
-                        ],
-                      },
-                      { path: 'metrics', element: <ClawMetricsScreen /> },
-                      { path: 'settings', element: <ClawSettingsScreen /> },
-                    ],
-                  },
-                ],
-              },
-              {
-                path: 'onboarding',
-                element: <QuestionnaireScreen />,
-              },
-              {
-                path: 'rca',
-                element: <RCAListScreen />,
-              },
-              {
-                path: 'rca/:rcaId',
-                element: <RCADetailScreen />,
-              },
-              {
-                path: 'chat',
-                element: <ChatScreen />,
-                children: [
-                  // Directory routes (nested under dir)
-                  {
-                    path: 'dir',
-                    children: [
-                      {
-                        index: true,
-                        element: <ChatRedirect />,
-                      },
-                      // Canvas from directory (must come before :channelId)
-                      {
-                        path: 'canvas',
-                        element: <CanvasScreen />,
-                      },
-                      {
-                        path: 'canvas/:canvasId',
-                        element: <CanvasScreen />,
-                      },
-                      // Threads (must come before :channelId)
-                      {
-                        path: 'threads',
-                        element: <UserThreads />,
-                        children: [
-                          { index: true, element: null },
-                          {
-                            path: ':channelId/:conversationId',
-                            element: <ThreadMessages />,
-                          },
-                        ],
-                      },
-                      // Unreads inbox (must come before :channelId)
-                      {
-                        path: 'unreads',
-                        element: <UnreadsInbox />,
-                      },
-                      // Recap (must come before :channelId)
-                      {
-                        path: 'recap',
-                        children: [
-                          {
-                            index: true,
-                            element: <RecapPanel />,
-                          },
-                          {
-                            path: ':channelId',
-                            element: <RecapPanel />,
-                            children: [
-                              {
-                                path: ':conversationId',
-                                element: <ThreadMessages />,
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      // My Tickets (must come before :channelId)
-                      {
-                        path: 'my-tickets',
-                        element: <MyTicketsScreen />,
-                      },
-                      // Channel routes (must come after specific routes)
-                      {
-                        path: ':channelId',
-                        element: <ChatView />,
-                        children: [
-                          {
-                            index: true,
-                            element: (
-                              <div className='flex items-center justify-center h-full text-muted-foreground'>
-                                Select a conversation to view messages
-                              </div>
-                            ),
-                          },
-                          {
-                            path: 'group/:groupId',
-                            element: <UserGroupSidePanel />,
-                          },
-                          {
-                            path: ':conversationId',
-                            element: <ThreadMessages />,
-                          },
-                          {
-                            path: ':conversationId/profile/:userId',
-                            element: <ProfileSidebar />,
-                          },
-                          {
-                            path: ':conversationId/:ticketId',
-                            element: <ThreadMessages />,
-                          },
-                          {
-                            path: 'profile/:userId',
-                            element: <ProfileSidebar />,
-                          },
-                          {
-                            path: 'tickets/:ticketId',
-                            element: <TicketView />,
-                          },
-                          {
-                            path: 'canvas',
-                            element: <CanvasScreen />,
-                          },
-                          {
-                            path: 'canvas/:canvasId',
-                            element: <CanvasScreen />,
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  // DM routes (full screen with DM list sidebar)
-                  {
-                    path: 'dm',
-                    element: <DmsPage />,
-                    children: [
-                      { index: true, element: null },
-                      { path: 'compose', element: <KeyedComposeDmPanel /> },
-                      ...sharedChatRoutes,
-                    ],
-                  },
-                  // Bookmarks (full screen with bookmarks list sidebar)
-                  {
-                    path: 'bookmarks',
-                    element: <BookmarksPanel />,
-                    children: [{ index: true, element: null }, ...sharedChatRoutes],
-                  },
-                  // Drafts & Sent combined page
-                  {
-                    path: 'drafts-sent',
-                    element: <DraftsAndSentPage />,
-                    children: [{ index: true, element: null }, ...sharedChatRoutes],
-                  },
-                  // Redirect old drafts route to new combined page
-                  {
-                    path: 'drafts',
-                    element: <Navigate to='../drafts-sent?tab=drafts' replace />,
-                    children: [{ index: true, element: null }, ...sharedChatRoutes],
-                  },
-                  // Redirect old sent route to new combined page
-                  {
-                    path: 'sent',
-                    element: <Navigate to='../drafts-sent?tab=sent' replace />,
-                    children: [{ index: true, element: null }, ...sharedChatRoutes],
-                  },
-                  // Redirect old scheduled route to new combined page
-                  {
-                    path: 'scheduled',
-                    element: <Navigate to='../drafts-sent?tab=scheduled' replace />,
-                    children: [{ index: true, element: null }, ...sharedChatRoutes],
-                  },
-                  // Canvas (full screen with 2-panel layout on desktop)
-                  {
-                    path: 'canvas',
-                    element: <CanvasPanel />,
-                    children: [
-                      {
-                        index: true,
-                        element: null,
-                      },
-                      {
-                        path: ':canvasId',
-                        element: <CanvasScreen />,
-                      },
-                    ],
-                  },
-                  // Activity (full screen with activity list sidebar)
-                  {
-                    path: 'activity',
-                    element: <ActivityListView />,
-                    children: [
-                      { index: true, element: null },
-                      // Desk/Support tickets opened from the Activity list render
-                      // here so the list stays mounted (instead of redirecting to
-                      // the full /support inbox). Static `ticket` segment is matched
-                      // ahead of the shared `:channelId` route.
-                      { path: 'ticket/:channelId', element: <ActivitySupportTicket /> },
-                      { path: 'ticket/:channelId/:ticketId', element: <ActivitySupportTicket /> },
-                      ...sharedChatRoutes,
-                    ],
-                  },
-                  // Search (full screen)
-                  {
-                    path: 'search',
-                    element: <Search />,
-                  },
-                  // Catch-all redirect for old routes: /chat/:channelId/* -> /chat/dir/:channelId/*
-                  {
-                    path: '*',
-                    element: <DirectoryRedirect />,
-                  },
-                ],
-              },
-              {
-                path: 'search-results',
-                element: <SearchResults />,
-              },
-              {
-                path: 'product-insights',
-                element: (
-                  <ResourceProtectedRoute resourceName='PRODUCT-INSIGHTS'>
-                    <ProductInsightsScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'ticket-reports',
-                element: (
-                  <ResourceProtectedRoute resourceName='TICKET-REPORTS' minAccess='WRITE'>
-                    <TicketReportsScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'agents',
-                element: (
-                  <ResourceProtectedRoute resourceName='AGENTS'>
-                    <AgentsScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'claw-agents',
-                element: (
-                  <GuestBlockedRoute>
-                    <ClawAgentsScreen />
-                  </GuestBlockedRoute>
-                ),
-                children: [
-                  { index: true, element: <AgentsTab /> },
-                  { path: 'create', element: <ClawAgentCreateScreen /> },
-                  { path: 'agents/:agentSlug', element: <ClawAgentDetailScreen /> },
-                  { path: 'mcp', element: <McpTab /> },
-                  { path: 'mcp/:mcpId', element: <ClawMcpDetailScreen /> },
-                  { path: 'skills', element: <SkillsTab /> },
-                  { path: 'skills/create', element: <ClawSkillCreateScreen /> },
-                  { path: 'skills/:skillSlug', element: <ClawSkillDetailScreen /> },
-                  { path: 'subagents', element: <SubagentsTab /> },
-                  { path: 'subagents/create', element: <ClawSubagentCreateScreen /> },
-                  { path: 'subagents/:subagentName', element: <ClawSubagentDetailScreen /> },
-                  { path: 'organization', element: <ClawOrganizationScreen /> },
-                  {
-                    path: 'digital-twin',
-                    element: <ClawDigitalTwinScreen />,
-                    children: [
-                      { index: true, element: <DigitalTwinMemoriesTab /> },
-                      { path: 'hot', element: <DigitalTwinHotTab /> },
-                      { path: 'proposals', element: <DigitalTwinProposalsTab /> },
-                      { path: 'recall', element: <DigitalTwinRecallTab /> },
-                      { path: 'graph', element: <DigitalTwinGraphTab /> },
-                      { path: 'metrics', element: <ClawDigitalTwinMetricsScreen /> },
-                      { path: 'settings', element: <DigitalTwinSettingsTab /> },
-                    ],
-                  },
-                  { path: 'metrics', element: <ClawMetricsScreen /> },
-                  { path: 'settings', element: <ClawSettingsScreen /> },
-                ],
-              },
-              {
-                path: 'knowledge-base',
-                element: <KnowledgeBaseV2Layout />,
-                children: [
-                  {
-                    index: true,
-                    element: <KnowledgeBaseV2Screen />,
-                  },
-                  {
-                    // The file viewer still reads projectId / channelId /
-                    // collectionId / folderId from the URL.
-                    path: ':projectId/:channelId/:collectionId/:folderId/:fileId',
-                    element: <FileViewerLayout />,
-                  },
-                  // Back-compat shims: pre-port URLs (path-only nesting) get
-                  // redirected to the new ?cl=&parent= layout so browser
-                  // history entries don't 404 after the route change.
-                  { path: ':projectId', element: <LegacyKbRedirect /> },
-                  { path: ':projectId/:channelId', element: <LegacyKbRedirect /> },
-                  {
-                    path: ':projectId/:channelId/:collectionId',
-                    element: <LegacyKbRedirect />,
-                  },
-                  {
-                    path: ':projectId/:channelId/:collectionId/:folderId',
-                    element: <LegacyKbRedirect />,
-                  },
-                ],
-              },
-              {
-                path: 'memory',
-                element: <MemoryScreen />,
-              },
-              {
-                path: 'analytics',
-                element: (
-                  <ResourceProtectedRoute resourceName='ANALYTICS'>
-                    <AnalyticsScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'projects',
-                element: (
-                  <ResourceProtectedRoute resourceName='PROJECTS'>
-                    <ProjectsScreen />
-                  </ResourceProtectedRoute>
-                ),
-                children: [
-                  {
-                    index: true,
-                    element: <MyTicketsScreen />,
-                  },
-                  {
-                    path: 'views',
-                    element: <Navigate to='/projects' replace />,
-                  },
-                  {
-                    path: 'views/new',
-                    element: <ProjectViewBuilder />,
-                  },
-                  {
-                    path: 'views/:viewId',
-                    element: <ProjectViewBuilder />,
-                  },
-                  {
-                    path: ':projectId',
-                    element: <KanbanBoardScreen />,
-                  },
-                  {
-                    path: ':projectId/:boardId',
-                    element: <KanbanBoardScreen />,
-                  },
-                  {
-                    path: ':projectId/:boardId/:ticketId',
-                    element: <TicketView />,
-                  },
-                ],
-              },
-              {
-                path: 'sdlc',
-                element: <SdlcScreen />,
-              },
-              {
-                path: 'sdlc/:repoId',
-                element: <SdlcScreen />,
-              },
-              {
-                path: 'sdlc/:repoId/:section',
-                element: <SdlcScreen />,
-              },
-              {
-                path: 'team-intelligence',
-                element: (
-                  <ResourceProtectedRoute resourceName='TEAM-INTELLIGENCE-DASHBOARD'>
-                    <TeamIntelligenceScreen />
-                  </ResourceProtectedRoute>
-                ),
-                children: [
-                  {
-                    index: true,
-                    element: <TeamIntelligenceOrgScreen />,
-                  },
-                  {
-                    path: 'team/:teamId',
-                    element: <TeamIntelligenceTeamScreen />,
-                  },
-                  {
-                    path: 'member/:memberEmail',
-                    element: <TeamIntelligenceMemberScreen />,
-                  },
-                ],
-              },
-              {
-                path: 'user-groups',
-                element: (
-                  <ResourceProtectedRoute
-                    resourceName='USER-GROUPS'
-                    minAccess='WRITE'
-                    allowUserGroupCreator
-                  >
-                    <UserGroupsScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'listProjects',
-                element: (
-                  <ResourceProtectedRoute resourceName='LISTPROJECTS'>
-                    <ProjectsListView />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'releaseManager',
-                element: <ReleaseManagerView />,
-              },
-              {
-                path: 'listProjects/:projectId',
-                element: <ProjectDetailScreen />,
-              },
-              {
-                path: 'listProjects/:projectId/releases/:releaseTicketId',
-                element: <ReleaseDetailScreen />,
-              },
-              {
-                path: 'calls',
-                element: <CallHistoryScreen />,
-                children: [
-                  {
-                    path: ':callId/detail',
-                    element: <CallDetailScreen />,
-                  },
-                ],
-              },
-              {
-                path: 'calls/:callId/:callType',
-                element: <CallPage />,
-              },
-              {
-                path: 'call/:callId',
-                element: <CallRouteHandler />,
-              },
-              {
-                path: 'recordings',
-                element: <RecordingsRoute />,
-              },
-              {
-                path: 'recordings/:recordingId',
-                element: <RecordingDetailRoute />,
-              },
-              {
-                path: 'user-groups/:userGroupId/assignment-config',
-                element: (
-                  <ResourceProtectedRoute
-                    resourceName='USER-GROUPS'
-                    minAccess='WRITE'
-                    allowUserGroupCreator
-                  >
-                    <AssignmentConfigWrapper />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'analytics-dashboard',
-                element: (
-                  <ResourceProtectedRoute resourceName='ANALYTICS'>
-                    <DashboardCreation />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'analytics-dashboard/:dashboardId',
-                element: (
-                  <ResourceProtectedRoute resourceName='ANALYTICS'>
-                    <QueryDashboardScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'dashboards',
-                element: (
-                  <ResourceProtectedRoute resourceName='ANALYTICS'>
-                    <DynamicDashboardPanel />
-                  </ResourceProtectedRoute>
-                ),
-                children: [
-                  { index: true, element: null },
-                  {
-                    path: ':dashboardId',
-                    element: <DynamicDashboardScreen />,
-                  },
-                ],
-              },
-              {
-                path: 'support',
-                element: (
-                  <ResourceProtectedRoute resourceName='SUPPORT'>
-                    <SaveRoute
-                      keyword='support'
-                      stripSearchParams={['settings', 'openSettings']}
-                      preserveSearchParams={[
-                        'emailConnected',
-                        'emailError',
-                        'channelEmailMailboxConnected',
-                        'deskIntegrations',
-                        'workspaceMailboxConnected',
-                        'email',
-                        'provider',
-                      ]}
-                      redirectOnlyAt={/^\/[^/]+\/support\/?$/}
-                    >
-                      <SupportScreen />
-                    </SaveRoute>
-                  </ResourceProtectedRoute>
-                ),
-                children: [
-                  {
-                    path: ':channelId',
-                    element: <Outlet />,
-                    children: [
-                      {
-                        path: ':ticketId',
-                        element: <Outlet />,
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                path: 'browser',
-                element: <BrowserTabsScreen />,
-              },
-              {
-                path: 'workspace-management',
-                element: (
-                  <ResourceProtectedRoute resourceName='WORKSPACE'>
-                    <WorkspaceManagementScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'organisations',
-                element: (
-                  <ResourceProtectedRoute resourceName='ORGANIZATIONS'>
-                    <OrganisationsScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'forms',
-                element: (
-                  <ResourceProtectedRoute resourceName='FORMS'>
-                    <FormScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'scheduled-messages',
-                element: <ScheduledMessageScreen />,
-              },
-              {
-                path: 'automations',
-                element: <AutomationsListScreen />,
-              },
-              {
-                path: 'automations/approvals',
-                element: <AutomationApprovalsScreen />,
-              },
-              {
-                path: 'automations/new',
-                element: <AutomationBuilderScreen />,
-              },
-              {
-                path: 'automations/:id',
-                element: <AutomationBuilderScreen />,
-              },
-              {
-                path: 'automations/:id/runs',
-                element: <AutomationRunsScreen />,
-              },
-              {
-                path: 'automations/:id/runs/:runId',
-                element: <AutomationRunDetailScreen />,
-              },
-              {
-                path: 'apps',
-                element: <AppsScreen />,
-              },
-              {
-                path: 'resource-access',
-                element: (
-                  <ResourceProtectedRoute resourceName='USERS'>
-                    <ResourceAccessScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'roles',
-                element: (
-                  <ResourceProtectedRoute resourceName='ROLES'>
-                    <RoleManagementScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'jira-migration',
-                element: (
-                  <ResourceProtectedRoute resourceName='TICKET-MIGRATION'>
-                    <JiraMigrationScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'migration/confluence',
-                element: (
-                  <ResourceProtectedRoute resourceName='CONFLUENCE-MIGRATION'>
-                    <ConfluenceMigrationScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'migration/whatsapp',
-                element: (
-                  <ResourceProtectedRoute resourceName='TICKET-MIGRATION'>
-                    <WhatsAppBulkMigrationScreen />
-                  </ResourceProtectedRoute>
-                ),
-              },
-              {
-                path: 'guide',
-                element: <UserGuideScreen />,
-              },
-            ],
-          },
-        ],
-      },
+/** Real screen in the SDLC bundle; the framed placeholder in the main one. */
+const SdlcRouteElement = (): ReactElement =>
+  isSdlcSurface ? <SdlcScreen /> : <SdlcFrameViewport />;
 
-      {
-        path: '/call/:callId',
-        element: (
-          <EncryptionBootstrapProvider>
-            <ZeroProvider>
-              <CallRouteHandler />
-            </ZeroProvider>
-          </EncryptionBootstrapProvider>
-        ),
-      },
-      {
-        path: '/redirected',
-        element: (
-          <EncryptionBootstrapProvider>
-            <ZeroProvider>
-              <CanvasRedirectPage />
-            </ZeroProvider>
-          </EncryptionBootstrapProvider>
-        ),
-      },
-      {
-        path: '/calls/:callId/:callType',
-        element: (
-          <EncryptionBootstrapProvider>
-            <ZeroProvider>
-              <CallPage />
-            </ZeroProvider>
-          </EncryptionBootstrapProvider>
-        ),
-      },
-      {
-        path: '/newWindow/chat/dir',
-        element: (
-          <EncryptionBootstrapProvider>
+export const router = createBrowserRouter(
+  [
+    {
+      element: <ProtectedRoute />,
+      errorElement: <RouterErrorFallback />,
+      children: [
+        {
+          path: '/newWindow/claw',
+          element: <ClawOverlay />,
+        },
+      ],
+    },
+    {
+      element: <SplashScreen />,
+      errorElement: <RouterErrorFallback />,
+      children: [
+        {
+          path: '/',
+          element: <ProtectedRoute />,
+          children: [
+            {
+              index: true,
+              element: <WorkspaceRedirect />,
+            },
+            {
+              path: ':workspaceId',
+              element: <AppRoot />,
+              children: [
+                {
+                  index: true,
+                  element: <HomeScreen />,
+                },
+                {
+                  path: 'ai',
+                  children: [
+                    { index: true, element: <Navigate to='chat/new' replace /> },
+                    { path: 'chat/new', element: <AIScreen /> },
+                    { path: 'daily-brief', element: <AIDailyBriefScreen /> },
+                    { path: 'daily-brief/:briefDate', element: <AIDailyBriefScreen /> },
+                    { path: 'library', element: <AILibraryScreen /> },
+                    {
+                      path: 'admin',
+                      element: (
+                        <RequireClawAdmin>
+                          <AIAdminScreen />
+                        </RequireClawAdmin>
+                      ),
+                    },
+                    { path: 'library/agent/create', element: <AIAgentCreateScreen /> },
+                    { path: 'library/subagent/create', element: <AISubagentCreateScreen /> },
+                    { path: 'library/skill/create', element: <AISkillCreateScreen /> },
+                    { path: 'library/agent/:slug/edit', element: <AIAgentEditScreen /> },
+                    { path: 'library/agent/:slug', element: <AIAgentDetailScreen /> },
+                    { path: 'library/subagent/:name/edit', element: <AISubagentEditScreen /> },
+                    { path: 'library/subagent/:name', element: <AISubagentDetailScreen /> },
+                    { path: 'library/skill/:slug', element: <AISkillDetailScreen /> },
+                    { path: 'library/mcp/:type', element: <AIMcpDetailScreen /> },
+                    { path: 'knowledge', element: <AIKnowledgeScreen /> },
+                    {
+                      path: 'organization',
+                      element: (
+                        <RequireOrgManager>
+                          <AIOrganizationScreen />
+                        </RequireOrgManager>
+                      ),
+                    },
+                    {
+                      element: <AISectionLayout />,
+                      children: [
+                        {
+                          path: 'digital-twin',
+                          element: <ClawDigitalTwinScreen />,
+                          children: [
+                            { index: true, element: <DigitalTwinMemoriesTab /> },
+                            { path: 'hot', element: <DigitalTwinHotTab /> },
+                            { path: 'proposals', element: <DigitalTwinProposalsTab /> },
+                            { path: 'recall', element: <DigitalTwinRecallTab /> },
+                            { path: 'graph', element: <DigitalTwinGraphTab /> },
+                            { path: 'metrics', element: <ClawDigitalTwinMetricsScreen /> },
+                            { path: 'settings', element: <DigitalTwinSettingsTab /> },
+                          ],
+                        },
+                        { path: 'metrics', element: <ClawMetricsScreen /> },
+                        { path: 'settings', element: <ClawSettingsScreen /> },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  path: 'onboarding',
+                  element: <QuestionnaireScreen />,
+                },
+                {
+                  path: 'rca',
+                  element: <RCAListScreen />,
+                },
+                {
+                  path: 'rca/:rcaId',
+                  element: <RCADetailScreen />,
+                },
+                {
+                  path: 'chat',
+                  element: <ChatScreen />,
+                  children: [
+                    // Directory routes (nested under dir)
+                    {
+                      path: 'dir',
+                      children: [
+                        {
+                          index: true,
+                          element: <ChatRedirect />,
+                        },
+                        // Canvas from directory (must come before :channelId)
+                        {
+                          path: 'canvas',
+                          element: <CanvasScreen />,
+                        },
+                        {
+                          path: 'canvas/:canvasId',
+                          element: <CanvasScreen />,
+                        },
+                        // Threads (must come before :channelId)
+                        {
+                          path: 'threads',
+                          element: <UserThreads />,
+                          children: [
+                            { index: true, element: null },
+                            {
+                              path: ':channelId/:conversationId',
+                              element: <ThreadMessages />,
+                            },
+                          ],
+                        },
+                        // Unreads inbox (must come before :channelId)
+                        {
+                          path: 'unreads',
+                          element: <UnreadsInbox />,
+                        },
+                        // Recap (must come before :channelId)
+                        {
+                          path: 'recap',
+                          children: [
+                            {
+                              index: true,
+                              element: <RecapPanel />,
+                            },
+                            {
+                              path: ':channelId',
+                              element: <RecapPanel />,
+                              children: [
+                                {
+                                  path: ':conversationId',
+                                  element: <ThreadMessages />,
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        // My Tickets (must come before :channelId)
+                        {
+                          path: 'my-tickets',
+                          element: <MyTicketsScreen />,
+                        },
+                        // Channel routes (must come after specific routes)
+                        {
+                          path: ':channelId',
+                          element: <ChatView />,
+                          children: [
+                            {
+                              index: true,
+                              element: (
+                                <div className='flex items-center justify-center h-full text-muted-foreground'>
+                                  Select a conversation to view messages
+                                </div>
+                              ),
+                            },
+                            {
+                              path: 'group/:groupId',
+                              element: <UserGroupSidePanel />,
+                            },
+                            {
+                              path: ':conversationId',
+                              element: <ThreadMessages />,
+                            },
+                            {
+                              path: ':conversationId/profile/:userId',
+                              element: <ProfileSidebar />,
+                            },
+                            {
+                              path: ':conversationId/:ticketId',
+                              element: <ThreadMessages />,
+                            },
+                            {
+                              path: 'profile/:userId',
+                              element: <ProfileSidebar />,
+                            },
+                            {
+                              path: 'tickets/:ticketId',
+                              element: <TicketView />,
+                            },
+                            {
+                              path: 'canvas',
+                              element: <CanvasScreen />,
+                            },
+                            {
+                              path: 'canvas/:canvasId',
+                              element: <CanvasScreen />,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    // DM routes (full screen with DM list sidebar)
+                    {
+                      path: 'dm',
+                      element: <DmsPage />,
+                      children: [
+                        { index: true, element: null },
+                        { path: 'compose', element: <KeyedComposeDmPanel /> },
+                        ...sharedChatRoutes,
+                      ],
+                    },
+                    // Bookmarks (full screen with bookmarks list sidebar)
+                    {
+                      path: 'bookmarks',
+                      element: <BookmarksPanel />,
+                      children: [{ index: true, element: null }, ...sharedChatRoutes],
+                    },
+                    // Drafts & Sent combined page
+                    {
+                      path: 'drafts-sent',
+                      element: <DraftsAndSentPage />,
+                      children: [{ index: true, element: null }, ...sharedChatRoutes],
+                    },
+                    // Redirect old drafts route to new combined page
+                    {
+                      path: 'drafts',
+                      element: <Navigate to='../drafts-sent?tab=drafts' replace />,
+                      children: [{ index: true, element: null }, ...sharedChatRoutes],
+                    },
+                    // Redirect old sent route to new combined page
+                    {
+                      path: 'sent',
+                      element: <Navigate to='../drafts-sent?tab=sent' replace />,
+                      children: [{ index: true, element: null }, ...sharedChatRoutes],
+                    },
+                    // Redirect old scheduled route to new combined page
+                    {
+                      path: 'scheduled',
+                      element: <Navigate to='../drafts-sent?tab=scheduled' replace />,
+                      children: [{ index: true, element: null }, ...sharedChatRoutes],
+                    },
+                    // Canvas (full screen with 2-panel layout on desktop)
+                    {
+                      path: 'canvas',
+                      element: <CanvasPanel />,
+                      children: [
+                        {
+                          index: true,
+                          element: null,
+                        },
+                        {
+                          path: ':canvasId',
+                          element: <CanvasScreen />,
+                        },
+                      ],
+                    },
+                    // Activity (full screen with activity list sidebar)
+                    {
+                      path: 'activity',
+                      element: <ActivityListView />,
+                      children: [
+                        { index: true, element: null },
+                        // Desk/Support tickets opened from the Activity list render
+                        // here so the list stays mounted (instead of redirecting to
+                        // the full /support inbox). Static `ticket` segment is matched
+                        // ahead of the shared `:channelId` route.
+                        { path: 'ticket/:channelId', element: <ActivitySupportTicket /> },
+                        { path: 'ticket/:channelId/:ticketId', element: <ActivitySupportTicket /> },
+                        ...sharedChatRoutes,
+                      ],
+                    },
+                    // Search (full screen)
+                    {
+                      path: 'search',
+                      element: <Search />,
+                    },
+                    // Catch-all redirect for old routes: /chat/:channelId/* -> /chat/dir/:channelId/*
+                    {
+                      path: '*',
+                      element: <DirectoryRedirect />,
+                    },
+                  ],
+                },
+                {
+                  path: 'search-results',
+                  element: <SearchResults />,
+                },
+                {
+                  path: 'product-insights',
+                  element: (
+                    <ResourceProtectedRoute resourceName='PRODUCT-INSIGHTS'>
+                      <ProductInsightsScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'ticket-reports',
+                  element: (
+                    <ResourceProtectedRoute resourceName='TICKET-REPORTS' minAccess='WRITE'>
+                      <TicketReportsScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'agents',
+                  element: (
+                    <ResourceProtectedRoute resourceName='AGENTS'>
+                      <AgentsScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'claw-agents',
+                  element: (
+                    <GuestBlockedRoute>
+                      <ClawAgentsScreen />
+                    </GuestBlockedRoute>
+                  ),
+                  children: [
+                    { index: true, element: <AgentsTab /> },
+                    { path: 'create', element: <ClawAgentCreateScreen /> },
+                    { path: 'agents/:agentSlug', element: <ClawAgentDetailScreen /> },
+                    { path: 'mcp', element: <McpTab /> },
+                    { path: 'mcp/:mcpId', element: <ClawMcpDetailScreen /> },
+                    { path: 'skills', element: <SkillsTab /> },
+                    { path: 'skills/create', element: <ClawSkillCreateScreen /> },
+                    { path: 'skills/:skillSlug', element: <ClawSkillDetailScreen /> },
+                    { path: 'subagents', element: <SubagentsTab /> },
+                    { path: 'subagents/create', element: <ClawSubagentCreateScreen /> },
+                    { path: 'subagents/:subagentName', element: <ClawSubagentDetailScreen /> },
+                    { path: 'organization', element: <ClawOrganizationScreen /> },
+                    {
+                      path: 'digital-twin',
+                      element: <ClawDigitalTwinScreen />,
+                      children: [
+                        { index: true, element: <DigitalTwinMemoriesTab /> },
+                        { path: 'hot', element: <DigitalTwinHotTab /> },
+                        { path: 'proposals', element: <DigitalTwinProposalsTab /> },
+                        { path: 'recall', element: <DigitalTwinRecallTab /> },
+                        { path: 'graph', element: <DigitalTwinGraphTab /> },
+                        { path: 'metrics', element: <ClawDigitalTwinMetricsScreen /> },
+                        { path: 'settings', element: <DigitalTwinSettingsTab /> },
+                      ],
+                    },
+                    { path: 'metrics', element: <ClawMetricsScreen /> },
+                    { path: 'settings', element: <ClawSettingsScreen /> },
+                  ],
+                },
+                {
+                  path: 'knowledge-base',
+                  element: <KnowledgeBaseV2Layout />,
+                  children: [
+                    {
+                      index: true,
+                      element: <KnowledgeBaseV2Screen />,
+                    },
+                    {
+                      // The file viewer still reads projectId / channelId /
+                      // collectionId / folderId from the URL.
+                      path: ':projectId/:channelId/:collectionId/:folderId/:fileId',
+                      element: <FileViewerLayout />,
+                    },
+                    // Back-compat shims: pre-port URLs (path-only nesting) get
+                    // redirected to the new ?cl=&parent= layout so browser
+                    // history entries don't 404 after the route change.
+                    { path: ':projectId', element: <LegacyKbRedirect /> },
+                    { path: ':projectId/:channelId', element: <LegacyKbRedirect /> },
+                    {
+                      path: ':projectId/:channelId/:collectionId',
+                      element: <LegacyKbRedirect />,
+                    },
+                    {
+                      path: ':projectId/:channelId/:collectionId/:folderId',
+                      element: <LegacyKbRedirect />,
+                    },
+                  ],
+                },
+                {
+                  path: 'memory',
+                  element: <MemoryScreen />,
+                },
+                {
+                  path: 'analytics',
+                  element: (
+                    <ResourceProtectedRoute resourceName='ANALYTICS'>
+                      <AnalyticsScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'projects',
+                  element: (
+                    <ResourceProtectedRoute resourceName='PROJECTS'>
+                      <ProjectsScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                  children: [
+                    {
+                      index: true,
+                      element: <MyTicketsScreen />,
+                    },
+                    {
+                      path: 'views',
+                      element: <Navigate to='/projects' replace />,
+                    },
+                    {
+                      path: 'views/new',
+                      element: <ProjectViewBuilder />,
+                    },
+                    {
+                      path: 'views/:viewId',
+                      element: <ProjectViewBuilder />,
+                    },
+                    {
+                      path: ':projectId',
+                      element: <KanbanBoardScreen />,
+                    },
+                    {
+                      path: ':projectId/:boardId',
+                      element: <KanbanBoardScreen />,
+                    },
+                    {
+                      path: ':projectId/:boardId/:ticketId',
+                      element: <TicketView />,
+                    },
+                  ],
+                },
+                {
+                  path: 'sdlc',
+                  element: <SdlcRouteElement />,
+                },
+                {
+                  path: 'sdlc/:repoId',
+                  element: <SdlcRouteElement />,
+                },
+                {
+                  path: 'sdlc/:repoId/:section',
+                  element: <SdlcRouteElement />,
+                },
+                {
+                  path: 'team-intelligence',
+                  element: (
+                    <ResourceProtectedRoute resourceName='TEAM-INTELLIGENCE-DASHBOARD'>
+                      <TeamIntelligenceScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                  children: [
+                    {
+                      index: true,
+                      element: <TeamIntelligenceOrgScreen />,
+                    },
+                    {
+                      path: 'team/:teamId',
+                      element: <TeamIntelligenceTeamScreen />,
+                    },
+                    {
+                      path: 'member/:memberEmail',
+                      element: <TeamIntelligenceMemberScreen />,
+                    },
+                  ],
+                },
+                {
+                  path: 'user-groups',
+                  element: (
+                    <ResourceProtectedRoute
+                      resourceName='USER-GROUPS'
+                      minAccess='WRITE'
+                      allowUserGroupCreator
+                    >
+                      <UserGroupsScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'listProjects',
+                  element: (
+                    <ResourceProtectedRoute resourceName='LISTPROJECTS'>
+                      <ProjectsListView />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'releaseManager',
+                  element: <ReleaseManagerView />,
+                },
+                {
+                  path: 'listProjects/:projectId',
+                  element: <ProjectDetailScreen />,
+                },
+                {
+                  path: 'listProjects/:projectId/releases/:releaseTicketId',
+                  element: <ReleaseDetailScreen />,
+                },
+                {
+                  path: 'calls',
+                  element: <CallHistoryScreen />,
+                  children: [
+                    {
+                      path: ':callId/detail',
+                      element: <CallDetailScreen />,
+                    },
+                  ],
+                },
+                {
+                  path: 'calls/:callId/:callType',
+                  element: <CallPage />,
+                },
+                {
+                  path: 'call/:callId',
+                  element: <CallRouteHandler />,
+                },
+                {
+                  path: 'recordings',
+                  element: <RecordingsRoute />,
+                },
+                {
+                  path: 'recordings/:recordingId',
+                  element: <RecordingDetailRoute />,
+                },
+                {
+                  path: 'user-groups/:userGroupId/assignment-config',
+                  element: (
+                    <ResourceProtectedRoute
+                      resourceName='USER-GROUPS'
+                      minAccess='WRITE'
+                      allowUserGroupCreator
+                    >
+                      <AssignmentConfigWrapper />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'analytics-dashboard',
+                  element: (
+                    <ResourceProtectedRoute resourceName='ANALYTICS'>
+                      <DashboardCreation />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'analytics-dashboard/:dashboardId',
+                  element: (
+                    <ResourceProtectedRoute resourceName='ANALYTICS'>
+                      <QueryDashboardScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'dashboards',
+                  element: (
+                    <ResourceProtectedRoute resourceName='ANALYTICS'>
+                      <DynamicDashboardPanel />
+                    </ResourceProtectedRoute>
+                  ),
+                  children: [
+                    { index: true, element: null },
+                    {
+                      path: ':dashboardId',
+                      element: <DynamicDashboardScreen />,
+                    },
+                  ],
+                },
+                {
+                  path: 'support',
+                  element: (
+                    <ResourceProtectedRoute resourceName='SUPPORT'>
+                      <SaveRoute
+                        keyword='support'
+                        stripSearchParams={['settings', 'openSettings']}
+                        preserveSearchParams={[
+                          'emailConnected',
+                          'emailError',
+                          'channelEmailMailboxConnected',
+                          'deskIntegrations',
+                          'workspaceMailboxConnected',
+                          'email',
+                          'provider',
+                        ]}
+                        redirectOnlyAt={/^\/[^/]+\/support\/?$/}
+                      >
+                        <SupportScreen />
+                      </SaveRoute>
+                    </ResourceProtectedRoute>
+                  ),
+                  children: [
+                    {
+                      path: ':channelId',
+                      element: <Outlet />,
+                      children: [
+                        {
+                          path: ':ticketId',
+                          element: <Outlet />,
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  path: 'browser',
+                  element: <BrowserTabsScreen />,
+                },
+                {
+                  path: 'workspace-management',
+                  element: (
+                    <ResourceProtectedRoute resourceName='WORKSPACE'>
+                      <WorkspaceManagementScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'organisations',
+                  element: (
+                    <ResourceProtectedRoute resourceName='ORGANIZATIONS'>
+                      <OrganisationsScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'forms',
+                  element: (
+                    <ResourceProtectedRoute resourceName='FORMS'>
+                      <FormScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'scheduled-messages',
+                  element: <ScheduledMessageScreen />,
+                },
+                {
+                  path: 'automations',
+                  element: <AutomationsListScreen />,
+                },
+                {
+                  path: 'automations/approvals',
+                  element: <AutomationApprovalsScreen />,
+                },
+                {
+                  path: 'automations/new',
+                  element: <AutomationBuilderScreen />,
+                },
+                {
+                  path: 'automations/:id',
+                  element: <AutomationBuilderScreen />,
+                },
+                {
+                  path: 'automations/:id/runs',
+                  element: <AutomationRunsScreen />,
+                },
+                {
+                  path: 'automations/:id/runs/:runId',
+                  element: <AutomationRunDetailScreen />,
+                },
+                {
+                  path: 'apps',
+                  element: <AppsScreen />,
+                },
+                {
+                  path: 'resource-access',
+                  element: (
+                    <ResourceProtectedRoute resourceName='USERS'>
+                      <ResourceAccessScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'roles',
+                  element: (
+                    <ResourceProtectedRoute resourceName='ROLES'>
+                      <RoleManagementScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'jira-migration',
+                  element: (
+                    <ResourceProtectedRoute resourceName='TICKET-MIGRATION'>
+                      <JiraMigrationScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'migration/confluence',
+                  element: (
+                    <ResourceProtectedRoute resourceName='CONFLUENCE-MIGRATION'>
+                      <ConfluenceMigrationScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'migration/whatsapp',
+                  element: (
+                    <ResourceProtectedRoute resourceName='TICKET-MIGRATION'>
+                      <WhatsAppBulkMigrationScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'guide',
+                  element: <UserGuideScreen />,
+                },
+              ],
+            },
+          ],
+        },
+
+        {
+          path: '/call/:callId',
+          element: (
+            <EncryptionBootstrapProvider>
+              <ZeroProvider>
+                <CallRouteHandler />
+              </ZeroProvider>
+            </EncryptionBootstrapProvider>
+          ),
+        },
+        {
+          path: '/redirected',
+          element: (
+            <EncryptionBootstrapProvider>
+              <ZeroProvider>
+                <CanvasRedirectPage />
+              </ZeroProvider>
+            </EncryptionBootstrapProvider>
+          ),
+        },
+        {
+          path: '/calls/:callId/:callType',
+          element: (
+            <EncryptionBootstrapProvider>
+              <ZeroProvider>
+                <CallPage />
+              </ZeroProvider>
+            </EncryptionBootstrapProvider>
+          ),
+        },
+        {
+          path: '/newWindow/chat/dir',
+          element: (
+            <EncryptionBootstrapProvider>
+              <ZeroProvider>
+                <ZeroFallbackProvider>
+                  <InitialStateLoader>
+                    <EditProvider>
+                      <div className='h-full bg-background'>
+                        <Outlet />
+                      </div>
+                      <AttachmentGalleryModal />
+                      <AttachmentCitationPreview />
+                      <ThreadCitationModal />
+                      <TranscriptCitationModal />
+                    </EditProvider>
+                  </InitialStateLoader>
+                </ZeroFallbackProvider>
+              </ZeroProvider>
+            </EncryptionBootstrapProvider>
+          ),
+          children: [
+            {
+              path: ':channelId',
+              element: <ChatView />,
+            },
+            {
+              path: ':channelId/:conversationId',
+              element: <ThreadMessages />,
+            },
+            {
+              path: ':channelId/:conversationId/:ticketId',
+              element: <ThreadMessages />,
+            },
+          ],
+        },
+        {
+          path: '/newWindow/create-ticket',
+          element: (
             <ZeroProvider>
               <ZeroFallbackProvider>
                 <InitialStateLoader>
                   <EditProvider>
                     <div className='h-full bg-background'>
-                      <Outlet />
+                      <CreateTicketWindow />
                     </div>
                     <AttachmentGalleryModal />
-                    <AttachmentCitationPreview />
-                    <ThreadCitationModal />
-                    <TranscriptCitationModal />
                   </EditProvider>
                 </InitialStateLoader>
               </ZeroFallbackProvider>
             </ZeroProvider>
-          </EncryptionBootstrapProvider>
-        ),
-        children: [
-          {
-            path: ':channelId',
-            element: <ChatView />,
-          },
-          {
-            path: ':channelId/:conversationId',
-            element: <ThreadMessages />,
-          },
-          {
-            path: ':channelId/:conversationId/:ticketId',
-            element: <ThreadMessages />,
-          },
-        ],
-      },
-      {
-        path: '/newWindow/create-ticket',
-        element: (
-          <ZeroProvider>
-            <ZeroFallbackProvider>
-              <InitialStateLoader>
-                <EditProvider>
-                  <div className='h-full bg-background'>
-                    <CreateTicketWindow />
-                  </div>
-                  <AttachmentGalleryModal />
-                </EditProvider>
-              </InitialStateLoader>
-            </ZeroFallbackProvider>
-          </ZeroProvider>
-        ),
-      },
-      {
-        path: '/invite',
-        element: <AcceptInvitation />,
-      },
-      {
-        path: '/community',
-        element: <CommunityWorkspaceSelectionRoute />,
-      },
-      {
-        path: '/auth',
-        element: <AuthScreen />,
-      },
-      {
-        path: '/workspaces',
-        element: <WorkspaceSelectionScreen />,
-      },
-      {
-        path: '/no-access',
-        element: <NoOrganizationAccessScreen />,
-      },
-      {
-        path: '/launch',
-        element: <LaunchScreen />,
-      },
-      {
-        path: '/system',
-        element: <SystemPalette />,
-      },
-    ],
-  },
-  // Last, so it only matches once every route above has failed to.
-  {
-    path: '*',
-    element: <NotFoundScreen />,
-    errorElement: <RouterErrorFallback />,
-  },
-]);
+          ),
+        },
+        {
+          path: '/invite',
+          element: <AcceptInvitation />,
+        },
+        {
+          path: '/community',
+          element: <CommunityWorkspaceSelectionRoute />,
+        },
+        {
+          path: '/auth',
+          element: <AuthScreen />,
+        },
+        {
+          path: '/workspaces',
+          element: <WorkspaceSelectionScreen />,
+        },
+        {
+          path: '/no-access',
+          element: <NoOrganizationAccessScreen />,
+        },
+        {
+          path: '/launch',
+          element: <LaunchScreen />,
+        },
+        {
+          path: '/system',
+          element: <SystemPalette />,
+        },
+      ],
+    },
+    // Last, so it only matches once every route above has failed to.
+    {
+      path: '*',
+      element: <NotFoundScreen />,
+      errorElement: <RouterErrorFallback />,
+    },
+  ],
+  // The lane serves under /sdlc-app; every route above is matched relative to it.
+  APP_BASE_PATH === '/' ? undefined : { basename: APP_BASE_PATH },
+);

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameContext.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameContext.tsx
@@ -1,0 +1,58 @@
+import {
+  createContext,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+// Carries the SDLC frame's viewport from the route to the shell-owned host. The
+// route contributes geometry only — owning the frame, or its portal target, would
+// detach the iframe on unmount and destroy its browsing context.
+
+export interface SdlcFrameViewport {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface SdlcFrameContextValue {
+  /** Null while no SDLC route is mounted, which hides the frame. */
+  viewport: SdlcFrameViewport | null;
+  setViewport: (viewport: SdlcFrameViewport | null) => void;
+}
+
+const SdlcFrameContext = createContext<SdlcFrameContextValue | null>(null);
+
+export const SdlcFrameProvider = ({ children }: { children: ReactNode }): ReactElement => {
+  const [viewport, setViewportState] = useState<SdlcFrameViewport | null>(null);
+
+  const setViewport = useCallback((next: SdlcFrameViewport | null): void => {
+    setViewportState(previous => {
+      if (previous === next) return previous;
+      if (!previous || !next) return next;
+      // Rect updates fire on every observation; skip no-op renders.
+      const unchanged =
+        previous.top === next.top &&
+        previous.left === next.left &&
+        previous.width === next.width &&
+        previous.height === next.height;
+      return unchanged ? previous : next;
+    });
+  }, []);
+
+  const value = useMemo(() => ({ viewport, setViewport }), [viewport, setViewport]);
+
+  return <SdlcFrameContext.Provider value={value}>{children}</SdlcFrameContext.Provider>;
+};
+
+export function useSdlcFrame(): SdlcFrameContextValue {
+  const context = useContext(SdlcFrameContext);
+  if (!context) {
+    throw new Error('useSdlcFrame must be used inside SdlcFrameProvider');
+  }
+  return context;
+}

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
@@ -1,0 +1,137 @@
+import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { SDLC_APP_BASE_PATH } from '../../config';
+import { useSdlcFrame } from './SdlcFrameContext';
+import { isSdlcPath, parseSdlcFrameMessage, SDLC_FRAME_MESSAGE } from './sdlcFrameMessages';
+
+/**
+ * Owns the SDLC lane's iframe for the lifetime of the workspace.
+ *
+ * Mounted above the router so leaving /sdlc hides the frame instead of unmounting
+ * it, and portalled to document.body so no layout branch in AppRoot can reparent
+ * it — moving an iframe in the DOM reloads it. AppRoot is mounted under
+ * ':workspaceId', so a workspace switch resets the frame.
+ *
+ * See docs/sdlc-fast-lane.md.
+ */
+const SdlcFrameHost = (): ReactElement | null => {
+  const { viewport } = useSdlcFrame();
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  // Last path each side told the other, so echoes do not loop.
+  const lastFromFrameRef = useRef<string | null>(null);
+  const lastToFrameRef = useRef<string | null>(null);
+
+  const container = useMemo(() => {
+    if (typeof document === 'undefined') return null;
+    const element = document.createElement('div');
+    element.dataset['sdlcFrameHost'] = 'true';
+    return element;
+  }, []);
+
+  useEffect(() => {
+    if (!container) return undefined;
+    document.body.appendChild(container);
+    return () => container.remove();
+  }, [container]);
+
+  const initialSrcRef = useRef<string | null>(null);
+  const [hasActivated, setHasActivated] = useState(false);
+  // Only the reset control may remount the frame; a URL-derived key would not.
+  const [resetCount, setResetCount] = useState(0);
+
+  // Captured on first SDLC visit, not at mount: AppRoot mounts on any route under
+  // :workspaceId, so at mount the location is usually a different screen.
+  useEffect(() => {
+    if (!viewport || initialSrcRef.current || !workspaceId) return;
+    initialSrcRef.current = `${SDLC_APP_BASE_PATH}${location.pathname}${location.search}`;
+    setHasActivated(true);
+  }, [viewport, workspaceId, location.pathname, location.search]);
+
+  // frame → parent
+  useEffect(() => {
+    const onMessage = (event: MessageEvent): void => {
+      if (event.origin !== window.location.origin) return;
+      if (!iframeRef.current || event.source !== iframeRef.current.contentWindow) return;
+
+      const message = parseSdlcFrameMessage(event.data);
+      if (!message) return;
+
+      if (message.type === SDLC_FRAME_MESSAGE.ready) {
+        setIsReady(true);
+        return;
+      }
+
+      if (message.type === SDLC_FRAME_MESSAGE.reset) {
+        // Timestamp forces a fresh document rather than a cached one. JS cannot
+        // request a true cache-bypassing reload.
+        const root = `/${workspaceId}/sdlc`;
+        initialSrcRef.current = `${SDLC_APP_BASE_PATH}${root}?_reset=${Date.now()}`;
+        lastFromFrameRef.current = null;
+        lastToFrameRef.current = null;
+        setIsReady(false);
+        setResetCount(count => count + 1);
+        if (location.pathname !== root) void navigate(root, { replace: true });
+        return;
+      }
+
+      if (message.type !== SDLC_FRAME_MESSAGE.route) return;
+
+      lastFromFrameRef.current = message.path;
+      // Only while on screen — a hidden frame must not move the address bar.
+      const current = `${location.pathname}${location.search}`;
+      if (viewport && isSdlcPath(message.path) && message.path !== current) {
+        void navigate(message.path, { replace: true });
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [location.pathname, location.search, navigate, viewport, workspaceId]);
+
+  // parent → frame
+  useEffect(() => {
+    if (!isReady || !viewport) return;
+    const target = iframeRef.current?.contentWindow;
+    if (!target) return;
+
+    const path = `${location.pathname}${location.search}`;
+    if (!isSdlcPath(location.pathname)) return;
+    if (path === lastFromFrameRef.current || path === lastToFrameRef.current) return;
+
+    lastToFrameRef.current = path;
+    target.postMessage({ type: SDLC_FRAME_MESSAGE.navigate, path }, window.location.origin);
+  }, [isReady, viewport, location.pathname, location.search]);
+
+  if (!container || !hasActivated || !initialSrcRef.current) return null;
+
+  return createPortal(
+    <iframe
+      key={resetCount}
+      ref={iframeRef}
+      src={initialSrcRef.current}
+      title='SDLC'
+      style={{
+        position: 'fixed',
+        top: viewport?.top ?? 0,
+        left: viewport?.left ?? 0,
+        width: viewport?.width ?? 0,
+        height: viewport?.height ?? 0,
+        border: 0,
+        visibility: viewport ? 'visible' : 'hidden',
+        pointerEvents: viewport ? 'auto' : 'none',
+        zIndex: 1,
+      }}
+      allow='clipboard-read; clipboard-write'
+    />,
+    container,
+  );
+};
+
+export default SdlcFrameHost;

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameViewport.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameViewport.tsx
@@ -1,0 +1,48 @@
+import { ReactElement, useEffect, useRef } from 'react';
+import { useSdlcFrame } from './SdlcFrameContext';
+
+/**
+ * The /sdlc route element in the main bundle. Reports where the frame should
+ * appear and, by unmounting, that it should be hidden. Never mounts the frame
+ * itself — see SdlcFrameHost.
+ */
+const SdlcFrameViewport = (): ReactElement => {
+  const { setViewport } = useSdlcFrame();
+  const slotRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = slotRef.current;
+    if (!element) return undefined;
+
+    const publish = (): void => {
+      const rect = element.getBoundingClientRect();
+      setViewport({
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      });
+    };
+
+    publish();
+
+    // Catches the AI drawer / debugger panel resizing the content area.
+    const observer = new ResizeObserver(publish);
+    observer.observe(element);
+    // A position change with no size change would not trigger the observer.
+    window.addEventListener('resize', publish);
+    window.addEventListener('scroll', publish, true);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', publish);
+      window.removeEventListener('scroll', publish, true);
+      // Hides the frame without unmounting it.
+      setViewport(null);
+    };
+  }, [setViewport]);
+
+  return <div ref={slotRef} className='h-full w-full' />;
+};
+
+export default SdlcFrameViewport;

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -34,6 +34,7 @@ import {
   Users,
   X,
 } from 'lucide-react';
+import { isFramedSdlcSurface, requestSdlcFrameReset } from './useSdlcFrameBridge';
 import { toast } from 'sonner';
 import { Button } from '../../components/ui/Button';
 import { Dialog } from '../../components/ui/Dialog/Dialog';
@@ -1162,8 +1163,24 @@ export default function SdlcScreen(): ReactElement {
         style={{ backdropFilter: 'blur(var(--sidebar-background-blur))' }}
       >
         <div className='border-b border-sidebar-border-muted p-4'>
-          <div className='text-[11px] font-semibold uppercase tracking-[0.18em] text-sidebar-foreground'>
-            SDLC Hub
+          <div className='flex items-center justify-between gap-2'>
+            <div className='text-[11px] font-semibold uppercase tracking-[0.18em] text-sidebar-foreground'>
+              SDLC Hub
+            </div>
+            {/* Escape hatch for a wedged frame; only meaningful when framed. */}
+            {isFramedSdlcSurface() && (
+              <button
+                type='button'
+                onClick={requestSdlcFrameReset}
+                title='Reload SDLC Hub — discards this session and starts fresh at the hub root'
+                aria-label='Reload SDLC Hub'
+                className='rounded-md p-1 text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-accent-ring'
+                data-track-category='SdlcHub'
+                data-track-name='FrameReset'
+              >
+                <RefreshCw className='h-3.5 w-3.5' aria-hidden='true' />
+              </button>
+            )}
           </div>
           <Select
             value={repo.id}

--- a/apps/dashboard/src/routes/SdlcScreen/sdlcFrameMessages.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/sdlcFrameMessages.ts
@@ -1,0 +1,72 @@
+// postMessage contract between the main bundle and the SDLC lane's iframe. The
+// frame is kept alive across route changes, so it cannot be navigated by swapping
+// `src` — that would reload it. Paths on the wire are basename-free: both bundles
+// share one route table and react-router strips the basename, so a path means the
+// same thing on both sides.
+
+export const SDLC_FRAME_MESSAGE = {
+  navigate: 'xyne:sdlc-frame:navigate',
+  route: 'xyne:sdlc-frame:route',
+  ready: 'xyne:sdlc-frame:ready',
+  reset: 'xyne:sdlc-frame:reset',
+} as const;
+
+export interface SdlcFrameNavigateMessage {
+  type: typeof SDLC_FRAME_MESSAGE.navigate;
+  path: string;
+}
+
+export interface SdlcFrameRouteMessage {
+  type: typeof SDLC_FRAME_MESSAGE.route;
+  path: string;
+}
+
+export interface SdlcFrameReadyMessage {
+  type: typeof SDLC_FRAME_MESSAGE.ready;
+}
+
+/** Frame → parent: destroy this frame and mount a fresh one at the SDLC root. */
+export interface SdlcFrameResetMessage {
+  type: typeof SDLC_FRAME_MESSAGE.reset;
+}
+
+export type SdlcFrameMessage =
+  | SdlcFrameNavigateMessage
+  | SdlcFrameRouteMessage
+  | SdlcFrameReadyMessage
+  | SdlcFrameResetMessage;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Both sync directions check this rather than the viewport alone: leaving /sdlc
+ * updates the location and clears the viewport in separate effects, so there is a
+ * render where the new non-SDLC path is visible while the viewport still looks
+ * active — enough to push the frame onto /chat and lose its state.
+ */
+export function isSdlcPath(pathname: string): boolean {
+  return /^\/[^/]+\/sdlc(\/|$)/.test(pathname);
+}
+
+/** Narrows the shape only — callers must also check `event.origin`. */
+export function parseSdlcFrameMessage(data: unknown): SdlcFrameMessage | null {
+  if (!isRecord(data)) return null;
+  const { type } = data;
+
+  if (type === SDLC_FRAME_MESSAGE.ready || type === SDLC_FRAME_MESSAGE.reset) {
+    return { type };
+  }
+
+  if (type === SDLC_FRAME_MESSAGE.navigate || type === SDLC_FRAME_MESSAGE.route) {
+    // Rooted same-origin paths only; '//' would be another host.
+    const { path } = data;
+    if (typeof path !== 'string' || !path.startsWith('/') || path.startsWith('//')) {
+      return null;
+    }
+    return { type, path };
+  }
+
+  return null;
+}

--- a/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { isSdlcSurface } from '../../config';
+import { parseSdlcFrameMessage, SDLC_FRAME_MESSAGE } from './sdlcFrameMessages';
+
+/** True when this document is the SDLC bundle running inside the parent's frame. */
+export function isFramedSdlcSurface(): boolean {
+  return isSdlcSurface && typeof window !== 'undefined' && window.parent !== window;
+}
+
+/**
+ * Escape hatch for a wedged frame. It is long-lived by design, so without this
+ * the only way to a clean one is reloading the whole dashboard.
+ */
+export function requestSdlcFrameReset(): void {
+  if (!isFramedSdlcSurface()) return;
+  window.parent.postMessage({ type: SDLC_FRAME_MESSAGE.reset }, window.location.origin);
+}
+
+/**
+ * The SDLC bundle's half of the frame contract: applies NAVIGATE from the parent
+ * and reports its own route back. Active only when framed.
+ */
+export function useSdlcFrameBridge(): void {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Skip reporting a route the parent just asked for.
+  const lastFromParentRef = useRef<string | null>(null);
+  const lastReportedRef = useRef<string | null>(null);
+
+  const enabled = isFramedSdlcSurface();
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    const onMessage = (event: MessageEvent): void => {
+      if (event.origin !== window.location.origin) return;
+      if (event.source !== window.parent) return;
+
+      const message = parseSdlcFrameMessage(event.data);
+      if (!message || message.type !== SDLC_FRAME_MESSAGE.navigate) return;
+
+      lastFromParentRef.current = message.path;
+      void navigate(message.path);
+    };
+
+    window.addEventListener('message', onMessage);
+    window.parent.postMessage({ type: SDLC_FRAME_MESSAGE.ready }, window.location.origin);
+
+    return () => window.removeEventListener('message', onMessage);
+  }, [enabled, navigate]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const path = `${location.pathname}${location.search}`;
+    if (path === lastFromParentRef.current || path === lastReportedRef.current) return;
+
+    lastReportedRef.current = path;
+    window.parent.postMessage({ type: SDLC_FRAME_MESSAGE.route, path }, window.location.origin);
+  }, [enabled, location.pathname, location.search]);
+}

--- a/apps/dashboard/src/services/clients/apiClient.ts
+++ b/apps/dashboard/src/services/clients/apiClient.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosE
 import { v4 as uuidv4 } from 'uuid';
 import { reactNativeBridge } from '../../utils/reactNativeBridge';
 import { mixpanelService, EVENTS, EVENT_PROPERTIES } from '../Analytics/mixpanelService';
-import { API_BASE_URL } from '../../config';
+import { API_BASE_URL, APP_BASE_PATH } from '../../config';
 import { logger, Logger } from '../../utils/logger';
 import {
   httpRequestDuration,
@@ -106,7 +106,11 @@ apiConfig.interceptors.request.use(
 
       // X-Workspace-Id for multi-workspace. Main routes are /:workspaceId/...; standalone
       // /newWindow/* windows carry it as a query param (then fall back to lastActiveWorkspaceId).
-      const firstPathSegment = window.location.pathname.match(/^\/([^/]+)/)?.[1];
+      // The lane serves under the /sdlc-app basename, whose segment would otherwise
+      // read as the workspace id. APP_BASE_PATH is '' in the main bundle.
+      const path = window.location.pathname;
+      const appPath = path.startsWith(APP_BASE_PATH) ? path.slice(APP_BASE_PATH.length) : path;
+      const firstPathSegment = appPath.match(/^\/([^/]+)/)?.[1];
       let workspaceId: string | undefined = firstPathSegment;
       if (firstPathSegment === 'newWindow') {
         const search = new URLSearchParams(window.location.search);

--- a/apps/dashboard/src/zero/dropZeroDatabases.ts
+++ b/apps/dashboard/src/zero/dropZeroDatabases.ts
@@ -1,0 +1,80 @@
+import { dropAllDatabases, dropDatabase } from '@rocicorp/zero';
+import { ZERO_STORAGE_KEY } from '../config';
+
+// Zero's dropAllDatabases() deletes every Zero store in the origin, not just this
+// client's — which would wipe the SDLC bundle's store (and its unacked mutations)
+// whenever the main bundle switches workspace, re-auths or logs out.
+//
+// Zero names its store `rep:zero-<userID>-<laneKey>:<format>:<schemaVersion>`,
+// where laneKey hashes {storageKey, mutateUrl, queryUrl} — build constants, so it
+// is stable per bundle. Filtering on it drops this lane's stores for every user
+// and schema version without touching the other lane's.
+
+const IDB_PREFIX = 'rep:zero-';
+
+let laneKey: string | null = null;
+
+const laneCacheKey = `xyne:zero-lane:${ZERO_STORAGE_KEY || 'default'}`;
+
+function parseLaneKey(idbName: string): string | null {
+  if (!idbName.startsWith(IDB_PREFIX)) return null;
+  // userID may contain '-', so take the segment after the LAST one.
+  const name = idbName.split(':')[1];
+  if (!name) return null;
+  return name.slice(name.lastIndexOf('-') + 1) || null;
+}
+
+/** Call with `zero.idbName` after constructing the client. */
+export function rememberZeroLane(idbName: string): void {
+  const key = parseLaneKey(idbName);
+  if (!key) return;
+  laneKey = key;
+  try {
+    // Cached so logout can still scope its drop after the client is torn down.
+    localStorage.setItem(laneCacheKey, key);
+  } catch {
+    // Private mode — the in-memory value still covers this session.
+  }
+}
+
+function currentLaneKey(): string | null {
+  if (laneKey) return laneKey;
+  try {
+    laneKey = localStorage.getItem(laneCacheKey);
+  } catch {
+    laneKey = null;
+  }
+  return laneKey;
+}
+
+/** Drops this lane's Zero databases. Never rejects. */
+export async function dropZeroDatabases(): Promise<void> {
+  // Scoped even when this bundle sets no storageKey: the lane key still differs
+  // between bundles (it hashes storageKey + mutate/query URLs), and the main
+  // bundle is the one that drops most often. Falling back to dropAllDatabases
+  // here deleted the other lane's store out from under a live client, which
+  // surfaces as Zero's IDBNotFoundError "Expected IndexedDB not found".
+  const key = currentLaneKey();
+  // Zero never initialised here, so anything we dropped would be the other lane's.
+  if (!key) return;
+
+  // Unavailable on Firefox; indexedDBService already depends on it. Bail rather
+  // than fall back to a cross-lane wipe.
+  if (typeof indexedDB.databases !== 'function') return;
+
+  const databases = await indexedDB.databases().catch(() => []);
+  const ours = databases
+    .map(db => db.name)
+    .filter((name): name is string => !!name && parseLaneKey(name) === key);
+
+  await Promise.all(ours.map(name => dropDatabase(name).catch(() => undefined)));
+}
+
+/**
+ * Drops every lane's Zero databases. Correct only at logout, where both bundles
+ * are torn down. Everywhere else use dropZeroDatabases(): deleting the other
+ * lane's store under a live client is what raises IDBNotFoundError.
+ */
+export async function dropAllZeroDatabases(): Promise<void> {
+  await dropAllDatabases().catch(() => undefined);
+}

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -1,138 +1,191 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import packageJson from './package.json';
 import { readFileSync } from 'fs';
 
-const pkg = JSON.parse(
-  readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8')
-);
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
 
-export default defineConfig({
-  plugins: [
-    react(),
-    {
-      name: 'version-file',
-      // Emit version.json through Rollup so Vite writes it into the build's outDir itself.
-      // The previous approach used writeFileSync('dist/version.json') in closeBundle, which
-      // assumed dist/ already existed — that fails on a CLEAN build (fresh CI workspace) with
-      // ENOENT, and only "worked" when a prior build left dist/ behind. emitFile has no such
-      // assumption and is the environment-safe way to add an asset to the bundle.
-      generateBundle() {
-        this.emitFile({
-          type: 'asset',
-          fileName: 'version.json',
-          source: JSON.stringify({ version: pkg.version }, null, 2),
-        });
-      }
+export default defineConfig(({ mode }) => {
+  // Vite puts .env values on import.meta.env, not process.env, so this file
+  // cannot see them without loading explicitly. process.env last so a shell value
+  // still wins and existing invocations are unchanged.
+  const env: Record<string, string | undefined> = {
+    ...loadEnv(mode, process.cwd(), ''),
+    ...process.env,
+  };
+
+  // Deployment lane. Unset for the main bundle, which keeps base '/' and 5173.
+  const appBasePath = env.VITE_APP_BASE_PATH || '/';
+  const isSdlcSurface = env.VITE_XYNE_SURFACE === 'sdlc';
+  const devPort = Number(env.VITE_DEV_PORT) || (isSdlcSurface ? 5175 : 5173);
+
+  // Dev only: the main server stands in for the edge, so the iframe is same-origin
+  // exactly as in prod. No rewriting, mirroring the deployed setup.
+  const sdlcEdgeProxy = {
+    '/sdlc-app': {
+      target: env.VITE_SDLC_APP_URL || 'http://localhost:5175',
+      changeOrigin: true,
+      secure: false,
+      ws: true,
     },
-    viteStaticCopy({
-      targets: [
-        // PDF.js worker - renamed to .js for nginx compatibility
-        {
-          src: 'node_modules/pdfjs-dist/build/pdf.worker.min.mjs',
-          dest: 'pdfjs',
-          rename: 'pdf.worker.min.js',
+    '/sdlc-api': {
+      target: env.VITE_SDLC_BACKEND_URL || 'http://localhost:3011',
+      changeOrigin: true,
+      secure: false,
+      ws: true,
+    },
+    // Shared local zero-cache: both lanes read the same Postgres in dev, so a
+    // second one adds setup for no coverage.
+    '/sdlc-zero': {
+      target: env.VITE_SDLC_ZERO_SERVER || 'http://localhost:4848',
+      changeOrigin: true,
+      secure: false,
+      ws: true,
+    },
+  };
+
+  return {
+    base: appBasePath,
+    // Both lanes run from this same project dir, so they would share
+    // node_modules/.vite and invalidate each other's prebundled deps
+    // ("504 Outdated Optimize Dep"). Give the SDLC server its own.
+    ...(isSdlcSurface ? { cacheDir: 'node_modules/.vite-sdlc' } : {}),
+    plugins: [
+      react(),
+      {
+        name: 'version-file',
+        // Emit version.json through Rollup so Vite writes it into the build's outDir itself.
+        // The previous approach used writeFileSync('dist/version.json') in closeBundle, which
+        // assumed dist/ already existed — that fails on a CLEAN build (fresh CI workspace) with
+        // ENOENT, and only "worked" when a prior build left dist/ behind. emitFile has no such
+        // assumption and is the environment-safe way to add an asset to the bundle.
+        generateBundle() {
+          this.emitFile({
+            type: 'asset',
+            fileName: 'version.json',
+            source: JSON.stringify({ version: pkg.version }, null, 2),
+          });
         },
-        // PDF.js WASM files (openjpeg.wasm, qcms_bg.wasm, etc.)
-        {
-          src: 'node_modules/pdfjs-dist/wasm/*',
-          dest: 'pdfjs/wasm',
+      },
+      viteStaticCopy({
+        targets: [
+          // PDF.js worker - renamed to .js for nginx compatibility
+          {
+            src: 'node_modules/pdfjs-dist/build/pdf.worker.min.mjs',
+            dest: 'pdfjs',
+            rename: 'pdf.worker.min.js',
+          },
+          // PDF.js WASM files (openjpeg.wasm, qcms_bg.wasm, etc.)
+          {
+            src: 'node_modules/pdfjs-dist/wasm/*',
+            dest: 'pdfjs/wasm',
+          },
+        ],
+      }),
+    ],
+    build: {
+      manifest: true,
+      reportCompressedSize: false,
+    },
+    optimizeDeps: {
+      exclude: ['@terrastruct/d2'],
+    },
+    server: {
+      port: devPort,
+      host: true,
+      allowedHosts: ['dashboard', 'localhost', '.localhost'],
+      proxy: {
+        // Same-origin proxy so the dashboard can call the claw-auth backend
+        // (which sets no CORS headers) during local dev, mirroring
+        // xyne-claw-auth/frontend/vite.config.ts.
+        '/claw/api/v1': {
+          target: env.VITE_CLAW_BACKEND_URL || 'http://localhost:3003',
+          changeOrigin: true,
+          secure: false,
         },
+        // The SDLC server is served through this one, so it must not self-proxy.
+        ...(isSdlcSurface ? {} : sdlcEdgeProxy),
+        ...(env.VITE_ENVIRONMENT === 'test'
+          ? {
+              '/api': {
+                target: env.VITE_API_BASE_URL,
+                changeOrigin: true,
+                secure: false,
+                ws: true,
+              },
+              '/zero': {
+                target: env.VITE_ZERO_SERVER || 'http://localhost:4848',
+                changeOrigin: true,
+                secure: false,
+                ws: true,
+              },
+            }
+          : {}),
+      },
+    },
+    preview: {
+      port: 5173,
+      host: true,
+      allowedHosts: ['dashboard', 'localhost', '.localhost'],
+      proxy: {
+        // Keep the same-origin routes used by browser tests when the test image
+        // serves its prebuilt bundle with `vite preview`.
+        '/claw/api/v1': {
+          target: env.VITE_CLAW_BACKEND_URL || 'http://localhost:3003',
+          changeOrigin: true,
+          secure: false,
+        },
+        ...(env.VITE_ENVIRONMENT === 'test'
+          ? {
+              '/api': {
+                target: env.VITE_API_BASE_URL,
+                changeOrigin: true,
+                secure: false,
+                ws: true,
+              },
+              '/zero': {
+                target: env.VITE_ZERO_SERVER,
+                changeOrigin: true,
+                secure: false,
+                ws: true,
+              },
+            }
+          : {}),
+      },
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@/lib': path.resolve(__dirname, './src/shared/lib'),
+        '@/components': path.resolve(__dirname, './src/shared/components'),
+        '@/hooks': path.resolve(__dirname, './src/shared/hooks'),
+        '@/workflow-ui': path.resolve(__dirname, './src/workflow-ui'),
+        // Alias the real package to a private name so the shim can import it
+        // without creating a circular dependency.
+        'react-router-dom-actual': path.resolve(__dirname, 'node_modules/react-router-dom'),
+        // Transparently replace react-router-dom with our workspace-aware shim.
+        // All existing `import { useNavigate, Link } from 'react-router-dom'` calls
+        // now get workspace-prefixed versions at runtime with zero per-file changes.
+        'react-router-dom': path.resolve(__dirname, 'src/lib/react-router-dom-shim.ts'),
+      },
+      dedupe: [
+        'react',
+        'react-dom',
+        '@rocicorp/zero',
+        '@tanstack/react-query',
+        '@xstate/react',
+        'xstate',
       ],
-    }),
-  ],
-  build: {
-    manifest: true,
-    reportCompressedSize: false,
-  },
-  optimizeDeps: {
-    exclude: ['@terrastruct/d2'],
-  },
-  server: {
-    port: 5173,
-    host: true,
-    allowedHosts: ['dashboard', 'localhost', '.localhost'],
-    proxy: {
-      // Same-origin proxy so the dashboard can call the claw-auth backend
-      // (which sets no CORS headers) during local dev, mirroring
-      // xyne-claw-auth/frontend/vite.config.ts.
-      '/claw/api/v1': {
-        target: process.env.VITE_CLAW_BACKEND_URL || 'http://localhost:3003',
-        changeOrigin: true,
-        secure: false,
-      },
-      ...(process.env.VITE_ENVIRONMENT === 'test'
-        ? {
-            '/api': {
-              target: process.env.VITE_API_BASE_URL,
-              changeOrigin: true,
-              secure: false,
-              ws: true,
-            },
-            '/zero': {
-              target: process.env.VITE_ZERO_SERVER || 'http://localhost:4848',
-              changeOrigin: true,
-              secure: false,
-              ws: true,
-            },
-          }
-        : {}),
     },
-  },
-  preview: {
-    port: 5173,
-    host: true,
-    allowedHosts: ['dashboard', 'localhost', '.localhost'],
-    proxy: {
-      // Keep the same-origin routes used by browser tests when the test image
-      // serves its prebuilt bundle with `vite preview`.
-      '/claw/api/v1': {
-        target: process.env.VITE_CLAW_BACKEND_URL || 'http://localhost:3003',
-        changeOrigin: true,
-        secure: false,
-      },
-      ...(process.env.VITE_ENVIRONMENT === 'test'
-        ? {
-            '/api': {
-              target: process.env.VITE_API_BASE_URL,
-              changeOrigin: true,
-              secure: false,
-              ws: true,
-            },
-            '/zero': {
-              target: process.env.VITE_ZERO_SERVER,
-              changeOrigin: true,
-              secure: false,
-              ws: true,
-            },
-          }
-        : {}),
+    define: {
+      // Keys are the literal source tokens Vite replaces; only values come from env.
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.VITE_API_URL': JSON.stringify(env.VITE_API_URL),
+      'process.env.VITE_GOOGLE_CLIENT_ID': JSON.stringify(env.VITE_GOOGLE_CLIENT_ID),
+      'process.env.VITE_MIXPANEL_TOKEN': JSON.stringify(env.VITE_MIXPANEL_TOKEN),
+      __APP_VERSION__: JSON.stringify(packageJson.version),
     },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@/lib': path.resolve(__dirname, './src/shared/lib'),
-      '@/components': path.resolve(__dirname, './src/shared/components'),
-      '@/hooks': path.resolve(__dirname, './src/shared/hooks'),
-      '@/workflow-ui': path.resolve(__dirname, './src/workflow-ui'),
-      // Alias the real package to a private name so the shim can import it
-      // without creating a circular dependency.
-      'react-router-dom-actual': path.resolve(__dirname, 'node_modules/react-router-dom'),
-      // Transparently replace react-router-dom with our workspace-aware shim.
-      // All existing `import { useNavigate, Link } from 'react-router-dom'` calls
-      // now get workspace-prefixed versions at runtime with zero per-file changes.
-      'react-router-dom': path.resolve(__dirname, 'src/lib/react-router-dom-shim.ts'),
-    },
-    dedupe: ['react', 'react-dom', '@rocicorp/zero', '@tanstack/react-query', '@xstate/react', 'xstate']
-  },
-  define: {
-    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-    'process.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL),
-    'process.env.VITE_GOOGLE_CLIENT_ID': JSON.stringify(process.env.VITE_GOOGLE_CLIENT_ID),
-    'process.env.VITE_MIXPANEL_TOKEN': JSON.stringify(process.env.VITE_MIXPANEL_TOKEN),
-    __APP_VERSION__: JSON.stringify(packageJson.version),
-  },
+  };
 });

--- a/docs/sdlc-fast-lane.md
+++ b/docs/sdlc-fast-lane.md
@@ -1,0 +1,364 @@
+# SDLC fast lane
+
+The SDLC surface ships on its own cadence, independent of the main release train.
+It is the **same source tree** built a second time with different env, deployed as
+its own frontend image, backend Deployment and zero-cache, and embedded by the
+main dashboard in an iframe.
+
+Nothing here is active by default. With the lane's env vars unset, both the main
+bundle and the main backend build and behave exactly as they did before.
+
+---
+
+## Shape
+
+```
+                       one origin: app.spaces.xyne.juspay.net
+                                      │
+        ┌─────────────────────────────┼──────────────────────────────┐
+        │      edge (prod: GKE Ingress · sandbox: GCLB → NEGs)         │
+        └──┬────────────┬─────────────┬──────────────┬───────────────┘
+           │            │             │              │
+      /*   │      /api/*│    /zero/*  │  /sdlc-app/* │  /sdlc-api/*
+           │            │             │              │  /sdlc-zero/*
+           ▼            ▼             ▼              ▼
+     ┌──────────┐ ┌──────────┐ ┌───────────┐  ┌──────────────────────┐
+     │ dashboard│ │ backend  │ │zero-cache │  │  SDLC lane           │
+     │  (main)  │ │ (main)   │ │  (main)   │  │  dashboard / backend │
+     └──────────┘ └──────────┘ └───────────┘  │  / zero-cache        │
+                                              └──────────────────────┘
+     main release train ───────────────────►   ships independently ──►
+```
+
+The main bundle frames `/sdlc-app/...` for its `/sdlc` routes. The iframe is
+owned by `SdlcFrameHost`, mounted above the router and portalled to `document.body`,
+so leaving `/sdlc` hides it rather than destroying it and returning is instant.
+The SDLC bundle serves that path with the app chrome hidden, so it looks like an
+ordinary panel.
+
+**Same origin on purpose.** The SDLC lane is a *path* on the main host, never a
+subdomain. That keeps the `SameSite=strict` auth cookies working with no widening
+of their `Domain`, and it makes URL path the single routing signal — the only
+mechanism that works for the iframe document, XHR **and** the Zero WebSocket
+alike. A browser cannot attach a custom header to an iframe navigation or to a
+`WebSocket`, and a cookie is scoped to the origin rather than to a frame, so
+neither headers nor cookies can route these three consistently. Do not move the
+lane to a subdomain, or switch routing to a cookie, without revisiting all three.
+
+---
+
+## No prefix rewriting is required
+
+Every SDLC service answers on its prefix directly, so the edge only has to
+*match and forward*. In production that is a hard requirement, not a preference:
+the GCE-class Ingress fronting `spaces.xyne.juspay.net` has no rewrite capability
+at all, which is exactly why `/api/` and `/zero/` reach their services unrewritten
+today.
+
+| Prefix | Handled by | How |
+| --- | --- | --- |
+| `/sdlc-app/*` | SDLC frontend image | Built with `VITE_APP_BASE_PATH=/sdlc-app/`, so Vite emits `/sdlc-app/assets/…`, and the image stores its files under that subdirectory (`STATIC_SUBDIR=sdlc-app`). nginx serves the SPA fallback from `/sdlc-app/index.html`. |
+| `/sdlc-api/*` | SDLC backend | `API_PATH_PREFIX=/sdlc-api` — the first middleware in `app.ts` rewrites the path onto `/api` internally, so every route stays mounted exactly once. |
+| `/sdlc-zero/*` | SDLC zero-cache | zero-cache matches its sync route by suffix and accepts any leading prefix. Verified against a running instance: a WebSocket upgrade to `/sync/v51/connect`, `/zero/sync/v51/connect` and `/sdlc-zero/sync/v51/connect` all return `101 Switching Protocols`. (Its `/keepalive` endpoint is root-only, which is unrelated — the client never calls it under a prefix.) |
+
+---
+
+## Edge configuration
+
+The two clusters differ, so check which one you are targeting.
+
+### Production — a GKE Ingress with plain prefix rules
+
+`xyne-ing` in `xyne-apps` fronts `spaces.xyne.juspay.net`. It is a GCE-class
+Ingress (pre-shared cert, `k8s1-…` NEG backends) and every existing rule is a
+plain `Prefix` → Service with **no rewrite annotation**:
+
+```
+Prefix  /api/        -> xyne-backend:3001
+Prefix  /zero/       -> xyne-spaces-zero:8080
+Prefix  /claw        -> xyne-claw-auth-frontend:8083
+Prefix  /external/   -> xyne-dashboard-external:8080
+Prefix  /            -> xyne-dashboard:8080          # catch-all, last
+```
+
+`/claw` and `/external/` are the precedent worth noting: **separate frontend
+deployments already served under a path prefix on the same host.** The SDLC lane
+is a third instance of that, not a new idea.
+
+Add three rules ahead of the `/` catch-all:
+
+```yaml
+- path: /sdlc-app/
+  pathType: Prefix
+  backend: { service: { name: xyne-sdlc-dashboard, port: { number: 8080 } } }
+- path: /sdlc-api/
+  pathType: Prefix
+  backend: { service: { name: xyne-sdlc-backend,   port: { number: 3001 } } }
+- path: /sdlc-zero/
+  pathType: Prefix
+  backend: { service: { name: xyne-sdlc-zero,      port: { number: 8080 } } }
+```
+
+A GCE-class Ingress cannot rewrite paths at all, so the no-rewrite design is a
+hard requirement here rather than a preference — and it is why `/api/` and
+`/zero/` reach their services unrewritten today.
+
+### Sandbox — standalone NEGs, no Ingress
+
+There is no Ingress object; Services are `ClusterIP` with
+`cloud.google.com/neg: {"ingress":true}` and a GCLB targets the NEGs from
+outside the cluster. The work there is a backend service per NEG plus URL map
+path rules. A GCLB URL map *can* rewrite — do not use it. Both prefixes are
+load-bearing by the time the request lands: the backend maps `/sdlc-api` onto
+`/api` itself, and the frontend's assets live under `/sdlc-app/` on disk, so a
+prefix strip at the edge is a double-strip.
+
+## Following the existing lane pattern
+
+The cluster already runs several parallel lanes — `playground`, `external`,
+`mtls`, `demo` — and each is the same four-part set. Copy it rather than
+inventing a new shape:
+
+| Lane component | Existing example | SDLC equivalent |
+| --- | --- | --- |
+| dashboard | `xyne-dashboard-playground` | `xyne-sdlc-dashboard` |
+| backend | `xyne-backend-playground` | `xyne-sdlc-backend` |
+| zero view-syncer | `xyne-spaces-zero-playground` | `xyne-sdlc-zero` |
+| zero replication-manager | `xyne-spaces-zero-replication-playground` | *optional — see below* |
+
+Deployments are named `<component>-<commit-sha>` and created fresh per build,
+with a stable Service selecting them by label.
+
+## The lane's config lives in two env files
+
+Both are **tracked** — the gitignore excludes `.env`, `.env.local` and
+`.env.*.local`, not `.env.sdlc`. Neither holds secrets; machine-specific
+overrides go in the gitignored `.env.sdlc.local` beside them.
+
+| File | Loaded by | Holds |
+| --- | --- | --- |
+| `apps/dashboard/.env.sdlc` | `vite --mode sdlc` (`dev:sdlc`, `build:sdlc`) | surface, base path, API base override, zero path, zero storage key, dev port |
+| `apps/backend/.env.sdlc` | `dotenv -e .env.sdlc -e .env.local` (`dev:sdlc`) | `PORT`, `API_PATH_PREFIX` |
+
+Two precedence rules to know, because they differ:
+
+- **Vite**: an env var that already exists in the shell **wins over every `.env`
+  file**, so a Docker `ENV` silently shadows `.env.sdlc`. This is why the lane
+  uses its own `VITE_ZERO_PATH` rather than overriding `VITE_ZERO_SERVER`, which
+  the Dockerfile bakes to an absolute URL.
+- **dotenv-cli**: the **first** `-e` file wins (it does not override
+  already-set variables). Hence `-e .env.sdlc -e .env.local` in that order.
+
+## Building the SDLC images
+
+Frontend — same Dockerfile, three build args; everything else comes from
+`.env.sdlc`:
+
+```bash
+docker build -f apps/dashboard/Dockerfile . \
+  --build-arg BUILD_SCRIPT=build:sdlc \
+  --build-arg STATIC_SUBDIR=sdlc-app \
+    -t xyne-sdlc-dashboard
+```
+
+`VITE_ZERO_STORAGE_KEY` (set to `sdlc` in `.env.sdlc`) **must** differ from the
+main bundle's. It is what gives the SDLC Zero client its own IndexedDB; without
+it the two clients share one store on the origin and wipe each other on any
+workspace switch, re-auth, logout or schema refresh (see
+`apps/dashboard/src/zero/dropZeroDatabases.ts`).
+
+Backend — the existing image, with `PORT` and `API_PATH_PREFIX=/sdlc-api` set
+from the deployment (the same values `.env.sdlc` uses locally).
+
+**Run the API only — no worker.** The worker is a separate entrypoint
+(`start:worker`) consuming shared BullMQ queues. A second worker on the same
+Redis would double-process every job in the main lane.
+
+zero view-syncer — see the deployment step below; it consumes the existing
+change stream and points its mutate/query URLs at the SDLC backend.
+
+---
+
+## Local development
+
+```bash
+pnpm run up         # or: pnpm dev
+```
+
+Pick **"Core + SDLC lane"** at the app prompt. Or select `sdlc-backend` and
+`sdlc-dashboard` under "Pick apps", or skip the prompt entirely:
+
+```bash
+XYNE_DEV_APPS=dashboard,backend,worker,sdlc-backend,sdlc-dashboard pnpm dev
+```
+
+| Process | Port | Script |
+| --- | --- | --- |
+| dashboard (main) | 5173 | `dev` |
+| backend (main) | 3001 | `dev` |
+| sdlc-dashboard | 5175 | `dev:sdlc` |
+| sdlc-backend | 3011 | `dev:sdlc` |
+
+The lane is **not** an entry in the infra feature picker (the one that asks about
+Claw, Canvas, Calls, Search…). That picker chooses docker containers, and this
+lane needs none — it is two extra node processes plus proxy rules.
+
+Locally the lane shares the main zero-cache on 4848 rather than running a second
+one; both lanes read the same Postgres, so a second cache would add setup for no
+coverage. Point `VITE_SDLC_ZERO_SERVER` at one to exercise the real two-cache
+shape.
+
+Open **http://localhost:5173** as usual. The main vite server plays the part the
+edge plays in a deployed environment: it proxies `/sdlc-app`, `/sdlc-api` and
+`/sdlc-zero` to the lane's processes. That keeps the iframe same-origin in dev
+exactly as in prod, so cookie behaviour is the same and there is no dev-only
+routing quirk to debug around.
+
+Do not open `http://localhost:5175` directly — the bundle expects to be reached
+through the main origin.
+
+Both lanes share one Postgres and one Redis locally, matching the deployed shape.
+
+---
+
+## Deploying to production
+
+### The ordering constraint that matters
+
+**Deploy the SDLC lane before the main bundle.** The main bundle's `/sdlc` route
+no longer renders the SDLC screen inline — it renders an iframe pointing at
+`/sdlc-app`. Ship main first and every user's SDLC tab is a blank frame until the
+lane and its Ingress rules exist. That is an outage of the surface, caused purely
+by ordering.
+
+Note also that **the first rollout is not independent**: it needs a main-lane
+release, because the main bundle has to learn to frame the lane. Independence
+starts from the second SDLC deploy onward.
+
+### Order of operations
+
+1. **Land the migrations** (normal release train, ahead of everything else).
+   Three SDLC migrations, all additive and nullable, no backfill required:
+   `20260808162841_add_sdlc_hub`, `20260810144756_remove_sdlc_vcs_runtime_grants`,
+   `20260814090000_remove_project_sdlc_board`. Safe to apply while the current
+   main build is running — nothing reads the new columns yet.
+
+2. **Deploy the SDLC backend.** Existing backend image, no rebuild needed — it is
+   the same code with different env:
+
+   ```
+   PORT=3001
+   API_PATH_PREFIX=/sdlc-api
+   ```
+   plus the same database, Redis and secret set as the main backend.
+
+   **API only — do not start the worker.** It is a separate entrypoint
+   (`start:worker`); a second worker on the same Redis double-processes every job
+   in the main lane.
+
+3. **Deploy the SDLC zero view-syncer** — see the phasing note below; you may be
+   able to skip this on day one.
+
+   Zero is already split here into a view-syncer and a replication-manager, so a
+   second view-syncer can consume the EXISTING change stream and adds **no new
+   replication slot**:
+
+   ```
+   ZERO_CHANGE_STREAMER_URI=http://xyne-spaces-zero-replication:80
+   ZERO_MUTATE_URL=http://xyne-sdlc-backend:3001/api/zero/push
+   ZERO_QUERY_URL=http://xyne-sdlc-backend:3001/api/zero/query
+   ZERO_UPSTREAM_DB / ZERO_CVR_DB                     same as the main lane
+   ZERO_REPLICA_FILE=/var/zero/replica.db
+   ZERO_QUERY_FORWARD_COOKIES=true
+   ZERO_MUTATE_FORWARD_COOKIES=true
+   ZERO_PORT=4848
+   ```
+
+   Sharing the replication-manager is the cheaper option and is what removes the
+   WAL concern below. The other lanes each run their own replicator
+   (`xyne-spaces-zero-replication-playground` and friends) — copy that only if
+   the SDLC lane genuinely needs an independent replication position.
+
+4. **Build and deploy the SDLC frontend image:**
+
+   ```bash
+   docker build -f apps/dashboard/Dockerfile . \
+     --build-arg BUILD_SCRIPT=build:sdlc \
+     --build-arg STATIC_SUBDIR=sdlc-app \
+          -t xyne-sdlc-dashboard
+   ```
+
+5. **Add the Ingress rules** (see "Edge configuration" above) — `/sdlc-app`,
+   `/sdlc-api`, `/sdlc-zero`, all `pathType: Prefix`, above the `/` catch-all. No
+   rewrite annotations.
+
+6. **Verify the lane standalone, before main can reach it.** Hit
+   `https://<host>/sdlc-app/<workspaceId>/sdlc` directly in a browser. It should
+   render the SDLC Hub chromeless. If this fails, stop — do not proceed to step 7,
+   because that is what makes it user-visible.
+
+7. **Redeploy the main dashboard** from this branch. No new build args: the main
+   bundle's defaults are unchanged, and `VITE_SDLC_APP_BASE_PATH` falls back to
+   `/sdlc-app` in `config.ts`.
+
+   Deliberately do **not** set `ZERO_STORAGE_KEY` on the main image. Leaving it
+   empty keeps main's IndexedDB name byte-identical, so the rollout does not force
+   a full Zero resync for every user.
+
+### Consider skipping the second zero-cache on day one
+
+Point the SDLC bundle at the existing cache (`VITE_ZERO_PATH=/zero` in `.env.sdlc`) and
+drop the `/sdlc-zero` Ingress rule. You still get independently deployable SDLC
+frontend and backend, which is most of the benefit, and you avoid the second
+replication slot entirely on the riskiest day.
+
+What you give up until you add it: the lane cannot change the Zero schema or
+mutators independently, because the shared cache forwards mutations to the *main*
+backend. Add the cache when the lane actually needs to diverge — that is the
+point where the WAL supervision below starts to matter.
+
+### Rollback
+
+Redeploy the previous main dashboard image. Its `/sdlc` route renders the SDLC
+screen inline again and stops referencing `/sdlc-app` entirely. The lane's own
+services can keep running or be scaled to zero — nothing else points at them.
+Nothing needs to be undone in the database: the migrations are additive, and the
+previous build simply ignores the new columns.
+
+---
+
+## Rules that keep the lanes independent
+
+1. **Schema changes stay on the slow train.** One Postgres serves both lanes.
+   Migrations must be additive and backward compatible — nullable columns, no
+   drops, no renames, no type changes — and should land through the normal
+   release train *ahead* of the SDLC code that uses them. Application code moves
+   fast; schema does not.
+2. **Keep `packages/shared/src/zero/schema.ts` identical across lanes** at any
+   given deploy. Each zero-cache only replicates the tables its own schema
+   declares, so additive DDL is invisible to the other lane — but a client whose
+   schema version disagrees with its cache gets `SchemaVersionNotSupported`,
+   which drops local state and reloads.
+3. **Rebase onto `main` frequently.** Deployment separation does not reduce merge
+   conflicts; only editing fewer shared registries does. The hot files are
+   `zero/schema.ts`, `zero/queries.ts`, `zero/mutators.ts`, `acl/tables/index.ts`,
+   `AppRoot.tsx` and `navigationConfig.ts`.
+4. **Only add a replication slot deliberately.** A second view-syncer pointed at
+   the existing `xyne-spaces-zero-replication` adds no slot and needs no extra
+   supervision — that is the recommended shape. If instead the lane gets its own
+   replication-manager, it does add a slot, and Postgres retains WAL until every
+   slot has consumed it: a stalled or scaled-to-zero replicator can then fill the
+   primary's disk and take down the main product. In that case set
+   `max_slot_wal_keep_size` and alert on `pg_replication_slots.wal_status` before
+   it goes live.
+
+---
+
+## Known trade-off
+
+The SDLC bundle currently builds the **entire** app — it shares the main route
+table so that neither bundle diverges. That keeps the diff small and rebases
+cheap, at the cost of a large bundle for one screen. Giving the SDLC lane its own
+entry with only SDLC routes would shrink it, but introduces permanent structural
+divergence in `AppRoot.tsx` — already one of the hottest rebase files. Worth
+revisiting once the lane is stable and its real divergence is known.

--- a/scripts/dev-interactive.mjs
+++ b/scripts/dev-interactive.mjs
@@ -72,10 +72,33 @@ export const APPS = [
     feature: "claw",
     port: 5174,
   },
+  // Reached through the main dashboard on 5173, which proxies /sdlc-app,
+  // /sdlc-api and /sdlc-zero to them.
+  {
+    id: "sdlc-backend",
+    filter: "xyne-spaces-backend",
+    script: "dev:sdlc",
+    hint: "SDLC API server · http://localhost:3011",
+    color: "yellow",
+    feature: "sdlc",
+    port: 3011,
+  },
+  {
+    id: "sdlc-dashboard",
+    filter: "xyne-spaces-dashboard",
+    script: "dev:sdlc",
+    hint: "SDLC web UI · http://localhost:5173/sdlc-app/",
+    color: "magenta",
+    feature: "sdlc",
+    port: 5175,
+  },
 ];
 
 const appIds = APPS.map((app) => app.id);
 const coreIds = APPS.filter((app) => app.core).map((app) => app.id);
+// The SDLC lane. Not in the infra feature picker — that one chooses docker
+// containers and this lane needs none. See docs/sdlc-fast-lane.md.
+const sdlcIds = APPS.filter((app) => app.feature === "sdlc").map((app) => app.id);
 
 const commandFor = (app) => `pnpm --filter ${app.filter} ${app.script}`;
 
@@ -275,6 +298,11 @@ async function promptForApps(initial) {
   presetOptions.push(
     { value: "all", label: "Everything", hint: appIds.join(", ") },
     { value: "core", label: "Core", hint: coreIds.join(", ") },
+    {
+      value: "core+sdlc",
+      label: "Core + SDLC lane",
+      hint: [...coreIds, ...sdlcIds].join(", "),
+    },
     { value: "custom", label: "Pick apps", hint: "choose exactly what runs" },
   );
 
@@ -289,6 +317,7 @@ async function promptForApps(initial) {
   if (preset === "last") return initial;
   if (preset === "all") return [...appIds];
   if (preset === "core") return [...coreIds];
+  if (preset === "core+sdlc") return appIds.filter((id) => [...coreIds, ...sdlcIds].includes(id));
 
   const picked = await clack.multiselect({
     message: "Select apps (space to toggle, enter to confirm)",


### PR DESCRIPTION
Backport of the SDLC fast lane to `release-20260821`. Same change as #761 (→ `main`) and what already ships on `release-20260817`.

### Why this branch needs it

`release-20260821` was cut from `main` before the lane landed, so it has the SDLC **feature** but none of the lane infrastructure or the fixes. Without this, an 0821 release ships a dashboard image with no `/sdlc-app` bundle, and the lane can only be rebuilt from `release-20260817`.

### What it adds

- **frontend** — `VITE_APP_BASE_PATH` basename, its own vite cache dir, nginx `location /sdlc-app/`, Dockerfile `BUILD_SCRIPT` / `STATIC_SUBDIR` build args
- **backend** — `API_PATH_PREFIX` maps `/sdlc-api` onto `/api`
- **zero** — `VITE_ZERO_PATH` gives the lane its own zero-cache, resolved against the serving host so one build runs behind any hostname
- **storage** — `VITE_ZERO_STORAGE_KEY` scopes the lane's IndexedDB; drops are lane-scoped everywhere except logout, where both bundles are torn down together
- **apiClient** — strips the basename before deriving the workspace id, which the lane would otherwise read as `sdlc-app`

The main bundle is unaffected: every lane variable is empty in that build, so each addition short-circuits to the existing behaviour.

### How it was produced

Cherry-picked from the rebased `main` PR (#761) — **no conflicts**, since 0821 is cut from main.

### Verified

| check | result |
|---|---|
| dashboard `typecheck` | 0 errors |
| dashboard `format:check` | clean |
| dashboard `lint` | 0 errors (2242 pre-existing warnings) |
| lane markers vs `release-20260817` | 12/12 identical counts, 0 drift |

Run against a real `pnpm install` + `prisma generate` + `db:common:generate` + shared/icons build in a clean worktree.

### Note

Deploying the lane also needs the istio routes for `/sdlc-app/`, `/sdlc-api/` and `/sdlc-zero/`; those already exist in prod and are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)