### PR TITLE
feat: add encryption key rotation backfill

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -45,7 +45,8 @@
     "db:common:deploy": "prisma migrate deploy --schema prisma-common/schema.prisma",
     "db:common:push": "dotenv -e .env.local -- sh -c 'prisma db push --schema prisma-common/schema.prisma'",
     "db:common:studio": "dotenv -e .env.local -- sh -c 'prisma studio --schema prisma-common/schema.prisma'",
-    "prepare": "husky"
+    "prepare": "husky",
+    "encryption:backfill": "dotenv -e .env.local -- tsx src/migration/scripts/backfillEncryptionKeyRotation.ts"
   },
   "keywords": [
     "xyne",

--- a/apps/backend/src/migration/scripts/backfillEncryptionKeyRotation.ts
+++ b/apps/backend/src/migration/scripts/backfillEncryptionKeyRotation.ts
@@ -1,0 +1,749 @@
+import { PrismaClient } from '@prisma/client';
+import {
+  rotateCiphertext,
+  rotateEncryptedJsonStrings,
+  type CiphertextRotationResult,
+  type JsonRotationStats,
+} from '../../services/encryptionRotation';
+import { decrypt, encrypt, getActiveEncryptionKeyId } from '../../services/encryptionService';
+
+interface Options {
+  apply: boolean;
+  batchSize: number;
+  confirmedKeyId: string | null;
+  targets: Set<string> | null;
+  help: boolean;
+  listTargets: boolean;
+}
+
+interface ScalarRow {
+  id: string;
+  value: string;
+}
+
+interface TargetStats {
+  rowsScanned: number;
+  valuesScanned: number;
+  legacy: number;
+  active: number;
+  otherKey: number;
+  malformed: number;
+  failed: number;
+  wouldRotate: number;
+  rotated: number;
+  updated: number;
+  casSkipped: number;
+  updateFailed: number;
+  invalidJson: number;
+  blockedRows: number;
+  byKeyId: Record<string, number>;
+}
+
+interface ScalarTarget {
+  name: string;
+  fetch: (afterId: string | null, batchSize: number) => Promise<ScalarRow[]>;
+  update: (id: string, originalValue: string, rotatedValue: string) => Promise<number>;
+}
+
+const DEFAULT_BATCH_SIZE = 100;
+const MAX_BATCH_SIZE = 1000;
+const WORKFLOW_TARGET = 'workflows.context';
+
+const TARGET_NAMES = [
+  'workflow-mappings.entitySecret',
+  'org-llm-credentials.credentials',
+  'user-external-tokens.encryptedToken',
+  'user-external-tokens.refreshToken',
+  'external-sources.credentials',
+  'apps.signingSecret',
+  'installed-apps.signingSecret',
+  'incoming-webhooks.secret',
+  'data-sources.credentials',
+  WORKFLOW_TARGET,
+] as const;
+
+function writeStdout(...parts: unknown[]): void {
+  process.stdout.write(parts.map(String).join(' ') + '\n');
+}
+
+function writeStderr(...parts: unknown[]): void {
+  process.stderr.write(parts.map(String).join(' ') + '\n');
+}
+
+function printHelp(): void {
+  writeStdout(`
+Encryption key-rotation backfill
+
+Dry-run is the default:
+
+  pnpm run encryption:backfill
+
+Apply changes:
+
+  pnpm run encryption:backfill -- \\
+    --apply \\
+    --confirm-active-key=<keyId>
+
+Options:
+
+  --apply
+      Write re-encrypted values. Without this flag, no database rows change.
+
+  --confirm-active-key=<keyId>
+      Required with --apply. Must exactly match the final key ID in
+      the ordered ENCRYPTION_KEYS array.
+
+  --batch-size=<1-${MAX_BATCH_SIZE}>
+      Number of rows fetched per batch. Default: ${DEFAULT_BATCH_SIZE}.
+
+  --target=<target>
+      Process one target. May be supplied more than once.
+
+  --list-targets
+      Print available target names.
+
+  --help
+      Print this help.
+`);
+}
+
+function parseOptions(argv: string[]): Options {
+  const options: Options = {
+    apply: false,
+    batchSize: DEFAULT_BATCH_SIZE,
+    confirmedKeyId: null,
+    targets: null,
+    help: false,
+    listTargets: false,
+  };
+
+  const selectedTargets = new Set<string>();
+
+  for (const argument of argv) {
+    // pnpm may forward its argument separator to the script.
+    if (argument === '--') {
+      continue;
+    }
+
+    if (argument === '--apply') {
+      options.apply = true;
+      continue;
+    }
+
+    if (argument === '--help' || argument === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (argument === '--list-targets') {
+      options.listTargets = true;
+      continue;
+    }
+
+    if (argument.startsWith('--batch-size=')) {
+      const raw = argument.slice('--batch-size='.length);
+      const parsed = Number.parseInt(raw, 10);
+
+      if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_BATCH_SIZE) {
+        throw new Error(`--batch-size must be between 1 and ${MAX_BATCH_SIZE}`);
+      }
+
+      options.batchSize = parsed;
+      continue;
+    }
+
+    if (argument.startsWith('--confirm-active-key=')) {
+      options.confirmedKeyId = argument.slice('--confirm-active-key='.length).trim();
+      continue;
+    }
+
+    if (argument.startsWith('--target=')) {
+      const target = argument.slice('--target='.length).trim();
+
+      if (!target) {
+        throw new Error('--target must not be empty');
+      }
+
+      selectedTargets.add(target);
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  if (selectedTargets.size > 0) {
+    options.targets = selectedTargets;
+  }
+
+  return options;
+}
+
+function createStats(): TargetStats {
+  return {
+    rowsScanned: 0,
+    valuesScanned: 0,
+    legacy: 0,
+    active: 0,
+    otherKey: 0,
+    malformed: 0,
+    failed: 0,
+    wouldRotate: 0,
+    rotated: 0,
+    updated: 0,
+    casSkipped: 0,
+    updateFailed: 0,
+    invalidJson: 0,
+    blockedRows: 0,
+    byKeyId: {},
+  };
+}
+
+function incrementKey(stats: TargetStats, keyId: string, count = 1): void {
+  stats.byKeyId[keyId] = (stats.byKeyId[keyId] ?? 0) + count;
+}
+
+function recordCiphertextResult(stats: TargetStats, result: CiphertextRotationResult): void {
+  stats.valuesScanned += 1;
+
+  switch (result.classification.kind) {
+    case 'legacy':
+      stats.legacy += 1;
+      incrementKey(stats, result.classification.keyId);
+      break;
+    case 'active':
+      stats.active += 1;
+      incrementKey(stats, result.classification.keyId);
+      break;
+    case 'other-key':
+      stats.otherKey += 1;
+      incrementKey(stats, result.classification.keyId);
+      break;
+    case 'malformed':
+      stats.malformed += 1;
+      break;
+  }
+
+  switch (result.outcome) {
+    case 'failed':
+      stats.failed += 1;
+      break;
+    case 'would-rotate':
+      stats.wouldRotate += 1;
+      break;
+    case 'rotated':
+      stats.rotated += 1;
+      break;
+    default:
+      break;
+  }
+}
+
+function mergeJsonStats(target: TargetStats, source: JsonRotationStats): void {
+  target.valuesScanned += source.encryptedValues;
+  target.legacy += source.legacy;
+  target.active += source.active;
+  target.otherKey += source.otherKey;
+  target.malformed += source.malformed;
+  target.failed += source.failed;
+  target.wouldRotate += source.wouldRotate;
+  target.rotated += source.rotated;
+
+  for (const [keyId, count] of Object.entries(source.byKeyId)) {
+    incrementKey(target, keyId, count);
+  }
+}
+
+function isSelected(name: string, selectedTargets: Set<string> | null): boolean {
+  return selectedTargets === null || selectedTargets.has(name);
+}
+
+async function processScalarTarget(
+  target: ScalarTarget,
+  options: Options,
+  activeKeyId: string
+): Promise<TargetStats> {
+  const stats = createStats();
+  let afterId: string | null = null;
+
+  for (;;) {
+    const rows = await target.fetch(afterId, options.batchSize);
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    for (const row of rows) {
+      stats.rowsScanned += 1;
+
+      const result = rotateCiphertext(row.value, activeKeyId, options.apply);
+
+      recordCiphertextResult(stats, result);
+
+      if (options.apply && result.outcome === 'rotated') {
+        try {
+          const updated = await target.update(row.id, row.value, result.value);
+
+          if (updated === 1) {
+            stats.updated += 1;
+          } else {
+            stats.casSkipped += 1;
+          }
+        } catch {
+          stats.updateFailed += 1;
+        }
+      }
+    }
+
+    afterId = rows[rows.length - 1].id;
+
+    if (rows.length < options.batchSize) {
+      break;
+    }
+  }
+
+  return stats;
+}
+
+async function processWorkflowContexts(
+  prisma: PrismaClient,
+  options: Options,
+  activeKeyId: string
+): Promise<TargetStats> {
+  const stats = createStats();
+  let afterId: string | null = null;
+
+  for (;;) {
+    const rows: Array<{ id: string; context: string | null }> = await prisma.workflow.findMany({
+      where: {
+        context: { contains: 'enc:' },
+        ...(afterId ? { id: { gt: afterId } } : {}),
+      },
+      select: {
+        id: true,
+        context: true,
+      },
+      orderBy: { id: 'asc' },
+      take: options.batchSize,
+    });
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    for (const row of rows) {
+      stats.rowsScanned += 1;
+
+      if (!row.context) {
+        continue;
+      }
+
+      let parsed: unknown;
+
+      try {
+        parsed = JSON.parse(row.context);
+      } catch {
+        stats.invalidJson += 1;
+        continue;
+      }
+
+      const result = rotateEncryptedJsonStrings(parsed, activeKeyId, options.apply);
+
+      mergeJsonStats(stats, result.stats);
+
+      if (!options.apply || !result.changed) {
+        continue;
+      }
+
+      if (result.stats.failed > 0 || result.stats.malformed > 0) {
+        stats.blockedRows += 1;
+        continue;
+      }
+
+      const rotatedContext = JSON.stringify(result.value);
+
+      try {
+        const update = await prisma.workflow.updateMany({
+          where: {
+            id: row.id,
+            context: row.context,
+          },
+          data: {
+            context: rotatedContext,
+          },
+        });
+
+        if (update.count === 1) {
+          stats.updated += 1;
+        } else {
+          stats.casSkipped += 1;
+        }
+      } catch {
+        stats.updateFailed += 1;
+      }
+    }
+
+    afterId = rows[rows.length - 1].id;
+
+    if (rows.length < options.batchSize) {
+      break;
+    }
+  }
+
+  return stats;
+}
+
+function buildScalarTargets(prisma: PrismaClient): ScalarTarget[] {
+  return [
+    {
+      name: 'workflow-mappings.entitySecret',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.workflowMapping.findMany({
+          where: afterId ? { id: { gt: afterId } } : undefined,
+          select: { id: true, entitySecret: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.entitySecret,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.workflowMapping.updateMany({
+          where: { id, entitySecret: originalValue },
+          data: { entitySecret: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'org-llm-credentials.credentials',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.orgLLMServiceAccountCredential.findMany({
+          where: afterId ? { id: { gt: afterId } } : undefined,
+          select: { id: true, credentials: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.credentials,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.orgLLMServiceAccountCredential.updateMany({
+          where: { id, credentials: originalValue },
+          data: { credentials: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'user-external-tokens.encryptedToken',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.userExternalToken.findMany({
+          where: afterId ? { id: { gt: afterId } } : undefined,
+          select: { id: true, encryptedToken: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.encryptedToken,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.userExternalToken.updateMany({
+          where: { id, encryptedToken: originalValue },
+          data: { encryptedToken: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'user-external-tokens.refreshToken',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.userExternalToken.findMany({
+          where: {
+            refreshToken: { not: null },
+            ...(afterId ? { id: { gt: afterId } } : {}),
+          },
+          select: { id: true, refreshToken: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.refreshToken!,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.userExternalToken.updateMany({
+          where: { id, refreshToken: originalValue },
+          data: { refreshToken: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'external-sources.credentials',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.externalSource.findMany({
+          where: afterId ? { id: { gt: afterId } } : undefined,
+          select: { id: true, credentials: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.credentials,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.externalSource.updateMany({
+          where: { id, credentials: originalValue },
+          data: { credentials: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'apps.signingSecret',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.apps.findMany({
+          where: afterId ? { id: { gt: afterId } } : undefined,
+          select: { id: true, signingSecret: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.signingSecret,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.apps.updateMany({
+          where: { id, signingSecret: originalValue },
+          data: { signingSecret: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'installed-apps.signingSecret',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.installedApps.findMany({
+          where: {
+            signingSecret: { not: null },
+            ...(afterId ? { id: { gt: afterId } } : {}),
+          },
+          select: { id: true, signingSecret: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.signingSecret!,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.installedApps.updateMany({
+          where: { id, signingSecret: originalValue },
+          data: { signingSecret: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'incoming-webhooks.secret',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.appIncomingWebhook.findMany({
+          where: afterId ? { id: { gt: afterId } } : undefined,
+          select: { id: true, secret: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.secret,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.appIncomingWebhook.updateMany({
+          where: { id, secret: originalValue },
+          data: { secret: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+    {
+      name: 'data-sources.credentials',
+      fetch: async (afterId, batchSize) => {
+        const rows = await prisma.dataSource.findMany({
+          where: afterId ? { id: { gt: afterId } } : undefined,
+          select: { id: true, credentials: true },
+          orderBy: { id: 'asc' },
+          take: batchSize,
+        });
+
+        return rows.map((row) => ({
+          id: row.id,
+          value: row.credentials,
+        }));
+      },
+      update: async (id, originalValue, rotatedValue) => {
+        const result = await prisma.dataSource.updateMany({
+          where: { id, credentials: originalValue },
+          data: { credentials: rotatedValue },
+        });
+
+        return result.count;
+      },
+    },
+  ];
+}
+
+function validateTargetSelection(selectedTargets: Set<string> | null): void {
+  if (!selectedTargets) {
+    return;
+  }
+
+  const validTargets = new Set<string>(TARGET_NAMES);
+
+  for (const target of selectedTargets) {
+    if (!validTargets.has(target)) {
+      throw new Error(`Unknown target "${target}". Use --list-targets to see valid targets.`);
+    }
+  }
+}
+
+function validateEncryptionConfiguration(options: Options): string {
+  const activeKeyId = getActiveEncryptionKeyId();
+
+  if (!activeKeyId) {
+    throw new Error('ENCRYPTION_KEYS must contain at least one key before running the backfill');
+  }
+
+  if (options.apply && options.confirmedKeyId !== activeKeyId) {
+    throw new Error(`--apply requires --confirm-active-key=${activeKeyId}`);
+  }
+
+  const probePlaintext = 'encryption-rotation-preflight';
+  const probeCiphertext = encrypt(probePlaintext);
+
+  if (!probeCiphertext.startsWith(`v2:${activeKeyId}:`)) {
+    throw new Error('Encryption preflight did not use the final key in ENCRYPTION_KEYS');
+  }
+
+  if (decrypt(probeCiphertext) !== probePlaintext) {
+    throw new Error('Encryption preflight round-trip failed');
+  }
+
+  return activeKeyId;
+}
+
+function hasBlockingProblems(stats: TargetStats): boolean {
+  return (
+    stats.malformed > 0 ||
+    stats.failed > 0 ||
+    stats.updateFailed > 0 ||
+    stats.invalidJson > 0 ||
+    stats.blockedRows > 0 ||
+    stats.casSkipped > 0
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  if (options.listTargets) {
+    writeStdout(TARGET_NAMES.join('\n'));
+    return;
+  }
+
+  validateTargetSelection(options.targets);
+
+  const activeKeyId = validateEncryptionConfiguration(options);
+  const prisma = new PrismaClient();
+
+  const summaries: Record<string, TargetStats> = {};
+
+  try {
+    writeStdout(
+      JSON.stringify(
+        {
+          event: 'encryption_backfill_started',
+          mode: options.apply ? 'apply' : 'dry-run',
+          activeKeyId,
+          batchSize: options.batchSize,
+          targets: options.targets === null ? [...TARGET_NAMES] : [...options.targets],
+        },
+        null,
+        2
+      )
+    );
+
+    for (const target of buildScalarTargets(prisma)) {
+      if (!isSelected(target.name, options.targets)) {
+        continue;
+      }
+
+      summaries[target.name] = await processScalarTarget(target, options, activeKeyId);
+    }
+
+    if (isSelected(WORKFLOW_TARGET, options.targets)) {
+      summaries[WORKFLOW_TARGET] = await processWorkflowContexts(prisma, options, activeKeyId);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  const blocked = Object.values(summaries).some(hasBlockingProblems);
+
+  writeStdout(
+    JSON.stringify(
+      {
+        event: 'encryption_backfill_completed',
+        mode: options.apply ? 'apply' : 'dry-run',
+        activeKeyId,
+        blocked,
+        summaries,
+      },
+      null,
+      2
+    )
+  );
+
+  if (blocked) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((error) => {
+  writeStderr(
+    'Encryption backfill failed:',
+    error instanceof Error ? error.message : String(error)
+  );
+  process.exitCode = 1;
+});

--- a/apps/backend/src/migration/scripts/backfillEncryptionKeyRotation.ts
+++ b/apps/backend/src/migration/scripts/backfillEncryptionKeyRotation.ts
@@ -21,6 +21,11 @@ interface ScalarRow {
   value: string;
 }
 
+interface FailureSample {
+  rowId: string;
+  reason: string;
+}
+
 interface TargetStats {
   rowsScanned: number;
   valuesScanned: number;
@@ -29,11 +34,13 @@ interface TargetStats {
   otherKey: number;
   malformed: number;
   failed: number;
+  failureSamples: FailureSample[];
   wouldRotate: number;
   rotated: number;
   updated: number;
   casSkipped: number;
   updateFailed: number;
+  updateFailureSamples: FailureSample[];
   invalidJson: number;
   blockedRows: number;
   byKeyId: Record<string, number>;
@@ -47,7 +54,13 @@ interface ScalarTarget {
 
 const DEFAULT_BATCH_SIZE = 100;
 const MAX_BATCH_SIZE = 1000;
+const MAX_FAILURE_SAMPLES = 5;
 const WORKFLOW_TARGET = 'workflows.context';
+
+const SCOPE_NOTICE =
+  'Covers AES-256-CBC values written by encryptionService only; ' +
+  'AES-256-GCM envelopes are out of scope, and successful completion ' +
+  'does not authorize retirement of ENCRYPTION_KEY.';
 
 const TARGET_NAMES = [
   'workflow-mappings.entitySecret',
@@ -70,9 +83,29 @@ function writeStderr(...parts: unknown[]): void {
   process.stderr.write(parts.map(String).join(' ') + '\n');
 }
 
+function getFailureReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return message.replace(/\s+/g, ' ').slice(0, 500);
+}
+
+function recordFailureSample(samples: FailureSample[], rowId: string, error: unknown): void {
+  if (samples.length >= MAX_FAILURE_SAMPLES) {
+    return;
+  }
+
+  samples.push({
+    rowId,
+    reason: getFailureReason(error),
+  });
+}
+
 function printHelp(): void {
   writeStdout(`
 Encryption key-rotation backfill
+
+Scope:
+  ${SCOPE_NOTICE}
 
 Dry-run is the default:
 
@@ -187,11 +220,13 @@ function createStats(): TargetStats {
     otherKey: 0,
     malformed: 0,
     failed: 0,
+    failureSamples: [],
     wouldRotate: 0,
     rotated: 0,
     updated: 0,
     casSkipped: 0,
     updateFailed: 0,
+    updateFailureSamples: [],
     invalidJson: 0,
     blockedRows: 0,
     byKeyId: {},
@@ -277,6 +312,10 @@ async function processScalarTarget(
 
       const result = rotateCiphertext(row.value, activeKeyId, options.apply);
 
+      if (result.outcome === 'failed' && result.error) {
+        recordFailureSample(stats.failureSamples, row.id, result.error);
+      }
+
       recordCiphertextResult(stats, result);
 
       if (options.apply && result.outcome === 'rotated') {
@@ -288,8 +327,9 @@ async function processScalarTarget(
           } else {
             stats.casSkipped += 1;
           }
-        } catch {
+        } catch (err) {
           stats.updateFailed += 1;
+          recordFailureSample(stats.updateFailureSamples, row.id, err);
         }
       }
     }
@@ -348,6 +388,10 @@ async function processWorkflowContexts(
 
       const result = rotateEncryptedJsonStrings(parsed, activeKeyId, options.apply);
 
+      for (const reason of result.stats.failureSamples) {
+        recordFailureSample(stats.failureSamples, row.id, reason);
+      }
+
       mergeJsonStats(stats, result.stats);
 
       if (!options.apply || !result.changed) {
@@ -377,8 +421,9 @@ async function processWorkflowContexts(
         } else {
           stats.casSkipped += 1;
         }
-      } catch {
+      } catch (err) {
         stats.updateFailed += 1;
+        recordFailureSample(stats.updateFailureSamples, row.id, err);
       }
     }
 
@@ -694,6 +739,7 @@ async function main(): Promise<void> {
       JSON.stringify(
         {
           event: 'encryption_backfill_started',
+          scope: SCOPE_NOTICE,
           mode: options.apply ? 'apply' : 'dry-run',
           activeKeyId,
           batchSize: options.batchSize,
@@ -725,6 +771,8 @@ async function main(): Promise<void> {
     JSON.stringify(
       {
         event: 'encryption_backfill_completed',
+        scope: SCOPE_NOTICE,
+        legacyKeyRetirementAuthorized: false,
         mode: options.apply ? 'apply' : 'dry-run',
         activeKeyId,
         blocked,

--- a/apps/backend/src/services/encryptionRotation.diagnostics.test.ts
+++ b/apps/backend/src/services/encryptionRotation.diagnostics.test.ts
@@ -1,0 +1,69 @@
+import { rotateCiphertext, rotateEncryptedJsonStrings } from './encryptionRotation';
+import { _resetKeyRingCache, encrypt } from './encryptionService';
+
+const LEGACY_KEY = '11'.repeat(32);
+const K1 = '22'.repeat(32);
+const K2 = '33'.repeat(32);
+
+const originalEnvironment = {
+  legacy: process.env.ENCRYPTION_KEY,
+  keys: process.env.ENCRYPTION_KEYS,
+};
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function configure(entries: Array<{ id: string; key: string }>): void {
+  process.env.ENCRYPTION_KEY = LEGACY_KEY;
+  process.env.ENCRYPTION_KEYS = JSON.stringify(entries);
+  _resetKeyRingCache();
+}
+
+afterEach(() => {
+  restoreEnvironment('ENCRYPTION_KEY', originalEnvironment.legacy);
+  restoreEnvironment('ENCRYPTION_KEYS', originalEnvironment.keys);
+  _resetKeyRingCache();
+});
+
+describe('encryptionRotation diagnostics', () => {
+  test('preserves the missing-key failure reason', () => {
+    configure([{ id: 'k1', key: K1 }]);
+    const k1Ciphertext = encrypt('diagnostic-secret');
+
+    configure([{ id: 'k2', key: K2 }]);
+
+    const result = rotateCiphertext(k1Ciphertext, 'k2', false);
+
+    expect(result.outcome).toBe('failed');
+    expect(result.error).toMatch(/No encryption key registered for keyId "k1"/);
+    expect(result.error).not.toContain('diagnostic-secret');
+  });
+
+  test('surfaces bounded JSON rotation failure samples', () => {
+    configure([{ id: 'k1', key: K1 }]);
+    const k1Ciphertext = encrypt('nested-secret');
+
+    configure([{ id: 'k2', key: K2 }]);
+
+    const result = rotateEncryptedJsonStrings(
+      {
+        secret: `enc:${k1Ciphertext}`,
+        ordinary: 'unchanged',
+      },
+      'k2',
+      false
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.stats.failed).toBe(1);
+    expect(result.stats.failureSamples).toHaveLength(1);
+    expect(result.stats.failureSamples[0]).toMatch(/No encryption key registered for keyId "k1"/);
+    expect(result.stats.failureSamples[0]).not.toContain('nested-secret');
+    expect(result.value.ordinary).toBe('unchanged');
+  });
+});

--- a/apps/backend/src/services/encryptionRotation.test.ts
+++ b/apps/backend/src/services/encryptionRotation.test.ts
@@ -1,0 +1,153 @@
+import {
+  classifyCiphertext,
+  rotateCiphertext,
+  rotateEncryptedJsonStrings,
+} from './encryptionRotation';
+import { _resetKeyRingCache, decrypt, encrypt } from './encryptionService';
+
+const LEGACY_KEY = '11'.repeat(32);
+const K1 = '22'.repeat(32);
+const K2 = '33'.repeat(32);
+
+const originalEnvironment = {
+  legacy: process.env.ENCRYPTION_KEY,
+  keys: process.env.ENCRYPTION_KEYS,
+};
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function configure(activeKeyId?: 'k1' | 'k2'): void {
+  process.env.ENCRYPTION_KEY = LEGACY_KEY;
+
+  if (!activeKeyId) {
+    // An absent ordered ring makes encrypt() produce legacy iv:ciphertext.
+    delete process.env.ENCRYPTION_KEYS;
+  } else {
+    // The final ordered entry is the active writer.
+    const orderedKeys =
+      activeKeyId === 'k1'
+        ? [
+            { id: 'k2', key: K2 },
+            { id: 'k1', key: K1 },
+          ]
+        : [
+            { id: 'k1', key: K1 },
+            { id: 'k2', key: K2 },
+          ];
+
+    process.env.ENCRYPTION_KEYS = JSON.stringify(orderedKeys);
+  }
+
+  _resetKeyRingCache();
+}
+
+function createLegacyCiphertext(plaintext: string): string {
+  configure();
+  return encrypt(plaintext);
+}
+
+function createVersionedCiphertext(plaintext: string, keyId: 'k1' | 'k2'): string {
+  configure(keyId);
+  return encrypt(plaintext);
+}
+
+afterEach(() => {
+  restoreEnvironment('ENCRYPTION_KEY', originalEnvironment.legacy);
+  restoreEnvironment('ENCRYPTION_KEYS', originalEnvironment.keys);
+  _resetKeyRingCache();
+});
+
+describe('encryptionRotation', () => {
+  test('classifies legacy, active, other-key and malformed values', () => {
+    const legacy = createLegacyCiphertext('legacy-value');
+    const active = createVersionedCiphertext('active-value', 'k1');
+    const other = createVersionedCiphertext('other-value', 'k2');
+
+    expect(classifyCiphertext(legacy, 'k1')).toEqual({
+      kind: 'legacy',
+      keyId: 'legacy',
+    });
+
+    expect(classifyCiphertext(active, 'k1')).toEqual({
+      kind: 'active',
+      keyId: 'k1',
+    });
+
+    expect(classifyCiphertext(other, 'k1')).toEqual({
+      kind: 'other-key',
+      keyId: 'k2',
+    });
+
+    expect(classifyCiphertext('not-ciphertext', 'k1')).toEqual({
+      kind: 'malformed',
+    });
+  });
+
+  test('dry-run verifies decryptability without changing ciphertext', () => {
+    const legacy = createLegacyCiphertext('dry-run-value');
+    configure('k1');
+
+    const result = rotateCiphertext(legacy, 'k1', false);
+
+    expect(result.outcome).toBe('would-rotate');
+    expect(result.value).toBe(legacy);
+  });
+
+  test('apply re-encrypts legacy ciphertext with the active key', () => {
+    const legacy = createLegacyCiphertext('rotate-me');
+    configure('k1');
+
+    const result = rotateCiphertext(legacy, 'k1', true);
+
+    expect(result.outcome).toBe('rotated');
+    expect(result.value).toMatch(/^v2:k1:/);
+    expect(decrypt(result.value)).toBe('rotate-me');
+  });
+
+  test('already-active ciphertext remains unchanged', () => {
+    const active = createVersionedCiphertext('keep-me', 'k1');
+    configure('k1');
+
+    const result = rotateCiphertext(active, 'k1', true);
+
+    expect(result.outcome).toBe('already-active');
+    expect(result.value).toBe(active);
+  });
+
+  test('rotates nested enc values without changing unrelated strings', () => {
+    const legacy = createLegacyCiphertext('nested-secret');
+    configure('k1');
+
+    const input = {
+      steps: [
+        {
+          config: {
+            headers: {
+              authorization: `enc:${legacy}`,
+              ordinary: 'plain-value',
+            },
+          },
+        },
+      ],
+    };
+
+    const result = rotateEncryptedJsonStrings(input, 'k1', true);
+    const rotated = result.value.steps[0].config.headers.authorization;
+
+    expect(result.changed).toBe(true);
+    expect(rotated).toMatch(/^enc:v2:k1:/);
+    expect(decrypt(rotated.slice('enc:'.length))).toBe('nested-secret');
+    expect(result.value.steps[0].config.headers.ordinary).toBe('plain-value');
+    expect(result.stats.rotated).toBe(1);
+  });
+
+  test('rejects using legacy as the backfill destination', () => {
+    expect(() => classifyCiphertext('not-ciphertext', 'legacy')).toThrow('must not be "legacy"');
+  });
+});

--- a/apps/backend/src/services/encryptionRotation.ts
+++ b/apps/backend/src/services/encryptionRotation.ts
@@ -5,6 +5,7 @@ const LEGACY_KEY_ID = 'legacy';
 const ENCRYPTED_VALUE_PREFIX = 'enc:';
 const IV_HEX_LENGTH = 32;
 const AES_BLOCK_HEX_LENGTH = 32;
+const MAX_FAILURE_SAMPLES = 5;
 
 export type CiphertextClassification =
   | { kind: 'legacy'; keyId: typeof LEGACY_KEY_ID }
@@ -23,6 +24,7 @@ export interface CiphertextRotationResult {
   value: string;
   classification: CiphertextClassification;
   outcome: RotationOutcome;
+  error?: string;
 }
 
 export interface JsonRotationStats {
@@ -32,6 +34,7 @@ export interface JsonRotationStats {
   otherKey: number;
   malformed: number;
   failed: number;
+  failureSamples: string[];
   wouldRotate: number;
   rotated: number;
   byKeyId: Record<string, number>;
@@ -141,11 +144,12 @@ export function rotateCiphertext(
       classification,
       outcome: 'rotated',
     };
-  } catch {
+  } catch (err) {
     return {
       value,
       classification,
       outcome: 'failed',
+      error: err instanceof Error ? err.message : String(err),
     };
   }
 }
@@ -158,6 +162,7 @@ function createJsonRotationStats(): JsonRotationStats {
     otherKey: 0,
     malformed: 0,
     failed: 0,
+    failureSamples: [],
     wouldRotate: 0,
     rotated: 0,
     byKeyId: {},
@@ -190,6 +195,11 @@ function recordRotationResult(stats: JsonRotationStats, result: CiphertextRotati
   switch (result.outcome) {
     case 'failed':
       stats.failed += 1;
+
+      if (result.error && stats.failureSamples.length < MAX_FAILURE_SAMPLES) {
+        stats.failureSamples.push(result.error);
+      }
+
       break;
     case 'would-rotate':
       stats.wouldRotate += 1;

--- a/apps/backend/src/services/encryptionRotation.ts
+++ b/apps/backend/src/services/encryptionRotation.ts
@@ -1,0 +1,247 @@
+import { decrypt, encrypt } from './encryptionService';
+
+const VERSION_TAG = 'v2';
+const LEGACY_KEY_ID = 'legacy';
+const ENCRYPTED_VALUE_PREFIX = 'enc:';
+const IV_HEX_LENGTH = 32;
+const AES_BLOCK_HEX_LENGTH = 32;
+
+export type CiphertextClassification =
+  | { kind: 'legacy'; keyId: typeof LEGACY_KEY_ID }
+  | { kind: 'active'; keyId: string }
+  | { kind: 'other-key'; keyId: string }
+  | { kind: 'malformed' };
+
+export type RotationOutcome =
+  | 'already-active'
+  | 'would-rotate'
+  | 'rotated'
+  | 'malformed'
+  | 'failed';
+
+export interface CiphertextRotationResult {
+  value: string;
+  classification: CiphertextClassification;
+  outcome: RotationOutcome;
+}
+
+export interface JsonRotationStats {
+  encryptedValues: number;
+  legacy: number;
+  active: number;
+  otherKey: number;
+  malformed: number;
+  failed: number;
+  wouldRotate: number;
+  rotated: number;
+  byKeyId: Record<string, number>;
+}
+
+export interface JsonRotationResult<T> {
+  value: T;
+  changed: boolean;
+  stats: JsonRotationStats;
+}
+
+function requireRotationKeyId(activeKeyId: string): string {
+  const normalized = activeKeyId.trim();
+
+  if (!normalized) {
+    throw new Error('An active encryption key is required for an encryption backfill');
+  }
+
+  if (normalized === LEGACY_KEY_ID) {
+    throw new Error('The encryption backfill active key must not be "legacy"');
+  }
+
+  return normalized;
+}
+
+function isHex(value: string): boolean {
+  return value.length > 0 && value.length % 2 === 0 && /^[0-9a-f]+$/i.test(value);
+}
+
+function hasValidIv(value: string): boolean {
+  return value.length === IV_HEX_LENGTH && isHex(value);
+}
+
+function hasValidCiphertext(value: string): boolean {
+  return isHex(value) && value.length % AES_BLOCK_HEX_LENGTH === 0;
+}
+
+export function classifyCiphertext(value: string, activeKeyId: string): CiphertextClassification {
+  const normalizedActiveKeyId = requireRotationKeyId(activeKeyId);
+  const parts = value.split(':');
+
+  if (parts.length === 2 && hasValidIv(parts[0]) && hasValidCiphertext(parts[1])) {
+    return { kind: 'legacy', keyId: LEGACY_KEY_ID };
+  }
+
+  if (
+    parts.length === 4 &&
+    parts[0] === VERSION_TAG &&
+    parts[1].length > 0 &&
+    hasValidIv(parts[2]) &&
+    hasValidCiphertext(parts[3])
+  ) {
+    const keyId = parts[1];
+
+    return keyId === normalizedActiveKeyId
+      ? { kind: 'active', keyId }
+      : { kind: 'other-key', keyId };
+  }
+
+  return { kind: 'malformed' };
+}
+
+export function rotateCiphertext(
+  value: string,
+  activeKeyId: string,
+  apply: boolean
+): CiphertextRotationResult {
+  const normalizedActiveKeyId = requireRotationKeyId(activeKeyId);
+  const classification = classifyCiphertext(value, normalizedActiveKeyId);
+
+  if (classification.kind === 'malformed') {
+    return {
+      value,
+      classification,
+      outcome: 'malformed',
+    };
+  }
+
+  if (classification.kind === 'active') {
+    return {
+      value,
+      classification,
+      outcome: 'already-active',
+    };
+  }
+
+  try {
+    const plaintext = decrypt(value);
+
+    if (!apply) {
+      return {
+        value,
+        classification,
+        outcome: 'would-rotate',
+      };
+    }
+
+    const rotated = encrypt(plaintext);
+    const expectedPrefix = `${VERSION_TAG}:${normalizedActiveKeyId}:`;
+
+    if (!rotated.startsWith(expectedPrefix)) {
+      throw new Error(`encrypt() did not write with active key "${normalizedActiveKeyId}"`);
+    }
+
+    return {
+      value: rotated,
+      classification,
+      outcome: 'rotated',
+    };
+  } catch {
+    return {
+      value,
+      classification,
+      outcome: 'failed',
+    };
+  }
+}
+
+function createJsonRotationStats(): JsonRotationStats {
+  return {
+    encryptedValues: 0,
+    legacy: 0,
+    active: 0,
+    otherKey: 0,
+    malformed: 0,
+    failed: 0,
+    wouldRotate: 0,
+    rotated: 0,
+    byKeyId: {},
+  };
+}
+
+function recordRotationResult(stats: JsonRotationStats, result: CiphertextRotationResult): void {
+  stats.encryptedValues += 1;
+
+  switch (result.classification.kind) {
+    case 'legacy':
+      stats.legacy += 1;
+      break;
+    case 'active':
+      stats.active += 1;
+      break;
+    case 'other-key':
+      stats.otherKey += 1;
+      break;
+    case 'malformed':
+      stats.malformed += 1;
+      break;
+  }
+
+  if (result.classification.kind !== 'malformed') {
+    const keyId = result.classification.keyId;
+    stats.byKeyId[keyId] = (stats.byKeyId[keyId] ?? 0) + 1;
+  }
+
+  switch (result.outcome) {
+    case 'failed':
+      stats.failed += 1;
+      break;
+    case 'would-rotate':
+      stats.wouldRotate += 1;
+      break;
+    case 'rotated':
+      stats.rotated += 1;
+      break;
+    default:
+      break;
+  }
+}
+
+export function rotateEncryptedJsonStrings<T>(
+  input: T,
+  activeKeyId: string,
+  apply: boolean
+): JsonRotationResult<T> {
+  const normalizedActiveKeyId = requireRotationKeyId(activeKeyId);
+  const stats = createJsonRotationStats();
+  let changed = false;
+
+  function visit(value: unknown): unknown {
+    if (typeof value === 'string' && value.startsWith(ENCRYPTED_VALUE_PREFIX)) {
+      const ciphertext = value.slice(ENCRYPTED_VALUE_PREFIX.length);
+      const result = rotateCiphertext(ciphertext, normalizedActiveKeyId, apply);
+
+      recordRotationResult(stats, result);
+
+      if (result.outcome === 'rotated') {
+        changed = true;
+        return ENCRYPTED_VALUE_PREFIX + result.value;
+      }
+
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(visit);
+    }
+
+    if (value && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, nestedValue]) => [key, visit(nestedValue)])
+      );
+    }
+
+    return value;
+  }
+
+  return {
+    value: visit(input) as T,
+    changed,
+    stats,
+  };
+}

--- a/apps/backend/src/services/encryptionService.keySelection.test.ts
+++ b/apps/backend/src/services/encryptionService.keySelection.test.ts
@@ -1,0 +1,62 @@
+import crypto from 'crypto';
+import { _resetKeyRingCache, getActiveEncryptionKeyId } from './encryptionService';
+
+const KEY_K1 = crypto.randomBytes(32).toString('hex');
+const KEY_K2 = crypto.randomBytes(32).toString('hex');
+
+const ENV_KEYS = ['ENCRYPTION_KEY', 'ENCRYPTION_KEYS'] as const;
+
+let savedEnvironment: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnvironment = {};
+
+  for (const name of ENV_KEYS) {
+    savedEnvironment[name] = process.env[name];
+    delete process.env[name];
+  }
+
+  _resetKeyRingCache();
+});
+
+afterEach(() => {
+  for (const name of ENV_KEYS) {
+    const savedValue = savedEnvironment[name];
+
+    if (savedValue === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = savedValue;
+    }
+  }
+
+  _resetKeyRingCache();
+});
+
+describe('getActiveEncryptionKeyId', () => {
+  it('returns null when the ordered key ring is absent', () => {
+    expect(getActiveEncryptionKeyId()).toBeNull();
+  });
+
+  it('selects the final entry in ENCRYPTION_KEYS', () => {
+    process.env.ENCRYPTION_KEYS = JSON.stringify([
+      { id: 'k1', key: KEY_K1 },
+      { id: 'k2', key: KEY_K2 },
+    ]);
+
+    _resetKeyRingCache();
+
+    expect(getActiveEncryptionKeyId()).toBe('k2');
+  });
+
+  it('changes the writer when the array order changes', () => {
+    process.env.ENCRYPTION_KEYS = JSON.stringify([
+      { id: 'k2', key: KEY_K2 },
+      { id: 'k1', key: KEY_K1 },
+    ]);
+
+    _resetKeyRingCache();
+
+    expect(getActiveEncryptionKeyId()).toBe('k1');
+  });
+});

--- a/apps/backend/src/services/encryptionService.ts
+++ b/apps/backend/src/services/encryptionService.ts
@@ -171,6 +171,17 @@ export function _resetKeyRingCache(): void {
 }
 
 /**
+ * Return the ID of the current write key.
+ *
+ * ENCRYPTION_KEYS is ordered, so the final entry is the active writer.
+ * Returns null when the ordered ring is absent or empty and writes remain
+ * on the legacy ENCRYPTION_KEY format.
+ */
+export function getActiveEncryptionKeyId(): string | null {
+  return loadKeyRing().activeKeyId;
+}
+
+/**
  * Encrypt plaintext using AES-256-CBC.
  * Returns "v2:<keyId>:<iv>:<ciphertext>" when a write key is activated,
  * otherwise the legacy "<iv>:<ciphertext>" format (both hex).


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
Backfill defaults to dry-run.
--apply requires explicit active-key confirmation.
Updates use compare-and-swap.
The command is idempotent.
Local canary and second idempotency run passed.
Key retirement is a later operational configuration step, not automatic deletion by this PR.


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [x] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [x] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [x] Backward compatible with deployed code, or rollout order noted below
- [x] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [x] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [x] Empty state
- [ ] Large / realistic data volume
- [x] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind\n\n## Backfill scope

This command rotates only AES-256-CBC ciphertext written by the Spaces `encryptionService` in `iv:ciphertext` or `v2:keyId:iv:ciphertext` format. AES-256-GCM credential envelopes and Claw-auth MCP gateway ciphertext are outside this PR's scope. A successful run therefore does not, by itself, make the legacy `ENCRYPTION_KEY` safe to remove.\n