### PR TITLE
feat: claw per-run model, thinking and fast-mode controls (run path + chat composer)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -871,6 +871,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       designSelection,
       researchContext,
       speed: rawSpeed,
+      thinkingLevel: rawThinkingLevel,
     } = req.body as {
       message?: string;
       conversationId?: string;
@@ -899,12 +900,23 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
        *  modelSettings.speed for this run only — same credential, same model,
        *  Anthropic's faster tier. Omitted = agent default. */
       speed?: "standard" | "fast";
+      /** Per-message thinking level (the composer's model menu). Rides the
+       *  agent's modelSettings.thinkingLevel for this run only. */
+      thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high";
     };
     const userId = getRequesterId(req) ?? (req.body as { userId?: string }).userId;
     const speedOverride: "standard" | "fast" | undefined =
       rawSpeed === "fast" || rawSpeed === "standard" ? rawSpeed : undefined;
     if (rawSpeed !== undefined && !speedOverride) {
       res.status(400).json({ success: false, error: 'speed must be "standard" or "fast"' });
+      return;
+    }
+    const CHAT_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high"] as const;
+    const thinkingOverride = typeof rawThinkingLevel === "string" && (CHAT_THINKING_LEVELS as readonly string[]).includes(rawThinkingLevel)
+      ? rawThinkingLevel as (typeof CHAT_THINKING_LEVELS)[number]
+      : undefined;
+    if (rawThinkingLevel !== undefined && !thinkingOverride) {
+      res.status(400).json({ success: false, error: `thinkingLevel must be one of: ${CHAT_THINKING_LEVELS.join(", ")}` });
       return;
     }
 
@@ -1423,16 +1435,31 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       }
     }
 
-    // Per-message fast-mode toggle wins over the agent's saved
-    // modelSettings.speed for this run only (not persisted to the agent).
-    if (speedOverride) {
+    // Per-message fast-mode / thinking overrides win over the agent's saved
+    // modelSettings for this run only (not persisted to the agent). The
+    // thinking pick also outranks the fast profile's thinking override —
+    // claw overlays fastModeProfile.modelSettings over modelSettings on fast
+    // runs, so mirror the choice into the profile too when one exists.
+    if (speedOverride || thinkingOverride) {
       runAgentConfig = {
         ...(runAgentConfig ?? {}),
         modelSettings: {
           ...((runAgentConfig?.["modelSettings"] as Record<string, unknown> | undefined) ?? {}),
-          speed: speedOverride,
+          ...(speedOverride ? { speed: speedOverride } : {}),
+          ...(thinkingOverride ? { thinkingLevel: thinkingOverride } : {}),
         },
       };
+      const profile = runAgentConfig["fastModeProfile"];
+      if (thinkingOverride && profile && typeof profile === "object" && !Array.isArray(profile)
+          && (profile as Record<string, unknown>)["modelSettings"]) {
+        runAgentConfig["fastModeProfile"] = {
+          ...(profile as Record<string, unknown>),
+          modelSettings: {
+            ...((profile as Record<string, unknown>)["modelSettings"] as Record<string, unknown>),
+            thinkingLevel: thinkingOverride,
+          },
+        };
+      }
     }
     const effectiveAgentConfig = disableTools
       ? {

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -71,6 +71,15 @@ function sanitizeAgent<T extends Record<string, unknown>>(agent: T): T {
 function lightAgentProjection(agent: Record<string, unknown>, orgNames?: Map<string, string>): Record<string, unknown> {
   const owner = agent["owner"] as { id?: string; name?: string; email?: string } | null | undefined;
   const orgId = typeof agent["orgId"] === "string" ? agent["orgId"] : null;
+  // Derived flag for chat surfaces (Spaces Ask AI composer): whether this
+  // agent has fast mode configured — a fast-mode provider profile and/or a
+  // default speed in its model settings. The light list never exposes the
+  // config itself, so consumers get just the boolean.
+  const cfg = agent["config"] as Record<string, unknown> | null | undefined;
+  const ms = cfg?.["modelSettings"] as Record<string, unknown> | undefined;
+  const fastModeConfigured =
+    ms?.["speed"] === "fast" || ms?.["speed"] === "standard" ||
+    (cfg?.["fastModeProfile"] !== undefined && cfg?.["fastModeProfile"] !== null);
   return {
     id: agent["id"],
     slug: agent["slug"],
@@ -87,6 +96,7 @@ function lightAgentProjection(agent: Record<string, unknown>, orgNames?: Map<str
     isDefault: agent["isDefault"],
     activePromptVersion: agent["activePromptVersion"],
     kbScope: agent["kbScope"],
+    fastModeConfigured,
     modelId: agent["modelId"],
     spacesAppId: agent["spacesAppId"],
     spacesAppUserId: agent["spacesAppUserId"],

--- a/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
@@ -7,7 +7,7 @@ import { prisma } from "../db.js";
 import { chatMessageRepository, agentRunRepository, chatAttachmentRepository } from "../repositories/index.js";
 import { gcsService } from "../services/storageService.js";
 import { appendCitations, hydrateInvocationIcons } from "../lib/citations.js";
-import { resolveAgentProviderConfigs } from "../lib/agent-provider-config.js";
+import { resolveAgentProviderConfigs, agentDefaultSpeed, parseFastModeProfile } from "../lib/agent-provider-config.js";
 import { resolveFastMode } from "../lib/fast-mode.js";
 import { resolveSdlcRepositoryForUser } from "../lib/sdlc-repository-context.js";
 import {
@@ -350,6 +350,11 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
       researchContext,
       webSearchEnabled,
       deepResearchEnabled,
+      /** Per-message provider fast mode (Spaces composer ⚡ toggle). Overrides
+       *  the agent's modelSettings.speed for THIS run only; absent = agent
+       *  default. Invalid values are ignored rather than 400d — this route is
+       *  a pass-through for several callers. */
+      speed: rawSpeed,
       agentConfig,
       additionalInstructions,
       generateFollowUpSuggestions,
@@ -425,7 +430,9 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
     // to claw's env LITELLM_MODEL. Agent-level resolution (the same shared
     // resolver the headless + automation paths use). Body-supplied values win
     // only when the agent has no configured creds.
-    const resolvedProviders = await resolveAgentProviderConfigs(agentRow).catch(() => null);
+    const speedOverride = rawSpeed === "fast" || rawSpeed === "standard" ? rawSpeed : undefined;
+    const effectiveSpeed = speedOverride ?? agentDefaultSpeed(agentRow.config);
+    const resolvedProviders = await resolveAgentProviderConfigs(agentRow, { speed: effectiveSpeed }).catch(() => null);
     const resolvedProvider = resolvedProviders?.provider ?? (provider as string | undefined);
     const resolvedProviderConfigs =
       resolvedProviders && Object.keys(resolvedProviders.providerConfigs).length > 0
@@ -880,6 +887,26 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
         description: agentRow.description,
       },
     };
+    // Fast mode: forward the agent's model settings (with the effective speed)
+    // and fast-mode profile so claw applies the speed + run-setting overrides.
+    // ONLY when this run is fast — this route otherwise forwards no stored
+    // modelSettings, and standard runs must stay byte-identical to today.
+    if (effectiveSpeed === "fast") {
+      const storedConfig = (agentRow.config as Record<string, unknown> | null) ?? {};
+      const storedModelSettings = storedConfig["modelSettings"];
+      enrichedAgentConfig["modelSettings"] = {
+        ...(storedModelSettings && typeof storedModelSettings === "object" && !Array.isArray(storedModelSettings)
+          ? storedModelSettings as Record<string, unknown>
+          : {}),
+        speed: "fast",
+      };
+      const profile = parseFastModeProfile(storedConfig);
+      if (storedConfig["fastModeProfile"] !== undefined && storedConfig["fastModeProfile"] !== null) {
+        enrichedAgentConfig["fastModeProfile"] = storedConfig["fastModeProfile"];
+      }
+      log.info(`[run-stream] fast mode for ${slug} (override=${speedOverride ?? "agent-default"}, profile=${profile.providers})`);
+    }
+
     const fastModeEnabled = await resolveFastMode(
       convId,
       slug,

--- a/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
@@ -355,6 +355,9 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
        *  default. Invalid values are ignored rather than 400d — this route is
        *  a pass-through for several callers. */
       speed: rawSpeed,
+      /** Per-message thinking level (Spaces composer dropdown). Merged over the
+       *  agent's modelSettings for this run; invalid values are ignored. */
+      thinkingLevel: rawThinkingLevel,
       agentConfig,
       additionalInstructions,
       generateFollowUpSuggestions,
@@ -431,6 +434,10 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
     // resolver the headless + automation paths use). Body-supplied values win
     // only when the agent has no configured creds.
     const speedOverride = rawSpeed === "fast" || rawSpeed === "standard" ? rawSpeed : undefined;
+    const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high"];
+    const thinkingOverride = typeof rawThinkingLevel === "string" && THINKING_LEVELS.includes(rawThinkingLevel)
+      ? rawThinkingLevel
+      : undefined;
     const effectiveSpeed = speedOverride ?? agentDefaultSpeed(agentRow.config);
     const resolvedProviders = await resolveAgentProviderConfigs(agentRow, { speed: effectiveSpeed }).catch(() => null);
     const resolvedProvider = resolvedProviders?.provider ?? (provider as string | undefined);
@@ -891,20 +898,43 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
     // and fast-mode profile so claw applies the speed + run-setting overrides.
     // ONLY when this run is fast — this route otherwise forwards no stored
     // modelSettings, and standard runs must stay byte-identical to today.
-    if (effectiveSpeed === "fast") {
+    if (effectiveSpeed === "fast" || thinkingOverride) {
       const storedConfig = (agentRow.config as Record<string, unknown> | null) ?? {};
       const storedModelSettings = storedConfig["modelSettings"];
+      // Fast runs carry the agent's full model settings (this route otherwise
+      // forwards none) so the speed + fast-profile overrides apply in claw. A
+      // standard run with ONLY a thinking override forwards just that field —
+      // anything more would change behavior for settings this path never
+      // honored before. The per-message thinking override wins over both the
+      // stored value and the fast profile's override.
       enrichedAgentConfig["modelSettings"] = {
-        ...(storedModelSettings && typeof storedModelSettings === "object" && !Array.isArray(storedModelSettings)
+        ...(effectiveSpeed === "fast" && storedModelSettings && typeof storedModelSettings === "object" && !Array.isArray(storedModelSettings)
           ? storedModelSettings as Record<string, unknown>
           : {}),
-        speed: "fast",
+        ...(effectiveSpeed === "fast" ? { speed: "fast" } : {}),
+        ...(thinkingOverride ? { thinkingLevel: thinkingOverride } : {}),
       };
-      const profile = parseFastModeProfile(storedConfig);
-      if (storedConfig["fastModeProfile"] !== undefined && storedConfig["fastModeProfile"] !== null) {
-        enrichedAgentConfig["fastModeProfile"] = storedConfig["fastModeProfile"];
+      if (effectiveSpeed === "fast") {
+        const profile = parseFastModeProfile(storedConfig);
+        if (storedConfig["fastModeProfile"] !== undefined && storedConfig["fastModeProfile"] !== null) {
+          // Drop the profile's own thinking override when the user picked one
+          // for this message — claw overlays profile.modelSettings over
+          // modelSettings on fast runs, and the per-message choice must win.
+          const rawProfile = storedConfig["fastModeProfile"];
+          enrichedAgentConfig["fastModeProfile"] = thinkingOverride && rawProfile && typeof rawProfile === "object" && !Array.isArray(rawProfile) && (rawProfile as Record<string, unknown>)["modelSettings"]
+            ? {
+                ...(rawProfile as Record<string, unknown>),
+                modelSettings: {
+                  ...((rawProfile as Record<string, unknown>)["modelSettings"] as Record<string, unknown>),
+                  thinkingLevel: thinkingOverride,
+                },
+              }
+            : rawProfile;
+        }
+        log.info(`[run-stream] fast mode for ${slug} (override=${speedOverride ?? "agent-default"}, profile=${profile.providers}${thinkingOverride ? `, thinking=${thinkingOverride}` : ""})`);
+      } else {
+        log.info(`[run-stream] thinking override for ${slug}: ${thinkingOverride}`);
       }
-      log.info(`[run-stream] fast mode for ${slug} (override=${speedOverride ?? "agent-default"}, profile=${profile.providers})`);
     }
 
     const fastModeEnabled = await resolveFastMode(

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -2995,6 +2995,9 @@ export async function sendChatMessage(
      *  and model, faster tier. Overrides the agent's modelSettings.speed for
      *  this run only. */
     speed?: "standard" | "fast";
+    /** Per-turn thinking level (composer model menu). Overrides the agent's
+     *  modelSettings.thinkingLevel for this run only. */
+    thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high";
   },
 ): Promise<{ conversationId: string; reply: ChatReply }> {
   // Backward-compat: allow passing a single onProgress function (old signature).
@@ -3042,6 +3045,7 @@ export async function sendChatMessage(
       ...(requestOptions?.providerOverride ? { providerOverride: requestOptions.providerOverride } : {}),
       ...(requestOptions?.researchContext ? { researchContext: requestOptions.researchContext } : {}),
       ...(requestOptions?.speed ? { speed: requestOptions.speed } : {}),
+      ...(requestOptions?.thinkingLevel ? { thinkingLevel: requestOptions.thinkingLevel } : {}),
     }),
     ...(requestSignal ? { signal: requestSignal } : {}),
   });

--- a/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
@@ -194,62 +194,174 @@ function ProviderSelect({
  * lets any chat participant pin one for the current conversation. Empty models
  * ⇒ renders nothing (agent has no litellm credential). value "" = agent default
  * (no override). See ChatPageV3's fetch effect + handleSend(modelOverride). */
-function ModelSelect({
-  value,
+const CHAT_THINKING_OPTIONS: Array<{ value: "off" | "minimal" | "low" | "medium" | "high" | null; label: string }> = [
+  { value: null, label: "Default" },
+  { value: "off", label: "Off" },
+  { value: "minimal", label: "Minimal" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+];
+export type ChatThinkingLevel = "off" | "minimal" | "low" | "medium" | "high";
+
+/**
+ * Combined model + thinking picker for the chat composer, styled after the
+ * Claude app's model menu: the trigger leads with the model name
+ * ("Recommended" when no pin, thinking level beside it when set); the menu
+ * holds the Recommended row (agent's configured model in brackets), a search
+ * bar over the agent's allowed model list, and a Thinking entry whose options
+ * fly out to the right side.
+ */
+function ModelThinkingMenu({
   models,
   defaultModel,
+  selectedModel,
+  onSelectModel,
+  thinkingLevel,
+  onSelectThinking,
   disabled,
-  onChange,
 }: {
-  value: string;
   models: Array<{ id: string; name: string }>;
   defaultModel: string | null;
-  disabled: boolean;
-  onChange: (model: string) => void;
+  selectedModel: string;
+  onSelectModel: (model: string) => void;
+  thinkingLevel: ChatThinkingLevel | null;
+  onSelectThinking: (v: ChatThinkingLevel | null) => void;
+  disabled?: boolean;
 }) {
-  const options = useMemo(
-    () => [
-      { value: "", label: defaultModel ? `Default (${defaultModel})` : "Agent default" },
-      ...models.map((m) => ({ value: m.id, label: m.name })),
-    ],
-    [models, defaultModel],
-  );
-  if (models.length === 0) return null;
-  const current = options.find((o) => o.value === value) ?? options[0];
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [thinkingOpen, setThinkingOpen] = useState(false);
+  const close = () => { setOpen(false); setQuery(""); setThinkingOpen(false); };
+
+  const selected = models.find((m) => m.id === selectedModel) ?? null;
+  const q = query.trim().toLowerCase();
+  const filtered = q ? models.filter((m) => m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q)) : models;
+  const thinkingLabel = CHAT_THINKING_OPTIONS.find((o) => o.value === thinkingLevel)?.label ?? "Default";
+
+  const rowClass = (active: boolean) =>
+    `flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] transition-colors ${
+      active ? "bg-xyne-surface-sunken font-medium text-xyne-fg-primary" : "text-xyne-fg-primary hover:bg-xyne-surface-subtle"
+    }`;
 
   return (
-    <Menu
-      side="bottom"
-      align="start"
-      trigger={(triggerProps) => (
-        <button
-          {...(triggerProps as React.ButtonHTMLAttributes<HTMLButtonElement>)}
-          type="button"
-          data-id="model-select"
-          disabled={disabled}
-          className="flex w-full items-center gap-2 rounded-lg border border-xyne-border-subtle bg-xyne-surface px-3 py-2 text-left text-[13px] transition-colors hover:border-xyne-border hover:bg-xyne-surface-subtle disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          <span className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-xyne-fg-muted">
-            Model
-          </span>
-          <span className="flex-1 truncate font-medium text-xyne-fg-primary">
-            {current?.label ?? value}
-          </span>
-          <CaretDownIcon size={12} className="shrink-0 text-xyne-fg-tertiary" />
-        </button>
+    <div className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        data-id="model-thinking-trigger"
+        title={selected ? selected.id : defaultModel ? `Recommended (${defaultModel})` : "Recommended model"}
+        aria-label="Model and thinking"
+        onClick={() => (open ? close() : setOpen(true))}
+        className={`flex h-8 items-center gap-1.5 rounded-full bg-xyne-surface-subtle px-3 text-[12px] font-medium transition-colors ${
+          disabled ? "cursor-not-allowed opacity-50" : "hover:bg-xyne-surface-sunken"
+        } text-xyne-fg-primary`}
+      >
+        <SparkleIcon size={13} className="shrink-0 text-xyne-brand" />
+        <span className="max-w-[150px] truncate">{selected ? selected.name : defaultModel ?? "Recommended"}</span>
+        {thinkingLevel && <span className="text-xyne-fg-tertiary">{thinkingLabel}</span>}
+        <CaretDownIcon size={11} className="shrink-0 text-xyne-fg-tertiary" />
+      </button>
+
+      {open && (
+        <>
+          {/* click-outside backdrop */}
+          <div className="fixed inset-0 z-40" onClick={close} aria-hidden />
+          <div
+            data-id="model-thinking-menu"
+            className="absolute bottom-full left-0 z-50 mb-2 w-72 rounded-xl border border-xyne-border bg-xyne-surface p-1 shadow-[0_10px_40px_-8px_rgba(0,0,0,0.35)]"
+          >
+            {/* Recommended — clears the pin; the run uses the agent's configured model. */}
+            <button
+              type="button"
+              data-id="model-option-recommended"
+              onClick={() => { onSelectModel(""); close(); }}
+              className={rowClass(selectedModel === "")}
+            >
+              <span className="flex min-w-0 flex-col items-start gap-0.5">
+                <span className="font-medium">{defaultModel ?? "Recommended"}</span>
+                {defaultModel && (
+                  <span className="max-w-full truncate text-[11px] text-xyne-fg-tertiary">(Recommended)</span>
+                )}
+              </span>
+              {selectedModel === "" && <CheckIcon size={13} className="shrink-0 text-xyne-brand" />}
+            </button>
+
+            {models.length > 0 && (
+              <>
+                <div className="mx-1 my-1 h-px bg-xyne-border-subtle" />
+                <div className="mx-1 my-0.5 flex items-center gap-1.5 rounded-lg border border-xyne-border bg-xyne-surface-subtle px-2 py-1.5">
+                  <MagnifyingGlassIcon size={13} className="shrink-0 text-xyne-fg-muted" />
+                  <input
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search models…"
+                    data-id="model-search"
+                    className="w-full bg-transparent text-[13px] text-xyne-fg-primary outline-none placeholder:text-xyne-fg-muted"
+                  />
+                </div>
+                <div className="flex max-h-72 flex-col overflow-auto">
+                  {filtered.length === 0 ? (
+                    <div className="px-2.5 py-2 text-[13px] text-xyne-fg-tertiary">No models match</div>
+                  ) : (
+                    filtered.map((m) => (
+                      <button
+                        key={m.id}
+                        type="button"
+                        title={m.id}
+                        data-id={`model-option-${m.id}`}
+                        onClick={() => { onSelectModel(m.id); close(); }}
+                        className={rowClass(selectedModel === m.id)}
+                      >
+                        <span className="truncate font-mono text-[12.5px]">{m.name}</span>
+                        {selectedModel === m.id && <CheckIcon size={13} className="shrink-0 text-xyne-brand" />}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </>
+            )}
+
+            <div className="mx-1 my-1 h-px bg-xyne-border-subtle" />
+            {/* Thinking — options fly out to the right side. */}
+            <div className="relative">
+              <button
+                type="button"
+                data-id="thinking-expand"
+                aria-expanded={thinkingOpen}
+                onClick={() => setThinkingOpen((v) => !v)}
+                className="flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] text-xyne-fg-primary hover:bg-xyne-surface-subtle"
+              >
+                <span className="flex items-center gap-1.5 font-medium">
+                  <BrainIcon size={13} className="shrink-0 text-xyne-fg-tertiary" />
+                  Thinking
+                </span>
+                <span className="flex items-center gap-1 text-xyne-fg-tertiary">
+                  {thinkingLabel}
+                  <CaretRightIcon size={11} className="shrink-0" />
+                </span>
+              </button>
+              {thinkingOpen && (
+                <div className="absolute right-0 top-0 z-50 w-36 translate-x-[calc(100%+8px)] rounded-xl border border-xyne-border bg-xyne-surface p-1 shadow-[0_10px_40px_-8px_rgba(0,0,0,0.35)]">
+                  {CHAT_THINKING_OPTIONS.map((o) => (
+                    <button
+                      key={o.label}
+                      type="button"
+                      data-id={`thinking-option-${o.label.toLowerCase()}`}
+                      onClick={() => { onSelectThinking(o.value); close(); }}
+                      className={rowClass(o.value === thinkingLevel)}
+                    >
+                      <span>{o.label}</span>
+                      {o.value === thinkingLevel && <CheckIcon size={13} className="shrink-0 text-xyne-brand" />}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </>
       )}
-    >
-      {options.map((opt) => (
-        <MenuItem
-          key={opt.value || "__default__"}
-          selected={opt.value === value}
-          onSelect={() => { if (opt.value !== value) onChange(opt.value); }}
-          trailing={opt.value === value ? <CheckIcon size={12} className="text-xyne-brand" /> : undefined}
-        >
-          {opt.label}
-        </MenuItem>
-      ))}
-    </Menu>
+    </div>
   );
 }
 
@@ -1953,10 +2065,6 @@ function LeftPanel({
   onPickAgent,
   onClearAgent,
   onProviderChange,
-  litellmModels,
-  litellmDefaultModel,
-  selectedModel,
-  onModelChange,
   onNewConversation,
   onSelectConv,
   onTogglePin,
@@ -1972,10 +2080,6 @@ function LeftPanel({
   selectedProvider: string;
   providers: ProviderCredential[];
   providerChanging: boolean;
-  litellmModels: Array<{ id: string; name: string }>;
-  litellmDefaultModel: string | null;
-  selectedModel: string;
-  onModelChange: (model: string) => void;
   isPinned: (convId: string) => boolean;
   titleFor: (conv: ConversationWithAgent) => string;
   onPickAgent: () => void;
@@ -2114,13 +2218,6 @@ function LeftPanel({
           providers={providers}
           disabled={!activeAgent || providerChanging}
           onChange={onProviderChange}
-        />
-        <ModelSelect
-          value={selectedModel}
-          models={litellmModels}
-          defaultModel={litellmDefaultModel}
-          disabled={!activeAgent}
-          onChange={onModelChange}
         />
       </div>
 
@@ -2568,6 +2665,9 @@ export interface InputAreaProps {
    *  Rendered as a ⚡ pill in the button row next to attach / mention. */
   fastMode?: boolean;
   onToggleFastMode?: (enabled: boolean) => void;
+  /** Combined model + thinking picker (optional — only the agent chat wires
+   *  it). Rendered in the button row after the fast-mode pill. */
+  modelMenu?: React.ReactNode;
 }
 
 /**
@@ -2601,6 +2701,7 @@ export const InputArea = forwardRef<InputAreaHandle, InputAreaProps>(function In
     renderMentionPicker,
     fastMode,
     onToggleFastMode,
+    modelMenu,
   },
   ref,
 ) {
@@ -2846,6 +2947,7 @@ export const InputArea = forwardRef<InputAreaHandle, InputAreaProps>(function In
                   Fast mode
                 </button>
               )}
+              {modelMenu}
             </div>
 
             {sending ? (
@@ -4794,6 +4896,8 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
   // Per-chat provider fast mode — remembered per agent in localStorage so the
   // choice sticks across reloads. ON ⇒ every turn in this chat sends speed=fast.
   const [fastMode, setFastMode] = useState<boolean>(false);
+  // Per-chat thinking level from the composer's model menu (null = agent default).
+  const [thinkingLevel, setThinkingLevel] = useState<ChatThinkingLevel | null>(null);
   const [leftPanelWidth, setLeftPanelWidth]   = useState<number>(() => {
     try {
       const saved = localStorage.getItem("chat-left-panel-width");
@@ -5023,6 +5127,7 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
    * (no litellm credential, or error) ⇒ the picker hides itself. */
   useEffect(() => {
     setSelectedModel("");
+    setThinkingLevel(null);
     setFastMode(readStoredFastMode(activeAgentSlug));
     if (!activeAgentSlug || !userId) {
       setLitellmModels([]);
@@ -5442,16 +5547,17 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
   // Only an explicit ON is sent — OFF means "whatever the agent is configured
   // with", so the agent-level setting still applies.
   const speedOverride = fastMode ? ("fast" as const) : undefined;
+  const thinkingOverride = thinkingLevel ?? undefined;
 
   const handleRegenerate = useCallback((assistantMessageId: string) => {
     if (!activeAgentSlug || sending) return;
-    void regenerate(activeAgentSlug, userId, assistantMessageId, selectedModel || undefined, speedOverride);
-  }, [activeAgentSlug, sending, regenerate, userId, selectedModel, speedOverride]);
+    void regenerate(activeAgentSlug, userId, assistantMessageId, selectedModel || undefined, speedOverride, thinkingOverride);
+  }, [activeAgentSlug, sending, regenerate, userId, selectedModel, speedOverride, thinkingOverride]);
 
   const handleEditUserMessage = useCallback((userMessageId: string, text: string) => {
     if (!activeAgentSlug || sending) return;
-    void editLatestUserMessage(activeAgentSlug, userId, userMessageId, text, selectedModel || undefined, speedOverride);
-  }, [activeAgentSlug, sending, editLatestUserMessage, userId, selectedModel, speedOverride]);
+    void editLatestUserMessage(activeAgentSlug, userId, userMessageId, text, selectedModel || undefined, speedOverride, thinkingOverride);
+  }, [activeAgentSlug, sending, editLatestUserMessage, userId, selectedModel, speedOverride, thinkingOverride]);
 
   const handleSend = useCallback(() => {
     const text = inputValue.trim();
@@ -5554,8 +5660,10 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
           } : {}),
           // Per-chat model switch: pin the picked LiteLLM model for this turn.
           ...(selectedModel ? { modelOverride: selectedModel } : {}),
-          // Per-chat provider fast mode (sidebar toggle).
+          // Per-chat provider fast mode (composer toggle).
           ...(speedOverride ? { speed: speedOverride } : {}),
+          // Per-chat thinking level (composer model menu).
+          ...(thinkingOverride ? { thinkingLevel: thinkingOverride } : {}),
         });
         if (designSelectionSnapshot) setDesignSelection(null);
         if (manualEditsSnapshot.length > 0) {
@@ -5576,7 +5684,7 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
     };
 
     void dispatch();
-  }, [inputValue, pendingFiles, selectedContext, activeAgentSlug, userId, sending, send, mode, selectedModel, speedOverride, designSelection, designEditScope, designPreviewSource, manualEdits, editedDesignHtml]);
+  }, [inputValue, pendingFiles, selectedContext, activeAgentSlug, userId, sending, send, mode, selectedModel, speedOverride, thinkingOverride, designSelection, designEditScope, designPreviewSource, manualEdits, editedDesignHtml]);
 
   const handleApproveAction = useCallback(async (msgId: string, action: PendingAction) => {
     if (!activeAgentSlug) throw new Error("No active agent selected");
@@ -5655,10 +5763,6 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
             onPickAgent={() => setShowModal(true)}
             onClearAgent={handleClearAgent}
             onProviderChange={handleProviderChange}
-            litellmModels={litellmModels}
-            litellmDefaultModel={litellmDefaultModel}
-            selectedModel={selectedModel}
-            onModelChange={setSelectedModel}
             onNewConversation={handleNewConversation}
             onSelectConv={handleSelectConv}
             onTogglePin={handleTogglePin}
@@ -5860,6 +5964,17 @@ export function ChatPageV3({ mode = "chat" }: ChatPageV3Props) {
                   onToggleMention={handleToggleMention}
                   fastMode={fastMode}
                   onToggleFastMode={handleFastModeChange}
+                  modelMenu={
+                    <ModelThinkingMenu
+                      models={litellmModels}
+                      defaultModel={litellmDefaultModel}
+                      selectedModel={selectedModel}
+                      onSelectModel={setSelectedModel}
+                      thinkingLevel={thinkingLevel}
+                      onSelectThinking={setThinkingLevel}
+                      disabled={sending}
+                    />
+                  }
                   renderMentionPicker={() => (
                     <ContextPicker
                       slug={activeAgent.slug}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
@@ -342,7 +342,7 @@ function ModelThinkingMenu({
                 </span>
               </button>
               {thinkingOpen && (
-                <div className="absolute right-0 top-0 z-50 w-36 translate-x-[calc(100%+8px)] rounded-xl border border-xyne-border bg-xyne-surface p-1 shadow-[0_10px_40px_-8px_rgba(0,0,0,0.35)]">
+                <div className="absolute bottom-0 right-0 z-50 w-36 translate-x-[calc(100%+8px)] rounded-xl border border-xyne-border bg-xyne-surface p-1 shadow-[0_10px_40px_-8px_rgba(0,0,0,0.35)]">
                   {CHAT_THINKING_OPTIONS.map((o) => (
                     <button
                       key={o.label}

--- a/apps/xyne-claw-auth/frontend/src/v3/hooks/useChat.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/hooks/useChat.tsx
@@ -37,6 +37,9 @@ export interface SendOptions {
   /** Per-turn provider fast mode toggle (chat sidebar). Overrides the agent's
    *  saved modelSettings.speed for this run only. */
   speed?: "standard" | "fast";
+  /** Per-turn thinking level (composer model menu). Overrides the agent's
+   *  saved modelSettings.thinkingLevel for this run only. */
+  thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high";
 }
 
 /** A live event delivered by the /live SSE for a conversation being viewed. */
@@ -298,11 +301,11 @@ interface ChatContextValue {
   /** Branching: produce a sibling assistant under the same user parent.
    *  When assistantMessageId is provided, regenerates THAT assistant's reply;
    *  otherwise regenerates the latest visible assistant. */
-  regenerate: (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string, speed?: "standard" | "fast") => Promise<void>;
+  regenerate: (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string, speed?: "standard" | "fast", thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high") => Promise<void>;
   /** Branching: replace the latest visible user message with edited text and
    *  run a new turn as a sibling. Older messages cannot be edited (would
    *  require re-rooting the tree). */
-  editLatestUserMessage: (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string, speed?: "standard" | "fast") => Promise<void>;
+  editLatestUserMessage: (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string, speed?: "standard" | "fast", thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high") => Promise<void>;
   /** Branching: select which child of `parentId` should be visible. */
   selectBranch: (parentId: string, messageId: string) => void;
   /** Cancel the in-flight stream for the active session. No-op if nothing
@@ -575,6 +578,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
             ...(opts?.modelOverride ? { providerOverride: { provider: "litellm", model: opts.modelOverride } } : {}),
             ...(opts?.researchContext ? { researchContext: opts.researchContext } : {}),
             ...(opts?.speed ? { speed: opts.speed } : {}),
+            ...(opts?.thinkingLevel ? { thinkingLevel: opts.thinkingLevel } : {}),
           },
         );
 
@@ -685,7 +689,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   );
 
   const regenerate = useCallback(
-    async (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string, speed?: "standard" | "fast") => {
+    async (agentSlug: string, userId: string, assistantMessageId?: string, modelOverride?: string, speed?: "standard" | "fast", thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high") => {
       const key = activeKey;
       if (!key) return;
       const current = sessions.get(key);
@@ -800,10 +804,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           undefined,                     // signalOrIsEditUserMessage
           undefined,                     // editedUserMessageId
           controller.signal,             // explicit terminal signal
-          // Carry the per-chat model pick + fast mode so regenerate reruns the same way.
+          // Carry the per-chat model pick + fast mode + thinking so regenerate reruns the same way.
           {
             ...(modelOverride ? { providerOverride: { provider: "litellm", model: modelOverride } } : {}),
             ...(speed ? { speed } : {}),
+            ...(thinkingLevel ? { thinkingLevel } : {}),
           },
         );
         updateSession(key, (s) => {
@@ -865,7 +870,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   );
 
   const editLatestUserMessage = useCallback(
-    async (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string, speed?: "standard" | "fast") => {
+    async (agentSlug: string, userId: string, userMessageId: string, text: string, modelOverride?: string, speed?: "standard" | "fast", thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high") => {
       const key = activeKey;
       if (!key || !text.trim()) return;
       const current = sessions.get(key);
@@ -982,10 +987,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           true,                          // isEditUserMessage flag
           originalUser.id,               // editedUserMessageId
           controller.signal,             // explicit terminal signal
-          // Carry the per-chat model pick + fast mode so the edited turn reruns the same way.
+          // Carry the per-chat model pick + fast mode + thinking so the edited turn reruns the same way.
           {
             ...(modelOverride ? { providerOverride: { provider: "litellm", model: modelOverride } } : {}),
             ...(speed ? { speed } : {}),
+            ...(thinkingLevel ? { thinkingLevel } : {}),
           },
         );
         updateSession(key, (s) => {


### PR DESCRIPTION


https://github.com/user-attachments/assets/db90ef94-54e2-49a6-8db0-b42601fbb4d2



https://github.com/user-attachments/assets/bfceef85-a4db-4741-a405-c84636874a6d



## Type of Change

- [x] New feature

## Description

Claw-side per-run model / thinking / fast-mode controls. Contains the claw-auth half of the Spaces dashboard toggle AND the claw chat's own composer menu (dashboard/backend half ships separately on `main` from `feature/spaces-fast-mode-button`). No ticket.

- **`POST /run/stream`** accepts an optional `speed: "standard" | "fast"` (the Spaces composer's per-message ⚡ toggle; invalid values are ignored — this route is a multi-caller pass-through). The effective speed (override, else the agent's `modelSettings.speed`) now feeds `resolveAgentProviderConfigs`, so a fast run uses the agent's fast-mode provider profile. When the run is fast, the agent's stored `modelSettings` (with the effective speed merged) and `fastModeProfile` are forwarded to claw so the speed parameter and run-setting overrides apply. This route otherwise forwards **no** stored model settings, and standard runs stay byte-identical to before.
- **Light agent projection** (`GET /agents`, `view=light`) gains a derived `fastModeConfigured` boolean (config has `modelSettings.speed` and/or a `fastModeProfile`) so chat surfaces can gate the ⚡ toggle to agents that actually have fast mode set up — without exposing the config itself.

**Second commit — per-message thinking override.** `/run/stream` also accepts an optional `thinkingLevel: off | minimal | low | medium | high` (the composer's new Thinking dropdown; invalid values ignored). It is merged over the agent's `modelSettings` for this run and wins over the fast profile's thinking override on fast runs; a standard run with only a thinking override forwards just that one field, so runs without overrides remain byte-identical.

**Later commits:**
- `/run/stream` also accepts a per-message `thinkingLevel` (merged over the agent's model settings for the run; wins over the fast profile's thinking override on fast runs; no-override runs stay byte-identical).
- The **claw chat composer** gains the same combined Claude-style menu as the Spaces dashboard: trigger leads with the model name (the agent's configured model when unset, thinking level beside it), and the menu holds the recommended row (model name first, "(Recommended)" beneath), a search bar over the agent's allowed model list, and a Thinking entry whose options fly out to the right. The sidebar ModelSelect is replaced by it. `POST /agents/:slug/chat` accepts a validated per-message `thinkingLevel`; picks reset on agent change and carry through regenerate / edit-user. Verified with a recorded four-step proof against the stub provider (search filter, picked model serves the run, recommended falls back to the configured provider, Thinking → High lands as effort=high).

## Areas Touched

- [x] `apps/xyne-claw` / `apps/xyne-claw-auth` (claw-auth backend only)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] Existing contract modified — additive: optional `speed` on `POST /run/stream`; `fastModeConfigured` added to the light agents list.

---

## How did you test it?

End-to-end with the Spaces dashboard branch + the local Anthropic stub as the agent's Claude credential. A recorded Playwright script drives the real dashboard composer and asserts each step against the stub's request log (all four pass; recording shared in chat — drag-drop here to attach):

1. agent without fast mode → the composer shows no ⚡ button (`fastModeConfigured` false)
2. agent with fast mode → ⚡ appears
3. ⚡ off → provider request has no `speed`, no beta header (standard path unchanged)
4. ⚡ on → `speed="fast"` + `anthropic-beta: fast-mode-2026-02-01`, and the agent's fast-mode thinking override (`fastModeProfile.modelSettings.thinkingLevel=high` → `output_config.effort=high`) applies

### Automated

- [x] claw-auth unit tests still pass (`agent-config-validation`, `agent-provider-config.fast-profile`)
- [x] claw-auth backend `tsc --noEmit` clean

### Manual

- [x] Single user, dev auth, local dev stack, web browser

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Backend `typecheck` passes (claw-auth)
- [x] No new deps
- [x] Branch is `feature/*`; no ticket id (none given)
- [x] No debug logging or commented-out code left behind
