### PR TITLE
fix: XYNE-12345 render SDLC call mini-view in host via frame bridge (…

### DIFF
--- a/apps/dashboard/src/hooks/useCallActions.ts
+++ b/apps/dashboard/src/hooks/useCallActions.ts
@@ -10,6 +10,8 @@ import { useAuthContextValues } from './useAuth';
 import { isUserActiveInCall } from './useCalls';
 import { QueryResultType } from '@rocicorp/zero';
 import { queries } from '../zero/queries';
+import { isSdlcSurface } from '../config';
+import { SDLC_FRAME_MESSAGE } from '../routes/SdlcScreen/sdlcFrameMessages';
 
 type ActiveCall = QueryResultType<typeof queries.userActiveCalls>[number];
 
@@ -130,6 +132,25 @@ export const useCallActions = ({
   }, [machineState, zero, isMobile]);
 
   const handleCallClick = (): void => {
+    // SDLC lane: the iframe's call overlay is suppressed, so a call started here
+    // must be owned by the HOST for its mini-view to render globally. Hand the
+    // request across the frame bridge and stop — the host initiates on its own
+    // roomActor and shows the global mini-view.
+    if (isSdlcSurface) {
+      window.parent?.postMessage(
+        {
+          type: SDLC_FRAME_MESSAGE.initiateCall,
+          channelId,
+          ...(targetUserIds && { targetUserIds }),
+          ...(callDisplayName && { callDisplayName }),
+          ...(conversationId && { conversationId }),
+          ...(sdlcLink && { sdlcLink }),
+        },
+        window.location.origin,
+      );
+      return;
+    }
+
     if (hasActiveCallInChannel) {
       // If there's an active call in this channel
       if (isUserInCurrentChannelCall) {

--- a/apps/dashboard/src/hooks/useCallJoinOrInitiate.ts
+++ b/apps/dashboard/src/hooks/useCallJoinOrInitiate.ts
@@ -6,6 +6,8 @@ import { roomActor } from '../machines/roomMachine';
 import { CallType } from '@xyne/shared';
 import { reactNativeBridge } from '../utils/reactNativeBridge';
 import { usePlatform } from './usePlatform';
+import { isSdlcSurface } from '../config';
+import { SDLC_FRAME_MESSAGE } from '../routes/SdlcScreen/sdlcFrameMessages';
 
 interface JoinCallParams {
   callId: string;
@@ -153,6 +155,26 @@ export const useCallJoinOrInitiate = (): UseCallJoinOrInitiateReturn => {
     onComplete,
   }: InitiateCallParams): void => {
     if (!channelId) return;
+
+    // SDLC lane: the iframe's call overlay is deliberately suppressed, so a call
+    // started here must be owned by the HOST for its mini-view to render globally.
+    // Hand the request across the frame bridge and stop — the host's roomActor
+    // takes it from here. onComplete stays local (it cannot cross the boundary).
+    if (isSdlcSurface) {
+      window.parent?.postMessage(
+        {
+          type: SDLC_FRAME_MESSAGE.initiateCall,
+          channelId,
+          ...(targetUserIds && { targetUserIds }),
+          ...(callDisplayName && { callDisplayName }),
+          ...(conversationId && { conversationId }),
+          ...(sdlcLink && { sdlcLink }),
+        },
+        window.location.origin,
+      );
+      onComplete?.();
+      return;
+    }
 
     // Case 1: User not in any call - initiate directly
     if (!isInCall) {

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { SDLC_APP_BASE_PATH } from '../../config';
+import { useCallJoinOrInitiate } from '../../hooks/useCallJoinOrInitiate';
 import { useSdlcFrame } from './SdlcFrameContext';
 import { isSdlcPath, parseSdlcFrameMessage, SDLC_FRAME_MESSAGE } from './sdlcFrameMessages';
 
@@ -23,6 +24,14 @@ const SdlcFrameHost = (): ReactElement | null => {
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [isReady, setIsReady] = useState(false);
+
+  // The host owns the roomActor, so a call the SDLC frame requests is initiated
+  // here and its mini-view renders in the host's global overlay. Kept in a ref so
+  // the message listener below need not re-subscribe when the callback identity
+  // changes each render.
+  const { initiateCall } = useCallJoinOrInitiate();
+  const initiateCallRef = useRef(initiateCall);
+  initiateCallRef.current = initiateCall;
 
   // Last path each side told the other, so echoes do not loop.
   const lastFromFrameRef = useRef<string | null>(null);
@@ -65,6 +74,17 @@ const SdlcFrameHost = (): ReactElement | null => {
 
       if (message.type === SDLC_FRAME_MESSAGE.ready) {
         setIsReady(true);
+        return;
+      }
+
+      if (message.type === SDLC_FRAME_MESSAGE.initiateCall) {
+        initiateCallRef.current({
+          channelId: message.channelId,
+          ...(message.targetUserIds && { targetUserIds: message.targetUserIds }),
+          ...(message.callDisplayName && { callDisplayName: message.callDisplayName }),
+          ...(message.conversationId && { conversationId: message.conversationId }),
+          ...(message.sdlcLink && { sdlcLink: message.sdlcLink }),
+        });
         return;
       }
 

--- a/apps/dashboard/src/routes/SdlcScreen/sdlcFrameMessages.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/sdlcFrameMessages.ts
@@ -4,11 +4,14 @@
 // share one route table and react-router strips the basename, so a path means the
 // same thing on both sides.
 
+import type { SdlcCallLink } from '@xyne/shared';
+
 export const SDLC_FRAME_MESSAGE = {
   navigate: 'xyne:sdlc-frame:navigate',
   route: 'xyne:sdlc-frame:route',
   ready: 'xyne:sdlc-frame:ready',
   reset: 'xyne:sdlc-frame:reset',
+  initiateCall: 'xyne:sdlc-frame:initiate-call',
 } as const;
 
 export interface SdlcFrameNavigateMessage {
@@ -30,11 +33,27 @@ export interface SdlcFrameResetMessage {
   type: typeof SDLC_FRAME_MESSAGE.reset;
 }
 
+/**
+ * Frame → parent: initiate a call on the HOST's roomActor. The SDLC lane is a
+ * chromeless iframe whose own call overlay is suppressed, so a call started
+ * inside it must be owned by the host to render the global mini-view. Only
+ * serialisable call params cross the boundary — onComplete stays in the frame.
+ */
+export interface SdlcFrameInitiateCallMessage {
+  type: typeof SDLC_FRAME_MESSAGE.initiateCall;
+  channelId: string;
+  targetUserIds?: string[];
+  callDisplayName?: string;
+  conversationId?: string;
+  sdlcLink?: SdlcCallLink;
+}
+
 export type SdlcFrameMessage =
   | SdlcFrameNavigateMessage
   | SdlcFrameRouteMessage
   | SdlcFrameReadyMessage
-  | SdlcFrameResetMessage;
+  | SdlcFrameResetMessage
+  | SdlcFrameInitiateCallMessage;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -66,6 +85,22 @@ export function parseSdlcFrameMessage(data: unknown): SdlcFrameMessage | null {
       return null;
     }
     return { type, path };
+  }
+
+  if (type === SDLC_FRAME_MESSAGE.initiateCall) {
+    const { channelId, targetUserIds, callDisplayName, conversationId, sdlcLink } = data;
+    if (typeof channelId !== 'string' || !channelId) return null;
+    return {
+      type,
+      channelId,
+      ...(Array.isArray(targetUserIds) &&
+        targetUserIds.every((id): id is string => typeof id === 'string') && {
+          targetUserIds,
+        }),
+      ...(typeof callDisplayName === 'string' && { callDisplayName }),
+      ...(typeof conversationId === 'string' && { conversationId }),
+      ...(isRecord(sdlcLink) && { sdlcLink: sdlcLink as SdlcCallLink }),
+    };
   }
 
   return null;


### PR DESCRIPTION
…#924)

A call started inside the SDLC iframe was owned by the iframe's roomActor, whose GlobalCallOverlay is deliberately suppressed (isInPanelWebview), so the bottom-left mini-view never appeared. Add an initiate-call message to the SDLC frame bridge: in the SDLC lane, useCallActions.handleCallClick (and useCallJoinOrInitiate.initiateCall) post the request to the host instead of initiating locally, and SdlcFrameHost initiates on the host's roomActor so the host's global mini-view renders. Incoming-call handling is unchanged.


Claude-Session: https://claude.ai/code/session_01Lrm9YdnRGVYBZijLjim4Js

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
