### PR TITLE
fix: XYNE-56763 canvas sidebar starred section

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
@@ -1868,6 +1868,45 @@ export const CanvasList: React.FC<CanvasListProps> = ({
     </div>
   );
 
+  const renderStarredSection = (): React.ReactNode => {
+    if (!shouldShowStarredSection) return null;
+
+    return (
+      <div className='px-2.5 pb-1 pt-1'>
+        <div className='px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-sidebar-foreground/50'>
+          Starred
+        </div>
+        {visibleStarredCanvases.map(canvas => (
+          <div key={canvas.id}>{renderCanvasItem(canvas)}</div>
+        ))}
+        {hiddenStarredCount > 0 && (
+          <button
+            type='button'
+            onClick={() => setIsStarredSectionExpanded(true)}
+            className='flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[12px] font-medium text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+            data-track-category='CANVAS'
+            data-track-name='SHOW_MORE_STARRED_CANVASES'
+          >
+            <ChevronDown className='size-3.5 shrink-0' strokeWidth={2.2} />
+            See {hiddenStarredCount} more
+          </button>
+        )}
+        {isStarredSectionExpanded && starredCanvases.length > STARRED_SECTION_PAGE_SIZE && (
+          <button
+            type='button'
+            onClick={() => setIsStarredSectionExpanded(false)}
+            className='flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[12px] font-medium text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+            data-track-category='CANVAS'
+            data-track-name='SHOW_LESS_STARRED_CANVASES'
+          >
+            <ChevronRight className='size-3.5 shrink-0 -rotate-90' strokeWidth={2.2} />
+            Show less
+          </button>
+        )}
+      </div>
+    );
+  };
+
   const renderChannelFolderGroupedList = (): React.ReactNode => (
     <div className='h-full overflow-auto pb-2'>
       {hasChannelFolderGroupedResults ? (
@@ -2359,41 +2398,6 @@ export const CanvasList: React.FC<CanvasListProps> = ({
         </div>
       </div>
 
-      {shouldShowStarredSection && (
-        <div className='shrink-0 px-2.5 pt-1'>
-          <div className='px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-sidebar-foreground/50'>
-            Starred
-          </div>
-          {visibleStarredCanvases.map(canvas => (
-            <div key={canvas.id}>{renderCanvasItem(canvas)}</div>
-          ))}
-          {hiddenStarredCount > 0 && (
-            <button
-              type='button'
-              onClick={() => setIsStarredSectionExpanded(true)}
-              className='flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[12px] font-medium text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
-              data-track-category='CANVAS'
-              data-track-name='SHOW_MORE_STARRED_CANVASES'
-            >
-              <ChevronDown className='size-3.5 shrink-0' strokeWidth={2.2} />
-              See {hiddenStarredCount} more
-            </button>
-          )}
-          {isStarredSectionExpanded && starredCanvases.length > STARRED_SECTION_PAGE_SIZE && (
-            <button
-              type='button'
-              onClick={() => setIsStarredSectionExpanded(false)}
-              className='flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[12px] font-medium text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
-              data-track-category='CANVAS'
-              data-track-name='SHOW_LESS_STARRED_CANVASES'
-            >
-              <ChevronRight className='size-3.5 shrink-0 -rotate-90' strokeWidth={2.2} />
-              Show less
-            </button>
-          )}
-        </div>
-      )}
-
       <div className='flex-1 min-h-0'>
         {isInitialLoading || isChannelFolderViewInitialLoading ? (
           <div className='flex items-center justify-center h-64'>
@@ -2402,11 +2406,18 @@ export const CanvasList: React.FC<CanvasListProps> = ({
         ) : shouldRenderChannelFolderGroups ? (
           renderChannelFolderGroupedList()
         ) : filteredCanvases.length === 0 && isFilteredScanIncomplete ? (
-          <div className='flex items-center justify-center h-64'>
-            <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
+          <div className='h-full overflow-auto pb-2'>
+            {renderStarredSection()}
+            <div className='flex items-center justify-center h-64'>
+              <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
+            </div>
           </div>
         ) : filteredCanvases.length === 0 ? (
-          renderCanvasEmptyState()
+          shouldShowStarredSection ? (
+            <div className='h-full overflow-auto pb-2'>{renderStarredSection()}</div>
+          ) : (
+            renderCanvasEmptyState()
+          )
         ) : (
           <Virtuoso
             ref={canvasVirtuosoRef}
@@ -2420,6 +2431,7 @@ export const CanvasList: React.FC<CanvasListProps> = ({
             rangeChanged={handleVisibleRangeChanged}
             itemContent={(index, canvas) => renderListItem(index, canvas)}
             components={{
+              Header: () => renderStarredSection(),
               Footer: () =>
                 (isLoadingNext && shouldLoadMoreOnListEnd) || isFilteredScanIncomplete ? (
                   <div className='flex items-center justify-center py-4'>


### PR DESCRIPTION
…and collapse animation

Fixes the starred canvases section, the selection highlight on the active sidebar item, and the collapse animation for a sidebar section. Also closes the visual gap between consecutive cards in the date-grouped canvas list, which rendered flush against each other.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind


POT : https://drive.google.com/file/d/1R4NM7BgtKlp__55RgNtQ-unDfjc9b3DX/view?usp=sharing