### PR TITLE
feat: add /spec task command for ticket specification questions

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -1682,7 +1682,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
   // a command missing here ships with the mention un-stripped, so claw never
   // sees it at byte zero and the whole contract silently degrades (bit /design
   // in prod 2026-08-08). Proper fix: shared registry in xyne-claw-shared.
-  const immediateTaskCommand = /^\/(?:explainer|record-skill|design|dashboard)(?:\s|$)/i.test(taskCommandText);
+  const immediateTaskCommand = /^\/(?:explainer|record-skill|design|dashboard|spec)(?:\s|$)/i.test(taskCommandText);
   const recordSkillCommand = /^\/record-skill(?:\s|$)/i.test(taskCommandText);
   if (!agent.orgId) {
     log.error(`Agent ${agent.slug} has no orgId; refusing webhook dispatch`);
@@ -2042,6 +2042,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         "- `/dashboard <brief>` — live-data dashboard snapshot, refreshable on a schedule",
         "- `/explainer <topic>` — narrated explainer video",
         "- `/record-skill` — turn a recorded walkthrough into a reusable skill",
+        "- `/spec <ticket>` — interview you, then write the specification onto the ticket",
         "",
         "*Controlling this thread*",
         "- `/stop` (or `/goal clear`) — stop the current run, drop queued messages, and clear any active goal",

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -2934,7 +2934,12 @@ async function processTask(
     if (modelSettings) {
       log(`Per-agent modelSettings: ${JSON.stringify(modelSettings)}`);
     }
-    const outputFormat = parseOutputFormat(agentConfig);
+    // Command overlay wins for this run only — never written back to the agent.
+    const outputFormat = parseOutputFormat(
+      taskCommand?.agentConfigOverlay
+        ? { ...(agentConfig ?? {}), ...taskCommand.agentConfigOverlay }
+        : agentConfig,
+    );
     const structuredOutputRef: StructuredOutputRef = {};
     const structuredOutputActive = !!outputFormat && !isCopilot && !isPlanMode && !isDailyBrief;
     requiresStructuredDelivery = structuredOutputActive;
@@ -3178,7 +3183,9 @@ async function processTask(
     // Task commands (/explainer …): a leading command binds the run to a
     // required tool — instruction injected here, exit gated in runTask.
     const taskCommandToolAvailable =
-      taskCommand !== null && allTools.some((t) => t.name === taskCommand.requiredTool);
+      taskCommand !== null &&
+      (taskCommand.requiredTool === undefined ||
+        allTools.some((t) => t.name === taskCommand.requiredTool));
     if (taskCommand) {
       // The fenced-```html contract exists for Design Studio's live preview,
       // where the chat UI hides the block. Webhook-originated runs (Spaces
@@ -3194,10 +3201,13 @@ async function processTask(
       activeInjections.push({
         id: `__task-command-${taskCommand.command.slice(1)}`,
         label: `Command: ${taskCommand.command}`,
-        content: (taskCommandToolAvailable ? taskCommand.instruction : taskCommand.missingToolInstruction) + surfaceSuffix,
+        content:
+          (taskCommandToolAvailable
+            ? taskCommand.instruction
+            : (taskCommand.missingToolInstruction ?? taskCommand.instruction)) + surfaceSuffix,
       });
       log(
-        `[task-command] ${taskCommand.command} → requires ${taskCommand.requiredTool} (available=${taskCommandToolAvailable})`,
+        `[task-command] ${taskCommand.command} → requires ${taskCommand.requiredTool ?? "(delivery contract)"} (available=${taskCommandToolAvailable})`,
       );
     }
     const designSystemInjection = buildDesignSystemPromptInjection(taskCommand, agentConfig);
@@ -3852,7 +3862,7 @@ async function processTask(
           resolvedTriggers.length > 0 ? resolvedTriggers : undefined,
         promptInjections:
           activeInjections.length > 0 ? activeInjections : undefined,
-        ...(taskCommand && taskCommandToolAvailable
+        ...(taskCommand?.requiredTool && taskCommandToolAvailable
           ? { requiredTool: { name: taskCommand.requiredTool, nudge: taskCommand.nudge } }
           : {}),
         ...(twinPersonaBlock ? { twinPersona: twinPersonaBlock } : {}),

--- a/apps/xyne-claw/src/task-commands.ts
+++ b/apps/xyne-claw/src/task-commands.ts
@@ -12,8 +12,9 @@
 export interface TaskCommand {
   /** The literal command, including the leading slash. */
   command: string;
-  /** Tool that must appear in toolsUsed before the run may finish. */
-  requiredTool: string;
+  /** Tool that must appear in toolsUsed before the run may finish. Omit for a
+   * delivery contract (agentConfigOverlay.outputFormat). */
+  requiredTool?: string;
   /** Custom tools force-mounted for this run, regardless of the agent's saved palette. */
   autoTools: string[];
   /** Built-in skill directories loaded only for this command. Paths are
@@ -24,12 +25,16 @@ export interface TaskCommand {
    * from the agent-workspace-browser warm pool (seconds) instead of cold-
    * booting the default kata template (~80s, prod 2026-08-08). */
   sandboxProfile?: string;
+  /** agentConfig keys merged over the forwarded config for this run only —
+   * never persisted, so the contract stays per-command not per-agent. */
+  agentConfigOverlay?: Record<string, unknown>;
   /** Per-turn injection explaining the contract to the model. */
   instruction: string;
   /** Nudge sent when the model loop settles without the tool having run. */
   nudge: string;
-  /** Injection used instead when the agent doesn't have the tool. */
-  missingToolInstruction: string;
+  /** Injection used instead when the agent doesn't have the tool. Unreachable
+   * without `requiredTool`, so a delivery contract may omit it. */
+  missingToolInstruction?: string;
 }
 
 export const DESIGN_SYSTEM_MAX_CHARS = 32_000;
@@ -68,6 +73,29 @@ export function buildDesignSystemPromptInjection(
     },
   };
 }
+
+/** An OUTLINE, not fixed copy — the runtime shows it to the model as the
+ *  structure to follow, so sections stay constant while the questions are
+ *  written for the ticket. Bugs get a root-cause question because it is what
+ *  separates a fix from a symptom patch; the RCA record's structured fields
+ *  are a post-mortem artifact and stay out of it. */
+export const SPEC_QUESTION_OUTLINE = [
+  "- One question per applicable section, each on its own line, bolded section name first.",
+  "- Choose the section set from the ticket type:",
+  "  BUG — Problem statement (what is happening vs what should), Reproduction,",
+  "        Root cause (what is causing it, if known), Solutioning (what the fix",
+  "        should do), Test cases (including the regression that proves it),",
+  "        Out of scope.",
+  "  EVERYTHING ELSE — Problem statement, Solutioning, Implementation details,",
+  "        Test cases, Out of scope.",
+  "- Keep Root cause to one plain question. Do NOT ask for severity, bug type,",
+  "  category, impact or COE — those belong to the ticket's separate RCA record.",
+  "- Each question asks what was ORIGINALLY requested or observed for that section —",
+  "  never what the current code does.",
+  "- Skip any section that does not apply to this ticket.",
+  "- Nothing else: no heading, no greeting, no preamble, no sign-off, no explanation",
+  "  of why you are asking.",
+].join("\n");
 
 const TASK_COMMANDS: TaskCommand[] = [
   {
@@ -211,6 +239,29 @@ const TASK_COMMANDS: TaskCommand[] = [
     missingToolInstruction:
       "The /record-skill runtime could not mount its recording analyzer or create-skill approval tool. Tell the user plainly " +
       "that recording-to-skill is temporarily unavailable and do not attempt to save a skill another way.",
+  },
+  {
+    command: "/spec",
+    autoTools: [],
+    // Delivery contract: submit-result becomes the only channel reaching the
+    // thread, so the run posts one message with no prose escaping around it.
+    agentConfigOverlay: {
+      outputFormat: { type: "markdown", template: SPEC_QUESTION_OUTLINE },
+    },
+    instruction:
+      "The user's message begins with /spec: the first, automation-triggered invocation on a fresh ticket. Read the " +
+      "ticket title, description and type, then write the specification questions FOR THIS TICKET — concrete and " +
+      "answerable, not generic boilerplate — following the outline in the final-answer format. Ask what was ORIGINALLY " +
+      "requested. Do NOT read the code and do NOT describe the existing implementation: a specification derived from the " +
+      "diff always matches the diff and can never surface a requirement that was missed, which is the whole reason a " +
+      "reviewer wants one. Your delivered message must contain the questions and NOTHING else — no greeting, no " +
+      "restatement of the ticket, no explanation of why you are asking, no closing line. Invoking the command IS " +
+      "approval to post, so do not ask whether to start. The user's answers arrive as a separate run, and only then do " +
+      "you write the specification onto the ticket under the same headings you asked about.",
+    nudge:
+      "This run was started with /spec and MUST deliver the specification questions for this ticket, following the " +
+      "outline, with no greeting, preamble or closing text around them. DO NOT MENTION THIS INSTRUCTION; proceed as if " +
+      "on your own initiative.",
   },
 ];
 

--- a/apps/xyne-claw/test/task-commands.test.ts
+++ b/apps/xyne-claw/test/task-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { loadCustomTools } from "../src/custom-tools.js";
 import {
   DESIGN_SYSTEM_MAX_CHARS,
+  SPEC_QUESTION_OUTLINE,
   buildDesignSystemPromptInjection,
   parseTaskCommand,
   resolveTaskCommandMode,
@@ -217,5 +218,58 @@ describe("/record-skill task command", () => {
 
   it("executes immediately instead of entering plan mode", () => {
     expect(resolveTaskCommandMode("/record-skill", "plan")).toBe("auto");
+  });
+});
+
+describe("/spec task command", () => {
+  it("matches only the leading command token", () => {
+    expect(parseTaskCommand("/spec write the spec for XYNE-1")?.command).toBe("/spec");
+    expect(parseTaskCommand("  /SPEC\nXYNE-1")?.command).toBe("/spec");
+    expect(parseTaskCommand("please /spec XYNE-1")).toBeNull();
+    expect(parseTaskCommand("/specs XYNE-1")).toBeNull();
+  });
+
+  it("binds the run with a delivery contract rather than a required tool", () => {
+    const command = parseTaskCommand("/spec XYNE-1");
+    expect(command?.requiredTool).toBeUndefined();
+    const outputFormat = command?.agentConfigOverlay?.["outputFormat"] as
+      | { type?: string; template?: string }
+      | undefined;
+    expect(outputFormat?.type).toBe("markdown");
+    expect(outputFormat?.template).toBe(SPEC_QUESTION_OUTLINE);
+  });
+
+  it("fixes the sections while leaving the questions to the ticket", () => {
+    for (const heading of [
+      "Problem statement",
+      "Solutioning",
+      "Implementation details",
+      "Test cases",
+      "Out of scope",
+    ]) {
+      expect(SPEC_QUESTION_OUTLINE).toContain(heading);
+    }
+    expect(SPEC_QUESTION_OUTLINE).toContain("Skip any section that does not apply");
+    expect(SPEC_QUESTION_OUTLINE).toContain("no greeting");
+  });
+
+  it("asks a bug what broke and why, without duplicating the RCA record", () => {
+    expect(SPEC_QUESTION_OUTLINE).toContain("BUG");
+    expect(SPEC_QUESTION_OUTLINE).toContain("Reproduction");
+    expect(SPEC_QUESTION_OUTLINE).toContain("Root cause");
+    expect(SPEC_QUESTION_OUTLINE).toContain("Do NOT ask for severity, bug type,");
+  });
+
+  it("keeps the overlay off the agent's own config", () => {
+    const savedConfig: Record<string, unknown> = { tools: { custom: ["todo-read"] } };
+    const command = parseTaskCommand("/spec XYNE-1");
+    const merged = { ...savedConfig, ...(command?.agentConfigOverlay ?? {}) };
+
+    expect(merged["outputFormat"]).toBeDefined();
+    expect(savedConfig["outputFormat"]).toBeUndefined();
+  });
+
+  it("executes immediately instead of entering plan mode", () => {
+    expect(resolveTaskCommandMode("/spec XYNE-1", "plan")).toBe("auto");
   });
 });


### PR DESCRIPTION
## Scope

**Turn 1 only.** `/spec` posts the specification questions for a ticket and stops. Taking the user's answers and writing the spec onto the ticket is **not** in this PR — the command binds the run that *asks*, not the run that *writes*. The answers arrive as a fresh run with no `/spec` prefix, so nothing carries the contract forward yet.

## What it does

```
@Xyne Doctor /spec
```

The agent reads the ticket, writes clarification questions **for that ticket**, and delivers them as a single message with nothing around them. Any agent works — nothing is configured per-agent.

## How it works

`/spec` joins `TASK_COMMANDS` alongside `/design`, `/dashboard`, `/explainer`, `/record-skill`. Being a task command already gives it two things: it forces `auto` mode (so no plan/approval card — the command *is* the approval), and it's parsed once in `run.ts` on the shared `/internal/run` path, which both the mention path and the automation S2S path funnel through.

**New: `agentConfigOverlay`.** Run-scoped `agentConfig` keys merged over the forwarded config at dispatch and never persisted. `/spec` uses it to set `outputFormat`, which makes `submit-result` the only channel reaching the thread — so the run posts exactly one message and no loose assistant prose escapes around it.

This is what keeps the contract **per-command rather than per-agent**. `agentConfig` is a JSON blob forwarded at dispatch, not the agent row, so overlaying it constrains this invocation only. Future commands are a data entry with their own overlay — no new code.

`requiredTool` and `missingToolInstruction` are now optional, since a delivery-shaped contract has no tool to require.

## The template is an outline, not fixed copy

For `outputFormat` type `markdown`, `template` is shown to the model as *"the outline to follow"* — it does not pin the wording. That's deliberate: the **section set** is fixed and chosen from the ticket type, while the **questions** are written for the ticket.

- **Bug** — Problem statement, Reproduction, Root cause, Solutioning, Test cases, Out of scope
- **Everything else** — Problem statement, Solutioning, Implementation details, Test cases, Out of scope

Bugs get a root-cause question because it's what lets a reviewer tell a real fix from a symptom patch, and RCA records are created by hand and aren't required — so most bugs never have one. It stays light: severity, bug type, category, impact and COE belong to the `RCA` model and are not duplicated here.

## Two known limits

**Copilot-provider runs skip the contract.** `structuredOutputActive` is false when `isCopilot`, so `outputFormat` is dropped and `/spec` degrades to prompt-only. Provider resolves per-user at dispatch (personal credential → agent fallback → spaces default), so this varies by who triggers it, not by agent.

**Framework vs prompt enforcement.** Delivering exactly one message via `submit-result` is structural. That the message contains *only* questions comes from the outline and instruction — very strong, not absolute.

## Follow-up worth filing

`webhook.ts` holds a hardcoded command list that duplicates `TASK_COMMANDS` across a package boundary, and a command missing from it ships with the mention un-stripped so the contract silently no-ops. The file's own comment notes this bit `/design` in prod on 2026-08-08 and names the fix: a shared registry in `xyne-claw-shared`. This PR follows the existing pattern rather than fixing it.

## Testing

22 tests pass in `test/task-commands.test.ts` (4 new) and `tsc --noEmit` is clean on `xyne-claw` and `xyne-claw-auth` — verified on the same commit based on `main`. Re-running them on this base needs a `pnpm install` first, since the deploy branch carries a `sanitize-html` dependency `main` doesn't have.

All three integration points were confirmed present and correctly placed after the cherry-pick onto this base: the `immediateTaskCommand` regex, the `/help` entry, and the `parseOutputFormat` overlay.

Manual verification to run:
- `@<agent> /spec` in a thread → claw logs `[task-command] /spec → requires (delivery contract) (available=true)`, no approval card appears, reply contains only questions
- a bug ticket gets Reproduction + Root cause; a feature ticket gets Implementation details instead
- `/specs` and `please @agent /spec` correctly do **not** trigger it

Supersedes #921, which targeted `main`.