### PR TITLE
feat: warn before a workspace switch or refresh stops an active recording

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -24,6 +24,7 @@ import { initializeTelemetry } from './services/otel/init';
 import { KeyboardProvider } from './contexts/KeyboardContext';
 import { SwitchLoadingOverlay } from './components/SwitchLoadingOverlay/SwitchLoadingOverlay';
 import { RecordingInterruptGuard } from './components/Recording/RecordingInterruptGuard/RecordingInterruptGuard';
+import { WorkspaceSwitchToastListener } from './components/WorkspaceSwitchToastListener';
 import { TRUSTED_ORIGINS } from '@xyne/shared';
 import { DEFAULT_WORKSPACE_ID } from './config';
 import {
@@ -112,6 +113,7 @@ const App = (): ReactElement => {
                     </main>
                     <SwitchLoadingOverlay />
                     <RecordingInterruptGuard />
+                    <WorkspaceSwitchToastListener />
                     <Toaster
                       position='top-right'
                       richColors

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -23,6 +23,7 @@ import Wallpaper from './components/Wallpaper/Wallpaper';
 import { initializeTelemetry } from './services/otel/init';
 import { KeyboardProvider } from './contexts/KeyboardContext';
 import { SwitchLoadingOverlay } from './components/SwitchLoadingOverlay/SwitchLoadingOverlay';
+import { RecordingInterruptGuard } from './components/Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 import { TRUSTED_ORIGINS } from '@xyne/shared';
 import { DEFAULT_WORKSPACE_ID } from './config';
 import {
@@ -110,6 +111,7 @@ const App = (): ReactElement => {
                       <RouterProvider router={router}></RouterProvider>
                     </main>
                     <SwitchLoadingOverlay />
+                    <RecordingInterruptGuard />
                     <Toaster
                       position='top-right'
                       richColors

--- a/apps/dashboard/src/components/AppSidebar/WorkspaceSwitcher.tsx
+++ b/apps/dashboard/src/components/AppSidebar/WorkspaceSwitcher.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../machines/authMachine';
 import { queryClient } from '../../services/clients/queryClient';
 import { useCanCreateWorkspace } from '../../hooks/usePermissions';
+import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 type CreateWorkspaceType = (typeof WorkspaceType)[keyof typeof WorkspaceType];
 
@@ -192,6 +193,7 @@ export const WorkspaceSwitcher: React.FC = () => {
       setIsOpen(false);
       return;
     }
+    if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
     setSwitching(targetWorkspaceId);
     try {
       // NEW: Call switch-workspace API instead of logout
@@ -229,6 +231,7 @@ export const WorkspaceSwitcher: React.FC = () => {
   const handleCreate = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
     if (!workspaceName.trim()) return;
+    if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
     setCreating(true);
     setError(null);
     try {

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -20,6 +20,7 @@ import { queryCacheActor, type Conversation } from '../../machines/queryCacheMac
 import { MEETING_DETECTION_ENABLED_KEY } from '../../constants/settings';
 import {
   sendRecordingEvent,
+  stopRecordingForNavigation,
   stopRecordingForTeardown,
   useRecordingStore,
 } from '../../hooks/useRecordingStore';
@@ -615,7 +616,7 @@ export const NotificationHandler: React.FC = () => {
 
   useEffect(() => {
     if (!isElectron || !window.electronAPI?.onRecordingStopForTeardown) return;
-    return window.electronAPI.onRecordingStopForTeardown(stopRecordingForTeardown);
+    return window.electronAPI.onRecordingStopForTeardown(stopRecordingForNavigation);
   }, [isElectron]);
 
   // Same states useCallJoinOrInitiate treats as "in a call"; `initiating` lands

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -24,6 +24,7 @@ import {
   useRecordingStore,
 } from '../../hooks/useRecordingStore';
 import { sendSosAlertEvent } from '../../stores/sosAlertStore';
+import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 // Singleton: a fresh Audio element PER NOTIFICATION leaked native listener
 // registrations and media elements — heap analysis showed "JS event
@@ -140,6 +141,7 @@ export const NotificationHandler: React.FC = () => {
       const currentWorkspaceId = activeWorkspaceIdRef.current;
 
       if (targetWorkspaceId && targetWorkspaceId !== currentWorkspaceId) {
+        if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
         try {
           await axios.post(
             `${API_BASE_URL}/auth/switch-workspace`,
@@ -609,6 +611,11 @@ export const NotificationHandler: React.FC = () => {
   useEffect(() => {
     if (!isElectron || !window.electronAPI?.onRecordingSystemSuspend) return;
     return window.electronAPI.onRecordingSystemSuspend(stopRecordingForTeardown);
+  }, [isElectron]);
+
+  useEffect(() => {
+    if (!isElectron || !window.electronAPI?.onRecordingStopForTeardown) return;
+    return window.electronAPI.onRecordingStopForTeardown(stopRecordingForTeardown);
   }, [isElectron]);
 
   // Same states useCallJoinOrInitiate treats as "in a call"; `initiating` lands

--- a/apps/dashboard/src/components/Recording/RecordingInterruptGuard/RecordingInterruptGuard.tsx
+++ b/apps/dashboard/src/components/Recording/RecordingInterruptGuard/RecordingInterruptGuard.tsx
@@ -1,0 +1,218 @@
+import { ReactElement, useEffect, useRef, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ConnectionState, RoomEvent } from 'livekit-client';
+import { Dialog } from '../../ui/Dialog/Dialog';
+import { Button } from '../../ui/Button/Button';
+import { recordingStore } from '../../../stores/recordingStore';
+import { calculateRecordingElapsedMs, formatElapsedTime } from '../../../utils/recordingUtils';
+import {
+  getRecordingStatus,
+  stopRecordingForTeardown,
+  useRecordingStore,
+} from '../../../hooks/useRecordingStore';
+
+const DISCONNECT_TIMEOUT_MS = 3000;
+
+export type RecordingInterruptReason = 'workspaceSwitch' | 'reload';
+
+const COPY: Record<RecordingInterruptReason, { title: string; body: string; proceed: string }> = {
+  workspaceSwitch: {
+    title: 'Switching workspace will stop your recording',
+    body: 'Switching reloads the app, which ends this recording. Everything captured so far is saved to your recordings.',
+    proceed: 'Stop and switch',
+  },
+  reload: {
+    title: 'Reloading will stop your recording',
+    body: 'Reloading ends this recording. Everything captured so far is saved to your recordings.',
+    proceed: 'Stop and reload',
+  },
+};
+
+let openGuard:
+  | ((reason: RecordingInterruptReason, resolve: (proceed: boolean) => void) => void)
+  | null = null;
+
+export function isRecordingInterruptible(): boolean {
+  const status = getRecordingStatus();
+  return status === 'starting' || status === 'recording' || status === 'paused';
+}
+
+export async function confirmRecordingInterrupt(
+  reason: RecordingInterruptReason,
+): Promise<boolean> {
+  if (!isRecordingInterruptible()) return true;
+
+  const open = openGuard;
+  if (!open) return true;
+
+  return new Promise<boolean>(resolve => open(reason, resolve));
+}
+
+async function stopActiveRecording(): Promise<void> {
+  const { room } = recordingStore.getSnapshot().context;
+  stopRecordingForTeardown();
+
+  if (!room || room.state === ConnectionState.Disconnected) return;
+
+  await new Promise<void>(resolve => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const finish = (): void => {
+      if (timer) clearTimeout(timer);
+      room.off(RoomEvent.Disconnected, finish);
+      resolve();
+    };
+    timer = setTimeout(finish, DISCONNECT_TIMEOUT_MS);
+    room.on(RoomEvent.Disconnected, finish);
+  });
+}
+
+function StatusDot({ status }: { status: string }): ReactElement {
+  if (status === 'paused') {
+    return <span className='inline-flex size-2 rounded-full bg-amber-500' />;
+  }
+  if (status === 'starting') {
+    return <span className='inline-flex size-2 animate-pulse rounded-full bg-blue-500' />;
+  }
+  return (
+    <span className='relative inline-flex size-2'>
+      <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75' />
+      <span className='relative inline-flex size-2 rounded-full bg-red-500' />
+    </span>
+  );
+}
+
+export function RecordingInterruptGuard(): ReactElement | null {
+  const resolverRef = useRef<((proceed: boolean) => void) | null>(null);
+  const [reason, setReason] = useState<RecordingInterruptReason | null>(null);
+  const [stopping, setStopping] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const reduceMotion = useReducedMotion();
+
+  const status = useRecordingStore(ctx => ctx.status);
+  const startTime = useRecordingStore(ctx => ctx.startTime);
+  const pauseStartedAt = useRecordingStore(ctx => ctx.pauseStartedAt);
+  const accumulatedPausedMs = useRecordingStore(ctx => ctx.accumulatedPausedMs);
+
+  useEffect(() => {
+    openGuard = (nextReason, resolve): void => {
+      if (resolverRef.current) {
+        resolve(false);
+        return;
+      }
+      resolverRef.current = resolve;
+      setNow(Date.now());
+      setReason(nextReason);
+    };
+    return (): void => {
+      openGuard = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!reason || status !== 'recording') return undefined;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return (): void => clearInterval(id);
+  }, [reason, status]);
+
+  if (!reason) return null;
+
+  const copy = COPY[reason];
+  const isPaused = status === 'paused';
+  const elapsed = formatElapsedTime(
+    calculateRecordingElapsedMs(startTime, pauseStartedAt, accumulatedPausedMs, now),
+  );
+
+  const settle = (proceed: boolean): void => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setReason(null);
+    setStopping(false);
+    resolve?.(proceed);
+  };
+
+  const handleStop = (): void => {
+    setStopping(true);
+    void stopActiveRecording().then(() => settle(true));
+  };
+
+  const enter = (index: number): Record<string, unknown> =>
+    reduceMotion
+      ? {}
+      : {
+          initial: { opacity: 0, y: 4 },
+          animate: { opacity: 1, y: 0 },
+          transition: { type: 'spring', duration: 0.3, bounce: 0, delay: 0.04 * index },
+        };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open): void => {
+        if (!open) settle(false);
+      }}
+      title={copy.title}
+      description={copy.body}
+      testId='recording-interrupt-guard'
+      className='max-w-[460px] overflow-hidden rounded-xl'
+    >
+      <div className='px-5 pb-5 pt-5'>
+        <motion.div
+          {...enter(0)}
+          className='inline-flex items-center gap-2 rounded-full border border-border/70 bg-muted/50 py-1 pl-2.5 pr-3'
+        >
+          <StatusDot status={status} />
+          <span className='text-[11px] font-medium uppercase tracking-wider text-muted-foreground'>
+            {status === 'starting' ? 'Starting' : isPaused ? 'Paused' : 'Recording'}
+          </span>
+          {status !== 'starting' && (
+            <span className='text-[11px] font-semibold tabular-nums text-foreground'>
+              {elapsed}
+            </span>
+          )}
+        </motion.div>
+
+        <motion.h2
+          {...enter(1)}
+          className='mt-3.5 text-balance text-[17px] font-semibold leading-snug tracking-[-0.01em] text-foreground'
+        >
+          {copy.title}
+        </motion.h2>
+
+        <motion.p
+          {...enter(2)}
+          className='mt-2 text-pretty text-[13px] leading-relaxed text-muted-foreground'
+        >
+          {copy.body}
+        </motion.p>
+      </div>
+
+      <motion.div
+        {...enter(3)}
+        className='flex flex-col-reverse gap-2 border-t border-border/60 bg-muted/30 px-5 py-3.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between'
+      >
+        <Button
+          variant='ghost'
+          onClick={(): void => settle(false)}
+          disabled={stopping}
+          className='w-full shrink-0 active:scale-[0.96] sm:w-auto'
+          data-testid='recording-interrupt-keep'
+        >
+          Keep recording
+        </Button>
+
+        <div className='flex flex-col gap-2 sm:flex-row sm:items-center'>
+          <Button
+            variant='destructive'
+            onClick={handleStop}
+            loading={stopping}
+            disabled={stopping}
+            className='w-full shrink-0 active:scale-[0.96] sm:w-auto'
+            data-testid='recording-interrupt-stop'
+          >
+            {stopping ? 'Stopping' : copy.proceed}
+          </Button>
+        </div>
+      </motion.div>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/components/Recording/RecordingInterruptGuard/RecordingInterruptGuard.tsx
+++ b/apps/dashboard/src/components/Recording/RecordingInterruptGuard/RecordingInterruptGuard.tsx
@@ -7,7 +7,7 @@ import { recordingStore } from '../../../stores/recordingStore';
 import { calculateRecordingElapsedMs, formatElapsedTime } from '../../../utils/recordingUtils';
 import {
   getRecordingStatus,
-  stopRecordingForTeardown,
+  stopRecordingForNavigation,
   useRecordingStore,
 } from '../../../hooks/useRecordingStore';
 
@@ -50,7 +50,7 @@ export async function confirmRecordingInterrupt(
 
 async function stopActiveRecording(): Promise<void> {
   const { room } = recordingStore.getSnapshot().context;
-  stopRecordingForTeardown();
+  stopRecordingForNavigation();
 
   if (!room || room.state === ConnectionState.Disconnected) return;
 

--- a/apps/dashboard/src/components/SosAlert/SosAlertBanner.tsx
+++ b/apps/dashboard/src/components/SosAlert/SosAlertBanner.tsx
@@ -8,6 +8,7 @@ import { API_BASE_URL } from '../../config';
 import { queryClient } from '../../services/clients/queryClient';
 import { websocketService } from '../../services/clients/socketClient';
 import { sendSosAlertEvent, useSosAlertStore, type SosAlert } from '../../stores/sosAlertStore';
+import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 // Singleton audio element (same leak-avoidance pattern as NotificationHandler).
 let sirenAudio: HTMLAudioElement | null = null;
@@ -141,6 +142,7 @@ export const SosAlertBanner: React.FC = () => {
         alert.actionUrl || (alert.workspaceId ? `/${alert.workspaceId}/chat` : '/chat');
 
       if (alert.workspaceId && alert.workspaceId !== activeWorkspaceId) {
+        if (!(await confirmRecordingInterrupt('workspaceSwitch'))) return;
         try {
           await axios.post(
             `${API_BASE_URL}/auth/switch-workspace`,

--- a/apps/dashboard/src/components/WorkspaceSwitchToastListener.tsx
+++ b/apps/dashboard/src/components/WorkspaceSwitchToastListener.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import { consumeWorkspaceSwitchToast } from '../utils/workspaceSwitchToast';
+
+export function WorkspaceSwitchToastListener(): null {
+  const hasChecked = useRef(false);
+
+  useEffect(() => {
+    if (hasChecked.current) return;
+    hasChecked.current = true;
+
+    const pending = consumeWorkspaceSwitchToast();
+    if (!pending) return;
+    toast.success(pending.title, {
+      ...(pending.description ? { description: pending.description } : {}),
+      duration: 3000,
+    });
+  }, []);
+
+  return null;
+}

--- a/apps/dashboard/src/hooks/useRecordingStore.ts
+++ b/apps/dashboard/src/hooks/useRecordingStore.ts
@@ -3,6 +3,9 @@ import { useSyncExternalStore } from 'react';
 import type { RecordingLayout, RecordingState, TranscriptEntry } from '../stores/recordingStore';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 import { recordingStore as _rawStore } from '../stores/recordingStore';
+import { calculateRecordingElapsedMs } from '../utils/recordingUtils';
+import { formatDuration } from '../utils/dateUtils';
+import { setWorkspaceSwitchToast } from '../utils/workspaceSwitchToast';
 
 interface RecordingStoreSnapshot {
   status: 'active' | 'done' | 'error' | 'stopped';
@@ -33,7 +36,7 @@ export type RecordingStoreEvent =
     }
   | { type: 'pauseRecording' }
   | { type: 'resumeRecording' }
-  | { type: 'stopRecording' }
+  | { type: 'stopRecording'; silent?: boolean }
   | { type: 'setStatus'; status: RecordingState['status'] }
   | { type: 'error'; error: string }
   | { type: 'reset' }
@@ -76,14 +79,47 @@ export function getRecordingStatus(): RecordingState['status'] {
   return store.getSnapshot().context.status;
 }
 
-/** Stop whatever is in flight because the page or the machine is going away. */
-export function stopRecordingForTeardown(): void {
+/**
+ * Stop whatever is in flight because the page or the machine is going away.
+ * `silent` skips the "Recording stopped" toast for a caller that is about to
+ * navigate away and will show its own toast once the destination page mounts —
+ * the default toast would just be torn down mid-display by that navigation.
+ */
+export function stopRecordingForTeardown(options?: { silent?: boolean }): void {
   const status = getRecordingStatus();
   if (status === 'starting') {
     sendRecordingEvent({ type: 'requestStop' });
   } else if (status === 'recording' || status === 'paused') {
-    sendRecordingEvent({ type: 'stopRecording' });
+    sendRecordingEvent({ type: 'stopRecording', ...(options?.silent ? { silent: true } : {}) });
   }
+}
+
+/**
+ * Stop for a caller that is about to perform a same-origin hard navigation
+ * (workspace switch, reload). The normal "Recording stopped" toast would be
+ * torn down mid-display by that navigation, so it's stashed instead and shown
+ * once the destination page mounts (see `WorkspaceSwitchToastListener`).
+ */
+export function stopRecordingForNavigation(): void {
+  const { status, startTime, pauseStartedAt, accumulatedPausedMs } = store.getSnapshot().context;
+
+  // Still connecting — no room/duration to report yet. Fall back to the
+  // existing requestStop path; its own (non-silent) toast fires once the
+  // pending start resolves, same as before this helper existed.
+  if (status === 'starting') {
+    stopRecordingForTeardown();
+    return;
+  }
+  if (status !== 'recording' && status !== 'paused') return;
+
+  const durationMs = startTime
+    ? calculateRecordingElapsedMs(startTime, pauseStartedAt, accumulatedPausedMs)
+    : null;
+  setWorkspaceSwitchToast({
+    title: 'Recording stopped',
+    description: `Recording saved (${durationMs ? formatDuration(durationMs) : 'Unknown duration'})`,
+  });
+  stopRecordingForTeardown({ silent: true });
 }
 
 export interface UseTranscriptStreamReturn {

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -359,9 +359,10 @@ const AppRoot = (): ReactElement => {
   // do not expose a reliable lid-close event, so retain only the actual page
   // unload safeguard below.
   useEffect(() => {
-    window.addEventListener('pagehide', stopRecordingForTeardown);
+    const handlePageHide = (): void => stopRecordingForTeardown();
+    window.addEventListener('pagehide', handlePageHide);
     return (): void => {
-      window.removeEventListener('pagehide', stopRecordingForTeardown);
+      window.removeEventListener('pagehide', handlePageHide);
     };
   }, []);
 

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -119,6 +119,11 @@ import RecordingDetailRoute from './RecordingDetailRoute/RecordingDetailRoute';
 import { RecordingOverlay } from '../components/Recording/RecordingOverlay/RecordingOverlay';
 import { useRecordingVersion } from '../hooks/useRecordingVersion';
 import { stopRecordingForTeardown } from '../hooks/useRecordingStore';
+import { isElectronApp } from '../utils/electronApp';
+import {
+  confirmRecordingInterrupt,
+  isRecordingInterruptible,
+} from '../components/Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 import { NoteTakerOverlayHost } from './RecordingsV2Screen/components/NoteTakerOverlayHost';
 import FormScreen from './FormScreen/FormScreen';
 import ScheduledMessageScreen from './ScheduledMessageScreen/ScheduledMessageScreen';
@@ -357,6 +362,35 @@ const AppRoot = (): ReactElement => {
     window.addEventListener('pagehide', stopRecordingForTeardown);
     return (): void => {
       window.removeEventListener('pagehide', stopRecordingForTeardown);
+    };
+  }, []);
+
+  useEffect(() => {
+    const warnBeforeUnload = (event: BeforeUnloadEvent): void => {
+      if (isElectronApp()) return;
+      if (!isRecordingInterruptible()) return;
+      event.preventDefault();
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    return (): void => {
+      window.removeEventListener('beforeunload', warnBeforeUnload);
+    };
+  }, []);
+
+  useEffect(() => {
+    const interceptReload = (event: KeyboardEvent): void => {
+      if (isElectronApp()) return;
+      const isReloadCombo = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'r';
+      if (!isReloadCombo && event.key !== 'F5') return;
+      if (!isRecordingInterruptible()) return;
+      event.preventDefault();
+      void confirmRecordingInterrupt('reload').then(proceed => {
+        if (proceed) window.location.reload();
+      });
+    };
+    window.addEventListener('keydown', interceptReload, true);
+    return (): void => {
+      window.removeEventListener('keydown', interceptReload, true);
     };
   }, []);
   useShortcutById('global.openShortcutsHelp', () => setIsShortcutsModalOpen(prev => !prev));

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -29,6 +29,24 @@ let transcriptIdCounter = 0;
 // stop first so its callback cannot be mistaken for a server-side failure.
 const intentionallyDisconnectedRooms = new WeakSet<Room>();
 
+const PAGE_UNLOAD_GRACE_MS = 5000;
+let pageUnloading = false;
+let pageUnloadingReset: ReturnType<typeof setTimeout> | null = null;
+
+if (typeof window !== 'undefined') {
+  const markPageUnloading = (): void => {
+    pageUnloading = true;
+    if (pageUnloadingReset) clearTimeout(pageUnloadingReset);
+    pageUnloadingReset = setTimeout(() => {
+      pageUnloading = false;
+      pageUnloadingReset = null;
+    }, PAGE_UNLOAD_GRACE_MS);
+  };
+  for (const event of ['beforeunload', 'pagehide', 'freeze']) {
+    window.addEventListener(event, markPageUnloading);
+  }
+}
+
 export interface TranscriptEntry {
   id: number;
   speaker: string;
@@ -290,6 +308,7 @@ export const recordingStore = createStore({
 
       const handleRoomDisconnected = (): void => {
         if (intentionallyDisconnectedRooms.delete(room)) return;
+        if (pageUnloading) return;
 
         const current = recordingStore.getSnapshot().context;
         if (current.room !== room || !ACTIVE_STATUSES.has(current.status)) return;
@@ -308,6 +327,7 @@ export const recordingStore = createStore({
         try {
           const data = JSON.parse(metadata) as { recordingStartFailure?: unknown };
           if (data.recordingStartFailure !== true) return;
+          if (pageUnloading) return;
 
           const current = recordingStore.getSnapshot().context;
           if (current.room !== room || !ACTIVE_STATUSES.has(current.status)) return;

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -453,7 +453,7 @@ export const recordingStore = createStore({
       };
     },
 
-    stopRecording: (context): RecordingState => {
+    stopRecording: (context, event?: { silent?: boolean }): RecordingState => {
       const durationMs = context.startTime
         ? calculateRecordingElapsedMs(
             context.startTime,
@@ -479,12 +479,16 @@ export const recordingStore = createStore({
         playAudio(AUDIO_PATHS.RECORDING_END);
       }
 
-      // Show toast
-      const duration = durationMs ? formatDuration(durationMs) : 'Unknown duration';
-      toast.success('Recording stopped', {
-        description: `Recording saved (${duration})`,
-        duration: 3000,
-      });
+      // A caller about to navigate away (workspace switch, reload) shows this
+      // toast itself once the destination page mounts — this one would just be
+      // torn down mid-display by the hard navigation before it's legible.
+      if (!event?.silent) {
+        const duration = durationMs ? formatDuration(durationMs) : 'Unknown duration';
+        toast.success('Recording stopped', {
+          description: `Recording saved (${duration})`,
+          duration: 3000,
+        });
+      }
 
       // Reset state
       return {

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -100,6 +100,7 @@ export interface ElectronAPI {
   ) => Promise<{ saved: boolean; filePath?: string }>;
   onWindowModeChanged: (callback: (data: { compact: boolean }) => void) => () => void;
   onRecordingSystemSuspend: (callback: () => void) => () => void;
+  onRecordingStopForTeardown?: (callback: () => void) => () => void;
   onRecordingResumeRequest?: (callback: () => void) => () => void;
   onRecordingPauseRequest?: (callback: () => void) => () => void;
   onLog: (callback: (message: { data?: unknown[] }) => void) => () => void;

--- a/apps/dashboard/src/utils/workspaceSwitchToast.ts
+++ b/apps/dashboard/src/utils/workspaceSwitchToast.ts
@@ -1,0 +1,58 @@
+/**
+ * Carries a toast across the hard reload a workspace switch performs.
+ *
+ * Switching workspace flips the session cookie via a full-page navigation, which
+ * tears down whatever toast was showing before the user can read it. Stash the
+ * message just before navigating and the destination page shows it once it mounts.
+ * The entry expires so an abandoned/failed navigation can't resurrect a stale toast
+ * on some later, unrelated reload.
+ */
+
+const STORAGE_KEY = 'xyne:workspace-switch-toast';
+const TOAST_TTL_MS = 60 * 1000;
+
+export interface WorkspaceSwitchToast {
+  title: string;
+  description?: string;
+}
+
+interface StoredToast extends WorkspaceSwitchToast {
+  storedAt: number;
+}
+
+export const setWorkspaceSwitchToast = (toast: WorkspaceSwitchToast): void => {
+  try {
+    const stored: StoredToast = { ...toast, storedAt: Date.now() };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Unavailable storage only costs the destination toast.
+  }
+};
+
+export const consumeWorkspaceSwitchToast = (): WorkspaceSwitchToast | null => {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    sessionStorage.removeItem(STORAGE_KEY);
+
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      typeof (parsed as Partial<StoredToast>).storedAt !== 'number' ||
+      typeof (parsed as Partial<StoredToast>).title !== 'string'
+    ) {
+      return null;
+    }
+
+    const stored = parsed as StoredToast;
+    if (Date.now() - stored.storedAt >= TOAST_TTL_MS) return null;
+
+    return {
+      title: stored.title,
+      ...(typeof stored.description === 'string' ? { description: stored.description } : {}),
+    };
+  } catch {
+    return null;
+  }
+};

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -168,6 +168,12 @@ const electronAPI = {
     return () => ipcRenderer.removeListener('recording:system-suspend', listener);
   },
 
+  onRecordingStopForTeardown: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('recording:stop-for-teardown', listener);
+    return () => ipcRenderer.removeListener('recording:stop-for-teardown', listener);
+  },
+
   onRecordingResumeRequest: (callback: () => void) => {
     const listener = () => callback();
     ipcRenderer.on('recording:resume-requested', listener);

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -305,6 +305,30 @@ export function stopRecording(trigger: RecordingTrigger): void {
   log.info(`[RecordingController] Stop requested from ${trigger}`);
 }
 
+export async function stopRecordingForReload(timeoutMs = 3000): Promise<void> {
+  if (!isRecordingInProgress()) return;
+
+  const mainWindow = getMainWindow();
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+
+  mainWindow.webContents.send('recording:stop-for-teardown');
+  log.info('[RecordingController] Stop requested before reload');
+
+  await new Promise<void>(resolve => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let unsubscribe: (() => void) | null = null;
+    const finish = (): void => {
+      if (timer) clearTimeout(timer);
+      unsubscribe?.();
+      resolve();
+    };
+    unsubscribe = onRecordingStateChange(() => {
+      if (!isRecordingInProgress()) finish();
+    });
+    timer = setTimeout(finish, timeoutMs);
+  });
+}
+
 export function pauseRecordingFromOutside(trigger: RecordingTrigger): void {
   if (!active || paused) return;
   const mainWindow = getMainWindow();
@@ -347,6 +371,10 @@ export function setRecordingStarting(next: boolean): void {
     startingRecording = false;
     log.warn('[RecordingController] Recording start was not confirmed by the renderer');
   }, STARTING_RECORDING_TIMEOUT_MS);
+}
+
+export function isRecordingInProgress(): boolean {
+  return active || startingRecording;
 }
 
 // Calls enable the mic the same way recordings do, so the meeting detector must

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, shell, Menu, MenuItem, app } from 'electron';
+import { BrowserWindow, shell, Menu, MenuItem, app, dialog } from 'electron';
 import path from 'path';
 import log from 'electron-log/main';
 import { config } from '../app/config';
@@ -16,7 +16,28 @@ import { EnrollmentEvent } from '../services/logger/enrollment-events';
 import { handleCertificateError, isCertificateError } from '../services/certificate-error-handler';
 import { dashboardLoad, enrollmentSkipped, mtlsFrontendLoaded } from '../services/enrollmentMetrics';
 import { safeRecordMetric } from '../services/telemetry';
+import { isRecordingInProgress, stopRecordingForReload } from '../services/recording-controller';
 import type { Counter } from '@opentelemetry/api';
+
+async function confirmReloadWhileRecording(window: BrowserWindow): Promise<boolean> {
+  if (!isRecordingInProgress()) return true;
+
+  const { response } = await dialog.showMessageBox(window, {
+    type: 'warning',
+    buttons: ['Keep recording', 'Reload anyway'],
+    defaultId: 0,
+    cancelId: 0,
+    noLink: true,
+    title: 'Recording in progress',
+    message: 'Reloading will stop your recording.',
+    detail: 'Everything captured so far is saved to your recordings.',
+  });
+
+  if (response !== 1) return false;
+
+  await stopRecordingForReload();
+  return true;
+}
 
 let mainWindow: BrowserWindow | null = null;
 let isCompactMode = false;
@@ -255,6 +276,7 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
       try {
         if (mainWindow) {
           isReloading = true;
+          if (!(await confirmReloadWhileRecording(mainWindow))) return;
           // Clear cache before reloading for a true hard refresh
           await mainWindow.webContents.session.clearCache();
           await loadApp(mainWindow);
@@ -275,6 +297,7 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
       try {
         if (mainWindow) {
           isReloading = true;
+          if (!(await confirmReloadWhileRecording(mainWindow))) return;
           await loadUrl(mainWindow, mainWindow.webContents.getURL());
         }
       } catch (error) {


### PR DESCRIPTION
POT -  https://github.com/user-attachments/assets/2429b80c-e229-4ae2-9d92-ff1a7a7b1557



## Problem

Switching workspace and refreshing both tear down the page. That destroys the in-memory LiveKit `Room` held in `recordingStore`, so an in-progress recording ends with no warning at all. On the backend, `noteTakerCallRepository.handleParticipantLeave` ends the call the instant the participant disconnects — there is no grace period — so the recording is genuinely over, not merely interrupted.

None of these paths go through the React Router history stack (`window.location.href` for workspace switch, main-process `loadApp()` for Electron reload), so `useBlocker` would not guard any of them.

## What this does

Adds a confirmation guard on the **user-initiated** paths:

| Path | Desktop | Web |
| --- | --- | --- |
| Workspace switch (sidebar switcher, workspace create, cross-workspace notification click, SOS alert banner) | modal | modal |
| `Cmd/Ctrl+R`, `Cmd+Shift+R`, `F5` | native dialog | modal |
| Reload button, tab close, address bar | n/a | browser `beforeunload` prompt |

Electron's reload is confirmed with `dialog.showMessageBox` in the main process because `before-input-event` intercepts the keystroke before the renderer ever sees it, then asks the renderer to stop cleanly over a new `recording:stop-for-teardown` IPC channel and waits for confirmation before navigating. Web intercepts the keystroke in the renderer so browser users get the same modal; `beforeunload` stays as the backstop for the paths no keystroke handler can catch.

## Also fixed: a false "could not save this recording" toast

livekit-client defaults to `disconnectOnPageLeave: true`, so it disconnects the room itself on `beforeunload` — before the app's own `pagehide` teardown gets a chance to mark the disconnect intentional. `recordingStore` then reported an ordinary navigation as a server-side save failure, even though the backend finalizes the recording correctly on any dropped connection (`participant_left` → call ended → egress stopped → stitched → uploaded). Added a page-unload flag with a 5s grace window that suppresses both failure toasts while a real navigation is in flight, without changing any disconnect/network behavior.

## Notes

- Stopping now awaits the room disconnect (3s cap) before navigating, so the recording finalizes cleanly instead of going through the backend's crash-reconciliation path and yielding a truncated transcript.
- No pause option in the modal. Pausing would only cancel the navigation, leaving the user to reopen the switcher and stop anyway — "Keep recording" already covers "I changed my mind," and the recording overlay/tray already has its own pause control for that.
- The guard short-circuits to a no-op when nothing is recording.

## Not covered

Automatic reloads still end recordings silently and are out of scope here — most notably `ui-updater.ts`, which applies a staged UI update on window **blur**, so alt-tabbing during a recording can reload the app.

## Testing

`tsc --noEmit`, `eslint` (0 errors) and `prettier --check` pass for `apps/dashboard` and `apps/electron`.

Proof-of-testing video against the real running app (real login, real LiveKit recording) to follow as a comment.
