### PR TITLE
feat: XYNE-54938 local CLI harness replayed onto main with prod-readiness hardening

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -20,6 +20,4 @@ concurrency:
 
 jobs:
   ci:
-    uses: juspay/xyne-spaces/.github/workflows/ci.yml@main
-    permissions:
-      contents: read
+    uses: ./.github/workflows/ci.yml

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -20,4 +20,6 @@ concurrency:
 
 jobs:
   ci:
-    uses: ./.github/workflows/ci.yml
+    uses: juspay/xyne-spaces/.github/workflows/ci.yml@main
+    permissions:
+      contents: read

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -62,6 +62,7 @@ import { MarkdownMessageRenderer } from './MarkdownMessageRenderer';
 import { NonParticipantActions } from './NonParticipantActions';
 import { PostedInLink } from './PostedInLink';
 import { MessageHeader } from './MessageHeader';
+import { RunOriginChip } from './RunOriginChip';
 import HuddleIcon from '../../icons/HuddleIcon';
 import { MicOn } from '@xyne/icons';
 import workflowBotAvatar from './workflowBotAvatar.png';
@@ -1187,6 +1188,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                     : formatTimeAmPm(message.createdAt)}
                 </h3>
               </Tooltip>
+              {metadata?.['clawRunOrigin'] ? (
+                <RunOriginChip origin={metadata['clawRunOrigin']} />
+              ) : null}
               {headerContent}
             </div>
           )}

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.utils.ts
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.utils.ts
@@ -54,6 +54,13 @@ export interface MessageMetadata {
   // is the de-duplicated iconKey→data:URI map (registered via registerClawIcons).
   clawCitations?: Array<{ toolCallId: string; citations: unknown[] }>;
   clawCitationIcons?: Record<string, string>;
+  clawRunOrigin?: {
+    kind?: string;
+    provider?: string;
+    harnessName?: string;
+    label?: string;
+    ownerName?: string;
+  };
   // Forwarded message fields
   originalMessageId?: string;
   optionalText?: string;

--- a/apps/dashboard/src/components/ui/MessageBubble/RunOriginChip.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RunOriginChip.tsx
@@ -1,0 +1,68 @@
+import { ReactElement } from 'react';
+import { SiClaude } from 'react-icons/si';
+import { RiOpenaiFill } from 'react-icons/ri';
+import { Tooltip } from '../Tooltip';
+
+export interface RunOrigin {
+  kind?: string;
+  provider?: string;
+  harnessName?: string;
+  label?: string;
+  ownerName?: string;
+}
+
+type HarnessProvider = 'claude-code' | 'codex-cli';
+
+const HARNESS_BRAND: Record<
+  HarnessProvider,
+  { name: string; vendor: string; color: string; Icon: (p: { className?: string }) => ReactElement }
+> = {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  'claude-code': {
+    name: 'Claude Code',
+    vendor: 'Anthropic',
+    color: '#D97757',
+    Icon: ({ className }) => <SiClaude className={className} />,
+  },
+  'codex-cli': {
+    name: 'Codex CLI',
+    vendor: 'OpenAI',
+    color: '#10A37F',
+    Icon: ({ className }) => <RiOpenaiFill className={className} />,
+  },
+  /* eslint-enable @typescript-eslint/naming-convention */
+};
+
+const isHarnessProvider = (value: unknown): value is HarnessProvider =>
+  value === 'claude-code' || value === 'codex-cli';
+
+export function RunOriginChip({ origin }: { origin: RunOrigin }): ReactElement | null {
+  if (origin.kind !== 'local-harness' || !isHarnessProvider(origin.provider)) return null;
+
+  const brand = HARNESS_BRAND[origin.provider];
+  const label = origin.label?.trim() || brand.name;
+
+  return (
+    <Tooltip
+      side='top'
+      content={
+        <span className='block max-w-52 text-left leading-relaxed'>
+          Generated with their own {brand.vendor} login. Tools still ran on Xyne.
+        </span>
+      }
+    >
+      <span
+        data-testid='message-run-origin'
+        className='inline-flex max-w-[220px] shrink-0 items-center gap-1 rounded-full border border-border/70 bg-muted/40 py-px pl-1 pr-1.5 text-[11px] leading-none text-muted-foreground'
+      >
+        <span
+          className='flex size-3.5 shrink-0 items-center justify-center rounded-full'
+          style={{ backgroundColor: `${brand.color}1f`, color: brand.color }}
+        >
+          <brand.Icon className='size-2.5' />
+        </span>
+        <span className='truncate'>via {label}</span>
+      </span>
+    </Tooltip>
+  );
+}

--- a/apps/dashboard/src/config.ts
+++ b/apps/dashboard/src/config.ts
@@ -10,6 +10,11 @@ export const isTestEnv =
 export const isSandBox = hostname.includes('sandbox');
 export const isProd = !isLocalhost && !isSandBox && !isSandboxLocal;
 
+// Availability in the client is prod-agnostic now; the server's LOCAL_HARNESS_ENABLED
+// flag is the real gate for whether runs actually route to a local device.
+export const isLocalHarnessAvailable = (): boolean =>
+  typeof window !== 'undefined' && !!window.electronAPI?.localHarness;
+
 const protocol = isLocalhost || isTestEnv || isSandboxLocal ? 'http' : 'https';
 
 const ELECTRON_BACKEND_URL = isProd

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
@@ -1349,7 +1349,7 @@ const ClawSettingsScreen = (): ReactElement => {
       <div className='mb-6 flex flex-col gap-1'>
         <h1 className='text-lg font-semibold text-foreground'>Settings</h1>
         <p className='text-sm text-muted-foreground'>
-          Configure AI providers and agent model assignments.
+          Connect this machine, configure AI providers, and assign agent models.
         </p>
       </div>
 
@@ -1360,6 +1360,7 @@ const ClawSettingsScreen = (): ReactElement => {
       )}
 
       <div className='space-y-8'>
+        <LocalHarnessSection />
         <AIProvidersSection
           credentials={credentials}
           defaultProvider={defaultProvider}
@@ -1378,7 +1379,6 @@ const ClawSettingsScreen = (): ReactElement => {
           onMutate={invalidateSettings}
           onSaving={setSaving}
         />
-        <LocalHarnessSection />
         <AdvancedSettingsSection />
       </div>
     </div>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
@@ -58,6 +58,7 @@ import type {
   ProviderModelOption,
   ReasoningEffort,
 } from '@/services/claw/clawSettingsTypes';
+import LocalHarnessSection from './LocalHarnessSection';
 
 const PROVIDER_META: Record<ProviderId, { name: string; description: string; icon: typeof Plane }> =
   {
@@ -1377,6 +1378,7 @@ const ClawSettingsScreen = (): ReactElement => {
           onMutate={invalidateSettings}
           onSaving={setSaving}
         />
+        <LocalHarnessSection />
         <AdvancedSettingsSection />
       </div>
     </div>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/LocalHarnessSection.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/LocalHarnessSection.tsx
@@ -1,0 +1,215 @@
+import { ReactElement, useCallback, useEffect, useState } from 'react';
+import { Laptop, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/utils/classNames';
+import { Button } from '@/components/ui/Button';
+import { Badge } from '@/components/ui/Badge';
+import { Skeleton } from '@/components/ui/Skeleton';
+import type { LocalHarnessInstallation, LocalHarnessStatus } from '@/types/electron';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const HARNESS_LABEL: Record<LocalHarnessInstallation['provider'], string> = {
+  'claude-code': 'Claude Code',
+  'codex-cli': 'Codex CLI',
+};
+
+const INSTALL_HINT: Record<LocalHarnessInstallation['provider'], string> = {
+  'claude-code': 'npm i -g @anthropic-ai/claude-code, then run `claude` once to sign in.',
+  'codex-cli': 'npm i -g @openai/codex, then run `codex` once to sign in.',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const InstallationRow = ({ install }: { install: LocalHarnessInstallation }): ReactElement => (
+  <div className='flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2'>
+    <div className='min-w-0'>
+      <div className='flex items-center gap-2'>
+        <span className='text-sm font-medium text-foreground'>
+          {HARNESS_LABEL[install.provider]}
+        </span>
+        {install.version && (
+          <span className='truncate text-xs text-muted-foreground'>{install.version}</span>
+        )}
+      </div>
+      <p className='truncate font-mono text-xs text-muted-foreground'>{install.binaryPath}</p>
+    </div>
+    {install.authenticated ? (
+      <Badge variant='secondary'>Available</Badge>
+    ) : (
+      <Badge variant='secondary'>Not signed in</Badge>
+    )}
+  </div>
+);
+
+const LocalHarnessSection = (): ReactElement | null => {
+  const api = typeof window !== 'undefined' ? window.electronAPI?.localHarness : undefined;
+
+  const [status, setStatus] = useState<LocalHarnessStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!api) {
+      setLoading(false);
+      return;
+    }
+    try {
+      setStatus(await api.getStatus());
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to read local harness status');
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const rescan = async (): Promise<void> => {
+    if (!api || busy) return;
+    setBusy(true);
+    try {
+      await api.detect();
+      await load();
+      toast.success('Rescanned for local harnesses');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Rescan failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleConnection = async (): Promise<void> => {
+    if (!api || busy) return;
+    setBusy(true);
+    try {
+      const next = status?.connected ? await api.disconnect() : await api.connect();
+      setStatus(next);
+      toast.success(
+        next.connected ? 'This device is now connected' : 'This device was disconnected',
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update connection');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const header = (
+    <div className='mb-4'>
+      <div className='flex items-center gap-2'>
+        <Laptop className='size-4 text-muted-foreground' />
+        <h2 className='text-sm font-semibold text-foreground'>Local harness</h2>
+      </div>
+      <p className='mt-0.5 text-sm text-muted-foreground'>
+        Run agents on the Claude Code or Codex CLI installed on this machine, using your own login.
+        Tools, permissions, and approvals stay on Xyne’s servers.
+      </p>
+    </div>
+  );
+
+  if (!api) return null;
+
+  if (loading) {
+    return (
+      <section data-testid='claw-settings-local-harness'>
+        {header}
+        <Skeleton className='h-40 rounded-2xl' />
+      </section>
+    );
+  }
+
+  if (!status?.supported) return null;
+
+  const installations = status?.installations ?? [];
+  const usable = installations.filter(i => i.authenticated);
+  const connected = status?.connected ?? false;
+
+  return (
+    <section data-testid='claw-settings-local-harness'>
+      {header}
+
+      <div
+        className={cn(
+          'flex flex-col gap-4 rounded-2xl border p-4 transition-colors',
+          connected ? 'border-emerald-500/25 bg-emerald-500/5' : 'border-border bg-muted/40',
+        )}
+      >
+        <div className='flex items-start justify-between gap-3'>
+          <div className='min-w-0'>
+            <div className='flex items-center gap-2'>
+              <h3 className='truncate text-sm font-semibold text-foreground'>
+                {status?.deviceName ?? 'This device'}
+              </h3>
+              {connected && (
+                <Badge variant='success' className='gap-1'>
+                  <span className='size-1.5 rounded-full bg-white' />
+                  Connected
+                </Badge>
+              )}
+            </div>
+            <p className='text-xs text-muted-foreground'>
+              {connected
+                ? 'Agents set to a local harness will run here while the app is open.'
+                : 'Connect to let agents run on this machine.'}
+            </p>
+          </div>
+          <button
+            type='button'
+            onClick={() => void rescan()}
+            disabled={busy}
+            data-track-category='Claw Settings'
+            data-track-name='Rescan local harnesses'
+            aria-label='Rescan for local harnesses'
+            className='flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40'
+          >
+            <RefreshCw className={cn('size-4', busy && 'animate-spin')} />
+          </button>
+        </div>
+
+        {installations.length === 0 ? (
+          <div className='rounded-lg border border-dashed border-border px-3 py-4 text-sm text-muted-foreground'>
+            <p>No local harness found on this machine.</p>
+            <ul className='mt-2 space-y-1 text-xs'>
+              <li>Claude Code — {INSTALL_HINT['claude-code']}</li>
+              <li>Codex CLI — {INSTALL_HINT['codex-cli']}</li>
+            </ul>
+          </div>
+        ) : (
+          <div className='flex flex-col gap-2'>
+            {installations.map(install => (
+              <InstallationRow key={install.provider} install={install} />
+            ))}
+          </div>
+        )}
+
+        {status?.lastError && (
+          <p className='rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive'>
+            {status.lastError}
+          </p>
+        )}
+
+        <div className='flex items-center justify-between gap-3'>
+          <span className='text-xs text-muted-foreground'>
+            {!connected
+              ? usable.length > 0
+                ? `${usable.length} harness${usable.length === 1 ? '' : 'es'} ready to pair.`
+                : 'Sign in to a harness CLI before connecting.'
+              : 'Pick which harness an agent uses in its Model & Provider tab — this card only pairs the machine.'}
+          </span>
+          <Button
+            size='sm'
+            variant={connected ? 'secondary' : 'default'}
+            loading={busy}
+            disabled={busy || (!connected && usable.length === 0)}
+            onClick={() => void toggleConnection()}
+          >
+            {connected ? 'Disconnect' : 'Connect this device'}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default LocalHarnessSection;

--- a/apps/dashboard/src/routes/ClawAgentsScreen/LocalHarnessSection.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/LocalHarnessSection.tsx
@@ -1,51 +1,156 @@
 import { ReactElement, useCallback, useEffect, useState } from 'react';
-import { Laptop, RefreshCw } from 'lucide-react';
+import { Code2, Laptop, RefreshCw, Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/utils/classNames';
 import { Button } from '@/components/ui/Button';
 import { Badge } from '@/components/ui/Badge';
+import { Switch } from '@/components/ui/Switch';
 import { Skeleton } from '@/components/ui/Skeleton';
 import type { LocalHarnessInstallation, LocalHarnessStatus } from '@/types/electron';
+import {
+  getLocalHarnessDefaultProvider,
+  setLocalHarnessDefaultProvider,
+} from '@/services/claw/localHarnessService';
+
+type HarnessProvider = LocalHarnessInstallation['provider'];
 
 /* eslint-disable @typescript-eslint/naming-convention */
-const HARNESS_LABEL: Record<LocalHarnessInstallation['provider'], string> = {
-  'claude-code': 'Claude Code',
-  'codex-cli': 'Codex CLI',
-};
-
-const INSTALL_HINT: Record<LocalHarnessInstallation['provider'], string> = {
-  'claude-code': 'npm i -g @anthropic-ai/claude-code, then run `claude` once to sign in.',
-  'codex-cli': 'npm i -g @openai/codex, then run `codex` once to sign in.',
+const HARNESS_META: Record<
+  HarnessProvider,
+  { name: string; description: string; icon: typeof Sparkles; install: string }
+> = {
+  'claude-code': {
+    name: 'Claude Code',
+    description: 'Runs on your own Claude login',
+    icon: Sparkles,
+    install: 'npm i -g @anthropic-ai/claude-code, then run `claude` once to sign in.',
+  },
+  'codex-cli': {
+    name: 'Codex CLI',
+    description: 'Runs on your own OpenAI login',
+    icon: Code2,
+    install: 'npm i -g @openai/codex, then run `codex` once to sign in.',
+  },
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 
-const InstallationRow = ({ install }: { install: LocalHarnessInstallation }): ReactElement => (
-  <div className='flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2'>
-    <div className='min-w-0'>
-      <div className='flex items-center gap-2'>
-        <span className='text-sm font-medium text-foreground'>
-          {HARNESS_LABEL[install.provider]}
-        </span>
-        {install.version && (
-          <span className='truncate text-xs text-muted-foreground'>{install.version}</span>
+const HARNESS_ORDER: HarnessProvider[] = ['claude-code', 'codex-cli'];
+
+const errText = (err: unknown, fallback: string): string =>
+  err instanceof Error ? err.message : fallback;
+
+const HarnessCard = ({
+  provider,
+  install,
+  isDefault,
+  busy,
+  locked,
+  onToggleConnected,
+  onToggleDefault,
+}: {
+  provider: HarnessProvider;
+  install: LocalHarnessInstallation | undefined;
+  isDefault: boolean;
+  busy: boolean;
+  locked: boolean;
+  onToggleConnected: () => void;
+  onToggleDefault: (next: boolean) => void;
+}): ReactElement => {
+  const meta = HARNESS_META[provider];
+  const Icon = meta.icon;
+  const connected = install?.enabled === true;
+  const signedIn = install?.authenticated === true;
+
+  return (
+    <div
+      data-testid={`claw-settings-harness-${provider}`}
+      className={cn(
+        'flex min-h-40 flex-col gap-3 rounded-2xl border p-4 transition-colors',
+        connected ? 'border-emerald-500/25 bg-emerald-500/5' : 'border-border bg-muted/40',
+      )}
+    >
+      <div className='flex items-start justify-between gap-3'>
+        <div className='flex min-w-0 items-center gap-3'>
+          <div
+            className={cn(
+              'flex size-10 shrink-0 items-center justify-center rounded-lg',
+              connected
+                ? 'bg-emerald-500/10 text-emerald-600'
+                : 'bg-background text-muted-foreground',
+            )}
+          >
+            <Icon className='size-5' />
+          </div>
+          <div className='min-w-0'>
+            <div className='flex min-w-0 items-center gap-2'>
+              <h3 className='truncate text-sm font-semibold text-foreground'>{meta.name}</h3>
+              {install?.version && (
+                <span className='truncate text-xs text-muted-foreground'>{install.version}</span>
+              )}
+            </div>
+            <p className='truncate text-xs text-muted-foreground'>{meta.description}</p>
+          </div>
+        </div>
+        {connected && (
+          <Badge variant='success' className='gap-1'>
+            <span className='size-1.5 rounded-full bg-white' />
+            Connected
+          </Badge>
         )}
       </div>
-      <p className='truncate font-mono text-xs text-muted-foreground'>{install.binaryPath}</p>
+
+      {!install ? (
+        <p className='text-xs text-muted-foreground'>Not installed — {meta.install}</p>
+      ) : !signedIn ? (
+        <p className='text-xs text-muted-foreground'>
+          Found at <span className='font-mono'>{install.binaryPath}</span>, but not signed in. Run
+          it once in your terminal to log in.
+        </p>
+      ) : (
+        <p className='truncate font-mono text-xs text-muted-foreground'>{install.binaryPath}</p>
+      )}
+
+      {connected && (
+        <div className='flex items-center justify-between gap-3 rounded-lg border border-border bg-background/60 px-3 py-2'>
+          <div className='min-w-0'>
+            <p className='text-xs font-medium text-foreground'>Use for all my agents</p>
+            <p className='text-xs text-muted-foreground'>
+              Every agent runs here unless you pick something else for it.
+            </p>
+          </div>
+          <Switch
+            checked={isDefault}
+            disabled={locked}
+            onCheckedChange={onToggleDefault}
+            aria-label={`Use ${meta.name} for all my agents`}
+          />
+        </div>
+      )}
+
+      <div className='mt-auto flex justify-end'>
+        <Button
+          size='sm'
+          variant={connected ? 'secondary' : 'default'}
+          loading={busy}
+          disabled={locked || !signedIn}
+          onClick={onToggleConnected}
+          data-track-category='Claw Settings'
+          data-track-name={`${connected ? 'Disconnect' : 'Connect'} local harness: ${provider}`}
+        >
+          {connected ? 'Disconnect' : 'Connect'}
+        </Button>
+      </div>
     </div>
-    {install.authenticated ? (
-      <Badge variant='secondary'>Available</Badge>
-    ) : (
-      <Badge variant='secondary'>Not signed in</Badge>
-    )}
-  </div>
-);
+  );
+};
 
 const LocalHarnessSection = (): ReactElement | null => {
   const api = typeof window !== 'undefined' ? window.electronAPI?.localHarness : undefined;
 
   const [status, setStatus] = useState<LocalHarnessStatus | null>(null);
+  const [defaultProvider, setDefaultProvider] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [busy, setBusy] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
 
   const load = useCallback(async (): Promise<void> => {
     if (!api) {
@@ -53,9 +158,14 @@ const LocalHarnessSection = (): ReactElement | null => {
       return;
     }
     try {
-      setStatus(await api.getStatus());
+      const [next, preferred] = await Promise.all([
+        api.getStatus(),
+        getLocalHarnessDefaultProvider().catch(() => null),
+      ]);
+      setStatus(next);
+      setDefaultProvider(preferred);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to read local harness status');
+      toast.error(errText(err, 'Failed to read local harness status'));
     } finally {
       setLoading(false);
     }
@@ -67,31 +177,56 @@ const LocalHarnessSection = (): ReactElement | null => {
 
   const rescan = async (): Promise<void> => {
     if (!api || busy) return;
-    setBusy(true);
+    setBusy('rescan');
     try {
       await api.detect();
       await load();
-      toast.success('Rescanned for local harnesses');
+      toast.success('Rescanned this machine');
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Rescan failed');
+      toast.error(errText(err, 'Rescan failed'));
     } finally {
-      setBusy(false);
+      setBusy(null);
     }
   };
 
-  const toggleConnection = async (): Promise<void> => {
+  const toggleConnected = async (provider: HarnessProvider, connect: boolean): Promise<void> => {
     if (!api || busy) return;
-    setBusy(true);
+    setBusy(provider);
     try {
-      const next = status?.connected ? await api.disconnect() : await api.connect();
-      setStatus(next);
+      setStatus(await api.setProviderEnabled(provider, connect));
+      // A harness you just disconnected can't stay the default for every agent.
+      if (!connect && defaultProvider === provider) {
+        setDefaultProvider(await setLocalHarnessDefaultProvider(null));
+      }
       toast.success(
-        next.connected ? 'This device is now connected' : 'This device was disconnected',
+        connect
+          ? `${HARNESS_META[provider].name} is connected on this device`
+          : `${HARNESS_META[provider].name} was disconnected`,
       );
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to update connection');
+      toast.error(errText(err, 'Could not update this harness'));
     } finally {
-      setBusy(false);
+      setBusy(null);
+    }
+  };
+
+  const toggleDefault = async (provider: HarnessProvider, next: boolean): Promise<void> => {
+    if (busy) return;
+    const previous = defaultProvider;
+    setBusy(`default:${provider}`);
+    setDefaultProvider(next ? provider : null);
+    try {
+      await setLocalHarnessDefaultProvider(next ? provider : null);
+      toast.success(
+        next
+          ? `All your agents will run on ${HARNESS_META[provider].name}`
+          : 'Your agents use the workspace default again',
+      );
+    } catch (err) {
+      setDefaultProvider(previous);
+      toast.error(errText(err, 'Could not save your default harness'));
+    } finally {
+      setBusy(null);
     }
   };
 
@@ -102,8 +237,8 @@ const LocalHarnessSection = (): ReactElement | null => {
         <h2 className='text-sm font-semibold text-foreground'>Local harness</h2>
       </div>
       <p className='mt-0.5 text-sm text-muted-foreground'>
-        Run agents on the Claude Code or Codex CLI installed on this machine, using your own login.
-        Tools, permissions, and approvals stay on Xyne’s servers.
+        Connect the coding CLIs installed on this machine and run agents on your own login. Tools,
+        permissions and approvals still run on Xyne’s servers — only the model runs here.
       </p>
     </div>
   );
@@ -114,100 +249,62 @@ const LocalHarnessSection = (): ReactElement | null => {
     return (
       <section data-testid='claw-settings-local-harness'>
         {header}
-        <Skeleton className='h-40 rounded-2xl' />
+        <div className='grid gap-3 sm:grid-cols-2'>
+          <Skeleton className='h-40 rounded-2xl' />
+          <Skeleton className='h-40 rounded-2xl' />
+        </div>
       </section>
     );
   }
 
   if (!status?.supported) return null;
 
-  const installations = status?.installations ?? [];
-  const usable = installations.filter(i => i.authenticated);
-  const connected = status?.connected ?? false;
+  const byProvider = new Map(status.installations.map(install => [install.provider, install]));
 
   return (
     <section data-testid='claw-settings-local-harness'>
       {header}
 
-      <div
-        className={cn(
-          'flex flex-col gap-4 rounded-2xl border p-4 transition-colors',
-          connected ? 'border-emerald-500/25 bg-emerald-500/5' : 'border-border bg-muted/40',
-        )}
-      >
-        <div className='flex items-start justify-between gap-3'>
-          <div className='min-w-0'>
-            <div className='flex items-center gap-2'>
-              <h3 className='truncate text-sm font-semibold text-foreground'>
-                {status?.deviceName ?? 'This device'}
-              </h3>
-              {connected && (
-                <Badge variant='success' className='gap-1'>
-                  <span className='size-1.5 rounded-full bg-white' />
-                  Connected
-                </Badge>
-              )}
-            </div>
-            <p className='text-xs text-muted-foreground'>
-              {connected
-                ? 'Agents set to a local harness will run here while the app is open.'
-                : 'Connect to let agents run on this machine.'}
-            </p>
-          </div>
-          <button
-            type='button'
-            onClick={() => void rescan()}
-            disabled={busy}
-            data-track-category='Claw Settings'
-            data-track-name='Rescan local harnesses'
-            aria-label='Rescan for local harnesses'
-            className='flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40'
-          >
-            <RefreshCw className={cn('size-4', busy && 'animate-spin')} />
-          </button>
-        </div>
-
-        {installations.length === 0 ? (
-          <div className='rounded-lg border border-dashed border-border px-3 py-4 text-sm text-muted-foreground'>
-            <p>No local harness found on this machine.</p>
-            <ul className='mt-2 space-y-1 text-xs'>
-              <li>Claude Code — {INSTALL_HINT['claude-code']}</li>
-              <li>Codex CLI — {INSTALL_HINT['codex-cli']}</li>
-            </ul>
-          </div>
-        ) : (
-          <div className='flex flex-col gap-2'>
-            {installations.map(install => (
-              <InstallationRow key={install.provider} install={install} />
-            ))}
-          </div>
-        )}
-
-        {status?.lastError && (
-          <p className='rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive'>
-            {status.lastError}
-          </p>
-        )}
-
-        <div className='flex items-center justify-between gap-3'>
-          <span className='text-xs text-muted-foreground'>
-            {!connected
-              ? usable.length > 0
-                ? `${usable.length} harness${usable.length === 1 ? '' : 'es'} ready to pair.`
-                : 'Sign in to a harness CLI before connecting.'
-              : 'Pick which harness an agent uses in its Model & Provider tab — this card only pairs the machine.'}
-          </span>
-          <Button
-            size='sm'
-            variant={connected ? 'secondary' : 'default'}
-            loading={busy}
-            disabled={busy || (!connected && usable.length === 0)}
-            onClick={() => void toggleConnection()}
-          >
-            {connected ? 'Disconnect' : 'Connect this device'}
-          </Button>
-        </div>
+      <div className='mb-3 flex items-center justify-between gap-3'>
+        <p className='truncate text-xs text-muted-foreground'>
+          This device: <span className='font-medium text-foreground'>{status.deviceName}</span>
+        </p>
+        <button
+          type='button'
+          onClick={() => void rescan()}
+          disabled={busy !== null}
+          data-track-category='Claw Settings'
+          data-track-name='Rescan local harnesses'
+          aria-label='Rescan this machine for coding CLIs'
+          className='flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40'
+        >
+          <RefreshCw className={cn('size-4', busy === 'rescan' && 'animate-spin')} />
+        </button>
       </div>
+
+      <div className='grid gap-3 sm:grid-cols-2'>
+        {HARNESS_ORDER.map(provider => {
+          const install = byProvider.get(provider);
+          return (
+            <HarnessCard
+              key={provider}
+              provider={provider}
+              install={install}
+              isDefault={defaultProvider === provider}
+              busy={busy === provider}
+              locked={busy !== null}
+              onToggleConnected={() => void toggleConnected(provider, install?.enabled !== true)}
+              onToggleDefault={next => void toggleDefault(provider, next)}
+            />
+          );
+        })}
+      </div>
+
+      {status.lastError && (
+        <p className='mt-3 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive'>
+          {status.lastError}
+        </p>
+      )}
     </section>
   );
 };

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ModelProviderTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ModelProviderTab.tsx
@@ -19,14 +19,19 @@ import {
   ALL_PROVIDERS,
   applyModelProvider,
   EMPTY_MODEL_PROVIDER_DRAFT,
+  isLocalHarnessProvider,
+  LOCAL_HARNESS_MODEL_OPTIONS,
   modelProviderDirty,
   PROVIDER_DISPLAY,
   readModelProviderDraft,
   THINKING_OPTIONS,
   validateModelProvider,
+  type LocalHarnessProviderKey,
   type ModelProviderDraft,
 } from '@/services/claw/modelProviderConfig';
 import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { isLocalHarnessAvailable } from '@/config';
+import PersonalHarnessSection from './PersonalHarnessSection';
 
 interface ModelProviderTabProps {
   agent: Agent;
@@ -37,6 +42,10 @@ interface ModelProviderTabProps {
 // "cleared"). THINKING_OPTIONS uses '' to mean "platform default", so we swap
 // it for this sentinel at the UI boundary and map back to '' on change.
 const THINKING_DEFAULT = '__default__';
+
+const MODEL_DEFAULT = '__cli_default__';
+
+const MODEL_CUSTOM = '__custom__';
 
 const Section = ({
   title,
@@ -108,10 +117,11 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
 
   const [draft, setDraft] = useState<ModelProviderDraft>(EMPTY_MODEL_PROVIDER_DRAFT);
   const [saving, setSaving] = useState(false);
+  const [customModels, setCustomModels] = useState<Set<string>>(new Set());
 
-  // Seed on mount / when the agent identity changes.
   useEffect(() => {
     setDraft(readModelProviderDraft(agent.config));
+    setCustomModels(new Set());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent.id]);
 
@@ -119,9 +129,15 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
   const set = (patch: Partial<ModelProviderDraft>): void =>
     setDraft(prev => ({ ...prev, ...patch }));
 
+  const localHarnessAvailable = isLocalHarnessAvailable();
+
   const remaining = useMemo(
-    () => ALL_PROVIDERS.filter(p => !draft.providerOrder.includes(p)),
-    [draft.providerOrder],
+    () =>
+      ALL_PROVIDERS.filter(
+        p =>
+          !draft.providerOrder.includes(p) && (localHarnessAvailable || !isLocalHarnessProvider(p)),
+      ),
+    [draft.providerOrder, localHarnessAvailable],
   );
 
   const moveProvider = (idx: number, dir: -1 | 1): void => {
@@ -137,6 +153,14 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
 
   const temperatureConflict =
     draft.temperature.trim() !== '' && draft.thinkingLevel !== '' && draft.thinkingLevel !== 'off';
+
+  const localHarnesses = useMemo(
+    () =>
+      localHarnessAvailable
+        ? draft.providerOrder.filter((p): p is LocalHarnessProviderKey => isLocalHarnessProvider(p))
+        : [],
+    [draft.providerOrder, localHarnessAvailable],
+  );
 
   const handleSave = async (): Promise<void> => {
     if (!dirty || saving) return;
@@ -163,9 +187,12 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
 
   if (!isOwner) {
     return (
-      <div className='max-w-2xl rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground'>
-        This agent runs on the workspace default model. Only the owner can change the model or
-        provider.
+      <div className='flex max-w-2xl flex-col gap-8'>
+        <div className='rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground'>
+          This agent runs on the workspace default model. Only the owner can change the model or
+          provider.
+        </div>
+        <PersonalHarnessSection agentSlug={agent.slug} />
       </div>
     );
   }
@@ -219,6 +246,7 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
                   onClick={() => removeProvider(i)}
                   data-track-category='Claw Agents'
                   data-track-name='Remove provider'
+                  disabled={!localHarnessAvailable && isLocalHarnessProvider(p)}
                   aria-label={`Remove ${PROVIDER_DISPLAY[p] ?? p}`}
                   className={cn(iconBtn, 'hover:text-destructive')}
                 >
@@ -247,6 +275,69 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
           </div>
         )}
       </Section>
+
+      {localHarnesses.length > 0 && (
+        <Section
+          title='Local harness models'
+          description='Runs on your own machine using your own CLI login. Tools still execute on Xyne’s servers with the agent’s normal permissions — the local harness only runs the model.'
+        >
+          <div className='flex flex-col gap-4'>
+            {localHarnesses.map(harness => {
+              const current = draft.localHarnessModels[harness] ?? '';
+              const known = LOCAL_HARNESS_MODEL_OPTIONS[harness].some(o => o.value === current);
+              const isCustom = customModels.has(harness) || (current !== '' && !known);
+              const setModel = (value: string): void =>
+                set({ localHarnessModels: { ...draft.localHarnessModels, [harness]: value } });
+
+              return (
+                <div key={harness} className='flex max-w-sm flex-col gap-1.5'>
+                  <span className='text-xs font-medium text-foreground'>
+                    {PROVIDER_DISPLAY[harness] ?? harness}
+                  </span>
+                  <Select
+                    value={isCustom ? MODEL_CUSTOM : current || MODEL_DEFAULT}
+                    onValueChange={v => {
+                      setCustomModels(prev => {
+                        const next = new Set(prev);
+                        if (v === MODEL_CUSTOM) next.add(harness);
+                        else next.delete(harness);
+                        return next;
+                      });
+                      if (v !== MODEL_CUSTOM) setModel(v === MODEL_DEFAULT ? '' : v);
+                    }}
+                  >
+                    <SelectTrigger size='sm' className='w-full'>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LOCAL_HARNESS_MODEL_OPTIONS[harness].map(o => (
+                        <SelectItem key={o.value || MODEL_DEFAULT} value={o.value || MODEL_DEFAULT}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                      <SelectItem value={MODEL_CUSTOM}>Custom…</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {isCustom && (
+                    <Input
+                      value={current}
+                      onChange={e => setModel(e.target.value)}
+                      placeholder={
+                        harness === 'claude-code' ? 'e.g. claude-opus-4-5' : 'e.g. gpt-5.5'
+                      }
+                      aria-label={`Custom model for ${PROVIDER_DISPLAY[harness] ?? harness}`}
+                    />
+                  )}
+                </div>
+              );
+            })}
+            <span className='text-xs text-muted-foreground'>
+              Requires the Xyne desktop app with that harness connected. If no device is online,
+              runs fall back to the next provider in the order.
+            </span>
+          </div>
+        </Section>
+      )}
 
       <Section title='Provider policy'>
         <div className='grid gap-2 sm:grid-cols-2'>
@@ -339,6 +430,8 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
           </div>
         </div>
       </Section>
+
+      <PersonalHarnessSection agentSlug={agent.slug} />
 
       <div className='flex items-center gap-3 border-t border-border pt-4'>
         <Button

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/PersonalHarnessSection.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/PersonalHarnessSection.tsx
@@ -6,12 +6,27 @@ import { useAuth } from '@/hooks/useAuth';
 import type { LocalHarnessInstallation } from '@/types/electron';
 import {
   clearUserAgentProvider,
+  getLocalHarnessDefaultProvider,
   getUserAgentProvider,
   setUserAgentProvider,
 } from '@/services/claw/localHarnessService';
-import { isLocalHarnessProvider, PROVIDER_DISPLAY } from '@/services/claw/modelProviderConfig';
+import { PROVIDER_DISPLAY } from '@/services/claw/modelProviderConfig';
 
-const WORKSPACE_DEFAULT = 'spaces';
+/** Clearing the per-agent row is how an agent follows the account-wide default. */
+const INHERIT = '__inherit__';
+const HOSTED = 'spaces';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+// PROVIDER_DISPLAY spells these "Claude Code (this device)", which reads badly
+// once the row already says "this device" — use the bare product name here.
+const HARNESS_LABEL: Record<string, string> = {
+  'claude-code': 'Claude Code',
+  'codex-cli': 'Codex CLI',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const providerLabel = (provider: string): string =>
+  HARNESS_LABEL[provider] ?? PROVIDER_DISPLAY[provider] ?? provider;
 
 interface Props {
   agentSlug: string;
@@ -23,7 +38,8 @@ const PersonalHarnessSection = ({ agentSlug }: Props): ReactElement | null => {
   const api = typeof window !== 'undefined' ? window.electronAPI?.localHarness : undefined;
 
   const [installations, setInstallations] = useState<LocalHarnessInstallation[]>([]);
-  const [current, setCurrent] = useState<string>(WORKSPACE_DEFAULT);
+  const [accountDefault, setAccountDefault] = useState<string | null>(null);
+  const [current, setCurrent] = useState<string>(INHERIT);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -33,12 +49,14 @@ const PersonalHarnessSection = ({ agentSlug }: Props): ReactElement | null => {
       return;
     }
     try {
-      const [found, provider] = await Promise.all([
-        api.getStatus().then(s => s.installations.filter(i => i.authenticated)),
-        getUserAgentProvider(agentSlug, userId).catch(() => WORKSPACE_DEFAULT),
+      const [found, config, preferred] = await Promise.all([
+        api.getStatus().then(status => status.installations.filter(i => i.authenticated)),
+        getUserAgentProvider(agentSlug, userId).catch(() => null),
+        getLocalHarnessDefaultProvider().catch(() => null),
       ]);
       setInstallations(found);
-      setCurrent(provider || WORKSPACE_DEFAULT);
+      setAccountDefault(preferred);
+      setCurrent(!config || config.inherited ? INHERIT : config.provider);
     } catch {
       setInstallations([]);
     } finally {
@@ -52,18 +70,24 @@ const PersonalHarnessSection = ({ agentSlug }: Props): ReactElement | null => {
 
   if (!api || loading || installations.length === 0) return null;
 
+  // With no account default, an explicit "spaces" row and no row at all route
+  // identically, so they share one option rather than two rows meaning the same.
+  const effective = !accountDefault && current === HOSTED ? INHERIT : current;
+
   const choose = async (value: string): Promise<void> => {
-    if (saving || value === current) return;
+    if (saving || value === effective) return;
     setSaving(true);
     const previous = current;
     setCurrent(value);
     try {
-      if (value === WORKSPACE_DEFAULT) await clearUserAgentProvider(agentSlug, userId);
+      if (value === INHERIT) await clearUserAgentProvider(agentSlug, userId);
       else await setUserAgentProvider(agentSlug, userId, value);
       toast.success(
-        value === WORKSPACE_DEFAULT
-          ? 'Your runs use the workspace default again'
-          : `Your runs of this agent will use ${PROVIDER_DISPLAY[value] ?? value}`,
+        value === INHERIT
+          ? 'This agent follows your default again'
+          : value === HOSTED
+            ? 'Your runs of this agent stay on Xyne’s servers'
+            : `Your runs of this agent will use ${providerLabel(value)}`,
       );
     } catch (err) {
       setCurrent(previous);
@@ -74,13 +98,34 @@ const PersonalHarnessSection = ({ agentSlug }: Props): ReactElement | null => {
   };
 
   const options = [
-    { value: WORKSPACE_DEFAULT, label: 'Workspace default', detail: 'Runs on Xyne’s servers.' },
-    ...installations.map(i => ({
-      value: i.provider,
-      label: PROVIDER_DISPLAY[i.provider] ?? i.provider,
-      detail: i.version ? `${i.version} · this device` : 'this device',
+    {
+      value: INHERIT,
+      label: accountDefault
+        ? `Use my default (${providerLabel(accountDefault)})`
+        : 'Workspace default',
+      detail: accountDefault ? 'Set in Claw Agents → Settings.' : 'Runs on Xyne’s servers.',
+    },
+    ...installations.map(install => ({
+      value: install.provider,
+      label: providerLabel(install.provider),
+      detail: install.version ? `${install.version} · this device` : 'this device',
     })),
+    ...(accountDefault
+      ? [{ value: HOSTED, label: 'Xyne’s servers', detail: 'Ignore my default for this agent.' }]
+      : []),
   ];
+
+  // A provider picked on another surface (a personal Anthropic/Codex key, a
+  // harness that has since been disconnected) still has to render as THE
+  // selection — otherwise this list would show "inherit" and one stray click
+  // would clear a setting the user never touched here.
+  if (effective !== INHERIT && !options.some(option => option.value === effective)) {
+    options.push({
+      value: effective,
+      label: providerLabel(effective),
+      detail: 'your current pick for this agent',
+    });
+  }
 
   return (
     <section className='flex max-w-2xl flex-col gap-3'>
@@ -94,10 +139,13 @@ const PersonalHarnessSection = ({ agentSlug }: Props): ReactElement | null => {
         </p>
       </div>
 
-      <div className='flex flex-col'>
+      <div
+        className='flex flex-col'
+        role='radiogroup'
+        aria-label='Where your runs of this agent go'
+      >
         {options.map((option, i) => {
-          const selected =
-            option.value === current || (i === 0 && !isLocalHarnessProvider(current));
+          const selected = option.value === effective;
           return (
             <button
               key={option.value}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/PersonalHarnessSection.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/PersonalHarnessSection.tsx
@@ -1,0 +1,136 @@
+import { ReactElement, useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Laptop } from 'lucide-react';
+import { cn } from '@/utils/classNames';
+import { useAuth } from '@/hooks/useAuth';
+import type { LocalHarnessInstallation } from '@/types/electron';
+import {
+  clearUserAgentProvider,
+  getUserAgentProvider,
+  setUserAgentProvider,
+} from '@/services/claw/localHarnessService';
+import { isLocalHarnessProvider, PROVIDER_DISPLAY } from '@/services/claw/modelProviderConfig';
+
+const WORKSPACE_DEFAULT = 'spaces';
+
+interface Props {
+  agentSlug: string;
+}
+
+const PersonalHarnessSection = ({ agentSlug }: Props): ReactElement | null => {
+  const { user } = useAuth();
+  const userId = user?.id ?? '';
+  const api = typeof window !== 'undefined' ? window.electronAPI?.localHarness : undefined;
+
+  const [installations, setInstallations] = useState<LocalHarnessInstallation[]>([]);
+  const [current, setCurrent] = useState<string>(WORKSPACE_DEFAULT);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!api || !userId) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const [found, provider] = await Promise.all([
+        api.getStatus().then(s => s.installations.filter(i => i.authenticated)),
+        getUserAgentProvider(agentSlug, userId).catch(() => WORKSPACE_DEFAULT),
+      ]);
+      setInstallations(found);
+      setCurrent(provider || WORKSPACE_DEFAULT);
+    } catch {
+      setInstallations([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, agentSlug, userId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (!api || loading || installations.length === 0) return null;
+
+  const choose = async (value: string): Promise<void> => {
+    if (saving || value === current) return;
+    setSaving(true);
+    const previous = current;
+    setCurrent(value);
+    try {
+      if (value === WORKSPACE_DEFAULT) await clearUserAgentProvider(agentSlug, userId);
+      else await setUserAgentProvider(agentSlug, userId, value);
+      toast.success(
+        value === WORKSPACE_DEFAULT
+          ? 'Your runs use the workspace default again'
+          : `Your runs of this agent will use ${PROVIDER_DISPLAY[value] ?? value}`,
+      );
+    } catch (err) {
+      setCurrent(previous);
+      toast.error(err instanceof Error ? err.message : 'Could not save your choice');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const options = [
+    { value: WORKSPACE_DEFAULT, label: 'Workspace default', detail: 'Runs on Xyne’s servers.' },
+    ...installations.map(i => ({
+      value: i.provider,
+      label: PROVIDER_DISPLAY[i.provider] ?? i.provider,
+      detail: i.version ? `${i.version} · this device` : 'this device',
+    })),
+  ];
+
+  return (
+    <section className='flex max-w-2xl flex-col gap-3'>
+      <div className='flex flex-col gap-0.5'>
+        <div className='flex items-center gap-2'>
+          <Laptop className='size-4 text-muted-foreground' />
+          <h2 className='text-sm font-semibold text-foreground'>Run this agent on my machine</h2>
+        </div>
+        <p className='text-xs text-muted-foreground'>
+          Applies to your runs only — it doesn’t change the agent for anyone else.
+        </p>
+      </div>
+
+      <div className='flex flex-col'>
+        {options.map((option, i) => {
+          const selected =
+            option.value === current || (i === 0 && !isLocalHarnessProvider(current));
+          return (
+            <button
+              key={option.value}
+              type='button'
+              role='radio'
+              aria-checked={selected}
+              disabled={saving}
+              onClick={() => void choose(option.value)}
+              data-track-category='Claw Agents'
+              data-track-name={`Personal provider: ${option.value}`}
+              className={cn(
+                'flex items-center gap-3 py-2.5 text-left transition-opacity disabled:opacity-60',
+                i > 0 && 'border-t border-border',
+              )}
+            >
+              <span
+                className={cn(
+                  'flex size-4 shrink-0 items-center justify-center rounded-full border transition-colors',
+                  selected ? 'border-foreground' : 'border-border',
+                )}
+              >
+                {selected && <span className='size-1.5 rounded-full bg-foreground' />}
+              </span>
+              <span className='flex min-w-0 flex-1 items-baseline gap-2'>
+                <span className='text-sm text-foreground'>{option.label}</span>
+                <span className='truncate text-xs text-muted-foreground'>{option.detail}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default PersonalHarnessSection;

--- a/apps/dashboard/src/routes/OnboardingScreen/LocalHarnessOnboardingStep.tsx
+++ b/apps/dashboard/src/routes/OnboardingScreen/LocalHarnessOnboardingStep.tsx
@@ -1,0 +1,260 @@
+import React, { useEffect, useState } from 'react';
+import { Check } from 'lucide-react';
+import { cn } from '../../utils/classNames';
+import type { LocalHarnessInstallation } from '../../types/electron';
+import { findDefaultAgent, setUserAgentProvider } from '../../services/claw/localHarnessService';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const HARNESS_LABEL: Record<LocalHarnessInstallation['provider'], string> = {
+  'claude-code': 'Claude Code',
+  'codex-cli': 'Codex CLI',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const PLATFORM_NOUN: Record<string, string> = {
+  darwin: 'Mac',
+  win32: 'PC',
+  linux: 'machine',
+};
+
+function tildify(binaryPath: string): string {
+  const match = /^(\/Users\/[^/]+|\/home\/[^/]+|[A-Z]:\\Users\\[^\\]+)(.*)$/.exec(binaryPath);
+  return match ? `~${match[2]}` : binaryPath;
+}
+
+function machineLabel(deviceName: string): string {
+  return deviceName.replace(/\s*\([^)]*\)\s*$/, '').trim() || 'This machine';
+}
+
+type Phase = 'idle' | 'connecting' | 'connected';
+
+interface Props {
+  installations: LocalHarnessInstallation[];
+  userId: string;
+  onNext: () => void;
+}
+
+const LocalHarnessOnboardingStep: React.FC<Props> = ({ installations, userId, onNext }) => {
+  const [selected, setSelected] = useState<LocalHarnessInstallation['provider']>(
+    installations[0]?.provider ?? 'claude-code',
+  );
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [wiredAgent, setWiredAgent] = useState<string | null>(null);
+  const [machine, setMachine] = useState({ name: 'This machine', platform: '' });
+
+  useEffect(() => {
+    const api = window.electronAPI?.localHarness;
+    if (!api) return;
+    let cancelled = false;
+    void api
+      .getStatus()
+      .then(s => {
+        if (!cancelled) setMachine({ name: machineLabel(s.deviceName), platform: s.platform });
+      })
+      .catch(() => {});
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  const noun = PLATFORM_NOUN[machine.platform] ?? 'machine';
+  const busy = phase === 'connecting';
+  const single = installations.length === 1;
+  /* eslint-disable @typescript-eslint/naming-convention */
+  const groupRole = single ? {} : { role: 'radiogroup', 'aria-label': 'Which CLI to use' };
+  const radioProps = (checked: boolean): Record<string, unknown> => ({
+    role: 'radio',
+    'aria-checked': checked,
+  });
+  /* eslint-enable @typescript-eslint/naming-convention */
+
+  const connect = async (): Promise<void> => {
+    const api = window.electronAPI?.localHarness;
+    if (!api || busy) return;
+    setPhase('connecting');
+    setError(null);
+    try {
+      await api.connect();
+
+      const agent = await findDefaultAgent(userId).catch(() => null);
+      if (agent) {
+        await setUserAgentProvider(agent.slug, userId, selected);
+        setWiredAgent(agent.name);
+      }
+
+      setPhase('connected');
+      setTimeout(onNext, 1400);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not connect this device');
+      setPhase('idle');
+    }
+  };
+
+  return (
+    <div className='w-full h-screen flex items-center justify-center bg-background px-6'>
+      <div className='flex w-full max-w-lg flex-col gap-10 opacity-0 translate-y-6 animate-[fadeUp_.6s_ease-out_forwards] motion-reduce:animate-none motion-reduce:opacity-100 motion-reduce:translate-y-0'>
+        <header className='flex flex-col gap-3'>
+          <h2 className='text-3xl font-medium leading-tight text-foreground'>
+            This {noun} can run your agents
+          </h2>
+          <p className='text-sm leading-relaxed text-muted-foreground'>
+            {installations.length === 1
+              ? `${HARNESS_LABEL[installations[0]!.provider]} is signed in here.`
+              : 'Two coding CLIs are signed in here.'}{' '}
+            Connect and your agents think on this {noun}, on your own plan. Tools, permissions and
+            approvals stay in Xyne.
+          </p>
+        </header>
+
+        <div className='flex flex-col gap-3'>
+          <div className='relative flex items-center' aria-hidden='true'>
+            <span
+              className={cn(
+                'size-2.5 shrink-0 rounded-full transition-colors duration-500',
+                phase === 'connected' ? 'bg-emerald-500' : 'bg-foreground',
+              )}
+            />
+            <div className='relative mx-2 h-px flex-1'>
+              <div
+                className={cn(
+                  'absolute inset-0 transition-opacity duration-500',
+                  phase === 'connected'
+                    ? 'bg-emerald-500/40'
+                    : 'bg-[linear-gradient(90deg,currentColor_50%,transparent_50%)] bg-[length:6px_1px] text-border',
+                )}
+              />
+              {busy && (
+                <span className='absolute top-1/2 size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground animate-[railTravel_1.1s_ease-in-out_infinite] motion-reduce:hidden' />
+              )}
+            </div>
+            <span
+              className={cn(
+                'flex size-2.5 shrink-0 items-center justify-center rounded-full border transition-colors duration-500',
+                phase === 'connected'
+                  ? 'border-emerald-500 bg-emerald-500'
+                  : 'border-border bg-transparent',
+              )}
+            />
+          </div>
+          <div className='flex items-baseline justify-between text-xs'>
+            <span className='truncate pr-4 font-medium text-foreground'>{machine.name}</span>
+            <span className='shrink-0 text-muted-foreground'>Xyne Spaces</span>
+          </div>
+        </div>
+
+        <div className='flex flex-col' {...groupRole}>
+          {installations.map((install, i) => {
+            const isSelected = install.provider === selected;
+            const Row = single ? 'div' : 'button';
+            return (
+              <Row
+                key={install.provider}
+                {...(single
+                  ? {}
+                  : {
+                      type: 'button' as const,
+                      disabled: busy,
+                      onClick: () => setSelected(install.provider),
+                      ...radioProps(isSelected),
+                      'data-track-category': 'Onboarding',
+                      'data-track-name': `Select local harness: ${install.provider}`,
+                    })}
+                className={cn(
+                  'flex items-center gap-3 py-3 text-left transition-opacity',
+                  i > 0 && 'border-t border-border',
+                  !single &&
+                    'cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground',
+                  !single && !isSelected && 'opacity-45 hover:opacity-80',
+                  busy && 'pointer-events-none',
+                )}
+              >
+                {!single && (
+                  <span
+                    className={cn(
+                      'flex size-4 shrink-0 items-center justify-center rounded-full border transition-colors',
+                      isSelected ? 'border-foreground' : 'border-border',
+                    )}
+                  >
+                    {isSelected && <span className='size-1.5 rounded-full bg-foreground' />}
+                  </span>
+                )}
+                <span className='flex min-w-0 flex-1 flex-col gap-0.5'>
+                  <span className='flex items-baseline gap-2'>
+                    <span className='text-sm font-medium text-foreground'>
+                      {HARNESS_LABEL[install.provider]}
+                    </span>
+                    {install.version && (
+                      <span className='truncate text-xs text-muted-foreground'>
+                        {install.version}
+                      </span>
+                    )}
+                  </span>
+                  <span className='truncate font-mono text-xs text-muted-foreground'>
+                    {tildify(install.binaryPath)}
+                  </span>
+                </span>
+                <span className='flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground'>
+                  <span className='size-1.5 rounded-full bg-emerald-500' />
+                  Signed in
+                </span>
+              </Row>
+            );
+          })}
+        </div>
+
+        {error && (
+          <p role='alert' className='text-sm text-red-600'>
+            {error}
+          </p>
+        )}
+
+        {phase === 'connected' ? (
+          <p className='flex items-start gap-2 text-sm text-foreground'>
+            <Check className='mt-0.5 size-4 shrink-0 text-emerald-600' strokeWidth={2.5} />
+            {wiredAgent ? (
+              <span>
+                Connected. <span className='font-medium'>{wiredAgent}</span> will run on this {noun}
+                .
+              </span>
+            ) : (
+              <span>
+                Connected. Open any agent and pick &ldquo;Run this agent on my machine&rdquo; under
+                Model &amp; Provider.
+              </span>
+            )}
+          </p>
+        ) : (
+          <div className='flex items-center gap-6'>
+            <button
+              type='button'
+              onClick={() => void connect()}
+              disabled={busy}
+              data-track-category='Onboarding'
+              data-track-name='Connect local harness'
+              className='rounded-full bg-foreground px-6 py-3 text-sm font-medium text-background transition hover:opacity-90 active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground disabled:opacity-50 motion-reduce:active:scale-100'
+            >
+              {busy ? 'Connecting…' : `Connect this ${noun}`}
+            </button>
+            <button
+              type='button'
+              onClick={onNext}
+              disabled={busy}
+              data-track-category='Onboarding'
+              data-track-name='Skip local harness'
+              className='text-sm text-muted-foreground underline-offset-4 transition hover:text-foreground hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground disabled:opacity-50'
+            >
+              Not now
+            </button>
+          </div>
+        )}
+
+        <p className='text-xs text-muted-foreground'>
+          Change this any time in Claw Agents → Settings.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LocalHarnessOnboardingStep;

--- a/apps/dashboard/src/routes/OnboardingScreen/LocalHarnessOnboardingStep.tsx
+++ b/apps/dashboard/src/routes/OnboardingScreen/LocalHarnessOnboardingStep.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Check } from 'lucide-react';
 import { cn } from '../../utils/classNames';
 import type { LocalHarnessInstallation } from '../../types/electron';
-import { findDefaultAgent, setUserAgentProvider } from '../../services/claw/localHarnessService';
+import { setLocalHarnessDefaultProvider } from '../../services/claw/localHarnessService';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const HARNESS_LABEL: Record<LocalHarnessInstallation['provider'], string> = {
@@ -30,17 +30,16 @@ type Phase = 'idle' | 'connecting' | 'connected';
 
 interface Props {
   installations: LocalHarnessInstallation[];
-  userId: string;
   onNext: () => void;
 }
 
-const LocalHarnessOnboardingStep: React.FC<Props> = ({ installations, userId, onNext }) => {
+const LocalHarnessOnboardingStep: React.FC<Props> = ({ installations, onNext }) => {
   const [selected, setSelected] = useState<LocalHarnessInstallation['provider']>(
     installations[0]?.provider ?? 'claude-code',
   );
   const [phase, setPhase] = useState<Phase>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [wiredAgent, setWiredAgent] = useState<string | null>(null);
+  const [appliedToAll, setAppliedToAll] = useState(false);
   const [machine, setMachine] = useState({ name: 'This machine', platform: '' });
 
   useEffect(() => {
@@ -75,13 +74,17 @@ const LocalHarnessOnboardingStep: React.FC<Props> = ({ installations, userId, on
     setPhase('connecting');
     setError(null);
     try {
-      await api.connect();
+      await api.setProviderEnabled(selected, true);
 
-      const agent = await findDefaultAgent(userId).catch(() => null);
-      if (agent) {
-        await setUserAgentProvider(agent.slug, userId, selected);
-        setWiredAgent(agent.name);
-      }
+      // Picking a harness here is the answer to "run my agents on my machine",
+      // so it becomes the account-wide default rather than wiring one agent.
+      // A failure here still leaves a usable connection — say so instead of
+      // promising every agent will route locally.
+      setAppliedToAll(
+        await setLocalHarnessDefaultProvider(selected)
+          .then(() => true)
+          .catch(() => false),
+      );
 
       setPhase('connected');
       setTimeout(onNext, 1400);
@@ -102,8 +105,8 @@ const LocalHarnessOnboardingStep: React.FC<Props> = ({ installations, userId, on
             {installations.length === 1
               ? `${HARNESS_LABEL[installations[0]!.provider]} is signed in here.`
               : 'Two coding CLIs are signed in here.'}{' '}
-            Connect and your agents think on this {noun}, on your own plan. Tools, permissions and
-            approvals stay in Xyne.
+            Connect and every agent you run thinks on this {noun}, on your own plan. Tools,
+            permissions and approvals stay in Xyne.
           </p>
         </header>
 
@@ -212,10 +215,10 @@ const LocalHarnessOnboardingStep: React.FC<Props> = ({ installations, userId, on
         {phase === 'connected' ? (
           <p className='flex items-start gap-2 text-sm text-foreground'>
             <Check className='mt-0.5 size-4 shrink-0 text-emerald-600' strokeWidth={2.5} />
-            {wiredAgent ? (
+            {appliedToAll ? (
               <span>
-                Connected. <span className='font-medium'>{wiredAgent}</span> will run on this {noun}
-                .
+                Connected. <span className='font-medium'>All your agents</span> will run on this{' '}
+                {noun}.
               </span>
             ) : (
               <span>

--- a/apps/dashboard/src/routes/OnboardingScreen/OnboardingScreen.tsx
+++ b/apps/dashboard/src/routes/OnboardingScreen/OnboardingScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import Cookies from 'js-cookie';
 import { useAuth } from '../../hooks/useAuth';
@@ -7,6 +7,8 @@ import { useMigratedChannels, useChannelByName } from '../../hooks/useChannels';
 import { useProfilePictureUrl } from '../../hooks/useProfilePicture';
 import { authActor } from '../../machines/authMachine';
 import Confetti from 'react-confetti';
+import LocalHarnessOnboardingStep from './LocalHarnessOnboardingStep';
+import type { LocalHarnessInstallation } from '../../types/electron';
 
 const OnboardingScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -22,6 +24,26 @@ const OnboardingScreen: React.FC = () => {
   // Resolve the default "general" channel so first-time users land there after
   // onboarding instead of the user guide.
   const generalChannel = useChannelByName('general');
+
+  const [localHarnesses, setLocalHarnesses] = useState<LocalHarnessInstallation[]>([]);
+  const currentStepRef = useRef(0);
+  currentStepRef.current = currentStep;
+
+  useEffect(() => {
+    const api = window.electronAPI?.localHarness;
+    if (!api) return;
+    let cancelled = false;
+    void api
+      .detect()
+      .then(found => {
+        if (cancelled || currentStepRef.current !== 0) return;
+        setLocalHarnesses(found.filter(install => install.authenticated));
+      })
+      .catch(() => {});
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
 
   // Build onboarding steps dynamically based on whether user has migrated channels
   const hasMigratedChannels = migratedChannels?.length > 0;
@@ -52,6 +74,15 @@ const OnboardingScreen: React.FC = () => {
           {
             key: 'channels',
             title: '',
+            animation: 'fadeUp',
+          } as const,
+        ]
+      : []),
+    ...(localHarnesses.length > 0
+      ? [
+          {
+            key: 'localHarness',
+            title: 'Run agents on your own machine',
             animation: 'fadeUp',
           } as const,
         ]
@@ -244,6 +275,15 @@ const OnboardingScreen: React.FC = () => {
               </button>
             </div>
           </div>
+        );
+
+      case 'localHarness':
+        return (
+          <LocalHarnessOnboardingStep
+            installations={localHarnesses}
+            userId={targetUserId}
+            onNext={nextStep}
+          />
         );
 
       case 'profile':

--- a/apps/dashboard/src/routes/OnboardingScreen/OnboardingScreen.tsx
+++ b/apps/dashboard/src/routes/OnboardingScreen/OnboardingScreen.tsx
@@ -278,13 +278,7 @@ const OnboardingScreen: React.FC = () => {
         );
 
       case 'localHarness':
-        return (
-          <LocalHarnessOnboardingStep
-            installations={localHarnesses}
-            userId={targetUserId}
-            onNext={nextStep}
-          />
-        );
+        return <LocalHarnessOnboardingStep installations={localHarnesses} onNext={nextStep} />;
 
       case 'profile':
         return (

--- a/apps/dashboard/src/routes/QuestionnaireScreen/LocalHarnessStep.tsx
+++ b/apps/dashboard/src/routes/QuestionnaireScreen/LocalHarnessStep.tsx
@@ -1,0 +1,285 @@
+import { ReactElement, useState } from 'react';
+import { ArrowRight } from '@xyne/icons';
+import { Check, Laptop, Loader2 } from 'lucide-react';
+import type { LocalHarnessInstallation } from '../../types/electron';
+import { setLocalHarnessDefaultProvider } from '../../services/claw/localHarnessService';
+
+export type HarnessProvider = LocalHarnessInstallation['provider'];
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const HARNESS_LABEL: Record<HarnessProvider, string> = {
+  'claude-code': 'Claude Code',
+  'codex-cli': 'Codex CLI',
+};
+
+const HARNESS_VENDOR: Record<HarnessProvider, string> = {
+  'claude-code': 'Anthropic',
+  'codex-cli': 'OpenAI',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const PLATFORM_NOUN: Record<string, string> = {
+  darwin: 'Mac',
+  win32: 'PC',
+  linux: 'machine',
+};
+
+export const platformNoun = (platform: string): string => PLATFORM_NOUN[platform] ?? 'machine';
+
+export const machineLabel = (deviceName: string): string =>
+  deviceName.replace(/\s*\([^)]*\)\s*$/, '').trim() || 'This machine';
+
+const tildify = (binaryPath: string): string => {
+  const match = /^(\/Users\/[^/]+|\/home\/[^/]+|[A-Z]:\\Users\\[^\\]+)(.*)$/.exec(binaryPath);
+  return match ? `~${match[2]}` : binaryPath;
+};
+
+interface PanelProps {
+  installations: LocalHarnessInstallation[];
+  noun: string;
+  selected: HarnessProvider | null;
+  onSelect: (provider: HarnessProvider) => void;
+  connected: HarnessProvider | null;
+  onConnected: (provider: HarnessProvider) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export const LocalHarnessStepPanel = ({
+  installations,
+  noun,
+  selected,
+  onSelect,
+  connected,
+  onConnected,
+  onBack,
+  onNext,
+}: PanelProps): ReactElement => {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const provider = selected ?? installations[0]?.provider ?? null;
+
+  const handleConnect = async (): Promise<void> => {
+    const api = window.electronAPI?.localHarness;
+    if (!api || !provider || isConnecting) return;
+    setIsConnecting(true);
+    setError(null);
+    try {
+      await api.setProviderEnabled(provider, true);
+      await setLocalHarnessDefaultProvider(provider).catch(() => null);
+      onConnected(provider);
+      setTimeout(onNext, 1400);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Could not connect this ${noun}`);
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  return (
+    <div className='flex-1 flex flex-col justify-center max-w-[520px] w-full md:absolute md:left-12 lg:left-16 md:top-[276px] md:bottom-[38px] md:w-[calc(100%_-_96px)] md:max-w-[600px] md:justify-start'>
+      <h1 className='text-[28px] leading-[34px] font-bold text-[#242936]'>
+        This {noun} can run your agents
+      </h1>
+      <p className='mt-2 text-[14px] leading-[22px] text-[#777B85]'>
+        {installations.length === 1
+          ? `${HARNESS_LABEL[installations[0]!.provider]} is already signed in here.`
+          : 'Two coding CLIs are already signed in here.'}{' '}
+        Connect one and your agents think on this {noun}, on your own plan. Tools, permissions and
+        approvals stay in Xyne.
+      </p>
+
+      <div className='mt-[28px] h-px w-full bg-[#ECEFF3]' />
+
+      <div
+        className='mt-[36px] flex flex-col gap-3'
+        role='radiogroup'
+        aria-label='Which CLI to connect'
+      >
+        {installations.map(install => {
+          const isSelected = install.provider === provider;
+          return (
+            <button
+              key={install.provider}
+              type='button'
+              role='radio'
+              aria-checked={isSelected}
+              disabled={isConnecting || connected !== null}
+              onClick={() => onSelect(install.provider)}
+              className={`flex w-full items-center gap-3 rounded-[9px] border px-[14px] py-[12px] text-left transition-colors disabled:cursor-not-allowed ${
+                isSelected
+                  ? 'border-[#FF6868] bg-[#FFF1F1]'
+                  : 'border-[#DDE3EC] bg-white hover:border-[#C8D0DC] hover:bg-[#F8FAFC]'
+              }`}
+              data-track-category='Questionnaire'
+              data-track-name='SelectLocalHarness'
+              data-track-metadata={JSON.stringify({ provider: install.provider })}
+            >
+              <span
+                className={`flex size-[18px] shrink-0 items-center justify-center rounded-full border transition-colors ${
+                  isSelected ? 'border-[#FF6868]' : 'border-[#C8D0DC]'
+                }`}
+              >
+                {isSelected && <span className='size-2 rounded-full bg-[#FF6868]' />}
+              </span>
+              <span className='min-w-0 flex-1'>
+                <span className='flex items-baseline gap-2'>
+                  <span className='text-[14px] leading-[20px] font-semibold text-[#272B35]'>
+                    {HARNESS_LABEL[install.provider]}
+                  </span>
+                  <span className='truncate text-[12px] leading-[18px] text-[#8E939D]'>
+                    {install.version || HARNESS_VENDOR[install.provider]}
+                  </span>
+                </span>
+                <span className='mt-[3px] block truncate font-mono text-[12px] leading-[16px] text-[#9399A6]'>
+                  {tildify(install.binaryPath)}
+                </span>
+              </span>
+              <span className='flex shrink-0 items-center gap-1.5 text-[12px] leading-none text-[#5C9E7A]'>
+                <span className='size-1.5 rounded-full bg-[#5C9E7A]' />
+                Signed in
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <p role='alert' className='mt-4 text-[13px] leading-[20px] text-[#D8453F]'>
+          {error}
+        </p>
+      )}
+
+      {connected ? (
+        <p className='mt-[26px] flex items-start gap-2 text-[14px] leading-[22px] text-[#272B35]'>
+          <Check className='mt-[3px] size-4 shrink-0 text-[#3F9E6B]' strokeWidth={2.5} />
+          <span>
+            Connected. Every agent you run will think on this {noun}, using{' '}
+            <span className='font-semibold'>{HARNESS_LABEL[connected]}</span>.
+          </span>
+        </p>
+      ) : (
+        <div className='mt-auto mb-4 md:mb-0 flex items-center gap-5'>
+          <button
+            type='button'
+            onClick={onBack}
+            disabled={isConnecting}
+            className='text-[14px] text-[#8E939D] hover:text-[#272B35] transition-colors disabled:opacity-50'
+            data-track-category='Questionnaire'
+            data-track-name='LocalHarnessBack'
+          >
+            Back
+          </button>
+          <button
+            type='button'
+            onClick={() => void handleConnect()}
+            disabled={isConnecting || !provider}
+            className='inline-flex h-[48px] items-center gap-2.5 px-5 bg-[#FF6868] text-white text-[15px] font-semibold rounded-[10px] hover:bg-[#FF5A5A] disabled:bg-[#B9B9B9] disabled:opacity-100 disabled:cursor-not-allowed transition-colors'
+            data-track-category='Questionnaire'
+            data-track-name='ConnectLocalHarness'
+          >
+            {isConnecting ? (
+              <>
+                <Loader2 className='h-4 w-4 animate-spin' />
+                Connecting...
+              </>
+            ) : (
+              <>
+                Connect this {noun}
+                <ArrowRight className='w-4 h-4' />
+              </>
+            )}
+          </button>
+          <button
+            type='button'
+            onClick={onNext}
+            disabled={isConnecting}
+            className='text-[14px] text-[#8E939D] hover:text-[#272B35] transition-colors disabled:opacity-50'
+            data-track-category='Questionnaire'
+            data-track-name='SkipLocalHarness'
+          >
+            Not now
+          </button>
+        </div>
+      )}
+
+      <p className='mt-[18px] text-[12px] leading-[18px] text-[#9399A6]'>
+        You can change this any time in Claw Agents → Settings.
+      </p>
+    </div>
+  );
+};
+
+interface PreviewProps {
+  installations: LocalHarnessInstallation[];
+  selected: HarnessProvider | null;
+  connected: HarnessProvider | null;
+  deviceName: string;
+}
+
+export const LocalHarnessStepPreview = ({
+  installations,
+  selected,
+  connected,
+  deviceName,
+}: PreviewProps): ReactElement => {
+  const provider = connected ?? selected ?? installations[0]?.provider ?? null;
+
+  return (
+    <div className='w-[368px] rounded-[16px] border border-[#E2E5EA] bg-white shadow-[0_18px_38px_rgba(27,36,52,0.13)] overflow-hidden'>
+      <div className='h-[48px] flex items-center justify-center border-b border-[#EFF2F6]'>
+        <div className='w-[86px] h-[20px] rounded-full border border-[#E5EAF0] bg-[#F3F5F8] shadow-[inset_0_1px_3px_rgba(20,31,48,0.08)]' />
+      </div>
+
+      <div className='px-[26px] pb-[28px] pt-[30px]'>
+        <div className='flex items-center gap-3'>
+          <div className='flex size-[42px] shrink-0 items-center justify-center rounded-[12px] border border-[#E2E5EA] bg-[#F8FAFD]'>
+            <Laptop className='size-5 text-[#5F646D]' />
+          </div>
+          <div className='min-w-0'>
+            <p className='truncate text-[15px] leading-[20px] font-semibold text-[#242936]'>
+              {deviceName}
+            </p>
+            <p className='text-[13px] leading-[18px] text-[#9399A6]'>
+              {provider ? HARNESS_LABEL[provider] : 'Your machine'}
+            </p>
+          </div>
+        </div>
+
+        <div className='relative my-[22px] ml-[20px] h-[54px] w-px'>
+          <div
+            className={`absolute inset-0 transition-colors duration-500 ${
+              connected
+                ? 'bg-[#5C9E7A]'
+                : 'bg-[linear-gradient(180deg,#D4DAE4_50%,transparent_50%)] bg-[length:1px_6px]'
+            }`}
+          />
+          {!connected && (
+            <span className='absolute left-1/2 size-1.5 -translate-x-1/2 rounded-full bg-[#FF6868] animate-[railTravelVertical_1.4s_ease-in-out_infinite] motion-reduce:hidden' />
+          )}
+        </div>
+
+        <div className='flex items-center gap-3'>
+          <div className='flex size-[42px] shrink-0 items-center justify-center rounded-[12px] bg-gradient-to-b from-[#FF8C8C] to-[#FF4F4F] shadow-[0_8px_18px_rgba(255,79,79,0.24)]'>
+            <img src='/svgs/icons/genius-star-white.svg' alt='' className='size-[22px]' />
+          </div>
+          <div className='min-w-0'>
+            <p className='text-[15px] leading-[20px] font-semibold text-[#242936]'>Xyne Spaces</p>
+            <p className='text-[13px] leading-[18px] text-[#9399A6]'>
+              Tools, permissions and approvals
+            </p>
+          </div>
+        </div>
+
+        <div className='mt-[26px] rounded-[10px] border border-[#E7EBF1] bg-[#F8FAFD] px-[14px] py-[12px]'>
+          <p className='text-[13px] leading-[19px] text-[#5F646D]'>
+            {connected
+              ? 'Your agents now think on this machine, on your own plan.'
+              : 'The model runs here. Everything else keeps running on Xyne.'}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/QuestionnaireScreen/QuestionnaireScreen.tsx
+++ b/apps/dashboard/src/routes/QuestionnaireScreen/QuestionnaireScreen.tsx
@@ -14,6 +14,16 @@ import {
   uploadProfilePicture as uploadProfilePictureViaApi,
 } from '../../services/userProfile/userProfileService';
 import { v4 as uuidv4 } from 'uuid';
+import type { LocalHarnessInstallation } from '../../types/electron';
+import {
+  LocalHarnessStepPanel,
+  LocalHarnessStepPreview,
+  machineLabel,
+  platformNoun,
+  type HarnessProvider,
+} from './LocalHarnessStep';
+
+type StepKey = 'name' | 'company' | 'harness' | 'ai';
 
 const TEAM_SIZE_OPTIONS = ['0-10', '11-100', '100-1000', '1000+'] as const;
 type TeamSize = (typeof TEAM_SIZE_OPTIONS)[number];
@@ -27,6 +37,8 @@ const QuestionnaireScreen = (): ReactElement | null => {
 
   const [currentStep, setCurrentStep] = useState(0);
   const [isCompleting, setIsCompleting] = useState(false);
+  const currentStepRef = useRef(0);
+  currentStepRef.current = currentStep;
 
   const [displayName, setDisplayName] = useState(user?.['displayName'] || user?.name || '');
   const [role, setRole] = useState('');
@@ -36,8 +48,21 @@ const QuestionnaireScreen = (): ReactElement | null => {
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const [harnesses, setHarnesses] = useState<LocalHarnessInstallation[]>([]);
+  const [harnessDevice, setHarnessDevice] = useState({ name: 'This machine', platform: '' });
+  const [selectedHarness, setSelectedHarness] = useState<HarnessProvider | null>(null);
+  const [connectedHarness, setConnectedHarness] = useState<HarnessProvider | null>(null);
+
   const { url: existingPictureUrl } = useProfilePictureUrl(user?.id || '', user?.picture);
   const effectivePhotoUrl = photoPreviewUrl || existingPictureUrl || null;
+
+  const steps: StepKey[] = [
+    'name',
+    'company',
+    ...(harnesses.length > 0 ? (['harness'] as StepKey[]) : []),
+    'ai',
+  ];
+  const step: StepKey = steps[currentStep] ?? 'name';
 
   useEffect(() => {
     const isNewUserCookie = Cookies.get('is_new_user');
@@ -45,6 +70,22 @@ const QuestionnaireScreen = (): ReactElement | null => {
       void navigate('/');
     }
   }, [navigate]);
+
+  useEffect(() => {
+    const api = window.electronAPI?.localHarness;
+    if (!api) return;
+    let cancelled = false;
+    void Promise.all([api.detect(), api.getStatus()])
+      .then(([found, status]) => {
+        if (cancelled || currentStepRef.current > 1) return;
+        setHarnesses(found.filter(install => install.authenticated));
+        setHarnessDevice({ name: machineLabel(status.deviceName), platform: status.platform });
+      })
+      .catch(() => {});
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!displayName && user) {
@@ -125,13 +166,13 @@ const QuestionnaireScreen = (): ReactElement | null => {
   };
 
   const canAdvance = (): boolean => {
-    if (currentStep === 0) return displayName.trim().length > 0;
-    if (currentStep === 1) return companyName.trim().length > 0 && companySize !== '';
+    if (step === 'name') return displayName.trim().length > 0;
+    if (step === 'company') return companyName.trim().length > 0 && companySize !== '';
     return true;
   };
 
   const handleNext = (): void => {
-    if (currentStep < 2) {
+    if (currentStep < steps.length - 1) {
       if (!canAdvance()) return;
       setCurrentStep(currentStep + 1);
       return;
@@ -139,7 +180,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
     void handleComplete();
   };
 
-  if (currentStep === 2) {
+  if (step === 'ai') {
     return (
       <div className='relative h-[100dvh] w-full overflow-hidden bg-white'>
         <img
@@ -245,7 +286,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
           className='h-7 w-auto self-start md:absolute md:left-12 lg:left-16 md:top-[34px] md:h-[30px]'
         />
 
-        {currentStep === 0 && (
+        {step === 'name' && (
           <div className='flex-1 flex flex-col justify-center max-w-[520px] w-full md:absolute md:left-12 lg:left-16 md:top-[329px] md:bottom-[38px] md:w-[calc(100%_-_96px)] md:max-w-[600px] md:justify-start'>
             <h1 className='text-[30px] leading-[36px] md:text-[30px] md:leading-[36px] font-bold text-[#1f2430]'>
               Whats your name?
@@ -323,7 +364,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
           </div>
         )}
 
-        {currentStep === 1 && (
+        {step === 'company' && (
           <div className='flex-1 flex flex-col justify-center max-w-[520px] w-full md:absolute md:left-12 lg:left-[100px] md:top-[276px] md:bottom-[38px] md:w-[calc(100%_-_96px)] lg:w-[calc(100%_-_200px)] md:max-w-[776px] md:justify-start'>
             <h1 className='text-[28px] leading-[34px] font-bold text-[#242936]'>
               Tell us about your company
@@ -408,11 +449,24 @@ const QuestionnaireScreen = (): ReactElement | null => {
             </div>
           </div>
         )}
+
+        {step === 'harness' && (
+          <LocalHarnessStepPanel
+            installations={harnesses}
+            noun={platformNoun(harnessDevice.platform)}
+            selected={selectedHarness}
+            onSelect={setSelectedHarness}
+            connected={connectedHarness}
+            onConnected={setConnectedHarness}
+            onBack={() => setCurrentStep(currentStep - 1)}
+            onNext={handleNext}
+          />
+        )}
       </div>
 
       {/* Right panel */}
       <div className='hidden md:flex items-center justify-center bg-[#F8F9FB] border-l border-[#ECEFF3]'>
-        {currentStep === 0 && (
+        {step === 'name' && (
           <div className='w-[368px] rounded-[16px] border border-[#E2E5EA] bg-white shadow-[0_18px_38px_rgba(27,36,52,0.13)] overflow-hidden'>
             <div className='h-[48px] flex items-center justify-center'>
               <div className='w-[86px] h-[20px] rounded-full border border-[#E5EAF0] bg-[#F3F5F8] shadow-[inset_0_1px_3px_rgba(20,31,48,0.08)]' />
@@ -439,7 +493,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
           </div>
         )}
 
-        {currentStep === 1 && (
+        {step === 'company' && (
           <div className='relative h-full w-full overflow-hidden bg-[#F8F9FB]'>
             <div className='absolute left-0 right-0 top-[164px] h-[calc(100%-164px)] bg-[#F5F8FC]' />
             <div className='absolute left-[16.5%] right-0 top-[164px] z-[3] h-[18px] border-t border-[#DDE5F0] bg-white' />
@@ -484,6 +538,15 @@ const QuestionnaireScreen = (): ReactElement | null => {
               </div>
             </div>
           </div>
+        )}
+
+        {step === 'harness' && (
+          <LocalHarnessStepPreview
+            installations={harnesses}
+            selected={selectedHarness}
+            connected={connectedHarness}
+            deviceName={harnessDevice.name}
+          />
         )}
       </div>
     </div>

--- a/apps/dashboard/src/services/claw/clawAuthAgentTypes.ts
+++ b/apps/dashboard/src/services/claw/clawAuthAgentTypes.ts
@@ -122,7 +122,6 @@ export interface Agent {
   readonly scope: string;
   readonly ownerUserId: string | null;
   readonly enabled: boolean;
-  readonly isDefault?: boolean;
   readonly color: string;
   readonly modelId?: string;
   readonly config: Record<string, unknown>;

--- a/apps/dashboard/src/services/claw/clawAuthAgentTypes.ts
+++ b/apps/dashboard/src/services/claw/clawAuthAgentTypes.ts
@@ -122,6 +122,7 @@ export interface Agent {
   readonly scope: string;
   readonly ownerUserId: string | null;
   readonly enabled: boolean;
+  readonly isDefault?: boolean;
   readonly color: string;
   readonly modelId?: string;
   readonly config: Record<string, unknown>;

--- a/apps/dashboard/src/services/claw/localHarnessService.ts
+++ b/apps/dashboard/src/services/claw/localHarnessService.ts
@@ -1,6 +1,4 @@
 import { clawRequest } from './clawRequest';
-import { listClawAuthAgents } from './clawAuthAgentsService';
-import type { Agent } from './clawAuthAgentTypes';
 
 const USER_ID_HEADER = 'x-user-id';
 
@@ -20,12 +18,23 @@ export async function setUserAgentProvider(
   return body.data;
 }
 
-export async function getUserAgentProvider(slug: string, userId: string): Promise<string> {
-  const body = await clawRequest<{ success: boolean; data: { provider: string } }>(
-    `/api/v1/agents/${encodeURIComponent(slug)}/user-config/${encodeURIComponent(userId)}`,
-    { headers: { [USER_ID_HEADER]: userId } },
-  );
-  return body.data.provider;
+export interface UserAgentProvider {
+  provider: string;
+  /** True when the user never picked a provider for this agent. */
+  inherited: boolean;
+}
+
+export async function getUserAgentProvider(
+  slug: string,
+  userId: string,
+): Promise<UserAgentProvider> {
+  const body = await clawRequest<{
+    success: boolean;
+    data: { provider: string; inherited?: boolean };
+  }>(`/api/v1/agents/${encodeURIComponent(slug)}/user-config/${encodeURIComponent(userId)}`, {
+    headers: { [USER_ID_HEADER]: userId },
+  });
+  return { provider: body.data.provider, inherited: body.data.inherited === true };
 }
 
 export async function clearUserAgentProvider(slug: string, userId: string): Promise<void> {
@@ -35,8 +44,25 @@ export async function clearUserAgentProvider(slug: string, userId: string): Prom
   );
 }
 
-export async function findDefaultAgent(userId: string): Promise<Agent | null> {
-  const agents = await listClawAuthAgents(userId);
-  const enabled = agents.filter(agent => agent.enabled);
-  return enabled.find(agent => agent.isDefault) ?? enabled[0] ?? null;
+/**
+ * The user's account-wide default harness. When set, every agent this user runs
+ * goes to that harness unless the agent carries a per-agent override — so it is
+ * what "use this harness for all my agents" writes, and what a newly created
+ * agent inherits without any extra wiring.
+ */
+export async function getLocalHarnessDefaultProvider(): Promise<string | null> {
+  const body = await clawRequest<{ success: boolean; data: { defaultProvider: string | null } }>(
+    '/api/v1/local-harness/preferences',
+  );
+  return body.data.defaultProvider;
+}
+
+export async function setLocalHarnessDefaultProvider(
+  defaultProvider: string | null,
+): Promise<string | null> {
+  const body = await clawRequest<{ success: boolean; data: { defaultProvider: string | null } }>(
+    '/api/v1/local-harness/preferences',
+    { method: 'PUT', body: JSON.stringify({ defaultProvider }) },
+  );
+  return body.data.defaultProvider;
 }

--- a/apps/dashboard/src/services/claw/localHarnessService.ts
+++ b/apps/dashboard/src/services/claw/localHarnessService.ts
@@ -1,0 +1,42 @@
+import { clawRequest } from './clawRequest';
+import { listClawAuthAgents } from './clawAuthAgentsService';
+import type { Agent } from './clawAuthAgentTypes';
+
+const USER_ID_HEADER = 'x-user-id';
+
+export async function setUserAgentProvider(
+  slug: string,
+  userId: string,
+  provider: string,
+): Promise<{ provider: string }> {
+  const body = await clawRequest<{ success: boolean; data: { provider: string } }>(
+    `/api/v1/agents/${encodeURIComponent(slug)}/user-config/${encodeURIComponent(userId)}`,
+    {
+      method: 'PUT',
+      headers: { [USER_ID_HEADER]: userId },
+      body: JSON.stringify({ provider }),
+    },
+  );
+  return body.data;
+}
+
+export async function getUserAgentProvider(slug: string, userId: string): Promise<string> {
+  const body = await clawRequest<{ success: boolean; data: { provider: string } }>(
+    `/api/v1/agents/${encodeURIComponent(slug)}/user-config/${encodeURIComponent(userId)}`,
+    { headers: { [USER_ID_HEADER]: userId } },
+  );
+  return body.data.provider;
+}
+
+export async function clearUserAgentProvider(slug: string, userId: string): Promise<void> {
+  await clawRequest<{ success: boolean }>(
+    `/api/v1/agents/${encodeURIComponent(slug)}/user-config/${encodeURIComponent(userId)}`,
+    { method: 'DELETE', headers: { [USER_ID_HEADER]: userId } },
+  );
+}
+
+export async function findDefaultAgent(userId: string): Promise<Agent | null> {
+  const agents = await listClawAuthAgents(userId);
+  const enabled = agents.filter(agent => agent.enabled);
+  return enabled.find(agent => agent.isDefault) ?? enabled[0] ?? null;
+}

--- a/apps/dashboard/src/services/claw/modelProviderConfig.ts
+++ b/apps/dashboard/src/services/claw/modelProviderConfig.ts
@@ -5,9 +5,18 @@
 // updateAgent(slug, { config }); only non-model keys (tools, behaviour) are left
 // untouched on save.
 
-/** Providers an agent can be routed through, in canonical order. */
-export const ALL_PROVIDERS = ['codex', 'claude', 'copilot', 'openrouter', 'spaces'] as const;
+export const HOSTED_PROVIDERS = ['codex', 'claude', 'copilot', 'openrouter', 'spaces'] as const;
+
+export const LOCAL_HARNESS_PROVIDERS = ['claude-code', 'codex-cli'] as const;
+export type LocalHarnessProviderKey = (typeof LOCAL_HARNESS_PROVIDERS)[number];
+
+export const ALL_PROVIDERS = [...HOSTED_PROVIDERS, ...LOCAL_HARNESS_PROVIDERS] as const;
 export type ProviderKey = (typeof ALL_PROVIDERS)[number];
+
+export const isLocalHarnessProvider = (p: string): p is LocalHarnessProviderKey =>
+  (LOCAL_HARNESS_PROVIDERS as readonly string[]).includes(p);
+
+/* eslint-disable @typescript-eslint/naming-convention */
 
 /** User-facing labels for the wire-level provider keys. */
 export const PROVIDER_DISPLAY: Record<string, string> = {
@@ -16,7 +25,29 @@ export const PROVIDER_DISPLAY: Record<string, string> = {
   claude: 'Anthropic Claude',
   codex: 'OpenAI Codex',
   openrouter: 'OpenRouter',
+  'claude-code': 'Claude Code (this device)',
+  'codex-cli': 'Codex CLI (this device)',
 };
+
+export const LOCAL_HARNESS_MODEL_OPTIONS: Record<
+  LocalHarnessProviderKey,
+  ReadonlyArray<{ value: string; label: string }>
+> = {
+  'claude-code': [
+    { value: '', label: 'CLI default' },
+    { value: 'opus', label: 'Opus — most capable' },
+    { value: 'sonnet', label: 'Sonnet — balanced' },
+    { value: 'haiku', label: 'Haiku — fastest' },
+  ],
+  'codex-cli': [
+    { value: '', label: 'CLI default' },
+    { value: 'gpt-5.5', label: 'gpt-5.5' },
+    { value: 'gpt-5.4', label: 'gpt-5.4' },
+    { value: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
+  ],
+};
+
+/* eslint-enable @typescript-eslint/naming-convention */
 
 /** Extended-thinking levels for the model settings. '' = platform default. */
 export const THINKING_OPTIONS = [
@@ -41,6 +72,7 @@ export interface ModelProviderDraft {
   temperature: string;
   maxTokens: string;
   thinkingLevel: string;
+  localHarnessModels: Record<string, string>;
 }
 
 type ConfigBag = Record<string, unknown> | undefined | null;
@@ -51,12 +83,23 @@ interface ProviderConfigShape {
   providerOrder?: unknown;
   providerAlwaysOn?: unknown;
   subagentProviderMode?: unknown;
+  localHarnessModels?: unknown;
   modelSettings?: {
     model?: unknown;
     temperature?: unknown;
     maxTokens?: unknown;
     thinkingLevel?: unknown;
   };
+}
+
+function readLocalHarnessModels(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out: Record<string, string> = {};
+  for (const harness of LOCAL_HARNESS_PROVIDERS) {
+    const value = (raw as Record<string, unknown>)[harness];
+    if (typeof value === 'string' && value) out[harness] = value;
+  }
+  return out;
 }
 
 /** Reads the model/provider draft out of an agent's config bag. */
@@ -75,6 +118,7 @@ export function readModelProviderDraft(config: ConfigBag): ModelProviderDraft {
     temperature: typeof ms.temperature === 'number' ? String(ms.temperature) : '',
     maxTokens: typeof ms.maxTokens === 'number' ? String(ms.maxTokens) : '',
     thinkingLevel: typeof ms.thinkingLevel === 'string' ? ms.thinkingLevel : '',
+    localHarnessModels: readLocalHarnessModels(c.localHarnessModels),
   };
 }
 
@@ -133,8 +177,14 @@ export function applyModelProvider(
   if (draft.subagentMode === 'parent') next['subagentProviderMode'] = 'parent';
   else delete next['subagentProviderMode'];
 
-  // Model run params. The Spaces model is fixed — preserve any out-of-band model
-  // value rather than wiping it.
+  const harnessModels: Record<string, string> = {};
+  for (const harness of draft.providerOrder.filter(isLocalHarnessProvider)) {
+    const model = draft.localHarnessModels[harness]?.trim();
+    if (model) harnessModels[harness] = model;
+  }
+  if (Object.keys(harnessModels).length > 0) next['localHarnessModels'] = harnessModels;
+  else delete next['localHarnessModels'];
+
   const existing = (config ?? {}) as ProviderConfigShape;
   const existingMs = existing.modelSettings ?? {};
   const settings: Record<string, unknown> = {};

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -196,6 +196,10 @@ export interface ElectronAPI {
     detect: () => Promise<LocalHarnessInstallation[]>;
     connect: () => Promise<LocalHarnessStatus>;
     disconnect: () => Promise<LocalHarnessStatus>;
+    setProviderEnabled: (
+      provider: LocalHarnessInstallation['provider'],
+      enabled: boolean,
+    ) => Promise<LocalHarnessStatus>;
   };
   saveErrorReportFile?(
     fileName: string,
@@ -215,6 +219,8 @@ export interface LocalHarnessInstallation {
   binaryPath: string;
   version: string;
   authenticated: boolean;
+  /** Whether the user connected this harness on this device. */
+  enabled?: boolean;
 }
 
 export interface LocalHarnessStatus {

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -191,6 +191,12 @@ export interface ElectronAPI {
     setEnabled: (enabled: boolean) => void;
     onEnabledChanged: (callback: (enabled: boolean) => void) => () => void;
   };
+  localHarness?: {
+    getStatus: () => Promise<LocalHarnessStatus>;
+    detect: () => Promise<LocalHarnessInstallation[]>;
+    connect: () => Promise<LocalHarnessStatus>;
+    disconnect: () => Promise<LocalHarnessStatus>;
+  };
   saveErrorReportFile?(
     fileName: string,
     buffer: ArrayBuffer | null,
@@ -202,6 +208,23 @@ export interface ElectronAPI {
   readErrorReportRecordingFile?(recordingToken: string): Promise<ArrayBuffer>;
   cleanupErrorReportRecording?(filePath: string): Promise<void>;
   onErrorReportRecordingProgress?(callback: (data: { elapsedSeconds: number }) => void): () => void;
+}
+
+export interface LocalHarnessInstallation {
+  provider: 'claude-code' | 'codex-cli';
+  binaryPath: string;
+  version: string;
+  authenticated: boolean;
+}
+
+export interface LocalHarnessStatus {
+  supported: boolean;
+  connected: boolean;
+  deviceId: string | null;
+  deviceName: string;
+  platform: string;
+  installations: LocalHarnessInstallation[];
+  lastError: string | null;
 }
 
 declare global {

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -203,6 +203,12 @@ export default {
           '88%': { opacity: '1' },
           '100%': { left: '100%', opacity: '0' },
         },
+        railTravelVertical: {
+          '0%': { top: '0%', opacity: '0' },
+          '12%': { opacity: '1' },
+          '88%': { opacity: '1' },
+          '100%': { top: '100%', opacity: '0' },
+        },
         'slide-in-up': {
           from: {
             opacity: '0',

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -197,6 +197,12 @@ export default {
           '0%': { opacity: '0', transform: 'translateX(32px)' },
           '100%': { opacity: '1', transform: 'translateX(0)' },
         },
+        railTravel: {
+          '0%': { left: '0%', opacity: '0' },
+          '12%': { opacity: '1' },
+          '88%': { opacity: '1' },
+          '100%': { left: '100%', opacity: '0' },
+        },
         'slide-in-up': {
           from: {
             opacity: '0',

--- a/apps/electron/src/app/config.ts
+++ b/apps/electron/src/app/config.ts
@@ -11,6 +11,7 @@ export interface AppConfig {
   MTLS_IDENTITY_NAME: string;
   UNPROTECTED_URL: string;
   FRONTEND_URL: string;
+  CLAW_AUTH_URL: string;
   DEEP_LINK_PROTOCOL: string;
   USER_DATA_SUFFIX: string;         // Appended to userData dir to isolate flavors
   APP_NAME: string;
@@ -43,6 +44,7 @@ const devConfig: AppConfig = {
   MTLS_IDENTITY_NAME: 'Web Simulation Client',
   UNPROTECTED_URL: 'http://localhost:4001',
   FRONTEND_URL: 'http://localhost:5173',
+  CLAW_AUTH_URL: 'http://localhost:3003',
   DEEP_LINK_PROTOCOL: 'xyne-spaces-dev',
   USER_DATA_SUFFIX: '-dev',
   APP_NAME: 'Xyne Spaces DEV',
@@ -74,6 +76,7 @@ const prodConfig: AppConfig = {
   MTLS_IDENTITY_NAME: 'Web Simulation Client',
   UNPROTECTED_URL: 'https://spaces.xyne.juspay.net', // Non-mTLS endpoint only reserved for pre-enrollment logs and metrics
   FRONTEND_URL: 'https://app.spaces.xyne.juspay.net',
+  CLAW_AUTH_URL: 'https://app.spaces.xyne.juspay.net',
   DEEP_LINK_PROTOCOL: 'xyne-spaces',
   USER_DATA_SUFFIX: '',             // Empty — prod keeps original path, no migration needed
   APP_NAME: 'Xyne Spaces',
@@ -106,6 +109,7 @@ const sandboxConfig: AppConfig = {
   MTLS_IDENTITY_NAME: 'Web Simulation Client Sandbox',
   UNPROTECTED_URL: 'https://spaces.xyne.juspay.net', // Non-mTLS endpoint only reserved for pre-enrollment logs and metrics
   FRONTEND_URL: 'https://app.spaces.sandbox.xyne.juspay.net',
+  CLAW_AUTH_URL: 'https://app.spaces.sandbox.xyne.juspay.net',
   DEEP_LINK_PROTOCOL: 'xyne-spaces-sandbox',
   USER_DATA_SUFFIX: '-sandbox',
   APP_NAME: 'Xyne Spaces Sandbox',
@@ -133,6 +137,12 @@ const sandboxConfig: AppConfig = {
 
 const baseConfig: AppConfig = process.env.NODE_ENV === 'development' ? devConfig
   : (APP_ENV === 'sandbox' ? sandboxConfig : prodConfig);
+
+// Local harness is allowed in ALL build targets (incl. prod). The authoritative
+// enable/disable gate lives server-side (LOCAL_HARNESS_ENABLED in xyne-claw-auth);
+// this client flag only controls whether we detect/offer a local CLI connection.
+// Override to false at build time via FEATURE_LOCAL_HARNESS_DISABLED for an emergency kill.
+export const ENABLE_LOCAL_HARNESS = process.env['FEATURE_LOCAL_HARNESS_DISABLED'] !== 'true';
 
 export const config: AppConfig = {
   ...baseConfig,

--- a/apps/electron/src/app/main.ts
+++ b/apps/electron/src/app/main.ts
@@ -1,7 +1,7 @@
 import { app, dialog, Menu, MenuItem, MenuItemConstructorOptions } from 'electron';
 import path from 'path';
 import log from 'electron-log/main';
-import { config } from './config';
+import { config, ENABLE_LOCAL_HARNESS } from './config';
 import { setupDeepLinks } from '../services/deep-links';
 import { setupIpcHandlers } from '../ipc/handlers';
 import { createMainWindow, getMainWindow, setWindowReferences } from '../window/manager';
@@ -13,6 +13,8 @@ import {
 import { setupMTLS } from '../services/mtls';
 import { agentAuthService } from '../services/agent-auth';
 import { installElectronLogStackHook, Logger } from '../services/logger/Logger';
+import { localHarnessBridge } from '../services/local-harness';
+import { BrowserWindow } from 'electron';
 import { EnrollmentEvent } from '../services/logger/enrollment-events';
 import { startVersionChecker, stopVersionChecker } from '../services/version-checker';
 import ElectronEvent from '../services/logger/electron-events';
@@ -85,6 +87,8 @@ app.on('before-quit', async () => {
 
   // Stop meeting detector
   meetingDetectorService.stop();
+
+  localHarnessBridge.stop();
 
   // Gracefully stop agent auth server
   try {
@@ -177,6 +181,7 @@ async function initializeApp(): Promise<void> {
 
   // Auto-start agent authorization server
   startAgentAuthServerInBackground();
+  startLocalHarnessBridgeInBackground();
 
   // Initialize UI updater (checks for updates in background)
   if (config.useBundledUI) {
@@ -218,6 +223,15 @@ function startAgentAuthServerInBackground(): void {
     .catch((error) => {
       log.error('[App] Failed to start agent auth server:', error);
     });
+}
+
+function startLocalHarnessBridgeInBackground(): void {
+  if (!ENABLE_LOCAL_HARNESS) return;
+  try {
+    localHarnessBridge.start();
+  } catch (error) {
+    log.error('[App] Failed to start local harness bridge:', error);
+  }
 }
 
 function startMeetingDetectorInBackground(): void {

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, shell, app, BrowserView, BrowserWindow, desktopCapturer, dialog } from 'electron';
+import { ipcMain, shell, app, session, BrowserView, BrowserWindow, desktopCapturer, dialog } from 'electron';
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { promises as fs } from 'fs';
 import * as path from 'path';
@@ -6,7 +6,7 @@ import { clearAllCookies, clearBrowserTabsData, syncXyneCookiesToBrowserPanel } 
 import { showNotification, NotificationData, showCallNotification, closeCallNotification, CallNotificationData } from '../services/notifications';
 import { getMainWindow, loadApp, toggleWindowCompactMode } from '../window/manager';
 import { setupMTLSIpcHandlers } from './mtls-handlers';
-import { config } from '../app/config';
+import { config, ENABLE_LOCAL_HARNESS } from '../app/config';
 import { performHardReload } from '../services/version-checker';
 import { Logger, errorLogger } from '../services/logger/Logger';
 import ElectronEvent from '../services/logger/electron-events';
@@ -36,6 +36,7 @@ import {
 import { meetingDetectorService } from '../services/meeting-detector';
 import { browserSettingsService, BrowserSettings } from '../services/browser-settings';
 import { errorReportRecorder } from '../services/error-report-recorder';
+import { localHarnessBridge } from '../services/local-harness';
 
 
 let previewBrowserView: BrowserView | null = null;
@@ -704,4 +705,45 @@ export function setupIpcHandlers(): void {
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
+
+  const requireLocalHarness = (event: IpcMainInvokeEvent): void => {
+    if (!isMainWindowSender(event)) throw new Error('Unauthorized sender');
+    if (!ENABLE_LOCAL_HARNESS) throw new Error('Local harness is not available in this build');
+  };
+
+  ipcMain.handle('local-harness:status', async (event) => {
+    if (!isMainWindowSender(event)) throw new Error('Unauthorized sender');
+    if (!ENABLE_LOCAL_HARNESS) {
+      return {
+        supported: false,
+        connected: false,
+        deviceId: null,
+        deviceName: '',
+        platform: process.platform,
+        installations: [],
+        lastError: null,
+      };
+    }
+    return localHarnessBridge.status();
+  });
+
+  ipcMain.handle('local-harness:detect', async (event) => {
+    requireLocalHarness(event);
+    return localHarnessBridge.refreshInstallations();
+  });
+
+  ipcMain.handle('local-harness:connect', async (event) => {
+    requireLocalHarness(event);
+    return localHarnessBridge.connect(await xyneCookieHeader());
+  });
+
+  ipcMain.handle('local-harness:disconnect', async (event) => {
+    requireLocalHarness(event);
+    return localHarnessBridge.disconnect(await xyneCookieHeader());
+  });
+}
+
+async function xyneCookieHeader(): Promise<string> {
+  const cookies = await session.defaultSession.cookies.get({ url: config.FRONTEND_URL });
+  return cookies.map((c) => `${c.name}=${c.value}`).join('; ');
 }

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -36,7 +36,7 @@ import {
 import { meetingDetectorService } from '../services/meeting-detector';
 import { browserSettingsService, BrowserSettings } from '../services/browser-settings';
 import { errorReportRecorder } from '../services/error-report-recorder';
-import { localHarnessBridge } from '../services/local-harness';
+import { localHarnessBridge, LOCAL_HARNESS_PROVIDERS, type LocalHarnessProvider } from '../services/local-harness';
 
 
 let previewBrowserView: BrowserView | null = null;
@@ -729,7 +729,19 @@ export function setupIpcHandlers(): void {
 
   ipcMain.handle('local-harness:detect', async (event) => {
     requireLocalHarness(event);
-    return localHarnessBridge.refreshInstallations();
+    return localHarnessBridge.rescan();
+  });
+
+  ipcMain.handle('local-harness:set-provider', async (event, provider: unknown, enabled: unknown) => {
+    requireLocalHarness(event);
+    if (!LOCAL_HARNESS_PROVIDERS.includes(provider as LocalHarnessProvider)) {
+      throw new Error('Unknown local harness provider');
+    }
+    return localHarnessBridge.setProviderEnabled(
+      provider as LocalHarnessProvider,
+      enabled === true,
+      await xyneCookieHeader(),
+    );
   });
 
   ipcMain.handle('local-harness:connect', async (event) => {

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -443,6 +443,13 @@ const electronAPI = {
       return () => ipcRenderer.removeListener('claw:enabled-changed', listener);
     },
   },
+
+  localHarness: {
+    getStatus: () => ipcRenderer.invoke('local-harness:status'),
+    detect: () => ipcRenderer.invoke('local-harness:detect'),
+    connect: () => ipcRenderer.invoke('local-harness:connect'),
+    disconnect: () => ipcRenderer.invoke('local-harness:disconnect'),
+  },
 };
 
 if (isTrustedOrigin()) {

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -449,6 +449,8 @@ const electronAPI = {
     detect: () => ipcRenderer.invoke('local-harness:detect'),
     connect: () => ipcRenderer.invoke('local-harness:connect'),
     disconnect: () => ipcRenderer.invoke('local-harness:disconnect'),
+    setProviderEnabled: (provider: string, enabled: boolean) =>
+      ipcRenderer.invoke('local-harness:set-provider', provider, enabled),
   },
 };
 

--- a/apps/electron/src/services/local-harness/adapters/claudeCode.ts
+++ b/apps/electron/src/services/local-harness/adapters/claudeCode.ts
@@ -1,0 +1,128 @@
+import { randomBytes } from 'crypto';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import log from 'electron-log/main';
+import type { HarnessAdapter, HarnessRunContext, HarnessRunOutcome } from './types';
+import { spawnJsonLines } from './streamJson';
+
+export class ClaudeCodeAdapter implements HarnessAdapter {
+  async run(ctx: HarnessRunContext): Promise<HarnessRunOutcome> {
+    const { envelope } = ctx;
+
+    const prompt = ctx.envelope.context
+      ? `${ctx.envelope.context}\n\n---\n\n${envelope.task}`
+      : envelope.task;
+
+    const mcpConfigPath = join(tmpdir(), `xyne-mcp-${randomBytes(12).toString('hex')}.json`);
+    await fs.writeFile(mcpConfigPath, JSON.stringify(ctx.mcpConfig), { mode: 0o600 });
+
+    const args = [
+      '-p',
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--append-system-prompt',
+      envelope.systemPrompt,
+      '--mcp-config',
+      mcpConfigPath,
+      '--strict-mcp-config',
+      '--setting-sources',
+      '',
+      '--tools',
+      '',
+      '--permission-mode',
+      'bypassPermissions',
+    ];
+
+    if (envelope.model) args.push('--model', envelope.model);
+    if (ctx.resumeSessionId) args.push('--resume', ctx.resumeSessionId);
+
+    let text = '';
+    let harnessSessionId: string | undefined;
+    let effectiveModel: string | undefined;
+    let resultError: string | undefined;
+    const toolsUsed = new Set<string>();
+    let tokenUsage: { input?: number; output?: number } | undefined;
+
+    let result;
+    try {
+      result = await spawnJsonLines({
+        binaryPath: ctx.binaryPath,
+        args,
+        stdin: prompt,
+        cwd: tmpdir(),
+        env: { ...process.env },
+        signal: ctx.signal,
+        timeoutMs: envelope.timeoutMs,
+        onEvent: (event) => {
+          const type = event['type'];
+
+          if (typeof event['session_id'] === 'string') harnessSessionId = event['session_id'];
+
+          if (type === 'system' && event['subtype'] === 'init') {
+            if (typeof event['model'] === 'string') effectiveModel = event['model'];
+            ctx.onProgress({ kind: 'status', label: 'Starting local harness' });
+            return;
+          }
+
+          if (type === 'assistant') {
+            const message = event['message'] as { content?: unknown } | undefined;
+            for (const block of asBlocks(message?.content)) {
+              if (block['type'] === 'text' && typeof block['text'] === 'string') {
+                text += block['text'];
+                ctx.onProgress({ kind: 'text', delta: block['text'] });
+              } else if (block['type'] === 'tool_use' && typeof block['name'] === 'string') {
+                toolsUsed.add(block['name']);
+              }
+            }
+            return;
+          }
+
+          if (type === 'result') {
+            if (typeof event['result'] === 'string' && event['result']) text = event['result'];
+            if (event['is_error'] === true) {
+              resultError =
+                typeof event['result'] === 'string' ? event['result'] : 'Claude Code reported an error';
+            }
+            const usage = event['usage'] as { input_tokens?: number; output_tokens?: number } | undefined;
+            if (usage) tokenUsage = { input: usage.input_tokens, output: usage.output_tokens };
+          }
+        },
+      });
+    } finally {
+      await fs.rm(mcpConfigPath, { force: true }).catch(() => {});
+    }
+
+    if (result.aborted) {
+      return { status: 'cancelled', text: '', ...(harnessSessionId ? { harnessSessionId } : {}) };
+    }
+    if (result.timedOut) {
+      return { status: 'failed', text: '', error: 'Claude Code exceeded the run time limit' };
+    }
+    if (result.exitCode !== 0 || resultError) {
+      const detail = resultError ?? result.stderr.trim() ?? '';
+      log.warn(`[LocalHarness] claude-code exit=${result.exitCode} error=${detail.slice(0, 300)}`);
+      return {
+        status: 'failed',
+        text: '',
+        error: detail || `Claude Code exited with code ${result.exitCode}`,
+        ...(harnessSessionId ? { harnessSessionId } : {}),
+      };
+    }
+
+    return {
+      status: 'done',
+      text,
+      toolsUsed: [...toolsUsed],
+      ...(tokenUsage ? { tokenUsage } : {}),
+      ...(effectiveModel ? { effectiveModel } : {}),
+      ...(harnessSessionId ? { harnessSessionId } : {}),
+    };
+  }
+}
+
+function asBlocks(content: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(content)) return [];
+  return content.filter((b): b is Record<string, unknown> => !!b && typeof b === 'object' && !Array.isArray(b));
+}

--- a/apps/electron/src/services/local-harness/adapters/codexCli.ts
+++ b/apps/electron/src/services/local-harness/adapters/codexCli.ts
@@ -1,0 +1,136 @@
+import { tmpdir } from 'os';
+import log from 'electron-log/main';
+import type { HarnessAdapter, HarnessRunContext, HarnessRunOutcome } from './types';
+import { spawnJsonLines } from './streamJson';
+
+const TOKEN_ENV_VAR = 'XYNE_LOCAL_HARNESS_TOKEN';
+
+export class CodexCliAdapter implements HarnessAdapter {
+  async run(ctx: HarnessRunContext): Promise<HarnessRunOutcome> {
+    const { envelope } = ctx;
+
+    const prompt = [
+      `<system>\n${envelope.systemPrompt}\n</system>`,
+      envelope.context ? `<context>\n${envelope.context}\n</context>` : '',
+      envelope.task,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const facade = (ctx.mcpConfig['mcpServers'] as Record<string, { url?: string; headers?: Record<string, string> }>)[
+      ctx.mcpServerName
+    ];
+    const facadeUrl = facade?.url ?? '';
+    const facadeToken = (facade?.headers?.['Authorization'] ?? '').replace(/^Bearer\s+/i, '');
+
+    const args = ['exec'];
+    if (ctx.resumeSessionId) args.push('resume', ctx.resumeSessionId);
+
+    args.push(
+      '--json',
+      '--skip-git-repo-check',
+      '--ignore-user-config',
+      '-c',
+      'features.shell_tool=false',
+      '-c',
+      'features.unified_exec=false',
+      '-c',
+      'features.web_search_request=false',
+      '-c',
+      'sandbox_mode="read-only"',
+      '-c',
+      'approval_policy="never"',
+      '-c',
+      `mcp_servers.${ctx.mcpServerName}.url=${JSON.stringify(facadeUrl)}`,
+      '-c',
+      `mcp_servers.${ctx.mcpServerName}.bearer_token_env_var=${JSON.stringify(TOKEN_ENV_VAR)}`,
+      '-c',
+      `mcp_servers.${ctx.mcpServerName}.default_tools_approval_mode="approve"`,
+    );
+
+    if (envelope.model) args.push('--model', envelope.model);
+
+    let text = '';
+    let harnessSessionId: string | undefined;
+    let resultError: string | undefined;
+    const toolsUsed = new Set<string>();
+    let tokenUsage: { input?: number; output?: number } | undefined;
+
+    const result = await spawnJsonLines({
+      binaryPath: ctx.binaryPath,
+      args,
+      stdin: prompt,
+      cwd: tmpdir(),
+      env: { ...process.env, [TOKEN_ENV_VAR]: facadeToken },
+      signal: ctx.signal,
+      timeoutMs: envelope.timeoutMs,
+      onEvent: (event) => {
+        switch (event['type']) {
+          case 'thread.started':
+            if (typeof event['thread_id'] === 'string') harnessSessionId = event['thread_id'];
+            ctx.onProgress({ kind: 'status', label: 'Starting local harness' });
+            break;
+
+          case 'item.started':
+          case 'item.completed': {
+            const item = event['item'] as Record<string, unknown> | undefined;
+            if (!item) break;
+
+            if (item['type'] === 'agent_message' && event['type'] === 'item.completed') {
+              if (typeof item['text'] === 'string' && item['text']) {
+                text = item['text'];
+                ctx.onProgress({ kind: 'text', delta: item['text'] });
+              }
+            }
+
+            if (item['type'] === 'mcp_tool_call' && typeof item['tool'] === 'string') {
+              toolsUsed.add(item['tool']);
+              const err = item['error'] as { message?: unknown } | null | undefined;
+              if (event['type'] === 'item.completed' && item['status'] === 'failed' && err) {
+                log.warn(`[LocalHarness] codex MCP tool ${String(item['tool'])} failed: ${String(err.message)}`);
+              }
+            }
+            break;
+          }
+
+          case 'turn.completed': {
+            const usage = event['usage'] as { input_tokens?: number; output_tokens?: number } | undefined;
+            if (usage) tokenUsage = { input: usage.input_tokens, output: usage.output_tokens };
+            break;
+          }
+
+          case 'turn.failed':
+          case 'error':
+            resultError =
+              typeof event['message'] === 'string' ? event['message'] : 'Codex reported an error';
+            break;
+        }
+      },
+    });
+
+    if (result.aborted) {
+      return { status: 'cancelled', text: '', ...(harnessSessionId ? { harnessSessionId } : {}) };
+    }
+    if (result.timedOut) {
+      return { status: 'failed', text: '', error: 'Codex exceeded the run time limit' };
+    }
+    if (result.exitCode !== 0 || resultError) {
+      const detail = resultError ?? result.stderr.trim();
+      log.warn(`[LocalHarness] codex exit=${result.exitCode} error=${detail.slice(0, 300)}`);
+      return {
+        status: 'failed',
+        text: '',
+        error: detail || `Codex exited with code ${result.exitCode}`,
+        ...(harnessSessionId ? { harnessSessionId } : {}),
+      };
+    }
+
+    return {
+      status: 'done',
+      text,
+      toolsUsed: [...toolsUsed],
+      ...(tokenUsage ? { tokenUsage } : {}),
+      ...(harnessSessionId ? { harnessSessionId } : {}),
+    };
+  }
+}

--- a/apps/electron/src/services/local-harness/adapters/streamJson.ts
+++ b/apps/electron/src/services/local-harness/adapters/streamJson.ts
@@ -1,0 +1,103 @@
+import { spawn } from 'child_process';
+import log from 'electron-log/main';
+
+export interface SpawnJsonLinesOptions {
+  binaryPath: string;
+  args: string[];
+  stdin?: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  signal: AbortSignal;
+  timeoutMs: number;
+  onEvent: (event: Record<string, unknown>) => void;
+}
+
+export interface SpawnJsonLinesResult {
+  exitCode: number | null;
+  stderr: string;
+  timedOut: boolean;
+  aborted: boolean;
+}
+
+const STDERR_TAIL_LIMIT = 4000;
+
+export function spawnJsonLines(opts: SpawnJsonLinesOptions): Promise<SpawnJsonLinesResult> {
+  return new Promise((resolve) => {
+    const child = spawn(opts.binaryPath, opts.args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      detached: process.platform !== 'win32',
+    });
+
+    let stdoutBuffer = '';
+    let stderr = '';
+    let timedOut = false;
+    let aborted = false;
+    let settled = false;
+
+    const killTree = () => {
+      if (child.pid === undefined) return;
+      try {
+        if (process.platform === 'win32') child.kill('SIGKILL');
+        else process.kill(-child.pid, 'SIGKILL');
+      } catch {}
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killTree();
+    }, opts.timeoutMs);
+
+    const onAbort = () => {
+      aborted = true;
+      killTree();
+    };
+    opts.signal.addEventListener('abort', onAbort, { once: true });
+
+    const settle = (exitCode: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      opts.signal.removeEventListener('abort', onAbort);
+      resolve({ exitCode, stderr: stderr.slice(-STDERR_TAIL_LIMIT), timedOut, aborted });
+    };
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdoutBuffer += chunk;
+      let newline = stdoutBuffer.indexOf('\n');
+      while (newline !== -1) {
+        const line = stdoutBuffer.slice(0, newline).trim();
+        stdoutBuffer = stdoutBuffer.slice(newline + 1);
+        newline = stdoutBuffer.indexOf('\n');
+        if (!line) continue;
+        try {
+          const parsed = JSON.parse(line) as unknown;
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            opts.onEvent(parsed as Record<string, unknown>);
+          }
+        } catch {
+          log.debug(`[LocalHarness] non-JSON stdout line: ${line.slice(0, 200)}`);
+        }
+      }
+    });
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+      if (stderr.length > STDERR_TAIL_LIMIT * 2) stderr = stderr.slice(-STDERR_TAIL_LIMIT);
+    });
+
+    child.on('error', (err) => {
+      stderr += `\n${err.message}`;
+      settle(null);
+    });
+    child.on('close', (code) => settle(code));
+
+    child.stdin.on('error', () => {});
+    if (opts.stdin !== undefined) child.stdin.write(opts.stdin);
+    child.stdin.end();
+  });
+}

--- a/apps/electron/src/services/local-harness/adapters/types.ts
+++ b/apps/electron/src/services/local-harness/adapters/types.ts
@@ -1,0 +1,19 @@
+import type { LocalHarnessProgressEvent, LocalHarnessRunEnvelope, LocalHarnessRunResult } from '../contract';
+
+export interface HarnessRunContext {
+  envelope: LocalHarnessRunEnvelope;
+  binaryPath: string;
+  mcpConfig: Record<string, unknown>;
+  mcpServerName: string;
+  resumeSessionId?: string | undefined;
+  onProgress: (event: LocalHarnessProgressEvent) => void;
+  signal: AbortSignal;
+}
+
+export interface HarnessRunOutcome extends LocalHarnessRunResult {
+  harnessSessionId?: string;
+}
+
+export interface HarnessAdapter {
+  run(ctx: HarnessRunContext): Promise<HarnessRunOutcome>;
+}

--- a/apps/electron/src/services/local-harness/bridge.ts
+++ b/apps/electron/src/services/local-harness/bridge.ts
@@ -33,6 +33,7 @@ interface PersistedState {
   deviceId?: string;
   deviceTokenEnc?: string;
   deviceTokenPlain?: string;
+  enabledProviders?: LocalHarnessProvider[];
 }
 
 export class LocalHarnessBridge {
@@ -76,12 +77,47 @@ export class LocalHarnessBridge {
     return `${hostname()} (${app.getName()})`;
   }
 
+  // Which harnesses the user connected on this device. No stored set but an
+  // existing pairing means the device was paired before per-harness connect
+  // shipped, when pairing meant "every signed-in CLI" — keep those whole. With
+  // no pairing nothing is connected, otherwise a machine that merely HAS the
+  // CLIs installed would render as already connected.
+  private enabledProviders(): Set<LocalHarnessProvider> {
+    const stored = this.store.get('enabledProviders');
+    if (stored) return new Set(stored);
+    if (!this.deviceToken()) return new Set();
+    return new Set(this.installations.filter((i) => i.authenticated).map((i) => i.provider));
+  }
+
+  private setEnabledProviders(providers: Set<LocalHarnessProvider>): void {
+    this.store.set('enabledProviders', [...providers]);
+    this.installations = this.installations.map((i) => ({ ...i, enabled: providers.has(i.provider) }));
+  }
+
   async refreshInstallations(): Promise<LocalHarnessInstallation[]> {
-    this.installations = await detectInstallations().catch((err) => {
+    const found = await detectInstallations().catch((err) => {
       log.warn('[LocalHarness] detection failed:', err);
-      return [];
+      return [] as LocalHarnessInstallation[];
     });
+    // Seed before reading enabledProviders(): its legacy fallback derives the
+    // set from the freshly detected installations.
+    this.installations = found;
+    const enabled = this.enabledProviders();
+    this.installations = found.map((i) => ({ ...i, enabled: enabled.has(i.provider) }));
     return this.installations;
+  }
+
+  // Rescan: re-probe the CLIs and, if this device is paired, tell the server
+  // what changed (a CLI installed or signed in after pairing would otherwise
+  // stay invisible to run routing until the next connect).
+  async rescan(): Promise<LocalHarnessInstallation[]> {
+    const installations = await this.refreshInstallations();
+    if (this.deviceToken()) {
+      await this.syncInstallations().catch((err) => {
+        log.warn('[LocalHarness] installation sync after rescan failed:', err);
+      });
+    }
+    return installations;
   }
 
   async status(): Promise<LocalHarnessStatus> {
@@ -97,9 +133,7 @@ export class LocalHarnessBridge {
     };
   }
 
-  async connect(cookieHeader: string): Promise<LocalHarnessStatus> {
-    await this.refreshInstallations();
-
+  private async registerDevice(cookieHeader: string): Promise<void> {
     const res = await fetch(`${this.baseUrl()}/local-harness/devices`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Cookie: cookieHeader },
@@ -121,9 +155,85 @@ export class LocalHarnessBridge {
 
     this.store.set('deviceId', body.data.deviceId);
     this.setDeviceToken(body.data.deviceToken);
-    this.lastError = null;
     log.info(`[LocalHarness] paired device ${body.data.deviceId}`);
+  }
 
+  // Pushes the current installation list (including which harnesses the user
+  // has connected) to an ALREADY paired device. Re-registering instead would
+  // rotate the device token and 401 the long-poll this app has in flight.
+  private async syncInstallations(): Promise<void> {
+    const token = this.deviceToken();
+    if (!token) return;
+    const res = await fetch(`${this.baseUrl()}/local-harness-bridge/installations`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        protocolVersion: LOCAL_HARNESS_PROTOCOL_VERSION,
+        installations: this.installations,
+      }),
+    });
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error ?? `Failed to update this device (HTTP ${res.status})`);
+    }
+  }
+
+  // Connect/disconnect ONE harness. The pairing exists only while at least one
+  // harness is connected — the last disconnect revokes the device rather than
+  // leaving an idle poller against the server.
+  async setProviderEnabled(
+    provider: LocalHarnessProvider,
+    enabled: boolean,
+    cookieHeader: string,
+  ): Promise<LocalHarnessStatus> {
+    await this.refreshInstallations();
+
+    if (enabled) {
+      const install = this.installations.find((i) => i.provider === provider);
+      if (!install) throw new Error(`No ${provider} installation was found on this device`);
+      if (!install.authenticated) throw new Error(`Sign in to ${provider} in your terminal first`);
+    }
+
+    const previous = this.enabledProviders();
+    const next = new Set(previous);
+    if (enabled) next.add(provider);
+    else next.delete(provider);
+    this.setEnabledProviders(next);
+
+    if (next.size === 0) return this.disconnect(cookieHeader);
+
+    try {
+      if (this.deviceToken()) await this.syncInstallations();
+      else await this.registerDevice(cookieHeader);
+    } catch (err) {
+      // Never leave the card showing "connected" for something the server
+      // never heard about.
+      this.setEnabledProviders(previous);
+      throw err;
+    }
+
+    this.lastError = null;
+    log.info(`[LocalHarness] ${provider} ${enabled ? 'connected' : 'disconnected'} on this device`);
+    this.start();
+    return this.status();
+  }
+
+  async connect(cookieHeader: string): Promise<LocalHarnessStatus> {
+    await this.refreshInstallations();
+
+    const usable = this.installations.filter((i) => i.authenticated).map((i) => i.provider);
+    if (usable.length === 0) throw new Error('No signed-in local harness was found on this device');
+
+    const previous = this.enabledProviders();
+    this.setEnabledProviders(new Set(usable));
+    try {
+      await this.registerDevice(cookieHeader);
+    } catch (err) {
+      this.setEnabledProviders(previous);
+      throw err;
+    }
+
+    this.lastError = null;
     this.start();
     return this.status();
   }
@@ -140,6 +250,8 @@ export class LocalHarnessBridge {
     this.store.delete('deviceId');
     this.store.delete('deviceTokenEnc');
     this.store.delete('deviceTokenPlain');
+    this.store.set('enabledProviders', []);
+    this.installations = this.installations.map((i) => ({ ...i, enabled: false }));
     this.harnessSessions.clear();
     return this.status();
   }
@@ -163,8 +275,8 @@ export class LocalHarnessBridge {
 
     await this.refreshInstallations();
     log.info(
-      `[LocalHarness] poll loop started with ${this.installations.length} installation(s): ` +
-        `[${this.installations.map(i => i.provider).join(',')}]`,
+      `[LocalHarness] poll loop started with ${this.installations.length} installation(s), connected: ` +
+        `[${this.installations.filter(i => i.enabled).map(i => i.provider).join(',')}]`,
     );
 
     try {

--- a/apps/electron/src/services/local-harness/bridge.ts
+++ b/apps/electron/src/services/local-harness/bridge.ts
@@ -22,6 +22,8 @@ import type { HarnessAdapter } from './adapters/types';
 
 const MCP_SERVER_NAME = 'xyne';
 
+class StaleDevicePairingError extends Error {}
+
 const POLL_ERROR_BACKOFF_MS = 5000;
 
 const ADAPTERS: Record<LocalHarnessProvider, HarnessAdapter> = {
@@ -172,10 +174,17 @@ export class LocalHarnessBridge {
         installations: this.installations,
       }),
     });
+    if (res.status === 401) throw new StaleDevicePairingError('Device pairing is no longer valid');
     if (!res.ok) {
       const body = (await res.json().catch(() => ({}))) as { error?: string };
       throw new Error(body.error ?? `Failed to update this device (HTTP ${res.status})`);
     }
+  }
+
+  private clearPairing(): void {
+    this.store.delete('deviceId');
+    this.store.delete('deviceTokenEnc');
+    this.store.delete('deviceTokenPlain');
   }
 
   // Connect/disconnect ONE harness. The pairing exists only while at least one
@@ -203,8 +212,18 @@ export class LocalHarnessBridge {
     if (next.size === 0) return this.disconnect(cookieHeader);
 
     try {
-      if (this.deviceToken()) await this.syncInstallations();
-      else await this.registerDevice(cookieHeader);
+      if (this.deviceToken()) {
+        try {
+          await this.syncInstallations();
+        } catch (err) {
+          if (!(err instanceof StaleDevicePairingError)) throw err;
+          log.warn('[LocalHarness] stored device token is unknown to the server — re-pairing');
+          this.clearPairing();
+          await this.registerDevice(cookieHeader);
+        }
+      } else {
+        await this.registerDevice(cookieHeader);
+      }
     } catch (err) {
       // Never leave the card showing "connected" for something the server
       // never heard about.
@@ -247,9 +266,7 @@ export class LocalHarnessBridge {
         headers: { Cookie: cookieHeader },
       }).catch((err) => log.warn('[LocalHarness] revoke failed (clearing locally anyway):', err));
     }
-    this.store.delete('deviceId');
-    this.store.delete('deviceTokenEnc');
-    this.store.delete('deviceTokenPlain');
+    this.clearPairing();
     this.store.set('enabledProviders', []);
     this.installations = this.installations.map((i) => ({ ...i, enabled: false }));
     this.harnessSessions.clear();

--- a/apps/electron/src/services/local-harness/bridge.ts
+++ b/apps/electron/src/services/local-harness/bridge.ts
@@ -1,0 +1,327 @@
+import { hostname } from 'os';
+import { app, safeStorage } from 'electron';
+import Store from 'electron-store';
+import log from 'electron-log/main';
+import { config } from '../../app/config';
+import {
+  LOCAL_HARNESS_PROTOCOL_VERSION,
+  type LocalHarnessInstallation,
+  type LocalHarnessPollResult,
+  type LocalHarnessProgressEvent,
+  type LocalHarnessProvider,
+  type LocalHarnessRunEnvelope,
+  type LocalHarnessRunResult,
+  type LocalHarnessStatus,
+  type LocalHarnessToolSpec,
+} from './contract';
+import { detectInstallations } from './detect';
+import { ToolFacadeServer } from './toolFacade';
+import { ClaudeCodeAdapter } from './adapters/claudeCode';
+import { CodexCliAdapter } from './adapters/codexCli';
+import type { HarnessAdapter } from './adapters/types';
+
+const MCP_SERVER_NAME = 'xyne';
+
+const POLL_ERROR_BACKOFF_MS = 5000;
+
+const ADAPTERS: Record<LocalHarnessProvider, HarnessAdapter> = {
+  'claude-code': new ClaudeCodeAdapter(),
+  'codex-cli': new CodexCliAdapter(),
+};
+
+interface PersistedState {
+  deviceId?: string;
+  deviceTokenEnc?: string;
+  deviceTokenPlain?: string;
+}
+
+export class LocalHarnessBridge {
+  private readonly store = new Store<PersistedState>({ name: 'local-harness' });
+  private installations: LocalHarnessInstallation[] = [];
+  private polling = false;
+  private stopped = true;
+  private lastError: string | null = null;
+  private activeRun: { runId: string; controller: AbortController } | null = null;
+  private readonly harnessSessions = new Map<string, string>();
+
+  private baseUrl(): string {
+    return new URL('/claw/api/v1', config.CLAW_AUTH_URL).toString().replace(/\/+$/, '');
+  }
+
+  private deviceToken(): string | null {
+    const enc = this.store.get('deviceTokenEnc');
+    if (enc) {
+      try {
+        return safeStorage.decryptString(Buffer.from(enc, 'base64'));
+      } catch (err) {
+        log.warn('[LocalHarness] failed to decrypt device token — re-pair required:', err);
+        return null;
+      }
+    }
+    return this.store.get('deviceTokenPlain') ?? null;
+  }
+
+  private setDeviceToken(token: string): void {
+    if (safeStorage.isEncryptionAvailable()) {
+      this.store.set('deviceTokenEnc', safeStorage.encryptString(token).toString('base64'));
+      this.store.delete('deviceTokenPlain');
+      return;
+    }
+    log.warn('[LocalHarness] OS keychain unavailable — storing device token unencrypted');
+    this.store.set('deviceTokenPlain', token);
+    this.store.delete('deviceTokenEnc');
+  }
+
+  private deviceName(): string {
+    return `${hostname()} (${app.getName()})`;
+  }
+
+  async refreshInstallations(): Promise<LocalHarnessInstallation[]> {
+    this.installations = await detectInstallations().catch((err) => {
+      log.warn('[LocalHarness] detection failed:', err);
+      return [];
+    });
+    return this.installations;
+  }
+
+  async status(): Promise<LocalHarnessStatus> {
+    if (this.installations.length === 0) await this.refreshInstallations();
+    return {
+      supported: true,
+      connected: !this.stopped && !!this.deviceToken(),
+      deviceId: this.store.get('deviceId') ?? null,
+      deviceName: this.deviceName(),
+      platform: process.platform,
+      installations: this.installations,
+      lastError: this.lastError,
+    };
+  }
+
+  async connect(cookieHeader: string): Promise<LocalHarnessStatus> {
+    await this.refreshInstallations();
+
+    const res = await fetch(`${this.baseUrl()}/local-harness/devices`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: cookieHeader },
+      body: JSON.stringify({
+        protocolVersion: LOCAL_HARNESS_PROTOCOL_VERSION,
+        deviceName: this.deviceName(),
+        platform: process.platform,
+        installations: this.installations,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error ?? `Device registration failed (HTTP ${res.status})`);
+    }
+
+    const body = (await res.json()) as { data?: { deviceId?: string; deviceToken?: string } };
+    if (!body.data?.deviceId || !body.data?.deviceToken) throw new Error('Device registration returned no token');
+
+    this.store.set('deviceId', body.data.deviceId);
+    this.setDeviceToken(body.data.deviceToken);
+    this.lastError = null;
+    log.info(`[LocalHarness] paired device ${body.data.deviceId}`);
+
+    this.start();
+    return this.status();
+  }
+
+  async disconnect(cookieHeader: string): Promise<LocalHarnessStatus> {
+    const deviceId = this.store.get('deviceId');
+    this.stop();
+    if (deviceId) {
+      await fetch(`${this.baseUrl()}/local-harness/devices/${encodeURIComponent(deviceId)}`, {
+        method: 'DELETE',
+        headers: { Cookie: cookieHeader },
+      }).catch((err) => log.warn('[LocalHarness] revoke failed (clearing locally anyway):', err));
+    }
+    this.store.delete('deviceId');
+    this.store.delete('deviceTokenEnc');
+    this.store.delete('deviceTokenPlain');
+    this.harnessSessions.clear();
+    return this.status();
+  }
+
+  start(): void {
+    if (!this.stopped) return;
+    if (!this.deviceToken()) return;
+    this.stopped = false;
+    void this.pollLoop();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.activeRun?.controller.abort();
+    this.activeRun = null;
+  }
+
+  private async pollLoop(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+
+    await this.refreshInstallations();
+    log.info(
+      `[LocalHarness] poll loop started with ${this.installations.length} installation(s): ` +
+        `[${this.installations.map(i => i.provider).join(',')}]`,
+    );
+
+    try {
+      while (!this.stopped) {
+        const token = this.deviceToken();
+        if (!token) break;
+
+        try {
+          const res = await fetch(`${this.baseUrl()}/local-harness-bridge/runs/next`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+
+          if (res.status === 401) {
+            this.lastError = 'This device is no longer paired. Reconnect from Settings.';
+            log.warn('[LocalHarness] device token rejected — stopping poll loop');
+            this.stop();
+            break;
+          }
+          if (!res.ok) throw new Error(`Poll failed (HTTP ${res.status})`);
+
+          const body = (await res.json()) as { data?: LocalHarnessPollResult };
+          this.lastError = null;
+          if (body.data?.status === 'run') {
+            await this.executeRun(body.data.run, token);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.lastError = message;
+          log.warn(`[LocalHarness] poll error: ${message}`);
+          await delay(POLL_ERROR_BACKOFF_MS);
+        }
+      }
+    } finally {
+      this.polling = false;
+      log.info('[LocalHarness] poll loop stopped');
+    }
+  }
+
+  private async executeRun(envelope: LocalHarnessRunEnvelope, token: string): Promise<void> {
+    const adapter = ADAPTERS[envelope.provider];
+    let installation = this.installations.find((i) => i.provider === envelope.provider);
+
+    if (!installation) {
+      log.warn(`[LocalHarness] ${envelope.provider} not in cached installations — re-probing`);
+      await this.refreshInstallations();
+      installation = this.installations.find((i) => i.provider === envelope.provider);
+    }
+
+    if (!adapter || !installation) {
+      await this.reportResult(envelope.runId, token, {
+        status: 'failed',
+        text: '',
+        error: `No local ${envelope.provider} installation is available on this device`,
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    this.activeRun = { runId: envelope.runId, controller };
+
+    const facade = new ToolFacadeServer({
+      listTools: () => this.fetchTools(envelope.runId, token),
+      callTool: (spec, args) => this.callTool(envelope.runId, token, spec, args),
+      onToolStarted: (toolName) => {
+        void this.reportProgress(envelope.runId, token, { kind: 'tool', toolName });
+      },
+    });
+
+    try {
+      await facade.start();
+
+      log.info(
+        `[LocalHarness] run=${envelope.runId} agent=${envelope.agentSlug} provider=${envelope.provider} ` +
+          `requestedModel=${envelope.model ?? '(cli default)'} binary=${installation.binaryPath}`,
+      );
+
+      const outcome = await adapter.run({
+        envelope,
+        binaryPath: installation.binaryPath,
+        mcpConfig: facade.mcpConfig(MCP_SERVER_NAME),
+        mcpServerName: MCP_SERVER_NAME,
+        resumeSessionId: this.harnessSessions.get(envelope.conversationId),
+        onProgress: (event) => {
+          void this.reportProgress(envelope.runId, token, event);
+        },
+        signal: controller.signal,
+      });
+
+      if (outcome.harnessSessionId) {
+        this.harnessSessions.set(envelope.conversationId, outcome.harnessSessionId);
+      }
+
+      log.info(
+        `[LocalHarness] run=${envelope.runId} status=${outcome.status} ` +
+          `effectiveModel=${outcome.effectiveModel ?? '(not reported)'} ` +
+          `tools=[${(outcome.toolsUsed ?? []).join(',')}] chars=${outcome.text.length}` +
+          `${outcome.error ? ` error=${outcome.error}` : ''}`,
+      );
+
+      const { harnessSessionId: _ignored, ...result } = outcome;
+      await this.reportResult(envelope.runId, token, result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(`[LocalHarness] run ${envelope.runId} failed: ${message}`);
+      await this.reportResult(envelope.runId, token, { status: 'failed', text: '', error: message });
+    } finally {
+      await facade.stop().catch(() => {});
+      this.activeRun = null;
+    }
+  }
+
+  private async fetchTools(runId: string, token: string): Promise<LocalHarnessToolSpec[]> {
+    const res = await fetch(`${this.baseUrl()}/local-harness-bridge/runs/${encodeURIComponent(runId)}/tools`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`Tool listing failed (HTTP ${res.status})`);
+    const body = (await res.json()) as { data?: { tools?: LocalHarnessToolSpec[] } };
+    return body.data?.tools ?? [];
+  }
+
+  private async callTool(
+    runId: string,
+    token: string,
+    spec: LocalHarnessToolSpec,
+    args: Record<string, unknown>,
+  ): Promise<{ ok: boolean; content: string }> {
+    const res = await fetch(`${this.baseUrl()}/local-harness-bridge/runs/${encodeURIComponent(runId)}/tools/call`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ serverType: spec.serverType, toolName: spec.toolName, params: args }),
+    });
+    const body = (await res.json().catch(() => ({}))) as { data?: { ok?: boolean; content?: string }; error?: string };
+    if (!res.ok) return { ok: false, content: body.error ?? `Tool call failed (HTTP ${res.status})` };
+    return { ok: body.data?.ok !== false, content: body.data?.content ?? '' };
+  }
+
+  private async reportProgress(runId: string, token: string, event: LocalHarnessProgressEvent): Promise<void> {
+    await fetch(`${this.baseUrl()}/local-harness-bridge/runs/${encodeURIComponent(runId)}/progress`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(event),
+    }).catch(() => {});
+  }
+
+  private async reportResult(runId: string, token: string, result: LocalHarnessRunResult): Promise<void> {
+    await fetch(`${this.baseUrl()}/local-harness-bridge/runs/${encodeURIComponent(runId)}/result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(result),
+    }).catch((err) => {
+      log.error(`[LocalHarness] failed to report result for run ${runId}:`, err);
+    });
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const localHarnessBridge = new LocalHarnessBridge();

--- a/apps/electron/src/services/local-harness/bridge.ts
+++ b/apps/electron/src/services/local-harness/bridge.ts
@@ -25,6 +25,7 @@ const MCP_SERVER_NAME = 'xyne';
 class StaleDevicePairingError extends Error {}
 
 const POLL_ERROR_BACKOFF_MS = 5000;
+const RUN_HEARTBEAT_MS = 30000;
 
 const ADAPTERS: Record<LocalHarnessProvider, HarnessAdapter> = {
   'claude-code': new ClaudeCodeAdapter(),
@@ -362,6 +363,12 @@ export class LocalHarnessBridge {
       },
     });
 
+    const heartbeat = setInterval(() => {
+      void fetch(`${this.baseUrl()}/local-harness-bridge/ping`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }).catch(() => {});
+    }, RUN_HEARTBEAT_MS);
+
     try {
       await facade.start();
 
@@ -400,6 +407,7 @@ export class LocalHarnessBridge {
       log.error(`[LocalHarness] run ${envelope.runId} failed: ${message}`);
       await this.reportResult(envelope.runId, token, { status: 'failed', text: '', error: message });
     } finally {
+      clearInterval(heartbeat);
       await facade.stop().catch(() => {});
       this.activeRun = null;
     }

--- a/apps/electron/src/services/local-harness/contract.ts
+++ b/apps/electron/src/services/local-harness/contract.ts
@@ -12,6 +12,9 @@ export interface LocalHarnessInstallation {
   binaryPath: string;
   version: string;
   authenticated: boolean;
+  // Whether the user connected THIS harness on THIS device. Each harness pairs
+  // independently, so Claude Code can be on while Codex CLI stays off.
+  enabled?: boolean;
 }
 
 export interface LocalHarnessDeviceRegistration {

--- a/apps/electron/src/services/local-harness/contract.ts
+++ b/apps/electron/src/services/local-harness/contract.ts
@@ -1,0 +1,81 @@
+
+export type LocalHarnessProvider = 'claude-code' | 'codex-cli';
+
+export const LOCAL_HARNESS_PROVIDERS: readonly LocalHarnessProvider[] = ['claude-code', 'codex-cli'];
+
+export const LOCAL_HARNESS_PROTOCOL_VERSION = 1;
+
+export const LOCAL_HARNESS_SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+
+export interface LocalHarnessInstallation {
+  provider: LocalHarnessProvider;
+  binaryPath: string;
+  version: string;
+  authenticated: boolean;
+}
+
+export interface LocalHarnessDeviceRegistration {
+  protocolVersion: number;
+  deviceName: string;
+  platform: string;
+  installations: LocalHarnessInstallation[];
+}
+
+export interface LocalHarnessRunEnvelope {
+  protocolVersion: number;
+  runId: string;
+  sessionId: string;
+  conversationId: string;
+  provider: LocalHarnessProvider;
+  model: string | null;
+  agentSlug: string;
+  agentName: string;
+  systemPrompt: string;
+  task: string;
+  context: string | null;
+  timeoutMs: number;
+}
+
+export type LocalHarnessPollResult =
+  | { status: 'idle' }
+  | { status: 'run'; run: LocalHarnessRunEnvelope };
+
+export interface LocalHarnessToolSpec {
+  name: string;
+  serverType: string;
+  toolName: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  write: boolean;
+}
+
+export interface LocalHarnessToolCallResponse {
+  ok: boolean;
+  content: string;
+}
+
+export type LocalHarnessProgressEvent =
+  | { kind: 'text'; delta: string }
+  | { kind: 'tool'; toolName: string }
+  | { kind: 'status'; label: string };
+
+export type LocalHarnessRunStatus = 'done' | 'failed' | 'cancelled';
+
+export interface LocalHarnessRunResult {
+  status: LocalHarnessRunStatus;
+  text: string;
+  toolsUsed?: string[];
+  tokenUsage?: { input?: number; output?: number };
+  effectiveModel?: string;
+  error?: string;
+}
+
+export interface LocalHarnessStatus {
+  supported: boolean;
+  connected: boolean;
+  deviceId: string | null;
+  deviceName: string;
+  platform: string;
+  installations: LocalHarnessInstallation[];
+  lastError: string | null;
+}

--- a/apps/electron/src/services/local-harness/detect.ts
+++ b/apps/electron/src/services/local-harness/detect.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'child_process';
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import log from 'electron-log/main';
+import { LOCAL_HARNESS_PROVIDERS, type LocalHarnessInstallation, type LocalHarnessProvider } from './contract';
+
+const PROBE_TIMEOUT_MS = 8000;
+
+const HARNESS_BINARIES: Record<LocalHarnessProvider, string> = {
+  'claude-code': 'claude',
+  'codex-cli': 'codex',
+};
+
+function candidateDirectories(): string[] {
+  const home = homedir();
+  return [
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/usr/bin',
+    join(home, '.local', 'bin'),
+    join(home, '.bun', 'bin'),
+    join(home, '.claude', 'local'),
+    join(home, '.npm-global', 'bin'),
+    join(home, 'AppData', 'Roaming', 'npm'),
+    ...(process.env['PATH'] ?? '').split(process.platform === 'win32' ? ';' : ':').filter(Boolean),
+  ];
+}
+
+function resolveBinary(name: string): string | null {
+  const suffixes = process.platform === 'win32' ? ['.cmd', '.exe', ''] : [''];
+  for (const dir of candidateDirectories()) {
+    for (const suffix of suffixes) {
+      const candidate = join(dir, `${name}${suffix}`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function run(binary: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(binary, args, { timeout: PROBE_TIMEOUT_MS, windowsHide: true }, (error, stdout, stderr) => {
+      const code = error && typeof (error as { code?: unknown }).code === 'number' ? (error as { code: number }).code : error ? 1 : 0;
+      resolve({ code, stdout: String(stdout ?? ''), stderr: String(stderr ?? '') });
+    });
+  });
+}
+
+function hasStoredLogin(provider: LocalHarnessProvider): boolean {
+  const home = homedir();
+  if (provider === 'claude-code') {
+    return (
+      existsSync(join(home, '.claude', '.credentials.json')) ||
+      existsSync(join(home, '.claude.json')) ||
+      !!process.env['ANTHROPIC_API_KEY']
+    );
+  }
+  return existsSync(join(home, '.codex', 'auth.json')) || !!process.env['OPENAI_API_KEY'];
+}
+
+export async function detectInstallations(): Promise<LocalHarnessInstallation[]> {
+  const found: LocalHarnessInstallation[] = [];
+
+  for (const provider of LOCAL_HARNESS_PROVIDERS) {
+    const binaryPath = resolveBinary(HARNESS_BINARIES[provider]);
+    if (!binaryPath) continue;
+
+    const { code, stdout, stderr } = await run(binaryPath, ['--version']).catch(() => ({
+      code: 1,
+      stdout: '',
+      stderr: '',
+    }));
+    const version = (stdout || stderr).trim().split('\n')[0] ?? '';
+    const authenticated = hasStoredLogin(provider);
+
+    found.push({ provider, binaryPath, version, authenticated });
+    log.info(
+      `[LocalHarness] detected ${provider} at ${binaryPath} version="${version}" authenticated=${authenticated} probeExit=${code}`,
+    );
+  }
+
+  return found;
+}

--- a/apps/electron/src/services/local-harness/index.ts
+++ b/apps/electron/src/services/local-harness/index.ts
@@ -1,5 +1,6 @@
 export { localHarnessBridge, LocalHarnessBridge } from './bridge';
 export { detectInstallations } from './detect';
+export { LOCAL_HARNESS_PROVIDERS } from './contract';
 export type {
   LocalHarnessInstallation,
   LocalHarnessProvider,

--- a/apps/electron/src/services/local-harness/index.ts
+++ b/apps/electron/src/services/local-harness/index.ts
@@ -1,0 +1,7 @@
+export { localHarnessBridge, LocalHarnessBridge } from './bridge';
+export { detectInstallations } from './detect';
+export type {
+  LocalHarnessInstallation,
+  LocalHarnessProvider,
+  LocalHarnessStatus,
+} from './contract';

--- a/apps/electron/src/services/local-harness/toolFacade.ts
+++ b/apps/electron/src/services/local-harness/toolFacade.ts
@@ -113,7 +113,13 @@ export class ToolFacadeServer {
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`[LocalHarness] facade method ${body.method} failed: ${message}`);
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id, error: { code: -32603, message } }));
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          error: { code: -32603, message: 'Internal error' },
+        }),
+      );
     }
   }
 

--- a/apps/electron/src/services/local-harness/toolFacade.ts
+++ b/apps/electron/src/services/local-harness/toolFacade.ts
@@ -1,0 +1,178 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http';
+import { randomBytes } from 'crypto';
+import { AddressInfo } from 'net';
+import log from 'electron-log/main';
+import type { LocalHarnessToolSpec } from './contract';
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+export interface ToolFacadeHandlers {
+  listTools: () => Promise<LocalHarnessToolSpec[]>;
+  callTool: (spec: LocalHarnessToolSpec, args: Record<string, unknown>) => Promise<{ ok: boolean; content: string }>;
+  onToolStarted?: (toolName: string) => void;
+}
+
+export class ToolFacadeServer {
+  private server: Server | null = null;
+  private port = 0;
+  private readonly token = randomBytes(32).toString('base64url');
+  private toolsByName = new Map<string, LocalHarnessToolSpec>();
+
+  constructor(private readonly handlers: ToolFacadeHandlers) {}
+
+  async start(): Promise<{ url: string; token: string }> {
+    if (this.server) return { url: this.url(), token: this.token };
+
+    this.server = createServer((req, res) => {
+      void this.handle(req, res);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.server!.once('error', reject);
+      this.server!.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    this.port = (this.server.address() as AddressInfo).port;
+    log.info(`[LocalHarness] tool facade listening on ${this.url()}`);
+    return { url: this.url(), token: this.token };
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    this.server = null;
+    this.toolsByName.clear();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private url(): string {
+    return `http://127.0.0.1:${this.port}/mcp`;
+  }
+
+  mcpConfig(serverName: string): Record<string, unknown> {
+    return {
+      mcpServers: {
+        [serverName]: {
+          type: 'http',
+          url: this.url(),
+          headers: { Authorization: `Bearer ${this.token}` },
+        },
+      },
+    };
+  }
+
+  private isCrossSiteBrowserRequest(req: IncomingMessage): boolean {
+    const origin = req.headers['origin'];
+    if (typeof origin === 'string' && origin.length > 0) return true;
+    const secFetchSite = req.headers['sec-fetch-site'];
+    return typeof secFetchSite === 'string' && secFetchSite !== 'none' && secFetchSite !== 'same-origin';
+  }
+
+  private authorized(req: IncomingMessage): boolean {
+    const header = req.headers.authorization;
+    return typeof header === 'string' && header === `Bearer ${this.token}`;
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (this.isCrossSiteBrowserRequest(req) || !this.authorized(req)) {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Forbidden' }));
+      return;
+    }
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Method not allowed' }));
+      return;
+    }
+
+    let body: JsonRpcRequest;
+    try {
+      body = JSON.parse(await readBody(req)) as JsonRpcRequest;
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      return;
+    }
+
+    if (body.id === undefined || body.id === null) {
+      res.writeHead(202, { 'Content-Type': 'application/json' });
+      res.end('');
+      return;
+    }
+
+    try {
+      const result = await this.dispatch(body);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id, result }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`[LocalHarness] facade method ${body.method} failed: ${message}`);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id, error: { code: -32603, message } }));
+    }
+  }
+
+  private async dispatch(req: JsonRpcRequest): Promise<unknown> {
+    switch (req.method) {
+      case 'initialize':
+        return {
+          protocolVersion: '2025-06-18',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'xyne-spaces', version: '1.0.0' },
+        };
+
+      case 'ping':
+        return {};
+
+      case 'tools/list': {
+        const tools = await this.handlers.listTools();
+        this.toolsByName = new Map(tools.map((t) => [t.name, t]));
+        return {
+          tools: tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            inputSchema: t.inputSchema,
+          })),
+        };
+      }
+
+      case 'tools/call': {
+        const name = req.params?.['name'];
+        const args = req.params?.['arguments'];
+        if (typeof name !== 'string') throw new Error('tools/call requires a string name');
+
+        const spec = this.toolsByName.get(name);
+        if (!spec) {
+          return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+        }
+
+        this.handlers.onToolStarted?.(spec.toolName);
+        const result = await this.handlers.callTool(
+          spec,
+          args && typeof args === 'object' && !Array.isArray(args) ? (args as Record<string, unknown>) : {},
+        );
+        return {
+          content: [{ type: 'text', text: result.content }],
+          ...(result.ok ? {} : { isError: true }),
+        };
+      }
+
+      default:
+        throw new Error(`Unsupported method: ${req.method}`);
+    }
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}

--- a/apps/xyne-claw-auth/backend/.env.example
+++ b/apps/xyne-claw-auth/backend/.env.example
@@ -37,7 +37,7 @@ CLAW_ADMIN_EMAILS=
 
 # Microsoft OAuth (for microsoft-agent)
 MICROSOFT_CLIENT_ID=your-microsoft-client-id
-MICROSOFT_CLIENT_SECRET=your-microsoft-client-secret 
+MICROSOFT_CLIENT_SECRET=your-microsoft-client-secret
 MICROSOFT_REDIRECT_URI=your-microsoft-redirect-uri
 MICROSOFT_TENANT_ID=your-microsoft-tenant-id
 # Chat attachment storage (GCS)
@@ -92,3 +92,9 @@ CLAUDE_OAUTH_TOKEN_URL=
 CLAUDE_OAUTH_REDIRECT_URI=
 CLAUDE_OAUTH_SCOPES=
 CLAUDE_OAUTH_PKCE_PREFIX=claude-pkce-user:
+
+# Local harness (Claude Code / Codex) — see local-harness.ts
+LOCAL_HARNESS_ENABLED=true
+LOCAL_HARNESS_DEFAULT_ALL=false
+LOCAL_HARNESS_POLL_TIMEOUT_MS=25000
+LOCAL_HARNESS_RUN_TIMEOUT_MS=900000

--- a/apps/xyne-claw-auth/backend/.env.example
+++ b/apps/xyne-claw-auth/backend/.env.example
@@ -37,7 +37,7 @@ CLAW_ADMIN_EMAILS=
 
 # Microsoft OAuth (for microsoft-agent)
 MICROSOFT_CLIENT_ID=your-microsoft-client-id
-MICROSOFT_CLIENT_SECRET=your-microsoft-client-secret
+MICROSOFT_CLIENT_SECRET=your-microsoft-client-secret 
 MICROSOFT_REDIRECT_URI=your-microsoft-redirect-uri
 MICROSOFT_TENANT_ID=your-microsoft-tenant-id
 # Chat attachment storage (GCS)

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260824090000_add_local_harness/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260824090000_add_local_harness/migration.sql
@@ -1,0 +1,58 @@
+
+CREATE TABLE "local_harness_devices" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "deviceName" TEXT NOT NULL,
+    "platform" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "installations" JSONB NOT NULL DEFAULT '[]',
+    "lastSeenAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "local_harness_devices_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "local_harness_devices_tokenHash_key" ON "local_harness_devices"("tokenHash");
+CREATE INDEX "local_harness_devices_userId_revokedAt_idx" ON "local_harness_devices"("userId", "revokedAt");
+
+ALTER TABLE "local_harness_devices"
+    ADD CONSTRAINT "local_harness_devices_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "local_harness_runs" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "agentSlug" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "model" TEXT,
+    "deviceId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'queued',
+    "envelope" JSONB NOT NULL,
+    "progressUrl" TEXT NOT NULL,
+    "callbackUrl" TEXT NOT NULL,
+    "error" TEXT,
+    "claimedAt" TIMESTAMP(3),
+    "finishedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "local_harness_runs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "local_harness_runs_sessionId_key" ON "local_harness_runs"("sessionId");
+CREATE INDEX "local_harness_runs_userId_status_createdAt_idx" ON "local_harness_runs"("userId", "status", "createdAt");
+CREATE INDEX "local_harness_runs_status_expiresAt_idx" ON "local_harness_runs"("status", "expiresAt");
+
+ALTER TABLE "local_harness_runs"
+    ADD CONSTRAINT "local_harness_runs_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "local_harness_runs"
+    ADD CONSTRAINT "local_harness_runs_deviceId_fkey"
+    FOREIGN KEY ("deviceId") REFERENCES "local_harness_devices"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260824090000_add_local_harness/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260824090000_add_local_harness/migration.sql
@@ -56,3 +56,5 @@ ALTER TABLE "local_harness_runs"
 ALTER TABLE "local_harness_runs"
     ADD CONSTRAINT "local_harness_runs_deviceId_fkey"
     FOREIGN KEY ("deviceId") REFERENCES "local_harness_devices"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "users" ADD COLUMN "localHarnessDefaultProvider" TEXT;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -59,6 +59,8 @@ model User {
   digitalTwinPipelineEvents            DigitalTwinPipelineEvent[]
   agentMemoryFiles                     AgentMemoryFile[]
   twinBehaviorSignals                  TwinBehaviorSignal[]
+  localHarnessDevices                  LocalHarnessDevice[]
+  localHarnessRuns                     LocalHarnessRun[]
 
   /// Daily Brief opt-in (morning digest). When true, the leader-locked daily
   /// cron enqueues a brief-generation job for this user; when false the cron
@@ -803,6 +805,52 @@ model UserProviderCredentials {
   @@map("user_provider_credentials")
 }
 
+model LocalHarnessDevice {
+  id         String   @id @default(cuid())
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  orgId      String
+  deviceName String
+  platform   String
+  tokenHash  String   @unique
+  installations Json  @default("[]")
+  lastSeenAt DateTime?
+  revokedAt  DateTime?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  runs       LocalHarnessRun[]
+
+  @@index([userId, revokedAt])
+  @@map("local_harness_devices")
+}
+
+model LocalHarnessRun {
+  id            String   @id @default(cuid())
+  sessionId     String   @unique
+  userId        String
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  orgId         String
+  agentSlug     String
+  provider      String
+  model         String?
+  deviceId      String?
+  device        LocalHarnessDevice? @relation(fields: [deviceId], references: [id], onDelete: SetNull)
+  status        String   @default("queued")
+  envelope      Json
+  progressUrl   String   @db.Text
+  callbackUrl   String   @db.Text
+  error         String?  @db.Text
+  claimedAt     DateTime?
+  finishedAt    DateTime?
+  expiresAt     DateTime
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([userId, status, createdAt])
+  @@index([status, expiresAt])
+  @@map("local_harness_runs")
+}
+
 model UserSubagentConfig {
   userId       String
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -1459,14 +1507,12 @@ model Skill {
   @@map("skills")
 }
 
-/**
- * Sibling files that ship alongside a skill's main SKILL.md (which lives in
- * Skill.content). Materialized into the session workspace under
- * `data/session-skills/<scope>/<slug>/<relativePath>` so pi's resource
- * loader sees the whole directory.
- * relativePath is always a normalized POSIX path inside the skill dir —
- * no leading slash, no "..", no absolute paths. Enforced at write time.
- */
+// Sibling files that ship alongside a skill's main SKILL.md (which lives in
+// Skill.content). Materialized into the session workspace under
+// `data/session-skills/<scope>/<slug>/<relativePath>` so pi's resource
+// loader sees the whole directory.
+// relativePath is always a normalized POSIX path inside the skill dir —
+// no leading slash, no "..", no absolute paths. Enforced at write time.
 model SkillFile {
   id           String   @id @default(cuid())
   skillId      String

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1508,12 +1508,14 @@ model Skill {
   @@map("skills")
 }
 
-// Sibling files that ship alongside a skill's main SKILL.md (which lives in
-// Skill.content). Materialized into the session workspace under
-// `data/session-skills/<scope>/<slug>/<relativePath>` so pi's resource
-// loader sees the whole directory.
-// relativePath is always a normalized POSIX path inside the skill dir —
-// no leading slash, no "..", no absolute paths. Enforced at write time.
+/**
+ * Sibling files that ship alongside a skill's main SKILL.md (which lives in
+ * Skill.content). Materialized into the session workspace under
+ * `data/session-skills/<scope>/<slug>/<relativePath>` so pi's resource
+ * loader sees the whole directory.
+ * relativePath is always a normalized POSIX path inside the skill dir —
+ * no leading slash, no "..", no absolute paths. Enforced at write time.
+ */
 model SkillFile {
   id           String   @id @default(cuid())
   skillId      String

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -61,6 +61,7 @@ model User {
   twinBehaviorSignals                  TwinBehaviorSignal[]
   localHarnessDevices                  LocalHarnessDevice[]
   localHarnessRuns                     LocalHarnessRun[]
+  localHarnessDefaultProvider          String?
 
   /// Daily Brief opt-in (morning digest). When true, the leader-locked daily
   /// cron enqueues a brief-generation job for this user; when false the cron

--- a/apps/xyne-claw-auth/backend/src/config.ts
+++ b/apps/xyne-claw-auth/backend/src/config.ts
@@ -88,6 +88,14 @@ export const CONFIG = {
   cliTokensEnabled: ["1", "true", "on", "yes"].includes(
     (process.env["CLI_TOKENS_ENABLED"] ?? "").trim().toLowerCase(),
   ),
+  localHarnessEnabled: ["1", "true", "on", "yes"].includes(
+    (process.env["LOCAL_HARNESS_ENABLED"] ?? "").trim().toLowerCase(),
+  ),
+  localHarnessDefaultAll: ["1", "true", "on", "yes"].includes(
+    (process.env["LOCAL_HARNESS_DEFAULT_ALL"] ?? "").trim().toLowerCase(),
+  ),
+  localHarnessPollTimeoutMs: Number(process.env["LOCAL_HARNESS_POLL_TIMEOUT_MS"] ?? 25_000),
+  localHarnessRunTimeoutMs: Number(process.env["LOCAL_HARNESS_RUN_TIMEOUT_MS"] ?? 900_000),
   xyneSpacesCallbackUrl: process.env["XYNE_SPACES_CALLBACK_URL"] ?? "",
   spacesBackendUrl: process.env["SPACES_BACKEND_URL"] ?? "http://localhost:3001",
   // Cluster-internal Spaces URL — used for high-volume server-to-server API
@@ -354,6 +362,17 @@ export const CONFIG = {
     "<heisenberg-url>"
   ).replace(/\/+$/, ""),
 } as const;
+
+// Prod safety gate: the claw-auth → session-MCP relay and the run callbacks
+// authenticate to xyne-claw with x-s2s-key. If the local harness is enabled in
+// production without that shared secret, every relay/callback would be sent
+// UNAUTHENTICATED — fail fast at boot instead of shipping an open bridge.
+if (CONFIG.localHarnessEnabled && CONFIG.isProduction && !CONFIG.xyneClawS2sKey) {
+  throw new Error(
+    "LOCAL_HARNESS_ENABLED=true in production requires XYNE_CLAW_S2S_KEY to be set " +
+    "(the local-harness MCP relay and run callbacks must be S2S-authenticated).",
+  );
+}
 
 // Grafana → error auto-fix pipeline (lives here — claw stays stateless; the
 // queues + fix records ride this service's existing Redis).

--- a/apps/xyne-claw-auth/backend/src/lib/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/local-harness.ts
@@ -7,6 +7,8 @@ import type {
 } from "xyne-claw-shared";
 import { LOCAL_HARNESS_PROVIDERS, LOCAL_HARNESS_PROTOCOL_VERSION, isLocalHarnessProvider } from "xyne-claw-shared";
 import { CONFIG } from "../config.js";
+import { prisma } from "../db.js";
+import { redisService } from "../redis.js";
 import { createLogger } from "../logger.js";
 import { mintSessionToken } from "./session-tokens.js";
 import { authenticatedProviders, localHarnessRepository } from "../repositories/localHarnessRepository.js";
@@ -105,6 +107,7 @@ export async function dispatchLocalHarnessRun(args: {
   context: string | null;
   progressUrl: string;
   callbackUrl: string;
+  serverFallbackBody: Record<string, unknown>;
 }): Promise<{ sessionId: string; runId: string }> {
   const sessionId = randomUUID();
   const model = args.model ?? defaultModelForProvider(args.target.provider);
@@ -137,10 +140,72 @@ export async function dispatchLocalHarnessRun(args: {
     expiresAt: new Date(Date.now() + CONFIG.localHarnessRunTimeoutMs),
   });
 
+  await rememberServerFallback(run.id, args.serverFallbackBody);
+
   log.info(
     `[local-harness] run queued id=${run.id} session=${sessionId} agent=${args.agentSlug} provider=${args.target.provider} model=${model ?? "(cli default)"} device=${args.target.device.id}`,
   );
   return { sessionId, runId: run.id };
+}
+
+const FALLBACK_KEY_PREFIX = "local-harness-fallback:";
+
+function fallbackKey(runId: string): string {
+  return `${FALLBACK_KEY_PREFIX}${runId}`;
+}
+
+async function rememberServerFallback(runId: string, body: Record<string, unknown>): Promise<void> {
+  const ttlSeconds = Math.ceil(CONFIG.localHarnessRunTimeoutMs / 1000) + 600;
+  await redisService
+    .getConnection()
+    .set(fallbackKey(runId), JSON.stringify(body), "EX", ttlSeconds)
+    .catch((err: unknown) => {
+      log.warn(`[local-harness] could not stash server fallback for run=${runId}: ${err instanceof Error ? err.message : String(err)}`);
+    });
+}
+
+export async function failOverToServerRun(run: LocalHarnessRun, reason: string): Promise<boolean> {
+  const raw = await redisService.getConnection().get(fallbackKey(run.id)).catch(() => null);
+  if (!raw) {
+    log.warn(`[local-harness] no stashed server fallback for run=${run.id} — cannot recover (${reason})`);
+    await localHarnessRepository.settleFallback(run.id, false, reason);
+    return false;
+  }
+
+  try {
+    const res = await fetch(`${CONFIG.internalUrl}/claw/api/v1/internal/run`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+      },
+      body: raw,
+      signal: AbortSignal.timeout(30_000),
+    });
+    const body = (await res.json().catch(() => ({}))) as { success?: boolean; sessionId?: string; error?: string };
+    if (!res.ok || !body.success || !body.sessionId) {
+      throw new Error(body.error ?? `HTTP ${res.status}`);
+    }
+
+    await redisService.getConnection().del(fallbackKey(run.id)).catch(() => {});
+    await localHarnessRepository.settleFallback(run.id, true, reason);
+    log.info(
+      `[local-harness] failed over to server run=${run.id} provider=${run.provider} agent=${run.agentSlug} ` +
+        `newSession=${body.sessionId} reason="${reason}"`,
+    );
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`[local-harness] server fallback dispatch failed run=${run.id} reason="${reason}": ${message}`);
+    await localHarnessRepository.settleFallback(run.id, false, `${reason}; server fallback also failed: ${message}`);
+    return false;
+  }
+}
+
+export async function recoverFailedLocalRun(run: LocalHarnessRun, reason: string): Promise<boolean> {
+  const owned = await localHarnessRepository.beginFallback(run.id).catch(() => null);
+  if (owned === false) return true;
+  return failOverToServerRun(run, reason);
 }
 
 export function flattenToolName(serverType: string, toolName: string): string {
@@ -268,6 +333,44 @@ function toCallbackStatus(status: "done" | "failed" | "cancelled"): "completed" 
   return status === "done" ? "completed" : status;
 }
 
+const PROVIDER_LABEL: Record<string, string> = {
+  "claude-code": "Claude Code",
+  "codex-cli": "Codex CLI",
+};
+
+export function localHarnessProviderLabel(provider: string): string {
+  return PROVIDER_LABEL[provider] ?? provider;
+}
+
+function possessive(name: string): string {
+  return /s$/i.test(name) ? `${name}'` : `${name}'s`;
+}
+
+export interface LocalHarnessAttribution {
+  provider: string;
+  harnessName: string;
+  label: string;
+  ownerName: string;
+}
+
+export async function describeLocalHarnessRun(run: LocalHarnessRun): Promise<LocalHarnessAttribution> {
+  const harnessName = localHarnessProviderLabel(run.provider);
+
+  const user = await prisma.user
+    .findUnique({ where: { id: run.userId }, select: { name: true, email: true } })
+    .catch(() => null);
+
+  const fullName = user?.name?.trim() || user?.email?.split("@")[0] || "";
+  const ownerName = fullName.split(/\s+/)[0] ?? "";
+
+  return {
+    provider: run.provider,
+    harnessName,
+    label: ownerName ? `${possessive(ownerName)} ${harnessName}` : harnessName,
+    ownerName,
+  };
+}
+
 export async function relayResult(
   run: LocalHarnessRun,
   result: {
@@ -278,7 +381,12 @@ export async function relayResult(
     effectiveModel?: string;
     error?: string;
   },
+  opts: { localHarnessUnreachable?: boolean } = {},
 ): Promise<void> {
+  const localHarness = result.status === "done"
+    ? await describeLocalHarnessRun(run).catch(() => null)
+    : null;
+
   await fetch(run.callbackUrl, {
     method: "POST",
     headers: callbackHeaders(run),
@@ -289,6 +397,8 @@ export async function relayResult(
       userId: run.userId,
       provider: run.provider,
       model: result.effectiveModel ?? run.model ?? undefined,
+      ...(localHarness ? { localHarness } : {}),
+      ...(opts.localHarnessUnreachable ? { localHarnessUnreachable: true, localHarnessProvider: run.provider } : {}),
       ...(result.toolsUsed?.length ? { toolsUsed: result.toolsUsed } : {}),
       ...(result.tokenUsage ? { tokenUsage: result.tokenUsage } : {}),
       ...(result.error ? { error: result.error } : {}),

--- a/apps/xyne-claw-auth/backend/src/lib/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/local-harness.ts
@@ -33,13 +33,32 @@ export async function resolveLocalHarnessTarget(args: {
   userId: string;
   orgId: string;
   providerOrder: string[];
+  /**
+   * RAW UserAgentConfig.provider for this agent — `undefined` when the user
+   * never picked one. An explicit hosted pick ("spaces"/"claude"/"codex"/
+   * "copilot") is a per-agent opt-out, so the user's account-wide default
+   * harness is skipped for it.
+   */
   personalProvider?: string | undefined;
 }): Promise<{ provider: LocalHarnessProvider; device: LocalHarnessDevice } | undefined> {
   if (!CONFIG.localHarnessEnabled) return undefined;
 
-  const ordered = [args.personalProvider, ...args.providerOrder].filter(
-    (p): p is LocalHarnessProvider => isLocalHarnessProvider(p),
-  );
+  // Account-wide default (onboarding / Claw Settings "use for all my agents").
+  // Ranks below the per-agent pick and above the agent's own providerOrder: it
+  // is the user's preference, and a personal preference already outranks agent
+  // config everywhere else.
+  const userDefault =
+    args.personalProvider === undefined
+      ? await localHarnessRepository.getUserDefaultProvider(args.userId).catch(() => null)
+      : null;
+
+  const ordered = [
+    ...new Set(
+      [args.personalProvider, userDefault, ...args.providerOrder].filter(
+        (p): p is LocalHarnessProvider => isLocalHarnessProvider(p),
+      ),
+    ),
+  ];
   if (ordered.length === 0) {
     // Workspace policy decides whether an agent with no explicit local-harness
     // provider order may still auto-route to an online device. 'all' opts every
@@ -47,6 +66,9 @@ export async function resolveLocalHarnessTarget(args: {
     // the LOCAL_HARNESS_DEFAULT_ALL env only when the org has no stored setting.
     const mode = (await localHarnessRepository.getOrgHarnessMode(args.orgId).catch(() => null))
       ?? (CONFIG.localHarnessDefaultAll ? "all" : "selected");
+    // A per-agent pick of ANY provider — including "spaces", which means "use
+    // the agent's own configuration, not my personal one" — opts this agent out
+    // of the blanket auto-route.
     if (mode !== "all" || args.personalProvider) return undefined;
     const devices = await localHarnessRepository.listOnlineDevices(args.userId).catch(() => [] as LocalHarnessDevice[]);
     for (const device of devices) {

--- a/apps/xyne-claw-auth/backend/src/lib/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/local-harness.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+import type { LocalHarnessDevice, LocalHarnessRun } from "@prisma/client";
+import type {
+  LocalHarnessProvider,
+  LocalHarnessRunEnvelope,
+  LocalHarnessToolSpec,
+} from "xyne-claw-shared";
+import { LOCAL_HARNESS_PROVIDERS, LOCAL_HARNESS_PROTOCOL_VERSION, isLocalHarnessProvider } from "xyne-claw-shared";
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+import { mintSessionToken } from "./session-tokens.js";
+import { authenticatedProviders, localHarnessRepository } from "../repositories/localHarnessRepository.js";
+
+const log = createLogger("local-harness");
+
+export { LOCAL_HARNESS_PROVIDERS, isLocalHarnessProvider };
+
+const SESSION_TOKEN_TTL_SECONDS = 3600;
+
+export function defaultModelForProvider(provider: LocalHarnessProvider): string | null {
+  return provider === "claude-code" ? "sonnet" : null;
+}
+
+export function pinnedModelForProvider(config: unknown, provider: LocalHarnessProvider): string | null {
+  const cfg = (config as Record<string, unknown> | null) ?? null;
+  const models = cfg?.["localHarnessModels"];
+  if (!models || typeof models !== "object" || Array.isArray(models)) return null;
+  const value = (models as Record<string, unknown>)[provider];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export async function resolveLocalHarnessTarget(args: {
+  userId: string;
+  orgId: string;
+  providerOrder: string[];
+  personalProvider?: string | undefined;
+}): Promise<{ provider: LocalHarnessProvider; device: LocalHarnessDevice } | undefined> {
+  if (!CONFIG.localHarnessEnabled) return undefined;
+
+  const ordered = [args.personalProvider, ...args.providerOrder].filter(
+    (p): p is LocalHarnessProvider => isLocalHarnessProvider(p),
+  );
+  if (ordered.length === 0) {
+    // Workspace policy decides whether an agent with no explicit local-harness
+    // provider order may still auto-route to an online device. 'all' opts every
+    // agent in; 'selected' (default) requires an explicit opt-in. Falls back to
+    // the LOCAL_HARNESS_DEFAULT_ALL env only when the org has no stored setting.
+    const mode = (await localHarnessRepository.getOrgHarnessMode(args.orgId).catch(() => null))
+      ?? (CONFIG.localHarnessDefaultAll ? "all" : "selected");
+    if (mode !== "all" || args.personalProvider) return undefined;
+    const devices = await localHarnessRepository.listOnlineDevices(args.userId).catch(() => [] as LocalHarnessDevice[]);
+    for (const device of devices) {
+      const provider = authenticatedProviders(device).find(isLocalHarnessProvider);
+      if (provider) {
+        log.info(`[local-harness] auto-routing user=${args.userId} to ${provider} on device=${device.id}`);
+        return { provider, device };
+      }
+    }
+    return undefined;
+  }
+
+  for (const provider of ordered) {
+    const devices = await localHarnessRepository
+      .listOnlineDevicesForProvider(args.userId, provider)
+      .catch(() => [] as LocalHarnessDevice[]);
+    const device = devices[0];
+    if (device) return { provider, device };
+    log.info(`[local-harness] no online device for provider=${provider} user=${args.userId} — falling back to server run`);
+  }
+  return undefined;
+}
+
+export async function dispatchLocalHarnessRun(args: {
+  target: { provider: LocalHarnessProvider; device: LocalHarnessDevice };
+  userId: string;
+  orgId: string;
+  conversationId: string;
+  agentSlug: string;
+  agentName: string;
+  systemPrompt: string;
+  model: string | null;
+  task: string;
+  context: string | null;
+  progressUrl: string;
+  callbackUrl: string;
+}): Promise<{ sessionId: string; runId: string }> {
+  const sessionId = randomUUID();
+  const model = args.model ?? defaultModelForProvider(args.target.provider);
+
+  const envelope: LocalHarnessRunEnvelope = {
+    protocolVersion: LOCAL_HARNESS_PROTOCOL_VERSION,
+    runId: "",
+    sessionId,
+    conversationId: args.conversationId,
+    provider: args.target.provider,
+    model,
+    agentSlug: args.agentSlug,
+    agentName: args.agentName,
+    systemPrompt: args.systemPrompt,
+    task: args.task,
+    context: args.context,
+    timeoutMs: CONFIG.localHarnessRunTimeoutMs,
+  };
+
+  const run = await localHarnessRepository.enqueueRun({
+    sessionId,
+    userId: args.userId,
+    orgId: args.orgId,
+    agentSlug: args.agentSlug,
+    provider: args.target.provider,
+    model,
+    envelope: envelope as unknown as never,
+    progressUrl: args.progressUrl,
+    callbackUrl: args.callbackUrl,
+    expiresAt: new Date(Date.now() + CONFIG.localHarnessRunTimeoutMs),
+  });
+
+  log.info(
+    `[local-harness] run queued id=${run.id} session=${sessionId} agent=${args.agentSlug} provider=${args.target.provider} model=${model ?? "(cli default)"} device=${args.target.device.id}`,
+  );
+  return { sessionId, runId: run.id };
+}
+
+export function flattenToolName(serverType: string, toolName: string): string {
+  return `${serverType}.${toolName}`;
+}
+
+type McpServerTools = {
+  serverType?: string;
+  serverName?: string;
+  tools?: Array<{ name?: string; description?: string; inputSchema?: Record<string, unknown> }>;
+  writeTools?: string[];
+};
+
+function sessionAuthHeaders(run: Pick<LocalHarnessRun, "sessionId" | "userId" | "agentSlug">): Record<string, string> {
+  const token = mintSessionToken({
+    sessionId: run.sessionId,
+    userId: run.userId,
+    agentSlug: run.agentSlug,
+    ttlSeconds: SESSION_TOKEN_TTL_SECONDS,
+  });
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+    ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+  };
+}
+
+function mcpUrl(sessionId: string, suffix: string): string {
+  return `${CONFIG.internalUrl}/claw/api/v1/sessions/${encodeURIComponent(sessionId)}/mcp/${suffix}`;
+}
+
+export async function listToolsForRun(run: LocalHarnessRun): Promise<LocalHarnessToolSpec[]> {
+  const res = await fetch(mcpUrl(run.sessionId, "tools"), { headers: sessionAuthHeaders(run) });
+  if (!res.ok) {
+    log.warn(`[local-harness] tool listing failed run=${run.id} status=${res.status}`);
+    return [];
+  }
+  const body = (await res.json()) as { success?: boolean; data?: McpServerTools[] };
+  const servers = Array.isArray(body.data) ? body.data : [];
+
+  const specs: LocalHarnessToolSpec[] = [];
+  const seen = new Set<string>();
+  for (const server of servers) {
+    const serverType = server.serverType;
+    if (!serverType) continue;
+    const writeTools = new Set(server.writeTools ?? []);
+    for (const tool of server.tools ?? []) {
+      if (!tool.name) continue;
+      const name = flattenToolName(serverType, tool.name);
+      if (seen.has(name)) continue;
+      seen.add(name);
+      specs.push({
+        name,
+        serverType,
+        toolName: tool.name,
+        description: tool.description ?? "",
+        inputSchema: tool.inputSchema ?? { type: "object", properties: {} },
+        write: writeTools.has(tool.name),
+      });
+    }
+  }
+  return specs;
+}
+
+export async function callToolForRun(
+  run: LocalHarnessRun,
+  call: { serverType: string; toolName: string; params: Record<string, unknown> },
+): Promise<{ ok: boolean; content: string }> {
+  const res = await fetch(mcpUrl(run.sessionId, "call"), {
+    method: "POST",
+    headers: sessionAuthHeaders(run),
+    body: JSON.stringify({ serverType: call.serverType, tool: call.toolName, params: call.params }),
+  });
+
+  const body = (await res.json().catch(() => ({}))) as {
+    success?: boolean;
+    error?: string;
+    data?: { content?: string; pendingAction?: unknown } | string;
+  };
+
+  if (!res.ok || body.success === false) {
+    const message = body.error ?? `Tool call failed (HTTP ${res.status})`;
+    log.info(`[local-harness] tool call rejected run=${run.id} tool=${call.serverType}/${call.toolName}: ${message}`);
+    return { ok: false, content: message };
+  }
+
+  const data = body.data;
+  const content = typeof data === "string" ? data : (data?.content ?? "");
+
+  if (typeof data !== "string" && data?.pendingAction) {
+    log.info(`[local-harness] write tool needs approval run=${run.id} tool=${call.serverType}/${call.toolName} — not supported from a local harness`);
+    return {
+      ok: false,
+      content: `${call.toolName} needs approval before it can run, which isn't supported from a local harness yet. Re-run this agent on Xyne's servers to approve the action.`,
+    };
+  }
+
+  return { ok: true, content };
+}
+
+function callbackHeaders(run: Pick<LocalHarnessRun, "sessionId" | "userId" | "agentSlug">): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+    "x-session-token": mintSessionToken({
+      sessionId: run.sessionId,
+      userId: run.userId,
+      agentSlug: run.agentSlug,
+      ttlSeconds: SESSION_TOKEN_TTL_SECONDS,
+    }),
+  };
+}
+
+export async function relayProgress(run: LocalHarnessRun, body: Record<string, unknown>): Promise<void> {
+  await fetch(run.progressUrl, {
+    method: "POST",
+    headers: callbackHeaders(run),
+    body: JSON.stringify({ ...body, sessionId: run.sessionId }),
+  }).catch((err) => {
+    log.warn(`[local-harness] progress relay failed run=${run.id}: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}
+
+function toCallbackStatus(status: "done" | "failed" | "cancelled"): "completed" | "failed" | "cancelled" {
+  return status === "done" ? "completed" : status;
+}
+
+export async function relayResult(
+  run: LocalHarnessRun,
+  result: {
+    status: "done" | "failed" | "cancelled";
+    text: string;
+    toolsUsed?: string[];
+    tokenUsage?: { input?: number; output?: number };
+    effectiveModel?: string;
+    error?: string;
+  },
+): Promise<void> {
+  await fetch(run.callbackUrl, {
+    method: "POST",
+    headers: callbackHeaders(run),
+    body: JSON.stringify({
+      status: toCallbackStatus(result.status),
+      result: result.text,
+      sessionId: run.sessionId,
+      userId: run.userId,
+      provider: run.provider,
+      model: result.effectiveModel ?? run.model ?? undefined,
+      ...(result.toolsUsed?.length ? { toolsUsed: result.toolsUsed } : {}),
+      ...(result.tokenUsage ? { tokenUsage: result.tokenUsage } : {}),
+      ...(result.error ? { error: result.error } : {}),
+    }),
+  }).catch((err) => {
+    log.warn(`[local-harness] result relay failed run=${run.id}: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -69,6 +69,8 @@ import { dailyBriefRouter } from "./routes/daily-brief.js";
 import { pendingQuestionsRouter } from "./routes/pending-questions.js";
 import { ttsRouter } from "./routes/tts.js";
 import { settingsRouter } from "./routes/settings.js";
+import { beginLocalHarnessDrain, localHarnessBridgeRouter, localHarnessRouter } from "./routes/local-harness.js";
+import { initLocalHarnessExpirySweep } from "./services/localHarnessExpiry.js";
 import { runsRouter } from "./routes/runs.js";
 import { metricsRouter } from "./routes/metrics.js";
 import { memoryRouter } from "./routes/memory.js";
@@ -303,6 +305,10 @@ app.use(`${BASE}/scheduled-jobs`, requireAuth, requireNoAccessToken, scheduledJo
 // flow-action consumes them through the module's atomic Redis helper.
 app.use(`${BASE}/pending-questions`, requireStrictS2S, pendingQuestionsRouter);
 app.use(`${BASE}/settings`, requireAuth, requireNoAccessToken, settingsRouter);
+// Local harness: device management is user-authed; the bridge router is
+// device-token authed inside (requireDevice) and rate-limited per device.
+app.use(`${BASE}/local-harness`, requireUserAuth, localHarnessRouter);
+app.use(`${BASE}/local-harness-bridge`, localHarnessBridgeRouter);
 // allowReadAccessToken (NOT the hard barrier): CLI tokens carry runs:read so
 // the CLI can list/search/fetch its own runs (GET /runs/light, /runs/search,
 // /runs/:id). Reads pass with the scope; token writes are still rejected.
@@ -391,6 +397,7 @@ listen(CONFIG.port, () => {
     void ensureTickScheduler().catch((err) =>
       log.error("[boot] awakening tick scheduler registration failed:", err),
     );
+    initLocalHarnessExpirySweep();
   // Upsert custom tools from the shared registry so newly added tools (e.g.
     // google-sheets-create, google-forms-create) show up in the agent UI on
     // restart without needing a manual POST /tools/sync call.
@@ -410,6 +417,9 @@ async function shutdown(signal: string): Promise<void> {
     errorPipelineRunner.stop();
   } else {
     // API pod: drain the background fleet (none of it ran on the runner pod).
+    // Stop parking new local-harness long-polls first so in-flight bridge
+    // connections return idle and the pod can exit without dropping a run.
+    beginLocalHarnessDrain();
     stopBitbucketStatsBackgroundRefresh();
     await closeWorker().catch(() => {});
     await closeRunRecoveryWorker().catch(() => {});

--- a/apps/xyne-claw-auth/backend/src/repositories/index.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/index.ts
@@ -14,6 +14,7 @@ export { userProviderCredentialsRepository } from "./userProviderCredentialsRepo
 export { agentProviderCredentialsRepository } from "./agentProviderCredentialsRepository.js";
 export { sharedProviderCredentialRepository } from "./sharedProviderCredentialRepository.js";
 export { userSubagentConfigRepository } from "./userSubagentConfigRepository.js";
+export { localHarnessRepository } from "./localHarnessRepository.js";
 export { userRepository } from "./userRepository.js";
 export { skillRepository } from "./skillRepository.js";
 export { subagentDefinitionRepository } from "./subagentDefinitionRepository.js";

--- a/apps/xyne-claw-auth/backend/src/repositories/localHarnessRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/localHarnessRepository.ts
@@ -1,0 +1,241 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import type { LocalHarnessDevice, LocalHarnessRun, Prisma } from "@prisma/client";
+import { prisma } from "../db.js";
+
+export const LOCAL_HARNESS_ONLINE_WINDOW_MS = 90_000;
+
+export function generateDeviceToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function hashDeviceToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function deviceTokenHashEquals(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "hex");
+  const bufB = Buffer.from(b, "hex");
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+}
+
+export function isDeviceOnline(device: Pick<LocalHarnessDevice, "lastSeenAt">, now = Date.now()): boolean {
+  return !!device.lastSeenAt && now - device.lastSeenAt.getTime() < LOCAL_HARNESS_ONLINE_WINDOW_MS;
+}
+
+export function authenticatedProviders(device: Pick<LocalHarnessDevice, "installations">): string[] {
+  const installations = Array.isArray(device.installations) ? device.installations : [];
+  return installations.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    return record["authenticated"] === true && typeof record["provider"] === "string" ? [record["provider"]] : [];
+  });
+}
+
+export const localHarnessRepository = {
+  // Workspace all/selected policy. Stored on Organization.metadata.localHarness
+  // .mode so no dedicated table/migration is needed. 'all' = every mention-driven
+  // run may route to an online device; 'selected' = only agents that explicitly
+  // opt in (via providerOrder) or a per-user personal provider route locally.
+  getOrgHarnessMode: async (orgId: string): Promise<"all" | "selected" | null> => {
+    const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { metadata: true } });
+    const meta = org?.metadata && typeof org.metadata === "object" && !Array.isArray(org.metadata)
+      ? (org.metadata as Record<string, unknown>)
+      : null;
+    const lh = meta && typeof meta["localHarness"] === "object" && meta["localHarness"]
+      ? (meta["localHarness"] as Record<string, unknown>)
+      : null;
+    const mode = lh?.["mode"];
+    return mode === "all" || mode === "selected" ? mode : null;
+  },
+
+  setOrgHarnessMode: async (orgId: string, mode: "all" | "selected"): Promise<void> => {
+    const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { metadata: true } });
+    const meta = org?.metadata && typeof org.metadata === "object" && !Array.isArray(org.metadata)
+      ? { ...(org.metadata as Record<string, unknown>) }
+      : {};
+    const lh = typeof meta["localHarness"] === "object" && meta["localHarness"]
+      ? (meta["localHarness"] as Record<string, unknown>)
+      : {};
+    meta["localHarness"] = { ...lh, mode };
+    await prisma.organization.update({ where: { id: orgId }, data: { metadata: meta as Prisma.InputJsonValue } });
+  },
+
+  registerDevice: async (args: {
+    userId: string;
+    orgId: string;
+    deviceName: string;
+    platform: string;
+    installations: Prisma.InputJsonValue;
+  }): Promise<{ device: LocalHarnessDevice; token: string }> => {
+    const token = generateDeviceToken();
+    const tokenHash = hashDeviceToken(token);
+
+    const existing = await prisma.localHarnessDevice.findFirst({
+      where: { userId: args.userId, deviceName: args.deviceName },
+    });
+
+    const device = existing
+      ? await prisma.localHarnessDevice.update({
+          where: { id: existing.id },
+          data: {
+            orgId: args.orgId,
+            platform: args.platform,
+            installations: args.installations,
+            tokenHash,
+            revokedAt: null,
+            lastSeenAt: new Date(),
+          },
+        })
+      : await prisma.localHarnessDevice.create({
+          data: {
+            userId: args.userId,
+            orgId: args.orgId,
+            deviceName: args.deviceName,
+            platform: args.platform,
+            installations: args.installations,
+            tokenHash,
+            lastSeenAt: new Date(),
+          },
+        });
+
+    return { device, token };
+  },
+
+  findDeviceByToken: async (token: string): Promise<LocalHarnessDevice | null> => {
+    const device = await prisma.localHarnessDevice.findUnique({ where: { tokenHash: hashDeviceToken(token) } });
+    if (!device || device.revokedAt) return null;
+    if (!deviceTokenHashEquals(device.tokenHash, hashDeviceToken(token))) return null;
+    return device;
+  },
+
+  listDevices: (userId: string): Promise<LocalHarnessDevice[]> =>
+    prisma.localHarnessDevice.findMany({
+      where: { userId, revokedAt: null },
+      orderBy: { createdAt: "desc" },
+    }),
+
+  listOnlineDevicesForProvider: async (userId: string, provider: string): Promise<LocalHarnessDevice[]> => {
+    const devices = await prisma.localHarnessDevice.findMany({ where: { userId, revokedAt: null } });
+    const now = Date.now();
+    return devices.filter((device) => isDeviceOnline(device, now) && authenticatedProviders(device).includes(provider));
+  },
+
+  listOnlineDevices: async (userId: string): Promise<LocalHarnessDevice[]> => {
+    const devices = await prisma.localHarnessDevice.findMany({
+      where: { userId, revokedAt: null },
+      orderBy: { lastSeenAt: "desc" },
+    });
+    const now = Date.now();
+    return devices.filter((device) => isDeviceOnline(device, now));
+  },
+
+  revokeDevice: async (userId: string, deviceId: string): Promise<boolean> => {
+    const result = await prisma.localHarnessDevice.updateMany({
+      where: { id: deviceId, userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    return result.count > 0;
+  },
+
+  touchDevice: (deviceId: string): Promise<unknown> =>
+    prisma.localHarnessDevice.update({ where: { id: deviceId }, data: { lastSeenAt: new Date() } }),
+
+  enqueueRun: (args: {
+    sessionId: string;
+    userId: string;
+    orgId: string;
+    agentSlug: string;
+    provider: string;
+    model: string | null;
+    envelope: Prisma.InputJsonValue;
+    progressUrl: string;
+    callbackUrl: string;
+    expiresAt: Date;
+  }): Promise<LocalHarnessRun> =>
+    prisma.localHarnessRun.create({
+      data: {
+        sessionId: args.sessionId,
+        userId: args.userId,
+        orgId: args.orgId,
+        agentSlug: args.agentSlug,
+        provider: args.provider,
+        model: args.model,
+        envelope: args.envelope,
+        progressUrl: args.progressUrl,
+        callbackUrl: args.callbackUrl,
+        expiresAt: args.expiresAt,
+      },
+    }),
+
+  claimNextRun: async (device: LocalHarnessDevice, providers: string[]): Promise<LocalHarnessRun | null> => {
+    if (providers.length === 0) return null;
+    const candidates = await prisma.localHarnessRun.findMany({
+      where: {
+        userId: device.userId,
+        // Defence in depth: a run is only ever claimable by a device in the
+        // SAME org as the run. userId already implies the org, but asserting
+        // orgId makes cross-org leakage impossible even if a user's org moves.
+        orgId: device.orgId,
+        status: "queued",
+        provider: { in: providers },
+        expiresAt: { gt: new Date() },
+      },
+      orderBy: { createdAt: "asc" },
+      take: 5,
+    });
+
+    for (const candidate of candidates) {
+      const claimed = await prisma.localHarnessRun.updateMany({
+        where: { id: candidate.id, status: "queued" },
+        data: { status: "claimed", deviceId: device.id, claimedAt: new Date() },
+      });
+      if (claimed.count > 0) {
+        return prisma.localHarnessRun.findUnique({ where: { id: candidate.id } });
+      }
+    }
+    return null;
+  },
+
+  releaseRun: (runId: string): Promise<unknown> =>
+    prisma.localHarnessRun.updateMany({
+      where: { id: runId, status: "claimed" },
+      data: { status: "queued", deviceId: null, claimedAt: null },
+    }),
+
+  findOwnedRun: async (runId: string, device: LocalHarnessDevice): Promise<LocalHarnessRun | null> => {
+    const run = await prisma.localHarnessRun.findUnique({ where: { id: runId } });
+    if (!run) return null;
+    if (run.userId !== device.userId || run.orgId !== device.orgId || run.deviceId !== device.id) return null;
+    return run;
+  },
+
+  markRunning: (runId: string): Promise<unknown> =>
+    prisma.localHarnessRun.updateMany({ where: { id: runId, status: "claimed" }, data: { status: "running" } }),
+
+  finishRun: async (runId: string, status: "done" | "failed" | "cancelled", error?: string): Promise<boolean> => {
+    const result = await prisma.localHarnessRun.updateMany({
+      where: { id: runId, status: { in: ["queued", "claimed", "running"] } },
+      data: { status, finishedAt: new Date(), ...(error ? { error } : {}) },
+    });
+    return result.count > 0;
+  },
+
+  findBySessionId: (sessionId: string): Promise<LocalHarnessRun | null> =>
+    prisma.localHarnessRun.findUnique({ where: { sessionId } }),
+
+  expireStaleRuns: async (limit = 50): Promise<LocalHarnessRun[]> => {
+    const stale = await prisma.localHarnessRun.findMany({
+      where: { status: { in: ["queued", "claimed", "running"] }, expiresAt: { lt: new Date() } },
+      take: limit,
+    });
+    const expired: LocalHarnessRun[] = [];
+    for (const run of stale) {
+      const updated = await prisma.localHarnessRun.updateMany({
+        where: { id: run.id, status: { in: ["queued", "claimed", "running"] } },
+        data: { status: "failed", finishedAt: new Date(), error: "Local harness did not report a result in time" },
+      });
+      if (updated.count > 0) expired.push(run);
+    }
+    return expired;
+  },
+};

--- a/apps/xyne-claw-auth/backend/src/repositories/localHarnessRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/localHarnessRepository.ts
@@ -22,16 +22,35 @@ export function isDeviceOnline(device: Pick<LocalHarnessDevice, "lastSeenAt">, n
   return !!device.lastSeenAt && now - device.lastSeenAt.getTime() < LOCAL_HARNESS_ONLINE_WINDOW_MS;
 }
 
+// Providers this device can actually run right now: the CLI is signed in AND the
+// user has connected that harness here. `enabled === undefined` means the device
+// was registered before per-harness pairing shipped, when connecting paired every
+// signed-in CLI at once — keep those working instead of silently going dark.
 export function authenticatedProviders(device: Pick<LocalHarnessDevice, "installations">): string[] {
   const installations = Array.isArray(device.installations) ? device.installations : [];
   return installations.flatMap((entry) => {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
     const record = entry as Record<string, unknown>;
-    return record["authenticated"] === true && typeof record["provider"] === "string" ? [record["provider"]] : [];
+    if (record["authenticated"] !== true || record["enabled"] === false) return [];
+    return typeof record["provider"] === "string" ? [record["provider"]] : [];
   });
 }
 
 export const localHarnessRepository = {
+  // Per-user default harness. Set in onboarding / Claw Settings; consulted for
+  // every agent this user runs that has no per-agent override of its own.
+  getUserDefaultProvider: async (userId: string): Promise<string | null> => {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { localHarnessDefaultProvider: true },
+    });
+    return user?.localHarnessDefaultProvider ?? null;
+  },
+
+  setUserDefaultProvider: async (userId: string, provider: string | null): Promise<void> => {
+    await prisma.user.update({ where: { id: userId }, data: { localHarnessDefaultProvider: provider } });
+  },
+
   // Workspace all/selected policy. Stored on Organization.metadata.localHarness
   // .mode so no dedicated table/migration is needed. 'all' = every mention-driven
   // run may route to an online device; 'selected' = only agents that explicitly
@@ -139,6 +158,15 @@ export const localHarnessRepository = {
 
   touchDevice: (deviceId: string): Promise<unknown> =>
     prisma.localHarnessDevice.update({ where: { id: deviceId }, data: { lastSeenAt: new Date() } }),
+
+  // Per-harness connect/disconnect. Authed by the device token the app already
+  // holds, so toggling one harness does NOT rotate the pairing token the way a
+  // re-registration would (that would 401 the in-flight long-poll).
+  updateInstallations: (deviceId: string, installations: Prisma.InputJsonValue): Promise<unknown> =>
+    prisma.localHarnessDevice.update({
+      where: { id: deviceId },
+      data: { installations, lastSeenAt: new Date() },
+    }),
 
   enqueueRun: (args: {
     sessionId: string;

--- a/apps/xyne-claw-auth/backend/src/repositories/localHarnessRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/localHarnessRepository.ts
@@ -4,6 +4,8 @@ import { prisma } from "../db.js";
 
 export const LOCAL_HARNESS_ONLINE_WINDOW_MS = 90_000;
 
+const LIVE_RUN_STATUSES: string[] = ["queued", "claimed", "running"];
+
 export function generateDeviceToken(): string {
   return randomBytes(32).toString("base64url");
 }
@@ -251,19 +253,75 @@ export const localHarnessRepository = {
   findBySessionId: (sessionId: string): Promise<LocalHarnessRun | null> =>
     prisma.localHarnessRun.findUnique({ where: { sessionId } }),
 
-  expireStaleRuns: async (limit = 50): Promise<LocalHarnessRun[]> => {
-    const stale = await prisma.localHarnessRun.findMany({
-      where: { status: { in: ["queued", "claimed", "running"] }, expiresAt: { lt: new Date() } },
-      take: limit,
-    });
-    const expired: LocalHarnessRun[] = [];
-    for (const run of stale) {
-      const updated = await prisma.localHarnessRun.updateMany({
-        where: { id: run.id, status: { in: ["queued", "claimed", "running"] } },
-        data: { status: "failed", finishedAt: new Date(), error: "Local harness did not report a result in time" },
+  findAbandonedRuns: async (args: {
+    claimTimeoutMs: number;
+    limit?: number;
+  }): Promise<Array<{ run: LocalHarnessRun; reason: string }>> => {
+    const now = Date.now();
+    const limit = args.limit ?? 50;
+
+    const [stalled, inFlight] = await Promise.all([
+      prisma.localHarnessRun.findMany({
+        where: {
+          status: { in: LIVE_RUN_STATUSES },
+          OR: [
+            { expiresAt: { lt: new Date(now) } },
+            { status: "queued", createdAt: { lt: new Date(now - args.claimTimeoutMs) } },
+          ],
+        },
+        orderBy: { createdAt: "asc" },
+        take: limit,
+      }),
+      prisma.localHarnessRun.findMany({
+        where: { status: { in: ["claimed", "running"] } },
+        orderBy: { createdAt: "asc" },
+        take: limit,
+      }),
+    ]);
+
+    const abandoned: Array<{ run: LocalHarnessRun; reason: string }> = stalled.map((run) => ({
+      run,
+      reason:
+        run.expiresAt.getTime() < now
+          ? "the local harness never reported a result"
+          : "no local device picked the run up",
+    }));
+
+    const seen = new Set(abandoned.map(({ run }) => run.id));
+    const candidates = inFlight.filter((run) => !seen.has(run.id) && run.deviceId);
+    if (candidates.length > 0) {
+      const devices = await prisma.localHarnessDevice.findMany({
+        where: { id: { in: [...new Set(candidates.map((run) => run.deviceId as string))] } },
+        select: { id: true, lastSeenAt: true, revokedAt: true },
       });
-      if (updated.count > 0) expired.push(run);
+      const deviceById = new Map(devices.map((device) => [device.id, device]));
+      for (const run of candidates) {
+        const device = deviceById.get(run.deviceId as string);
+        if (device && (device.revokedAt || !isDeviceOnline(device, now))) {
+          abandoned.push({ run, reason: "the local device went offline mid-run" });
+        }
+      }
     }
-    return expired;
+
+    return abandoned;
+  },
+
+  beginFallback: async (runId: string): Promise<boolean> => {
+    const result = await prisma.localHarnessRun.updateMany({
+      where: { id: runId, status: { in: LIVE_RUN_STATUSES } },
+      data: { status: "failing_over" },
+    });
+    return result.count > 0;
+  },
+
+  settleFallback: async (runId: string, ok: boolean, error?: string): Promise<void> => {
+    await prisma.localHarnessRun.updateMany({
+      where: { id: runId, status: "failing_over" },
+      data: {
+        status: ok ? "failed_over" : "failed",
+        finishedAt: new Date(),
+        ...(error ? { error } : {}),
+      },
+    });
   },
 };

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -1642,7 +1642,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       userId,
       orgId: agent.orgId,
       providerOrder: configuredProviderOrder,
-      personalProvider: selectedPersonalProvider,
+      personalProvider: rawPersonalProvider,
     }).catch((err: unknown) => {
       log.warn("[agent-chat] local-harness resolution failed — using server run:", err instanceof Error ? err.message : err);
       return undefined;

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -14,6 +14,7 @@ import { cancelRunRecovery } from "../queue/run-recovery-worker.js";
 import { decrypt } from "../crypto.js";
 import { CONFIG } from "../config.js";
 import { KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget, agentDefaultSpeed, providerConfigForSpeed, applyFastModeModels } from "../lib/agent-provider-config.js";
+import { dispatchLocalHarnessRun, isLocalHarnessProvider, pinnedModelForProvider, resolveLocalHarnessTarget } from "../lib/local-harness.js";
 import { resolveFastMode } from "../lib/fast-mode.js";
 import { extractFollowUpSuggestionsFromInvocations } from "../lib/follow-up-suggestions.js";
 import { getRequesterId, getOrgId, getAgentEditAccess, isClawAdmin } from "../middleware/agent-acl.js";
@@ -1421,9 +1422,10 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
     const rawPersonalProvider = userAgentConfig?.provider;
     // "spaces" is the platform-default sentinel, not a real personal credential —
     // saving it should not override the agent-level providerOrder/credentials.
-    const personalProvider = rawPersonalProvider && rawPersonalProvider !== "spaces"
+    const selectedPersonalProvider = rawPersonalProvider && rawPersonalProvider !== "spaces"
       ? rawPersonalProvider
       : undefined;
+    const personalProvider = isLocalHarnessProvider(selectedPersonalProvider) ? undefined : selectedPersonalProvider;
     // Effective speed for THIS run: the composer toggle wins, else the agent
     // default. Fast mode may resolve against its own provider profile
     // (config.fastModeProfile) — same credential keys, possibly different
@@ -1434,6 +1436,10 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
     const rawProviderOrder = speedConfig["providerOrder"];
     const agentProviderOrder: string[] = Array.isArray(rawProviderOrder)
       ? rawProviderOrder.filter((p): p is string => typeof p === "string" && KNOWN_PROVIDERS.has(p))
+      : [];
+    const rawConfiguredProviderOrder = (agent.config as Record<string, unknown> | null)?.["providerOrder"];
+    const configuredProviderOrder: string[] = Array.isArray(rawConfiguredProviderOrder)
+      ? rawConfiguredProviderOrder.filter((p): p is string => typeof p === "string")
       : [];
     const userProvider = personalProvider ?? agentLevelProvider;
 
@@ -1632,6 +1638,16 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       fastMode: fastModeEnabled,
     };
 
+    const localTarget = await resolveLocalHarnessTarget({
+      userId,
+      orgId: agent.orgId,
+      providerOrder: configuredProviderOrder,
+      personalProvider: selectedPersonalProvider,
+    }).catch((err: unknown) => {
+      log.warn("[agent-chat] local-harness resolution failed — using server run:", err instanceof Error ? err.message : err);
+      return undefined;
+    });
+
     // SSE consumer path. We send Accept: text/event-stream so the /run proxy
     // routes us through SSE pass-through (one ordered TCP connection from
     // claw → claw-auth) instead of falling back to the legacy POST bridge,
@@ -1644,7 +1660,23 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
     // run-stream.ts — so all the finalize + persistAssistantResult + resolve
     // wiring stays in one place.
     let runBody: { success: boolean; sessionId?: string; error?: string; deferred?: boolean };
-    if (CONFIG.clawSseTransport) {
+    if (localTarget) {
+      const dispatched = await dispatchLocalHarnessRun({
+        target: localTarget,
+        userId,
+        orgId: agent.orgId,
+        conversationId,
+        agentSlug: slug,
+        agentName: agent.name,
+        systemPrompt: agent.systemPrompt,
+        model: pinnedModelForProvider(runAgentConfig, localTarget.provider),
+        task: message.trim(),
+        context: resolvedContext.promptPrefix || null,
+        progressUrl,
+        callbackUrl,
+      });
+      runBody = { success: true, sessionId: dispatched.sessionId };
+    } else if (CONFIG.clawSseTransport) {
       runBody = await runAgentChatViaSse({
         forwardBody,
         callbackId,

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -1674,6 +1674,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
         context: resolvedContext.promptPrefix || null,
         progressUrl,
         callbackUrl,
+        serverFallbackBody: forwardBody,
       });
       runBody = { success: true, sessionId: dispatched.sessionId };
     } else if (CONFIG.clawSseTransport) {

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -2740,7 +2740,10 @@ router.get("/:slug/user-config/:userId", pinUserIdParam, async (req: Request<{ s
     const config = await userAgentConfigRepository.findByUserAndAgent(req.params.userId, agent.orgId, req.params.slug);
     res.json({
       success: true,
-      data: { provider: config?.provider ?? "spaces" },
+      // `inherited` separates "never picked one" from an explicit "spaces" pick.
+      // Both report provider "spaces", but only the former follows the user's
+      // account-wide default harness (User.localHarnessDefaultProvider).
+      data: { provider: config?.provider ?? "spaces", inherited: !config },
     });
   } catch (err) {
     log.error("[agents] get user-config error:", err);

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -9,6 +9,7 @@ import { validateSubagentInput, ValidationError as SubagentValidationError } fro
 import { getSubagentDefinition, buildCloneApprovalFlow, normalizeAgentPrivacy, parseAgentPrivacy } from "xyne-claw-shared";
 import { spacesAppFetch } from "../lib/spaces-api.js";
 import { getWorkspaceIdForUser } from "../lib/spaces-db.js";
+import { LOCAL_HARNESS_PROVIDERS } from "../lib/local-harness.js";
 import { prisma } from "../db.js";
 import { CONFIG } from "../config.js";
 import { encrypt, decrypt } from "../crypto.js";
@@ -2750,8 +2751,15 @@ router.get("/:slug/user-config/:userId", pinUserIdParam, async (req: Request<{ s
 router.put("/:slug/user-config/:userId", pinUserIdParam, async (req: Request<{ slug: string; userId: string }>, res: Response) => {
   try {
     const { provider } = req.body as { provider?: string };
-    if (!provider || !["spaces", "copilot", "claude", "codex"].includes(provider)) {
-      res.status(400).json({ success: false, error: "provider must be 'spaces', 'copilot', 'claude', or 'codex'" });
+    const allowedProviders = [
+      "spaces",
+      "copilot",
+      "claude",
+      "codex",
+      ...(CONFIG.localHarnessEnabled ? LOCAL_HARNESS_PROVIDERS : []),
+    ];
+    if (!provider || !allowedProviders.includes(provider)) {
+      res.status(400).json({ success: false, error: `provider must be one of: ${allowedProviders.join(", ")}` });
       return;
     }
     const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));

--- a/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
@@ -1,0 +1,329 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import type { LocalHarnessDevice } from "@prisma/client";
+import type {
+  LocalHarnessDeviceStatus,
+  LocalHarnessInstallation,
+  LocalHarnessPollResult,
+  LocalHarnessRunEnvelope,
+} from "xyne-claw-shared";
+import {
+  isLocalHarnessDeviceRegistration,
+  isLocalHarnessProgressEvent,
+  isLocalHarnessRunResult,
+  isLocalHarnessToolCallRequest,
+} from "xyne-claw-shared";
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+import { getOrgId, getRequesterId, isOrgAdmin } from "../middleware/agent-acl.js";
+import { isDeviceOnline, localHarnessRepository } from "../repositories/localHarnessRepository.js";
+import { callToolForRun, listToolsForRun, relayProgress, relayResult } from "../lib/local-harness.js";
+
+const log = createLogger("local-harness-routes");
+
+// --- Prod-readiness guards for the long-poll bridge ---
+// Per-device cap on concurrent /runs/next long-polls. Each poll pins a
+// connection + a DB-polling loop for up to localHarnessPollTimeoutMs; without
+// a cap a single device (or a leaked token) could exhaust the connection pool.
+const MAX_CONCURRENT_POLLS_PER_DEVICE = 2;
+const activePolls = new Map<string, number>();
+
+// Graceful drain: on SIGTERM we stop parking new long-poll loops so in-flight
+// connections return `idle` quickly and the pod can exit without dropping a
+// claimed run. Wired from main.ts's shutdown handler.
+let draining = false;
+export function beginLocalHarnessDrain(): void {
+  draining = true;
+  log.info(`[local-harness][metric] drain_started active_poll_devices=${activePolls.size}`);
+}
+
+function requireFeature(_req: Request, res: Response, next: NextFunction): void {
+  if (!CONFIG.localHarnessEnabled) {
+    res.status(404).json({ success: false, error: "Local harness is not enabled" });
+    return;
+  }
+  next();
+}
+
+const router = Router();
+router.use(requireFeature);
+
+function toDeviceStatus(device: LocalHarnessDevice): LocalHarnessDeviceStatus {
+  return {
+    deviceId: device.id,
+    deviceName: device.deviceName,
+    platform: device.platform,
+    installations: (Array.isArray(device.installations) ? device.installations : []) as unknown as LocalHarnessInstallation[],
+    lastSeenAt: device.lastSeenAt ? device.lastSeenAt.toISOString() : null,
+    online: isDeviceOnline(device),
+    createdAt: device.createdAt.toISOString(),
+  };
+}
+
+router.post("/devices", async (req: Request, res: Response) => {
+  const userId = getRequesterId(req);
+  const orgId = getOrgId(req);
+  if (!userId || !orgId) {
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+  if (!isLocalHarnessDeviceRegistration(req.body)) {
+    res.status(400).json({ success: false, error: "Invalid device registration payload" });
+    return;
+  }
+
+  try {
+    const { device, token } = await localHarnessRepository.registerDevice({
+      userId,
+      orgId,
+      deviceName: req.body.deviceName.trim(),
+      platform: req.body.platform.trim(),
+      installations: req.body.installations as unknown as never,
+    });
+    log.info(
+      `[local-harness] device registered id=${device.id} user=${userId} installs=[${req.body.installations
+        .map((i) => `${i.provider}${i.authenticated ? "" : ":unauth"}`)
+        .join(",")}]`,
+    );
+    res.json({ success: true, data: { deviceId: device.id, deviceToken: token } });
+  } catch (err) {
+    log.error("[local-harness] device registration failed:", err);
+    res.status(500).json({ success: false, error: "Failed to register device" });
+  }
+});
+
+router.get("/devices", async (req: Request, res: Response) => {
+  const userId = getRequesterId(req);
+  if (!userId) {
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+  const devices = await localHarnessRepository.listDevices(userId).catch(() => [] as LocalHarnessDevice[]);
+  res.json({ success: true, data: devices.map(toDeviceStatus) });
+});
+
+router.delete("/devices/:deviceId", async (req: Request<{ deviceId: string }>, res: Response) => {
+  const userId = getRequesterId(req);
+  if (!userId) {
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+  const revoked = await localHarnessRepository.revokeDevice(userId, req.params.deviceId).catch(() => false);
+  if (!revoked) {
+    res.status(404).json({ success: false, error: "Device not found" });
+    return;
+  }
+  log.info(`[local-harness] device revoked id=${req.params.deviceId} user=${userId}`);
+  res.json({ success: true });
+});
+
+router.get("/workspace-settings", async (req: Request, res: Response) => {
+  const orgId = getOrgId(req);
+  if (!orgId) {
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+  const mode = (await localHarnessRepository.getOrgHarnessMode(orgId).catch(() => null))
+    ?? (CONFIG.localHarnessDefaultAll ? "all" : "selected");
+  res.json({ success: true, data: { mode } });
+});
+
+router.put("/workspace-settings", async (req: Request, res: Response) => {
+  const userId = getRequesterId(req);
+  const orgId = getOrgId(req);
+  if (!userId || !orgId) {
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+  if (!(await isOrgAdmin(userId, orgId).catch(() => false))) {
+    res.status(403).json({ success: false, error: "Only a workspace admin can change local-harness settings" });
+    return;
+  }
+  const mode = (req.body as { mode?: unknown } | null)?.mode;
+  if (mode !== "all" && mode !== "selected") {
+    res.status(400).json({ success: false, error: "mode must be 'all' or 'selected'" });
+    return;
+  }
+  await localHarnessRepository.setOrgHarnessMode(orgId, mode);
+  log.info(`[local-harness] workspace mode set org=${orgId} mode=${mode} by=${userId}`);
+  res.json({ success: true, data: { mode } });
+});
+
+const bridgeRouter = Router();
+bridgeRouter.use(requireFeature);
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      localHarnessDevice?: LocalHarnessDevice;
+    }
+  }
+}
+
+async function requireDevice(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const header = req.headers.authorization;
+  if (!header || !header.toLowerCase().startsWith("bearer ")) {
+    res.status(401).json({ success: false, error: "Device token required" });
+    return;
+  }
+  const device = await localHarnessRepository.findDeviceByToken(header.slice(7).trim()).catch(() => null);
+  if (!device) {
+    res.status(401).json({ success: false, error: "Invalid or revoked device token" });
+    return;
+  }
+  req.localHarnessDevice = device;
+  next();
+}
+
+bridgeRouter.use(requireDevice);
+
+bridgeRouter.get("/runs/next", async (req: Request, res: Response) => {
+  const device = req.localHarnessDevice!;
+  await localHarnessRepository.touchDevice(device.id).catch(() => {});
+
+  // Draining for shutdown: don't park a new loop, answer idle immediately so
+  // the client re-polls the next (healthy) pod.
+  if (draining) {
+    res.json({ success: true, data: { status: "idle" } as LocalHarnessPollResult });
+    return;
+  }
+
+  const inflight = activePolls.get(device.id) ?? 0;
+  if (inflight >= MAX_CONCURRENT_POLLS_PER_DEVICE) {
+    log.warn(`[local-harness][metric] poll_rejected device=${device.id} inflight=${inflight}`);
+    res.status(429).json({ success: false, error: "Too many concurrent poll connections" });
+    return;
+  }
+  activePolls.set(device.id, inflight + 1);
+  try {
+
+  const providers = (Array.isArray(device.installations) ? device.installations : [])
+    .map((entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+      const record = entry as Record<string, unknown>;
+      return record["authenticated"] === true && typeof record["provider"] === "string" ? record["provider"] : null;
+    })
+    .filter((p): p is string => p !== null);
+
+  const deadline = Date.now() + CONFIG.localHarnessPollTimeoutMs;
+  let aborted = false;
+  req.on("close", () => {
+    aborted = true;
+  });
+
+  while (!aborted && !draining && Date.now() < deadline) {
+    const run = await localHarnessRepository.claimNextRun(device, providers).catch(() => null);
+    if (run) {
+      if (aborted) {
+        await localHarnessRepository.releaseRun(run.id).catch(() => {});
+        log.info(`[local-harness] run released id=${run.id} — device disconnected mid-claim`);
+        return;
+      }
+      const envelope = run.envelope as unknown as LocalHarnessRunEnvelope;
+      log.info(`[local-harness][metric] run_claimed id=${run.id} device=${device.id} agent=${run.agentSlug}`);
+      const payload: LocalHarnessPollResult = { status: "run", run: { ...envelope, runId: run.id } };
+      res.json({ success: true, data: payload });
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+    if (aborted) return;
+    const idle: LocalHarnessPollResult = { status: "idle" };
+    res.json({ success: true, data: idle });
+  } finally {
+    const remaining = (activePolls.get(device.id) ?? 1) - 1;
+    if (remaining <= 0) activePolls.delete(device.id);
+    else activePolls.set(device.id, remaining);
+  }
+});
+
+async function ownedRun(req: Request<{ runId: string }>, res: Response) {
+  const device = req.localHarnessDevice!;
+  const run = await localHarnessRepository.findOwnedRun(req.params.runId, device).catch(() => null);
+  if (!run) {
+    res.status(404).json({ success: false, error: "Run not found" });
+    return null;
+  }
+  if (run.status === "done" || run.status === "failed" || run.status === "cancelled") {
+    res.status(409).json({ success: false, error: "Run already finished" });
+    return null;
+  }
+  return run;
+}
+
+bridgeRouter.get("/runs/:runId/tools", async (req: Request<{ runId: string }>, res: Response) => {
+  const run = await ownedRun(req, res);
+  if (!run) return;
+  try {
+    const tools = await listToolsForRun(run);
+    res.json({ success: true, data: { runId: run.id, tools } });
+  } catch (err) {
+    log.error(`[local-harness] tool listing failed run=${run.id}:`, err);
+    res.status(502).json({ success: false, error: "Failed to list tools" });
+  }
+});
+
+bridgeRouter.post("/runs/:runId/tools/call", async (req: Request<{ runId: string }>, res: Response) => {
+  const run = await ownedRun(req, res);
+  if (!run) return;
+  if (!isLocalHarnessToolCallRequest(req.body)) {
+    res.status(400).json({ success: false, error: "Invalid tool call payload" });
+    return;
+  }
+  const { serverType, toolName, params } = req.body;
+  try {
+    const result = await callToolForRun(run, { serverType, toolName, params: params ?? {} });
+    res.json({ success: true, data: result });
+  } catch (err) {
+    log.error(`[local-harness] tool call failed run=${run.id} tool=${serverType}/${toolName}:`, err);
+    res.status(502).json({ success: false, error: "Tool execution failed" });
+  }
+});
+
+bridgeRouter.post("/runs/:runId/progress", async (req: Request<{ runId: string }>, res: Response) => {
+  const run = await ownedRun(req, res);
+  if (!run) return;
+  res.json({ success: true });
+
+  const event = req.body;
+  if (!isLocalHarnessProgressEvent(event)) return;
+  await localHarnessRepository.markRunning(run.id).catch(() => {});
+
+  switch (event.kind) {
+    case "text":
+      await relayProgress(run, { textDelta: event.delta });
+      break;
+    case "tool":
+      await relayProgress(run, { toolLabel: event.toolName });
+      break;
+    case "status":
+      await relayProgress(run, { toolLabel: event.label });
+      break;
+  }
+});
+
+bridgeRouter.post("/runs/:runId/result", async (req: Request<{ runId: string }>, res: Response) => {
+  const run = await ownedRun(req, res);
+  if (!run) return;
+  if (!isLocalHarnessRunResult(req.body)) {
+    res.status(400).json({ success: false, error: "Invalid run result payload" });
+    return;
+  }
+  const result = req.body;
+  res.json({ success: true });
+
+  const won = await localHarnessRepository.finishRun(run.id, result.status, result.error).catch(() => false);
+  if (!won) {
+    log.warn(`[local-harness] result ignored id=${run.id} — run already finished (expired or cancelled)`);
+    return;
+  }
+  log.info(
+    `[local-harness] run finished id=${run.id} status=${result.status} provider=${run.provider} ` +
+      `requestedModel=${run.model ?? "(cli default)"} effectiveModel=${result.effectiveModel ?? "(not reported)"} ` +
+      `chars=${result.text.length}${result.error ? ` error=${result.error}` : ""}`,
+  );
+  await relayResult(run, result);
+});
+
+export { router as localHarnessRouter, bridgeRouter as localHarnessBridgeRouter };

--- a/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
@@ -8,14 +8,16 @@ import type {
 } from "xyne-claw-shared";
 import {
   isLocalHarnessDeviceRegistration,
+  isLocalHarnessInstallationSync,
   isLocalHarnessProgressEvent,
+  isLocalHarnessProvider,
   isLocalHarnessRunResult,
   isLocalHarnessToolCallRequest,
 } from "xyne-claw-shared";
 import { CONFIG } from "../config.js";
 import { createLogger } from "../logger.js";
 import { getOrgId, getRequesterId, isOrgAdmin } from "../middleware/agent-acl.js";
-import { isDeviceOnline, localHarnessRepository } from "../repositories/localHarnessRepository.js";
+import { authenticatedProviders, isDeviceOnline, localHarnessRepository } from "../repositories/localHarnessRepository.js";
 import { callToolForRun, listToolsForRun, relayProgress, relayResult } from "../lib/local-harness.js";
 
 const log = createLogger("local-harness-routes");
@@ -116,6 +118,41 @@ router.delete("/devices/:deviceId", async (req: Request<{ deviceId: string }>, r
   res.json({ success: true });
 });
 
+// Per-user default harness — "use this harness for all my agents". Written by
+// onboarding and by the Local harness card in Claw Settings; read by
+// resolveLocalHarnessTarget for every agent the user has no override on.
+router.get("/preferences", async (req: Request, res: Response) => {
+  const userId = getRequesterId(req);
+  if (!userId) {
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+  const defaultProvider = await localHarnessRepository.getUserDefaultProvider(userId).catch(() => null);
+  res.json({ success: true, data: { defaultProvider } });
+});
+
+router.put("/preferences", async (req: Request, res: Response) => {
+  const userId = getRequesterId(req);
+  if (!userId) {
+    res.status(401).json({ success: false, error: "Authentication required" });
+    return;
+  }
+  const defaultProvider = (req.body as { defaultProvider?: unknown } | null)?.defaultProvider ?? null;
+  if (defaultProvider !== null && !isLocalHarnessProvider(defaultProvider)) {
+    res.status(400).json({ success: false, error: "defaultProvider must be a local harness provider or null" });
+    return;
+  }
+  try {
+    await localHarnessRepository.setUserDefaultProvider(userId, defaultProvider);
+  } catch (err) {
+    log.error("[local-harness] failed to save default provider:", err);
+    res.status(500).json({ success: false, error: "Failed to save your default harness" });
+    return;
+  }
+  log.info(`[local-harness] user default harness user=${userId} provider=${defaultProvider ?? "(none)"}`);
+  res.json({ success: true, data: { defaultProvider } });
+});
+
 router.get("/workspace-settings", async (req: Request, res: Response) => {
   const orgId = getOrgId(req);
   if (!orgId) {
@@ -177,6 +214,31 @@ async function requireDevice(req: Request, res: Response, next: NextFunction): P
 
 bridgeRouter.use(requireDevice);
 
+// Per-harness connect/disconnect from the desktop app. Device-token authed on
+// purpose: re-POSTing /devices would rotate the pairing token and 401 the
+// long-poll this same app has in flight.
+bridgeRouter.put("/installations", async (req: Request, res: Response) => {
+  const device = req.localHarnessDevice!;
+  if (!isLocalHarnessInstallationSync(req.body)) {
+    res.status(400).json({ success: false, error: "Invalid installations payload" });
+    return;
+  }
+  try {
+    await localHarnessRepository.updateInstallations(device.id, req.body.installations as unknown as never);
+  } catch (err) {
+    log.error(`[local-harness] installation sync failed device=${device.id}:`, err);
+    res.status(500).json({ success: false, error: "Failed to update installations" });
+    return;
+  }
+  log.info(
+    `[local-harness] installations synced device=${device.id} enabled=[${req.body.installations
+      .filter((i) => i.authenticated && i.enabled !== false)
+      .map((i) => i.provider)
+      .join(",")}]`,
+  );
+  res.json({ success: true });
+});
+
 bridgeRouter.get("/runs/next", async (req: Request, res: Response) => {
   const device = req.localHarnessDevice!;
   await localHarnessRepository.touchDevice(device.id).catch(() => {});
@@ -197,13 +259,7 @@ bridgeRouter.get("/runs/next", async (req: Request, res: Response) => {
   activePolls.set(device.id, inflight + 1);
   try {
 
-  const providers = (Array.isArray(device.installations) ? device.installations : [])
-    .map((entry) => {
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
-      const record = entry as Record<string, unknown>;
-      return record["authenticated"] === true && typeof record["provider"] === "string" ? record["provider"] : null;
-    })
-    .filter((p): p is string => p !== null);
+  const providers = authenticatedProviders(device);
 
   const deadline = Date.now() + CONFIG.localHarnessPollTimeoutMs;
   let aborted = false;

--- a/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
@@ -1,4 +1,6 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
+import rateLimit, { ipKeyGenerator, type RateLimitRequestHandler } from "express-rate-limit";
+import { createHash } from "node:crypto";
 import type { LocalHarnessDevice } from "@prisma/client";
 import type {
   LocalHarnessDeviceStatus,
@@ -36,6 +38,44 @@ const log = createLogger("local-harness-routes");
 const MAX_CONCURRENT_POLLS_PER_DEVICE = 2;
 const activePolls = new Map<string, number>();
 
+const RATE_WINDOW_MS = 5 * 60 * 1000;
+
+const deviceKey = (req: Request): string => {
+  const header = req.headers.authorization;
+  return header
+    ? createHash("sha256").update(header).digest("hex").slice(0, 32)
+    : ipKeyGenerator(req.ip ?? "unknown");
+};
+
+const tooManyRequests = { success: false, error: "Too many requests. Please slow down." };
+
+const pollLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: RATE_WINDOW_MS,
+  limit: 120,
+  keyGenerator: deviceKey,
+  message: tooManyRequests,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const bridgeLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: RATE_WINDOW_MS,
+  limit: 900,
+  keyGenerator: deviceKey,
+  message: tooManyRequests,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const userLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: RATE_WINDOW_MS,
+  limit: 120,
+  keyGenerator: (req) => getRequesterId(req) ?? ipKeyGenerator(req.ip ?? "unknown"),
+  message: tooManyRequests,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 // Graceful drain: on SIGTERM we stop parking new long-poll loops so in-flight
 // connections return `idle` quickly and the pod can exit without dropping a
 // claimed run. Wired from main.ts's shutdown handler.
@@ -55,6 +95,7 @@ function requireFeature(_req: Request, res: Response, next: NextFunction): void 
 
 const router = Router();
 router.use(requireFeature);
+router.use(userLimiter);
 
 function toDeviceStatus(device: LocalHarnessDevice): LocalHarnessDeviceStatus {
   return {
@@ -219,6 +260,8 @@ async function requireDevice(req: Request, res: Response, next: NextFunction): P
   next();
 }
 
+bridgeRouter.use(bridgeLimiter);
+bridgeRouter.use("/runs/next", pollLimiter);
 bridgeRouter.use(requireDevice);
 
 // Per-harness connect/disconnect from the desktop app. Device-token authed on

--- a/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
@@ -36,6 +36,7 @@ const log = createLogger("local-harness-routes");
 // connection + a DB-polling loop for up to localHarnessPollTimeoutMs; without
 // a cap a single device (or a leaked token) could exhaust the connection pool.
 const MAX_CONCURRENT_POLLS_PER_DEVICE = 2;
+const DEVICE_TOUCH_INTERVAL_MS = 30_000;
 const activePolls = new Map<string, number>();
 
 const RATE_WINDOW_MS = 5 * 60 * 1000;
@@ -256,6 +257,9 @@ async function requireDevice(req: Request, res: Response, next: NextFunction): P
     res.status(401).json({ success: false, error: "Invalid or revoked device token" });
     return;
   }
+  if (!device.lastSeenAt || Date.now() - device.lastSeenAt.getTime() >= DEVICE_TOUCH_INTERVAL_MS) {
+    void localHarnessRepository.touchDevice(device.id).catch(() => {});
+  }
   req.localHarnessDevice = device;
   next();
 }
@@ -263,6 +267,10 @@ async function requireDevice(req: Request, res: Response, next: NextFunction): P
 bridgeRouter.use(bridgeLimiter);
 bridgeRouter.use("/runs/next", pollLimiter);
 bridgeRouter.use(requireDevice);
+
+bridgeRouter.get("/ping", (_req: Request, res: Response) => {
+  res.json({ success: true });
+});
 
 // Per-harness connect/disconnect from the desktop app. Device-token authed on
 // purpose: re-POSTing /devices would rotate the pairing token and 401 the
@@ -291,7 +299,6 @@ bridgeRouter.put("/installations", async (req: Request, res: Response) => {
 
 bridgeRouter.get("/runs/next", async (req: Request, res: Response) => {
   const device = req.localHarnessDevice!;
-  await localHarnessRepository.touchDevice(device.id).catch(() => {});
 
   // Draining for shutdown: don't park a new loop, answer idle immediately so
   // the client re-polls the next (healthy) pod.

--- a/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/local-harness.ts
@@ -18,7 +18,14 @@ import { CONFIG } from "../config.js";
 import { createLogger } from "../logger.js";
 import { getOrgId, getRequesterId, isOrgAdmin } from "../middleware/agent-acl.js";
 import { authenticatedProviders, isDeviceOnline, localHarnessRepository } from "../repositories/localHarnessRepository.js";
-import { callToolForRun, listToolsForRun, relayProgress, relayResult } from "../lib/local-harness.js";
+import {
+  callToolForRun,
+  listToolsForRun,
+  localHarnessProviderLabel,
+  recoverFailedLocalRun,
+  relayProgress,
+  relayResult,
+} from "../lib/local-harness.js";
 
 const log = createLogger("local-harness-routes");
 
@@ -301,7 +308,7 @@ async function ownedRun(req: Request<{ runId: string }>, res: Response) {
     res.status(404).json({ success: false, error: "Run not found" });
     return null;
   }
-  if (run.status === "done" || run.status === "failed" || run.status === "cancelled") {
+  if (run.status !== "queued" && run.status !== "claimed" && run.status !== "running") {
     res.status(409).json({ success: false, error: "Run already finished" });
     return null;
   }
@@ -368,6 +375,18 @@ bridgeRouter.post("/runs/:runId/result", async (req: Request<{ runId: string }>,
   }
   const result = req.body;
   res.json({ success: true });
+
+  if (result.status === "failed") {
+    const harness = localHarnessProviderLabel(run.provider);
+    const detail = result.error?.trim() ? `${harness} failed: ${result.error.trim()}` : `${harness} failed`;
+    if (await recoverFailedLocalRun(run, detail)) {
+      log.info(`[local-harness] run ${run.id} failed locally — handed to the server fallback (${detail})`);
+      return;
+    }
+    log.error(`[local-harness] run ${run.id} failed locally AND the server fallback failed — surfacing to the user`);
+    await relayResult(run, { ...result, error: detail }, { localHarnessUnreachable: true });
+    return;
+  }
 
   const won = await localHarnessRepository.finishRun(run.id, result.status, result.error).catch(() => false);
   if (!won) {

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -3256,7 +3256,19 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
     // A dispatch that dies on a TRANSIENT upstream failure (envoy 502/503/504
     // "no healthy upstream" during a claw rollout, a connection refusal against
     // a terminating pod) is retryable — the run never started, so nothing is
-    // duplicated by trying again. Mirrors routes/run.ts fetchClawRunWithRetry.
+    // duplicated by trying again. Without this, a routine claw deploy turns
+    // every in-flight mention into a user-visible "I couldn't start this
+    // request: no healthy upstream" (observed prod 2026-08-05) even though a
+    // retry two seconds later would have succeeded. Mirrors the retry the /run
+    // proxy already does (routes/run.ts fetchClawRunWithRetry).
+    //
+    // The ladder must OUTLAST a claw rollout, not just a blip: envoy keeps
+    // returning 503 for the full pod-boot window (image pull + boot +
+    // readiness, 1–3 min observed prod 2026-08-06 — a 2s×2 ladder exhausted in
+    // 4.5s and still posted the "briefly unavailable" notice for every mention
+    // landing mid-deploy). This runs after the webhook was ack'd, so waiting
+    // here blocks no caller; the message is already acked and the queue slot
+    // is held for this conversation.
     const DISPATCH_RETRY_DELAYS_MS = [2_000, 4_000, 8_000, 15_000, 30_000, 45_000, 60_000];
     const isTransientUpstream = (status: number, body: string): boolean =>
       status === 502 || status === 503 || status === 504 ||
@@ -3269,6 +3281,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         if (attempt > 0) await new Promise((r) => setTimeout(r, DISPATCH_RETRY_DELAYS_MS[attempt - 1]));
         const res = await fetchRun();
         if (res.ok) return res;
+        // Peek at the body WITHOUT consuming the caller's copy.
         const peek = await res.clone().text().catch(() => "");
         if (!isTransientUpstream(res.status, peek)) return res;
         lastRes = res;

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -37,6 +37,7 @@ import {
 import { getValidClaudeBearer } from "../lib/claude-oauth-refresh.js";
 import { getValidCodexBearer } from "../lib/codex-oauth-refresh.js";
 import { resolveAgentProviderConfigs, resolveSubagentProviderMode, KNOWN_PROVIDERS, buildProviderConfig, agentCredRefreshTarget, userCredRefreshTarget, agentDefaultSpeed, providerConfigForSpeed, applyFastModeModels } from "../lib/agent-provider-config.js";
+import { dispatchLocalHarnessRun, isLocalHarnessProvider, pinnedModelForProvider, resolveLocalHarnessTarget } from "../lib/local-harness.js";
 import { expandSpacesMentions, resolveUnboundMentions } from "../lib/mention-transform.js";
 import { shouldTwinRespond, recordTwinSilence, FAIL_CLOSED } from "../services/twinRespondGate.js";
 import { recordTwinApprovalPending } from "../services/twinResponseFeedback.js";
@@ -2516,9 +2517,12 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       ? await userAgentConfigRepository.findByUserAndAgent(targetUserId, agent.orgId, agent.slug).catch(() => null)
       : null;
     const rawPersonalProvider = userAgentConfig?.provider;
-    const personalProvider = rawPersonalProvider && rawPersonalProvider !== "spaces"
+    const selectedPersonalProvider = rawPersonalProvider && rawPersonalProvider !== "spaces"
       ? rawPersonalProvider
       : undefined;
+    const personalProvider = isLocalHarnessProvider(selectedPersonalProvider)
+      ? undefined
+      : selectedPersonalProvider;
 
     // Agent-level fallback: shared keys the agent's owner/admin configured.
     // Anurag's framing: "If someone configures codex at xyne doctor level then
@@ -3252,19 +3256,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
     // A dispatch that dies on a TRANSIENT upstream failure (envoy 502/503/504
     // "no healthy upstream" during a claw rollout, a connection refusal against
     // a terminating pod) is retryable — the run never started, so nothing is
-    // duplicated by trying again. Without this, a routine claw deploy turns
-    // every in-flight mention into a user-visible "I couldn't start this
-    // request: no healthy upstream" (observed prod 2026-08-05) even though a
-    // retry two seconds later would have succeeded. Mirrors the retry the /run
-    // proxy already does (routes/run.ts fetchClawRunWithRetry).
-    //
-    // The ladder must OUTLAST a claw rollout, not just a blip: envoy keeps
-    // returning 503 for the full pod-boot window (image pull + boot +
-    // readiness, 1–3 min observed prod 2026-08-06 — a 2s×2 ladder exhausted in
-    // 4.5s and still posted the "briefly unavailable" notice for every mention
-    // landing mid-deploy). This runs after the webhook was ack'd, so waiting
-    // here blocks no caller; the message is already acked and the queue slot
-    // is held for this conversation.
+    // duplicated by trying again. Mirrors routes/run.ts fetchClawRunWithRetry.
     const DISPATCH_RETRY_DELAYS_MS = [2_000, 4_000, 8_000, 15_000, 30_000, 45_000, 60_000];
     const isTransientUpstream = (status: number, body: string): boolean =>
       status === 502 || status === 503 || status === 504 ||
@@ -3277,7 +3269,6 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         if (attempt > 0) await new Promise((r) => setTimeout(r, DISPATCH_RETRY_DELAYS_MS[attempt - 1]));
         const res = await fetchRun();
         if (res.ok) return res;
-        // Peek at the body WITHOUT consuming the caller's copy.
         const peek = await res.clone().text().catch(() => "");
         if (!isTransientUpstream(res.status, peek)) return res;
         lastRes = res;
@@ -3289,21 +3280,69 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       return lastRes!;
     };
 
-    let runRes: Awaited<ReturnType<typeof fetchRun>>;
-    try {
-      runRes = await fetchRunWithRetry();
-    } catch (err) {
-      // Dispatch never happened — free the global twin slot, and drain/free the
-      // per-user FIFO slot so a queued follow-up tag isn't wedged behind a run
-      // that never started.
-      if (globalTwinSlotToken !== null) void releaseTwinSlot(globalTwinSlotToken);
-      if (twinConvSlotToken !== null && payload.conversationId) {
-        await drainNextQueued(payload.conversationId, runAgentSlug, twinConvSlotToken, twinUserScope).catch(() => {});
-      }
-      throw err;
-    }
+    // Local-harness routing: only mention-driven runs are eligible. If the user
+    // has an online authenticated local device for a preferred provider, the run
+    // is dispatched there; otherwise we fall through to the server run below.
+    const localHarnessEligible = eventType === "USER_MENTIONED" || eventType === "APP_MENTIONED";
+    const rawAgentOrder = (agentRow?.config as Record<string, unknown> | null)?.["providerOrder"];
+    const localTarget = localHarnessEligible
+      ? await resolveLocalHarnessTarget({
+          userId: targetUserId,
+          orgId: agent.orgId,
+          providerOrder: Array.isArray(rawAgentOrder)
+            ? rawAgentOrder.filter((p): p is string => typeof p === "string")
+            : [],
+          personalProvider: selectedPersonalProvider,
+        }).catch((err: unknown) => {
+          log.warn("Local-harness resolution failed — using server run", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return undefined;
+        })
+      : undefined;
 
-    const body = (await runRes.json()) as { success: boolean; sessionId?: string; error?: string };
+    let body: { success: boolean; sessionId?: string; error?: string };
+    let runRes: Awaited<ReturnType<typeof fetchRun>> | undefined;
+    if (localTarget) {
+      let dispatched: Awaited<ReturnType<typeof dispatchLocalHarnessRun>>;
+      try {
+        dispatched = await dispatchLocalHarnessRun({
+          target: localTarget,
+          userId: targetUserId,
+          orgId: agent.orgId,
+          conversationId: payload.conversationId,
+          agentSlug: runAgentSlug,
+          agentName: agentRow?.name ?? agent.slug,
+          systemPrompt: agentRow?.systemPrompt ?? "",
+          model: pinnedModelForProvider(agentRow?.config, localTarget.provider),
+          task,
+          context: dispatchContext || null,
+          progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
+          callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/result`,
+        });
+      } catch (err) {
+        if (globalTwinSlotToken !== null) void releaseTwinSlot(globalTwinSlotToken);
+        if (twinConvSlotToken !== null && payload.conversationId) {
+          await drainNextQueued(payload.conversationId, runAgentSlug, twinConvSlotToken, twinUserScope).catch(() => {});
+        }
+        throw err;
+      }
+      body = { success: true, sessionId: dispatched.sessionId };
+    } else {
+      try {
+        runRes = await fetchRunWithRetry();
+      } catch (err) {
+        // Dispatch never happened — free the global twin slot, and drain/free the
+        // per-user FIFO slot so a queued follow-up tag isn't wedged behind a run
+        // that never started.
+        if (globalTwinSlotToken !== null) void releaseTwinSlot(globalTwinSlotToken);
+        if (twinConvSlotToken !== null && payload.conversationId) {
+          await drainNextQueued(payload.conversationId, runAgentSlug, twinConvSlotToken, twinUserScope).catch(() => {});
+        }
+        throw err;
+      }
+      body = (await runRes.json()) as { success: boolean; sessionId?: string; error?: string };
+    }
 
     // Re-key the GLOBAL twin slot to the real sessionId (released by
     // /webhook/result); free it immediately if the dispatch didn't produce a run.
@@ -3358,15 +3397,19 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
 
       // Run-recovery / goal-replay reuses the SAME dispatchPayload that was
       // dispatched above (built once before the per-user gate) — byte-identical
-      // replay, no mention-note drift.
-      await registerRunRecovery({
-        rootSessionId: body.sessionId,
-        maxRetries: CONFIG.runRecoveryMaxRetries,
-        timeoutMs: CONFIG.runRecoveryTimeoutMs,
-        retryBackoffMs: CONFIG.runRecoveryBackoffMs,
-        dispatchPayload,
-        sessionContext,
-      });
+      // replay, no mention-note drift. Skipped on the local-harness path: the
+      // run lives in the user's Electron app, so a server-side retry can't
+      // recover it.
+      if (!localTarget) {
+        await registerRunRecovery({
+          rootSessionId: body.sessionId,
+          maxRetries: CONFIG.runRecoveryMaxRetries,
+          timeoutMs: CONFIG.runRecoveryTimeoutMs,
+          retryBackoffMs: CONFIG.runRecoveryBackoffMs,
+          dispatchPayload,
+          sessionContext,
+        });
+      }
 
       // /goal turn-0 persistence: same dispatchPayload is replayed by the
       // relooper for each subsequent turn (task is overwritten with the
@@ -3421,7 +3464,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       // reads as an agent fault and tells the user nothing actionable.
       const notice = /disabled/i.test(refusal)
         ? `🚫 **${agent.slug}** is currently disabled — an admin can re-enable it in the agent dashboard.`
-        : isTransientUpstream(runRes.status, refusal)
+        : runRes && isTransientUpstream(runRes.status, refusal)
           ? `⏳ The agent service is briefly unavailable (deploy or restart in progress). Please send that again in a moment.`
           : `⚠️ I couldn't start this request: ${refusal}`;
       await spacesAppFetch("/chat/postMessage", {

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -3292,7 +3292,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
           providerOrder: Array.isArray(rawAgentOrder)
             ? rawAgentOrder.filter((p): p is string => typeof p === "string")
             : [],
-          personalProvider: selectedPersonalProvider,
+          personalProvider: rawPersonalProvider,
         }).catch((err: unknown) => {
           log.warn("Local-harness resolution failed — using server run", {
             error: err instanceof Error ? err.message : String(err),

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -3319,6 +3319,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
           context: dispatchContext || null,
           progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
           callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/result`,
+          serverFallbackBody: dispatchPayload as unknown as Record<string, unknown>,
         });
       } catch (err) {
         if (globalTwinSlotToken !== null) void releaseTwinSlot(globalTwinSlotToken);
@@ -4715,6 +4716,15 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     pendingGoalSuggestion?: { condition: string; rationale: string };
     provider?: string;
     model?: string;
+    localHarness?: {
+      provider: string;
+      harnessName: string;
+      label: string;
+      ownerName: string;
+      deviceName?: string;
+    };
+    localHarnessUnreachable?: boolean;
+    localHarnessProvider?: string;
     fastMode?: boolean;
     // Conversation identity claw ships on every callback (see
     // xyne-claw/src/routes/run.ts:1040-1046). Used by the conv-keyed
@@ -5519,9 +5529,12 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       ctx.responseMode === "conversation"
     ) {
       const isQuota = /\b429\b|quota|rate.?limit|exceeded|out of credit/i.test(rawErr);
-      const notice = isQuota
-        ? "⚠️ I couldn't respond — the provider configured for this agent is out of quota / rate-limited right now. Please retry shortly, or switch the agent's provider in its settings."
-        : "⚠️ I couldn't complete this request due to an internal error. Please try again.";
+      const harnessLabel = payload.localHarnessProvider === "codex-cli" ? "Codex CLI" : "Claude Code";
+      const notice = payload.localHarnessUnreachable
+        ? `⚠️ I couldn't reach **${harnessLabel}** on your machine, and running this on Xyne's servers instead didn't start either. Open the Xyne desktop app (or turn off the local harness for this agent) and try again.`
+        : isQuota
+          ? "⚠️ I couldn't respond — the provider configured for this agent is out of quota / rate-limited right now. Please retry shortly, or switch the agent's provider in its settings."
+          : "⚠️ I couldn't complete this request due to an internal error. Please try again.";
       await spacesAppFetch("/chat/postMessage", {
         channelId: ctx.channelId,
         conversationId: ctx.conversationId,
@@ -6668,8 +6681,12 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // buildThreadCitationMeta). Used by the copilot/pendingResponses posts
     // below, which deliver the answer via a different path than the normal
     // conversation branch (convMetadata) and would otherwise ship no citations.
+    const runOriginMeta: Record<string, unknown> = payload.localHarness
+      ? { clawRunOrigin: { kind: "local-harness", ...payload.localHarness } }
+      : {};
+
     const buildPostMetadata = (text: string): Record<string, unknown> => {
-      const meta: Record<string, unknown> = { contentFormat: "markdown" };
+      const meta: Record<string, unknown> = { contentFormat: "markdown", ...runOriginMeta };
       const tc = buildThreadCitationMeta(citationInvocations, text);
       if (tc) {
         meta["clawCitations"] = tc.clawCitations;
@@ -6858,6 +6875,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       );
       const convMetadata = {
         contentFormat: "markdown",
+        ...runOriginMeta,
         ...(threadCitationMeta
           ? {
               clawCitations: threadCitationMeta.clawCitations,

--- a/apps/xyne-claw-auth/backend/src/services/localHarnessExpiry.ts
+++ b/apps/xyne-claw-auth/backend/src/services/localHarnessExpiry.ts
@@ -1,0 +1,32 @@
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+import { relayResult } from "../lib/local-harness.js";
+import { localHarnessRepository } from "../repositories/localHarnessRepository.js";
+
+const log = createLogger("local-harness-expiry");
+
+const SWEEP_INTERVAL_MS = 30_000;
+
+export function initLocalHarnessExpirySweep(): void {
+  if (!CONFIG.localHarnessEnabled) return;
+
+  const timer = setInterval(() => {
+    void (async () => {
+      const expired = await localHarnessRepository.expireStaleRuns().catch((err) => {
+        log.warn("[local-harness] expiry sweep failed:", err instanceof Error ? err.message : err);
+        return [];
+      });
+      for (const run of expired) {
+        log.warn(`[local-harness] run expired id=${run.id} device=${run.deviceId ?? "(unclaimed)"} agent=${run.agentSlug}`);
+        await relayResult(run, {
+          status: "failed",
+          text: "",
+          error: "The local harness stopped responding — the desktop app may be offline.",
+        });
+      }
+    })();
+  }, SWEEP_INTERVAL_MS);
+
+  timer.unref();
+  log.info("[local-harness] expiry sweep started");
+}

--- a/apps/xyne-claw-auth/backend/src/services/localHarnessExpiry.ts
+++ b/apps/xyne-claw-auth/backend/src/services/localHarnessExpiry.ts
@@ -1,32 +1,45 @@
 import { CONFIG } from "../config.js";
 import { createLogger } from "../logger.js";
-import { relayResult } from "../lib/local-harness.js";
+import { failOverToServerRun, localHarnessProviderLabel, relayResult } from "../lib/local-harness.js";
 import { localHarnessRepository } from "../repositories/localHarnessRepository.js";
 
 const log = createLogger("local-harness-expiry");
 
-const SWEEP_INTERVAL_MS = 30_000;
+const SWEEP_INTERVAL_MS = 15_000;
+
+const CLAIM_TIMEOUT_MS = 30_000;
 
 export function initLocalHarnessExpirySweep(): void {
   if (!CONFIG.localHarnessEnabled) return;
 
   const timer = setInterval(() => {
     void (async () => {
-      const expired = await localHarnessRepository.expireStaleRuns().catch((err) => {
-        log.warn("[local-harness] expiry sweep failed:", err instanceof Error ? err.message : err);
-        return [];
-      });
-      for (const run of expired) {
-        log.warn(`[local-harness] run expired id=${run.id} device=${run.deviceId ?? "(unclaimed)"} agent=${run.agentSlug}`);
-        await relayResult(run, {
-          status: "failed",
-          text: "",
-          error: "The local harness stopped responding — the desktop app may be offline.",
+      const abandoned = await localHarnessRepository
+        .findAbandonedRuns({ claimTimeoutMs: CLAIM_TIMEOUT_MS })
+        .catch((err) => {
+          log.warn("[local-harness] abandoned-run sweep failed:", err instanceof Error ? err.message : err);
+          return [];
         });
+
+      for (const { run, reason } of abandoned) {
+        if (!(await localHarnessRepository.beginFallback(run.id).catch(() => false))) continue;
+
+        log.warn(
+          `[local-harness] run abandoned id=${run.id} device=${run.deviceId ?? "(unclaimed)"} ` +
+            `agent=${run.agentSlug} provider=${run.provider} reason="${reason}"`,
+        );
+
+        if (await failOverToServerRun(run, reason)) continue;
+
+        await relayResult(
+          run,
+          { status: "failed", text: "", error: `${localHarnessProviderLabel(run.provider)}: ${reason}` },
+          { localHarnessUnreachable: true },
+        );
       }
     })();
   }, SWEEP_INTERVAL_MS);
 
   timer.unref();
-  log.info("[local-harness] expiry sweep started");
+  log.info("[local-harness] abandoned-run sweep started");
 }

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -14,6 +14,33 @@ export type { Citation, CitationIconKey } from "./types/citation.js";
 export { citationIconUrl, citationIconKey, iconUrlForKey, toolIconKey, CITATION_ICONS } from "./types/citation.js";
 export type { TwinDelivery, TwinDeliveryAction, TwinReplyDestination, TwinDestinationCandidate } from "./types/twin-delivery.js";
 export { isTwinDelivery } from "./types/twin-delivery.js";
+export type {
+  LocalHarnessProvider,
+  LocalHarnessInstallation,
+  LocalHarnessDeviceRegistration,
+  LocalHarnessDeviceCredential,
+  LocalHarnessDeviceStatus,
+  LocalHarnessRunEnvelope,
+  LocalHarnessPollResult,
+  LocalHarnessToolSpec,
+  LocalHarnessToolList,
+  LocalHarnessToolCallRequest,
+  LocalHarnessToolCallResponse,
+  LocalHarnessProgressEvent,
+  LocalHarnessRunStatus,
+  LocalHarnessRunResult,
+} from "./types/local-harness.js";
+export {
+  LOCAL_HARNESS_PROVIDERS,
+  LOCAL_HARNESS_PROTOCOL_VERSION,
+  LOCAL_HARNESS_SAFE_NAME,
+  isLocalHarnessProvider,
+  isSafeLocalHarnessName,
+  isLocalHarnessToolCallRequest,
+  isLocalHarnessRunResult,
+  isLocalHarnessProgressEvent,
+  isLocalHarnessDeviceRegistration,
+} from "./types/local-harness.js";
 export {
   normalizeSkillContent,
   hashSkillContent,

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -18,6 +18,7 @@ export type {
   LocalHarnessProvider,
   LocalHarnessInstallation,
   LocalHarnessDeviceRegistration,
+  LocalHarnessInstallationSync,
   LocalHarnessDeviceCredential,
   LocalHarnessDeviceStatus,
   LocalHarnessRunEnvelope,
@@ -40,6 +41,7 @@ export {
   isLocalHarnessRunResult,
   isLocalHarnessProgressEvent,
   isLocalHarnessDeviceRegistration,
+  isLocalHarnessInstallationSync,
 } from "./types/local-harness.js";
 export {
   normalizeSkillContent,

--- a/packages/xyne-claw-shared/src/types/local-harness.ts
+++ b/packages/xyne-claw-shared/src/types/local-harness.ts
@@ -1,0 +1,157 @@
+
+export type LocalHarnessProvider = "claude-code" | "codex-cli";
+
+export const LOCAL_HARNESS_PROVIDERS: readonly LocalHarnessProvider[] = ["claude-code", "codex-cli"];
+
+export function isLocalHarnessProvider(v: unknown): v is LocalHarnessProvider {
+  return typeof v === "string" && (LOCAL_HARNESS_PROVIDERS as readonly string[]).includes(v);
+}
+
+export const LOCAL_HARNESS_SAFE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+
+export function isSafeLocalHarnessName(v: unknown): v is string {
+  return typeof v === "string" && LOCAL_HARNESS_SAFE_NAME.test(v);
+}
+
+export const LOCAL_HARNESS_PROTOCOL_VERSION = 1;
+
+export interface LocalHarnessInstallation {
+  provider: LocalHarnessProvider;
+  binaryPath: string;
+  version: string;
+  authenticated: boolean;
+}
+
+export interface LocalHarnessDeviceRegistration {
+  protocolVersion: number;
+  deviceName: string;
+  platform: string;
+  installations: LocalHarnessInstallation[];
+}
+
+export interface LocalHarnessDeviceCredential {
+  deviceId: string;
+  deviceToken: string;
+}
+
+export interface LocalHarnessDeviceStatus {
+  deviceId: string;
+  deviceName: string;
+  platform: string;
+  installations: LocalHarnessInstallation[];
+  lastSeenAt: string | null;
+  online: boolean;
+  createdAt: string;
+}
+
+export interface LocalHarnessRunEnvelope {
+  protocolVersion: number;
+  runId: string;
+  sessionId: string;
+  conversationId: string;
+  provider: LocalHarnessProvider;
+  model: string | null;
+  agentSlug: string;
+  agentName: string;
+  systemPrompt: string;
+  task: string;
+  context: string | null;
+  timeoutMs: number;
+}
+
+export type LocalHarnessPollResult =
+  | { status: "idle" }
+  | { status: "run"; run: LocalHarnessRunEnvelope };
+
+export interface LocalHarnessToolSpec {
+  name: string;
+  serverType: string;
+  toolName: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  write: boolean;
+}
+
+export interface LocalHarnessToolList {
+  runId: string;
+  tools: LocalHarnessToolSpec[];
+}
+
+export interface LocalHarnessToolCallRequest {
+  serverType: string;
+  toolName: string;
+  params: Record<string, unknown>;
+}
+
+export interface LocalHarnessToolCallResponse {
+  ok: boolean;
+  content: string;
+}
+
+export type LocalHarnessProgressEvent =
+  | { kind: "text"; delta: string }
+  | { kind: "tool"; toolName: string }
+  | { kind: "status"; label: string };
+
+export type LocalHarnessRunStatus = "done" | "failed" | "cancelled";
+
+export interface LocalHarnessRunResult {
+  status: LocalHarnessRunStatus;
+  text: string;
+  toolsUsed?: string[];
+  tokenUsage?: { input?: number; output?: number };
+  effectiveModel?: string;
+  error?: string;
+}
+
+export function isLocalHarnessToolCallRequest(v: unknown): v is LocalHarnessToolCallRequest {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  if (!isSafeLocalHarnessName(r["serverType"])) return false;
+  if (!isSafeLocalHarnessName(r["toolName"])) return false;
+  const params = r["params"];
+  return params === undefined || (typeof params === "object" && params !== null && !Array.isArray(params));
+}
+
+export function isLocalHarnessRunResult(v: unknown): v is LocalHarnessRunResult {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  const status = r["status"];
+  if (status !== "done" && status !== "failed" && status !== "cancelled") return false;
+  return typeof r["text"] === "string";
+}
+
+export function isLocalHarnessProgressEvent(v: unknown): v is LocalHarnessProgressEvent {
+  if (!v || typeof v !== "object") return false;
+  const e = v as Record<string, unknown>;
+  switch (e["kind"]) {
+    case "text":
+      return typeof e["delta"] === "string";
+    case "tool":
+      return isSafeLocalHarnessName(e["toolName"]);
+    case "status":
+      return typeof e["label"] === "string";
+    default:
+      return false;
+  }
+}
+
+export function isLocalHarnessDeviceRegistration(v: unknown): v is LocalHarnessDeviceRegistration {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  if (r["protocolVersion"] !== LOCAL_HARNESS_PROTOCOL_VERSION) return false;
+  if (typeof r["deviceName"] !== "string" || !r["deviceName"].trim()) return false;
+  if (typeof r["platform"] !== "string" || !r["platform"].trim()) return false;
+  const installations = r["installations"];
+  if (!Array.isArray(installations)) return false;
+  return installations.every((i) => {
+    if (!i || typeof i !== "object") return false;
+    const inst = i as Record<string, unknown>;
+    return (
+      isLocalHarnessProvider(inst["provider"]) &&
+      typeof inst["binaryPath"] === "string" &&
+      typeof inst["version"] === "string" &&
+      typeof inst["authenticated"] === "boolean"
+    );
+  });
+}

--- a/packages/xyne-claw-shared/src/types/local-harness.ts
+++ b/packages/xyne-claw-shared/src/types/local-harness.ts
@@ -20,6 +20,20 @@ export interface LocalHarnessInstallation {
   binaryPath: string;
   version: string;
   authenticated: boolean;
+  /**
+   * Whether the user has connected THIS harness on THIS device. Each harness is
+   * paired independently, so a device can have Claude Code connected while Codex
+   * CLI stays off. Absent on devices registered before per-harness pairing —
+   * treat `undefined` as connected so those keep working (see
+   * `authenticatedProviders`).
+   */
+  enabled?: boolean;
+}
+
+/** Device-token authed installation refresh (per-harness connect/disconnect). */
+export interface LocalHarnessInstallationSync {
+  protocolVersion: number;
+  installations: LocalHarnessInstallation[];
 }
 
 export interface LocalHarnessDeviceRegistration {
@@ -136,22 +150,33 @@ export function isLocalHarnessProgressEvent(v: unknown): v is LocalHarnessProgre
   }
 }
 
-export function isLocalHarnessDeviceRegistration(v: unknown): v is LocalHarnessDeviceRegistration {
-  if (!v || typeof v !== "object") return false;
-  const r = v as Record<string, unknown>;
-  if (r["protocolVersion"] !== LOCAL_HARNESS_PROTOCOL_VERSION) return false;
-  if (typeof r["deviceName"] !== "string" || !r["deviceName"].trim()) return false;
-  if (typeof r["platform"] !== "string" || !r["platform"].trim()) return false;
-  const installations = r["installations"];
-  if (!Array.isArray(installations)) return false;
-  return installations.every((i) => {
+function isInstallationArray(v: unknown): v is LocalHarnessInstallation[] {
+  if (!Array.isArray(v)) return false;
+  return v.every((i) => {
     if (!i || typeof i !== "object") return false;
     const inst = i as Record<string, unknown>;
     return (
       isLocalHarnessProvider(inst["provider"]) &&
       typeof inst["binaryPath"] === "string" &&
       typeof inst["version"] === "string" &&
-      typeof inst["authenticated"] === "boolean"
+      typeof inst["authenticated"] === "boolean" &&
+      (inst["enabled"] === undefined || typeof inst["enabled"] === "boolean")
     );
   });
+}
+
+export function isLocalHarnessDeviceRegistration(v: unknown): v is LocalHarnessDeviceRegistration {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  if (r["protocolVersion"] !== LOCAL_HARNESS_PROTOCOL_VERSION) return false;
+  if (typeof r["deviceName"] !== "string" || !r["deviceName"].trim()) return false;
+  if (typeof r["platform"] !== "string" || !r["platform"].trim()) return false;
+  return isInstallationArray(r["installations"]);
+}
+
+export function isLocalHarnessInstallationSync(v: unknown): v is LocalHarnessInstallationSync {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  if (r["protocolVersion"] !== LOCAL_HARNESS_PROTOCOL_VERSION) return false;
+  return isInstallationArray(r["installations"]);
 }


### PR DESCRIPTION
Replay the local CLI harness feature from stale PR #184 onto current main, then apply prod-readiness fixes #1-#8 and #11. Summary of changes:

- Enables local harness in production behind the server-side LOCAL_HARNESS_ENABLED flag.
- Makes XYNE_CLAW_S2S_KEY mandatory when local harness is enabled in production, ensuring all MCP relay and run callbacks are S2S-authenticated.
- Adds per-device poll concurrency cap and graceful shutdown drain on the /runs/next long-poll bridge.
- Re-timestamps the Prisma migration to 20260824090000.
- Adds workspace-level all/selected toggle stored in Organization.metadata, with admin-only PUT endpoint.
- Adds structured metric logs for run_claimed, poll_rejected, and drain events.
- Enforces explicit orgId scoping on run claim and owned-run lookup.
- Fixes webhook.ts merge artifacts in the run-result refusal path.

Backend typecheck passed. Full dashboard UI for the workspace toggle was not wired yet.