### PR TITLE
feat: fast-mode run-setting overrides (shared by default, per-field opt-out)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.test.ts
@@ -29,3 +29,14 @@ describe("validateAgentModelConfig — fastModeProfile", () => {
     expect(validateAgentModelConfig({ fastModeProfile: { extra: 1 } }).ok).toBe(false);
   });
 });
+
+describe("validateAgentModelConfig — fastModeProfile.modelSettings", () => {
+  it("accepts run-setting overrides", () => {
+    expect(validateAgentModelConfig({ fastModeProfile: { modelSettings: { thinkingLevel: "high", model: "glm-latest", maxTokens: 32000 } } })).toEqual({ ok: true });
+  });
+  it("rejects bad fields and a nested speed", () => {
+    expect(validateAgentModelConfig({ fastModeProfile: { modelSettings: { thinkingLevel: "ultra" } } }).ok).toBe(false);
+    expect(validateAgentModelConfig({ fastModeProfile: { modelSettings: { speed: "fast" } } }).error).toMatch(/speed is not allowed/);
+    expect(validateAgentModelConfig({ fastModeProfile: { modelSettings: { temperature: 2 } } }).ok).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
@@ -156,7 +156,7 @@ const PROFILE_PROVIDERS = new Set(["codex", "claude", "copilot", "openrouter", "
 function validateFastModeProfile(raw: unknown): ConfigValidationResult {
   if (raw === undefined || raw === null) return { ok: true };
   if (!isPlainObject(raw)) return fail("fastModeProfile must be an object");
-  const allowed = new Set(["providers", "providerOrder", "models"]);
+  const allowed = new Set(["providers", "providerOrder", "models", "modelSettings"]);
   for (const key of Object.keys(raw)) {
     if (!allowed.has(key)) return fail(`fastModeProfile.${key} is not a recognized setting`);
   }
@@ -169,6 +169,17 @@ function validateFastModeProfile(raw: unknown): ConfigValidationResult {
       return fail(`fastModeProfile.providerOrder must list providers from: ${[...PROFILE_PROVIDERS].join(", ")}`);
     }
   }
+  if (raw["modelSettings"] !== undefined) {
+    // Fast-mode run-setting overrides — same fields/clamps as the top-level
+    // modelSettings, minus `speed` (the profile IS the fast side; a nested
+    // speed would be circular). Set fields override standard field-by-field.
+    if (isPlainObject(raw["modelSettings"]) && (raw["modelSettings"] as Record<string, unknown>)["speed"] !== undefined) {
+      return fail("fastModeProfile.modelSettings.speed is not allowed (the profile only applies in fast mode)");
+    }
+    const ms = validateModelSettings(raw["modelSettings"]);
+    if (!ms.ok) return fail(`fastModeProfile.${ms.error ?? "modelSettings invalid"}`);
+  }
+
   if (raw["models"] !== undefined) {
     const models = raw["models"];
     if (!isPlainObject(models)) return fail("fastModeProfile.models must be an object of provider → model id");

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
@@ -1054,12 +1054,7 @@ export function ProviderTabV3({ agent, userId }: Props) {
               <h3 className="text-[14px] font-semibold text-xyne-fg-primary">
                 Configure Credentials
               </h3>
-              {providerView === "fast" && (
-                <span className="inline-flex items-center gap-1 text-[11px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5 dark:text-amber-300 dark:bg-amber-950/30 dark:border-amber-700/60">
-                  <LightningIcon size={11} weight="fill" />
-                  Shared with standard mode
-                </span>
-              )}
+
               <span
                 className="inline-flex items-center gap-1 text-[11px] font-medium text-xyne-success-fg bg-xyne-success-bg border border-xyne-success-border rounded-full px-2 py-0.5"
                 title="Credentials are encrypted at rest and never returned by the API."
@@ -1069,7 +1064,9 @@ export function ProviderTabV3({ agent, userId }: Props) {
               </span>
             </div>
             <p className="mt-1 text-[12px] text-xyne-fg-secondary">
-              API keys for the providers above. Stored encrypted; the platform never returns plaintext.
+              {providerView === "fast"
+                ? "Shared with standard mode by default — override any setting below for fast mode only."
+                : "API keys for the providers above. Stored encrypted; the platform never returns plaintext."}
             </p>
           </div>
           {!adding && (
@@ -1095,7 +1092,7 @@ export function ProviderTabV3({ agent, userId }: Props) {
             pencil expands the full model-settings editor (model, temperature,
             thinking, max tokens, JSON output). */}
         <ul className="space-y-2.5">
-          <SpacesDefaultRowV3 agent={agent} />
+          <SpacesDefaultRowV3 key={providerView} agent={agent} view={providerView} />
         </ul>
 
         {loading ? (

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/SpacesDefaultRowV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/SpacesDefaultRowV3.tsx
@@ -60,14 +60,30 @@ interface ModelSettings {
 
 interface Props {
   agent: Agent;
+  /** "standard" edits config.modelSettings. "fast" edits
+   *  config.fastModeProfile.modelSettings — per-field OVERRIDES applied only
+   *  to fast-mode runs; blank fields inherit the standard value. Mount with
+   *  `key={view}` so the draft reseeds when the view switches. */
+  view?: "standard" | "fast";
 }
 
-export function SpacesDefaultRowV3({ agent }: Props) {
-  const readSettings = (): ModelSettings => {
+export function SpacesDefaultRowV3({ agent, view = "standard" }: Props) {
+  const isFast = view === "fast";
+  const readStandard = (): ModelSettings => {
     const cfg = (agent.config ?? {}) as Record<string, unknown>;
     const msRaw = cfg["modelSettings"];
     return msRaw && typeof msRaw === "object" && !Array.isArray(msRaw) ? (msRaw as ModelSettings) : {};
   };
+  const readSettings = (): ModelSettings => {
+    if (!isFast) return readStandard();
+    const cfg = (agent.config ?? {}) as Record<string, unknown>;
+    const profile = cfg["fastModeProfile"];
+    const msRaw = profile && typeof profile === "object" && !Array.isArray(profile)
+      ? (profile as Record<string, unknown>)["modelSettings"]
+      : undefined;
+    return msRaw && typeof msRaw === "object" && !Array.isArray(msRaw) ? (msRaw as ModelSettings) : {};
+  };
+  const standard = readStandard();
 
   const initial = readSettings();
   const [savedSettings, setSavedSettings] = useState<ModelSettings>(initial);
@@ -133,7 +149,8 @@ export function SpacesDefaultRowV3({ agent }: Props) {
     }
     if (thinkingLevel) settings.thinkingLevel = thinkingLevel;
     // Fast mode is owned by the provider card above — carry it through untouched.
-    if (readSettings().speed === "fast") settings.speed = "fast";
+    // (Only the standard bag carries `speed`; the fast bag would be circular.)
+    if (!isFast && readSettings().speed === "fast") settings.speed = "fast";
     if (thinkingConflict) {
       showSnackbar({ variant: "error", title: 'Temperature requires thinking "Off" — thinking models ignore temperature' });
       return;
@@ -145,14 +162,26 @@ export function SpacesDefaultRowV3({ agent }: Props) {
     setSaving(true);
     try {
       const cfg = { ...((agent.config ?? {}) as Record<string, unknown>) };
-      if (Object.keys(settings).length > 0) cfg["modelSettings"] = settings as unknown as Record<string, unknown>;
-      else delete cfg["modelSettings"];
-      await updateAgent(agent.slug, { config: cfg });
-      // Mutate the prop-derived config (same pattern as the provider-order
-      // card) so other saves in this mount merge against fresh values.
       const live = agent.config as Record<string, unknown>;
-      if (cfg["modelSettings"]) live["modelSettings"] = cfg["modelSettings"];
-      else delete live["modelSettings"];
+      if (isFast) {
+        // Merge into the fast profile, preserving providers/providerOrder/models.
+        const profile = { ...((cfg["fastModeProfile"] as Record<string, unknown> | undefined) ?? {}) };
+        if (Object.keys(settings).length > 0) profile["modelSettings"] = settings as unknown as Record<string, unknown>;
+        else delete profile["modelSettings"];
+        if (Object.keys(profile).length > 0) cfg["fastModeProfile"] = profile;
+        else delete cfg["fastModeProfile"];
+        await updateAgent(agent.slug, { config: cfg });
+        if (cfg["fastModeProfile"]) live["fastModeProfile"] = cfg["fastModeProfile"];
+        else delete live["fastModeProfile"];
+      } else {
+        if (Object.keys(settings).length > 0) cfg["modelSettings"] = settings as unknown as Record<string, unknown>;
+        else delete cfg["modelSettings"];
+        await updateAgent(agent.slug, { config: cfg });
+        // Mutate the prop-derived config (same pattern as the provider-order
+        // card) so other saves in this mount merge against fresh values.
+        if (cfg["modelSettings"]) live["modelSettings"] = cfg["modelSettings"];
+        else delete live["modelSettings"];
+      }
       setSavedSettings(settings);
       setEditing(false);
     } catch (err) {
@@ -161,6 +190,11 @@ export function SpacesDefaultRowV3({ agent }: Props) {
       setSaving(false);
     }
   };
+
+  // Inherit labels for the fast view — what a blank field falls back to.
+  const stdModelLabel = standard.model || "platform default";
+  const stdThinkingLabel = standard.thinkingLevel || "platform setting";
+  const inheritOptionLabel = isFast ? `Same as standard (${stdModelLabel})` : "Platform default (from environment)";
 
   // Compact summary of the saved non-default settings for the collapsed row.
   const summaryParts: string[] = [];
@@ -177,6 +211,11 @@ export function SpacesDefaultRowV3({ agent }: Props) {
             <span className="inline-flex items-center text-[11px] font-medium text-xyne-fg-tertiary bg-xyne-surface-sunken border border-xyne-border rounded-full px-2 py-0.5">
               Platform default
             </span>
+            {isFast && (
+              <span data-id="spaces-fast-overrides-badge" className="inline-flex items-center text-[11px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-2 py-0.5 dark:text-amber-300 dark:bg-amber-950/30 dark:border-amber-700/60">
+                Fast mode overrides
+              </span>
+            )}
             <span className="inline-flex items-center gap-1 text-[11px] font-medium text-xyne-success-fg">
               <span className="w-1.5 h-1.5 rounded-full bg-xyne-success" />
               Always available
@@ -186,7 +225,7 @@ export function SpacesDefaultRowV3({ agent }: Props) {
             <>
               <div className="grid grid-cols-[80px_1fr] gap-x-3 gap-y-0.5 text-[12px]">
                 <span className="text-xyne-fg-tertiary">Model</span>
-                <span className="text-xyne-fg-primary font-mono truncate">{savedSettings.model || "Platform default"}</span>
+                <span className="text-xyne-fg-primary font-mono truncate">{savedSettings.model || (isFast ? `Same as standard (${stdModelLabel})` : "Platform default")}</span>
                 {summaryParts.length > 0 && (
                   <>
                     <span className="text-xyne-fg-tertiary">Settings</span>
@@ -195,8 +234,9 @@ export function SpacesDefaultRowV3({ agent }: Props) {
                 )}
               </div>
               <div className="text-[11px] text-xyne-fg-tertiary">
-                No credential needed. Used when no provider above serves the run, and as the final quota fallback.
-                To run on your own key and pick from its models, add a “LiteLLM (own key)” provider above.
+                {isFast
+                  ? "Overrides applied only to fast-mode runs. Blank fields use the standard settings."
+                  : "No credential needed. Used when no provider above serves the run, and as the final quota fallback. To run on your own key and pick from its models, add a “LiteLLM (own key)” provider above."}
               </div>
             </>
           )}
@@ -224,7 +264,7 @@ export function SpacesDefaultRowV3({ agent }: Props) {
               onChange={(e) => setModelMode(e.target.value === "custom" ? "custom" : "default")}
               className={INPUT_CLASS}
             >
-              <option value="default">Platform default (from environment)</option>
+              <option value="default">{inheritOptionLabel}</option>
               <option value="custom">Custom model…</option>
             </select>
             {modelMode === "custom" && (
@@ -241,21 +281,26 @@ export function SpacesDefaultRowV3({ agent }: Props) {
               />
             )}
             <p className="mt-1 text-[11px] text-xyne-fg-muted">
-              {modelMode === "custom"
-                ? "Any model id served by the platform LiteLLM proxy. Applies to runs served by Spaces — premium providers keep the model set on their own credential."
-                : "Runs on whichever model the platform is configured with (LITELLM_MODEL). Switch to a custom model to pin this agent to a specific one."}
+              {isFast
+                ? "Model for fast-mode Spaces runs. Leave on inherit to use the standard model."
+                : modelMode === "custom"
+                  ? "Any model id served by the platform LiteLLM proxy. Applies to runs served by Spaces — premium providers keep the model set on their own credential."
+                  : "Runs on whichever model the platform is configured with (LITELLM_MODEL). Switch to a custom model to pin this agent to a specific one."}
             </p>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className={LABEL_CLASS}>Thinking level</label>
               <select
+                data-id="spaces-thinking-level"
                 value={thinkingLevel}
                 onChange={(e) => setThinkingLevel(e.target.value)}
                 className={INPUT_CLASS}
               >
                 {THINKING_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
+                  <option key={o.value} value={o.value}>
+                    {o.value === "" && isFast ? `Same as standard (${stdThinkingLabel})` : o.label}
+                  </option>
                 ))}
               </select>
             </div>
@@ -264,7 +309,7 @@ export function SpacesDefaultRowV3({ agent }: Props) {
               <input
                 value={temperature}
                 onChange={(e) => setTemperature(e.target.value)}
-                placeholder="provider default"
+                placeholder={isFast ? `same as standard (${standard.temperature ?? "provider default"})` : "provider default"}
                 inputMode="decimal"
                 className={INPUT_CLASS}
               />
@@ -283,7 +328,7 @@ export function SpacesDefaultRowV3({ agent }: Props) {
               <input
                 value={maxTokens}
                 onChange={(e) => setMaxTokens(e.target.value)}
-                placeholder="16384"
+                placeholder={isFast ? `same as standard (${standard.maxTokens ?? 16384})` : "16384"}
                 inputMode="numeric"
                 className={INPUT_CLASS}
               />
@@ -292,9 +337,9 @@ export function SpacesDefaultRowV3({ agent }: Props) {
           </div>
 
           <p className="mt-3 text-[11px] text-xyne-fg-tertiary">
-            Temperature, thinking and max tokens apply to whichever provider serves the run
-            (including quota fallbacks). The model applies only to Spaces runs; premium providers
-            pick their model on their credential. Model changes are recorded in the admin audit log.
+            {isFast
+              ? "These override the standard settings for fast-mode runs only. Thinking, temperature and max tokens apply to whichever provider serves the run."
+              : "Temperature, thinking and max tokens apply to whichever provider serves the run (including quota fallbacks). The model applies only to Spaces runs; premium providers pick their model on their credential. Model changes are recorded in the admin audit log."}
           </p>
 
           <div className="mt-4 flex items-center gap-2">

--- a/apps/xyne-claw/src/agent-model-settings.ts
+++ b/apps/xyne-claw/src/agent-model-settings.ts
@@ -54,11 +54,11 @@ export interface AgentModelSettings {
 export const MAX_TOKENS_MIN = 1024;
 export const MAX_TOKENS_MAX = 64000;
 
-export function parseModelSettings(agentConfig: Record<string, unknown> | undefined): AgentModelSettings | undefined {
-  const raw = agentConfig?.["modelSettings"];
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
-  const r = raw as Record<string, unknown>;
+/** Parse + clamp the shared model-settings fields out of one settings bag. */
+function parseSettingsFields(raw: unknown): AgentModelSettings {
   const out: AgentModelSettings = {};
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return out;
+  const r = raw as Record<string, unknown>;
 
   if (typeof r["model"] === "string" && r["model"].trim()) out.model = r["model"].trim();
 
@@ -73,9 +73,31 @@ export function parseModelSettings(agentConfig: Record<string, unknown> | undefi
   if (typeof r["thinkingLevel"] === "string" && (THINKING_LEVELS as readonly string[]).includes(r["thinkingLevel"])) {
     out.thinkingLevel = r["thinkingLevel"] as ModelSettingsThinkingLevel;
   }
+  return out;
+}
 
-  const speed = parseModelSpeed(r["speed"]);
+export function parseModelSettings(agentConfig: Record<string, unknown> | undefined): AgentModelSettings | undefined {
+  const out = parseSettingsFields(agentConfig?.["modelSettings"]);
+  const r = agentConfig?.["modelSettings"];
+  const speed = r && typeof r === "object" && !Array.isArray(r)
+    ? parseModelSpeed((r as Record<string, unknown>)["speed"])
+    : undefined;
   if (speed) out.speed = speed;
+
+  // Fast-mode run-setting overrides (config.fastModeProfile.modelSettings):
+  // when THIS run is fast (agent default, or the per-message toggle merged in
+  // by claw-auth), set fields override the standard values field-by-field —
+  // unset fields inherit. So "Spaces on minimal thinking normally, high in
+  // fast mode" is one thinkingLevel override; temperature/maxTokens/thinking
+  // apply to whichever provider serves the run (a fast thinkingLevel also
+  // outranks a codex credential's reasoningEffort, same as the standard one).
+  if (out.speed === "fast") {
+    const profile = agentConfig?.["fastModeProfile"];
+    if (profile && typeof profile === "object" && !Array.isArray(profile)) {
+      const overrides = parseSettingsFields((profile as Record<string, unknown>)["modelSettings"]);
+      Object.assign(out, overrides);
+    }
+  }
 
   return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/apps/xyne-claw/test/model-speed.test.ts
+++ b/apps/xyne-claw/test/model-speed.test.ts
@@ -124,3 +124,24 @@ describe("modelSettings.speed", () => {
     expect(parseModelSettings({ modelSettings: { speed: true } })).toBeUndefined();
   });
 });
+
+describe("fastModeProfile.modelSettings overlay", () => {
+  const cfg = (speed?: string) => ({
+    modelSettings: { model: "kimi-latest", thinkingLevel: "minimal", maxTokens: 8192, ...(speed ? { speed } : {}) },
+    fastModeProfile: { providers: "custom", providerOrder: ["claude"], modelSettings: { thinkingLevel: "high", model: "glm-latest" } },
+  });
+
+  it("overlays set fields when the run is fast; unset fields inherit", () => {
+    expect(parseModelSettings(cfg("fast"))).toEqual({ model: "glm-latest", thinkingLevel: "high", maxTokens: 8192, speed: "fast" });
+  });
+
+  it("ignores the overlay at standard speed", () => {
+    expect(parseModelSettings(cfg())).toEqual({ model: "kimi-latest", thinkingLevel: "minimal", maxTokens: 8192 });
+    expect(parseModelSettings(cfg("standard"))).toEqual({ model: "kimi-latest", thinkingLevel: "minimal", maxTokens: 8192, speed: "standard" });
+  });
+
+  it("clamps overlay values like the base fields", () => {
+    const c = { modelSettings: { speed: "fast" }, fastModeProfile: { modelSettings: { temperature: 9, maxTokens: 1 } } };
+    expect(parseModelSettings(c)).toEqual({ speed: "fast", temperature: 1, maxTokens: 1024 });
+  });
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/fe05f234-d394-44a5-bcb2-7716a9c4c7d7



## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Follow-up to #917. The fast-mode profile could swap providers/models, but the **run settings** (Spaces model, thinking level, temperature, max output tokens) were always shared with standard mode. Now `config.fastModeProfile.modelSettings` carries per-field overrides applied only to fast-mode runs — **shared with standard by default; set a field to diverge, blank fields keep inheriting**. No ticket.

- **claw**: `parseModelSettings` overlays the profile's `modelSettings` when the run is fast (agent default or the per-message composer toggle — the effective speed already rides `modelSettings.speed`), so every dispatch path gets it for free. Thinking / temperature / max tokens apply to whichever provider serves the run, so a fast-mode thinking override also governs Codex / Copilot runs (it outranks the credential's `reasoningEffort`, same precedence as the standard setting).
- **claw-auth**: `fastModeProfile.modelSettings` validated with the same clamps as top-level `modelSettings`; a nested `speed` is rejected (circular).
- **UI**: in the Model & provider **Fast mode** view, the Spaces card becomes a "Fast mode overrides" editor — same fields, each defaulting to "Same as standard" with the standard value shown as the placeholder. The Configure Credentials badge was replaced with a plain description line: "Shared with standard mode by default — override any setting below for fast mode only."

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section** (rides the agent's JSONB `config`)

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] Existing contract modified — `PUT /agents/:slug` accepts `config.fastModeProfile.modelSettings` (additive; invalid shapes 400)
- [ ] Breaking for dashboard / electron / external / bots

---

## How did you test it?

Same stub-Anthropic setup as #917 (local Messages API stub as a Claude credential's base URL; the reply echoes the request). A recorded Playwright script drives the real UI and asserts each step against the stub's request log — all four pass (recording shared in chat; drag-drop onto this description to attach):

1. standard run (composer ⚡ off, standard thinking **Minimal**) → no `speed`, `output_config.effort=low`
2. Fast mode view → Spaces "Fast mode overrides" → thinking **High** → save → `fastModeProfile.modelSettings.thinkingLevel=high` while `modelSettings.thinkingLevel` stays `minimal`
3. composer ⚡ on → `speed="fast"` + beta header on the profile's `claude-opus-4-8` with `effort=high`
4. composer ⚡ off → standard again: no `speed`, `effort=low` (override doesn't leak)

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [x] Claw tests — new overlay cases in `test/model-speed.test.ts` (32 pass); same 5 pre-existing env-related failures as noted on #917
- [ ] End-to-end suite — `pnpm run test`
- [x] Added / updated tests for this change — claw `model-speed.test.ts`, claw-auth `agent-config-validation.test.ts` (11 pass)
- [ ] Not covered by tests

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (claw `:3002`, claw-auth backend `:3003`, claw-auth UI `:5174`, spaces backend `:3001`)

**Sync & resilience** — not applicable (no Zero)

**Surface & data**
- [x] Web browser
- [x] Empty state (no overrides = full inherit)
- [x] Error paths — invalid override fields / nested `speed` → 400

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes (shared packages untouched)
- [x] Backend `typecheck` + `build` pass — claw + claw-auth backend `tsc --noEmit` clean
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass — claw-auth frontend `tsc -b` clean (spaces dashboard untouched)
- [x] Formatting clean in the packages I touched
- [x] New deps — none
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `feature/*` — no ticket id (none given)
- [x] Docs / guidelines updated where behaviour changed — inline module docs
- [x] No debug logging or commented-out code left behind
