### PR TITLE
fix: XYNE-56756 appscreen and incoming webhook fix

### DIFF
--- a/apps/backend/src/apps/controllers/incomingWebhookController.ts
+++ b/apps/backend/src/apps/controllers/incomingWebhookController.ts
@@ -276,6 +276,9 @@ class IncomingWebhookController {
         res.status(400).send('invalid_payload');
         return;
       }
+      logger.info('[INCOMING-WEBHOOK] BODY', {
+        body: context.body,
+      });
 
       // Unauthenticated webhook: no req.user, so open an explicit tenant scope from the
       // validated :workspaceId URL param so the workspaceId stamper fills downstream writes.

--- a/apps/backend/src/apps/platform-adapters/slack/controller.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/controller.ts
@@ -313,6 +313,7 @@ export class SlackController {
 	});
 
 	chatPostMessage = wrapSlackHandler(async (req: Request, res: Response) => {
+		logger.info("[SLACK-POST-MESSAGE] Received request", { body: req.body, query: req.query, headers: req.headers });
 		const parsed = PostMessageSchema.safeParse(req.body);
 		if (!parsed.success) {
 			res.status(200).json({ ok: false, error: "invalid_arguments" });
@@ -736,6 +737,7 @@ export class SlackController {
 	});
 
 	filesUpload = wrapSlackHandler(async (req: Request, res: Response) => {
+		logger.info("[SLACK-FILES-UPLOAD] Received request", { body: req.body, query: req.query, headers: req.headers });
 		const parsed = FilesUploadSchema.safeParse(req.body);
 		if (!parsed.success) {
 			res.status(200).json({ ok: false, error: "invalid_arguments" });

--- a/apps/dashboard/src/components/Apps/AppsTable/AppsTable.tsx
+++ b/apps/dashboard/src/components/Apps/AppsTable/AppsTable.tsx
@@ -106,14 +106,16 @@ export const AppsTable = ({
   // Check if user has admin access
   const hasAdminAccess = appAccessLevel === 'ADMIN';
 
-  // Who may edit, by screen:
-  // - Installed view: editing the install copy -> any XYNE-APPS admin.
+  // Who may OPEN the edit dialog, by screen:
+  // - Installed view: any XYNE-APPS admin, plus the app's creator (webhooks only -- see below).
   // - Org/Marketplace view: editing the app template -> creator only (matches AppsACL.canUpdate).
   const canEditApp = (app: AppRow): boolean => {
     if (appAccessLevel === 'READ' || appAccessLevel === null) return false;
-    if (isInstalledView) return hasAdminAccess;
+    if (isInstalledView) return hasAdminAccess || app.createdBy === currentUserId;
     return app.createdBy === currentUserId;
   };
+
+  const canEditInstallSettings = (): boolean => !isInstalledView || hasAdminAccess;
 
   const [editingAppId, setEditingAppId] = useState<string | null>(null);
   const [editingApp, setEditingApp] = useState<AppRow | null>(null);
@@ -476,6 +478,7 @@ export const AppsTable = ({
             appInstallations={editingApp.installations}
             editMode={isInstalledView ? 'install' : 'template'}
             installedAppId={isInstalledView ? (editingApp.installations?.[0]?.id ?? null) : null}
+            canEditInstallSettings={canEditInstallSettings()}
             onSave={handleSaveEdit}
             onUploadPicture={uploadPictureHandler}
             isLoading={isUpdatingApp}

--- a/apps/dashboard/src/components/Apps/EditAppForm/EditAppForm.tsx
+++ b/apps/dashboard/src/components/Apps/EditAppForm/EditAppForm.tsx
@@ -479,6 +479,8 @@ interface PermissionsSectionProps {
   // workspace's installed_app_permissions (admin, Installed screen).
   editMode: 'template' | 'install';
   installedAppId: string | null;
+  // true -> render the section but lock every control (app creator on the Installed screen).
+  readOnly?: boolean;
 }
 
 const PermissionsSection = ({
@@ -486,6 +488,7 @@ const PermissionsSection = ({
   isInstalled,
   editMode,
   installedAppId,
+  readOnly = false,
 }: PermissionsSectionProps): ReactElement => {
   const isInstallMode = editMode === 'install' && !!installedAppId;
   const [available, setAvailable] = useState<AppPermission[]>([]);
@@ -495,6 +498,8 @@ const PermissionsSection = ({
   const [statusMap, setStatusMap] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  // Everything the `saving` flag already disables should also be disabled when read-only.
+  const locked = saving || readOnly;
 
   // Always load the full registry
   useEffect(() => {
@@ -649,7 +654,7 @@ const PermissionsSection = ({
             variant='ghost'
             className='h-7 text-xs'
             onClick={handleToggleSelectAll}
-            disabled={saving || !loaded || available.length === 0}
+            disabled={locked || !loaded || available.length === 0}
             data-track-category='Apps'
             data-track-name='ToggleSelectAllPermissions'
           >
@@ -661,7 +666,7 @@ const PermissionsSection = ({
             variant='outline'
             className='h-7 text-xs'
             onClick={() => void handleSave()}
-            disabled={saving || !loaded}
+            disabled={locked || !loaded}
           >
             {saving ? 'Saving…' : 'Save Permissions'}
           </Button>
@@ -672,7 +677,7 @@ const PermissionsSection = ({
               variant='default'
               className='h-7 text-xs'
               onClick={() => void handleActivate()}
-              disabled={activating || saving}
+              disabled={activating || locked}
               title='Re-sync this install to activate pending permission changes'
             >
               {activating ? 'Applying…' : 'Apply & activate'}
@@ -695,16 +700,16 @@ const PermissionsSection = ({
               <div
                 key={scope}
                 role='button'
-                tabIndex={saving ? -1 : 0}
+                tabIndex={locked ? -1 : 0}
                 aria-pressed={selected.has(scope)}
                 className={`flex items-start gap-2.5 group px-3 py-2 outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
-                  saving ? 'cursor-not-allowed' : 'cursor-pointer'
+                  locked ? 'cursor-not-allowed' : 'cursor-pointer'
                 }`}
                 onClick={() => {
-                  if (!saving) handleToggle(scope, !selected.has(scope));
+                  if (!locked) handleToggle(scope, !selected.has(scope));
                 }}
                 onKeyDown={e => {
-                  if (saving) return;
+                  if (locked) return;
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
                     handleToggle(scope, !selected.has(scope));
@@ -718,7 +723,7 @@ const PermissionsSection = ({
                 <span className='mt-0.5 pointer-events-none'>
                   <Checkbox
                     checked={selected.has(scope)}
-                    disabled={saving}
+                    disabled={locked}
                     onChange={checked => handleToggle(scope, checked)}
                     label=''
                   />
@@ -763,6 +768,9 @@ export interface EditAppFormProps {
   // (admin; edits this workspace's install — webhook + permissions, commands read-only).
   editMode?: 'template' | 'install';
   installedAppId?: string | null;
+  // false = the app's creator viewing their own install: every section still renders, but each
+  // control is locked -- Incoming Webhooks is the only editable one. Admins/template edits pass true.
+  canEditInstallSettings?: boolean;
   onSave: (data: { description: string; webhookUrl: string }) => Promise<void>;
   onUploadPicture?: ((appId: string, file: File) => Promise<void>) | undefined;
   isLoading?: boolean | undefined;
@@ -859,6 +867,7 @@ export const EditAppForm = ({
   appInstallations,
   editMode = 'template',
   installedAppId = null,
+  canEditInstallSettings = true,
   onSave,
   onUploadPicture,
   isLoading = false,
@@ -867,7 +876,11 @@ export const EditAppForm = ({
   // Install mode = editing this workspace's install (admin). Template mode = editing the app
   // (creator). In install mode commands and name/description are read-only (template-owned).
   const isInstallMode = editMode === 'install';
-  const [activeSection, setActiveSection] = useState<EditAppSection>('basic');
+  // The app's creator on the Installed screen: everything is locked except Incoming Webhooks, so
+  // open on that section rather than dropping them onto a Basic info form they can't submit.
+  const [activeSection, setActiveSection] = useState<EditAppSection>(
+    canEditInstallSettings ? 'basic' : 'incoming',
+  );
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [botChannels, setBotChannels] = useState<BotChannel[]>([]);
   const [webhooks, setWebhooks] = useState<IncomingWebhook[]>([]);
@@ -1206,6 +1219,9 @@ export const EditAppForm = ({
   }, [appDescription, webhookUrlValue, reset]);
 
   const onSubmit = async (formData: EditAppFormData): Promise<void> => {
+    // Authoritative gate: the Save button is disabled, but a stray Enter in another section's
+    // input can still trigger implicit form submission, so re-check rather than trust the button.
+    if (!canEditInstallSettings) return;
     await onSave({
       description: formData.description.trim(),
       webhookUrl: formData.webhookUrl.trim(),
@@ -1290,6 +1306,13 @@ export const EditAppForm = ({
 
         {/* Section content */}
         <div role='tabpanel' className='flex-1 overflow-y-auto p-6 space-y-6'>
+          {!canEditInstallSettings && (
+            <div className='bg-amber-500/10 border border-amber-500/30 text-amber-600 px-3 py-2 rounded-md text-sm dark:bg-amber-500/10 dark:text-amber-400'>
+              You&apos;re viewing this app as its creator. Only a workspace apps admin can change
+              these settings — you can create and manage Incoming Webhooks.
+            </div>
+          )}
+
           {activeSection === 'basic' && (
             <>
               <SectionHeading
@@ -1360,7 +1383,7 @@ export const EditAppForm = ({
                       id='webhookUrl'
                       type='url'
                       placeholder='https://your-app.com/webhook'
-                      disabled={isLoading}
+                      disabled={isLoading || !canEditInstallSettings}
                       className='text-foreground'
                       {...field}
                     />
@@ -1397,7 +1420,7 @@ export const EditAppForm = ({
                       variant='outline'
                       size='sm'
                       onClick={handleUploadClick}
-                      disabled={isLoading}
+                      disabled={isLoading || !canEditInstallSettings}
                       className='gap-1'
                       title='Upload bot profile picture'
                     >
@@ -1905,6 +1928,7 @@ export const EditAppForm = ({
               isInstalled={isInstallMode || isAppInstalled}
               editMode={editMode}
               installedAppId={installedAppId}
+              readOnly={!canEditInstallSettings}
             />
           )}
         </div>
@@ -1919,7 +1943,7 @@ export const EditAppForm = ({
         {activeSection === 'basic' && (
           <Button
             type='submit'
-            disabled={isLoading}
+            disabled={isLoading || !canEditInstallSettings}
             data-track-category='Apps'
             data-track-name='EditApp'
           >

--- a/apps/dashboard/src/routes/AppsScreen/AppsScreen.tsx
+++ b/apps/dashboard/src/routes/AppsScreen/AppsScreen.tsx
@@ -23,8 +23,8 @@ const ITEMS_PER_PAGE = 15;
 type AppsView = 'installed' | 'org' | 'marketplace';
 
 const VIEW_TABS: { value: AppsView; label: string }[] = [
-  { value: 'installed', label: 'Installed' },
   { value: 'org', label: 'Org Apps' },
+  { value: 'installed', label: 'Installed' },
   { value: 'marketplace', label: 'Marketplace' },
 ];
 
@@ -39,7 +39,7 @@ const AppsScreen = (): ReactElement => {
   const currentPage = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
   const view: AppsView = isAppsView(searchParams.get('view'))
     ? (searchParams.get('view') as AppsView)
-    : 'installed';
+    : 'org';
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
