### PR TITLE
fix: XYNE-56828 passig conversation id for cold start

### DIFF
--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -249,6 +249,18 @@ const ChannelInfoModal = ({
 
 const ALL_CHANNELS_ID = 'all';
 
+// `cid` lets refresh / new-tab / copied links start the email query without
+// waiting for the ticket lookup (router state does this for in-app clicks).
+const ticketDetailPath = (
+  base: string,
+  channelId: string,
+  xyneId: string,
+  conversationId?: string | null,
+): string =>
+  conversationId
+    ? `${base}/${channelId}/${xyneId}?cid=${encodeURIComponent(conversationId)}`
+    : `${base}/${channelId}/${xyneId}`;
+
 const composerOpenByConv = new Map<string, boolean>();
 
 // ---------------------------------------------------------------------------
@@ -1708,9 +1720,15 @@ const SupportScreen = (): ReactElement => {
         clearTicketSelection();
         setShowMergeDialog(false);
         if (parentTicket) {
-          void navigate(`${supportBase}/${parentTicket.channelId}/${parentTicket.xyneId}`, {
-            state: { conversationId: parentTicket.conversationId, ticketId: parentTicket.id },
-          });
+          void navigate(
+            ticketDetailPath(
+              supportBase,
+              parentTicket.channelId,
+              parentTicket.xyneId,
+              parentTicket.conversationId,
+            ),
+            { state: { conversationId: parentTicket.conversationId, ticketId: parentTicket.id } },
+          );
         }
       } catch (error: unknown) {
         const err = error as {
@@ -2001,7 +2019,12 @@ const SupportScreen = (): ReactElement => {
     (e: React.MouseEvent | KeyboardEvent, ticket: Ticket) => {
       const isCmdClick = 'metaKey' in e && (e.metaKey || e.ctrlKey);
       const ticketData = ticket as SupportTicket;
-      const ticketUrl = `${supportBase}/${ticketData.channelId}/${ticketData.xyneId}`;
+      const ticketUrl = ticketDetailPath(
+        supportBase,
+        ticketData.channelId,
+        ticketData.xyneId,
+        ticketData.conversationId,
+      );
 
       // Only open in new tab on desktop when Cmd/Ctrl+Click is pressed
       if (!isMobile && isCmdClick) {
@@ -3383,12 +3406,17 @@ const SupportScreen = (): ReactElement => {
                         isMember={isSelectedChannelJoined}
                         ticketFilter={ticketFilter}
                         onTicketClick={ticket => {
-                          void navigate(`${supportBase}/${ticket.channelId}/${ticket.xyneId}`, {
-                            state: {
-                              conversationId: ticket.conversationId,
-                              ticketId: ticket.id,
+                          void navigate(
+                            ticketDetailPath(
+                              supportBase,
+                              ticket.channelId,
+                              ticket.xyneId,
+                              ticket.conversationId,
+                            ),
+                            {
+                              state: { conversationId: ticket.conversationId, ticketId: ticket.id },
                             },
-                          });
+                          );
                         }}
                         onTicketsLoaded={setKanbanTickets}
                       />
@@ -3404,12 +3432,17 @@ const SupportScreen = (): ReactElement => {
                         selectedIds={selectedTicketIds}
                         onSelectionChange={handleTableSelectionChange}
                         onTicketClick={ticket => {
-                          void navigate(`${supportBase}/${ticket.channelId}/${ticket.xyneId}`, {
-                            state: {
-                              conversationId: ticket.conversationId,
-                              ticketId: ticket.id,
+                          void navigate(
+                            ticketDetailPath(
+                              supportBase,
+                              ticket.channelId,
+                              ticket.xyneId,
+                              ticket.conversationId,
+                            ),
+                            {
+                              state: { conversationId: ticket.conversationId, ticketId: ticket.id },
                             },
-                          });
+                          );
                         }}
                       />
                     ) : (
@@ -3430,12 +3463,17 @@ const SupportScreen = (): ReactElement => {
                         onToggleSelectAll={handleToggleSelectAll}
                         onTicketsLoaded={setKanbanTickets}
                         onTicketClick={ticket => {
-                          void navigate(`${supportBase}/${ticket.channelId}/${ticket.xyneId}`, {
-                            state: {
-                              conversationId: ticket.conversationId,
-                              ticketId: ticket.id,
+                          void navigate(
+                            ticketDetailPath(
+                              supportBase,
+                              ticket.channelId,
+                              ticket.xyneId,
+                              ticket.conversationId,
+                            ),
+                            {
+                              state: { conversationId: ticket.conversationId, ticketId: ticket.id },
                             },
-                          });
+                          );
                         }}
                       />
                     )}
@@ -3778,7 +3816,7 @@ export const SupportTicketDetail = ({
   };
   // List navigation supplies stable IDs in router state; direct URL loads and
   // new-tab openings fall back to the :ticketId path parameter below.
-  const stateConversationId = routerState?.conversationId ?? null;
+  const stateConversationId = routerState?.conversationId ?? searchParams.get('cid');
   const ticketId = routerState?.ticketId ?? null;
 
   // channelId for ACL + query gating — comes from the URL path. Both ticket
@@ -4007,12 +4045,10 @@ export const SupportTicketDetail = ({
     if (!t.xyneId) return;
     const nextChannelId = t.channelId || channelIdParam;
     if (!nextChannelId) return;
-    void navigate(`${navBasePath ?? supportBase}/${nextChannelId}/${t.xyneId}`, {
-      state: {
-        conversationId: t.conversationId,
-        ticketId: t.id,
-      },
-    });
+    void navigate(
+      ticketDetailPath(navBasePath ?? supportBase, nextChannelId, t.xyneId, t.conversationId),
+      { state: { conversationId: t.conversationId, ticketId: t.id } },
+    );
   };
 
   type DeskNavRow = {
@@ -5332,13 +5368,21 @@ const EmailThreadItem = ({
         });
 
         if (channelIdParam) {
-          void navigate(`/support/${channelIdParam}/${response.data.newTicket.xyneId}`, {
-            state: {
-              conversationId: response.data.newTicket.conversationId,
-              title: email.subject,
-              ticketId: response.data.newTicket.ticketId,
+          void navigate(
+            ticketDetailPath(
+              '/support',
+              channelIdParam,
+              response.data.newTicket.xyneId,
+              response.data.newTicket.conversationId,
+            ),
+            {
+              state: {
+                conversationId: response.data.newTicket.conversationId,
+                title: email.subject,
+                ticketId: response.data.newTicket.ticketId,
+              },
             },
-          });
+          );
         }
       }
     } catch (err) {

--- a/packages/shared/src/hooks/useUserGroupSearch.ts
+++ b/packages/shared/src/hooks/useUserGroupSearch.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { useQuery } from './useQuery.js';
-import { queries } from '../zero/queries.js';
+import { useSelector } from '@xstate/react';
+import { stateMachineActor } from '../machines/stateMachine.js';
 
 export interface UserGroupLike {
   id: string;
@@ -20,9 +20,10 @@ export const useUserGroupSearch = (
   searchQuery: string,
   limit: number = 10,
 ): UserGroupLike[] => {
-  const [allUserGroups, details] = useQuery(queries.getAllUserGroups());
+  // Groups are loaded once by InitialStateLoader (getAllUserGroups) — read them
+  // from the state machine instead of opening a live Zero query per mount.
+  const allUserGroups = useSelector(stateMachineActor, state => state.context.allUserGroups);
   return useMemo(() => {
-    if (details.type !== 'complete') return [];
     if (!allUserGroups || allUserGroups.length === 0) return [];
 
     let filtered: UserGroupLike[];
@@ -39,5 +40,5 @@ export const useUserGroupSearch = (
         .sort((a, b) => a.name.localeCompare(b.name));
     }
     return filtered.slice(0, limit);
-  }, [allUserGroups, details.type, searchQuery, limit]);
+  }, [allUserGroups, searchQuery, limit]);
 };


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
