### PR TITLE
fix: auto-insert Spaces tools for Spaces runs

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/agent-card.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-card.test.ts
@@ -11,9 +11,9 @@ import {
 } from "./agent-card.js";
 import type { AvailableToolsCatalog } from "../routes/tools.js";
 
-// Minimal catalog shaped like buildAvailableToolsCatalog's output. Only the two
-// buckets the resolver reads are populated — everything else is irrelevant here
-// and deliberately stays unmatched (see the "gateway/MCP tokens" test).
+// Minimal catalog shaped like buildAvailableToolsCatalog's output. It includes
+// subagents, custom tools, MCP integration tools and gateway integrations so the
+// resolver can round-trip every agent.config.tools bucket.
 const catalog = {
   subagents: [
     { name: "spaces", description: "", serverType: "xyne-spaces", progressLabel: "", progressLabels: [], source: "builtin" },
@@ -26,7 +26,26 @@ const catalog = {
     { source: "custom:report", tools: [{ slug: "create-html-report", name: "Create Report" }] },
   ],
   serverTools: {},
-  integrations: [],
+  integrations: [
+    {
+      slug: "xyne-spaces",
+      label: "Xyne Spaces",
+      kind: "mcp",
+      connected: true,
+      readTools: [{ slug: "xyne-spaces__spaces-search", name: "spaces-search", description: "", riskLevel: "read" }],
+      writeTools: [{ slug: "xyne-spaces__spaces-create-ticket", name: "spaces-create-ticket", description: "", riskLevel: "write" }],
+      usageCount: 0,
+    },
+    {
+      slug: "gateway:jira/primary",
+      label: "Jira (primary)",
+      kind: "gateway",
+      connected: true,
+      readTools: [{ slug: "gateway:jira/primary__search", name: "search", description: "", riskLevel: "read" }],
+      writeTools: [],
+      usageCount: 0,
+    },
+  ],
 } as unknown as AvailableToolsCatalog;
 
 describe("resolveAgentCapabilities", () => {
@@ -34,6 +53,8 @@ describe("resolveAgentCapabilities", () => {
     const resolved = await resolveAgentCapabilities(["spaces", "web-search"], catalog);
     expect(resolved.subagents).toEqual(["spaces"]);
     expect(resolved.custom).toEqual(["web-search"]);
+    expect(resolved.direct).toEqual([]);
+    expect(resolved.gateway).toEqual([]);
     expect(resolved.unknown).toEqual([]);
     expect(resolved.capabilities).toEqual([
       // iconKey is the subagent's serverType, NOT its name — the brand asset for
@@ -44,18 +65,35 @@ describe("resolveAgentCapabilities", () => {
     ]);
   });
 
-  it("reports unmatched tokens instead of guessing a bucket", async () => {
-    // An MCP/gateway token needs a source-scoped selection key whose bucket
-    // depends on integration state; mis-bucketing it would silently mis-wire the
-    // agent, so it must surface on the card rather than be dropped or assumed.
+  it("persists source-scoped MCP tool slugs into tools.direct", async () => {
     const resolved = await resolveAgentCapabilities(
-      ["spaces", "Bitbucket__create_pull_request", "invented-tool"],
+      ["spaces", "xyne-spaces__spaces-search", "xyne-spaces__spaces-create-ticket"],
       catalog,
     );
     expect(resolved.subagents).toEqual(["spaces"]);
+    expect(resolved.direct).toEqual(["xyne-spaces__spaces-search", "xyne-spaces__spaces-create-ticket"]);
+    expect(resolved.unknown).toEqual([]);
+    expect(resolved.capabilities.map((c) => c.id)).toEqual([
+      "spaces",
+      "xyne-spaces__spaces-search",
+      "xyne-spaces__spaces-create-ticket",
+    ]);
+  });
+
+  it("persists gateway integration slugs into tools.gateway", async () => {
+    const resolved = await resolveAgentCapabilities(["gateway:jira/primary"], catalog);
+    expect(resolved.gateway).toEqual(["gateway:jira/primary"]);
+    expect(resolved.capabilities).toEqual([
+      { id: "gateway:jira/primary", label: "Jira (primary)", kind: "tool" },
+    ]);
+  });
+
+  it("reports truly unmatched tokens", async () => {
+    const resolved = await resolveAgentCapabilities(["spaces", "invented-tool"], catalog);
+    expect(resolved.subagents).toEqual(["spaces"]);
     expect(resolved.custom).toEqual([]);
-    expect(resolved.unknown).toEqual(["Bitbucket__create_pull_request", "invented-tool"]);
-    expect(unknownToolsNote(resolved.unknown)).toContain("Bitbucket__create_pull_request");
+    expect(resolved.unknown).toEqual(["invented-tool"]);
+    expect(unknownToolsNote(resolved.unknown)).toContain("invented-tool");
   });
 
   it("is case- and whitespace-exact (a near miss is reported, never silently matched)", async () => {
@@ -89,14 +127,18 @@ describe("toolIdsFromConfig", () => {
     // The profile card round-trips: config.tools → ids → resolved capabilities,
     // so a live agent's card shows exactly what it was granted.
     expect(
-      toolIdsFromConfig({ tools: { subagents: ["spaces", "google"], custom: ["web-search"] } }),
-    ).toEqual(["spaces", "google", "web-search"]);
+      toolIdsFromConfig({
+        tools: {
+          subagents: ["spaces", "google"],
+          direct: ["xyne-spaces__spaces-search"],
+          gateway: ["gateway:jira/primary"],
+          custom: ["web-search"],
+        },
+      }),
+    ).toEqual(["spaces", "google", "xyne-spaces__spaces-search", "gateway:jira/primary", "web-search"]);
   });
 
-  it("ignores buckets this card does not own, and malformed config", () => {
-    // gateway/direct use a different addressing scheme; reading them here would
-    // render chips whose ids the resolver can never match.
-    expect(toolIdsFromConfig({ tools: { gateway: ["x"], direct: ["y"] } })).toEqual([]);
+  it("ignores malformed config", () => {
     expect(toolIdsFromConfig({ tools: { subagents: "not-an-array" } })).toEqual([]);
     expect(toolIdsFromConfig(null)).toEqual([]);
     expect(toolIdsFromConfig({})).toEqual([]);
@@ -105,8 +147,9 @@ describe("toolIdsFromConfig", () => {
 
 describe("toConfigTools", () => {
   it("omits empty buckets so a tool-less agent gets {}", () => {
-    expect(toConfigTools({ subagents: [], custom: [] })).toEqual({});
-    expect(toConfigTools({ subagents: ["spaces"], custom: [] })).toEqual({ subagents: ["spaces"] });
+    expect(toConfigTools({ subagents: [], direct: [], gateway: [], custom: [] })).toEqual({});
+    expect(toConfigTools({ subagents: ["spaces"], direct: [], gateway: [], custom: [] })).toEqual({ subagents: ["spaces"] });
+    expect(toConfigTools({ subagents: [], direct: ["xyne-spaces__spaces-search"], gateway: [], custom: [] })).toEqual({ direct: ["xyne-spaces__spaces-search"] });
   });
 });
 
@@ -138,6 +181,8 @@ describe("identity builders", () => {
   const resolved = {
     capabilities: [{ id: "spaces", label: "spaces", kind: "subagent" as const }],
     subagents: ["spaces"],
+    direct: [],
+    gateway: [],
     custom: [],
     unknown: [],
   };

--- a/apps/xyne-claw-auth/backend/src/lib/agent-card.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-card.ts
@@ -9,12 +9,10 @@
  * two surfaces cannot drift: the card a user approves and the card that later
  * describes the created agent are built from the same shape.
  *
- * Capability resolution is deliberately CONSERVATIVE. A flat token is accepted
- * only as an exact match on a catalog subagent NAME or a custom tool SLUG —
- * the two buckets whose meaning does not depend on integration state. MCP-server
- * and gateway tokens need a source-scoped selection key, and guessing their
- * bucket would silently mis-wire the agent, so they come back as `unknown` and
- * are reported on the card instead of being dropped in silence.
+ * Capability resolution is deliberately CONSERVATIVE. A token is accepted only
+ * as an exact match on a catalog subagent name, custom tool slug, MCP tool
+ * selection key, or gateway integration slug. Near-misses are reported on the
+ * card instead of being silently guessed into the wrong bucket.
  */
 
 import { agentIdentity, type AgentCapability, type AgentIdentity } from "xyne-claw-shared";
@@ -25,6 +23,8 @@ import { writeAuditLog } from "./audit.js";
 import { createLogger } from "../logger.js";
 
 const log = createLogger("agent-card");
+
+const trimToken = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
 
 /** Slug rule enforced everywhere an agent slug is accepted (tool → card → create). */
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -51,6 +51,10 @@ export interface ResolvedCapabilities {
   capabilities: AgentCapability[];
   /** config.tools.subagents — matched subagent names. */
   subagents: string[];
+  /** config.tools.direct — matched MCP tool selection keys. */
+  direct: string[];
+  /** config.tools.gateway — matched gateway service/source selection keys. */
+  gateway: string[];
   /** config.tools.custom — matched custom tool slugs. */
   custom: string[];
   /** Tokens that matched nothing. Reported on the card, never persisted. */
@@ -73,18 +77,32 @@ export async function resolveAgentCapabilities(
   const customBySlug = new Map(
     catalog.customGroups.flatMap((g) => g.tools.map((t) => [t.slug, t] as const)),
   );
+  const directBySlug = new Map(
+    catalog.integrations.flatMap((integration) =>
+      [...integration.readTools, ...integration.writeTools].map((tool) => [tool.slug, { integration, tool }] as const),
+    ),
+  );
+  const gatewayBySlug = new Map(
+    catalog.integrations
+      .filter((integration) => integration.kind === "gateway")
+      .map((integration) => [integration.slug, integration] as const),
+  );
 
   const subagents: string[] = [];
+  const direct: string[] = [];
+  const gateway: string[] = [];
   const custom: string[] = [];
   const unknown: string[] = [];
   const seen = new Set<string>();
 
   for (const raw of requested) {
-    const token = raw.trim();
+    const token = trimToken(raw);
     if (!token || seen.has(token)) continue;
     seen.add(token);
     if (subagentByName.has(token)) subagents.push(token);
     else if (customBySlug.has(token)) custom.push(token);
+    else if (directBySlug.has(token)) direct.push(token);
+    else if (gatewayBySlug.has(token)) gateway.push(token);
     else unknown.push(token);
   }
 
@@ -137,6 +155,20 @@ export async function resolveAgentCapabilities(
           : {}),
       };
     }),
+    ...direct.map((slug) => {
+      const match = directBySlug.get(slug);
+      return {
+        id: slug,
+        label: match?.tool.name ?? slug,
+        kind: "tool" as const,
+        ...(match?.integration.slug ? { iconKey: match.integration.slug } : {}),
+      };
+    }),
+    ...gateway.map((slug) => ({
+      id: slug,
+      label: gatewayBySlug.get(slug)?.label ?? slug,
+      kind: "tool" as const,
+    })),
     ...custom.map((slug) => ({
       id: slug,
       label: customBySlug.get(slug)?.name ?? slug,
@@ -144,7 +176,7 @@ export async function resolveAgentCapabilities(
     })),
   ];
 
-  return { capabilities, subagents, custom, unknown };
+  return { capabilities, subagents, direct, gateway, custom, unknown };
 }
 
 /**
@@ -160,16 +192,20 @@ export function toolIdsFromConfig(config: unknown): string[] {
     Array.isArray(tools[key])
       ? (tools[key] as unknown[]).filter((v): v is string => typeof v === "string")
       : [];
-  return [...read("subagents"), ...read("custom")];
+  return [...read("subagents"), ...read("direct"), ...read("gateway"), ...read("custom")];
 }
 
 /** The `config.tools` object, omitting empty buckets so a tool-less agent gets `{}`. */
-export function toConfigTools(resolved: Pick<ResolvedCapabilities, "subagents" | "custom">): {
+export function toConfigTools(resolved: Pick<ResolvedCapabilities, "subagents" | "direct" | "gateway" | "custom">): {
   subagents?: string[];
+  direct?: string[];
+  gateway?: string[];
   custom?: string[];
 } {
   return {
     ...(resolved.subagents.length > 0 ? { subagents: resolved.subagents } : {}),
+    ...(resolved.direct.length > 0 ? { direct: resolved.direct } : {}),
+    ...(resolved.gateway.length > 0 ? { gateway: resolved.gateway } : {}),
     ...(resolved.custom.length > 0 ? { custom: resolved.custom } : {}),
   };
 }

--- a/apps/xyne-claw-auth/backend/src/lib/session-context.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-context.ts
@@ -113,6 +113,9 @@ export interface SessionContext {
   externalResultCallback?: ExternalResultCallbackConfig;
   /** Terminal result target for a run dispatched from a per-agent Slack app. */
   slackDelivery?: SlackDeliveryTarget;
+  /** Surface that dispatched this run. Used by MCP tool filtering to apply
+   *  surface-scoped default tools without mutating the stored agent config. */
+  triggerSource?: "spaces" | "scheduled" | "chat" | "api" | "automation" | "slack";
   /**
    * When true, the result-forward branch resolves the agent's plain `@Name`
    * mentions into clickable/notifying Spaces mentions (name→userId via

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -699,13 +699,21 @@ async function loadSlackSurfaceCredentials(
   };
 }
 
+function withSubagent(config: AgentToolsConfig, subagentName: string): AgentToolsConfig {
+  const subagents = Array.isArray(config.subagents)
+    ? config.subagents.filter((value): value is string => typeof value === "string")
+    : [];
+  if (subagents.includes(subagentName)) return config;
+  return { ...config, subagents: [...subagents, subagentName] };
+}
+
 /**
- * Mirror the per-run Slack subagent injection at the claw-auth enforcement
- * boundary. MCP listing/call routes load the agent's stored config, not the
- * agentConfig override forwarded to claw, so without this the virtual Slack
- * group is created and then immediately filtered back out.
+ * Mirror per-run surface tool injection at the claw-auth enforcement boundary.
+ * MCP listing/call routes load the agent's stored config, not the agentConfig
+ * override forwarded to claw, so without this a surface-default virtual group
+ * is created and then immediately filtered back out.
  */
-async function withSlackSurfaceToolsConfig(
+async function withSurfaceDefaultToolsConfig(
   config: AgentToolsConfig | undefined,
   sessionId: string,
 ): Promise<AgentToolsConfig | undefined> {
@@ -713,13 +721,26 @@ async function withSlackSurfaceToolsConfig(
 
   const { getSession } = await import("./webhook.js");
   const runCtx = await getSession(sessionId).catch(() => null);
-  if (!runCtx?.slackDelivery?.surfaceAgentId || !runCtx.slackDelivery.teamId) return config;
 
-  const subagents = Array.isArray(config.subagents)
-    ? config.subagents.filter((value): value is string => typeof value === "string")
-    : [];
-  if (subagents.includes("slack")) return config;
-  return { ...config, subagents: [...subagents, "slack"] };
+  let effective = config;
+  if (runCtx?.slackDelivery?.surfaceAgentId && runCtx.slackDelivery.teamId) {
+    effective = withSubagent(effective, "slack");
+  }
+
+  // Spaces-originated runs already carry the agent's Spaces app/user context in
+  // the session and credential fallback. Give those runs the Spaces subagent by
+  // default, matching Slack's surface-default injection, without mutating the
+  // stored agent config or granting Spaces tools to API/chat/scheduled runs.
+  const isSpacesSurface =
+    runCtx?.triggerSource === "spaces" ||
+    runCtx?.triggerSource === "automation" ||
+    runCtx?.isAutomation === true ||
+    (runCtx?.triggerSource == null && !!runCtx?.spacesAppId && !!runCtx?.spacesAppUserId && !runCtx?.slackDelivery);
+  if (isSpacesSurface) {
+    effective = withSubagent(effective, "spaces");
+  }
+
+  return effective;
 }
 
 async function loadEffectiveCredentialsWithSpacesFallback(
@@ -804,7 +825,7 @@ router.get("/:sessionId/mcp/tools", async (req: Request<{ sessionId: string }>, 
     const sessionAgentOrgId = await resolveSessionAgentOrgId(userId, spacesAppId);
     const sessionAgentTools = await loadSessionAgentToolsContext(agentSlug, spacesAppId, sessionAgentOrgId);
     const strictAgentToolsConfig = isStrictAgentToolsEnabled()
-      ? await withSlackSurfaceToolsConfig(sessionAgentTools?.toolsConfig, req.params.sessionId)
+      ? await withSurfaceDefaultToolsConfig(sessionAgentTools?.toolsConfig, req.params.sessionId)
       : undefined;
     const tenantUniqueId = resolveGatewayTenantForRequest();
 
@@ -1267,7 +1288,7 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
     const sessionAgentOrgId = await resolveSessionAgentOrgId(userId, spacesAppId);
     const sessionAgentTools = await loadSessionAgentToolsContext(agentSlug, spacesAppId, sessionAgentOrgId);
     const strictAgentToolsConfig = isStrictAgentToolsEnabled()
-      ? await withSlackSurfaceToolsConfig(sessionAgentTools?.toolsConfig, req.params.sessionId)
+      ? await withSurfaceDefaultToolsConfig(sessionAgentTools?.toolsConfig, req.params.sessionId)
       : undefined;
     const { serverType, tool, params, permission, backendId } = req.body as {
       serverType?: string;

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -180,6 +180,8 @@ type AgentRunTriggerSource = "spaces" | "scheduled" | "chat" | "api" | "automati
 
 function triggerSourceForEventType(eventType: unknown, requested: unknown): AgentRunTriggerSource {
   if (requested === "slack") return "slack";
+  if (requested === "api") return "api";
+  if (requested === "chat") return "chat";
   if (eventType === "automation") return "automation";
   if (eventType === "scheduled_job") return "scheduled";
   return "spaces";
@@ -1348,6 +1350,7 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
           spacesAppId: agent.spacesAppId ?? "",
           spacesAppUserId: agent.spacesAppUserId ?? "",
           rootAgentSlug: agentSlug || "assistant",
+          triggerSource: defaultTriggerSource,
           ...(traceId ? { traceId } : {}),
           ...(externalResultCallback ? { externalResultCallback } : {}),
           ...(defaultTriggerSource === "slack" && slackDelivery ? { slackDelivery } : {}),

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -2676,6 +2676,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
           spacesAppUserId: agent.spacesAppUserId,
           traceId,
           rootAgentSlug: agent.slug,
+          triggerSource: "spaces",
           escalatedProvider,
           // Preserve other prior-session fields where helpful.
           ...(priorSession?.workflowId ? { workflowId: priorSession.workflowId } : {}),
@@ -3054,6 +3055,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       spacesAppUserId: agent.spacesAppUserId,
       traceId,
       rootAgentSlug: agent.slug,
+      triggerSource: "spaces",
       ...(resolvedParentProvider ? { provider: resolvedParentProvider } : {}),
       ...(escalatedProvider ? { escalatedProvider } : {}),
       ...(userSpacesWorkspaceId ? { workspaceId: userSpacesWorkspaceId } : {}),
@@ -3988,6 +3990,7 @@ export async function handleAutomationWebhook(
       // Explicit automation marker — routes/mcp.ts keys the app-mode Spaces
       // MCP swap on this (not on the resolveMentions proxy).
       isAutomation: true,
+      triggerSource: "automation",
       // Forward the resolved result to the automation's original callback (so
       // step-1.output.result carries clickable mentions) instead of posting a
       // bot message, and turn on mention resolution for that forward.
@@ -6821,6 +6824,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             chainDepth: currentDepth + 1,
             rootAgentSlug,
             workflowId: binding.workflowId,
+            triggerSource: "spaces",
             ...(ctx.traceId ? { traceId: ctx.traceId } : {}),
           };
           await setSession(runBody.sessionId, targetContext);

--- a/apps/xyne-claw-auth/backend/src/surfaces/slack/dispatch.ts
+++ b/apps/xyne-claw-auth/backend/src/surfaces/slack/dispatch.ts
@@ -148,6 +148,7 @@ export async function dispatchSlackRun(input: {
     spacesAppId: "",
     spacesAppUserId: "",
     rootAgentSlug: input.agent.slug,
+    triggerSource: "slack",
     slackDelivery,
   });
   return body.sessionId;

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -1924,6 +1924,28 @@ async function processTask(
 
     // For google-agent: fetch the user's Google OAuth token from xyne-claw-auth
     const effectiveConfig = { ...(agentConfig ?? {}) };
+
+    // Surface-default tool injection, per run only. Slack already injects its
+    // subagent in claw-auth before dispatch; Spaces runs arrive directly from
+    // the Spaces webhook and need the same default here so mention/automation
+    // runs can read the room without mutating the stored agent config. A missing
+    // tools object means the agent is unrestricted, so do not create one.
+    const effectiveTools = effectiveConfig["tools"];
+    if (
+      (eventType === "APP_MENTIONED" || eventType === "DIRECT_MESSAGE" || eventType === "USER_MENTIONED" || eventType === "automation") &&
+      effectiveTools &&
+      typeof effectiveTools === "object" &&
+      !Array.isArray(effectiveTools)
+    ) {
+      const toolsObj = effectiveTools as Record<string, unknown>;
+      const subagents = Array.isArray(toolsObj["subagents"])
+        ? (toolsObj["subagents"] as unknown[]).filter((value): value is string => typeof value === "string")
+        : [];
+      if (!subagents.includes("spaces")) {
+        effectiveConfig["tools"] = { ...toolsObj, subagents: [...subagents, "spaces"] };
+      }
+    }
+
     // Parent agent's provider config — looked up from user's provider credentials.
     // We also reuse it to drive custom:create-ppt so PPT generation uses the
     // same user credential/model instead of shared env keys.

--- a/apps/xyne-claw/src/subagent-tools.ts
+++ b/apps/xyne-claw/src/subagent-tools.ts
@@ -1420,17 +1420,22 @@ function resolveCustomSubagentTools(
 
   if (directNames.size > 0) {
     for (const group of groups) {
-      const writeSet = new Set(group.writeTools.map(String));
       for (const t of group.tools) {
         const name = extractToolName(t.name);
-        if (directNames.has(name) && !writeSet.has(name)) out.push(t);
+        // Include write tools too. Their ToolDefinition still queues a signed
+        // pendingAction via the parent run's MCP wrapper; it does not execute
+        // until the human approval card is approved in claw-auth.
+        if (directNames.has(name)) out.push(t);
       }
     }
   }
   if (customSlugs.size > 0 && customTools) {
     for (const t of customTools) {
       const slug = customToolSlug(t);
-      if (customSlugs.has(slug) && !isCustomWriteTool(t)) out.push(t);
+      // Custom write tools follow the same signed pendingAction path as MCP
+      // writes, so custom subagents can now own the full workflow while the
+      // approval gate remains outside the child LLM.
+      if (customSlugs.has(slug)) out.push(t);
     }
   }
   return out;
@@ -1439,7 +1444,9 @@ function resolveCustomSubagentTools(
 /**
  * Group MCP tool groups into subagent wrappers based on serverType.
  * Also wraps custom tools whose `source` matches a subagent definition.
- * Write tools (from adapter's writeTools) stay as direct tools in the parent agent.
+ * Write tools are included in the subagent palette and still use the parent
+ * run's signed pendingAction approval gate; they are also hoisted as direct
+ * tools for backwards compatibility with existing parent-driven approvals.
  * Server types without a matching SubagentDefinition pass through as direct tools.
  */
 export function buildSubagentTools(
@@ -1483,25 +1490,25 @@ export function buildSubagentTools(
     const def = findSubagentDefinitionForServer(group.serverType);
 
     if (def) {
-      // Split write tools out as direct (they need user approval in the parent agent)
       const writeSet = new Set(group.writeTools.map(String));
-      const readTools = group.tools.filter((t) => !writeSet.has(extractToolName(t.name)));
       const writeTools = group.tools.filter((t) => writeSet.has(extractToolName(t.name)));
 
-      if (readTools.length > 0) {
+      if (group.tools.length > 0) {
         const skills = subagentSkills?.[def.name] ?? subagentSkills?.["__default"];
         const bonus = bonusToolsBySubagent?.[def.name] ?? [];
-        subagentTools.push(makeSubagentTool(def, [...readTools, ...bonus], skillTriggers, skills, providerResolution, progressCtx));
+        subagentTools.push(makeSubagentTool(def, [...group.tools, ...bonus], skillTriggers, skills, providerResolution, progressCtx));
 
-        // Hoist user-picked reads into the parent's direct palette too. The
+        // Hoist user-picked tools into the parent's direct palette too. The
         // subagent wrapper above already contains them — this just exposes a
         // second path so the parent agent can call e.g. `bitbucket__get_pull_request`
         // without going through the `bitbucket` subagent. Picked-as-direct +
         // picked-as-subagent both work; the parent-level filter in run.ts
         // decides which path actually surfaces to the model.
-        const hoisted = readTools.filter((t) => isDirectPick(t.name));
+        const hoisted = group.tools.filter((t) => isDirectPick(t.name));
         if (hoisted.length > 0) directTools.push(...hoisted);
       }
+      // Backwards compatibility: keep write tools visible at parent level for
+      // agents/prompts that already perform parent-driven approval flows.
       directTools.push(...writeTools);
     } else {
       // No subagent definition for this server type — keep all as direct
@@ -1538,15 +1545,10 @@ export function buildSubagentTools(
       if (def && tools.length > 0) {
         const customSkills = subagentSkills?.[def.name] ?? subagentSkills?.["__default"];
         const filteredTools = tools;
-        // Custom write tools (e.g. google-sheets-create/append/update) must
-        // remain parent-level approval tools. Do not put them in child LLM
-        // palettes: the child can otherwise queue writes and then speak as if
-        // it completed the whole multi-step write flow after approval.
-        const readTools = filteredTools.filter((t) => !isCustomWriteTool(t));
         const writeTools = filteredTools.filter(isCustomWriteTool);
         const bonus = bonusToolsBySubagent?.[def.name] ?? [];
-        if (readTools.length > 0 || bonus.length > 0) {
-          subagentTools.push(makeSubagentTool(def, [...readTools, ...bonus], skillTriggers, customSkills, providerResolution, progressCtx));
+        if (filteredTools.length > 0 || bonus.length > 0) {
+          subagentTools.push(makeSubagentTool(def, [...filteredTools, ...bonus], skillTriggers, customSkills, providerResolution, progressCtx));
         }
 
         // Same individual-pick hoist as the built-in MCP branch above: any
@@ -1557,8 +1559,10 @@ export function buildSubagentTools(
         // check that bitbucket/spaces direct picks use — one config knob,
         // one mental model. The tool stays accessible inside the subagent
         // wrapper too.
-        const hoisted = readTools.filter((t) => isDirectPick(t.name));
+        const hoisted = filteredTools.filter((t) => isDirectPick(t.name));
         if (hoisted.length > 0) directTools.push(...hoisted);
+        // Backwards compatibility for existing prompts that expect custom write
+        // tools to be parent-level approval tools.
         remainingCustomTools.push(...writeTools);
       } else {
         remainingCustomTools.push(...tools);

--- a/apps/xyne-claw/test/subagent-write-tools.test.ts
+++ b/apps/xyne-claw/test/subagent-write-tools.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { buildSubagentTools, type CustomSubagentSpec } from "../src/subagent-tools.js";
+import type { McpToolGroup } from "../src/mcp.js";
+
+function tool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text" as const, text: `${name} result` }], details: {} };
+    },
+  } as ToolDefinition;
+}
+
+describe("subagent write tools", () => {
+  const spacesGroup: McpToolGroup = {
+    serverType: "xyne-spaces",
+    serverName: "Xyne_Spaces",
+    tools: [tool("Xyne_Spaces__spaces-search"), tool("Xyne_Spaces__spaces-create-ticket")],
+    writeTools: ["spaces-create-ticket"],
+  };
+
+  it("keeps built-in connector write tools on the subagent while preserving parent-level approval compatibility", () => {
+    const { subagentTools, directTools } = buildSubagentTools([spacesGroup]);
+
+    expect(subagentTools.map((t) => t.name)).toEqual(["spaces"]);
+    // Existing parent-driven prompts still see write tools directly. The same
+    // ToolDefinition is also inside the spaces subagent palette, where its MCP
+    // execute path queues a signed pendingAction instead of executing writes.
+    expect(directTools.map((t) => t.name)).toEqual(["Xyne_Spaces__spaces-create-ticket"]);
+  });
+
+  it("allows custom subagents to resolve selected write tools", () => {
+    const spec: CustomSubagentSpec = {
+      name: "ticket-writer",
+      description: "creates tickets",
+      progressLabels: [],
+      systemPrompt: "Create the requested ticket.",
+      paramName: "question",
+      paramDescription: "Ticket request",
+      tools: { direct: ["spaces-create-ticket"] },
+      skills: [],
+    };
+
+    const { subagentTools } = buildSubagentTools([spacesGroup], undefined, undefined, undefined, undefined, undefined, undefined, [spec]);
+
+    expect(subagentTools.map((t) => t.name)).toEqual(["spaces", "ticket-writer"]);
+  });
+});


### PR DESCRIPTION
## Summary
- auto-inject the `spaces` subagent for Spaces-originated and automation runs, mirroring Slack surface-default tool injection without mutating stored agent configs
- mirror the same surface-default injection in claw-auth MCP list/call enforcement using session `triggerSource`
- include MCP/custom write tools inside subagent palettes while preserving the existing signed pendingAction approval flow and parent-level write-tool compatibility
- allow agent-card tool resolution to persist MCP direct tool slugs and gateway slugs instead of reporting them as unknown

## Validation
- `git diff --check`
- `pnpm --dir apps/xyne-claw exec tsc --noEmit --pretty false`

## Validation notes
- `pnpm --dir apps/xyne-claw-auth/backend exec tsc --noEmit --pretty false` is blocked in this sandbox by missing generated Prisma client (`Cannot find module '.prisma/client/default'`). `prisma generate` timed out.
- `pnpm --dir apps/xyne-claw-auth/backend exec vitest run src/lib/agent-card.test.ts` is blocked by the same missing Prisma client.
- `pnpm --dir apps/xyne-claw exec vitest run test/subagent-write-tools.test.ts` is blocked under sandbox Node v20 by `undici@8` requiring `webidl.util.markAsUncloneable` (repo package expects Node >=22).
