### PR TITLE
feat: fast mode toggle in the Ask AI composer

### DIFF
--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -108,6 +108,9 @@ const XyneAIRequestSchemaV2 = z.object({
   // word, so camelCase and snake_case are identical — no dual key needed
   // (unlike webSearchEnabled/web_search_enabled above).
   instant: z.boolean().optional().default(false),
+  // Per-message provider fast mode (the composer's ⚡ toggle). Single word →
+  // no snake_case alias needed. Absent = the agent's configured default.
+  speed: z.enum(['standard', 'fast']).optional(),
   researchContext: ResearchContextSchema.optional().nullable(),
   research_context: ResearchContextSchema.optional().nullable(),
   attachments: z
@@ -245,6 +248,7 @@ export class XyneAIControllerV2 {
       deepResearchEnabled: deepResearchEnabledCC,
       deep_research_enabled: deepResearchEnabledSC,
       instant,
+      speed,
       researchContext,
       research_context,
       attachments,
@@ -538,6 +542,7 @@ export class XyneAIControllerV2 {
           webSearchEnabled,
           deepResearchEnabled,
           instant,
+          ...(speed ? { speed } : {}),
           researchContext: effectiveResearchContext,
           ...(sdlcDashboardContext && { dashboardContext: sdlcDashboardContext }),
           createCanvasEnabled,

--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -111,6 +111,9 @@ const XyneAIRequestSchemaV2 = z.object({
   // Per-message provider fast mode (the composer's ⚡ toggle). Single word →
   // no snake_case alias needed. Absent = the agent's configured default.
   speed: z.enum(['standard', 'fast']).optional(),
+  // Per-run thinking level from the composer's dropdown. Absent = the agent's
+  // configured default (modelSettings.thinkingLevel or provider default).
+  thinkingLevel: z.enum(['off', 'minimal', 'low', 'medium', 'high']).optional(),
   researchContext: ResearchContextSchema.optional().nullable(),
   research_context: ResearchContextSchema.optional().nullable(),
   attachments: z
@@ -249,6 +252,7 @@ export class XyneAIControllerV2 {
       deep_research_enabled: deepResearchEnabledSC,
       instant,
       speed,
+      thinkingLevel,
       researchContext,
       research_context,
       attachments,
@@ -543,6 +547,7 @@ export class XyneAIControllerV2 {
           deepResearchEnabled,
           instant,
           ...(speed ? { speed } : {}),
+          ...(thinkingLevel ? { thinkingLevel } : {}),
           researchContext: effectiveResearchContext,
           ...(sdlcDashboardContext && { dashboardContext: sdlcDashboardContext }),
           createCanvasEnabled,

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -108,6 +108,10 @@ export interface ClawRunRequest {
    *  claw-auth's /run/stream, which applies the agent's fast-mode provider
    *  profile + run-setting overrides for this run. Omitted = agent default. */
   speed?: 'standard' | 'fast';
+  /** Per-message thinking level (composer dropdown). Forwarded to claw-auth's
+   *  /run/stream, which merges it over the agent's modelSettings for this run.
+   *  Absent = agent default. */
+  thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high';
 }
 
 export interface ClawRunStreamResult {
@@ -613,6 +617,7 @@ export async function runClawAgentStream(
     ...(request.instant && { instant: true }),
     ...(request.researchContext && { researchContext: request.researchContext }),
     ...(request.speed && { speed: request.speed }),
+    ...(request.thinkingLevel && { thinkingLevel: request.thinkingLevel }),
     agentConfig: {
       webSearchEnabled: String(request.webSearchEnabled),
       deepResearchEnabled: String(request.deepResearchEnabled),

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -104,6 +104,10 @@ export interface ClawRunRequest {
    *  which would let a crafted request rewrite the agent's tools config.
    *  claw-auth re-validates and no-ops the pin if it can't serve it. */
   providerOverride?: { provider: string; model?: string };
+  /** Per-message provider fast mode (the composer's ⚡ toggle). Forwarded to
+   *  claw-auth's /run/stream, which applies the agent's fast-mode provider
+   *  profile + run-setting overrides for this run. Omitted = agent default. */
+  speed?: 'standard' | 'fast';
 }
 
 export interface ClawRunStreamResult {
@@ -155,6 +159,10 @@ export interface AccessibleClawAgent {
    *  askAI composer shows a locked "Instant" indicator instead of its
    *  normal per-message toggle for such agents, and never for others. */
   instantAgent?: boolean;
+  /** True when the agent has fast mode configured (a fast-mode provider
+   *  profile and/or a default speed in its model settings) — from claw-auth's
+   *  lightAgentProjection. Gates the composer's ⚡ Fast mode toggle. */
+  fastModeConfigured?: boolean;
 }
 
 export interface ClawConversationSummary {
@@ -604,6 +612,7 @@ export async function runClawAgentStream(
     ...(request.deepResearchEnabled && { deepResearchEnabled: true }),
     ...(request.instant && { instant: true }),
     ...(request.researchContext && { researchContext: request.researchContext }),
+    ...(request.speed && { speed: request.speed }),
     agentConfig: {
       webSearchEnabled: String(request.webSearchEnabled),
       deepResearchEnabled: String(request.deepResearchEnabled),
@@ -908,6 +917,9 @@ interface RawClawAgent {
   /** Top-level in the light-list response (agents.ts's lightAgentProjection
    *  derives it from config.instantAgent, but doesn't expose config itself). */
   instantAgent?: boolean;
+  /** Computed by claw-auth's lightAgentProjection from config.modelSettings /
+   *  config.fastModeProfile (config itself is not exposed on the light list). */
+  fastModeConfigured?: boolean;
 }
 
 export async function listAccessibleClawAgents(req: {
@@ -989,6 +1001,7 @@ export async function listAccessibleClawAgents(req: {
         rootCollectionId: rootByCollectionId.get(c.collectionId) ?? c.collectionId,
       })),
       instantAgent: agent.instantAgent === true,
+      fastModeConfigured: agent.fastModeConfigured === true,
     };
   });
 

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -389,7 +389,7 @@ function ModelThinkingSelector({
             </span>
           </button>
           {thinkingOpen && (
-            <div className='absolute right-0 top-0 z-50 w-40 translate-x-[calc(100%+6px)] rounded-lg border border-border bg-popover p-1 shadow-lg'>
+            <div className='absolute bottom-0 right-0 z-50 w-40 translate-x-[calc(100%+6px)] rounded-lg border border-border bg-popover p-1 shadow-lg'>
               {THINKING_LEVEL_OPTIONS.map(o => (
                 <button
                   key={o.label}

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -236,6 +236,10 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
   const [webSearchEnabled, setWebSearchEnabled] = useState(() => seed.webSearchEnabled);
   const [deepResearchEnabled, setDeepResearchEnabled] = useState(() => seed.deepResearchEnabled);
   const [createCanvasEnabled, setCreateCanvasEnabled] = useState(() => seed.createCanvasEnabled);
+  // Provider fast mode (⚡). Only meaningful — and only rendered — when the
+  // selected agent has fast mode configured; buildContext forces it false
+  // otherwise so a stale toggle can't ride along after switching agents.
+  const [fastModeEnabled, setFastModeEnabled] = useState(() => seed.fastMode);
 
   // Locked, not a toggle — see xyne-claw-auth's AgentDetailLeftColumn.tsx
   // "Instant Agent" setting and ChatPageV3.tsx's matching indicator. Every
@@ -254,6 +258,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
     [composerAgents, selectedAgentSlug],
   );
   const instant = selectedAgent?.instantAgent === true;
+  const fastModeConfigured = selectedAgent?.fastModeConfigured === true;
 
   const { data: configData } = useQuery<XyneAIConfigResponse>({
     queryKey: ['xyne-ai-config'],
@@ -280,6 +285,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       deepResearchEnabled: deepResearchAccessible ? deepResearchEnabled : false,
       createCanvasEnabled,
       instant,
+      fastMode: fastModeConfigured ? fastModeEnabled : false,
     }),
     [
       selections,
@@ -289,6 +295,8 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       deepResearchEnabled,
       createCanvasEnabled,
       instant,
+      fastModeConfigured,
+      fastModeEnabled,
       webSearchAccessible,
       deepResearchAccessible,
     ],
@@ -774,6 +782,20 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
                 disabled={!deepResearchAccessible}
                 trackName='TOGGLE_DEEP_RESEARCH'
               />
+              {/* Provider fast mode — same credentials, faster serving via the
+                  agent's fast-mode setup (Anthropic fast tier / fast profile,
+                  configured in the claw agent's Model & provider tab). Only
+                  rendered for agents that actually have it configured. */}
+              {fastModeConfigured && (
+                <ToolbarButton
+                  icon={<Zap className='h-4 w-4' aria-hidden strokeWidth={1.75} />}
+                  label={fastModeEnabled ? 'Fast mode enabled' : 'Enable fast mode'}
+                  onClick={() => setFastModeEnabled(v => !v)}
+                  active={fastModeEnabled}
+                  activeClass='bg-secondary text-status-pending'
+                  trackName='TOGGLE_FAST_MODE'
+                />
+              )}
               <ToolbarButton
                 icon={<FileIcon className='h-4 w-4' aria-hidden strokeWidth={1.75} />}
                 label={createCanvasEnabled ? 'Create canvas enabled' : 'Create canvas'}

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -30,12 +30,17 @@ import {
   Zap,
   Brain,
   ChevronDown,
+  ChevronRight,
+  Check,
+  Search,
+  Sparkles,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { DANGEROUS_EXTENSIONS } from '@xyne/shared';
 import { AIAgentSelector } from './AIAgentSelector';
-import { ModelSelector } from '../Chat/XyneAISidebar/components/ModelSelector';
+import { formatModelLabel } from '../Chat/XyneAISidebar/components/ModelSelector';
+import type { ClawAgentModel } from '../../services/clawAgentModelsService';
 import { fetchClawAgentModels } from '../../services/clawAgentModelsService';
 import { Popover } from '../ui/Popover';
 import { ComposerCollectionPicker } from './ComposerCollectionPicker';
@@ -217,54 +222,190 @@ const THINKING_LEVEL_OPTIONS: Array<{ value: 'off' | 'minimal' | 'low' | 'medium
   { value: 'high', label: 'High' },
 ];
 
-function ThinkingSelector({
-  value,
-  onSelect,
+/**
+ * Combined model + thinking picker, styled after the Claude app's model menu:
+ * the trigger leads with the MODEL name ("Recommended" when no pin, with the
+ * thinking level beside it when set), and the menu holds the Recommended row,
+ * a search bar over the account's allowed models, and an expandable Thinking
+ * section (Default / Off / Minimal / Low / Medium / High).
+ */
+function ModelThinkingSelector({
+  models,
+  defaultModel,
+  selectedModel,
+  onSelectModel,
+  thinkingLevel,
+  onSelectThinking,
   disabled,
 }: {
-  value: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null;
-  onSelect: (v: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null) => void;
+  models: ClawAgentModel[];
+  defaultModel: string | null;
+  selectedModel: string | null;
+  onSelectModel: (m: string | null) => void;
+  thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null;
+  onSelectThinking: (v: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null) => void;
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const current = THINKING_LEVEL_OPTIONS.find(o => o.value === value) ?? { value: null, label: 'Default' };
+  const [query, setQuery] = useState('');
+  const [thinkingOpen, setThinkingOpen] = useState(false);
+
+  const selected = useMemo(
+    () => models.find(m => m.id === selectedModel) ?? null,
+    [models, selectedModel],
+  );
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return models;
+    return models.filter(m => m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q));
+  }, [models, query]);
+  const thinkingLabel = THINKING_LEVEL_OPTIONS.find(o => o.value === thinkingLevel)?.label ?? 'Default';
+
+  const rowClass = (active: boolean) =>
+    cn(
+      'flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 mx-0 text-left text-sm transition-colors',
+      active ? 'bg-primary/10 text-primary' : 'hover:bg-accent text-foreground',
+    );
+
   return (
     <Popover
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={o => {
+        setOpen(o);
+        if (!o) {
+          setQuery('');
+          setThinkingOpen(false);
+        }
+      }}
+      align='end'
+      sideOffset={4}
       trigger={
         <button
           type='button'
           disabled={disabled}
-          title={value ? `Thinking: ${current.label} (this chat)` : 'Thinking level — agent default'}
-          aria-label='Thinking level'
-          data-track-name='OPEN_THINKING_SELECTOR'
+          title={selected ? selected.id : defaultModel ? `Recommended (${defaultModel})` : 'Recommended model'}
+          aria-label='Model and thinking'
+          data-track-category='XyneAI'
+          data-track-name='OPEN_MODEL_SELECTOR'
           className={cn(
-            'flex h-7 items-center gap-1 rounded-lg border border-border px-2 text-sm transition-colors',
+            'flex h-7 items-center gap-1.5 rounded-lg border border-border px-2 text-sm transition-colors',
             disabled ? 'cursor-not-allowed opacity-60' : 'hover:bg-accent cursor-pointer',
-            value ? 'text-status-pending' : 'text-muted-foreground',
           )}
         >
-          <Brain className='h-3.5 w-3.5 shrink-0' aria-hidden strokeWidth={1.75} />
-          <span className='font-medium'>{value ? current.label : 'Thinking'}</span>
-          <ChevronDown className='h-3 w-3 shrink-0' aria-hidden />
+          <Sparkles className='h-3.5 w-3.5 shrink-0 text-primary' aria-hidden strokeWidth={1.75} />
+          <span className='font-medium text-foreground truncate max-w-[160px]'>
+            {selected ? formatModelLabel(selected.name) : 'Recommended'}
+          </span>
+          {thinkingLevel && <span className='text-muted-foreground'>{thinkingLabel}</span>}
+          <ChevronDown className='h-3 w-3 shrink-0 text-muted-foreground' aria-hidden />
         </button>
       }
-      className='w-40 p-1'
+      className='w-72 p-0 bg-popover border border-border rounded-lg shadow-lg overflow-hidden'
     >
-      {THINKING_LEVEL_OPTIONS.map(o => (
+      <div className='flex flex-col py-1 px-1'>
+        {/* Recommended — clears the pin; the run uses the model configured in the DB. */}
         <button
-          key={o.label}
           type='button'
-          onClick={() => { onSelect(o.value); setOpen(false); }}
-          className={cn(
-            'flex w-full items-center rounded-md px-2.5 py-1.5 text-left text-sm hover:bg-accent',
-            o.value === value && 'bg-accent font-medium',
-          )}
+          onClick={() => {
+            onSelectModel(null);
+            setOpen(false);
+          }}
+          data-track-category='XyneAI'
+          data-track-name='SELECT_MODEL'
+          data-track-metadata='{"model":"recommended"}'
+          className={rowClass(selectedModel === null)}
         >
-          {o.label}
+          <span className='flex flex-col items-start gap-0.5'>
+            <span className='font-medium'>Recommended</span>
+            {defaultModel && (
+              <span className='text-[11px] text-muted-foreground truncate max-w-full'>
+                {formatModelLabel(defaultModel)}
+              </span>
+            )}
+          </span>
+          {selectedModel === null && <Check className='h-3.5 w-3.5 shrink-0' aria-hidden />}
         </button>
-      ))}
+
+        {models.length > 0 && (
+          <>
+            <div className='my-1 h-px bg-border mx-1' />
+            {/* Search over the account's allowed model list. */}
+            <div className='flex items-center gap-1.5 rounded-md border border-border mx-1 my-0.5 px-2 py-1'>
+              <Search className='h-3.5 w-3.5 shrink-0 text-muted-foreground' aria-hidden />
+              <input
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder='Search models…'
+                data-id='model-search'
+                className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
+              />
+            </div>
+            <div className='flex max-h-56 flex-col overflow-auto'>
+              {filtered.length === 0 ? (
+                <div className='px-2.5 py-2 text-sm text-muted-foreground'>No models match</div>
+              ) : (
+                filtered.map(m => (
+                  <button
+                    key={m.id}
+                    type='button'
+                    title={m.id}
+                    onClick={() => {
+                      onSelectModel(m.id);
+                      setOpen(false);
+                    }}
+                    data-track-category='XyneAI'
+                    data-track-name='SELECT_MODEL'
+                    data-track-metadata={JSON.stringify({ model: m.id })}
+                    className={rowClass(selectedModel === m.id)}
+                  >
+                    <span className='font-medium truncate'>{formatModelLabel(m.name)}</span>
+                    {selectedModel === m.id && <Check className='h-3.5 w-3.5 shrink-0' aria-hidden />}
+                  </button>
+                ))
+              )}
+            </div>
+          </>
+        )}
+
+        <div className='my-1 h-px bg-border mx-1' />
+        {/* Thinking — expands inline to the level options. */}
+        <button
+          type='button'
+          onClick={() => setThinkingOpen(v => !v)}
+          data-id='thinking-expand'
+          aria-expanded={thinkingOpen}
+          className='flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left text-sm hover:bg-accent'
+        >
+          <span className='flex items-center gap-1.5 font-medium'>
+            <Brain className='h-3.5 w-3.5 shrink-0 text-muted-foreground' aria-hidden strokeWidth={1.75} />
+            Thinking
+          </span>
+          <span className='flex items-center gap-1 text-muted-foreground'>
+            {thinkingLabel}
+            {thinkingOpen ? (
+              <ChevronDown className='h-3 w-3 shrink-0' aria-hidden />
+            ) : (
+              <ChevronRight className='h-3 w-3 shrink-0' aria-hidden />
+            )}
+          </span>
+        </button>
+        {thinkingOpen &&
+          THINKING_LEVEL_OPTIONS.map(o => (
+            <button
+              key={o.label}
+              type='button'
+              onClick={() => {
+                onSelectThinking(o.value);
+                setOpen(false);
+              }}
+              data-id={`thinking-option-${o.label.toLowerCase()}`}
+              className={cn('pl-8', rowClass(o.value === thinkingLevel))}
+            >
+              <span>{o.label}</span>
+              {o.value === thinkingLevel && <Check className='h-3.5 w-3.5 shrink-0' aria-hidden />}
+            </button>
+          ))}
+      </div>
     </Popover>
   );
 }
@@ -915,15 +1056,15 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
             </div>
 
             <div className='flex shrink-0 items-center gap-1.5'>
-              <ModelSelector
-                selectedModel={selectedModel}
+              <ModelThinkingSelector
                 models={agentModelsData?.models ?? []}
                 defaultModel={agentModelsData?.defaultModel ?? null}
-                onSelect={setSelectedModel}
+                selectedModel={selectedModel}
+                onSelectModel={setSelectedModel}
+                thinkingLevel={thinkingLevel}
+                onSelectThinking={setThinkingLevel}
                 disabled={pending}
-                compact
               />
-              <ThinkingSelector value={thinkingLevel} onSelect={setThinkingLevel} disabled={pending} />
               {showAgentSelector && (
                 <AIAgentSelector
                   disabled={pending}

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -294,13 +294,17 @@ function ModelThinkingSelector({
         >
           <Sparkles className='h-3.5 w-3.5 shrink-0 text-primary' aria-hidden strokeWidth={1.75} />
           <span className='font-medium text-foreground truncate max-w-[160px]'>
-            {selected ? formatModelLabel(selected.name) : 'Recommended'}
+            {selected
+              ? formatModelLabel(selected.name)
+              : defaultModel
+                ? formatModelLabel(defaultModel)
+                : 'Recommended'}
           </span>
           {thinkingLevel && <span className='text-muted-foreground'>{thinkingLabel}</span>}
           <ChevronDown className='h-3 w-3 shrink-0 text-muted-foreground' aria-hidden />
         </button>
       }
-      className='w-72 p-0 bg-popover border border-border rounded-lg shadow-lg overflow-hidden'
+      className='w-80 p-0 bg-popover border border-border rounded-lg shadow-lg overflow-visible'
     >
       <div className='flex flex-col py-1 px-1'>
         {/* Recommended — clears the pin; the run uses the model configured in the DB. */}
@@ -316,11 +320,9 @@ function ModelThinkingSelector({
           className={rowClass(selectedModel === null)}
         >
           <span className='flex flex-col items-start gap-0.5'>
-            <span className='font-medium'>Recommended</span>
+            <span className='font-medium'>{defaultModel ? formatModelLabel(defaultModel) : 'Recommended'}</span>
             {defaultModel && (
-              <span className='text-[11px] text-muted-foreground truncate max-w-full'>
-                {formatModelLabel(defaultModel)}
-              </span>
+              <span className='text-[11px] text-muted-foreground truncate max-w-full'>(Recommended)</span>
             )}
           </span>
           {selectedModel === null && <Check className='h-3.5 w-3.5 shrink-0' aria-hidden />}
@@ -340,7 +342,7 @@ function ModelThinkingSelector({
                 className='w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground'
               />
             </div>
-            <div className='flex max-h-56 flex-col overflow-auto'>
+            <div className='flex max-h-80 flex-col overflow-auto'>
               {filtered.length === 0 ? (
                 <div className='px-2.5 py-2 text-sm text-muted-foreground'>No models match</div>
               ) : (
@@ -368,43 +370,44 @@ function ModelThinkingSelector({
         )}
 
         <div className='my-1 h-px bg-border mx-1' />
-        {/* Thinking — expands inline to the level options. */}
-        <button
-          type='button'
-          onClick={() => setThinkingOpen(v => !v)}
-          data-id='thinking-expand'
-          aria-expanded={thinkingOpen}
-          className='flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left text-sm hover:bg-accent'
-        >
-          <span className='flex items-center gap-1.5 font-medium'>
-            <Brain className='h-3.5 w-3.5 shrink-0 text-muted-foreground' aria-hidden strokeWidth={1.75} />
-            Thinking
-          </span>
-          <span className='flex items-center gap-1 text-muted-foreground'>
-            {thinkingLabel}
-            {thinkingOpen ? (
-              <ChevronDown className='h-3 w-3 shrink-0' aria-hidden />
-            ) : (
+        {/* Thinking — opens a submenu to the right side of the menu. */}
+        <div className='relative'>
+          <button
+            type='button'
+            onClick={() => setThinkingOpen(v => !v)}
+            data-id='thinking-expand'
+            aria-expanded={thinkingOpen}
+            className='flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left text-sm hover:bg-accent'
+          >
+            <span className='flex items-center gap-1.5 font-medium'>
+              <Brain className='h-3.5 w-3.5 shrink-0 text-muted-foreground' aria-hidden strokeWidth={1.75} />
+              Thinking
+            </span>
+            <span className='flex items-center gap-1 text-muted-foreground'>
+              {thinkingLabel}
               <ChevronRight className='h-3 w-3 shrink-0' aria-hidden />
-            )}
-          </span>
-        </button>
-        {thinkingOpen &&
-          THINKING_LEVEL_OPTIONS.map(o => (
-            <button
-              key={o.label}
-              type='button'
-              onClick={() => {
-                onSelectThinking(o.value);
-                setOpen(false);
-              }}
-              data-id={`thinking-option-${o.label.toLowerCase()}`}
-              className={cn('pl-8', rowClass(o.value === thinkingLevel))}
-            >
-              <span>{o.label}</span>
-              {o.value === thinkingLevel && <Check className='h-3.5 w-3.5 shrink-0' aria-hidden />}
-            </button>
-          ))}
+            </span>
+          </button>
+          {thinkingOpen && (
+            <div className='absolute right-0 top-0 z-50 w-40 translate-x-[calc(100%+6px)] rounded-lg border border-border bg-popover p-1 shadow-lg'>
+              {THINKING_LEVEL_OPTIONS.map(o => (
+                <button
+                  key={o.label}
+                  type='button'
+                  onClick={() => {
+                    onSelectThinking(o.value);
+                    setOpen(false);
+                  }}
+                  data-id={`thinking-option-${o.label.toLowerCase()}`}
+                  className={rowClass(o.value === thinkingLevel)}
+                >
+                  <span>{o.label}</span>
+                  {o.value === thinkingLevel && <Check className='h-3.5 w-3.5 shrink-0' aria-hidden />}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </Popover>
   );

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -28,11 +28,16 @@ import {
   Hash,
   Lock,
   Zap,
+  Brain,
+  ChevronDown,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { DANGEROUS_EXTENSIONS } from '@xyne/shared';
 import { AIAgentSelector } from './AIAgentSelector';
+import { ModelSelector } from '../Chat/XyneAISidebar/components/ModelSelector';
+import { fetchClawAgentModels } from '../../services/clawAgentModelsService';
+import { Popover } from '../ui/Popover';
 import { ComposerCollectionPicker } from './ComposerCollectionPicker';
 import { ComposerVoiceButton } from './ComposerVoiceButton';
 import { cn } from '../../utils/classNames';
@@ -200,6 +205,70 @@ function ToolbarButton({
   );
 }
 
+/** Per-run thinking level for the composer. null = the agent's configured
+ *  default. Applies to whichever provider serves the run (same precedence as
+ *  the agent's modelSettings.thinkingLevel). */
+const THINKING_LEVEL_OPTIONS: Array<{ value: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null; label: string }> = [
+  { value: null, label: 'Default' },
+  { value: 'off', label: 'Off' },
+  { value: 'minimal', label: 'Minimal' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+function ThinkingSelector({
+  value,
+  onSelect,
+  disabled,
+}: {
+  value: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null;
+  onSelect: (v: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = THINKING_LEVEL_OPTIONS.find(o => o.value === value) ?? { value: null, label: 'Default' };
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      trigger={
+        <button
+          type='button'
+          disabled={disabled}
+          title={value ? `Thinking: ${current.label} (this chat)` : 'Thinking level — agent default'}
+          aria-label='Thinking level'
+          data-track-name='OPEN_THINKING_SELECTOR'
+          className={cn(
+            'flex h-7 items-center gap-1 rounded-lg border border-border px-2 text-sm transition-colors',
+            disabled ? 'cursor-not-allowed opacity-60' : 'hover:bg-accent cursor-pointer',
+            value ? 'text-status-pending' : 'text-muted-foreground',
+          )}
+        >
+          <Brain className='h-3.5 w-3.5 shrink-0' aria-hidden strokeWidth={1.75} />
+          <span className='font-medium'>{value ? current.label : 'Thinking'}</span>
+          <ChevronDown className='h-3 w-3 shrink-0' aria-hidden />
+        </button>
+      }
+      className='w-40 p-1'
+    >
+      {THINKING_LEVEL_OPTIONS.map(o => (
+        <button
+          key={o.label}
+          type='button'
+          onClick={() => { onSelect(o.value); setOpen(false); }}
+          className={cn(
+            'flex w-full items-center rounded-md px-2.5 py-1.5 text-left text-sm hover:bg-accent',
+            o.value === value && 'bg-accent font-medium',
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </Popover>
+  );
+}
+
 export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function AIComposer(
   {
     autoFocus,
@@ -240,6 +309,12 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
   // selected agent has fast mode configured; buildContext forces it false
   // otherwise so a stale toggle can't ride along after switching agents.
   const [fastModeEnabled, setFastModeEnabled] = useState(() => seed.fastMode);
+  // Per-run model pin + thinking level. The model list is the account's allowed
+  // models off the selected agent's shared LiteLLM key; "Default" = the model
+  // configured in the DB. Both reset when the agent changes — a pick from one
+  // agent's list may not exist on another's.
+  const [selectedModel, setSelectedModel] = useState<string | null>(() => seed.model);
+  const [thinkingLevel, setThinkingLevel] = useState<'off' | 'minimal' | 'low' | 'medium' | 'high' | null>(() => seed.thinkingLevel);
 
   // Locked, not a toggle — see xyne-claw-auth's AgentDetailLeftColumn.tsx
   // "Instant Agent" setting and ChatPageV3.tsx's matching indicator. Every
@@ -259,6 +334,17 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
   );
   const instant = selectedAgent?.instantAgent === true;
   const fastModeConfigured = selectedAgent?.fastModeConfigured === true;
+
+  const modelAgentSlug = selectedAgentSlug ?? 'ask-ai';
+  const { data: agentModelsData } = useQuery({
+    queryKey: ['claw-agent-models', modelAgentSlug],
+    queryFn: () => fetchClawAgentModels(modelAgentSlug),
+    staleTime: 60_000,
+  });
+  useEffect(() => {
+    setSelectedModel(null);
+    setThinkingLevel(null);
+  }, [modelAgentSlug]);
 
   const { data: configData } = useQuery<XyneAIConfigResponse>({
     queryKey: ['xyne-ai-config'],
@@ -286,6 +372,8 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       createCanvasEnabled,
       instant,
       fastMode: fastModeConfigured ? fastModeEnabled : false,
+      model: selectedModel,
+      thinkingLevel,
     }),
     [
       selections,
@@ -297,6 +385,8 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       instant,
       fastModeConfigured,
       fastModeEnabled,
+      selectedModel,
+      thinkingLevel,
       webSearchAccessible,
       deepResearchAccessible,
     ],
@@ -825,6 +915,15 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
             </div>
 
             <div className='flex shrink-0 items-center gap-1.5'>
+              <ModelSelector
+                selectedModel={selectedModel}
+                models={agentModelsData?.models ?? []}
+                defaultModel={agentModelsData?.defaultModel ?? null}
+                onSelect={setSelectedModel}
+                disabled={pending}
+                compact
+              />
+              <ThinkingSelector value={thinkingLevel} onSelect={setThinkingLevel} disabled={pending} />
               {showAgentSelector && (
                 <AIAgentSelector
                   disabled={pending}

--- a/apps/dashboard/src/components/AIScreen/composerContext.ts
+++ b/apps/dashboard/src/components/AIScreen/composerContext.ts
@@ -35,6 +35,10 @@ export interface ComposerContext {
   /** Single search + single answer pass instead of the full agentic tool
    *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
   instant: boolean;
+  /** Provider fast mode (⚡ toggle) — same credentials, the agent's fast-mode
+   *  provider profile / run-setting overrides. Only offered when the selected
+   *  agent has fast mode configured; false otherwise. */
+  fastMode: boolean;
 }
 
 export const EMPTY_COMPOSER_CONTEXT: ComposerContext = {
@@ -50,6 +54,7 @@ export const EMPTY_COMPOSER_CONTEXT: ComposerContext = {
   deepResearchEnabled: false,
   createCanvasEnabled: false,
   instant: false,
+  fastMode: false,
 };
 
 /** True when the snapshot carries any context/toggle worth sending as overrides. */
@@ -66,7 +71,8 @@ export function hasComposerContext(ctx: ComposerContext): boolean {
     ctx.webSearchEnabled ||
     ctx.deepResearchEnabled ||
     ctx.createCanvasEnabled ||
-    ctx.instant
+    ctx.instant ||
+    ctx.fastMode
   );
 }
 
@@ -95,6 +101,7 @@ export function toStreamOverrides(ctx: ComposerContext): StreamOverrides {
     deepResearchEnabled: ctx.deepResearchEnabled,
     createCanvasEnabled: ctx.createCanvasEnabled,
     instant: ctx.instant,
+    ...(ctx.fastMode ? { speed: 'fast' as const } : {}),
     researchContext: ctx.research,
   };
 }

--- a/apps/dashboard/src/components/AIScreen/composerContext.ts
+++ b/apps/dashboard/src/components/AIScreen/composerContext.ts
@@ -39,6 +39,14 @@ export interface ComposerContext {
    *  provider profile / run-setting overrides. Only offered when the selected
    *  agent has fast mode configured; false otherwise. */
   fastMode: boolean;
+  /** Per-run model pin from the composer's model dropdown. The list comes from
+   *  the account's allowed models (the agent's shared LiteLLM key's /v1/models);
+   *  null = "Default" — the model configured in the DB. A pick is the source of
+   *  truth for the run: it overrides the agent's configured model. */
+  model: string | null;
+  /** Per-run thinking level from the composer's thinking dropdown.
+   *  null = the agent's configured default. */
+  thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null;
 }
 
 export const EMPTY_COMPOSER_CONTEXT: ComposerContext = {
@@ -55,6 +63,8 @@ export const EMPTY_COMPOSER_CONTEXT: ComposerContext = {
   createCanvasEnabled: false,
   instant: false,
   fastMode: false,
+  model: null,
+  thinkingLevel: null,
 };
 
 /** True when the snapshot carries any context/toggle worth sending as overrides. */
@@ -72,7 +82,9 @@ export function hasComposerContext(ctx: ComposerContext): boolean {
     ctx.deepResearchEnabled ||
     ctx.createCanvasEnabled ||
     ctx.instant ||
-    ctx.fastMode
+    ctx.fastMode ||
+    ctx.model !== null ||
+    ctx.thinkingLevel !== null
   );
 }
 
@@ -102,6 +114,8 @@ export function toStreamOverrides(ctx: ComposerContext): StreamOverrides {
     createCanvasEnabled: ctx.createCanvasEnabled,
     instant: ctx.instant,
     ...(ctx.fastMode ? { speed: 'fast' as const } : {}),
+    ...(ctx.model ? { model: ctx.model } : {}),
+    ...(ctx.thinkingLevel ? { thinkingLevel: ctx.thinkingLevel } : {}),
     researchContext: ctx.research,
   };
 }

--- a/apps/dashboard/src/hooks/useXyneAIStream.ts
+++ b/apps/dashboard/src/hooks/useXyneAIStream.ts
@@ -30,6 +30,12 @@ export interface StreamOverrides {
   instant?: boolean;
   /** Per-message provider fast mode (composer ⚡ toggle). Absent = agent default. */
   speed?: 'standard' | 'fast';
+  /** Per-run model pin from the composer's model dropdown. Absent = hook-level
+   *  `model` (the sidebar's picker), which itself defaults to the DB-configured
+   *  model. A pick is the source of truth for the run. */
+  model?: string | null;
+  /** Per-run thinking level. Absent = the agent's configured default. */
+  thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high';
   researchContext?: ResearchContext | null;
   ticketIds?: string[];
   canvasIds?: string[];
@@ -293,6 +299,8 @@ export const useXyneAIStream = ({
         ov && 'createCanvasEnabled' in ov ? !!ov.createCanvasEnabled : createCanvasEnabled;
       const eInstant = ov && 'instant' in ov ? !!ov.instant : instant;
       const eSpeed = ov?.speed;
+      const eModel = ov && 'model' in ov ? (ov.model ?? null) : model;
+      const eThinkingLevel = ov?.thinkingLevel;
       const eResearchContext =
         ov && 'researchContext' in ov ? (ov.researchContext ?? null) : researchContext;
       const eChannelIds = ov?.channelIds ?? channelIds;
@@ -431,7 +439,8 @@ export const useXyneAIStream = ({
           agentSlug: agentSlug ?? undefined,
           // v1 resolves its model from env and ignores the pin, so only send it
           // on v2 rather than letting a stale pick ride along invisibly.
-          ...(isV2 && model ? { model } : {}),
+          ...(isV2 && eModel ? { model: eModel } : {}),
+          ...(eThinkingLevel ? { thinkingLevel: eThinkingLevel } : {}),
           ...(suppressCompletionToast && { suppressCompletionToast: true }),
           version: isV2 ? 'v2' : 'v1',
         },

--- a/apps/dashboard/src/hooks/useXyneAIStream.ts
+++ b/apps/dashboard/src/hooks/useXyneAIStream.ts
@@ -28,6 +28,8 @@ export interface StreamOverrides {
   /** Single search + single answer pass instead of the full agentic tool
    *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
   instant?: boolean;
+  /** Per-message provider fast mode (composer ⚡ toggle). Absent = agent default. */
+  speed?: 'standard' | 'fast';
   researchContext?: ResearchContext | null;
   ticketIds?: string[];
   canvasIds?: string[];
@@ -290,6 +292,7 @@ export const useXyneAIStream = ({
       const eCreateCanvasEnabled =
         ov && 'createCanvasEnabled' in ov ? !!ov.createCanvasEnabled : createCanvasEnabled;
       const eInstant = ov && 'instant' in ov ? !!ov.instant : instant;
+      const eSpeed = ov?.speed;
       const eResearchContext =
         ov && 'researchContext' in ov ? (ov.researchContext ?? null) : researchContext;
       const eChannelIds = ov?.channelIds ?? channelIds;
@@ -412,6 +415,7 @@ export const useXyneAIStream = ({
           deepResearchEnabled: eDeepResearchEnabled,
           createCanvasEnabled: eCreateCanvasEnabled,
           instant: eInstant,
+          ...(eSpeed ? { speed: eSpeed } : {}),
           researchContext: eResearchContext,
           attachments,
           parentMessageId,

--- a/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
+++ b/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
@@ -95,6 +95,8 @@ export interface StreamRequest {
   instant?: boolean;
   /** Per-message provider fast mode (composer ⚡ toggle). Absent = agent default. */
   speed?: 'standard' | 'fast';
+  /** Per-run thinking level (composer dropdown). Absent = agent default. */
+  thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high';
   researchContext?: ResearchContext | null | undefined;
   attachments: MessageAttachment[];
   parentMessageId?: string | undefined;
@@ -1055,6 +1057,7 @@ class XyneAIStreamManager {
           createCanvasEnabled: request.createCanvasEnabled ?? false,
           instant: request.instant ?? false,
           ...(request.speed ? { speed: request.speed } : {}),
+          ...(request.thinkingLevel ? { thinkingLevel: request.thinkingLevel } : {}),
           researchContext: request.researchContext
             ? request.researchContext.id
               ? {

--- a/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
+++ b/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
@@ -93,6 +93,8 @@ export interface StreamRequest {
   /** Single search + single answer pass instead of the full agentic tool
    *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
   instant?: boolean;
+  /** Per-message provider fast mode (composer ⚡ toggle). Absent = agent default. */
+  speed?: 'standard' | 'fast';
   researchContext?: ResearchContext | null | undefined;
   attachments: MessageAttachment[];
   parentMessageId?: string | undefined;
@@ -1052,6 +1054,7 @@ class XyneAIStreamManager {
           deepResearchEnabled: request.deepResearchEnabled ?? false,
           createCanvasEnabled: request.createCanvasEnabled ?? false,
           instant: request.instant ?? false,
+          ...(request.speed ? { speed: request.speed } : {}),
           researchContext: request.researchContext
             ? request.researchContext.id
               ? {

--- a/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
+++ b/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
@@ -37,6 +37,8 @@ export interface WorkerStartStreamMessage {
       /** Single search + single answer pass instead of the full agentic tool
        *  loop — see xyne-claw-auth's run-stream.ts POST / instant branch. */
       instant?: boolean;
+      /** Per-message provider fast mode (composer ⚡ toggle). Absent = agent default. */
+      speed?: 'standard' | 'fast';
       researchContext?: { type: string; id?: string; name: string } | null;
       canvasId?: string;
       messageAttachmentIds?: string[];
@@ -184,6 +186,7 @@ async function executeStream(
         deep_research_enabled: requestBody.deepResearchEnabled ?? false,
         create_canvas_enabled: requestBody.createCanvasEnabled ?? false,
         instant: requestBody.instant ?? false,
+        ...(requestBody.speed ? { speed: requestBody.speed } : {}),
         research_context: requestBody.researchContext ?? null,
         ...(requestBody.canvasId && {
           canvas_id: requestBody.canvasId,

--- a/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
+++ b/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
@@ -39,6 +39,8 @@ export interface WorkerStartStreamMessage {
       instant?: boolean;
       /** Per-message provider fast mode (composer ⚡ toggle). Absent = agent default. */
       speed?: 'standard' | 'fast';
+      /** Per-run thinking level (composer dropdown). Absent = agent default. */
+      thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high';
       researchContext?: { type: string; id?: string; name: string } | null;
       canvasId?: string;
       messageAttachmentIds?: string[];
@@ -187,6 +189,7 @@ async function executeStream(
         create_canvas_enabled: requestBody.createCanvasEnabled ?? false,
         instant: requestBody.instant ?? false,
         ...(requestBody.speed ? { speed: requestBody.speed } : {}),
+        ...(requestBody.thinkingLevel ? { thinkingLevel: requestBody.thinkingLevel } : {}),
         research_context: requestBody.researchContext ?? null,
         ...(requestBody.canvasId && {
           canvas_id: requestBody.canvasId,

--- a/apps/dashboard/src/services/clawAgentListService.ts
+++ b/apps/dashboard/src/services/clawAgentListService.ts
@@ -32,6 +32,10 @@ export interface AccessibleClawAgent {
    *  search/single-answer instant KB path — the composer shows a locked
    *  "Instant" indicator for it instead of the normal per-message toggle. */
   instantAgent?: boolean;
+  /** True when the agent has fast mode configured (fast-mode provider profile
+   *  and/or a default speed in its model settings). Gates the composer's
+   *  ⚡ Fast mode toggle — agents without it show no fast-mode affordance. */
+  fastModeConfigured?: boolean;
 }
 
 export async function fetchAccessibleClawAgents(): Promise<AccessibleClawAgent[]> {


### PR DESCRIPTION


https://github.com/user-attachments/assets/b1d3ed38-5c65-4b5b-a206-c1752cc8a8c4



## Type of Change

- [x] New feature

## Description

Adds a per-message **⚡ Fast mode** toggle to the Ask AI composer on `/ai`, shown **only for agents that have fast mode configured** in claw (surfaced by claw-auth's light agent projection as `fastModeConfigured`; claw-auth half ships from `feature/claw-fast-mode-run-stream` on the deploy branch). No ticket.

- The button sits in the composer toolbar next to web search / deep research, using the same `ToolbarButton` pattern; agents without fast mode show no affordance and never send the field.
- Plumbing mirrors the `instant` flag end to end: `AIComposer` state → `ComposerContext.fastMode` → `toStreamOverrides` (`speed: 'fast'`) → `useXyneAIStream` → `XyneAIStreamManager` / stream worker body → `xyneAIControllerV2` (`speed: z.enum(['standard','fast']).optional()`) → `ClawRunRequest.speed` → claw-auth `/run/stream`.
- Absent `speed` = the agent's configured default, so existing behavior is untouched.

**Fourth commit** puts the model name first: the recommended row leads with the DB-configured model and shows "(Recommended)" beneath; the trigger pill shows that model when no pin is set.

**Third commit** reshapes the two dropdowns into one Claude-style menu: the trigger leads with the model name ("Recommended" when unset, thinking level beside it), and the menu holds the Recommended row (labeled from the DB), a search bar over the allowed model list, and an expandable Thinking section.

**Second commit — model + thinking dropdowns.** The composer also gains two per-run dropdowns next to the agent selector:
- **Model** — reuses the sidebar's `ModelSelector`: the list is the account's allowed models (the agent's shared LiteLLM key's `/v1/models`) and "Default" is labeled with the model configured in the DB. A pick is the source of truth for the run — it rides the existing validated model pin (`providerOverride`), which wins over the agent's configured provider/model. Hidden when the agent has no LiteLLM credential.
- **Thinking** — Default / Off / Minimal / Low / Medium / High, sent as an optional zod-validated `thinkingLevel` and merged over the agent's model settings for this run by claw-auth's `/run/stream`. Absent = agent default.

Both reset on agent change. Verified with a second recorded proof (shared in chat): the allowed list + DB default render, a picked model actually serves the run, Default falls back to the agent's configured model, and Thinking → High reaches the provider as `effort=high`.

## Areas Touched

- [x] `apps/backend` (API)
- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] Existing contract modified — additive: optional `speed` on the xyne-ai chat request; `fastModeConfigured` passed through on `GET /api/xyne-ai/agents`.

---

## How did you test it?

End-to-end against a local claw stack (claw-auth branch above) with a stub Anthropic endpoint as the test agent's Claude credential. Recorded Playwright proof driving the real `/ai` composer, each step asserted from the stub's request log — all four pass (recording shared in chat; drag-drop here to attach):

1. normal agent → no ⚡ button
2. fast-mode-configured agent → ⚡ appears
3. ⚡ off → request has no `speed` parameter
4. ⚡ on → `speed="fast"` + fast-mode beta header, and the agent's fast-mode thinking override applies

### Automated

- [x] Dashboard `tsc --noEmit` clean
- [x] Backend: no new type errors in touched files (`clawAgentService`, `xyneAIControllerV2`) — full backend `tsc` has ~2.6k pre-existing errors in this env (ungenerated clients), identical before/after
- [ ] Not covered by unit tests — UI toggle + passthrough; covered by the recorded E2E above

### Manual

- [x] Single user, dev auth (`ENABLE_DEV_AUTH`), local dev, web browser

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Dashboard `typecheck` passes
- [x] No new deps
- [x] Branch is `feature/*`; no ticket id (none given)
- [x] No debug logging or commented-out code left behind
