### PR TITLE
fix: XYNE-56792 Fix visibility tab error for non-group admins

### DIFF
--- a/apps/dashboard/src/components/UserGroup/AssignmentConfigScreen/AssignmentConfigScreen.tsx
+++ b/apps/dashboard/src/components/UserGroup/AssignmentConfigScreen/AssignmentConfigScreen.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useState, useEffect, useMemo } from 'react';
 import { useZero } from '../../../hooks/useZero';
+import { useAuthContextValues } from '../../../hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { ArrowLeft, PauseCircle, Settings02 } from '@xyne/icons';
@@ -51,6 +52,7 @@ export const AssignmentConfigScreen = ({
 }: AssignmentConfigScreenProps): ReactElement => {
   const navigate = useNavigate();
   const zero = useZero();
+  const { userID } = useAuthContextValues();
   const [selectedBoardId, setSelectedBoardId] = useState<string | null>(null);
   const [boardWeight, setBoardWeight] = useState<string>('1');
   const [isSaving, setIsSaving] = useState(false);
@@ -106,6 +108,13 @@ export const AssignmentConfigScreen = ({
           userGroupId,
           boardId: 'nonexistent',
         }),
+  );
+
+  // Workload/complexity data is ACL-scoped to group members: if the viewer isn't
+  // in the group, those queries silently sync empty rather than erroring.
+  const isCurrentUserGroupMember = useMemo(
+    () => (userGroupMembers ?? []).some(mapping => mapping.userId === userID),
+    [userGroupMembers, userID],
   );
 
   const allUsers = useActiveUsers();
@@ -1215,6 +1224,7 @@ export const AssignmentConfigScreen = ({
               workloadMappings={userWorkloadMappings}
               boardComplexityScores={boardComplexityScores}
               expertiseMappings={expertiseMappings}
+              isCurrentUserGroupMember={isCurrentUserGroupMember}
             />
           )}
         </div>

--- a/apps/dashboard/src/components/UserGroup/AssignmentConfigScreen/VisibilityTab.tsx
+++ b/apps/dashboard/src/components/UserGroup/AssignmentConfigScreen/VisibilityTab.tsx
@@ -26,6 +26,7 @@ interface VisibilityTabProps {
   workloadMappings: readonly WorkloadMappingLike[] | null | undefined;
   boardComplexityScores: readonly ComplexityScoreLike[] | null | undefined;
   expertiseMappings: readonly ExpertiseMappingLike[] | null | undefined;
+  isCurrentUserGroupMember: boolean;
 }
 
 /**
@@ -41,6 +42,7 @@ export function VisibilityTab({
   workloadMappings,
   boardComplexityScores,
   expertiseMappings,
+  isCurrentUserGroupMember,
 }: VisibilityTabProps): ReactElement {
   const scoreRows = useMemo(
     () =>
@@ -56,6 +58,16 @@ export function VisibilityTab({
   );
 
   const selectedBoardName = boards.find(b => b.id === selectedBoardId)?.name;
+
+  if (!isCurrentUserGroupMember) {
+    return (
+      <div className='rounded-2xl border border-border bg-card p-8 text-center'>
+        <p className='text-[13px] text-muted-foreground'>
+          You need to be part of this user group to see member workloads.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
POT - 
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/cbcc91cd-e186-4575-aaa1-4dc15413df42" />
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/26cfcbe6-85ff-4481-b244-2cd703ea84f9" />


Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
