### PR TITLE
feat: setup internal claw calls (#778)

### DIFF
--- a/apps/backend/src/apps/controllers/commandController.ts
+++ b/apps/backend/src/apps/controllers/commandController.ts
@@ -11,7 +11,8 @@ import {
 } from '@/database/repositories/appCommandRepository';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
-import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
+import { SsrfBlockedError } from '@/utils/ssrfGuard';
+import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
 import { ConversationParticipation, MessageType } from '@xyne/shared';
 
 /**
@@ -624,26 +625,33 @@ export class CommandController {
         eventType,
       });
 
-      // Reject webhook URLs whose host resolves to an internal/private address.
+      // Resolve INTERNAL apps to their in-cluster pod URL; EXTERNAL apps go through the SSRF guard.
+      const dispatchHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'X-Xyne-Event': eventType,
+      };
+      let dispatchUrl: string;
       try {
-        await assertWebhookUrlSafe(match.webhookUrl);
+        const prepared = await prepareAppWebhookDispatch(match.webhookUrl, dispatchHeaders);
+        dispatchUrl = prepared.url;
       } catch (err) {
         if (err instanceof SsrfBlockedError) {
           logger.warn('[COMMAND-DISPATCH] Blocked SSRF-unsafe webhook URL', {
             appId: match.appId,
             reason: err.message,
           });
-          throw new Error('App webhook URL is not allowed');
+        } else {
+          logger.error('[COMMAND-DISPATCH] Could not resolve app webhook URL', {
+            appId: match.appId,
+            error: err,
+          });
         }
-        throw err;
+        throw new Error('App webhook URL is not allowed');
       }
 
-      const appResponse = await fetch(match.webhookUrl, {
+      const appResponse = await fetch(dispatchUrl, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Xyne-Event': eventType,
-        },
+        headers: dispatchHeaders,
         body: JSON.stringify(payload),
         redirect: 'manual',
         signal: AbortSignal.timeout(30_000),

--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
-import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
+import { SsrfBlockedError } from '@/utils/ssrfGuard';
 import { signWebhookPayload } from '@/apps/core/eventSubscriptionUtils';
+import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
 import { decrypt } from '@/services/encryptionService';
 import { SNS_CONFIRM_ACTION_ID } from './amazonSnsWebhookParser';
 import { incomingWebhookController } from './incomingWebhookController';
@@ -125,27 +126,31 @@ export class FlowController {
 
       logger.info('[FLOW-ACTION] Calling app backend', { appId, actionId, type, messageId });
 
-      // Reject webhook URLs whose host resolves to an internal/private address.
+      // Resolve INTERNAL apps to their in-cluster pod URL; EXTERNAL apps go through the SSRF guard.
+      const dispatchHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'X-Xyne-Event': 'flow_action',
+        'X-Xyne-Signature': signature,
+        'X-Source': 'XyneSpaces',
+      };
+      let dispatchUrl: string;
       try {
-        await assertWebhookUrlSafe(installedApp.webhookUrl);
+        const prepared = await prepareAppWebhookDispatch(installedApp.webhookUrl, dispatchHeaders);
+        dispatchUrl = prepared.url;
       } catch (err) {
         if (err instanceof SsrfBlockedError) {
           logger.warn('[FLOW-ACTION] Blocked SSRF-unsafe webhook URL', { appId, reason: err.message });
-          res.status(502).json({ error: 'App webhook URL is not allowed' });
-          return;
+        } else {
+          logger.error('[FLOW-ACTION] Could not resolve app webhook URL', { appId, error: err });
         }
-        throw err;
+        res.status(502).json({ error: 'App webhook URL is not allowed' });
+        return;
       }
 
       // 6. Call the app backend synchronously.
-      const appResponse = await fetch(installedApp.webhookUrl, {
+      const appResponse = await fetch(dispatchUrl, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Xyne-Event': 'flow_action',
-          'X-Xyne-Signature': signature,
-          'X-Source': 'XyneSpaces',
-        },
+        headers: dispatchHeaders,
         body,
         redirect: 'manual',
         signal: AbortSignal.timeout(30_000),

--- a/apps/backend/src/apps/core/appUrlResolver.ts
+++ b/apps/backend/src/apps/core/appUrlResolver.ts
@@ -1,0 +1,62 @@
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
+
+export interface ResolvedAppWebhook {
+  url: string;
+  isInternal: boolean;
+}
+
+/**
+ * Resolve an app's dispatch URL. If the webhookUrl's host is present in the
+ * internal host map (config.apps.internalHostMap, parsed from the
+ * INTERNAL_APP_HOST_MAP stringified-JSON env var), rewrite it to the in-cluster
+ * pod URL; otherwise pass the stored webhookUrl through unchanged.
+ */
+export function resolveAppWebhookUrl(webhookUrl: string): ResolvedAppWebhook {
+  let parsed: URL;
+  try {
+    parsed = new URL(webhookUrl);
+  } catch {
+    throw new Error(`[APP-URL-RESOLVER] Invalid webhook URL: ${webhookUrl}`);
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const internalBase = config.apps.internalHostMap[host];
+  if (!internalBase) {
+    return { url: webhookUrl, isInternal: false };
+  }
+
+  const resolved = `${internalBase}${parsed.pathname}${parsed.search}${parsed.hash}`;
+  logger.debug('[APP-URL-RESOLVER] Resolved internal app webhook', {
+    externalHost: host,
+    resolvedUrl: resolved,
+  });
+  return { url: resolved, isInternal: true };
+}
+
+/**
+ * Resolve + guard an outbound app-webhook dispatch. If the host maps to an
+ * internal pod URL, skip the SSRF guard (host from trusted config) and attach
+ * the S2S key; otherwise run the SSRF guard. Caller MUST pass `redirect:
+ * 'manual'` on its fetch.
+ */
+export async function prepareAppWebhookDispatch(
+  webhookUrl: string,
+  headers: Record<string, string> = {},
+): Promise<{ url: string; headers: Record<string, string>; isInternal: boolean }> {
+  const { url, isInternal } = resolveAppWebhookUrl(webhookUrl);
+  if (isInternal) {
+    const s2sKey = config.internalS2sKey;
+    if (s2sKey) {
+      headers['x-s2s-key'] = s2sKey;
+    } else {
+      logger.warn(
+        '[APP-URL-RESOLVER] Internal dispatch but INTERNAL_S2S_KEY is unset; sending without S2S auth',
+      );
+    }
+  } else {
+    await assertWebhookUrlSafe(url);
+  }
+  return { url, headers, isInternal };
+}

--- a/apps/backend/src/apps/core/eventSubscriptionUtils.ts
+++ b/apps/backend/src/apps/core/eventSubscriptionUtils.ts
@@ -3,7 +3,7 @@ import { isValidUrl } from '@/utils/urlUtils';
 import { BaseAppEvent } from '@/apps/types';
 import { logger } from '@/utils/logger';
 import { decrypt } from '@/services/encryptionService';
-import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
+import { prepareAppWebhookDispatch } from './appUrlResolver';
 import crypto from 'crypto';
 
 const installedAppsRepository = new InstalledAppsRepository();
@@ -19,23 +19,21 @@ export function signWebhookPayload(payload: string, signingSecret: string): stri
 export async function sendWebhookNotification(
     webhookUrl: string,
     event: BaseAppEvent,
-    signingSecret: string
+    signingSecret: string,
 ): Promise<{ status: number; body: unknown }> {
     const payload = JSON.stringify(event);
     const signature = signWebhookPayload(payload, signingSecret);
 
-    // SSRF guard: require a host that does not resolve to an internal/private
-    // address before every dispatch.
-    await assertWebhookUrlSafe(webhookUrl);
+    const { url, headers } = await prepareAppWebhookDispatch(webhookUrl, {
+        'Content-Type': 'application/json',
+        'X-Xyne-Signature': signature,
+        'X-Source': 'XyneSpaces',
+    });
 
     try {
-        const response = await fetch(webhookUrl, {
+        const response = await fetch(url, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Xyne-Signature': signature,
-                'X-Source': 'XyneSpaces'
-            },
+            headers,
             body: payload,
             // 'manual' so a 3xx to an internal host cannot bypass the guard above.
             redirect: 'manual',

--- a/apps/backend/src/apps/routes/prCheckCallback.ts
+++ b/apps/backend/src/apps/routes/prCheckCallback.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { validateS2SKey } from '@/middleware/validateS2SKey';
-import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
+import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
 
 const router = Router();
 
@@ -44,7 +44,6 @@ interface PRCheckRequestedPayload {
  */
 async function findVarysInstalledApp(): Promise<{ webhookUrl: string; userId: string } | null> {
   try {
-    // Find the Varys bot user by email (source of truth)
     const botUser = await db.user.findFirst({
       where: { email: VARYS_BOT_EMAIL },
     });
@@ -54,9 +53,9 @@ async function findVarysInstalledApp(): Promise<{ webhookUrl: string; userId: st
       return null;
     }
 
-    // Find installed app entry by userId
     const installedApp = await db.installedApps.findFirst({
       where: { userId: botUser.id },
+      select: { webhookUrl: true, userId: true },
     });
 
     if (!installedApp || !installedApp.webhookUrl) {
@@ -79,17 +78,16 @@ async function findVarysInstalledApp(): Promise<{ webhookUrl: string; userId: st
  */
 async function sendVarysWebhook(
   webhookUrl: string,
-  payload: PRCheckRequestedPayload
+  payload: PRCheckRequestedPayload,
 ): Promise<void> {
-  // Reject webhook URLs whose host resolves to an internal/private address.
-  await assertWebhookUrlSafe(webhookUrl);
+  const { url, headers } = await prepareAppWebhookDispatch(webhookUrl, {
+    'Content-Type': 'application/json',
+    'X-Xyne-Event': 'PR_CHECK_REQUESTED',
+  });
 
-  const response = await fetch(webhookUrl, {
+  const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Xyne-Event': 'PR_CHECK_REQUESTED',
-    },
+    headers,
     body: JSON.stringify(payload),
     redirect: 'manual',
     // Fail fast if Varys stalls — this runs inside a user-facing request.

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -3,6 +3,8 @@ import Joi from 'joi';
 
 dotenv.config();
 
+import { parseInternalAppHostMap } from '@/utils/internalHostMap';
+
 const envSchema = Joi.object({
   NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
   SANDBOX_TEST_MODE: Joi.boolean().default(false),
@@ -391,6 +393,9 @@ const envSchema = Joi.object({
   ASK_AI_VERSION: Joi.string().valid('v1', 'v2').default('v2'),
   // Internal S2S key for service-to-service communication
   INTERNAL_S2S_KEY: Joi.string().allow('').default(''),
+  // Stringified JSON mapping external webhook hosts to in-cluster pod base URLs.
+  // e.g. {"claw.example.com":"http://claw-auth.svc.cluster.local:3003"}
+  INTERNAL_APP_HOST_MAP: Joi.string().allow('').default(''),
   ENC_S2S_KEY: Joi.string().allow(''),
   ENCRYPTION_SERVICE_URL: Joi.string().uri().default('http://localhost:3012'),
   ENCRYPTION_REQUEST_TIMEOUT_MS: Joi.number().integer().min(1).default(5000),
@@ -943,6 +948,9 @@ export const config = {
     callbackUrl: (envVars.XYNE_CLAW_CALLBACK_URL || envVars.BACKEND_URL) as string,
   },
   internalS2sKey: envVars.INTERNAL_S2S_KEY as string,
+  apps: {
+    internalHostMap: parseInternalAppHostMap(envVars.INTERNAL_APP_HOST_MAP as string),
+  },
   askAI: {
     version: envVars.ASK_AI_VERSION as 'v1' | 'v2',
   },

--- a/apps/backend/src/services/callLlmRetry.ts
+++ b/apps/backend/src/services/callLlmRetry.ts
@@ -2,6 +2,9 @@ import { Agent, LLMClient, createUserMessage } from '@framework';
 import { config } from '@/config/env';
 import { extractAgentContent } from '@/utils/agentUtils';
 import { logger } from '@/utils/logger';
+import { repositories } from '@/database/repositories';
+import { orgLLMCredentialService } from '@/services/orgLLMCredentialService';
+import { OrgLLMServiceAccountPurpose } from '@xyne/shared';
 
 const MAX_ATTEMPTS = 5;
 const BASE_DELAY_MS = 120_000; // 2 minutes
@@ -40,7 +43,16 @@ export interface ExecuteStreamingLlmOptions {
   onDelta?: (accumulatedContent: string) => void | Promise<void>;
 }
 
-let streamingLlmClient: LLMClient | null = null;
+interface StreamingLlmCreds {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+}
+
+// Clients are keyed by the resolved credential tuple so that orgs with their
+// own provisioned LiteLLM keys each get an isolated client (and cache entry),
+// while callers without org provisioning share the env-configured one.
+const streamingLlmClients = new Map<string, LLMClient>();
 
 const sleep = (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms));
@@ -188,28 +200,60 @@ export async function executeCallLlmWithRetry(
 }
 
 /**
- * Returns a singleton LLMClient for streaming requests against the call LiteLLM
- * deployment. Returns null when credentials are not configured.
+ * Resolves the LiteLLM credentials for a streaming request. Delegates all
+ * DB / DEFAULT-purpose / env fallback logic to orgLLMCredentialService.
+ * Returns null when no credential is available (service's env fallback
+ * also empty).
  */
-function getStreamingLlmClient(): LLMClient | null {
-  const apiKey = config.llm.callLitellmApiKey;
-  const baseUrl = config.llm.litellmBaseUrl;
+async function resolveStreamingLlmCreds(callId?: string): Promise<StreamingLlmCreds | null> {
+  let userId: string | null = null;
 
-  if (!apiKey || !baseUrl) {
+  if (callId) {
+    try {
+      userId =
+        (await repositories.calls.findByExternalId(callId))?.createdByUserId ?? null;
+    } catch (error) {
+      logger.warn(`[${callId}] call lookup failed for org credential resolution`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const credential = await orgLLMCredentialService.getCredentialByUserId(
+    userId,
+    OrgLLMServiceAccountPurpose.CALL_TRANSCRIPT,
+  );
+
+  if (!credential?.apiKey || !credential.baseUrl) {
     return null;
   }
 
-  if (!streamingLlmClient) {
-    streamingLlmClient = new LLMClient({
+  return {
+    apiKey: credential.apiKey,
+    baseUrl: credential.baseUrl,
+    model: credential.defaultModel || config.llm.callLitellmModel || DEFAULT_MODEL,
+  };
+}
+
+/**
+ * Returns a cached LLMClient for the given resolved credentials; callers must
+ * resolve credentials first via resolveStreamingLlmCreds.
+ */
+function getStreamingLlmClient(creds: StreamingLlmCreds): LLMClient {
+  const cacheKey = `${creds.apiKey}\n${creds.baseUrl}\n${creds.model}`;
+
+  let client = streamingLlmClients.get(cacheKey);
+  if (!client) {
+    client = new LLMClient({
       provider: {
         type: 'litellm',
         config: {
-          apiKey,
-          baseUrl,
+          apiKey: creds.apiKey,
+          baseUrl: creds.baseUrl,
           timeout: STREAMING_REQUEST_TIMEOUT_MS,
         },
       },
-      defaultModel: config.llm.callLitellmModel || DEFAULT_MODEL,
+      defaultModel: creds.model,
       retry: {
         maxAttempts: MAX_ATTEMPTS,
         baseDelay: BASE_DELAY_MS,
@@ -217,9 +261,10 @@ function getStreamingLlmClient(): LLMClient | null {
         exponentialBackoff: true,
       },
     });
+    streamingLlmClients.set(cacheKey, client);
   }
 
-  return streamingLlmClient;
+  return client;
 }
 
 /**
@@ -238,9 +283,9 @@ export async function executeStreamingLlmRequest(
     return { ok: false, reason: 'cancelled' };
   }
 
-  const client = getStreamingLlmClient();
+  const creds = await resolveStreamingLlmCreds(options.callId);
 
-  if (!client) {
+  if (!creds) {
     logger.warn(`[${callId}] ${options.operation}_skipped`, {
       reason: 'litellm_credentials_missing',
     });
@@ -250,6 +295,8 @@ export async function executeStreamingLlmRequest(
       reason: 'litellm_credentials_missing',
     };
   }
+
+  const client = getStreamingLlmClient(creds);
 
   // The framework's client-level retry is a no-op for streaming: it retries the
   // synchronous call that constructs the async generator, which always

--- a/apps/backend/src/services/orgLLMCredentialService.ts
+++ b/apps/backend/src/services/orgLLMCredentialService.ts
@@ -302,8 +302,15 @@ class OrgLLMCredentialService {
     const baseUrl = config.litellm.baseUrl;
 
     if (!apiKey) {
+      logger.warn('[OrgLLMCredentialService] env fallback requested but env not configured', {
+        purpose,
+      });
       return null;
     }
+
+    logger.warn('[OrgLLMCredentialService] using env credential (no org-provisioned key in DB)', {
+      purpose,
+    });
 
     return {
       apiKey,

--- a/apps/backend/src/utils/internalHostMap.ts
+++ b/apps/backend/src/utils/internalHostMap.ts
@@ -1,0 +1,21 @@
+/**
+ * Parse the INTERNAL_APP_HOST_MAP env var (stringified JSON) into a
+ * { externalHost -> internalBaseUrl } map. Used by the app URL resolver to
+ * rewrite INTERNAL app webhook URLs to in-cluster pod URLs at dispatch time.
+ */
+export function parseInternalAppHostMap(raw: string): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+    const out: Record<string, string> = {};
+    for (const [host, base] of Object.entries(parsed)) {
+      if (typeof host === 'string' && typeof base === 'string' && host && base) {
+        out[host.toLowerCase()] = base.replace(/\/+$/, '');
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
* feat: calls llm call fix

* feat: internal mapping url for claw

* feat: keep the resolve internal hosts as a separate utils function

---------

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
