### PR TITLE
fix: XYNE-56726 use the system channel-naming rule for SDLC repo channels

### DIFF
--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -10,12 +10,15 @@ import {
   ChannelVisibility,
   SDLC_BASELINE_COUNT,
   WorkspaceRole,
+  normalizeChannelName,
+  validateChannelName,
   type AttachSdlcRepositoryInput,
   type CreateSdlcClawArtifactInput,
   type CreateSdlcLinkInput,
   type UpdateSdlcBaselineDraftInput,
   type UpdateSdlcClawArtifactInput,
 } from '@xyne/shared';
+import { ChannelRepository } from '@/database/repositories/channelRepository';
 import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
 import { sdlcQueue } from '@/queues/sdlcQueue';
@@ -66,6 +69,7 @@ import {
 import { sdlcVcs } from './vcs';
 
 const SDLC_FOLDERS = ['Baseline', 'PRDs', 'Tech Docs'] as const;
+const channelRepository = new ChannelRepository();
 type TransactionClient = Prisma.TransactionClient;
 
 export class SdlcHubService implements SdlcHub {
@@ -77,7 +81,11 @@ export class SdlcHubService implements SdlcHub {
   ): Promise<SdlcRepositoryHub> {
     const parsedRepository = sdlcVcs.parseRepository('GITHUB', input.url);
     const canonicalUrl = parsedRepository.canonicalUrl;
-    const name = input.name?.trim() || parsedRepository.name;
+    const name = normalizeChannelName(input.name?.trim() || parsedRepository.name);
+    const nameError = validateChannelName(name);
+    if (nameError) {
+      throw new AppError(nameError, 400);
+    }
 
     try {
       const repository = await this.prisma.$transaction(async (tx) => {
@@ -98,6 +106,10 @@ export class SdlcHubService implements SdlcHub {
           throw new AppError('Repository already has an SDLC hub in this workspace', 409);
         }
 
+        if (await channelRepository.checkDuplicateName(name, actor.workspaceId)) {
+          throw new AppError(`Channel with name "${name}" already exists.`, 409);
+        }
+
         const repoId = randomUUID();
         const channelId = randomUUID();
         const now = new Date();
@@ -105,9 +117,9 @@ export class SdlcHubService implements SdlcHub {
         await tx.channel.create({
           data: {
             id: channelId,
-            name: `${name} · SDLC`,
+            name,
             description: `Private SDLC workspace for ${name}`,
-            type: ChannelType.DEFAULT,
+            type: ChannelType.SDLC,
             scopeType: ChannelScopeType.DEFAULT,
             visibility: ChannelVisibility.PRIVATE,
             createdBy: actor.userId,
@@ -118,7 +130,6 @@ export class SdlcHubService implements SdlcHub {
             showTicketsTabTicketsInChat: false,
             metadata: {
               surface: 'SDLC',
-              hiddenFromChat: true,
               repoId,
             },
             channelStats: {

--- a/apps/dashboard/src/components/Activity/sdlcActivityNavigation.ts
+++ b/apps/dashboard/src/components/Activity/sdlcActivityNavigation.ts
@@ -21,10 +21,7 @@ const metadataRecord = (value: unknown): CanvasMetadata =>
 
 const sdlcRepoId = (metadata: unknown): string | null => {
   const value = metadataRecord(metadata);
-  return value['surface'] === 'SDLC' &&
-    value['hiddenFromChat'] === true &&
-    typeof value['repoId'] === 'string' &&
-    value['repoId']
+  return value['surface'] === 'SDLC' && typeof value['repoId'] === 'string' && value['repoId']
     ? value['repoId']
     : null;
 };

--- a/apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx
+++ b/apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx
@@ -2,7 +2,13 @@ import { logger, Event as LogEvent } from '../../../utils/logger';
 import { ReactElement, useState, useRef, useEffect } from 'react';
 import { flushSync } from 'react-dom';
 import { useZero } from '../../../hooks/useZero';
-import { Channel, ChannelRole, ChannelScopeType } from '@xyne/shared';
+import {
+  Channel,
+  ChannelRole,
+  ChannelScopeType,
+  normalizeChannelName,
+  validateChannelName,
+} from '@xyne/shared';
 import { mutators } from '../../../zero/mutators';
 import Button from '../../ui/Button';
 import { LucideSquarePen } from 'lucide-react';
@@ -142,13 +148,7 @@ const AboutChannel = ({
 
   // ----- Name editing -----
 
-  const validateName = (value: string): string => {
-    if (value.length < 2) return 'Channel name must be at least 2 characters';
-    if (value.length > 80) return 'Channel name must be 80 characters or less';
-    if (!/^[a-z0-9-_]+$/.test(value))
-      return 'Only lowercase letters, numbers, hyphens, and underscores are allowed';
-    return '';
-  };
+  const validateName = (value: string): string => validateChannelName(value) ?? '';
 
   const handleEditName = (): void => {
     setIsEditingName(true);
@@ -157,8 +157,7 @@ const AboutChannel = ({
   };
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    // Convert spaces to hyphens and force lowercase, matching AddChannelForm behaviour
-    const formatted = e.target.value.toLowerCase().replace(/\s+/g, '-');
+    const formatted = normalizeChannelName(e.target.value);
     setEditName(formatted);
     setNameError(validateName(formatted));
   };

--- a/apps/dashboard/src/components/Chat/AddChannelForm/AddChannelForm.tsx
+++ b/apps/dashboard/src/components/Chat/AddChannelForm/AddChannelForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, ReactElement, useMemo } from 'react';
-import { ANDROID_PACKAGE_NAME_PATTERN } from '@xyne/shared';
+import { ANDROID_PACKAGE_NAME_PATTERN, normalizeChannelName } from '@xyne/shared';
 import { useForm } from '@tanstack/react-form';
 import { useStore } from '@tanstack/react-store';
 import { useQuery } from '@tanstack/react-query';
@@ -471,12 +471,7 @@ export const AddChannelForm: React.FC<AddChannelFormProps> = ({
   }, [duplicateCheck, form]);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value;
-    // Convert spaces to hyphens, then remove special characters, keep only alphanumeric, hyphens, and underscores
-    const cleanValue = value
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-_]/g, '');
+    const cleanValue = normalizeChannelName(e.target.value);
     form.setFieldValue('name', cleanValue);
     setChannelName(cleanValue);
   };

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.utils.ts
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.utils.ts
@@ -95,10 +95,6 @@ export const groupChannelsByScope = (
   const channels: VisibleChannel[] = [];
   const directMessages: VisibleChannel[] = [];
   for (const channel of channelData) {
-    const metadata = channel.metadata as Record<string, unknown> | null | undefined;
-    if (metadata?.['surface'] === 'SDLC' && metadata['hiddenFromChat'] === true) {
-      continue;
-    }
     // EMAIL channels live in Xyne Desk, not in the chat directory.
     // TODO: filter this out at the source by excluding EMAIL-type channels in the
     // `visibleChannels` query itself, so the client never receives them here.

--- a/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
@@ -1,6 +1,14 @@
 import { ReactElement, useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate, useLocation, useSearchParams } from 'react-router-dom';
-import { BoardType, deserializeFlowPlan, type FlowPlan } from '@xyne/shared';
+import {
+  BoardType,
+  deserializeFlowPlan,
+  inferRepositoryNameFromUrl,
+  normalizeChannelName,
+  validateChannelName,
+  type FlowPlan,
+} from '@xyne/shared';
+import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Edit2, GitBranch, LayoutGrid, Rocket } from 'lucide-react';
 import { BoardsTable, type BoardWithStages } from '../../components/Board';
 import * as Tabs from '@radix-ui/react-tabs';
@@ -24,6 +32,7 @@ import { toast } from 'sonner';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { cn } from '../../utils/classNames';
 import { apiInstance } from '../../services/clients/apiClient';
+import { channelService } from '../../services/Chat/channelService';
 import { ProjectRepositoriesSection } from './ProjectRepositoriesSection';
 
 // Type for board data passed from BoardEditScreen to BoardStageConfigScreen
@@ -73,6 +82,8 @@ const ProjectDetailScreen = (): ReactElement => {
   const [showAddRepositoryModal, setShowAddRepositoryModal] = useState(false);
   const [repositoryUrl, setRepositoryUrl] = useState('');
   const [repositoryName, setRepositoryName] = useState('');
+  const [repositoryNameEdited, setRepositoryNameEdited] = useState(false);
+  const [debouncedRepositoryName, setDebouncedRepositoryName] = useState('');
   const [repositoryBranch, setRepositoryBranch] = useState('main');
   const [addingRepository, setAddingRepository] = useState(false);
   const [repositoryRefreshKey, setRepositoryRefreshKey] = useState(0);
@@ -211,6 +222,21 @@ const ProjectDetailScreen = (): ReactElement => {
     fullBoardDetailsStatus.type,
   ]);
 
+  useEffect(() => {
+    const timeoutId = setTimeout(() => setDebouncedRepositoryName(repositoryName), 500);
+    return (): void => clearTimeout(timeoutId);
+  }, [repositoryName]);
+
+  const { data: channelDuplicateCheck } = useQuery({
+    queryKey: ['checkDuplicateChannel', debouncedRepositoryName, 'default'],
+    queryFn: () => channelService.checkDuplicateChannel(debouncedRepositoryName, 'default'),
+    enabled:
+      Boolean(debouncedRepositoryName) && validateChannelName(debouncedRepositoryName) === null,
+    staleTime: 0,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
   const loading = project === undefined || boards === undefined;
 
   // Early return if no projectId
@@ -265,20 +291,36 @@ const ProjectDetailScreen = (): ReactElement => {
     }
   };
 
+  const repositoryNameError = repositoryName
+    ? (validateChannelName(repositoryName) ??
+      (channelDuplicateCheck?.isDuplicate ? 'Channel name already exists' : null))
+    : null;
+
+  const handleRepositoryUrlChange = (value: string): void => {
+    setRepositoryUrl(value);
+    if (repositoryNameEdited) return;
+    setRepositoryName(normalizeChannelName(inferRepositoryNameFromUrl(value) ?? ''));
+  };
+
+  const closeAddRepositoryModal = (): void => {
+    setShowAddRepositoryModal(false);
+    setRepositoryUrl('');
+    setRepositoryName('');
+    setRepositoryNameEdited(false);
+  };
+
   const handleAddRepository = async (): Promise<void> => {
-    if (!repositoryUrl.trim()) return;
+    if (!repositoryUrl.trim() || repositoryNameError || !repositoryName) return;
     setAddingRepository(true);
     try {
       await apiInstance.post('/sdlc/repositories', {
         projectId,
         url: repositoryUrl.trim(),
-        ...(repositoryName.trim() && { name: repositoryName.trim() }),
+        name: repositoryName,
         baseBranch: repositoryBranch.trim() || 'main',
       });
       toast.success('Repository attached');
-      setShowAddRepositoryModal(false);
-      setRepositoryUrl('');
-      setRepositoryName('');
+      closeAddRepositoryModal();
       setActiveTab('repos');
       setRepositoryRefreshKey(value => value + 1);
     } catch (error) {
@@ -765,7 +807,7 @@ const ProjectDetailScreen = (): ReactElement => {
 
       <Dialog
         open={showAddRepositoryModal}
-        onOpenChange={setShowAddRepositoryModal}
+        onOpenChange={open => (open ? setShowAddRepositoryModal(true) : closeAddRepositoryModal())}
         title='Add Repository'
         description='Create a private SDLC hub for this repository'
       >
@@ -789,24 +831,38 @@ const ProjectDetailScreen = (): ReactElement => {
             autoFocus
             required
             value={repositoryUrl}
-            onChange={event => setRepositoryUrl(event.target.value)}
+            onChange={event => handleRepositoryUrlChange(event.target.value)}
             className='mt-2 h-10 w-full rounded-md border bg-background px-3 outline-none focus:ring-2 focus:ring-ring'
             placeholder='https://github.com/org/repository.git'
             data-track-category='ProjectDetail'
             data-track-name='RepositoryUrlChanged'
           />
           <label htmlFor='sdlc-repository-name' className='mt-4 block text-sm font-medium'>
-            Display name <span className='font-normal text-muted-foreground'>(optional)</span>
+            Channel name
           </label>
           <input
             id='sdlc-repository-name'
+            required
             value={repositoryName}
-            onChange={event => setRepositoryName(event.target.value)}
-            className='mt-2 h-10 w-full rounded-md border bg-background px-3 outline-none focus:ring-2 focus:ring-ring'
-            placeholder='Inferred from URL'
+            onChange={event => {
+              setRepositoryNameEdited(true);
+              setRepositoryName(normalizeChannelName(event.target.value));
+            }}
+            className={cn(
+              'mt-2 h-10 w-full rounded-md border bg-background px-3 outline-none focus:ring-2 focus:ring-ring',
+              repositoryNameError && 'border-destructive focus:ring-destructive',
+            )}
             data-track-category='ProjectDetail'
             data-track-name='RepositoryNameChanged'
           />
+          <p
+            className={cn(
+              'mt-1 text-xs',
+              repositoryNameError ? 'text-destructive' : 'text-muted-foreground',
+            )}
+          >
+            {repositoryNameError ?? "Names this repository's SDLC channel."}
+          </p>
           <div className='mt-4'>
             <label htmlFor='sdlc-repository-branch' className='block text-sm font-medium'>
               Base branch
@@ -821,14 +877,14 @@ const ProjectDetailScreen = (): ReactElement => {
             />
           </div>
           <div className='mt-6 flex justify-end gap-2'>
-            <Button
-              type='button'
-              variant='outline'
-              onClick={() => setShowAddRepositoryModal(false)}
-            >
+            <Button type='button' variant='outline' onClick={closeAddRepositoryModal}>
               Cancel
             </Button>
-            <Button type='submit' loading={addingRepository} disabled={!repositoryUrl.trim()}>
+            <Button
+              type='submit'
+              loading={addingRepository}
+              disabled={!repositoryUrl.trim() || !repositoryName || Boolean(repositoryNameError)}
+            >
               Attach repository
             </Button>
           </div>

--- a/packages/shared/src/sdlc.ts
+++ b/packages/shared/src/sdlc.ts
@@ -613,6 +613,17 @@ export interface SdlcWikiCanvasMetadata {
 
 export interface SdlcChannelMetadata {
   surface: "SDLC";
-  hiddenFromChat: true;
   repoId: string;
+  hiddenFromChat?: true;
+}
+
+export function inferRepositoryNameFromUrl(raw: string): string | null {
+  const value = raw.trim().replace(/^git@([^:]+):/, "https://$1/");
+  const path = value.includes("://") ? value.split("://")[1] : value;
+  const segments = (path ?? "")
+    .split(/[?#]/)[0]!
+    .replace(/\.git$/i, "")
+    .split("/")
+    .filter(Boolean);
+  return segments.length >= 3 ? segments.at(-1)! : null;
 }

--- a/packages/shared/src/utils/channel.ts
+++ b/packages/shared/src/utils/channel.ts
@@ -28,3 +28,23 @@ export function deskTypeForChannelType(type: string | null | undefined): DeskTyp
       return DeskType.EMAIL;
   }
 }
+
+export const CHANNEL_NAME_MIN_LENGTH = 2;
+export const CHANNEL_NAME_MAX_LENGTH = 80;
+
+export function normalizeChannelName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-_]/g, '');
+}
+
+export function validateChannelName(value: string): string | null {
+  if (value.length < CHANNEL_NAME_MIN_LENGTH)
+    return `Channel name must be at least ${CHANNEL_NAME_MIN_LENGTH} characters`;
+  if (value.length > CHANNEL_NAME_MAX_LENGTH)
+    return `Channel name must be ${CHANNEL_NAME_MAX_LENGTH} characters or less`;
+  if (!/^[a-z0-9-_]+$/.test(value))
+    return 'Only lowercase letters, numbers, hyphens, and underscores are allowed';
+  return null;
+}

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -731,6 +731,7 @@ export enum ChannelType {
   APP = 'APP',
   CALL = 'CALL',
   SOCIAL_MEDIA = 'SOCIAL_MEDIA',
+  SDLC = 'SDLC',
 }
 
 // @ts-ignore TS1294


### PR DESCRIPTION
Same change as #902 (against `release-20260817`) and #898. Single commit, cherry-picked; the two auto-merged files were `AboutChannel.tsx` and `zero/types.ts`, both trivial.

## Problem

Attaching a repository named its SDLC hub channel `` `${name} · SDLC` `` — the repo name verbatim, case preserved, with a U+00B7 middle dot padded by spaces.

The system rule for channel names is lowercase, spaces to hyphens, nothing outside `[a-z0-9-_]`, 2–80 chars. So `Xyne-Spaces` produced `Xyne-Spaces · SDLC`, which fails the rename validator in `AboutChannel` — once created, the channel's name could never be corrected through the UI.

Root cause: the rule had **no single definition**. The normalize half was inline in `AddChannelForm`, the validate half inline in `AboutChannel`, and the backend had neither. SDLC didn't skip validation — there was nothing for it to call.

## Changes

**Shared** — `normalizeChannelName` / `validateChannelName` in `packages/shared/src/utils/channel.ts`, lifted verbatim from the two inline copies, plus `inferRepositoryNameFromUrl` for client-side autofill.

**Both chat forms** — `AddChannelForm` and `AboutChannel` call the shared helpers instead of their own copies. Behaviour unchanged, except `AboutChannel.handleNameChange` previously lowercased and dashed without stripping specials, so it could produce a value its own validator rejected; it now strips as you type.

**Repo-add form** (`ProjectDetailScreen`) — name autofills from the URL, normalizes as you type, and shows an inline duplicate error via the existing `checkDuplicateChannel` endpoint with the same 500 ms debounce as the main channel input. Submit disabled while invalid.

**Backend** (`SdlcHubService`) — normalizes and validates the name (400 on invalid) and calls the existing `ChannelRepository.checkDuplicateName` for uniqueness (409 on collision). It keeps its own transactional insert, as the desk services do — `ChannelRepository.create` isn't transaction-aware and can't take a preset id, and SDLC needs the channel id up front for `canvasFolders` and `repo.channelId` in the same transaction. **`channelRepository.ts` is untouched**; only call sites were added.

**Visibility** — SDLC channels now carry `ChannelType.SDLC` and are no longer filtered out of the chat directory, so they appear in the main channel list.

## Notes for review

- **No migration.** `channels.type` is a text column, so the enum gains a value only. The enum guard passes.
- `metadata.hiddenFromChat` is no longer written and is now optional. Existing rows still carry it, and SDLC channel identification in `sdlcActivityNavigation` falls back to `surface` + `repoId`, so old and new rows both resolve.
- The chat-directory filter was read-time, so **existing** SDLC channels become visible too, not just new ones.
- The duplicate check reads outside the transaction — the same race window `ChannelRepository.create` and `ChannelController` already have. `channels.name` has no unique constraint at the DB level.
- Existing channels named `<repo> · SDLC` are not renamed.

## Verification

- `packages/shared` build — pass
- dashboard `lint:errors-only` — pass (0 errors)
- dashboard `validate` — pass (0 errors)
- backend `typecheck` — **zero errors in any file this commit touches**. The worktree reports pre-existing errors from unbuilt workspace packages (`agentic-framework`, `prisma-common`); the error set is identical with and without this commit.
- gitleaks — no leaks; enum guard — pass

Manual: paste `https://github.com/org/Xyne-Spaces.git` → name autofills `xyne-spaces`; typing `My API v2` renders `my-api-v2`; an existing channel name shows the inline error and blocks submit; the created channel now passes the rename validator, which it never could before.

Services-Requiring-Redeployment:
  - backend
  - dashboard
