### PR TITLE
fix: keep the recordings list on the tab you left it on

### DIFF
--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -95,6 +95,7 @@ import { useSummaryTemplates } from '../../hooks/useSummaryTemplates';
 
 interface RecordingNavState {
   recordingIds?: string[];
+  from?: string;
 }
 
 const AUDIO_POLL_INTERVAL_MS = 10_000;
@@ -319,6 +320,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
   // j/k keyboard navigation between recordings
   const navState = location.state as RecordingNavState | null;
   const recordingIds = navState?.recordingIds;
+  const backTo = navState?.from ?? '/recordings';
   const currentIndex = useMemo(
     () => (recordingId ? (recordingIds?.indexOf(recordingId) ?? -1) : -1),
     [recordingId, recordingIds],
@@ -537,8 +539,8 @@ export default function RecordingDetailV2Screen(): ReactElement {
 
   const handleMinimize = useCallback((): void => {
     sendRecordingEvent({ type: 'setTranscriptMinimized', isMinimized: false });
-    void navigate('/recordings');
-  }, [navigate]);
+    void navigate(backTo);
+  }, [backTo, navigate]);
 
   /**
    * The panels differ wildly in height — a long transcript against a short notes
@@ -775,7 +777,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
       <RecordingLoadError
         failure={resolvedFailure}
         viewerEmail={currentUser?.email}
-        onBack={() => void navigate('/recordings')}
+        onBack={() => void navigate(backTo)}
       />
     );
   }
@@ -887,6 +889,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
             <RecordingDetailV2Header
               recording={recording}
               isLive={isLive}
+              backTo={backTo}
               titleState={titleState}
               onTitleUpdated={handleTitleUpdated}
               onLabelsUpdated={handleLabelsUpdated}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -28,6 +28,7 @@ import { RecordingTicketLink, type RecordingTicketTarget } from './RecordingTick
 export interface RecordingDetailV2HeaderProps {
   recording: RecordingDetail;
   isLive: boolean;
+  backTo: string;
   titleState?: RecordingTitleState;
   onTitleUpdated: (title: string) => void;
   onLabelsUpdated: (labels: string[]) => void;
@@ -60,6 +61,7 @@ const HeaderTitle = ({
 export const RecordingDetailV2Header = ({
   recording,
   isLive,
+  backTo,
   titleState,
   onTitleUpdated,
   onLabelsUpdated,
@@ -203,7 +205,7 @@ export const RecordingDetailV2Header = ({
           <li>
             <button
               type='button'
-              onClick={() => void navigate('/recordings')}
+              onClick={() => void navigate(backTo)}
               className='flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground duration-300'
               data-track-category='RecordingDetailV2'
               data-track-name='breadcrumb_recordings'

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { Virtuoso } from 'react-virtuoso';
 import { LayersTo, Spinner } from '@xyne/icons';
 import { CallStatus, TagMethod } from '@xyne/shared';
@@ -48,13 +48,15 @@ import { useSummaryTemplates } from '../../hooks/useSummaryTemplates';
 const RecordingsV2Screen = (): ReactElement => {
   const { isMobile } = usePlatform();
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const shouldReduceMotion = useReducedMotion();
   const requestedSummaryTemplateId = searchParams.get('summaryTemplateId');
   const shouldOpenTemplatesFromUrl =
     searchParams.get('templates') === '1' || requestedSummaryTemplateId !== null;
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
-  const [activeListTab, setActiveListTab] = useState<RecordingOwnershipTab>('created');
+  const activeListTab: RecordingOwnershipTab =
+    searchParams.get('tab') === 'shared' ? 'shared' : 'created';
   const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
   const [selectedDatePreset, setSelectedDatePreset] = useState<RecordingDatePreset>('all-time');
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
@@ -204,6 +206,21 @@ const RecordingsV2Screen = (): ReactElement => {
     [recordings],
   );
 
+  const setActiveListTab = useCallback(
+    (tab: RecordingOwnershipTab): void => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          if (tab === 'shared') next.set('tab', 'shared');
+          else next.delete('tab');
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
   const handleTabChange = useCallback(
     (tab: RecordingOwnershipTab): void => {
       if (tab === activeListTab) return;
@@ -213,7 +230,7 @@ const RecordingsV2Screen = (): ReactElement => {
       setSelectedLabels([]);
       setSelectedSharerIds([]);
     },
-    [activeListTab],
+    [activeListTab, setActiveListTab],
   );
 
   const handleCreatorChange = useCallback(
@@ -223,25 +240,31 @@ const RecordingsV2Screen = (): ReactElement => {
         setActiveListTab(creatorId === currentUser?.id ? 'created' : 'shared');
       }
     },
-    [currentUser?.id],
+    [currentUser?.id, setActiveListTab],
   );
 
   const handleOpenRecording = useCallback(
     (recordingId: string): void => {
       void navigate(`/recordings/${recordingId}`, {
-        state: { recordingIds: filteredRecordings.map(recording => recording.externalId) },
+        state: {
+          recordingIds: filteredRecordings.map(recording => recording.externalId),
+          from: `${location.pathname}${location.search}`,
+        },
       });
     },
-    [filteredRecordings, navigate],
+    [filteredRecordings, location.pathname, location.search, navigate],
   );
 
   const handleOpenLiveRecordingWindow = useCallback(
     (recordingId: string): void => {
       void navigate(`/recordings/${recordingId}`, {
-        state: { recordingIds: filteredRecordings.map(recording => recording.externalId) },
+        state: {
+          recordingIds: filteredRecordings.map(recording => recording.externalId),
+          from: `${location.pathname}${location.search}`,
+        },
       });
     },
-    [filteredRecordings, navigate],
+    [filteredRecordings, location.pathname, location.search, navigate],
   );
 
   const handleOpenAskAI = useCallback((): void => {


### PR DESCRIPTION
POT - https://github.com/user-attachments/assets/073cf7d6-dfa8-47ce-9106-9930befc6c5a

## Problem

Open a recording from the **Shared with me** tab, come back, and the list is on **Created by me**.

`recordings` and `recordings/:recordingId` are sibling routes in `AppRoot.tsx`, not nested — so opening a recording unmounts the list component entirely. `activeListTab` was plain `useState<RecordingOwnershipTab>('created')`, so it wasn't being reset, it was being destroyed and rebuilt from its default.

## Fix

**The tab lives in the URL.** `activeListTab` is derived from a `tab` search param, written through a `setActiveListTab` helper with `replace: true` so toggling doesn't stack history entries. This matches the dominant convention in the dashboard (`useSearchParams` + `replace: true`), and this screen already used `useSearchParams` for the templates modal.

**The detail view remembers where it came from.** The URL alone isn't enough here, because none of the ways out of the detail view pop history — they all navigate to a bare `/recordings`:

- the breadcrumb in `RecordingDetailV2Header`
- `handleMinimize`
- the error-state back button

Both navigation handlers now carry `from: <pathname><search>` in navigation state alongside the existing `recordingIds`, and all three exits route through it, falling back to `/recordings` when a recording is opened directly (deep link, notification). This mirrors the existing `returnTo` / `returnToUrl` pattern used by `TicketDetails` and `ClawAgentDetailV2`.

Prev/next paging already forwards the whole navigation state object, so the origin survives paging between recordings with j/k.

## Notes

- `handleCreatorChange` also switches tab when you pick a person in the People filter; it goes through the same URL-backed setter, so that behaviour is unchanged and now also survives the round trip.
- v1 `RecordingsScreen` has no ownership tabs, so this is v2-only.
- Filters (`selectedCreatorId`, `selectedDatePreset`, `selectedLabels`, `selectedSharerIds`), scroll position and the pagination cursor are still reset by the same unmount. Left alone deliberately — `handleTabChange` already clears those filters on every tab switch, so they're tab-scoped and ephemeral by design. Restoring them is a larger change (array params, plus Virtuoso `initialTopMostItemIndex` wiring that has no restore path today).

## Testing

`tsc --noEmit`, `eslint` (0 errors) and `prettier --check` pass for the three changed files.
