### PR TITLE
feat: XYNE-56574 folder-scoped kb-search in claw-auth

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
@@ -582,7 +582,22 @@ function buildVespaScope(
   ctx: KbResolution,
   explicitCollectionId: string | undefined,
 ): VespaScopeFilter | { error: string } {
-  if (explicitCollectionId) return { kind: "collection", ids: [explicitCollectionId] };
+  if (explicitCollectionId) {
+    const meta = ctx.collectionsById.get(explicitCollectionId);
+    // A non-root folder: Vespa's collectionId filter only ever matches a
+    // doc's ROOT collection, so this has to expand to explicit docIds
+    // instead (see collectAllowedVespaDocIds). Applies equally to a
+    // folder-picked attachedContext item and to the model passing a
+    // sub-folder id as kb-search's collectionId arg directly.
+    if (meta && meta.rootCollectionId !== explicitCollectionId) {
+      const docIds = collectAllowedVespaDocIds(ctx, explicitCollectionId);
+      if (docIds.length === 0) {
+        return { error: `Folder \`${explicitCollectionId}\` has no accessible files.` };
+      }
+      return { kind: "file", docIds };
+    }
+    return { kind: "collection", ids: [explicitCollectionId] };
+  }
   if (ctx.scope === "USER") return { kind: "none" };
 
   const hasWholeCollectionGrant = ctx.grants.some(g => g.fileId === null);
@@ -845,6 +860,29 @@ function countAllowedChildFolders(ctx: KbResolution, n: KbCollectionNode): numbe
   let total = 0;
   for (const c of n.children ?? []) if (collectionAllowed(ctx, c.id)) total++;
   return total;
+}
+
+/**
+ * Every allowed file's Vespa docId under `folderId`, recursively — used to
+ * scope a kb-search call to a non-root folder. Vespa's `collectionId` filter
+ * only ever matches a doc's ROOT collection (see buildVespaScope), so a
+ * folder id can't be filtered on directly; this expands it to explicit
+ * docIds instead, walking the tree already fetched for ACL checks (no extra
+ * network call). Re-applies fileAllowed() per file so a COLLECTIONS-scoped
+ * agent whose grant only covers part of this subtree doesn't leak the rest.
+ */
+function collectAllowedVespaDocIds(ctx: KbResolution, folderId: string): string[] {
+  const start = ctx.nodesById.get(folderId);
+  if (!start) return [];
+  const docIds: string[] = [];
+  const walk = (n: KbCollectionNode): void => {
+    for (const f of n.items ?? []) {
+      if (f.fileId && fileAllowed(ctx, f.id)) docIds.push(f.fileId);
+    }
+    for (const c of n.children ?? []) walk(c);
+  };
+  walk(start);
+  return docIds;
 }
 
 /**

--- a/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
+++ b/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
@@ -1,11 +1,11 @@
 import { interact, spacesFetch, type SpacesAuthContext } from "../mcp/servers/xyne-spaces-client.js";
 
-export type ContextType = "channel" | "ticket" | "canvas" | "call" | "activity" | "collection" | "file";
-// 'collection' / 'file' are not user-searchable via this service (they're
-// picked through the dashboard's KB picker, not via the generic search), so
-// they're intentionally excluded from the search-type enum.
+export type ContextType = "channel" | "ticket" | "canvas" | "call" | "activity" | "collection" | "file" | "folder";
+// 'collection' / 'file' / 'folder' are not user-searchable via this service
+// (they're picked through the dashboard's KB picker, not via the generic
+// search), so they're intentionally excluded from the search-type enum.
 export type ContextItemType = ContextType | "repository";
-export type ContextSearchType = Exclude<ContextType, "activity" | "collection" | "file"> | "repository" | "all";
+export type ContextSearchType = Exclude<ContextType, "activity" | "collection" | "file" | "folder"> | "repository" | "all";
 
 export interface ContextItem {
   id: string;
@@ -134,6 +134,7 @@ export function normalizeAttachedContext(input: unknown): { items: AttachedConte
     call: 0,
     collection: 0,
     file: 0,
+    folder: 0,
   };
 
   for (const raw of input) {
@@ -142,7 +143,7 @@ export function normalizeAttachedContext(input: unknown): { items: AttachedConte
     const type = obj["type"];
     const id = obj["id"];
     const title = obj["title"];
-    if (!isContextType(type)) return { items: [], error: "attachedContext.type must be one of channel|ticket|canvas|call|activity|collection|file" };
+    if (!isContextType(type)) return { items: [], error: "attachedContext.type must be one of channel|ticket|canvas|call|activity|collection|file|folder" };
     if (typeof id !== "string" || id.trim().length === 0) return { items: [], error: "attachedContext.id must be a non-empty string" };
     if (typeof title !== "string" || title.trim().length === 0) return { items: [], error: "attachedContext.title must be a non-empty string" };
     const threadId = obj["threadId"];
@@ -528,6 +529,7 @@ async function resolveSection(item: AttachedContextRef, auth?: SpacesAuthContext
   if (item.type === "activity") return resolveActivitySection(item);
   if (item.type === "collection") return resolveCollectionSection(item);
   if (item.type === "file") return resolveFileSection(item);
+  if (item.type === "folder") return resolveFolderSection(item);
   return resolveCallSection(item, auth);
 }
 
@@ -552,6 +554,23 @@ async function resolveFileSection(item: AttachedContextRef): Promise<ResolvedCon
   const lines = [
     `File: ${item.title} (fileId=${item.id})`,
     `Fetch: read its full content with \`kb-read-file\` (fileId=${item.id}).`,
+  ];
+  return { header, inlineText: lines.join("\n") };
+}
+
+/** Knowledge Base folder (a non-root collection node) attached from the
+ *  ask-ai v2 picker. Same shape as resolveCollectionSection — the `id` works
+ *  as a `collectionId` arg to kb-list-files/kb-search/kb-read-file exactly
+ *  like a root collection id does, since folders are collection-tree nodes
+ *  too. buildVespaScope (kb-handlers.ts) is what actually handles the
+ *  root-vs-folder distinction when kb-search turns this into a Vespa filter
+ *  — Vespa's collectionId filter only ever matches a doc's ROOT collection,
+ *  so a folder id there expands to explicit docIds instead. */
+async function resolveFolderSection(item: AttachedContextRef): Promise<ResolvedContextSection> {
+  const header = `Folder "${item.title}" (id=${item.id})`;
+  const lines = [
+    `Folder: ${item.title} (collectionId=${item.id})`,
+    `Fetch: enumerate files with \`kb-list-files\` (collectionId=${item.id}); find one with \`kb-search\` (collectionId=${item.id} + query); read a file with \`kb-read-file\` (fileId from kb-list-files).`,
   ];
   return { header, inlineText: lines.join("\n") };
 }
@@ -846,7 +865,8 @@ function isContextType(value: unknown): value is ContextType {
     value === "call" ||
     value === "activity" ||
     value === "collection" ||
-    value === "file"
+    value === "file" ||
+    value === "folder"
   );
 }
 
@@ -857,5 +877,6 @@ function labelForType(type: ContextType): string {
   if (type === "activity") return "Activity";
   if (type === "collection") return "Collection";
   if (type === "file") return "File";
+  if (type === "folder") return "Folder";
   return "Call";
 }


### PR DESCRIPTION
Adds a 'folder' attachedContext type (agentChatContextService.ts) and fixes buildVespaScope (kb-handlers.ts) to resolve a non-root collection id to explicit file docIds instead of the root-only collectionId filter — Vespa's collectionId filter only ever matches a doc's ROOT collection, so passing a sub-folder id there previously returned zero results silently, both for the new folder-scoped attachedContext pointer and for the model passing a sub-folder id as kb-search's own collectionId arg directly.

Split out from the spaces-side Ask AI folder-scoping feature (feature/kb-ui-change) since this service deploys independently.


Claude-Session: https://claude.ai/code/session_01YNRXfaxdt3aP8x15KNsnbj

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
