### PR TITLE
feat: provider fast mode with per-agent fast-mode provider profile (claw)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { validateAgentModelConfig } from "./agent-config-validation.js";
+
+describe("validateAgentModelConfig — modelSettings.speed", () => {
+  it("accepts fast / standard", () => {
+    expect(validateAgentModelConfig({ modelSettings: { speed: "fast" } })).toEqual({ ok: true });
+    expect(validateAgentModelConfig({ modelSettings: { speed: "standard" } })).toEqual({ ok: true });
+  });
+
+  it("rejects anything else", () => {
+    expect(validateAgentModelConfig({ modelSettings: { speed: "turbo" } }).error).toMatch(/modelSettings\.speed must be one of: standard, fast/);
+    expect(validateAgentModelConfig({ modelSettings: { speed: true } }).ok).toBe(false);
+  });
+
+  it("still rejects unknown modelSettings keys", () => {
+    expect(validateAgentModelConfig({ modelSettings: { fastMode: true } }).error).toMatch(/not a recognized setting/);
+  });
+});
+
+describe("validateAgentModelConfig — fastModeProfile", () => {
+  it("accepts inherit and a custom profile", () => {
+    expect(validateAgentModelConfig({ fastModeProfile: { providers: "inherit" } })).toEqual({ ok: true });
+    expect(validateAgentModelConfig({ fastModeProfile: { providers: "custom", providerOrder: ["claude", "spaces"], models: { claude: "claude-opus-5" } } })).toEqual({ ok: true });
+  });
+  it("rejects bad shapes", () => {
+    expect(validateAgentModelConfig({ fastModeProfile: { providers: "turbo" } }).ok).toBe(false);
+    expect(validateAgentModelConfig({ fastModeProfile: { providers: "custom", providerOrder: ["gemini"] } }).ok).toBe(false);
+    expect(validateAgentModelConfig({ fastModeProfile: { models: { claude: "" } } }).ok).toBe(false);
+    expect(validateAgentModelConfig({ fastModeProfile: { extra: 1 } }).ok).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
@@ -13,6 +13,8 @@
  */
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high"] as const;
+// Provider fast mode (Anthropic `speed: "fast"`). Mirrors xyne-claw/src/model-speed.ts.
+const MODEL_SPEEDS = ["standard", "fast"] as const;
 const MAX_TOKENS_MIN = 1024;
 const MAX_TOKENS_MAX = 64000;
 const MAX_SCHEMA_BYTES = 32 * 1024;
@@ -34,7 +36,7 @@ function validateModelSettings(raw: unknown): ConfigValidationResult {
   if (raw === undefined || raw === null) return { ok: true };
   if (!isPlainObject(raw)) return fail("modelSettings must be an object");
 
-  const allowed = new Set(["model", "temperature", "maxTokens", "thinkingLevel"]);
+  const allowed = new Set(["model", "temperature", "maxTokens", "thinkingLevel", "speed"]);
   for (const key of Object.keys(raw)) {
     if (!allowed.has(key)) return fail(`modelSettings.${key} is not a recognized setting`);
   }
@@ -63,6 +65,12 @@ function validateModelSettings(raw: unknown): ConfigValidationResult {
   if (raw["thinkingLevel"] !== undefined) {
     if (!(THINKING_LEVELS as readonly string[]).includes(raw["thinkingLevel"] as string)) {
       return fail(`modelSettings.thinkingLevel must be one of: ${THINKING_LEVELS.join(", ")}`);
+    }
+  }
+
+  if (raw["speed"] !== undefined) {
+    if (!(MODEL_SPEEDS as readonly string[]).includes(raw["speed"] as string)) {
+      return fail(`modelSettings.speed must be one of: ${MODEL_SPEEDS.join(", ")}`);
     }
   }
 
@@ -139,9 +147,44 @@ function validateOutputFormat(raw: unknown): ConfigValidationResult {
 }
 
 /** Validate the model-related keys of an agent `config` payload. */
+// Mirrors KNOWN_PROVIDERS in agent-provider-config.ts (kept local so this
+// module stays dependency-free).
+const PROFILE_PROVIDERS = new Set(["codex", "claude", "copilot", "openrouter", "litellm", "spaces"]);
+
+/** config.fastModeProfile — which providers fast mode runs on (see
+ *  agent-provider-config.ts → parseFastModeProfile for the shape). */
+function validateFastModeProfile(raw: unknown): ConfigValidationResult {
+  if (raw === undefined || raw === null) return { ok: true };
+  if (!isPlainObject(raw)) return fail("fastModeProfile must be an object");
+  const allowed = new Set(["providers", "providerOrder", "models"]);
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) return fail(`fastModeProfile.${key} is not a recognized setting`);
+  }
+  if (raw["providers"] !== undefined && raw["providers"] !== "inherit" && raw["providers"] !== "custom") {
+    return fail('fastModeProfile.providers must be "inherit" or "custom"');
+  }
+  if (raw["providerOrder"] !== undefined) {
+    const order = raw["providerOrder"];
+    if (!Array.isArray(order) || order.some((p) => typeof p !== "string" || !PROFILE_PROVIDERS.has(p))) {
+      return fail(`fastModeProfile.providerOrder must list providers from: ${[...PROFILE_PROVIDERS].join(", ")}`);
+    }
+  }
+  if (raw["models"] !== undefined) {
+    const models = raw["models"];
+    if (!isPlainObject(models)) return fail("fastModeProfile.models must be an object of provider → model id");
+    for (const [k, v] of Object.entries(models)) {
+      if (!PROFILE_PROVIDERS.has(k)) return fail(`fastModeProfile.models.${k} is not a known provider`);
+      if (typeof v !== "string" || !v.trim() || v.length > 200) return fail(`fastModeProfile.models.${k} must be a non-empty model id`);
+    }
+  }
+  return { ok: true };
+}
+
 export function validateAgentModelConfig(config: Record<string, unknown> | undefined): ConfigValidationResult {
   if (!config) return { ok: true };
   const ms = validateModelSettings(config["modelSettings"]);
   if (!ms.ok) return ms;
+  const fp = validateFastModeProfile(config["fastModeProfile"]);
+  if (!fp.ok) return fp;
   return validateOutputFormat(config["outputFormat"]);
 }

--- a/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.fast-profile.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.fast-profile.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../db.js", () => ({ prisma: {} }));
+vi.mock("../config.js", () => ({ CONFIG: { litellmUrl: "", litellmApiKey: "" } }));
+vi.mock("../crypto.js", () => ({ decrypt: () => "" }));
+vi.mock("../logger.js", () => ({ createLogger: () => ({ info() {}, warn() {}, error() {}, debug() {} }) }));
+vi.mock("../repositories/index.js", () => ({ agentProviderCredentialsRepository: { listByAgent: async () => [] }, userProviderCredentialsRepository: {}, sharedProviderCredentialRepository: {} }));
+vi.mock("./claude-oauth-refresh.js", () => ({ getValidClaudeBearer: async () => "" }));
+vi.mock("./codex-oauth-refresh.js", () => ({ getValidCodexBearer: async () => "" }));
+
+import { agentDefaultSpeed, applyFastModeModels, parseFastModeProfile, providerConfigForSpeed } from "./agent-provider-config.js";
+
+const base = { provider: "litellm", providerOrder: ["litellm", "spaces"], modelSettings: { speed: "fast" } };
+
+describe("fast-mode provider profile", () => {
+  it("defaults to inherit (same providers as standard)", () => {
+    expect(parseFastModeProfile(undefined).providers).toBe("inherit");
+    expect(parseFastModeProfile({ fastModeProfile: { providers: "custom" } })).toEqual({ providers: "custom", providerOrder: [], models: {} });
+    expect(providerConfigForSpeed(base, "fast")["providerOrder"]).toEqual(["litellm", "spaces"]);
+  });
+
+  it("swaps in the custom order only for fast speed, dropping the legacy provider", () => {
+    const cfg = { ...base, fastModeProfile: { providers: "custom", providerOrder: ["claude", "bogus", "spaces"], models: { claude: "claude-opus-5", nope: "x" } } };
+    const fast = providerConfigForSpeed(cfg, "fast");
+    expect(fast["providerOrder"]).toEqual(["claude", "spaces"]);
+    expect(fast["provider"]).toBeUndefined();
+    const std = providerConfigForSpeed(cfg, "standard");
+    expect(std["providerOrder"]).toEqual(["litellm", "spaces"]);
+    expect(std["provider"]).toBe("litellm");
+  });
+
+  it("applies per-provider model overrides in fast mode only", () => {
+    const cfg = { fastModeProfile: { providers: "custom", providerOrder: ["claude"], models: { claude: "claude-opus-5" } } };
+    const configs = { claude: { model: "claude-sonnet-5" }, litellm: { model: "open-fast" } };
+    applyFastModeModels(configs, cfg, "standard");
+    expect(configs.claude.model).toBe("claude-sonnet-5");
+    applyFastModeModels(configs, cfg, "fast");
+    expect(configs.claude.model).toBe("claude-opus-5");
+    expect(configs.litellm.model).toBe("open-fast");
+  });
+
+  it("reads the agent default speed from modelSettings", () => {
+    expect(agentDefaultSpeed(base)).toBe("fast");
+    expect(agentDefaultSpeed({})).toBe("standard");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.ts
@@ -61,6 +61,93 @@ export const KNOWN_PROVIDERS = new Set(["codex", "claude", "copilot", "openroute
  */
 export type SubagentProviderMode = "parent" | "spaces" | "fast-model";
 
+// ── Fast-mode provider profile ───────────────────────────────────────────────
+//
+// Fast mode (modelSettings.speed = "fast", or the per-message chat toggle) can
+// run on its OWN provider setup, configured in the agent's Model & provider tab
+// under the "Fast mode" view:
+//
+//   config.fastModeProfile = {
+//     providers: "inherit" | "custom",   // default inherit — same providers +
+//                                        // credentials as standard mode
+//     providerOrder?: string[],          // custom: fast-mode preference order
+//     models?: Record<provider, model>,  // custom: per-provider model override
+//                                        // (same credential key, different model)
+//   }
+//
+// Credential KEYS are per agent per provider and shared by both modes; the
+// profile only decides which providers are tried (and on which model). With
+// "inherit", fast mode is purely the provider-side speed tier (Anthropic
+// `speed: "fast"`) on the standard setup.
+//
+// NOT `config.fastMode` — that key is the legacy tool-catalog flag (`/fast`).
+
+export type ModelSpeed = "standard" | "fast";
+
+export interface FastModeProfile {
+  providers: "inherit" | "custom";
+  providerOrder: string[];
+  models: Record<string, string>;
+}
+
+export function parseFastModeProfile(config?: unknown): FastModeProfile {
+  const cfg = (config as Record<string, unknown> | null) ?? null;
+  const raw = cfg?.["fastModeProfile"];
+  const inherit: FastModeProfile = { providers: "inherit", providerOrder: [], models: {} };
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return inherit;
+  const r = raw as Record<string, unknown>;
+  if (r["providers"] !== "custom") return inherit;
+  const providerOrder = Array.isArray(r["providerOrder"])
+    ? (r["providerOrder"] as unknown[]).filter((p): p is string => typeof p === "string" && KNOWN_PROVIDERS.has(p))
+    : [];
+  const models: Record<string, string> = {};
+  const rawModels = r["models"];
+  if (rawModels && typeof rawModels === "object" && !Array.isArray(rawModels)) {
+    for (const [k, v] of Object.entries(rawModels as Record<string, unknown>)) {
+      if (KNOWN_PROVIDERS.has(k) && typeof v === "string" && v.trim()) models[k] = v.trim();
+    }
+  }
+  return { providers: "custom", providerOrder, models };
+}
+
+/** The agent's default speed (modelSettings.speed); per-run overrides win over it. */
+export function agentDefaultSpeed(config?: unknown): ModelSpeed {
+  const cfg = (config as Record<string, unknown> | null) ?? null;
+  const ms = cfg?.["modelSettings"] as Record<string, unknown> | undefined;
+  return ms?.["speed"] === "fast" ? "fast" : "standard";
+}
+
+/**
+ * The config whose providerOrder / provider the run should resolve against.
+ * Standard speed, or fast with an inherited profile ⇒ the config unchanged.
+ * Fast with a custom profile ⇒ providerOrder swapped for the fast-mode order
+ * (legacy single `provider` dropped so it can't leak the standard pick back in).
+ */
+export function providerConfigForSpeed(config: unknown, speed: ModelSpeed): Record<string, unknown> {
+  const cfg = { ...((config as Record<string, unknown> | null) ?? {}) };
+  if (speed !== "fast") return cfg;
+  const profile = parseFastModeProfile(cfg);
+  if (profile.providers !== "custom") return cfg;
+  cfg["providerOrder"] = profile.providerOrder;
+  delete cfg["provider"];
+  return cfg;
+}
+
+/** Apply the fast profile's per-provider model overrides to resolved configs (in place). */
+export function applyFastModeModels<T extends { model: string }>(
+  providerConfigs: Record<string, T>,
+  config: unknown,
+  speed: ModelSpeed,
+): void {
+  if (speed !== "fast") return;
+  const profile = parseFastModeProfile(config);
+  if (profile.providers !== "custom") return;
+  for (const [provider, model] of Object.entries(profile.models)) {
+    const c = providerConfigs[provider];
+    if (c) c.model = model;
+  }
+}
+
 export function resolveSubagentProviderMode(config?: unknown): SubagentProviderMode {
   const cfg = (config as Record<string, unknown> | null) ?? null;
   if (cfg?.["subagentProviderMode"] === "parent") return "parent";
@@ -200,9 +287,15 @@ export function buildProviderConfig(provider: string, row: CredRow): ProviderCon
  */
 export async function resolveAgentProviderConfigs(
   agent: { id: string; config?: unknown },
-  opts: { headlessBulk?: boolean } = {},
+  opts: { headlessBulk?: boolean; speed?: ModelSpeed } = {},
 ): Promise<ResolvedAgentProviders> {
-  const cfg = (agent.config as Record<string, unknown> | null) ?? null;
+  // Fast mode may run on its own provider profile (see providerConfigForSpeed).
+  // Callers that know a per-run speed pass it; otherwise the agent default applies.
+  const speed = opts.speed ?? agentDefaultSpeed(agent.config);
+  const cfg = providerConfigForSpeed(agent.config, speed);
+  if (speed === "fast" && parseFastModeProfile(agent.config).providers === "custom") {
+    log.info(`Provider resolution: agent=${agent.id} fast-mode profile → order=[${(cfg["providerOrder"] as string[]).join(",")}]`);
+  }
 
   // Per-agent model downgrade for headless bulk traffic (automations, the
   // error pipeline, scheduled jobs). These paths fire on every PR / message /
@@ -226,7 +319,7 @@ export async function resolveAgentProviderConfigs(
         config: { ...(cfg ?? {}), provider: automationProvider, providerOrder: [automationProvider], providerAlwaysOn: true },
       };
       log.info(`Provider resolution (headless-bulk): agent=${agent.id} automationProvider=${automationProvider} → forced parent`);
-      return resolveAgentProviderConfigs(bulkAgent);
+      return resolveAgentProviderConfigs(bulkAgent, { speed });
     }
     log.warn(`Provider resolution (headless-bulk): agent=${agent.id} unknown automationProvider="${automationProvider}" — ignoring`);
   }
@@ -246,6 +339,7 @@ export async function resolveAgentProviderConfigs(
     const built = buildProviderConfig(provider, row);
     if (built) providerConfigs[provider] = built;
   }
+  applyFastModeModels(providerConfigs, agent.config, speed);
 
   // Refresh short-lived OAuth tokens before use (persist the rotated token back
   // to the agent cred row), same as the chat path. api_key / not-yet-expired

--- a/apps/xyne-claw-auth/backend/src/lib/model-settings-audit.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/model-settings-audit.ts
@@ -18,7 +18,7 @@
 import { writeAuditLog } from "./audit.js";
 
 /** The modelSettings keys we track. Mirrors agent-config-validation.ts. */
-export const AUDITED_MODEL_SETTING_KEYS = ["model", "temperature", "maxTokens", "thinkingLevel"] as const;
+export const AUDITED_MODEL_SETTING_KEYS = ["model", "temperature", "maxTokens", "thinkingLevel", "speed"] as const;
 export type AuditedModelSettingKey = (typeof AUDITED_MODEL_SETTING_KEYS)[number];
 
 export type ModelSettingsSnapshot = Record<AuditedModelSettingKey, unknown>;
@@ -35,6 +35,7 @@ export function readModelSettingsSnapshot(config: unknown): ModelSettingsSnapsho
     temperature: ms["temperature"],
     maxTokens: ms["maxTokens"],
     thinkingLevel: ms["thinkingLevel"],
+    speed: ms["speed"],
   };
 }
 

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -11,7 +11,7 @@ import { prisma } from "../db.js";
 import { cancelRunRecovery } from "../queue/run-recovery-worker.js";
 import { decrypt } from "../crypto.js";
 import { CONFIG } from "../config.js";
-import { KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget } from "../lib/agent-provider-config.js";
+import { KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget, agentDefaultSpeed, providerConfigForSpeed, applyFastModeModels } from "../lib/agent-provider-config.js";
 import { resolveFastMode } from "../lib/fast-mode.js";
 import { extractFollowUpSuggestionsFromInvocations } from "../lib/follow-up-suggestions.js";
 import { getRequesterId, getOrgId, getAgentEditAccess, isClawAdmin } from "../middleware/agent-acl.js";
@@ -870,6 +870,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       designArtifactAttachmentId,
       designSelection,
       researchContext,
+      speed: rawSpeed,
     } = req.body as {
       message?: string;
       conversationId?: string;
@@ -894,8 +895,18 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       designArtifactAttachmentId?: string;
       designSelection?: unknown;
       researchContext?: { type?: unknown; id?: unknown; name?: unknown } | null;
+      /** Per-message provider fast mode (composer toggle). Rides the agent's
+       *  modelSettings.speed for this run only — same credential, same model,
+       *  Anthropic's faster tier. Omitted = agent default. */
+      speed?: "standard" | "fast";
     };
     const userId = getRequesterId(req) ?? (req.body as { userId?: string }).userId;
+    const speedOverride: "standard" | "fast" | undefined =
+      rawSpeed === "fast" || rawSpeed === "standard" ? rawSpeed : undefined;
+    if (rawSpeed !== undefined && !speedOverride) {
+      res.status(400).json({ success: false, error: 'speed must be "standard" or "fast"' });
+      return;
+    }
 
     if (!message || typeof message !== "string" || !message.trim()) {
       res.status(400).json({ success: false, error: "message is required" });
@@ -1296,8 +1307,14 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
     const personalProvider = rawPersonalProvider && rawPersonalProvider !== "spaces"
       ? rawPersonalProvider
       : undefined;
-    const agentLevelProvider = (agent.config as Record<string, unknown> | null)?.["provider"] as string | undefined;
-    const rawProviderOrder = (agent.config as Record<string, unknown> | null)?.["providerOrder"];
+    // Effective speed for THIS run: the composer toggle wins, else the agent
+    // default. Fast mode may resolve against its own provider profile
+    // (config.fastModeProfile) — same credential keys, possibly different
+    // providers/models. See lib/agent-provider-config.ts.
+    const effectiveSpeed = speedOverride ?? agentDefaultSpeed(agent.config);
+    const speedConfig = providerConfigForSpeed(agent.config, effectiveSpeed);
+    const agentLevelProvider = speedConfig["provider"] as string | undefined;
+    const rawProviderOrder = speedConfig["providerOrder"];
     const agentProviderOrder: string[] = Array.isArray(rawProviderOrder)
       ? rawProviderOrder.filter((p): p is string => typeof p === "string" && KNOWN_PROVIDERS.has(p))
       : [];
@@ -1326,6 +1343,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       const cfg = buildProviderConfig(row.provider, row);
       if (cfg) { providerConfigs[row.provider] = cfg; providerScope[row.provider] = "agent"; }
     }
+    applyFastModeModels(providerConfigs, agent.config, effectiveSpeed);
 
     // Refresh Claude OAuth before use (short-lived token; see webhook.ts for the
     // rationale). Mutates the resolved config's apiKey and persists the rotated
@@ -1405,6 +1423,17 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       }
     }
 
+    // Per-message fast-mode toggle wins over the agent's saved
+    // modelSettings.speed for this run only (not persisted to the agent).
+    if (speedOverride) {
+      runAgentConfig = {
+        ...(runAgentConfig ?? {}),
+        modelSettings: {
+          ...((runAgentConfig?.["modelSettings"] as Record<string, unknown> | undefined) ?? {}),
+          speed: speedOverride,
+        },
+      };
+    }
     const effectiveAgentConfig = disableTools
       ? {
           ...(runAgentConfig ?? {}),

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -35,7 +35,7 @@ import {
 } from "../lib/agent-card.js";
 import { getValidClaudeBearer } from "../lib/claude-oauth-refresh.js";
 import { getValidCodexBearer } from "../lib/codex-oauth-refresh.js";
-import { resolveAgentProviderConfigs, resolveSubagentProviderMode, KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget } from "../lib/agent-provider-config.js";
+import { resolveAgentProviderConfigs, resolveSubagentProviderMode, KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget, agentDefaultSpeed, providerConfigForSpeed, applyFastModeModels } from "../lib/agent-provider-config.js";
 import { expandSpacesMentions, resolveUnboundMentions } from "../lib/mention-transform.js";
 import { shouldTwinRespond, recordTwinSilence, FAIL_CLOSED } from "../services/twinRespondGate.js";
 import { recordTwinApprovalPending } from "../services/twinResponseFeedback.js";
@@ -2407,13 +2407,17 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
     //   1. personal provider (user picked in agent settings + has own creds)
     //   2. agent-level provider (agent.config.provider + agentProviderCredentials)
     //   3. "spaces" / LiteLLM platform default
-    const agentLevelProvider = (agentRow?.config as Record<string, unknown> | null)?.["provider"] as string | undefined;
+    // Agent-default fast mode may resolve against its own provider profile
+    // (config.fastModeProfile) — see lib/agent-provider-config.ts.
+    const mentionSpeed = agentDefaultSpeed(agentRow?.config);
+    const mentionSpeedConfig = providerConfigForSpeed(agentRow?.config, mentionSpeed);
+    const agentLevelProvider = mentionSpeedConfig["provider"] as string | undefined;
     // Owners can also pin an ordered preference list under config.providerOrder.
     // We use it (a) to pick which agent-level provider to bind as the parent
     // model, and (b) to thread the full fallback chain into the runtime so
     // claw can walk it on quota exhaustion instead of dropping straight to
     // LiteLLM. Validation: keep only known provider strings.
-    const rawProviderOrder = (agentRow?.config as Record<string, unknown> | null)?.["providerOrder"];
+    const rawProviderOrder = mentionSpeedConfig["providerOrder"];
     const agentProviderOrder: string[] = Array.isArray(rawProviderOrder)
       ? rawProviderOrder.filter((p): p is string => typeof p === "string" && KNOWN_PROVIDERS.has(p))
       : [];
@@ -2476,6 +2480,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         providerScope[provider] = "agent";
       }
     }
+    applyFastModeModels(providerConfigs, agentRow?.config, mentionSpeed);
 
     // Refresh the Claude OAuth token before use — it's short-lived. Codex
     // already stores+refreshes a bundle; Claude historically stored a raw token

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -2991,6 +2991,10 @@ export async function sendChatMessage(
     /** Trusted SDLC repository selection. The backend resolves and authorizes
      *  the id; URL/branch values are never accepted from the browser. */
     researchContext?: { type: "repository"; id: string; name?: string };
+    /** Per-turn provider fast mode (Anthropic `speed: "fast"`): same credential
+     *  and model, faster tier. Overrides the agent's modelSettings.speed for
+     *  this run only. */
+    speed?: "standard" | "fast";
   },
 ): Promise<{ conversationId: string; reply: ChatReply }> {
   // Backward-compat: allow passing a single onProgress function (old signature).
@@ -3037,6 +3041,7 @@ export async function sendChatMessage(
       ...(requestOptions?.designSelection ? { designSelection: requestOptions.designSelection } : {}),
       ...(requestOptions?.providerOverride ? { providerOverride: requestOptions.providerOverride } : {}),
       ...(requestOptions?.researchContext ? { researchContext: requestOptions.researchContext } : {}),
+      ...(requestOptions?.speed ? { speed: requestOptions.speed } : {}),
     }),
     ...(requestSignal ? { signal: requestSignal } : {}),
   });

--- a/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
+  LightningIcon,
   PlusIcon,
   PaperPlaneTiltIcon,
   StopIcon,
@@ -250,6 +251,31 @@ function ModelSelect({
       ))}
     </Menu>
   );
+}
+
+/* ── fast mode toggle ────────────────────────────────────────────── */
+
+/** localStorage key for the per-agent chat fast-mode preference. */
+function fastModeStorageKey(agentSlug: string): string {
+  return `chat-fast-mode:${agentSlug}`;
+}
+
+export function readStoredFastMode(agentSlug: string | null | undefined): boolean {
+  if (!agentSlug) return false;
+  try {
+    return localStorage.getItem(fastModeStorageKey(agentSlug)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredFastMode(agentSlug: string, enabled: boolean): void {
+  try {
+    if (enabled) localStorage.setItem(fastModeStorageKey(agentSlug), "1");
+    else localStorage.removeItem(fastModeStorageKey(agentSlug));
+  } catch {
+    /* storage unavailable (private mode / quota) — preference is session-only */
+  }
 }
 
 /* ── typing indicator ────────────────────────────────────────────── */
@@ -2538,6 +2564,10 @@ export interface InputAreaProps {
    *  we slot it in as a render prop so positioning relative to the input
    *  card lives here. */
   renderMentionPicker?: () => React.ReactNode;
+  /** Per-chat provider fast mode (optional — only the agent chat wires it).
+   *  Rendered as a ⚡ pill in the button row next to attach / mention. */
+  fastMode?: boolean;
+  onToggleFastMode?: (enabled: boolean) => void;
 }
 
 /**
@@ -2569,6 +2599,8 @@ export const InputArea = forwardRef<InputAreaHandle, InputAreaProps>(function In
     mentionOpen,
     onToggleMention,
     renderMentionPicker,
+    fastMode,
+    onToggleFastMode,
   },
   ref,
 ) {
@@ -2792,6 +2824,28 @@ export const InputArea = forwardRef<InputAreaHandle, InputAreaProps>(function In
               >
                 <AtIcon size={14} />
               </button>
+              {onToggleFastMode && (
+                <button
+                  type="button"
+                  data-id="fast-mode-toggle"
+                  data-enabled={fastMode ? "1" : "0"}
+                  role="switch"
+                  aria-checked={!!fastMode}
+                  aria-label="Use fast mode"
+                  title={fastMode
+                    ? "Fast mode ON for this chat — click to use the agent's default"
+                    : "Fast mode OFF (agent default) — click for faster output from the provider's fast tier"}
+                  onClick={() => onToggleFastMode(!fastMode)}
+                  className={`flex h-8 items-center gap-1.5 rounded-full px-3 text-[12px] font-medium transition-colors ${
+                    fastMode
+                      ? "bg-amber-500 text-white hover:bg-amber-600"
+                      : "bg-xyne-surface-subtle text-xyne-fg-tertiary hover:bg-xyne-surface-sunken hover:text-xyne-fg-primary"
+                  }`}
+                >
+                  <LightningIcon size={13} weight={fastMode ? "fill" : "bold"} />
+                  Fast mode
+                </button>
+              )}
             </div>
 
             {sending ? (
@@ -4737,6 +4791,9 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
   const [litellmModels, setLitellmModels] = useState<Array<{ id: string; name: string }>>([]);
   const [litellmDefaultModel, setLitellmDefaultModel] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState<string>("");
+  // Per-chat provider fast mode — remembered per agent in localStorage so the
+  // choice sticks across reloads. ON ⇒ every turn in this chat sends speed=fast.
+  const [fastMode, setFastMode] = useState<boolean>(false);
   const [leftPanelWidth, setLeftPanelWidth]   = useState<number>(() => {
     try {
       const saved = localStorage.getItem("chat-left-panel-width");
@@ -4966,6 +5023,7 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
    * (no litellm credential, or error) ⇒ the picker hides itself. */
   useEffect(() => {
     setSelectedModel("");
+    setFastMode(readStoredFastMode(activeAgentSlug));
     if (!activeAgentSlug || !userId) {
       setLitellmModels([]);
       setLitellmDefaultModel(null);
@@ -5377,15 +5435,23 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
     setEditedDesignHtml(null);
   }, [conversationId, displayedDesignVersion?.messageId, mode]);
 
+  const handleFastModeChange = useCallback((enabled: boolean) => {
+    setFastMode(enabled);
+    if (activeAgentSlug) writeStoredFastMode(activeAgentSlug, enabled);
+  }, [activeAgentSlug]);
+  // Only an explicit ON is sent — OFF means "whatever the agent is configured
+  // with", so the agent-level setting still applies.
+  const speedOverride = fastMode ? ("fast" as const) : undefined;
+
   const handleRegenerate = useCallback((assistantMessageId: string) => {
     if (!activeAgentSlug || sending) return;
-    void regenerate(activeAgentSlug, userId, assistantMessageId, selectedModel || undefined);
-  }, [activeAgentSlug, sending, regenerate, userId, selectedModel]);
+    void regenerate(activeAgentSlug, userId, assistantMessageId, selectedModel || undefined, speedOverride);
+  }, [activeAgentSlug, sending, regenerate, userId, selectedModel, speedOverride]);
 
   const handleEditUserMessage = useCallback((userMessageId: string, text: string) => {
     if (!activeAgentSlug || sending) return;
-    void editLatestUserMessage(activeAgentSlug, userId, userMessageId, text, selectedModel || undefined);
-  }, [activeAgentSlug, sending, editLatestUserMessage, userId, selectedModel]);
+    void editLatestUserMessage(activeAgentSlug, userId, userMessageId, text, selectedModel || undefined, speedOverride);
+  }, [activeAgentSlug, sending, editLatestUserMessage, userId, selectedModel, speedOverride]);
 
   const handleSend = useCallback(() => {
     const text = inputValue.trim();
@@ -5488,6 +5554,8 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
           } : {}),
           // Per-chat model switch: pin the picked LiteLLM model for this turn.
           ...(selectedModel ? { modelOverride: selectedModel } : {}),
+          // Per-chat provider fast mode (sidebar toggle).
+          ...(speedOverride ? { speed: speedOverride } : {}),
         });
         if (designSelectionSnapshot) setDesignSelection(null);
         if (manualEditsSnapshot.length > 0) {
@@ -5508,7 +5576,7 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
     };
 
     void dispatch();
-  }, [inputValue, pendingFiles, selectedContext, activeAgentSlug, userId, sending, send, mode, selectedModel, designSelection, designEditScope, designPreviewSource, manualEdits, editedDesignHtml]);
+  }, [inputValue, pendingFiles, selectedContext, activeAgentSlug, userId, sending, send, mode, selectedModel, speedOverride, designSelection, designEditScope, designPreviewSource, manualEdits, editedDesignHtml]);
 
   const handleApproveAction = useCallback(async (msgId: string, action: PendingAction) => {
     if (!activeAgentSlug) throw new Error("No active agent selected");
@@ -5790,6 +5858,8 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
                   onRemoveContext={handleRemoveContext}
                   mentionOpen={mentionOpen}
                   onToggleMention={handleToggleMention}
+                  fastMode={fastMode}
+                  onToggleFastMode={handleFastModeChange}
                   renderMentionPicker={() => (
                     <ContextPicker
                       slug={activeAgent.slug}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
@@ -723,7 +723,7 @@ export function ProviderTabV3({ agent, userId }: Props) {
             <p className="mt-1.5 text-[12px] text-xyne-fg-secondary">
               {providerView === "standard"
                 ? "Pick the providers that run this agent. They're tried in order — top first."
-                : "What runs when fast mode is on. Defaults to the standard setup; give fast mode its own providers if you want."}
+                : "Providers used when fast mode is on."}
             </p>
           </div>
           {/* Standard vs. fast mode — two provider setups for the one agent. */}
@@ -919,35 +919,20 @@ export function ProviderTabV3({ agent, userId }: Props) {
                   : "border-xyne-border bg-xyne-surface-subtle"
               }`}
             >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-1.5 text-[13px] font-medium text-xyne-fg-primary">
-                    <LightningIcon size={14} weight={fastMode ? "fill" : "bold"} className={fastMode ? "text-amber-500" : "text-xyne-fg-muted"} />
-                    Fast mode by default
-                  </div>
-                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
-                    {fastMode
-                      ? "On — every run of this agent starts in fast mode unless the chat toggle turns it off."
-                      : "Off — runs start at standard speed; users can switch fast mode on per chat from the composer."}
-                    {" "}On a Claude credential running Claude Opus 5 / Opus 4.8, fast mode also uses Anthropic's fast tier (premium pricing).
-                  </p>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-1.5 text-[13px] font-medium text-xyne-fg-primary">
+                  <LightningIcon size={14} weight={fastMode ? "fill" : "bold"} className={fastMode ? "text-amber-500" : "text-xyne-fg-muted"} />
+                  Turn on fast mode by default
                 </div>
-                <Switch checked={fastMode} onChange={setFastMode} ariaLabel="Fast mode by default" />
+                <Switch checked={fastMode} onChange={setFastMode} ariaLabel="Turn on fast mode by default" />
               </div>
             </div>
 
             {/* Which providers serve fast-mode runs. Inherit (default) = the
                 standard setup; custom = its own order + optional model pins. */}
             <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="text-[13px] font-medium text-xyne-fg-primary">Providers in fast mode</div>
-                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
-                    {fastProfileMode === "inherit"
-                      ? "Same as standard — fast mode runs on the standard providers and credentials above."
-                      : "Custom — fast mode has its own provider order. Credentials are shared with standard mode; pin a different model per provider if you want."}
-                  </p>
-                </div>
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-[13px] font-medium text-xyne-fg-primary">Providers in fast mode</div>
                 <div
                   role="radiogroup"
                   aria-label="Which providers fast mode runs on"

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
@@ -12,12 +12,14 @@ import {
   FloppyDiskIcon,
   PencilSimpleIcon,
   ShareNetworkIcon,
+  LightningIcon,
 } from "@phosphor-icons/react";
 import type { Agent, AgentLight } from "../../../../lib/types";
 import { useSnackbar } from "../../ui/Snackbar";
 import { Menu, MenuItem } from "../../ui/Menu";
 import { Dialog } from "../../ui/Dialog";
 import { Button } from "../../ui/Button";
+import { Switch } from "../../ui/Switch";
 import {
   updateAgent,
   listAgentProviderCredentials,
@@ -56,6 +58,148 @@ const AUTH_TYPE_DISPLAY: Record<string, string> = {
 };
 
 const ALL_PROVIDERS: ProviderKey[] = ["codex", "claude", "copilot", "openrouter", "litellm", "spaces"];
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Ordered provider list + "Available providers" chips. Used twice: for the
+ * standard provider order and for the fast-mode profile's own order. With
+ * `models` the fast view also lets each selected provider pin a model for
+ * fast mode (same credential key, different model); blank = the model saved
+ * on the credential.
+ * ───────────────────────────────────────────────────────────────────── */
+function ProviderOrderEditor({
+  order,
+  onChange,
+  models,
+  onModelChange,
+  modelPlaceholder,
+  readOnly,
+  idPrefix,
+}: {
+  order: string[];
+  onChange: (next: string[]) => void;
+  models?: Record<string, string>;
+  onModelChange?: (provider: string, model: string) => void;
+  modelPlaceholder?: (provider: string) => string;
+  readOnly?: boolean;
+  idPrefix: string;
+}) {
+  const move = (idx: number, dir: -1 | 1) => {
+    const target = idx + dir;
+    if (target < 0 || target >= order.length) return;
+    const next = [...order];
+    const tmp = next[idx]!;
+    next[idx] = next[target]!;
+    next[target] = tmp;
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(order.filter((_, i) => i !== idx));
+  const add = (p: string) => onChange(order.includes(p) ? order : [...order, p]);
+
+  return (
+    <>
+      {order.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-xyne-border bg-xyne-surface-subtle px-4 py-5 text-center text-[12px] text-xyne-fg-tertiary mb-4">
+          No providers selected yet — pick one or more below to start.
+        </div>
+      ) : (
+        <ol data-id={`${idPrefix}-order`} className={`space-y-2 mb-4 ${readOnly ? "opacity-60" : ""}`}>
+          {order.map((p, idx) => (
+            <li
+              key={p}
+              className="flex flex-wrap items-center gap-3 rounded-lg border border-xyne-border bg-xyne-surface-subtle px-3 py-2.5"
+            >
+              <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-xyne-fg-primary text-xyne-fg-inverse text-[12px] font-semibold tabular-nums">
+                {idx + 1}
+              </span>
+              <span className="flex-1 text-[13px] font-medium text-xyne-fg-primary">
+                {PROVIDER_DISPLAY[p] ?? p}
+              </span>
+              {models && onModelChange && p !== "spaces" && (
+                <input
+                  value={models[p] ?? ""}
+                  onChange={(e) => onModelChange(p, e.target.value)}
+                  placeholder={modelPlaceholder?.(p) ?? "model from credential"}
+                  spellCheck={false}
+                  autoComplete="off"
+                  disabled={readOnly}
+                  aria-label={`Fast-mode model for ${PROVIDER_DISPLAY[p] ?? p}`}
+                  title="Model to use in fast mode on this provider (same credential). Blank = the model saved on the credential."
+                  className="w-[200px] rounded-md border border-xyne-border bg-xyne-surface px-2 py-1 font-mono text-[12px] text-xyne-fg-primary placeholder-xyne-fg-muted focus:border-xyne-border-focus focus:outline-none disabled:opacity-60"
+                />
+              )}
+              {!readOnly && (
+                <div className="flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    disabled={idx === 0}
+                    onClick={() => move(idx, -1)}
+                    className="inline-flex items-center justify-center w-7 h-7 rounded-md text-xyne-fg-tertiary hover:bg-xyne-surface hover:text-xyne-fg-primary disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+                    title="Move up"
+                    aria-label="Move up"
+                  >
+                    <ArrowUpIcon size={13} weight="bold" />
+                  </button>
+                  <button
+                    type="button"
+                    disabled={idx === order.length - 1}
+                    onClick={() => move(idx, 1)}
+                    className="inline-flex items-center justify-center w-7 h-7 rounded-md text-xyne-fg-tertiary hover:bg-xyne-surface hover:text-xyne-fg-primary disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+                    title="Move down"
+                    aria-label="Move down"
+                  >
+                    <ArrowDownIcon size={13} weight="bold" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove(idx)}
+                    className="inline-flex items-center justify-center w-7 h-7 rounded-md text-xyne-fg-tertiary hover:bg-xyne-error-bg hover:text-xyne-error-fg transition-colors"
+                    title="Remove from order"
+                    aria-label="Remove from order"
+                  >
+                    <XIcon size={13} weight="bold" />
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {!readOnly && (
+        <div>
+          <div className="text-[12px] font-medium text-xyne-fg-tertiary mb-2">
+            Available providers
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {ALL_PROVIDERS.map((p) => {
+              const selected = order.includes(p);
+              return (
+                <button
+                  key={p}
+                  type="button"
+                  data-id={`${idPrefix}-pill-${p}`}
+                  onClick={() => (selected ? remove(order.indexOf(p)) : add(p))}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${
+                    selected
+                      ? "border-xyne-fg-primary bg-xyne-fg-primary text-xyne-fg-inverse"
+                      : "border-xyne-border bg-xyne-surface text-xyne-fg-secondary hover:border-xyne-border-strong hover:text-xyne-fg-primary"
+                  }`}
+                >
+                  {selected ? (
+                    <CheckIcon size={12} weight="bold" />
+                  ) : (
+                    <PlusIcon size={12} weight="bold" />
+                  )}
+                  {PROVIDER_DISPLAY[p] ?? p}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
 
 function formatRelativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
@@ -145,6 +289,49 @@ export function ProviderTabV3({ agent, userId }: Props) {
   const [automationMode, setAutomationMode] = useState<string>(seedAutomationMode);
   const [savedAutomationMode, setSavedAutomationMode] = useState<string>(seedAutomationMode);
 
+  /**
+   * Provider FAST MODE — Anthropic `speed: "fast"`. Same credential, same
+   * model, served from the provider's faster (premium-priced) tier. Honored
+   * by the runtime only when the run is served by a direct Claude credential
+   * on Claude Opus 5 / Opus 4.8; every other provider ignores it (logged, never
+   * a failed run). Can also be toggled per chat in the chat sidebar.
+   * Stored at agent.config.modelSettings.speed; undefined ⇒ standard.
+   */
+  const seedFastMode =
+    ((agent.config as Record<string, unknown> | undefined)?.["modelSettings"] as Record<string, unknown> | undefined)?.["speed"] === "fast";
+  const [fastMode, setFastMode] = useState<boolean>(seedFastMode);
+  const [savedFastMode, setSavedFastMode] = useState<boolean>(seedFastMode);
+
+  /**
+   * Fast-mode provider PROFILE — which providers (and on which model) run
+   * when fast mode is on. "inherit" (default) = the same providers +
+   * credentials as standard mode; "custom" = its own order below, with an
+   * optional per-provider model pin. Credential keys are per provider and
+   * shared by both modes. Stored at agent.config.fastModeProfile; mirrors
+   * claw-auth lib/agent-provider-config.ts → parseFastModeProfile.
+   */
+  const seedFastProfile = (() => {
+    const raw = (agent.config as Record<string, unknown> | undefined)?.["fastModeProfile"] as Record<string, unknown> | undefined;
+    const custom = raw?.["providers"] === "custom";
+    const order = custom && Array.isArray(raw?.["providerOrder"])
+      ? (raw!["providerOrder"] as unknown[]).filter((p): p is string => typeof p === "string" && (ALL_PROVIDERS as string[]).includes(p))
+      : [];
+    const models: Record<string, string> = {};
+    const rawModels = custom ? raw?.["models"] : undefined;
+    if (rawModels && typeof rawModels === "object") {
+      for (const [k, v] of Object.entries(rawModels as Record<string, unknown>)) if (typeof v === "string" && v.trim()) models[k] = v.trim();
+    }
+    return { mode: (custom ? "custom" : "inherit") as "custom" | "inherit", order, models };
+  })();
+  const [fastProfileMode, setFastProfileMode] = useState<"inherit" | "custom">(seedFastProfile.mode);
+  const [savedFastProfileMode, setSavedFastProfileMode] = useState<"inherit" | "custom">(seedFastProfile.mode);
+  const [fastOrder, setFastOrder] = useState<string[]>(seedFastProfile.order);
+  const [savedFastOrder, setSavedFastOrder] = useState<string[]>(seedFastProfile.order);
+  const [fastModels, setFastModels] = useState<Record<string, string>>(seedFastProfile.models);
+  const [savedFastModels, setSavedFastModels] = useState<Record<string, string>>(seedFastProfile.models);
+  /** Which provider setup the card is showing: standard or fast mode. */
+  const [providerView, setProviderView] = useState<"standard" | "fast">("standard");
+
   const [orderSaving, setOrderSaving] = useState(false);
   const [orderSaved, setOrderSaved] = useState(false);
   /** Provider preference order explainer modal — the inline wall of
@@ -158,7 +345,11 @@ export function ProviderTabV3({ agent, userId }: Props) {
     JSON.stringify(providerOrder) !== JSON.stringify(savedOrder) ||
     alwaysOn !== savedAlwaysOn ||
     subagentMode !== savedSubagentMode ||
-    automationMode !== savedAutomationMode;
+    automationMode !== savedAutomationMode ||
+    fastMode !== savedFastMode ||
+    fastProfileMode !== savedFastProfileMode ||
+    JSON.stringify(fastOrder) !== JSON.stringify(savedFastOrder) ||
+    JSON.stringify(fastModels) !== JSON.stringify(savedFastModels);
 
   const [creds, setCreds] = useState<AgentProviderCredentialStatus[]>([]);
   const [loading, setLoading] = useState(true);
@@ -418,13 +609,38 @@ export function ProviderTabV3({ agent, userId }: Props) {
       // minimal — the backend treats undefined as "same provider as chat".
       if (automationMode !== "default") cfg.automationProvider = automationMode;
       else delete cfg.automationProvider;
+      // Provider fast mode rides modelSettings (shared with the Spaces row's
+      // model/temperature/thinking fields) — merge, never replace, and drop the
+      // key entirely when off so the JSON stays minimal.
+      const ms = { ...((cfg.modelSettings as Record<string, unknown> | undefined) ?? {}) };
+      if (fastMode) ms.speed = "fast";
+      else delete ms.speed;
+      if (Object.keys(ms).length > 0) cfg.modelSettings = ms;
+      else delete cfg.modelSettings;
+      // Fast-mode provider profile. Omit entirely when inheriting (the
+      // default) so the JSON stays minimal; blank model pins are dropped.
+      if (fastProfileMode === "custom") {
+        const models: Record<string, string> = {};
+        for (const [k, v] of Object.entries(fastModels)) if (fastOrder.includes(k) && v.trim()) models[k] = v.trim();
+        cfg.fastModeProfile = { providers: "custom", providerOrder: fastOrder, ...(Object.keys(models).length ? { models } : {}) };
+      } else {
+        delete cfg.fastModeProfile;
+      }
       await updateAgent(agent.slug, { config: cfg });
+      // Keep the prop-derived config in step (the Spaces row merges against it).
+      const live = agent.config as Record<string, unknown>;
+      if (cfg.modelSettings) live["modelSettings"] = cfg.modelSettings;
+      else delete live["modelSettings"];
       // Mirror the just-saved state so future edits compute against it
       // and the dirty check clears (button returns to its quiet default).
       setSavedOrder([...providerOrder]);
       setSavedAlwaysOn(alwaysOn);
       setSavedSubagentMode(subagentMode);
       setSavedAutomationMode(automationMode);
+      setSavedFastMode(fastMode);
+      setSavedFastProfileMode(fastProfileMode);
+      setSavedFastOrder([...fastOrder]);
+      setSavedFastModels({ ...fastModels });
       setOrderSaved(true);
       // The button morphs to "Saved" briefly, then this resets to false —
       // since the dirty check now reads clean, the button drops back to
@@ -436,22 +652,6 @@ export function ProviderTabV3({ agent, userId }: Props) {
       setOrderSaving(false);
     }
   };
-
-  const moveOrderItem = (idx: number, dir: -1 | 1) => {
-    setProviderOrder((curr) => {
-      const target = idx + dir;
-      if (target < 0 || target >= curr.length) return curr;
-      const next = [...curr];
-      const tmp = next[idx]!;
-      next[idx] = next[target]!;
-      next[target] = tmp;
-      return next;
-    });
-  };
-  const removeOrderItem = (idx: number) =>
-    setProviderOrder((curr) => curr.filter((_, i) => i !== idx));
-  const addOrderItem = (p: string) =>
-    setProviderOrder((curr) => (curr.includes(p) ? curr : [...curr, p]));
 
   const submitForm = async () => {
     // apiKey is only required the FIRST time. If a credential already exists
@@ -521,243 +721,278 @@ export function ProviderTabV3({ agent, userId }: Props) {
               </button>
             </div>
             <p className="mt-1.5 text-[12px] text-xyne-fg-secondary">
-              Pick the providers that run this agent. They're tried in order — top first.
+              {providerView === "standard"
+                ? "Pick the providers that run this agent. They're tried in order — top first."
+                : "What runs when fast mode is on. Defaults to the standard setup; give fast mode its own providers if you want."}
             </p>
           </div>
-        </div>
-
-        {/* Always On vs. On /upgrade — policy switch for when the agent's
-            premium provider is actually consumed. Defaults to Always On for
-            backfill (matches every existing agent's pre-feature behavior). */}
-        <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-[13px] font-medium text-xyne-fg-primary">When to use these providers</div>
-              <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
-                {alwaysOn
-                  ? "Always on — every run uses the first provider above."
-                  : "On /upgrade only — runs default to the Spaces model (Kimi). Users opt in by typing /upgrade or accepting the prompt after a failure."}
-              </p>
-            </div>
-            <div
-              role="radiogroup"
-              aria-label="When to use the agent's premium provider"
-              className="flex shrink-0 rounded-full border border-xyne-border bg-xyne-surface p-0.5"
-            >
+          {/* Standard vs. fast mode — two provider setups for the one agent. */}
+          <div
+            role="tablist"
+            aria-label="Provider setup"
+            className="flex shrink-0 rounded-full border border-xyne-border bg-xyne-surface-subtle p-0.5"
+          >
+            {(["standard", "fast"] as const).map((v) => (
               <button
+                key={v}
                 type="button"
-                role="radio"
-                aria-checked={alwaysOn}
-                onClick={() => setAlwaysOn(true)}
-                className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
-                  alwaysOn
-                    ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+                role="tab"
+                data-id={`provider-view-${v}`}
+                aria-selected={providerView === v}
+                onClick={() => setProviderView(v)}
+                className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                  providerView === v
+                    ? v === "fast"
+                      ? "bg-amber-500 text-white"
+                      : "bg-xyne-fg-primary text-xyne-fg-inverse"
                     : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
                 }`}
               >
-                Always on
+                {v === "fast" && <LightningIcon size={11} weight="fill" />}
+                {v === "standard" ? "Standard" : "Fast mode"}
               </button>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={!alwaysOn}
-                onClick={() => setAlwaysOn(false)}
-                className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
-                  !alwaysOn
-                    ? "bg-xyne-fg-primary text-xyne-fg-inverse"
-                    : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
-                }`}
-              >
-                On /upgrade
-              </button>
-            </div>
+            ))}
           </div>
         </div>
 
-        {/* Subagent provider — which provider the agent's subagents run on when
-            they have no explicit per-subagent override. "Spaces default" (the
-            default) runs subagents on the cheaper platform model; "Follow parent"
-            inherits this agent's provider and uses more tokens on paid plans. */}
-        <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-[13px] font-medium text-xyne-fg-primary">Subagents</div>
-              <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
-                {subagentMode === "spaces"
-                  ? "Spaces default — subagents run on the Spaces platform model (cheaper/faster), even when this agent is on a premium provider."
-                  : "Follow parent — subagents run on the same provider as this agent."}
-                {" "}A per-subagent override, when set, always wins.
-              </p>
-            </div>
-            <div
-              role="radiogroup"
-              aria-label="Which provider subagents run on"
-              className="flex shrink-0 rounded-full border border-xyne-border bg-xyne-surface p-0.5"
-            >
-              <button
-                type="button"
-                role="radio"
-                aria-checked={subagentMode === "spaces"}
-                onClick={() => setSubagentMode("spaces")}
-                className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
-                  subagentMode === "spaces"
-                    ? "bg-xyne-fg-primary text-xyne-fg-inverse"
-                    : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
-                }`}
-              >
-                Spaces default
-              </button>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={subagentMode === "parent"}
-                onClick={() => setSubagentMode("parent")}
-                className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
-                  subagentMode === "parent"
-                    ? "bg-xyne-fg-primary text-xyne-fg-inverse"
-                    : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
-                }`}
-              >
-                Follow parent
-              </button>
-            </div>
-          </div>
-
-          {/* Cost warning — only when moving off the cheaper Spaces default. */}
-          {subagentMode === "parent" && (
-            <p className="mt-2.5 flex items-start gap-1.5 rounded-md border border-xyne-warning-border bg-xyne-warning-bg px-2.5 py-1.5 text-[11.5px] leading-relaxed text-xyne-warning-fg">
-              <WarningCircleIcon size={14} weight="fill" className="mt-px shrink-0" />
-              <span>
-                Subagents will run on this agent&apos;s provider. On paid / premium plans
-                this consumes noticeably more tokens and credits than the Spaces default.
-              </span>
-            </p>
-          )}
-        </div>
-
-        {/* Automation/scheduled model — headless bulk runs (automations, error
-            pipeline, scheduled jobs) fire on every PR / message / cron tick and
-            can dominate premium-provider usage. This downgrades ONLY those runs
-            to the platform default model; chat and mentions are unaffected. */}
-        <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-[13px] font-medium text-xyne-fg-primary">Automations &amp; scheduled runs</div>
-              <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
-                {automationMode === "default"
-                  ? "Same as chat — automation, scheduled, and error-pipeline runs use this agent's full provider order."
-                  : automationMode === "platform"
-                    ? "Platform default — automation, scheduled, and error-pipeline runs use the platform model; chat and mentions keep the premium provider."
-                    : `${PROVIDER_DISPLAY[automationMode] ?? automationMode} — automation, scheduled, and error-pipeline runs go to this provider only; chat and mentions keep the premium provider.`}
-              </p>
-            </div>
-            <select
-              aria-label="Which provider automation and scheduled runs use"
-              value={automationMode}
-              onChange={(e) => setAutomationMode(e.target.value)}
-              className="shrink-0 rounded-full border border-xyne-border bg-xyne-surface px-3 py-1.5 text-[11px] font-medium text-xyne-fg-primary"
-            >
-              <option value="default">Same as chat</option>
-              <option value="platform">Platform default</option>
-              {/* Only providers this agent actually has selected — routing
-                  automations at a provider with no credentials would fail every
-                  headless run, and the failure is silent (falls through). */}
-              {providerOrder.map((key) => (
-                <option key={key} value={key}>
-                  {PROVIDER_DISPLAY[key] ?? key}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        {/* Selected providers (the ordered list) */}
-        {providerOrder.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-xyne-border bg-xyne-surface-subtle px-4 py-5 text-center text-[12px] text-xyne-fg-tertiary mb-4">
-            No providers selected yet — pick one or more below to start.
-          </div>
-        ) : (
-          <ol className="space-y-2 mb-4">
-            {providerOrder.map((p, idx) => (
-              <li
-                key={p}
-                className="flex items-center gap-3 rounded-lg border border-xyne-border bg-xyne-surface-subtle px-3 py-2.5"
-              >
-                <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-xyne-fg-primary text-xyne-fg-inverse text-[12px] font-semibold tabular-nums">
-                  {idx + 1}
-                </span>
-                <span className="flex-1 text-[13px] font-medium text-xyne-fg-primary">
-                  {PROVIDER_DISPLAY[p] ?? p}
-                </span>
-                <div className="flex items-center gap-0.5">
+        {providerView === "standard" ? (
+          <>
+            {/* Always On vs. On /upgrade — policy switch for when the agent's
+                premium provider is actually consumed. Defaults to Always On for
+                backfill (matches every existing agent's pre-feature behavior). */}
+            <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[13px] font-medium text-xyne-fg-primary">When to use these providers</div>
+                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
+                    {alwaysOn
+                      ? "Always on — every run uses the first provider above."
+                      : "On /upgrade only — runs default to the Spaces model (Kimi). Users opt in by typing /upgrade or accepting the prompt after a failure."}
+                  </p>
+                </div>
+                <div
+                  role="radiogroup"
+                  aria-label="When to use the agent's premium provider"
+                  className="flex shrink-0 rounded-full border border-xyne-border bg-xyne-surface p-0.5"
+                >
                   <button
                     type="button"
-                    disabled={idx === 0}
-                    onClick={() => moveOrderItem(idx, -1)}
-                    className="inline-flex items-center justify-center w-7 h-7 rounded-md text-xyne-fg-tertiary hover:bg-xyne-surface hover:text-xyne-fg-primary disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
-                    title="Move up"
-                    aria-label="Move up"
+                    role="radio"
+                    aria-checked={alwaysOn}
+                    onClick={() => setAlwaysOn(true)}
+                    className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                      alwaysOn
+                        ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+                        : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
+                    }`}
                   >
-                    <ArrowUpIcon size={13} weight="bold" />
+                    Always on
                   </button>
                   <button
                     type="button"
-                    disabled={idx === providerOrder.length - 1}
-                    onClick={() => moveOrderItem(idx, 1)}
-                    className="inline-flex items-center justify-center w-7 h-7 rounded-md text-xyne-fg-tertiary hover:bg-xyne-surface hover:text-xyne-fg-primary disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
-                    title="Move down"
-                    aria-label="Move down"
+                    role="radio"
+                    aria-checked={!alwaysOn}
+                    onClick={() => setAlwaysOn(false)}
+                    className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                      !alwaysOn
+                        ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+                        : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
+                    }`}
                   >
-                    <ArrowDownIcon size={13} weight="bold" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => removeOrderItem(idx)}
-                    className="inline-flex items-center justify-center w-7 h-7 rounded-md text-xyne-fg-tertiary hover:bg-xyne-error-bg hover:text-xyne-error-fg transition-colors"
-                    title="Remove from order"
-                    aria-label="Remove from order"
-                  >
-                    <XIcon size={13} weight="bold" />
+                    On /upgrade
                   </button>
                 </div>
-              </li>
-            ))}
-          </ol>
-        )}
+              </div>
+            </div>
 
-        {/* Available providers — checkbox-style toggle so the chips
-            actually feel like "select these". Selected ones grey out
-            (they're already in the list above); unselected ones invite
-            the click. */}
-        <div>
-          <div className="text-[12px] font-medium text-xyne-fg-tertiary mb-2">
-            Available providers
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {ALL_PROVIDERS.map((p) => {
-              const selected = providerOrder.includes(p);
-              return (
-                <button
-                  key={p}
-                  type="button"
-                  onClick={() => (selected ? removeOrderItem(providerOrder.indexOf(p)) : addOrderItem(p))}
-                  className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${
-                    selected
-                      ? "border-xyne-fg-primary bg-xyne-fg-primary text-xyne-fg-inverse"
-                      : "border-xyne-border bg-xyne-surface text-xyne-fg-secondary hover:border-xyne-border-strong hover:text-xyne-fg-primary"
-                  }`}
+            {/* Subagent provider — which provider the agent's subagents run on when
+                they have no explicit per-subagent override. "Spaces default" (the
+                default) runs subagents on the cheaper platform model; "Follow parent"
+                inherits this agent's provider and uses more tokens on paid plans. */}
+            <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[13px] font-medium text-xyne-fg-primary">Subagents</div>
+                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
+                    {subagentMode === "spaces"
+                      ? "Spaces default — subagents run on the Spaces platform model (cheaper/faster), even when this agent is on a premium provider."
+                      : "Follow parent — subagents run on the same provider as this agent."}
+                    {" "}A per-subagent override, when set, always wins.
+                  </p>
+                </div>
+                <div
+                  role="radiogroup"
+                  aria-label="Which provider subagents run on"
+                  className="flex shrink-0 rounded-full border border-xyne-border bg-xyne-surface p-0.5"
                 >
-                  {selected ? (
-                    <CheckIcon size={12} weight="bold" />
-                  ) : (
-                    <PlusIcon size={12} weight="bold" />
-                  )}
-                  {PROVIDER_DISPLAY[p] ?? p}
-                </button>
-              );
-            })}
-          </div>
-        </div>
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={subagentMode === "spaces"}
+                    onClick={() => setSubagentMode("spaces")}
+                    className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                      subagentMode === "spaces"
+                        ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+                        : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
+                    }`}
+                  >
+                    Spaces default
+                  </button>
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={subagentMode === "parent"}
+                    onClick={() => setSubagentMode("parent")}
+                    className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                      subagentMode === "parent"
+                        ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+                        : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
+                    }`}
+                  >
+                    Follow parent
+                  </button>
+                </div>
+              </div>
+
+              {/* Cost warning — only when moving off the cheaper Spaces default. */}
+              {subagentMode === "parent" && (
+                <p className="mt-2.5 flex items-start gap-1.5 rounded-md border border-xyne-warning-border bg-xyne-warning-bg px-2.5 py-1.5 text-[11.5px] leading-relaxed text-xyne-warning-fg">
+                  <WarningCircleIcon size={14} weight="fill" className="mt-px shrink-0" />
+                  <span>
+                    Subagents will run on this agent&apos;s provider. On paid / premium plans
+                    this consumes noticeably more tokens and credits than the Spaces default.
+                  </span>
+                </p>
+              )}
+            </div>
+
+            {/* Automation/scheduled model — headless bulk runs (automations, error
+                pipeline, scheduled jobs) fire on every PR / message / cron tick and
+                can dominate premium-provider usage. This downgrades ONLY those runs
+                to the platform default model; chat and mentions are unaffected. */}
+            <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[13px] font-medium text-xyne-fg-primary">Automations &amp; scheduled runs</div>
+                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
+                    {automationMode === "default"
+                      ? "Same as chat — automation, scheduled, and error-pipeline runs use this agent's full provider order."
+                      : automationMode === "platform"
+                        ? "Platform default — automation, scheduled, and error-pipeline runs use the platform model; chat and mentions keep the premium provider."
+                        : `${PROVIDER_DISPLAY[automationMode] ?? automationMode} — automation, scheduled, and error-pipeline runs go to this provider only; chat and mentions keep the premium provider.`}
+                  </p>
+                </div>
+                <select
+                  aria-label="Which provider automation and scheduled runs use"
+                  value={automationMode}
+                  onChange={(e) => setAutomationMode(e.target.value)}
+                  className="shrink-0 rounded-full border border-xyne-border bg-xyne-surface px-3 py-1.5 text-[11px] font-medium text-xyne-fg-primary"
+                >
+                  <option value="default">Same as chat</option>
+                  <option value="platform">Platform default</option>
+                  {/* Only providers this agent actually has selected — routing
+                      automations at a provider with no credentials would fail every
+                      headless run, and the failure is silent (falls through). */}
+                  {providerOrder.map((key) => (
+                    <option key={key} value={key}>
+                      {PROVIDER_DISPLAY[key] ?? key}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <ProviderOrderEditor order={providerOrder} onChange={setProviderOrder} idPrefix="standard" />
+          </>
+        ) : (
+          <>
+            {/* Fast mode — the agent's DEFAULT speed. The composer toggle in
+                chat overrides it per conversation. Runtime: Anthropic
+                `speed: "fast"` on Claude Opus 5 / 4.8; other providers simply
+                run on whichever fast-mode providers are picked below. */}
+            <div
+              data-id="provider-fast-mode-row"
+              data-enabled={fastMode ? "1" : "0"}
+              className={`mb-4 rounded-lg border p-3 transition-colors ${
+                fastMode
+                  ? "border-amber-300 bg-amber-50 dark:border-amber-700/60 dark:bg-amber-950/30"
+                  : "border-xyne-border bg-xyne-surface-subtle"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5 text-[13px] font-medium text-xyne-fg-primary">
+                    <LightningIcon size={14} weight={fastMode ? "fill" : "bold"} className={fastMode ? "text-amber-500" : "text-xyne-fg-muted"} />
+                    Fast mode by default
+                  </div>
+                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
+                    {fastMode
+                      ? "On — every run of this agent starts in fast mode unless the chat toggle turns it off."
+                      : "Off — runs start at standard speed; users can switch fast mode on per chat from the composer."}
+                    {" "}On a Claude credential running Claude Opus 5 / Opus 4.8, fast mode also uses Anthropic's fast tier (premium pricing).
+                  </p>
+                </div>
+                <Switch checked={fastMode} onChange={setFastMode} ariaLabel="Fast mode by default" />
+              </div>
+            </div>
+
+            {/* Which providers serve fast-mode runs. Inherit (default) = the
+                standard setup; custom = its own order + optional model pins. */}
+            <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[13px] font-medium text-xyne-fg-primary">Providers in fast mode</div>
+                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
+                    {fastProfileMode === "inherit"
+                      ? "Same as standard — fast mode runs on the standard providers and credentials above."
+                      : "Custom — fast mode has its own provider order. Credentials are shared with standard mode; pin a different model per provider if you want."}
+                  </p>
+                </div>
+                <div
+                  role="radiogroup"
+                  aria-label="Which providers fast mode runs on"
+                  className="flex shrink-0 rounded-full border border-xyne-border bg-xyne-surface p-0.5"
+                >
+                  {(["inherit", "custom"] as const).map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      role="radio"
+                      data-id={`fast-profile-${m}`}
+                      aria-checked={fastProfileMode === m}
+                      onClick={() => {
+                        setFastProfileMode(m);
+                        // Seed a fresh custom order from the standard one so the
+                        // user edits a copy instead of starting from nothing.
+                        if (m === "custom" && fastOrder.length === 0) setFastOrder([...providerOrder]);
+                      }}
+                      className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                        fastProfileMode === m
+                          ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+                          : "text-xyne-fg-secondary hover:text-xyne-fg-primary"
+                      }`}
+                    >
+                      {m === "inherit" ? "Same as standard" : "Custom"}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {fastProfileMode === "inherit" ? (
+              <ProviderOrderEditor order={providerOrder} onChange={() => {}} readOnly idPrefix="fast-inherit" />
+            ) : (
+              <ProviderOrderEditor
+                order={fastOrder}
+                onChange={setFastOrder}
+                models={fastModels}
+                onModelChange={(provider, model) => setFastModels((m) => ({ ...m, [provider]: model }))}
+                modelPlaceholder={(provider) => creds.find((c) => c.provider === provider && c.configured)?.model ?? "model from credential"}
+                idPrefix="fast"
+              />
+            )}
+          </>
+        )}
 
         {/* Floating Save FAB — bottom-right of the card, icon-only at rest,
             expands into a labeled pill on hover/focus. Three visual states:
@@ -834,6 +1069,12 @@ export function ProviderTabV3({ agent, userId }: Props) {
               <h3 className="text-[14px] font-semibold text-xyne-fg-primary">
                 Configure Credentials
               </h3>
+              {providerView === "fast" && (
+                <span className="inline-flex items-center gap-1 text-[11px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5 dark:text-amber-300 dark:bg-amber-950/30 dark:border-amber-700/60">
+                  <LightningIcon size={11} weight="fill" />
+                  Shared with standard mode
+                </span>
+              )}
               <span
                 className="inline-flex items-center gap-1 text-[11px] font-medium text-xyne-success-fg bg-xyne-success-bg border border-xyne-success-border rounded-full px-2 py-0.5"
                 title="Credentials are encrypted at rest and never returned by the API."

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/SpacesDefaultRowV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/SpacesDefaultRowV3.tsx
@@ -52,6 +52,10 @@ interface ModelSettings {
   temperature?: number;
   maxTokens?: number;
   thinkingLevel?: string;
+  /** Provider fast mode (Anthropic `speed: "fast"`). Edited in the "Select
+   *  providers" card above, not here — this row only preserves it on save so
+   *  the two editors don't clobber each other's modelSettings. */
+  speed?: "standard" | "fast";
 }
 
 interface Props {
@@ -128,6 +132,8 @@ export function SpacesDefaultRowV3({ agent }: Props) {
       settings.maxTokens = m;
     }
     if (thinkingLevel) settings.thinkingLevel = thinkingLevel;
+    // Fast mode is owned by the provider card above — carry it through untouched.
+    if (readSettings().speed === "fast") settings.speed = "fast";
     if (thinkingConflict) {
       showSnackbar({ variant: "error", title: 'Temperature requires thinking "Off" — thinking models ignore temperature' });
       return;

--- a/apps/xyne-claw-auth/frontend/src/v3/hooks/useChat.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/hooks/useChat.tsx
@@ -34,6 +34,9 @@ export interface SendOptions {
   modelOverride?: string;
   /** Repository selected in the SDLC Agent composer. */
   researchContext?: { type: "repository"; id: string; name?: string };
+  /** Per-turn provider fast mode toggle (chat sidebar). Overrides the agent's
+   *  saved modelSettings.speed for this run only. */
+  speed?: "standard" | "fast";
 }
 
 /** A live event delivered by the /live SSE for a conversation being viewed. */
@@ -295,11 +298,11 @@ interface ChatContextValue {
   /** Branching: produce a sibling assistant under the same user parent.
    *  When assistantMessageId is provided, regenerates THAT assistant's reply;
    *  otherwise regenerates the latest visible assistant. */
-  regenerate: (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string) => Promise<void>;
+  regenerate: (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string, speed?: "standard" | "fast") => Promise<void>;
   /** Branching: replace the latest visible user message with edited text and
    *  run a new turn as a sibling. Older messages cannot be edited (would
    *  require re-rooting the tree). */
-  editLatestUserMessage: (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string) => Promise<void>;
+  editLatestUserMessage: (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string, speed?: "standard" | "fast") => Promise<void>;
   /** Branching: select which child of `parentId` should be visible. */
   selectBranch: (parentId: string, messageId: string) => void;
   /** Cancel the in-flight stream for the active session. No-op if nothing
@@ -571,6 +574,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
             ...(opts?.designSelection ? { designSelection: opts.designSelection } : {}),
             ...(opts?.modelOverride ? { providerOverride: { provider: "litellm", model: opts.modelOverride } } : {}),
             ...(opts?.researchContext ? { researchContext: opts.researchContext } : {}),
+            ...(opts?.speed ? { speed: opts.speed } : {}),
           },
         );
 
@@ -681,7 +685,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   );
 
   const regenerate = useCallback(
-    async (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string) => {
+    async (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string, speed?: "standard" | "fast") => {
       const key = activeKey;
       if (!key) return;
       const current = sessions.get(key);
@@ -796,8 +800,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           undefined,                     // signalOrIsEditUserMessage
           undefined,                     // editedUserMessageId
           controller.signal,             // explicit terminal signal
-          // Carry the per-chat model pick so regenerate reruns on the same model.
-          modelOverride ? { providerOverride: { provider: "litellm", model: modelOverride } } : undefined,
+          // Carry the per-chat model pick + fast mode so regenerate reruns the same way.
+          {
+            ...(modelOverride ? { providerOverride: { provider: "litellm", model: modelOverride } } : {}),
+            ...(speed ? { speed } : {}),
+          },
         );
         updateSession(key, (s) => {
           const withAssistantId = replaceMessageId(s, assistantId, result.reply.id ?? assistantId);
@@ -858,7 +865,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   );
 
   const editLatestUserMessage = useCallback(
-    async (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string) => {
+    async (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string, speed?: "standard" | "fast") => {
       const key = activeKey;
       if (!key || !text.trim()) return;
       const current = sessions.get(key);
@@ -975,8 +982,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           true,                          // isEditUserMessage flag
           originalUser.id,               // editedUserMessageId
           controller.signal,             // explicit terminal signal
-          // Carry the per-chat model pick so the edited turn reruns on it.
-          modelOverride ? { providerOverride: { provider: "litellm", model: modelOverride } } : undefined,
+          // Carry the per-chat model pick + fast mode so the edited turn reruns the same way.
+          {
+            ...(modelOverride ? { providerOverride: { provider: "litellm", model: modelOverride } } : {}),
+            ...(speed ? { speed } : {}),
+          },
         );
         updateSession(key, (s) => {
           const withUserId = result.reply.userMessageId

--- a/apps/xyne-claw/src/agent-model-settings.ts
+++ b/apps/xyne-claw/src/agent-model-settings.ts
@@ -14,6 +14,12 @@
  *                               // requires temperature=1 with extended thinking)
  *     maxTokens?: number        // max output tokens (default 16384)
  *     thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high"
+ *     speed?: "standard" | "fast"
+ *                               // provider fast mode (Anthropic `speed: "fast"`,
+ *                               // Opus 5 / 4.8 on a direct Claude credential).
+ *                               // Same credential + model, faster tier. NOT the
+ *                               // top-level agentConfig.fastMode tool-catalog
+ *                               // flag — see model-speed.ts
  *   }
  *
  *   config.outputFormat = {
@@ -30,6 +36,7 @@
  */
 
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { parseModelSpeed, type ModelSpeed } from "./model-speed.js";
 
 export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high"] as const;
 export type ModelSettingsThinkingLevel = (typeof THINKING_LEVELS)[number];
@@ -39,6 +46,7 @@ export interface AgentModelSettings {
   temperature?: number | undefined;
   maxTokens?: number | undefined;
   thinkingLevel?: ModelSettingsThinkingLevel | undefined;
+  speed?: ModelSpeed | undefined;
 }
 
 // Clamps mirror the control-plane validation (claw-auth routes/agents.ts) so a
@@ -65,6 +73,9 @@ export function parseModelSettings(agentConfig: Record<string, unknown> | undefi
   if (typeof r["thinkingLevel"] === "string" && (THINKING_LEVELS as readonly string[]).includes(r["thinkingLevel"])) {
     out.thinkingLevel = r["thinkingLevel"] as ModelSettingsThinkingLevel;
   }
+
+  const speed = parseModelSpeed(r["speed"]);
+  if (speed) out.speed = speed;
 
   return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -45,6 +45,7 @@ import { gcsUploadDebugRun } from "./storage.js";
 import { createCommandGuard } from "./command-guard.js";
 import { writeSessionSkills, deleteSessionSkills } from "./session-skills.js";
 import { installLlmCallMetrics } from "./llm-call-metrics.js";
+import { installFastMode, isAdaptiveThinkingClaudeModel, type ModelSpeed } from "./model-speed.js";
 import { installToolBudget } from "./tool-budget.js";
 import type { FastToolRuntimeController } from "./tool-catalog.js";
 
@@ -306,6 +307,14 @@ interface DebugThinkingConfiguration {
   wireMode: string;
 }
 
+/** Provider fast mode (modelSettings.speed) as it was resolved for this run —
+ *  so a "why wasn't it faster?" report can be answered from the trace. */
+interface DebugSpeedConfiguration {
+  requested: ModelSpeed;
+  applied: boolean;
+  reason: string;
+}
+
 interface DebugSessionSnapshot {
   schemaVersion: 1;
   conversationId?: string;
@@ -319,6 +328,8 @@ interface DebugSessionSnapshot {
   model?: string;
   /** Requested/effective thinking selection and its provider wire representation. */
   thinking?: DebugThinkingConfiguration;
+  /** Requested/applied provider fast mode and the eligibility verdict. */
+  speed?: DebugSpeedConfiguration;
   startedAt: string;
   finishedAt: string;
   task: string;
@@ -953,6 +964,12 @@ export function resolveModel(
   if (provider === "claude" && providerConfig?.apiKey) {
     const isOauthToken = (providerConfig as ClaudeConfig).authType === "oauth_token";
     const providerName = "anthropic-user";
+    // Claude 4.6+ takes adaptive thinking (`thinking: {type:"adaptive"}` +
+    // output_config.effort); pi-ai only flags that for its built-in catalogue,
+    // and falls back to budget_tokens for custom models — deprecated on 4.6 and
+    // a 400 from 4.7 on. Spell it out so Opus 4.8 / Opus 5 (the only fast-mode
+    // models) actually accept a thinking-enabled request.
+    const adaptiveThinking = isAdaptiveThinkingClaudeModel(providerConfig.model);
     modelRegistry.registerProvider(providerName, {
       baseUrl: providerConfig.baseUrl || "https://api.anthropic.com",
       apiKey: providerConfig.apiKey,
@@ -964,6 +981,7 @@ export function resolveModel(
           id: providerConfig.model,
           name: providerConfig.model,
           reasoning: true,
+          ...(adaptiveThinking ? { compat: { forceAdaptiveThinking: true } } : {}),
           input: ["text", "image"],
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           contextWindow: contextWindowFor(providerConfig.model),
@@ -975,7 +993,7 @@ export function resolveModel(
     if (!model) {
       throw new Error(`Failed to register Claude model "${providerConfig.model}" at ${providerConfig.baseUrl ?? "anthropic"}`);
     }
-    log.info(`[agent] Using Claude model: ${providerConfig.model} (${isOauthToken ? "oauth_token" : "api_key"}, reasoning)`);
+    log.info(`[agent] Using Claude model: ${providerConfig.model} (${isOauthToken ? "oauth_token" : "api_key"}, ${adaptiveThinking ? "adaptive thinking" : "reasoning"})`);
     return model;
   }
 
@@ -2242,6 +2260,14 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
       baseStreamFn(streamModel, streamContext, { ...(streamOptions ?? {}), temperature });
     log.info(`[agent] Applying per-agent temperature: ${temperature}`);
   }
+  // Provider fast mode (modelSettings.speed = "fast"): same credential, same
+  // model, Anthropic's faster tier. Gated to direct-Anthropic Opus 5 / 4.8 —
+  // see model-speed.ts for why it must never reach an ineligible provider.
+  const debugSpeed: DebugSpeedConfiguration | undefined = modelSettings?.speed
+    ? modelSettings.speed === "fast"
+      ? { requested: "fast", ...installFastMode(session.agent, model) }
+      : { requested: "standard", applied: false, reason: "standard speed requested" }
+    : undefined;
   installLlmCallMetrics(session.agent, sessionId ?? conversationId ?? "unknown", { fastMode: fastMode === true });
 
   // Mid-turn compaction: pi compacts AFTER an assistant message but doesn't
@@ -2432,6 +2458,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
         ...(provider ? { provider } : {}),
         model: model.id,
         thinking: debugThinking,
+        ...(debugSpeed ? { speed: debugSpeed } : {}),
         inProgress: true,
         startedAt: debugStartedIso,
         finishedAt: new Date().toISOString(),
@@ -2555,6 +2582,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     provider,
     model: model.id,
     thinking: debugThinking,
+    ...(debugSpeed ? { speed: debugSpeed } : {}),
     task,
     context: context ?? null,
     systemPromptOverride: Boolean(systemPromptOverride),
@@ -3501,6 +3529,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
         ...(provider ? { provider } : {}),
         model: model.id,
         thinking: debugThinking,
+        ...(debugSpeed ? { speed: debugSpeed } : {}),
         startedAt: debugStartedIso,
         finishedAt: new Date().toISOString(),
         task,
@@ -3677,6 +3706,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
           ...(provider ? { provider } : {}),
           model: model.id,
           thinking: debugThinking,
+          ...(debugSpeed ? { speed: debugSpeed } : {}),
           cancelled: true,
           startedAt: debugStartedIso,
           finishedAt: new Date().toISOString(),

--- a/apps/xyne-claw/src/model-speed.ts
+++ b/apps/xyne-claw/src/model-speed.ts
@@ -1,0 +1,147 @@
+/**
+ * Provider "fast mode" (Anthropic `speed: "fast"`).
+ *
+ * Distinct from claw's existing top-level `agentConfig.fastMode` — that one is
+ * the tool-catalog / no-delegation mode toggled with `/fast`. THIS is the
+ * inference-speed knob: the same provider credential, same model, same
+ * request — but the provider serves it from its faster (premium-priced) tier.
+ *
+ * Wire contract (Anthropic research preview, Opus 5 / Opus 4.8 only):
+ *   - request body gets `speed: "fast"`
+ *   - request carries the beta flag `anthropic-beta: fast-mode-2026-02-01`
+ *
+ * Other providers/models don't understand the parameter: sending it anyway
+ * would 400, which the provider-fallback chain reads as a provider failure and
+ * silently drops the run to the next provider. So `fastModeEligibility` gates
+ * it to the one combination that works, and `installFastMode` is a no-op
+ * (with a logged reason) everywhere else.
+ *
+ * Setting lives on `agentConfig.modelSettings.speed` (agent owner default) and
+ * can be overridden per run by the caller (claw-auth's chat composer merges the
+ * per-message toggle into the same field before dispatch).
+ */
+
+import type { Api, Context, Model, SimpleStreamOptions, AssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("model-speed");
+
+export const MODEL_SPEEDS = ["standard", "fast"] as const;
+export type ModelSpeed = (typeof MODEL_SPEEDS)[number];
+
+export const FAST_MODE_BETA = "fast-mode-2026-02-01";
+
+// pi-ai's OAuth client path sets these two betas itself; because headers are
+// merged with Object.assign (last write wins), a caller-supplied
+// `anthropic-beta` REPLACES that list rather than extending it. Re-state them
+// so fast mode can't silently strip the OAuth identity betas.
+const OAUTH_BETAS = ["claude-code-20250219", "oauth-2025-04-20"] as const;
+
+/** Direct-Anthropic provider name registered by resolveModel's `claude` branch. */
+export const ANTHROPIC_USER_PROVIDER = "anthropic-user";
+
+/** Models the Anthropic fast-mode preview accepts `speed: "fast"` for. Opus 4.7
+ *  had it and lost it (now errors); nothing else ever had it. */
+export function isFastModeCapableModel(modelId: string | undefined): boolean {
+  return /^claude-opus-(5|4-8)(?:$|[-@.])/i.test((modelId ?? "").trim());
+}
+
+/** Claude 4.6+ (Opus/Sonnet 4.6, 4.7, 4.8, the 5 family, Fable/Mythos) take
+ *  adaptive thinking; budget_tokens is deprecated on 4.6 and a 400 from 4.7 on.
+ *  pi-ai only knows this for its built-in catalogue, so custom-registered
+ *  models need `compat.forceAdaptiveThinking` spelled out. */
+export function isAdaptiveThinkingClaudeModel(modelId: string | undefined): boolean {
+  const id = (modelId ?? "").trim().toLowerCase();
+  if (/^claude-(fable|mythos)-/.test(id)) return true;
+  const m = /^claude-(?:opus|sonnet|haiku)-(\d+)(?:-(\d+))?/.exec(id);
+  if (!m) return false;
+  const major = Number(m[1]);
+  const minor = m[2] !== undefined ? Number(m[2]) : 0;
+  if (major >= 5) return true;
+  return major === 4 && minor >= 6;
+}
+
+export interface FastModeEligibility {
+  eligible: boolean;
+  reason: string;
+}
+
+export function fastModeEligibility(model: Pick<Model<Api>, "api" | "provider" | "id">): FastModeEligibility {
+  if (model.api !== "anthropic-messages") {
+    return { eligible: false, reason: `provider api "${model.api}" has no fast mode (Anthropic Messages only)` };
+  }
+  if (model.provider !== ANTHROPIC_USER_PROVIDER) {
+    return { eligible: false, reason: `provider "${model.provider}" is not the direct Anthropic API (Copilot/gateway shims don't forward speed)` };
+  }
+  if (!isFastModeCapableModel(model.id)) {
+    return { eligible: false, reason: `model "${model.id}" does not support fast mode (Claude Opus 5 / Opus 4.8 only)` };
+  }
+  return { eligible: true, reason: "direct Anthropic API + fast-mode-capable model" };
+}
+
+export function parseModelSpeed(raw: unknown): ModelSpeed | undefined {
+  return typeof raw === "string" && (MODEL_SPEEDS as readonly string[]).includes(raw) ? (raw as ModelSpeed) : undefined;
+}
+
+type StreamFn = (
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions,
+) => AssistantMessageEventStream | Promise<AssistantMessageEventStream>;
+
+type StreamAgent = { streamFn: StreamFn };
+
+function isOAuthApiKey(apiKey: string | undefined): boolean {
+  return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
+}
+
+/** Build the `anthropic-beta` value: extend whatever the caller already set,
+ *  otherwise re-state pi-ai's OAuth betas when the key is an OAuth token. */
+export function fastModeBetaHeader(existing: string | undefined, apiKey: string | undefined): string {
+  const base = existing
+    ? existing.split(",").map((s) => s.trim()).filter(Boolean)
+    : isOAuthApiKey(apiKey) ? [...OAUTH_BETAS] : [];
+  if (!base.includes(FAST_MODE_BETA)) base.push(FAST_MODE_BETA);
+  return base.join(",");
+}
+
+export interface FastModeInstallResult {
+  applied: boolean;
+  reason: string;
+}
+
+/**
+ * Wrap the session's streamFn so every LLM call for this run carries
+ * `speed: "fast"` + the beta header. Only wraps calls whose model is eligible
+ * (the session model can be swapped mid-run by compaction/fallback code, so
+ * eligibility is re-checked per call, not once at install time).
+ */
+export function installFastMode(agent: StreamAgent, sessionModel: Pick<Model<Api>, "api" | "provider" | "id">): FastModeInstallResult {
+  const eligibility = fastModeEligibility(sessionModel);
+  if (!eligibility.eligible) {
+    log.warn(`fast mode requested but NOT applied: ${eligibility.reason}`);
+    return { applied: false, reason: eligibility.reason };
+  }
+  const baseStreamFn = agent.streamFn;
+  agent.streamFn = (model, context, options) => {
+    if (!fastModeEligibility(model).eligible) {
+      return baseStreamFn(model, context, options);
+    }
+    const opts = options ?? {};
+    const headers = {
+      ...(opts.headers ?? {}),
+      "anthropic-beta": fastModeBetaHeader(opts.headers?.["anthropic-beta"], opts.apiKey),
+    };
+    const baseOnPayload = opts.onPayload;
+    const onPayload: NonNullable<SimpleStreamOptions["onPayload"]> = async (payload, payloadModel) => {
+      const next = (await baseOnPayload?.(payload, payloadModel)) ?? payload;
+      if (next && typeof next === "object" && !Array.isArray(next)) {
+        return { ...(next as Record<string, unknown>), speed: "fast" };
+      }
+      return next;
+    };
+    return baseStreamFn(model, context, { ...opts, headers, onPayload });
+  };
+  log.info(`fast mode ON for ${sessionModel.provider}/${sessionModel.id} (speed=fast, beta=${FAST_MODE_BETA})`);
+  return { applied: true, reason: eligibility.reason };
+}

--- a/apps/xyne-claw/test/model-speed.test.ts
+++ b/apps/xyne-claw/test/model-speed.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import {
+  FAST_MODE_BETA,
+  fastModeBetaHeader,
+  fastModeEligibility,
+  installFastMode,
+  isAdaptiveThinkingClaudeModel,
+  isFastModeCapableModel,
+  parseModelSpeed,
+} from "../src/model-speed.js";
+import { parseModelSettings } from "../src/agent-model-settings.js";
+
+const anthropicModel = (id: string, provider = "anthropic-user"): Pick<Model<Api>, "api" | "provider" | "id"> =>
+  ({ api: "anthropic-messages", provider, id });
+
+describe("isFastModeCapableModel", () => {
+  it("accepts Opus 5 and Opus 4.8 ids (bare or with a suffix)", () => {
+    expect(isFastModeCapableModel("claude-opus-5")).toBe(true);
+    expect(isFastModeCapableModel("claude-opus-4-8")).toBe(true);
+    expect(isFastModeCapableModel("claude-opus-5-20260601")).toBe(true);
+    expect(isFastModeCapableModel("Claude-Opus-4-8")).toBe(true);
+  });
+  it("rejects everything else (4.7 lost fast mode; Sonnet/Haiku/Fable never had it)", () => {
+    for (const id of ["claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-5", "claude-sonnet-4-6", "claude-fable-5", "claude-opus-50", "gpt-5.5", "", undefined]) {
+      expect(isFastModeCapableModel(id)).toBe(false);
+    }
+  });
+});
+
+describe("isAdaptiveThinkingClaudeModel", () => {
+  it("is true for 4.6+ and the 5 family", () => {
+    for (const id of ["claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-mythos-5", "claude-haiku-5"]) {
+      expect(isAdaptiveThinkingClaudeModel(id), id).toBe(true);
+    }
+  });
+  it("is false for budget_tokens-era models and non-Claude ids", () => {
+    for (const id of ["claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5", "claude-opus-4", "claude-3-7-sonnet", "gpt-5.5", undefined]) {
+      expect(isAdaptiveThinkingClaudeModel(id), String(id)).toBe(false);
+    }
+  });
+});
+
+describe("fastModeEligibility", () => {
+  it("is eligible only for direct-Anthropic Opus 5 / 4.8", () => {
+    expect(fastModeEligibility(anthropicModel("claude-opus-5")).eligible).toBe(true);
+    expect(fastModeEligibility(anthropicModel("claude-opus-4-8")).eligible).toBe(true);
+  });
+  it("explains each rejection", () => {
+    expect(fastModeEligibility({ api: "openai-completions", provider: "litellm", id: "glm-latest" }).reason).toMatch(/Anthropic Messages only/);
+    expect(fastModeEligibility(anthropicModel("claude-opus-5", "copilot-user")).reason).toMatch(/not the direct Anthropic API/);
+    expect(fastModeEligibility(anthropicModel("claude-sonnet-5")).reason).toMatch(/does not support fast mode/);
+  });
+});
+
+describe("fastModeBetaHeader", () => {
+  it("is just the fast-mode beta for API keys", () => {
+    expect(fastModeBetaHeader(undefined, "sk-ant-api03-xxx")).toBe(FAST_MODE_BETA);
+  });
+  it("re-states pi-ai's OAuth betas for OAuth tokens (Object.assign would otherwise drop them)", () => {
+    expect(fastModeBetaHeader(undefined, "sk-ant-oat01-xxx")).toBe(`claude-code-20250219,oauth-2025-04-20,${FAST_MODE_BETA}`);
+  });
+  it("extends an existing header without duplicating", () => {
+    expect(fastModeBetaHeader("foo-2025, bar-2026", undefined)).toBe(`foo-2025,bar-2026,${FAST_MODE_BETA}`);
+    expect(fastModeBetaHeader(FAST_MODE_BETA, undefined)).toBe(FAST_MODE_BETA);
+  });
+});
+
+describe("installFastMode", () => {
+  function captureAgent() {
+    const calls: Array<{ model: Model<Api>; options: SimpleStreamOptions | undefined }> = [];
+    const agent = {
+      streamFn: (model: Model<Api>, _context: unknown, options?: SimpleStreamOptions) => {
+        calls.push({ model, options });
+        return {} as never;
+      },
+    };
+    return { agent, calls };
+  }
+
+  it("adds speed=fast + the beta header for an eligible model and composes an existing onPayload", async () => {
+    const { agent, calls } = captureAgent();
+    const model = { ...anthropicModel("claude-opus-5"), baseUrl: "https://api.anthropic.com" } as Model<Api>;
+    const result = installFastMode(agent, model);
+    expect(result.applied).toBe(true);
+
+    const existingOnPayload: NonNullable<SimpleStreamOptions["onPayload"]> = (payload) => ({ ...(payload as object), marker: 1 });
+    await agent.streamFn(model, { messages: [] } as never, {
+      apiKey: "sk-ant-api03-xxx",
+      headers: { "x-custom": "1" },
+      onPayload: existingOnPayload,
+    });
+    expect(calls).toHaveLength(1);
+    const opts = calls[0]!.options!;
+    expect(opts.headers).toEqual({ "x-custom": "1", "anthropic-beta": FAST_MODE_BETA });
+    const payload = await opts.onPayload!({ model: "claude-opus-5", max_tokens: 10 }, model);
+    expect(payload).toEqual({ model: "claude-opus-5", max_tokens: 10, marker: 1, speed: "fast" });
+  });
+
+  it("leaves ineligible models untouched, both at install time and per call", async () => {
+    const { agent, calls } = captureAgent();
+    const litellm = { api: "openai-completions", provider: "litellm", id: "glm-latest", baseUrl: "x" } as Model<Api>;
+    expect(installFastMode(agent, litellm).applied).toBe(false);
+    const original = { headers: { a: "b" } };
+    await agent.streamFn(litellm, { messages: [] } as never, original);
+    expect(calls[0]!.options).toBe(original);
+
+    // Eligible session model, but a per-call swap to a different model (fallback/compaction) must not get speed=fast.
+    const { agent: agent2, calls: calls2 } = captureAgent();
+    const opus = { ...anthropicModel("claude-opus-5"), baseUrl: "x" } as Model<Api>;
+    installFastMode(agent2, opus);
+    const sonnet = { ...anthropicModel("claude-sonnet-5"), baseUrl: "x" } as Model<Api>;
+    await agent2.streamFn(sonnet, { messages: [] } as never, original);
+    expect(calls2[0]!.options).toBe(original);
+  });
+});
+
+describe("modelSettings.speed", () => {
+  it("parses fast/standard and drops junk", () => {
+    expect(parseModelSpeed("fast")).toBe("fast");
+    expect(parseModelSpeed("standard")).toBe("standard");
+    expect(parseModelSpeed("turbo")).toBeUndefined();
+    expect(parseModelSettings({ modelSettings: { speed: "fast" } })).toEqual({ speed: "fast" });
+    expect(parseModelSettings({ modelSettings: { speed: true } })).toBeUndefined();
+  });
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/60111fc7-cde8-4e03-ab2d-95a875d730a5



## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds **fast mode** to claw agents — configurable per agent (Model & provider tab) and per chat (composer pill). No ticket.

Two layers, honoured on every run path (dashboard chat, Spaces mentions, scheduled/automation, run-stream, slack/a2a):

1. **Provider fast tier.** When a run is in fast mode and the serving model is direct-Anthropic Claude Opus 5 / 4.8, claw sends Anthropic's `speed: "fast"` + `anthropic-beta: fast-mode-2026-02-01` on the same credential (`apps/xyne-claw/src/model-speed.ts`, wraps the session `streamFn`). Any other provider/model is skipped with a logged reason — it never 400s into the provider-fallback chain. The debug snapshot records `speed: {requested, applied, reason}`.
2. **Fast-mode provider profile.** `config.fastModeProfile` lets fast mode run on its own provider order with optional per-provider model pins (credential keys are shared with standard mode). Default is *inherit* (same providers + credentials as standard). Resolved in `lib/agent-provider-config.ts` (`providerConfigForSpeed` / `applyFastModeModels`) and applied in `resolveAgentProviderConfigs`, the chat route and the Spaces mention path.

Also: custom-registered Claude 4.6+ models now get `compat.forceAdaptiveThinking` — without it pi-ai sends `budget_tokens`, which Opus 4.7+ rejects with a 400, so fast mode could never succeed with thinking on.

Config: `modelSettings.speed: "standard" | "fast"` (agent default, validated + audited like the other model settings) and `config.fastModeProfile`. Deliberately **not** `config.fastMode`, which is the existing `/fast` tool-catalog flag.

UI:
- Model & provider → **Standard / ⚡ Fast mode** switch at the top of *Select providers*. Fast view: "Fast mode by default" switch, "Providers in fast mode: Same as standard | Custom", the same order editor + provider chips (with a model pin per provider), Configure Credentials badged "Shared with standard mode". One Save button.
- Chat composer: **⚡ Fast mode** pill next to attach / mention. On = this chat runs fast; off = agent default. Remembered per agent in localStorage.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section** (new settings live in the agent's JSONB `config`)

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [x] Existing contract modified (shape, status codes, auth) — `POST /agents/:slug/chat` accepts optional `speed: "standard" | "fast"` (400 on any other value); `PUT /agents/:slug` accepts `config.modelSettings.speed` and `config.fastModeProfile`. Both additive.
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

No Claude credential exists locally, so the Anthropic side was a **local stub of the Messages API** (records headers + body, streams a canned SSE reply that echoes what it received) registered as a Claude credential with Base URL `http://localhost:4999` on a personal agent. A recorded Playwright script drives the real UI and asserts every step against the stub's request log (all four pass):

1. composer pill off → request has **no** `speed` param
2. composer pill on → `speed="fast"` + `anthropic-beta: fast-mode-2026-02-01` on `claude-opus-5`, adaptive thinking (`thinking.type=adaptive` + `output_config.effort`)
3. Model & provider → Fast mode view → default ON + custom profile with Claude pinned to `claude-opus-4-8` → Save → `config.modelSettings.speed=fast`, `config.fastModeProfile` saved, audit row "speed: platform default → fast"
4. pill off, agent default on → request is `speed="fast"` on **`claude-opus-4-8`** (the profile's pin, not the credential's model)

Not exercised against the real Anthropic API (no key available) — the wire contract follows the documented fast-mode preview shape.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [x] Claw tests — `pnpm --filter xyne-claw run test` (new `test/model-speed.test.ts`: 12 pass; 5 pre-existing failures in memory-search / mid-turn-compaction / session-freshness / user-memory-curator-trace reproduce identically on the base commit)
- [ ] End-to-end suite — `pnpm run test`
- [x] Added / updated tests for this change — claw `model-speed.test.ts`; claw-auth `agent-config-validation.test.ts` + `agent-provider-config.fast-profile.test.ts` (9 pass)
- [ ] Not covered by tests

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (claw `:3002`, claw-auth backend `:3003`, claw-auth UI `:5174`, spaces backend `:3001`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — not applicable (no Zero)

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme (both themes styled; only checked light in the recording, dark in the Browser pane)
- [x] Empty state (fast profile with no providers selected)
- [ ] Large / realistic data volume
- [x] Error paths — invalid `speed` → 400; ineligible provider/model → fast mode skipped with logged reason, run proceeds

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes (not run — shared packages untouched)
- [x] Backend `typecheck` + `build` pass — claw `tsc --noEmit` and claw-auth backend `tsc --noEmit` clean (spaces backend untouched)
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass — claw-auth frontend `tsc -b` clean (eslint not installed in that package; spaces dashboard untouched)
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>` — no new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*` — no ticket id (none given)
- [x] Docs / guidelines updated where behaviour changed — inline module docs in `model-speed.ts`, `agent-model-settings.ts`, `agent-provider-config.ts`
- [x] No debug logging or commented-out code left behind

**Known pre-existing issue spotted while testing (not fixed here):** the v3 chat page fires `/agents` and `/agents?userId=` concurrently; when the `userId`-less response lands last, personal agents drop out of the list and the page falls back to "All agents" with no composer. Frequent in headless Playwright, occasional in a normal browser.
