### PR TITLE
Feature/recording canvas title sync

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -429,6 +429,10 @@ export class CallController {
         stage = 'notes_canvas_creation';
         await canvasAuthService.createCanvasForUser(notesCanvasId, userId, {
           title: 'Untitled Notes',
+          metadata: {
+            source: 'call_notes',
+            callId: callExternalId,
+          },
         });
 
         stage = 'detailed_summary_canvas_creation';

--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -1429,17 +1429,20 @@ export class CallDocumentService {
     currentVersion: number,
     callId: string,
     callTitle?: string | null,
-    citationCtx?: CitationContext
+    citationCtx?: CitationContext,
+    callStartedAt?: Date
   ): Promise<string | null> {
     try {
       const prisma = DatabaseClient.getInstance();
       const now = new Date();
 
-      // Prepare canvas content (title, content, mentions, citations)
+      // Prepare canvas content (title, content, mentions, citations). Falls back to
+      // a timestamp-based title (instead of the bare "(Updated)" placeholder) when
+      // callTitle isn't ready yet — e.g. AI title generation is still racing this update.
       const { title, content: sanitizedContent, mentionedUserIds } = await this.prepareCanvasContent(
         markdownSummary,
         channelId,
-        undefined,
+        callStartedAt,
         callTitle,
         citationCtx
       );
@@ -1635,7 +1638,8 @@ export class CallDocumentService {
         existingCanvas.version,
         callId,
         callTitle,
-        citationCtx
+        citationCtx,
+        callStartedAt
       );
 
       return {

--- a/apps/backend/src/services/canvasAuthService.ts
+++ b/apps/backend/src/services/canvasAuthService.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { db } from '@/database/client';
 import {
   resolveCanvasHierarchy,
@@ -11,6 +12,7 @@ import { isBaselineCanvasType } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
+import { repositories } from '@/database/repositories';
 
 export interface CanvasAuthResult {
   hasAccess: boolean;
@@ -349,6 +351,7 @@ class CanvasAuthService {
       projectId?: string;
       folderId?: string;
       title?: string;
+      metadata?: Record<string, unknown>;
     }
   ): Promise<void> {
     try {
@@ -435,6 +438,7 @@ class CanvasAuthService {
             ...(resolvedChannelId ? { channelId: resolvedChannelId } : {}),
             ...(resolvedProjectId ? { projectId: resolvedProjectId } : {}),
             ...(folderId ? { folderId } : {}),
+            ...(options?.metadata ? { metadata: options.metadata as Prisma.InputJsonValue } : {}),
           },
         }),
         db.canvasParticipant.upsert({
@@ -479,6 +483,40 @@ class CanvasAuthService {
       logger.error('Failed to auto-create canvas', { canvasId, userId, error });
       throw error;
     }
+  }
+
+  async syncNotesCanvasTitle(callDbId: string, callTitle: string): Promise<void> {
+    const call = await repositories.calls.findById(callDbId);
+    const notesCanvasId = (call?.metadata as Record<string, unknown> | null)?.notesCanvasId;
+    if (typeof notesCanvasId !== 'string' || !notesCanvasId) {
+      return;
+    }
+
+    await db.canvas.update({
+      where: { id: notesCanvasId },
+      data: { title: `Notes: ${callTitle}` },
+    });
+  }
+
+  /**
+   * Mirrors syncNotesCanvasTitle for the Detailed Summary canvas. Needed
+   * because summary generation reads Call.title concurrently with AI title
+   * generation (a race), so the summary canvas frequently gets created with
+   * a timestamp-fallback title before the real one is known — this corrects
+   * it once the title is actually saved.
+   */
+  async syncDetailedSummaryCanvasTitle(callDbId: string, callTitle: string): Promise<void> {
+    const call = await repositories.calls.findById(callDbId);
+    const detailedSummaryCanvasId = (call?.metadata as Record<string, unknown> | null)
+      ?.detailedSummaryCanvasId;
+    if (typeof detailedSummaryCanvasId !== 'string' || !detailedSummaryCanvasId) {
+      return;
+    }
+
+    await db.canvas.update({
+      where: { id: detailedSummaryCanvasId },
+      data: { title: `Summary: ${callTitle}` },
+    });
   }
 }
 

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -8,6 +8,7 @@ import { acquireLock, releaseLock } from '@/utils/distributedLock';
 import { transcriptService, type TranscriptEntry } from '@/services/transcriptService';
 import { callDocumentService, numberTranscriptSegments, type CitationContext } from '@/services/callDocumentService';
 import { findExistingDetailedSummaryCanvas } from '@/services/canvasService';
+import { canvasAuthService } from '@/services/canvasAuthService';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { tagService, TagServiceError } from '@/tags/service';
 import { tagRepository } from '@/database/repositories/tagRepository';
@@ -470,6 +471,16 @@ class NoteTakerTranscriptService {
       try {
         await repositories.calls.update(call.id, { title });
         logger.info(`[${callId}] call_record_updated`, { fields_updated: 'title', path: 'note_taker' });
+        try {
+          await canvasAuthService.syncNotesCanvasTitle(call.id, title);
+        } catch (syncError) {
+          logger.error(`[${callId}] notes_canvas_title_sync_failed`, { path: 'note_taker', error: syncError });
+        }
+        try {
+          await canvasAuthService.syncDetailedSummaryCanvasTitle(call.id, title);
+        } catch (syncError) {
+          logger.error(`[${callId}] detailed_summary_canvas_title_sync_failed`, { path: 'note_taker', error: syncError });
+        }
         // Thread-linked recording: patch the anchor message's content with
         // this title too (mirrors how a regular call's ended message shows its
         // AI text as message.content) so RecordingBubble never needs its own
@@ -569,6 +580,12 @@ class NoteTakerTranscriptService {
           return null;
         }
 
+        // Re-read the title here rather than reuse resolvedCallTitle: the AI title
+        // generation runs concurrently with generateRecordingSummary above and may
+        // have finished (and already synced the canvas title) while that LLM call
+        // was in flight. Using the stale value would clobber that sync right back.
+        const freshCallTitle = (await repositories.calls.findByExternalId(callId))?.title ?? resolvedCallTitle;
+
         const { canvasId } = await callDocumentService.createOrUpdateDetailedSummaryCanvas(
           callId,
           generated.summary,
@@ -577,7 +594,7 @@ class NoteTakerTranscriptService {
           null,
           call.startedAt,
           call.createdByUserId,
-          resolvedCallTitle,
+          freshCallTitle,
           citationCtx,
           workspaceId,
         );
@@ -751,6 +768,12 @@ class NoteTakerTranscriptService {
         return null;
       }
 
+      // Re-read the title here rather than reuse resolvedCallTitle: the AI title
+      // generation runs concurrently with the summary streaming above and may have
+      // finished (and already synced the canvas title) while that was in flight.
+      // Using the stale value would clobber that sync right back on finalize.
+      const freshCallTitle = (await repositories.calls.findByExternalId(callId))?.title ?? resolvedCallTitle;
+
       const finalized = await callDocumentService.finalizeDetailedSummaryCanvas(
         newCanvasId,
         generated.summary,
@@ -758,7 +781,7 @@ class NoteTakerTranscriptService {
         null,
         callId,
         call.startedAt,
-        resolvedCallTitle,
+        freshCallTitle,
         citationCtx,
       );
       if (!finalized) {
@@ -820,6 +843,7 @@ class NoteTakerTranscriptService {
         logger.error(`[${callId}] label_tag_failed`, { label: slug, path: 'note_taker', error });
       }
     }
+
     return tagIds;
   }
 

--- a/apps/dashboard/src/components/Canvas/Canvas.types.ts
+++ b/apps/dashboard/src/components/Canvas/Canvas.types.ts
@@ -158,7 +158,9 @@ export interface CanvasListProps {
   paginated?: boolean;
   channelId?: string;
   excludeCallGeneratedCanvases?: boolean;
+  excludeRecordingGeneratedCanvases?: boolean;
   onlyCallGeneratedCanvases?: boolean;
+  onlyRecordingGeneratedCanvases?: boolean;
   showStarredOnly?: boolean;
   includeArchived?: boolean;
   onlyArchived?: boolean;

--- a/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
@@ -58,8 +58,10 @@ import { toast } from 'sonner';
 import {
   filterArchivedCanvases,
   filterExcludedCallGeneratedCanvases,
+  filterExcludedRecordingGeneratedCanvases,
   filterStarredCanvases,
-  isExcludedCallGeneratedCanvas,
+  isAnyCallGeneratedCanvas,
+  isExcludedRecordingGeneratedCanvas,
   withStarredCanvasState,
 } from '../canvasFilters';
 import { cn } from '../../../utils/classNames';
@@ -486,6 +488,8 @@ const getFilteredCanvasItems = ({
   canvases,
   onlyCallGeneratedCanvases,
   excludeCallGeneratedCanvases,
+  excludeRecordingGeneratedCanvases,
+  onlyRecordingGeneratedCanvases,
   showStarredOnly,
   activeFilter,
   currentUserId,
@@ -499,6 +503,8 @@ const getFilteredCanvasItems = ({
   canvases: Canvas[];
   onlyCallGeneratedCanvases: boolean;
   excludeCallGeneratedCanvases: boolean;
+  excludeRecordingGeneratedCanvases: boolean;
+  onlyRecordingGeneratedCanvases: boolean;
   showStarredOnly: boolean;
   activeFilter: FilterTab;
   currentUserId?: string | undefined;
@@ -510,8 +516,13 @@ const getFilteredCanvasItems = ({
   filterSearchQuery?: boolean;
 }): Canvas[] => {
   let filtered = onlyCallGeneratedCanvases
-    ? canvases.filter(isExcludedCallGeneratedCanvas)
-    : filterExcludedCallGeneratedCanvases(canvases, excludeCallGeneratedCanvases);
+    ? canvases.filter(isAnyCallGeneratedCanvas)
+    : onlyRecordingGeneratedCanvases
+      ? canvases.filter(isExcludedRecordingGeneratedCanvas)
+      : filterExcludedRecordingGeneratedCanvases(
+          filterExcludedCallGeneratedCanvases(canvases, excludeCallGeneratedCanvases),
+          excludeRecordingGeneratedCanvases,
+        );
   filtered = filterStarredCanvases(filtered, showStarredOnly);
 
   filtered = filtered.filter(canvas =>
@@ -661,6 +672,8 @@ const ChannelScopeFolderGroupSection: React.FC<{
   searchQuery: string;
   onlyCallGeneratedCanvases: boolean;
   excludeCallGeneratedCanvases: boolean;
+  excludeRecordingGeneratedCanvases: boolean;
+  onlyRecordingGeneratedCanvases: boolean;
   showStarredOnly: boolean;
   includeArchived: boolean;
   onlyArchived: boolean;
@@ -679,6 +692,8 @@ const ChannelScopeFolderGroupSection: React.FC<{
   searchQuery,
   onlyCallGeneratedCanvases,
   excludeCallGeneratedCanvases,
+  excludeRecordingGeneratedCanvases,
+  onlyRecordingGeneratedCanvases,
   showStarredOnly,
   includeArchived,
   onlyArchived,
@@ -709,6 +724,8 @@ const ChannelScopeFolderGroupSection: React.FC<{
         canvases: archiveFilteredFolderCanvases,
         onlyCallGeneratedCanvases,
         excludeCallGeneratedCanvases,
+        excludeRecordingGeneratedCanvases,
+        onlyRecordingGeneratedCanvases,
         showStarredOnly,
         activeFilter,
         currentUserId,
@@ -724,7 +741,9 @@ const ChannelScopeFolderGroupSection: React.FC<{
       archiveFilteredFolderCanvases,
       currentUserId,
       excludeCallGeneratedCanvases,
+      excludeRecordingGeneratedCanvases,
       onlyCallGeneratedCanvases,
+      onlyRecordingGeneratedCanvases,
       searchQuery,
       searchScope,
       selectedLabel,
@@ -809,7 +828,9 @@ export const CanvasList: React.FC<CanvasListProps> = ({
   paginated = false,
   channelId,
   excludeCallGeneratedCanvases = true,
+  excludeRecordingGeneratedCanvases = true,
   onlyCallGeneratedCanvases = false,
+  onlyRecordingGeneratedCanvases = false,
   showStarredOnly = false,
   includeArchived = false,
   onlyArchived = false,
@@ -988,9 +1009,11 @@ export const CanvasList: React.FC<CanvasListProps> = ({
     activeFilter,
     channelId,
     excludeCallGeneratedCanvases,
+    excludeRecordingGeneratedCanvases,
     includeArchived,
     onlyArchived,
     onlyCallGeneratedCanvases,
+    onlyRecordingGeneratedCanvases,
     paginated,
     debouncedSearchQuery,
     searchScope,
@@ -1186,6 +1209,8 @@ export const CanvasList: React.FC<CanvasListProps> = ({
         canvases: itemsForMainList,
         onlyCallGeneratedCanvases,
         excludeCallGeneratedCanvases,
+        excludeRecordingGeneratedCanvases,
+        onlyRecordingGeneratedCanvases,
         showStarredOnly,
         activeFilter,
         currentUserId,
@@ -1201,8 +1226,10 @@ export const CanvasList: React.FC<CanvasListProps> = ({
       effectiveSearchScope,
       effectiveSelectedScopeChannelId,
       excludeCallGeneratedCanvases,
+      excludeRecordingGeneratedCanvases,
       itemsForMainList,
       onlyCallGeneratedCanvases,
+      onlyRecordingGeneratedCanvases,
       debouncedSearchQuery,
       selectedLabel,
       selectedSharedByUserId,
@@ -1212,6 +1239,7 @@ export const CanvasList: React.FC<CanvasListProps> = ({
 
   const hasPrimaryCanvasFilters =
     onlyCallGeneratedCanvases ||
+    onlyRecordingGeneratedCanvases ||
     onlyArchived ||
     showStarredOnly ||
     activeFilter !== 'all' ||
@@ -1226,6 +1254,8 @@ export const CanvasList: React.FC<CanvasListProps> = ({
     trimmedSearchQuery || 'no-search'
   }:${onlyCallGeneratedCanvases ? 'only-call' : 'mixed-call'}:${
     excludeCallGeneratedCanvases ? 'exclude-call' : 'include-call'
+  }:${excludeRecordingGeneratedCanvases ? 'exclude-recording' : 'include-recording'}:${
+    onlyRecordingGeneratedCanvases ? 'only-recording' : 'mixed-recording'
   }:${onlyArchived ? 'only-archived' : includeArchived ? 'with-archived' : 'without-archived'}:${
     showStarredOnly ? 'starred' : 'all-stars'
   }`;
@@ -1241,7 +1271,8 @@ export const CanvasList: React.FC<CanvasListProps> = ({
     Boolean(selectedLabel) ||
     trimmedSearchQuery.length > 0 ||
     showStarredOnly ||
-    onlyCallGeneratedCanvases;
+    onlyCallGeneratedCanvases ||
+    onlyRecordingGeneratedCanvases;
   const shouldScanFilteredUserPages =
     hasClientSideResultFilters &&
     effectiveSearchScope !== 'via_channel' &&
@@ -1279,6 +1310,8 @@ export const CanvasList: React.FC<CanvasListProps> = ({
         ),
         onlyCallGeneratedCanvases,
         excludeCallGeneratedCanvases,
+        excludeRecordingGeneratedCanvases,
+        onlyRecordingGeneratedCanvases,
         showStarredOnly,
         activeFilter,
         currentUserId,
@@ -1294,9 +1327,11 @@ export const CanvasList: React.FC<CanvasListProps> = ({
       effectiveSearchScope,
       effectiveSelectedScopeChannelId,
       excludeCallGeneratedCanvases,
+      excludeRecordingGeneratedCanvases,
       includeArchived,
       onlyArchived,
       onlyCallGeneratedCanvases,
+      onlyRecordingGeneratedCanvases,
       debouncedSearchQuery,
       selectedChannelRootCanvasesResult,
       selectedLabel,
@@ -1313,9 +1348,11 @@ export const CanvasList: React.FC<CanvasListProps> = ({
     effectiveSearchScope,
     effectiveSelectedScopeChannelId,
     excludeCallGeneratedCanvases,
+    excludeRecordingGeneratedCanvases,
     includeArchived,
     onlyArchived,
     onlyCallGeneratedCanvases,
+    onlyRecordingGeneratedCanvases,
     debouncedSearchQuery,
     selectedLabel,
     selectedSharedByUserId,
@@ -1582,7 +1619,7 @@ export const CanvasList: React.FC<CanvasListProps> = ({
         ? 'you'
         : userNameById.get(editorUserId) || (editorUserId ? 'Unknown' : 'someone');
     const labels = getCanvasLabels(canvas);
-    const isBotGeneratedCanvas = isExcludedCallGeneratedCanvas(canvas);
+    const isBotGeneratedCanvas = isAnyCallGeneratedCanvas(canvas);
     const isCanvasCreator = canvas.createdBy === currentUserId;
     const menuItems: CanvasCardMenuItem[] = [
       ...(onToggleStar
@@ -1888,6 +1925,8 @@ export const CanvasList: React.FC<CanvasListProps> = ({
                 searchQuery={debouncedSearchQuery}
                 onlyCallGeneratedCanvases={onlyCallGeneratedCanvases}
                 excludeCallGeneratedCanvases={excludeCallGeneratedCanvases}
+                excludeRecordingGeneratedCanvases={excludeRecordingGeneratedCanvases}
+                onlyRecordingGeneratedCanvases={onlyRecordingGeneratedCanvases}
                 showStarredOnly={showStarredOnly}
                 includeArchived={includeArchived}
                 onlyArchived={onlyArchived}

--- a/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.tsx
@@ -25,6 +25,7 @@ export const CanvasListGrouped: React.FC<CanvasListGroupedProps> = ({
   isPersonalSectionCollapsed,
   onSetPersonalSectionCollapsed,
   excludeCallGeneratedCanvases = true,
+  excludeRecordingGeneratedCanvases = true,
   showStarredOnly = false,
   includeArchived = false,
   onlyArchived = false,
@@ -64,6 +65,7 @@ export const CanvasListGrouped: React.FC<CanvasListGroupedProps> = ({
     currentUserId,
     collapsedProjects,
     excludeCallGeneratedCanvases,
+    excludeRecordingGeneratedCanvases,
     showStarredOnly,
     includeArchived,
     onlyArchived,
@@ -542,6 +544,7 @@ export const CanvasListGrouped: React.FC<CanvasListGroupedProps> = ({
           adminChannelIds={activeAdminChannelIds}
           isPersonalSectionCollapsed={isPersonalSectionCollapsed}
           excludeCallGeneratedCanvases={excludeCallGeneratedCanvases}
+          excludeRecordingGeneratedCanvases={excludeRecordingGeneratedCanvases}
           collapsedProjects={collapsedProjects}
           collapsedChannels={collapsedChannels}
           collapsedFolders={collapsedFolders}

--- a/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.utils.ts
+++ b/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.utils.ts
@@ -12,6 +12,7 @@ export interface CanvasListGroupedProps {
   isPersonalSectionCollapsed: boolean;
   onSetPersonalSectionCollapsed: (collapsed: boolean) => void;
   excludeCallGeneratedCanvases?: boolean;
+  excludeRecordingGeneratedCanvases?: boolean;
   showStarredOnly?: boolean;
   includeArchived?: boolean;
   onlyArchived?: boolean;

--- a/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGroupedContent.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGroupedContent.tsx
@@ -29,6 +29,7 @@ import type { CanvasUser, FolderGroup, ProjectGroup } from './CanvasListGrouped.
 import {
   filterArchivedCanvases,
   filterExcludedCallGeneratedCanvases,
+  filterExcludedRecordingGeneratedCanvases,
   filterStarredCanvases,
   withStarredCanvasState,
 } from '../canvasFilters';
@@ -85,6 +86,7 @@ interface FolderGroupSectionProps {
   setRenamingFolderName: React.Dispatch<React.SetStateAction<string>>;
   isCreatingCanvas: boolean;
   excludeCallGeneratedCanvases: boolean;
+  excludeRecordingGeneratedCanvases: boolean;
   showStarredOnly: boolean;
   onSelect: (e: React.MouseEvent | KeyboardEvent, canvas: Canvas) => void;
   onDelete?: ((id: string) => void) | undefined;
@@ -114,6 +116,7 @@ const FolderGroupSection: React.FC<FolderGroupSectionProps> = ({
   setRenamingFolderName,
   isCreatingCanvas,
   excludeCallGeneratedCanvases,
+  excludeRecordingGeneratedCanvases,
   showStarredOnly,
   onSelect,
   onDelete,
@@ -159,19 +162,23 @@ const FolderGroupSection: React.FC<FolderGroupSectionProps> = ({
   const folderCanvases = useMemo(
     () =>
       filterStarredCanvases(
-        filterExcludedCallGeneratedCanvases(
-          withStarredCanvasState(
-            filterArchivedCanvases(
-              toArray<Canvas>(isProjectFolder ? projectFolderCanvases : genericFolderCanvases),
-              { includeArchived, onlyArchived },
+        filterExcludedRecordingGeneratedCanvases(
+          filterExcludedCallGeneratedCanvases(
+            withStarredCanvasState(
+              filterArchivedCanvases(
+                toArray<Canvas>(isProjectFolder ? projectFolderCanvases : genericFolderCanvases),
+                { includeArchived, onlyArchived },
+              ),
             ),
+            excludeCallGeneratedCanvases,
           ),
-          excludeCallGeneratedCanvases,
+          excludeRecordingGeneratedCanvases,
         ),
         showStarredOnly,
       ),
     [
       excludeCallGeneratedCanvases,
+      excludeRecordingGeneratedCanvases,
       genericFolderCanvases,
       includeArchived,
       isProjectFolder,
@@ -368,6 +375,7 @@ interface ChannelSectionProps extends Omit<
   channelGroup: ProjectGroup['channels'][number];
   onRegisterFolderIds: (folderIds: readonly string[]) => void;
   excludeCallGeneratedCanvases: boolean;
+  excludeRecordingGeneratedCanvases: boolean;
   searchQuery: string;
 }
 
@@ -397,6 +405,7 @@ const ChannelSection: React.FC<ChannelSectionProps> = ({
   onDeleteFolder,
   onRegisterFolderIds,
   excludeCallGeneratedCanvases,
+  excludeRecordingGeneratedCanvases,
   showStarredOnly,
   includeArchived,
   onlyArchived,
@@ -424,20 +433,24 @@ const ChannelSection: React.FC<ChannelSectionProps> = ({
   const channelRootCanvases = useMemo(
     () =>
       filterStarredCanvases(
-        filterExcludedCallGeneratedCanvases(
-          withStarredCanvasState(
-            filterArchivedCanvases(toArray<Canvas>(channelRootCanvasesResult), {
-              includeArchived,
-              onlyArchived,
-            }),
+        filterExcludedRecordingGeneratedCanvases(
+          filterExcludedCallGeneratedCanvases(
+            withStarredCanvasState(
+              filterArchivedCanvases(toArray<Canvas>(channelRootCanvasesResult), {
+                includeArchived,
+                onlyArchived,
+              }),
+            ),
+            excludeCallGeneratedCanvases,
           ),
-          excludeCallGeneratedCanvases,
+          excludeRecordingGeneratedCanvases,
         ),
         showStarredOnly,
       ),
     [
       channelRootCanvasesResult,
       excludeCallGeneratedCanvases,
+      excludeRecordingGeneratedCanvases,
       includeArchived,
       onlyArchived,
       showStarredOnly,
@@ -524,6 +537,7 @@ const ChannelSection: React.FC<ChannelSectionProps> = ({
               setRenamingFolderName={setRenamingFolderName}
               isCreatingCanvas={isCreatingCanvas}
               excludeCallGeneratedCanvases={excludeCallGeneratedCanvases}
+              excludeRecordingGeneratedCanvases={excludeRecordingGeneratedCanvases}
               showStarredOnly={showStarredOnly}
               onSelect={onSelect}
               onDelete={onDelete}
@@ -593,6 +607,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({
   onDeleteFolder,
   onRegisterFolderIds,
   excludeCallGeneratedCanvases,
+  excludeRecordingGeneratedCanvases,
   showStarredOnly,
   includeArchived,
   onlyArchived,
@@ -614,16 +629,20 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({
   const projectRootCanvases = useMemo(
     () =>
       filterStarredCanvases(
-        filterExcludedCallGeneratedCanvases(
-          withStarredCanvasState(
-            filterArchivedCanvases(group.rootCanvases, { includeArchived, onlyArchived }),
+        filterExcludedRecordingGeneratedCanvases(
+          filterExcludedCallGeneratedCanvases(
+            withStarredCanvasState(
+              filterArchivedCanvases(group.rootCanvases, { includeArchived, onlyArchived }),
+            ),
+            excludeCallGeneratedCanvases,
           ),
-          excludeCallGeneratedCanvases,
+          excludeRecordingGeneratedCanvases,
         ),
         showStarredOnly,
       ),
     [
       excludeCallGeneratedCanvases,
+      excludeRecordingGeneratedCanvases,
       group.rootCanvases,
       includeArchived,
       onlyArchived,
@@ -740,6 +759,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({
               setRenamingFolderName={setRenamingFolderName}
               isCreatingCanvas={isCreatingCanvas}
               excludeCallGeneratedCanvases={excludeCallGeneratedCanvases}
+              excludeRecordingGeneratedCanvases={excludeRecordingGeneratedCanvases}
               showStarredOnly={showStarredOnly}
               onSelect={onSelect}
               onDelete={onDelete}
@@ -775,6 +795,7 @@ const ProjectSection: React.FC<ProjectSectionProps> = ({
               setRenamingFolderName={setRenamingFolderName}
               isCreatingCanvas={isCreatingCanvas}
               excludeCallGeneratedCanvases={excludeCallGeneratedCanvases}
+              excludeRecordingGeneratedCanvases={excludeRecordingGeneratedCanvases}
               showStarredOnly={showStarredOnly}
               onSelect={onSelect}
               onDelete={onDelete}
@@ -930,6 +951,7 @@ export interface CanvasListGroupedContentProps {
   adminChannelIds: ReadonlySet<string>;
   isPersonalSectionCollapsed: boolean;
   excludeCallGeneratedCanvases: boolean;
+  excludeRecordingGeneratedCanvases: boolean;
   showStarredOnly: boolean;
   collapsedProjects: ReadonlySet<string>;
   collapsedChannels: ReadonlySet<string>;
@@ -977,6 +999,7 @@ export const CanvasListGroupedContent: React.FC<CanvasListGroupedContentProps> =
   adminChannelIds,
   isPersonalSectionCollapsed,
   excludeCallGeneratedCanvases,
+  excludeRecordingGeneratedCanvases,
   showStarredOnly,
   collapsedProjects,
   collapsedChannels,
@@ -1010,9 +1033,12 @@ export const CanvasListGroupedContent: React.FC<CanvasListGroupedContentProps> =
 }) => {
   const isSearchActive = searchQuery.length > 0;
   const personalRootCanvases = useMemo(() => {
-    let filtered = filterExcludedCallGeneratedCanvases(
-      filterArchivedCanvases(personalCanvases, { includeArchived, onlyArchived }),
-      excludeCallGeneratedCanvases,
+    let filtered = filterExcludedRecordingGeneratedCanvases(
+      filterExcludedCallGeneratedCanvases(
+        filterArchivedCanvases(personalCanvases, { includeArchived, onlyArchived }),
+        excludeCallGeneratedCanvases,
+      ),
+      excludeRecordingGeneratedCanvases,
     );
 
     filtered = currentUserId
@@ -1025,6 +1051,7 @@ export const CanvasListGroupedContent: React.FC<CanvasListGroupedContentProps> =
   }, [
     currentUserId,
     excludeCallGeneratedCanvases,
+    excludeRecordingGeneratedCanvases,
     includeArchived,
     isSearchActive,
     onlyArchived,
@@ -1032,9 +1059,12 @@ export const CanvasListGroupedContent: React.FC<CanvasListGroupedContentProps> =
     searchQuery,
   ]);
   const sharedRootCanvases = useMemo(() => {
-    let filtered = filterExcludedCallGeneratedCanvases(
-      filterArchivedCanvases(personalCanvases, { includeArchived, onlyArchived }),
-      excludeCallGeneratedCanvases,
+    let filtered = filterExcludedRecordingGeneratedCanvases(
+      filterExcludedCallGeneratedCanvases(
+        filterArchivedCanvases(personalCanvases, { includeArchived, onlyArchived }),
+        excludeCallGeneratedCanvases,
+      ),
+      excludeRecordingGeneratedCanvases,
     );
 
     filtered = currentUserId ? filtered.filter(canvas => canvas.createdBy !== currentUserId) : [];
@@ -1045,6 +1075,7 @@ export const CanvasListGroupedContent: React.FC<CanvasListGroupedContentProps> =
   }, [
     currentUserId,
     excludeCallGeneratedCanvases,
+    excludeRecordingGeneratedCanvases,
     includeArchived,
     isSearchActive,
     onlyArchived,
@@ -1145,6 +1176,7 @@ export const CanvasListGroupedContent: React.FC<CanvasListGroupedContentProps> =
                 setRenamingFolderName={setRenamingFolderName}
                 isCreatingCanvas={isCreatingCanvas}
                 excludeCallGeneratedCanvases={excludeCallGeneratedCanvases}
+                excludeRecordingGeneratedCanvases={excludeRecordingGeneratedCanvases}
                 showStarredOnly={showStarredOnly}
                 onSelect={onSelect}
                 onDelete={onDelete}
@@ -1234,6 +1266,7 @@ export const CanvasListGroupedContent: React.FC<CanvasListGroupedContentProps> =
           onDeleteFolder={onDeleteFolder}
           onRegisterFolderIds={onRegisterFolderIds}
           excludeCallGeneratedCanvases={excludeCallGeneratedCanvases}
+          excludeRecordingGeneratedCanvases={excludeRecordingGeneratedCanvases}
           showStarredOnly={showStarredOnly}
           includeArchived={includeArchived}
           onlyArchived={onlyArchived}

--- a/apps/dashboard/src/components/Canvas/CanvasListGrouped/useCanvasListGroupedData.ts
+++ b/apps/dashboard/src/components/Canvas/CanvasListGrouped/useCanvasListGroupedData.ts
@@ -17,6 +17,7 @@ import {
 import {
   filterArchivedCanvases,
   filterExcludedCallGeneratedCanvases,
+  filterExcludedRecordingGeneratedCanvases,
   filterStarredCanvases,
   withStarredCanvasState,
 } from '../canvasFilters';
@@ -25,6 +26,7 @@ interface UseCanvasListGroupedDataParams {
   currentUserId?: string | undefined;
   collapsedProjects: ReadonlySet<string>;
   excludeCallGeneratedCanvases: boolean;
+  excludeRecordingGeneratedCanvases: boolean;
   showStarredOnly: boolean;
   includeArchived: boolean;
   onlyArchived: boolean;
@@ -53,6 +55,7 @@ export function useCanvasListGroupedData({
   currentUserId,
   collapsedProjects,
   excludeCallGeneratedCanvases,
+  excludeRecordingGeneratedCanvases,
   showStarredOnly,
   includeArchived,
   onlyArchived,
@@ -110,19 +113,23 @@ export function useCanvasListGroupedData({
   const lazyPersonalCanvases = useMemo(
     () =>
       filterStarredCanvases(
-        filterExcludedCallGeneratedCanvases(
-          withStarredCanvasState(
-            filterArchivedCanvases(toArray<Canvas>(personalCanvasesResult), {
-              includeArchived,
-              onlyArchived,
-            }),
+        filterExcludedRecordingGeneratedCanvases(
+          filterExcludedCallGeneratedCanvases(
+            withStarredCanvasState(
+              filterArchivedCanvases(toArray<Canvas>(personalCanvasesResult), {
+                includeArchived,
+                onlyArchived,
+              }),
+            ),
+            excludeCallGeneratedCanvases,
           ),
-          excludeCallGeneratedCanvases,
+          excludeRecordingGeneratedCanvases,
         ),
         showStarredOnly,
       ),
     [
       excludeCallGeneratedCanvases,
+      excludeRecordingGeneratedCanvases,
       includeArchived,
       onlyArchived,
       personalCanvasesResult,

--- a/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
@@ -79,6 +79,7 @@ const CanvasPanel = (): ReactElement => {
   const [isPersonalSectionCollapsed, setIsPersonalSectionCollapsed] = useState(false);
   const [excludeCallGeneratedCanvases] = useState(true);
   const [onlyCallGeneratedCanvases, setOnlyCallGeneratedCanvases] = useState(false);
+  const [onlyRecordingGeneratedCanvases, setOnlyRecordingGeneratedCanvases] = useState(false);
   const [onlyArchivedCanvases, setOnlyArchivedCanvases] = useState(false);
   const [groupedSearchQuery, setGroupedSearchQuery] = useState('');
   const [listOptionsOpen, setListOptionsOpen] = useState(false);
@@ -408,6 +409,30 @@ const CanvasPanel = (): ReactElement => {
                     className='items-start gap-2 rounded-lg px-2 py-2 text-[13px]'
                     onSelect={event => event.preventDefault()}
                     data-track-category='CANVAS'
+                    data-track-name='TOGGLE_ONLY_RECORDING_GENERATED_CANVASES'
+                  >
+                    <Bot size={15} className='mt-0.5 shrink-0 text-sidebar-foreground/55' />
+                    <span className='min-w-0 flex-1'>
+                      <span className='block leading-5'>Only recording-generated</span>
+                      <span className='block max-w-[170px] text-xs leading-4 text-sidebar-foreground/50'>
+                        Notes and summaries from your recordings
+                      </span>
+                    </span>
+                    <Switch
+                      id='only-recording-generated-canvases'
+                      checked={onlyRecordingGeneratedCanvases}
+                      onCheckedChange={checked => {
+                        setOnlyRecordingGeneratedCanvases(checked);
+                        if (checked) {
+                          setViewMode('list');
+                        }
+                      }}
+                    />
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className='items-start gap-2 rounded-lg px-2 py-2 text-[13px]'
+                    onSelect={event => event.preventDefault()}
+                    data-track-category='CANVAS'
                     data-track-name='TOGGLE_ONLY_ARCHIVED_CANVASES'
                   >
                     <Archive size={15} className='mt-0.5 shrink-0 text-sidebar-foreground/55' />
@@ -481,6 +506,7 @@ const CanvasPanel = (): ReactElement => {
                 onlyCallGeneratedCanvases ? false : excludeCallGeneratedCanvases
               }
               onlyCallGeneratedCanvases={onlyCallGeneratedCanvases}
+              onlyRecordingGeneratedCanvases={onlyRecordingGeneratedCanvases}
               showStarredOnly={false}
               onlyArchived={onlyArchivedCanvases}
               onToggleStar={handleToggleStar}

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -30,6 +30,7 @@ import { Popover } from '../../ui/Popover';
 import Input from '../../ui/Input';
 import AvatarGroup from '../../ui/Avatar/AvatarGroup';
 import {
+  AudioLines,
   ArrowLeft,
   Archive,
   CheckCircle,
@@ -87,6 +88,7 @@ import { apiInstance } from '../../../services/clients/apiClient';
 import { xyneAIActor, type CanvasInfo } from '../../../machines/xyneAIMachine';
 import { useAllVisibleChannels } from '@xyne/shared/hooks';
 import { usePersistedCanvasPreferences } from '../../../hooks/usePersistedCanvasPreferences';
+import { getRecordingCanvasCallId } from '../canvasFilters';
 import type { CanvasPanelOutletContext } from '../CanvasPanel/CanvasPanel';
 import { useNavigate } from '../../../hooks/useWorkspaceNavigate';
 import {
@@ -1092,6 +1094,15 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     });
   };
 
+  const recordingCallId = selectedCanvas ? getRecordingCanvasCallId(selectedCanvas) : null;
+  const handleOpenRecordingNotes = useCallback((): void => {
+    if (!recordingCallId) return;
+
+    void navigate(`/recordings/${encodeURIComponent(recordingCallId)}?tab=notes`, {
+      state: { from: `${location.pathname}${location.search}` },
+    });
+  }, [location.pathname, location.search, navigate, recordingCallId]);
+
   const handleExportMarkdown = useCallback((): void => {
     void (async (): Promise<void> => {
       try {
@@ -1362,6 +1373,24 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                         >
                           <Share01 size={16} className='shrink-0 opacity-60' />
                         </button>
+
+                        {recordingCallId && (
+                          <button
+                            type='button'
+                            onClick={handleOpenRecordingNotes}
+                            className={`${headerIconButtonClass} bg-muted text-muted-foreground hover:bg-border hover:text-foreground`}
+                            title='Open recording notes'
+                            aria-label='Open recording notes'
+                            data-track-category='CANVAS'
+                            data-track-name='Open_Recording_Notes_From_Canvas'
+                            data-track-metadata={JSON.stringify({
+                              canvasId: selectedCanvas.id,
+                              recordingId: recordingCallId,
+                            })}
+                          >
+                            <AudioLines size={16} strokeWidth={2.2} className='shrink-0' />
+                          </button>
+                        )}
 
                         {/* Icon button group */}
                         <div className='flex items-center gap-1'>

--- a/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
@@ -28,6 +28,7 @@ import {
 } from '../CanvasVersionHistory';
 import { isBaselineCanvasType, CanvasRole, CanvasVisibility } from '@xyne/shared';
 import {
+  AudioLines,
   ArrowLeft,
   Archive,
   Folder,
@@ -49,7 +50,12 @@ import { mutators } from '../../../zero/mutators';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useChannel } from '../../../hooks/useChannels';
 import { useCurrentUserGroupIds } from '../../../hooks/useUserGroup';
-import { filterExcludedCallGeneratedCanvases } from '../canvasFilters';
+import {
+  filterExcludedCallGeneratedCanvases,
+  filterExcludedRecordingGeneratedCanvases,
+  getRecordingCanvasCallId,
+  isExcludedRecordingGeneratedCanvas,
+} from '../canvasFilters';
 import { usePersistedCanvasPreferences } from '../../../hooks/usePersistedCanvasPreferences';
 import { Switch } from '@/components/ui/Switch';
 import {
@@ -122,6 +128,7 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
   const z = useZero();
   const { filter: activeFilter, setFilter: setActiveFilter } = usePersistedCanvasPreferences();
   const [excludeCallGeneratedCanvases, setExcludeCallGeneratedCanvases] = useState(true);
+  const [onlyRecordingGeneratedCanvases, setOnlyRecordingGeneratedCanvases] = useState(false);
   const [showStarredOnly, setShowStarredOnly] = useState(false);
   const [onlyArchivedCanvases, setOnlyArchivedCanvases] = useState(false);
   const [view, setView] = useState<'list' | 'editor'>('list');
@@ -150,8 +157,14 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
     [canvasList],
   );
   const canvases = useMemo(
-    () => filterExcludedCallGeneratedCanvases(canvasItems, excludeCallGeneratedCanvases),
-    [canvasItems, excludeCallGeneratedCanvases],
+    () =>
+      onlyRecordingGeneratedCanvases
+        ? canvasItems.filter(isExcludedRecordingGeneratedCanvas)
+        : filterExcludedRecordingGeneratedCanvases(
+            filterExcludedCallGeneratedCanvases(canvasItems, excludeCallGeneratedCanvases),
+            true,
+          ),
+    [canvasItems, excludeCallGeneratedCanvases, onlyRecordingGeneratedCanvases],
   );
   const folders = useMemo(() => (zeroFolders as CanvasFolder[] | undefined) ?? [], [zeroFolders]);
   const [canvas, setCanvas] = useState<Canvas | null>(null);
@@ -265,6 +278,15 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
 
   const isCanvasOwner = canvas?.createdBy === user?.id || effectiveAccessLevel === CanvasRole.OWNER;
   const isChannelArchived = !!channel?.isArchived;
+  const recordingCallId = canvas ? getRecordingCanvasCallId(canvas) : null;
+
+  const handleOpenRecordingNotes = useCallback((): void => {
+    if (!recordingCallId) return;
+
+    void navigate(`/recordings/${encodeURIComponent(recordingCallId)}?tab=notes`, {
+      state: { from: `${location.pathname}${location.search}` },
+    });
+  }, [location.pathname, location.search, navigate, recordingCallId]);
 
   useEffect(() => {
     previewVersionRef.current = null;
@@ -783,6 +805,15 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
                   />
                 </div>
               </Tooltip>
+              <Tooltip content='Only recording canvases' className='px-2 py-1 text-[10px]'>
+                <div className='origin-left scale-90'>
+                  <Switch
+                    id='only-channel-recording-generated-canvases'
+                    checked={onlyRecordingGeneratedCanvases}
+                    onCheckedChange={setOnlyRecordingGeneratedCanvases}
+                  />
+                </div>
+              </Tooltip>
               <Tooltip content='Only archived' className='px-2 py-1 text-[10px]'>
                 <div className='flex origin-left scale-90 items-center gap-1.5 rounded-md border border-border px-2 py-1 text-muted-foreground'>
                   <Archive size={14} />
@@ -1033,6 +1064,24 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
           {/* Share Button */}
           {canvas?.id && (
             <div className='ml-2 flex items-center gap-2'>
+              {recordingCallId && (
+                <Button
+                  variant='secondary'
+                  size='iconSm'
+                  onClick={handleOpenRecordingNotes}
+                  title='Open recording notes'
+                  aria-label='Open recording notes'
+                  data-track-category='CANVAS'
+                  data-track-name='Open_Recording_Notes_From_Channel_Canvas'
+                  data-track-metadata={JSON.stringify({
+                    canvasId: canvas.id,
+                    recordingId: recordingCallId,
+                    channelId,
+                  })}
+                >
+                  <AudioLines size={16} strokeWidth={2.2} />
+                </Button>
+              )}
               <Button
                 variant='secondary'
                 size='sm'

--- a/apps/dashboard/src/components/Canvas/canvasFilters.ts
+++ b/apps/dashboard/src/components/Canvas/canvasFilters.ts
@@ -2,7 +2,6 @@ import type { Canvas } from './Canvas.types';
 
 const EXCLUDED_CALL_GENERATED_SOURCES = new Set([
   'call_prd',
-  'call_detailed_summary',
   'genius_dm_response',
   'genius_canvas_long_response',
   'jira_migration_report',
@@ -13,6 +12,8 @@ const EXCLUDED_CALL_GENERATED_SOURCES = new Set([
   // Retired generators — kept so their existing legacy canvases stay filtered.
   'xyne_auto_rca',
 ]);
+
+const RECORDING_GENERATED_SOURCES = new Set(['call_notes', 'call_detailed_summary']);
 
 function getCanvasMetadataSource(canvas: Canvas): string | undefined {
   const metadata = canvas.metadata;
@@ -38,6 +39,40 @@ export function filterExcludedCallGeneratedCanvases(
   }
 
   return canvases.filter(canvas => !isExcludedCallGeneratedCanvas(canvas));
+}
+
+export function isExcludedRecordingGeneratedCanvas(canvas: Canvas): boolean {
+  const source = getCanvasMetadataSource(canvas);
+  return source ? RECORDING_GENERATED_SOURCES.has(source) : false;
+}
+
+export function getRecordingCanvasCallId(canvas: Canvas): string | null {
+  if (!isExcludedRecordingGeneratedCanvas(canvas)) {
+    return null;
+  }
+
+  const metadata = canvas.metadata;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  const callId = (metadata as Record<string, unknown>)['callId'];
+  return typeof callId === 'string' && callId ? callId : null;
+}
+
+export function filterExcludedRecordingGeneratedCanvases(
+  canvases: Canvas[],
+  excludeRecordingGeneratedCanvases: boolean,
+): Canvas[] {
+  if (!excludeRecordingGeneratedCanvases) {
+    return canvases;
+  }
+
+  return canvases.filter(canvas => !isExcludedRecordingGeneratedCanvas(canvas));
+}
+
+export function isAnyCallGeneratedCanvas(canvas: Canvas): boolean {
+  return isExcludedCallGeneratedCanvas(canvas) || isExcludedRecordingGeneratedCanvas(canvas);
 }
 
 export function filterStarredCanvases(canvases: Canvas[], showStarredOnly: boolean): Canvas[] {

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -140,6 +140,10 @@ export default function RecordingDetailV2Screen(): ReactElement {
   const { recordingId } = useParams<{ recordingId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
+  const requestedTab = useMemo(
+    () => new URLSearchParams(location.search).get('tab'),
+    [location.search],
+  );
   const speakerIdentificationEnabled = useSpeakerIdentificationEnabled();
   const currentUser = useSelf();
 
@@ -149,7 +153,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
   const [failure, setFailure] = useState<RecordingLoadFailure | null>(null);
   // Which of the two panes to show. The concrete second tab (transcript while live,
   // summary once ended) is derived below, so only the notes/not-notes choice is held.
-  const [tabPreference, setTabPreference] = useState<RecordingV2Tab>(getRecordingV2Tab);
+  const [tabPreference, setTabPreference] = useState<RecordingV2Tab>(() =>
+    requestedTab === 'notes' ? 'notes' : getRecordingV2Tab(),
+  );
   const [showTranscriptPanel, setShowTranscriptPanel] = useState(false);
   const [showPostToChannelModal, setShowPostToChannelModal] = useState(false);
   const [showPostToEmailModal, setShowPostToEmailModal] = useState(false);
@@ -182,6 +188,12 @@ export default function RecordingDetailV2Screen(): ReactElement {
   // Which line the transcript panel opens on: set by a timeline marker, null when the
   // panel is opened from the toolbar with no particular moment in mind.
   const [citationRef, setCitationRef] = useState<TranscriptPanelTarget | null>(null);
+
+  useEffect(() => {
+    if (requestedTab === 'notes') {
+      setTabPreference('notes');
+    }
+  }, [recordingId, requestedTab]);
 
   const exportGoogleDoc = async (documentTitle?: string): Promise<void> => {
     if (!recording || isExportingGoogleDoc) return;
@@ -320,7 +332,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
   const liveTabRecordingIdRef = useRef<string | null>(null);
   if (isLive && recordingId && liveTabRecordingIdRef.current !== recordingId) {
     liveTabRecordingIdRef.current = recordingId;
-    setTabPreference(getLiveRecordingV2Tab(recordingId));
+    setTabPreference(requestedTab === 'notes' ? 'notes' : getLiveRecordingV2Tab(recordingId));
   }
 
   // j/k keyboard navigation between recordings


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [x] Enhancement

## Description

Fixes XYNE-56822 by improving how recording-generated canvases behave in the Canvas experience.

This branch includes both commits applied on `feature/recording-canvas-title-sync`:
- `04ce082453` — sync Notes/Summary canvas titles with recording title and add recording-generated canvas filtering
- `ee355df912` — add recording shortcut icon in canvas header

### What changed and why

Recording-generated canvases were hard to identify and navigate from the Canvas surface. Notes/Summary canvases could also keep generic titles like `Untitled Notes` or timestamp fallback titles even after the recording title was generated.

This change:
- Tags headless recording notes canvases with metadata so the dashboard can identify them as recording-generated.
- Syncs Notes and Detailed Summary canvas titles after recording title generation.
- Adds filtering support so recording-generated canvases are hidden from regular canvas lists by default, but can be shown explicitly.
- Adds a recording shortcut icon in Canvas headers for recording-generated canvases, using the same waveform icon style as the recordings listing.
- Supports opening the associated recording detail page directly on the Notes tab.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`

## Files / Flow Touched

### Backend

- `apps/backend/src/controllers/callController.ts`
  - Adds `source: 'call_notes'`, `callId`, and `conversationId` metadata when creating headless recording notes canvases.
  - Needed so the frontend can distinguish recording notes canvases from normal user canvases.

- `apps/backend/src/controllers/livekitWebhookController.ts`
  - Syncs notes and detailed summary canvas titles after a conversation call title is generated.
  - Prevents generated canvases from staying with stale/fallback titles.

- `apps/backend/src/services/canvasAuthService.ts`
  - Adds `syncNotesCanvasTitle` and `syncDetailedSummaryCanvasTitle`.
  - Centralizes the title update logic for recording-linked canvases.

- `apps/backend/src/services/noteTakerTranscriptService.ts`
  - Calls the title sync helpers after AI-generated note-taker recording title is saved.
  - Handles the async race where summary canvas can be created before the final recording title exists.

### Dashboard

- `apps/dashboard/src/components/Canvas/canvasFilters.ts`
  - Adds recording-generated canvas detection using `call_notes` and `call_detailed_summary`.
  - Adds helper to extract recording `callId` from canvas metadata.

- `apps/dashboard/src/components/Canvas/Canvas.types.ts`
  - Extends Canvas list props for recording-generated filtering.

- `apps/dashboard/src/components/Canvas/CanvasList/*`
  - Excludes recording-generated canvases from regular canvas lists by default.
  - Supports showing only recording-generated canvases when the filter is enabled.

- `apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx`
  - Adds “Only recording-generated” list option.
  - Lets users intentionally find notes/summaries created from recordings.

- `apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx`
  - Adds a recording shortcut button in the canvas header for recording-generated canvases.
  - Uses the same `AudioLines` waveform icon style as recording listing.

- `apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx`
  - Adds the same recording shortcut in the channel canvas editor header.

- `apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx`
  - Reads `?tab=notes` so the canvas shortcut can navigate directly to the recording Notes tab.

## Zero (Sync) Changes

- [x] No Zero schema/mutator changes

## Schema & Data Changes

- [x] No schema changes

## Config, Environment & URLs

- [x] No config changes

## API Contract

- [x] No API changes

### Manual

- [ ] Not covered in this PR description
pot : https://drive.google.com/file/d/1Yq8F42IkmP2l6GOX4VUr7YEuRcig61bO/view?usp=sharing
