### PR TITLE
feat: XYNE-55716 add brief on/off toggle, improve metrics [release-20260817]

### DIFF
--- a/apps/backend/src/controllers/dailyBriefController.ts
+++ b/apps/backend/src/controllers/dailyBriefController.ts
@@ -7,6 +7,9 @@ import {
   saveDailyBriefSettings,
   getLatestDailyBrief,
   getDailyBriefHistory,
+  getDailyBriefDates,
+  getDailyBriefByDate,
+  postDailyBriefSwitched,
   regenerateDailyBriefStream,
 } from '../services/clawAgentService';
 
@@ -105,6 +108,48 @@ export async function getHistory(req: Request, res: Response) {
   } catch (error) {
     logger.error('[DailyBrief] Error fetching history:', error);
     return res.status(500).json({ error: 'Failed to load daily brief history' });
+  }
+}
+
+/** GET /api/daily-brief/dates — days the user has briefs for (date + status only). */
+export async function getDates(req: Request, res: Response) {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const limitRaw = Number(req.query.limit);
+    const limit = Number.isFinite(limitRaw) ? limitRaw : undefined;
+    const result = await getDailyBriefDates(req, userId, limit);
+    return res.json(unwrap(result));
+  } catch (error) {
+    logger.error('[DailyBrief] Error fetching dates:', error);
+    return res.status(500).json({ error: 'Failed to load daily brief dates' });
+  }
+}
+
+/** GET /api/daily-brief/by-date/:date — the stored brief for one YYYY-MM-DD bucket. */
+export async function getByDate(req: Request, res: Response) {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const { status, json } = await getDailyBriefByDate(req, userId, String(req.params.date ?? ''));
+    return res.status(status).json(unwrap(json));
+  } catch (error) {
+    logger.error('[DailyBrief] Error fetching brief by date:', error);
+    return res.status(500).json({ error: 'Failed to load daily brief' });
+  }
+}
+
+/** POST /api/daily-brief/switched — beacon: the user switched to another brief. */
+export async function postSwitched(req: Request, res: Response) {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+  try {
+    const source = typeof req.body?.source === 'string' ? req.body.source : 'history_menu';
+    const status = await postDailyBriefSwitched(req, userId, source);
+    return res.status(status === 204 ? 204 : 500).end();
+  } catch (error) {
+    logger.error('[DailyBrief] Error recording brief switch:', error);
+    return res.status(500).end();
   }
 }
 

--- a/apps/backend/src/routes/dailyBrief.ts
+++ b/apps/backend/src/routes/dailyBrief.ts
@@ -7,6 +7,9 @@ import {
   saveSettings,
   getLatest,
   getHistory,
+  getDates,
+  getByDate,
+  postSwitched,
   regenerate,
 } from '../controllers/dailyBriefController';
 
@@ -18,6 +21,9 @@ router.get('/settings', authMiddleware.authenticate, getSettings);
 router.put('/settings', authMiddleware.authenticate, saveSettings);
 router.get('/latest', authMiddleware.authenticate, getLatest);
 router.get('/history', authMiddleware.authenticate, getHistory);
+router.get('/dates', authMiddleware.authenticate, getDates);
+router.get('/by-date/:date', authMiddleware.authenticate, getByDate);
+router.post('/switched', authMiddleware.authenticate, postSwitched);
 router.post('/regenerate', authMiddleware.authenticate, regenerate);
 
 export default router;

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -1827,6 +1827,50 @@ export async function getDailyBriefHistory(
   return response.json();
 }
 
+/** GET the days the user has briefs for (date + status only — powers the date picker). */
+export async function getDailyBriefDates(
+  req: { headers?: { cookie?: string } },
+  userId: string,
+  limit?: number
+): Promise<unknown> {
+  const qs = typeof limit === 'number' && Number.isFinite(limit) ? `?limit=${encodeURIComponent(limit)}` : '';
+  const response = await fetch(`${DAILY_BRIEF_BASE()}/dates${qs}`, {
+    method: 'GET',
+    headers: { ...extractCookieHeader(req), ...extractUserIdHeader(userId) },
+  });
+  if (!response.ok) {
+    throw new Error(`[ClawAgentService] daily-brief dates GET ${response.status}: ${await safeReadText(response)}`);
+  }
+  return response.json();
+}
+
+/** GET the user's stored brief for one YYYY-MM-DD bucket. */
+export async function getDailyBriefByDate(
+  req: { headers?: { cookie?: string } },
+  userId: string,
+  date: string
+): Promise<{ status: number; json: unknown }> {
+  const response = await fetch(`${DAILY_BRIEF_BASE()}/by-date/${encodeURIComponent(date)}`, {
+    method: 'GET',
+    headers: { ...extractCookieHeader(req), ...extractUserIdHeader(userId) },
+  });
+  return { status: response.status, json: await response.json().catch(() => ({})) };
+}
+
+/** POST the "user switched briefs" beacon (fire-and-forget; never surfaced to the user). */
+export async function postDailyBriefSwitched(
+  req: { headers?: { cookie?: string } },
+  userId: string,
+  source: string
+): Promise<number> {
+  const response = await fetch(`${DAILY_BRIEF_BASE()}/switched`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...extractCookieHeader(req), ...extractUserIdHeader(userId) },
+    body: JSON.stringify({ source }),
+  });
+  return response.status;
+}
+
 /**
  * Regenerate the brief now, streaming the SSE straight through to the dashboard.
  * claw-auth already emits dashboard-facing frames (start / progress / complete /

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@300..700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Inconsolata:wght@400;500&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
     <title>Xyne Spaces</title>
     <!-- <title>Dev Factory - File Manager</title> -->
     <script src="https://apis.google.com/js/api.js"></script>

--- a/apps/dashboard/src/api/dailyBriefApi.ts
+++ b/apps/dashboard/src/api/dailyBriefApi.ts
@@ -6,6 +6,9 @@ import { apiInstance, BASE_URL } from '../services/clients/apiClient';
  * Minimal surface for the Daily Brief dashboard page:
  *   - getLatest()  → today's stored brief (or the most recent one)
  *   - getHistory() → the user's recent briefs, newest first
+ *   - getDates()   → every day the user has a brief for (date + status only)
+ *   - getByDate()  → the stored brief for one day
+ *   - trackSwitch() → beacon: the user switched to another brief
  *   - regenerate() → re-run the brief now, streaming progress over SSE
  *
  * This is intentionally thin — a starting point for UI developers to build on.
@@ -58,6 +61,12 @@ export interface DailyBriefHistoryItem {
   data?: DailyBriefPayload | null;
   agentSlug?: string | null;
   generatedAt?: string | null;
+}
+
+/** One day the user has a brief for (GET /daily-brief/dates) — no content. */
+export interface DailyBriefDate {
+  date: string;
+  status: string;
 }
 
 /** Callbacks for the regenerate SSE stream. */
@@ -120,6 +129,35 @@ export const dailyBriefApi = {
       params: { limit },
     });
     return Array.isArray(res.data) ? res.data : [];
+  },
+
+  /** Every day the user has a brief for, newest first — the date picker's calendar. */
+  getDates: async (limit = 365): Promise<DailyBriefDate[]> => {
+    const res = await apiInstance.get<DailyBriefDate[]>('/daily-brief/dates', {
+      params: { limit },
+    });
+    return Array.isArray(res.data) ? res.data : [];
+  },
+
+  /** The stored brief for one YYYY-MM-DD bucket (`status: 'none'` when there isn't one). */
+  getByDate: async (date: string): Promise<DailyBriefLatest> => {
+    const res = await apiInstance.get<DailyBriefLatest>(
+      `/daily-brief/by-date/${encodeURIComponent(date)}`,
+    );
+    return res.data;
+  },
+
+  /**
+   * Tell the server this user switched briefs. Counted server-side because the
+   * screen keeps the recent window in memory, so a switch is otherwise invisible.
+   * Fire-and-forget: a failed beacon must never surface to the reader.
+   */
+  trackSwitch: async (source: 'history_menu' | 'date_picker'): Promise<void> => {
+    try {
+      await apiInstance.post('/daily-brief/switched', { source });
+    } catch {
+      // best-effort telemetry
+    }
   },
 
   /**

--- a/apps/dashboard/src/components/AIScreen/AISidebar.tsx
+++ b/apps/dashboard/src/components/AIScreen/AISidebar.tsx
@@ -20,6 +20,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { useClawAdminAccessQuery } from '../../hooks/useClawAdminAccess';
 import { useClawOrgManageAccess } from '../../hooks/useClawOrganization';
 import { useAuth } from '../../hooks/useAuth';
+import { useDailyBriefEnabled } from '../../hooks/useDailyBriefEnabled';
 import { useV2SessionsList, useV2SessionInvalidator } from '../../hooks/useAskAISessionsV2';
 import { deleteV2Conversation } from '../../services/XyneAI/XyneAISessionsV2Service';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
@@ -63,6 +64,8 @@ interface AINavItem {
   trackName?: string;
   adminOnly?: boolean;
   orgManagerOnly?: boolean;
+  /** Hidden unless the user has the scheduled morning brief switched on. */
+  dailyBriefOnly?: boolean;
 }
 
 const NAV_ITEMS: AINavItem[] = [
@@ -86,6 +89,7 @@ const NAV_ITEMS: AINavItem[] = [
     to: '/ai/daily-brief/today',
     matchPath: '/ai/daily-brief',
     trackName: 'OPEN_DAILY_BRIEF',
+    dailyBriefOnly: true,
   },
 ];
 
@@ -342,8 +346,13 @@ export function AISidebar({
   const { user } = useAuth();
   const { isAdmin } = useClawAdminAccessQuery(user?.id);
   const { canManage: canManageOrg } = useClawOrgManageAccess();
+  const { enabled: dailyBriefEnabled } = useDailyBriefEnabled();
+  const onDailyBriefRoute = pathname.includes('/ai/daily-brief');
   const visibleNavItems = NAV_ITEMS.filter(
-    item => (!item.adminOnly || isAdmin) && (!item.orgManagerOnly || canManageOrg),
+    item =>
+      (!item.adminOnly || isAdmin) &&
+      (!item.orgManagerOnly || canManageOrg) &&
+      (!item.dailyBriefOnly || dailyBriefEnabled === true || onDailyBriefRoute),
   );
   const isNewChatActive = !routedActiveItem && !activeSessionId;
 

--- a/apps/dashboard/src/components/AIScreen/AISidebar.tsx
+++ b/apps/dashboard/src/components/AIScreen/AISidebar.tsx
@@ -67,7 +67,7 @@ interface AINavItem {
 
 const NAV_ITEMS: AINavItem[] = [
   { key: 'knowledge', label: 'Knowledge', icon: Notebook as NavIcon, to: '/ai/knowledge' },
-  { key: 'library', label: 'Library', icon: LayoutGridStackDown as NavIcon, to: '/ai/library' },
+  { key: 'agent-hub', label: 'Agent Hub', icon: LayoutGridStackDown as NavIcon, to: '/ai/library' },
   { key: 'digital-twin', label: 'Digital twin', icon: UserTwo as NavIcon, to: '/ai/digital-twin' },
   {
     key: 'organization',

--- a/apps/dashboard/src/components/Settings/DailyBriefToggle.tsx
+++ b/apps/dashboard/src/components/Settings/DailyBriefToggle.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react';
+import { Switch } from '../ui/Switch';
+import { cn } from '../../utils/classNames';
+import { useDailyBriefEnabled } from '../../hooks/useDailyBriefEnabled';
+
+interface DailyBriefToggleProps {
+  /** Morning Brief lives inside the Xyne AI sidebar, which "Open AI on launch" gates. */
+  available: boolean;
+}
+
+export function DailyBriefToggle({ available }: DailyBriefToggleProps): ReactElement {
+  const { enabled, loading, saving, setEnabled } = useDailyBriefEnabled();
+  const stranded = !available && enabled === true;
+
+  return (
+    <div
+      className='mt-3 border-t border-border pt-3'
+      data-track-category='DailyBrief'
+      data-track-name='daily-brief-preferences-toggle'
+    >
+      <div className='flex items-center justify-between gap-4'>
+        <div className={cn(!available && 'opacity-50')}>
+          <p className='text-sm font-medium text-foreground'>Morning brief</p>
+          <p className='mt-0.5 text-xs text-muted-foreground'>
+            {available
+              ? 'A brief of everything waiting on you, ready each morning'
+              : 'Needs “Open AI on launch” — the brief lives in the Xyne AI sidebar'}
+          </p>
+        </div>
+        <Switch
+          id='daily-brief-enabled'
+          checked={enabled === true}
+          disabled={!available || loading || saving}
+          onCheckedChange={setEnabled}
+        />
+      </div>
+      {stranded && (
+        <p className='mt-2 text-xs text-amber-600 dark:text-amber-500'>
+          Your morning brief is still being generated each day. Turn “Open AI on launch” back on to
+          switch it off.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -47,6 +47,7 @@ import { MeetingDetectionToggle } from '../MeetingDetectionToggle';
 import { MenuBarIconToggle } from '../MenuBarIconToggle';
 import { RecordingPillToggle } from '../RecordingPillToggle';
 import { ClawOverlayToggle } from '../ClawOverlayToggle';
+import { DailyBriefToggle } from '../DailyBriefToggle';
 import { UpdateAssignmentStatusModal } from '../../AppSidebar/UpdateAssignmentStatusModal';
 import { VoiceSignatureModal } from '../VoiceSignatureModal/VoiceSignatureModal';
 import HuddleIcon from '../../icons/HuddleIcon';
@@ -807,18 +808,21 @@ const MessagingSection: FC<{ state: PreferencesState }> = ({ state }) => (
 const LaunchSection: FC<{ state: PreferencesState }> = ({ state }) => (
   <div className='space-y-4'>
     <SectionHeader title='Launch' subtitle='Configure your startup experience' />
-    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Open AI on launch</p>
-        <p className='text-xs text-muted-foreground mt-0.5'>
-          Start with the Xyne AI landing page instead of chat
-        </p>
+    <div className='p-3 rounded-lg border border-border bg-muted/30'>
+      <div className='flex items-center justify-between gap-4'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Open AI on launch</p>
+          <p className='text-xs text-muted-foreground mt-0.5'>
+            Start with the Xyne AI landing page instead of chat
+          </p>
+        </div>
+        <Switch
+          id='ai-landing-default'
+          checked={state.aiLandingDefault}
+          onCheckedChange={state.setAiLandingDefault}
+        />
       </div>
-      <Switch
-        id='ai-landing-default'
-        checked={state.aiLandingDefault}
-        onCheckedChange={state.setAiLandingDefault}
-      />
+      <DailyBriefToggle available={state.aiLandingDefault} />
     </div>
     <ClawOverlayToggle />
   </div>

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -3540,12 +3540,16 @@ img.inline-emoji,
  * The blend design system uses styled-components with hardcoded light-mode colors
  * from module-level defaults (R.colors.gray). Hover states use !important CSS
  * which can't be overridden by inline styles from the ThemeProvider context.
+ *
+ * `.rdp-root` is excluded because react-day-picker builds a real <table>: each
+ * week is a <tr> of day <td>s, so without the guard hovering any day paints the
+ * whole week row. :where() keeps the exclusion specificity-free.
  */
-[data-theme="midnight"] tr:hover > td {
+[data-theme="midnight"] tr:hover:not(:where(.rdp-root *)) > td {
   background-color: #222530 !important;
 }
 
-[data-theme="midnight"] tr:hover {
+[data-theme="midnight"] tr:hover:not(:where(.rdp-root *)) {
   background-color: #222530 !important;
 }
 
@@ -3869,22 +3873,32 @@ img.inline-emoji,
 /* Blend DataTable header cells - ensure proper dark mode text color.
    These target app data grids. Message tables must be excluded: the markdown
    renderer emits a real <thead> (the composer does not), so without the guard
-   the two paths get different header colours in midnight. */
+   the two paths get different header colours in midnight. `.rdp-root` is
+   excluded for the same reason — react-day-picker's weekday row is a real
+   <thead><th>, which otherwise picks up the data-grid header surface. */
 [data-theme="midnight"]
-  th:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *),
+  th:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ),
 [data-theme="midnight"]
   th
-  *:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *),
+  *:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ),
 [data-theme="midnight"]
   th
-  span:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *) {
+  span:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ) {
   color: #d1d5db !important;
 }
 
 /* Specific targeting for table header text with lower contrast */
 [data-theme="midnight"]
   thead
-  th:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *) {
+  th:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ) {
   color: #d1d5db !important;
   background-color: #1a1a1a !important;
 }
@@ -3893,7 +3907,7 @@ img.inline-emoji,
 [data-theme="midnight"]
   th
   :is(p, div, span):not(
-    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
   ) {
   color: #d1d5db !important;
 }
@@ -3901,7 +3915,9 @@ img.inline-emoji,
 /* Ensure high contrast for all header content */
 [data-theme="midnight"]
   thead
-  *:not(:where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary) *) {
+  *:not(
+    :where(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary, .rdp-root) *
+  ) {
   color: #d1d5db !important;
 }
 

--- a/apps/dashboard/src/hooks/useDailyBriefEnabled.ts
+++ b/apps/dashboard/src/hooks/useDailyBriefEnabled.ts
@@ -1,0 +1,28 @@
+import { useEffect, useSyncExternalStore } from 'react';
+import {
+  getDailyBriefEnabledState,
+  loadDailyBriefEnabled,
+  setDailyBriefEnabled,
+  subscribeDailyBriefEnabled,
+} from '../stores/dailyBriefEnabledStore';
+
+export function useDailyBriefEnabled(): {
+  /** null while the config is still loading. */
+  enabled: boolean | null;
+  loading: boolean;
+  saving: boolean;
+  setEnabled: (enabled: boolean) => void;
+} {
+  const state = useSyncExternalStore(subscribeDailyBriefEnabled, getDailyBriefEnabledState);
+
+  useEffect(() => {
+    void loadDailyBriefEnabled();
+  }, []);
+
+  return {
+    enabled: state.enabled,
+    loading: state.enabled === null,
+    saving: state.saving,
+    setEnabled: setDailyBriefEnabled,
+  };
+}

--- a/apps/dashboard/src/routes/AIScreen/library/LibraryV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/LibraryV2.tsx
@@ -100,7 +100,7 @@ const LibraryV2 = (): ReactElement => {
         <div className='flex items-center gap-5 pt-5'>
           <div className='flex min-w-0 flex-1 flex-col justify-center gap-1'>
             <h1 className='text-2xl font-semibold leading-[1.2] tracking-[-0.24px] text-foreground'>
-              Library
+              Agent Hub
             </h1>
             <p className='text-[15px] leading-[1.2] text-muted-foreground'>
               View and manage agents, subagent, skills and MCP.

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefFeaturesDialog.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefFeaturesDialog.tsx
@@ -1,0 +1,309 @@
+import { ComponentType, ReactElement, Ref, useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useMeasure } from 'react-use';
+import { ListAiGenerated, ReminderAnticlockwise, Settings02 } from '@xyne/icons';
+import { Dialog } from '../../components/ui/Dialog/Dialog';
+import { cn } from '../../utils/classNames';
+import {
+  CARD_CHROME,
+  MiniBriefCard,
+  MiniBriefSkeleton,
+  MiniHistoryCard,
+  MiniSettingsCard,
+} from './briefFeatureViews';
+
+type FeatureTab = 'default' | 'settings' | 'regenerate' | 'history';
+
+// Both curves are strong ease-outs: fast start, gentle settle. Size and content
+// share a duration so the panel reads as one entity rather than two animations.
+const SIZE_EASE = [0.25, 1, 0.5, 1] as const;
+const CONTENT_EASE = [0.19, 1, 0.22, 1] as const;
+const SIZE_DURATION = 0.27;
+const ENTER_DURATION = 0.27;
+// The user has already decided by the time something leaves — exits get out of the way.
+const EXIT_DURATION = 0.27;
+/** Height of the absolutely-positioned title + tabs bar. The stage below it is
+ *  inset by this much so centring happens in the space actually left over. */
+const HEADER_H = 56;
+/** How long the regenerate demo holds on its skeleton before the brief resolves. */
+const SKELETON_MS = 1100;
+/** Order the stepper walks, and how long each step holds before advancing. */
+const STEPS: FeatureTab[] = ['default', 'regenerate', 'settings', 'history'];
+const STEP_MS = 3400;
+
+interface TabSpec {
+  value: Exclude<FeatureTab, 'default'>;
+  label: string;
+  icon: ComponentType<{ size?: number; className?: string }>;
+}
+
+const TABS: TabSpec[] = [
+  { value: 'regenerate', label: 'Regenerate', icon: ListAiGenerated },
+  { value: 'settings', label: 'Settings', icon: Settings02 },
+  { value: 'history', label: 'History', icon: ReminderAnticlockwise },
+];
+
+const TITLES: Record<FeatureTab, string> = {
+  default: 'Your morning brief',
+  regenerate: 'Re-run it any time',
+  settings: 'Make it yours',
+  history: 'Every brief, kept',
+};
+
+const DESCRIPTIONS: Record<FeatureTab, string> = {
+  default: 'Everything that needs you, is overdue, waiting, and assigned to you summarized',
+  settings: 'Customize tone, priorities, and what each section covers.',
+  regenerate: 'Re-run the brief with your latest tickets, threads, and approvals.',
+  history: 'Browse past briefs and see what changed day to day.',
+};
+
+interface BriefFeaturesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function BriefFeaturesDialog({
+  open,
+  onOpenChange,
+}: BriefFeaturesDialogProps): ReactElement {
+  const [tab, setTab] = useState<FeatureTab>('default');
+  const [regenSettled, setRegenSettled] = useState(false);
+  const [autoplay, setAutoplay] = useState(true);
+  const reduce = useReducedMotion();
+  const enter = reduce
+    ? { from: { opacity: 0 }, to: { opacity: 1 } }
+    : {
+        from: { opacity: 0, filter: 'blur(2px)', scale: 0.96 },
+        to: { opacity: 1, filter: 'blur(0px)', scale: 1 },
+      };
+  const [frameRef] = useMeasure();
+  const [contentRef, content] = useMeasure();
+
+  useEffect(() => {
+    if (!open) return;
+    setTab('default');
+    setAutoplay(true);
+  }, [open]);
+
+  // Regenerate demo: hold the skeleton, then resolve. Re-runs on every entry to
+  // the tab so the animation is the thing you actually see.
+  // Regenerate holds longer: its own skeleton eats the first second of the step.
+  const dwellMs = tab === 'regenerate' ? STEP_MS + SKELETON_MS : STEP_MS;
+
+  // Auto-advance. Off under reduced motion — auto-updating content is exactly
+  // what that preference asks us not to do — and off for good once the reader
+  // picks a tab themselves, so the stepper never fights them.
+  useEffect(() => {
+    if (!open || !autoplay || reduce) return undefined;
+    const id = window.setTimeout(() => {
+      setTab(current => STEPS[(STEPS.indexOf(current) + 1) % STEPS.length] ?? 'default');
+    }, dwellMs);
+    return () => window.clearTimeout(id);
+  }, [open, autoplay, reduce, tab, dwellMs]);
+
+  useEffect(() => {
+    if (tab !== 'regenerate') return undefined;
+    setRegenSettled(false);
+    const id = window.setTimeout(() => setRegenSettled(true), SKELETON_MS);
+    return () => window.clearTimeout(id);
+  }, [tab]);
+
+  const body = useMemo(() => {
+    switch (tab) {
+      case 'default':
+        return <MiniBriefCard />;
+      case 'regenerate':
+        return regenSettled ? <MiniBriefCard regenerated /> : <MiniBriefSkeleton />;
+      case 'settings':
+        return <MiniSettingsCard />;
+      case 'history':
+        return <MiniHistoryCard />;
+    }
+  }, [tab, regenSettled]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Xyne Brief'
+      description='What you can do with your daily brief'
+      className='h-[560px] w-[540px] max-w-[540px] rounded-[28px] border border-border p-1.5 pb-5'
+    >
+      <div className='flex h-full flex-col items-center gap-4'>
+        <div className='flex min-h-0 flex-1 flex-col items-center gap-3 self-stretch'>
+          {/* The frame is fixed; only what sits inside it changes size. */}
+          <div
+            ref={frameRef as Ref<HTMLDivElement> | undefined}
+            className={cn(
+              'relative min-h-0 flex-1 self-stretch overflow-hidden rounded-[22px] border border-border',
+              'shadow-[0px_43px_17px_0px_rgba(0,0,0,0.01),0px_24px_15px_0px_rgba(0,0,0,0.02),0px_11px_11px_0px_rgba(0,0,0,0.03),0px_3px_6px_0px_rgba(0,0,0,0.04)]',
+            )}
+          >
+            {/* Reuses the app's themed wallpaper variable rather than a new asset, so
+                midnight gets its own image for free. Scaled past the edges because
+                the blur would otherwise pull the frame's border inward. */}
+            <div
+              aria-hidden
+              className='app-wallpaper-image pointer-events-none absolute inset-0 scale-125 bg-cover bg-center bg-no-repeat blur-2xl'
+            />
+            <div aria-hidden className='pointer-events-none absolute inset-0 bg-background/50' />
+
+            {/* Everything that animates lives in a stage inset below the header,
+                so `justify-center` centres it in the free area rather than the
+                whole frame — otherwise the header's height all lands underneath.
+                It also gives the back cards' `calc(50% - …)` the right basis. */}
+            <div
+              className='absolute inset-x-0 bottom-0 flex items-center justify-center'
+              style={{ top: HEADER_H }}
+            >
+              {/* The container carries the card chrome, so its size change IS the
+                visible morph. z-10 keeps it above the transformed card behind it,
+                which would otherwise paint on top by CSS painting order. */}
+              <motion.div
+                className={cn(
+                  CARD_CHROME,
+                  'relative z-10 flex items-start justify-center overflow-hidden rounded-[16px] select-none',
+                )}
+                animate={{ width: content.width, height: content.height }}
+                transition={reduce ? { duration: 0 } : { duration: SIZE_DURATION, ease: SIZE_EASE }}
+              >
+                <div ref={contentRef as Ref<HTMLDivElement> | undefined} className='w-fit'>
+                  <AnimatePresence initial={false} mode='popLayout'>
+                    <motion.div
+                      key={tab === 'regenerate' ? `regenerate-${regenSettled}` : tab}
+                      initial={enter.from}
+                      animate={enter.to}
+                      exit={enter.from}
+                      transition={{ duration: ENTER_DURATION, ease: CONTENT_EASE }}
+                    >
+                      {body}
+                    </motion.div>
+                  </AnimatePresence>
+                </div>
+              </motion.div>
+            </div>
+
+            <div className='absolute top-0 inset-x-0 flex justify-between p-1.5 items-center'>
+              <p className='font-serif text-base italic leading-normal text-muted-foreground pl-2.5'>
+                Xyne Brief
+              </p>
+              <div className='bg-background flex shrink-0 items-center justify-center gap-2 border-[0.5px] border-border rounded-2xl p-2'>
+                {TABS.map(({ value, label, icon: IconComponent }) => {
+                  const isActive = tab === value;
+                  return (
+                    <button
+                      key={value}
+                      type='button'
+                      onClick={() => {
+                        setTab(isActive ? 'default' : value);
+                        setAutoplay(false);
+                      }}
+                      aria-pressed={isActive}
+                      data-track-category='DailyBrief'
+                      data-track-name='daily-brief-features-tab'
+                      data-track-metadata={JSON.stringify({ tab: value })}
+                      className={cn(
+                        'flex h-9 items-center rounded-[10px] px-2.5 transition-colors duration-200 ease-out',
+                        isActive
+                          ? 'bg-accent text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+                      )}
+                    >
+                      <span className='flex size-5 shrink-0 items-center justify-center'>
+                        <IconComponent size={20} />
+                      </span>
+                      <span
+                        className={cn(
+                          'grid overflow-hidden transition-[grid-template-columns,opacity,margin] duration-200 ease-out',
+                          isActive
+                            ? 'ml-2 grid-cols-[1fr] opacity-100'
+                            : 'grid-cols-[0fr] opacity-0',
+                        )}
+                      >
+                        <span className='min-w-0 overflow-hidden whitespace-nowrap text-[14px] font-medium leading-[1.2] tracking-[-0.1px]'>
+                          {label}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className='flex shrink-0 flex-col items-center gap-2'>
+          <div className='grid h-7 place-items-center'>
+            <AnimatePresence initial={false} mode='popLayout'>
+              <motion.p
+                key={tab}
+                initial={enter.from}
+                animate={enter.to}
+                exit={enter.from}
+                transition={{ duration: EXIT_DURATION, ease: CONTENT_EASE }}
+                className='col-start-1 row-start-1 text-center text-[17px] font-semibold tracking-[-0.2px] text-foreground'
+              >
+                {TITLES[tab]}
+              </motion.p>
+            </AnimatePresence>
+          </div>
+          <div className='grid h-16 place-items-start px-3'>
+            <AnimatePresence initial={false} mode='popLayout'>
+              <motion.p
+                key={tab}
+                initial={enter.from}
+                animate={enter.to}
+                exit={enter.from}
+                transition={{ duration: EXIT_DURATION, ease: CONTENT_EASE }}
+                className='col-start-1 row-start-1 text-center text-base font-normal leading-[1.5] tracking-[-0.1px] text-foreground'
+              >
+                {DESCRIPTIONS[tab]}
+              </motion.p>
+            </AnimatePresence>
+          </div>
+
+          <div className='flex items-center justify-center gap-1.5'>
+            {STEPS.map(step => {
+              const isActive = tab === step;
+              return (
+                <button
+                  key={step}
+                  type='button'
+                  aria-label={TITLES[step]}
+                  aria-current={isActive ? 'step' : undefined}
+                  onClick={() => {
+                    setTab(step);
+                    setAutoplay(false);
+                  }}
+                  data-track-category='DailyBrief'
+                  data-track-name='daily-brief-features-step'
+                  data-track-metadata={JSON.stringify({ step })}
+                  className={cn(
+                    'h-1.5 overflow-hidden rounded-full bg-muted-foreground/25 transition-all duration-300 ease-out',
+                    isActive ? 'w-7' : 'w-1.5 hover:bg-muted-foreground/50',
+                  )}
+                >
+                  {isActive && (
+                    <motion.span
+                      // Re-keyed per step so the fill restarts rather than resuming.
+                      key={`${step}-${String(autoplay)}`}
+                      className='block h-full rounded-full bg-primary'
+                      initial={{ width: autoplay && !reduce ? '0%' : '100%' }}
+                      animate={{ width: '100%' }}
+                      // A progress timer is constant motion — linear is correct here.
+                      transition={
+                        autoplay && !reduce
+                          ? { duration: dwellMs / 1000, ease: 'linear' }
+                          : { duration: 0 }
+                      }
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefHistoryMenu.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefHistoryMenu.tsx
@@ -1,45 +1,72 @@
-import { ReactElement, useState } from 'react';
-import { ChevronBigDown, ClockDefault, File02Default } from '@xyne/icons';
+import { ReactElement, Ref, useCallback, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useMeasure } from 'react-use';
+import { ClockDefault } from '@xyne/icons';
 import { Popover } from '../../components/ui/Popover';
 import { cn } from '../../utils/classNames';
 import { APP_NO_DRAG_STYLE } from '../../utils/electronApp';
+import { BriefListView } from './BriefListView';
+import { CalendarView } from './CalendarView';
 import type { DailyBriefHistoryItem } from '../../api/dailyBriefApi';
 
 export const HEADER_ICON_CLASS =
   'flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] text-muted-foreground ' +
   'transition-colors hover:bg-accent hover:text-foreground';
 
-function briefMenuLabel(date: string): string {
-  const parsed = new Date(`${date}T00:00:00`);
-  if (Number.isNaN(parsed.getTime())) return `Morning Brief ${date}`;
-  const day = parsed.getDate();
-  const month = parsed.toLocaleDateString(undefined, { month: 'short' });
-  return `Morning Brief ${day} ${month}`;
-}
+type BriefMenuView = 'list' | 'calendar';
 
 interface BriefHistoryMenuProps {
   history: DailyBriefHistoryItem[];
+  availableDates: string[];
   selectedDate: string | null;
-  onSelect: (date: string) => void;
+  onSelect: (date: string, source: 'history_menu' | 'date_picker') => void;
 }
-
-const COLLAPSED_COUNT = 5;
 
 export function BriefHistoryMenu({
   history,
+  availableDates,
   selectedDate,
   onSelect,
 }: BriefHistoryMenuProps): ReactElement {
   const [open, setOpen] = useState(false);
-  const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<BriefMenuView>('list');
+  const [elementRef, bounds] = useMeasure();
 
-  const handleOpenChange = (next: boolean): void => {
+  const handleOpenChange = useCallback((next: boolean): void => {
     setOpen(next);
-    if (!next) setExpanded(false);
-  };
+    if (next) setView('list');
+  }, []);
 
-  const visible = expanded ? history : history.slice(0, COLLAPSED_COUNT);
-  const hiddenCount = history.length - visible.length;
+  const handleSelect = useCallback(
+    (date: string, source: 'history_menu' | 'date_picker'): void => {
+      onSelect(date, source);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
+  const content = useMemo(() => {
+    switch (view) {
+      case 'list':
+        return (
+          <BriefListView
+            history={history}
+            selectedDate={selectedDate}
+            onSelect={handleSelect}
+            onBrowseDates={() => setView('calendar')}
+          />
+        );
+      case 'calendar':
+        return (
+          <CalendarView
+            availableDates={availableDates}
+            selectedDate={selectedDate}
+            onSelect={handleSelect}
+            onBack={() => setView('list')}
+          />
+        );
+    }
+  }, [view, history, availableDates, selectedDate, handleSelect]);
 
   return (
     <Popover
@@ -49,7 +76,7 @@ export function BriefHistoryMenu({
       align='end'
       sideOffset={8}
       collisionPadding={12}
-      className='w-[232px] max-h-[250px] overflow-y-auto rounded-[12px] border-border bg-popover p-1.5 shadow-lg'
+      className='w-[276px] overflow-hidden rounded-[12px] border-border bg-popover p-1.5 shadow-lg'
       trigger={
         <button
           type='button'
@@ -63,54 +90,30 @@ export function BriefHistoryMenu({
         </button>
       }
     >
-      {history.length === 0 ? (
-        <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No past briefs.</div>
-      ) : (
-        <ul className='flex flex-col gap-px'>
-          {visible.map(item => {
-            const isActive = selectedDate === item.date;
-            return (
-              <li key={item.date}>
-                <button
-                  type='button'
-                  onClick={() => {
-                    onSelect(item.date);
-                    setOpen(false);
-                  }}
-                  data-track-category='DailyBrief'
-                  data-track-name='daily-brief-history-item'
-                  className={cn(
-                    'flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left',
-                    'text-[14px] tracking-[-0.1px] transition-colors',
-                    isActive
-                      ? 'bg-accent font-medium text-foreground'
-                      : 'font-normal text-muted-foreground hover:bg-accent hover:text-foreground',
-                  )}
-                >
-                  <File02Default size={16} className='shrink-0 text-muted-foreground' />
-                  <span className='truncate'>{briefMenuLabel(item.date)}</span>
-                </button>
-              </li>
-            );
-          })}
-          {hiddenCount > 0 && (
-            <li>
-              <button
-                type='button'
-                onClick={() => setExpanded(true)}
-                data-track-category='DailyBrief'
-                data-track-name='daily-brief-history-show-all'
-                className='flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left text-[13px] font-medium tracking-[-0.1px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-              >
-                <span className='flex size-4 shrink-0 items-center justify-center'>
-                  <ChevronBigDown size={14} />
-                </span>
-                <span className='truncate'>Show all ({history.length})</span>
-              </button>
-            </li>
-          )}
-        </ul>
-      )}
+      <motion.div
+        className='~overflow-hidden'
+        animate={{
+          height: bounds.height,
+          transition: {
+            duration: 0.27,
+            ease: [0.25, 1, 0.5, 1],
+          },
+        }}
+      >
+        <div ref={elementRef as Ref<HTMLDivElement> | undefined}>
+          <AnimatePresence initial={false} mode='popLayout' custom={view}>
+            <motion.div
+              key={view}
+              initial={{ opacity: 0, scale: 1 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 1 }}
+              transition={{ duration: 0.27, ease: [0.26, 0.08, 0.25, 1] }}
+            >
+              {content}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </motion.div>
     </Popover>
   );
 }

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
@@ -5,9 +5,20 @@ import { cn } from '@/utils/classNames';
 interface BriefIntroBannerProps {
   onSeeMore: () => void;
   onDismiss: () => void;
+  /** Master opt-in for the scheduled brief. Undefined while the config is still loading. */
+  briefEnabled?: boolean | undefined;
+  onEnableBrief?: (() => void) | undefined;
+  enabling?: boolean | undefined;
 }
 
-export function BriefIntroBanner({ onSeeMore, onDismiss }: BriefIntroBannerProps): ReactElement {
+export function BriefIntroBanner({
+  onSeeMore,
+  onDismiss,
+  briefEnabled,
+  onEnableBrief,
+  enabling = false,
+}: BriefIntroBannerProps): ReactElement {
+  const showEnable = briefEnabled === false && onEnableBrief !== undefined;
   return (
     <div
       className={cn(
@@ -33,15 +44,34 @@ export function BriefIntroBanner({ onSeeMore, onDismiss }: BriefIntroBannerProps
         <p className='text-[16px] font-normal leading-[20px] text-foreground/80'>
           Everything that needs you, is overdue, waiting, and assigned to you summarized
         </p>
-        <button
-          type='button'
-          onClick={onSeeMore}
-          data-track-category='DailyBrief'
-          data-track-name='daily-brief-intro-see-more'
-          className='mt-1 flex h-7 items-center rounded-[8px] border border-border bg-background px-2.5 text-[14px] font-semibold leading-[20px] text-foreground shadow-sm transition-colors hover:bg-accent'
-        >
-          Learn more
-        </button>
+        {showEnable && (
+          <p className='text-[13px] leading-[18px] text-muted-foreground'>
+            You are not set up to receive this each morning yet.
+          </p>
+        )}
+        <div className='mt-1 flex items-center gap-2'>
+          {showEnable && (
+            <button
+              type='button'
+              onClick={onEnableBrief}
+              disabled={enabling}
+              data-track-category='DailyBrief'
+              data-track-name='daily-brief-intro-enable'
+              className='flex h-7 items-center rounded-[8px] bg-foreground px-2.5 text-[14px] font-semibold leading-[20px] text-background shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50'
+            >
+              {enabling ? 'Turning on…' : 'Turn on morning brief'}
+            </button>
+          )}
+          <button
+            type='button'
+            onClick={onSeeMore}
+            data-track-category='DailyBrief'
+            data-track-name='daily-brief-intro-see-more'
+            className='flex h-7 items-center rounded-[8px] border border-border bg-background px-2.5 text-[14px] font-semibold leading-[20px] text-foreground shadow-sm transition-colors hover:bg-accent'
+          >
+            Learn more
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
@@ -1,0 +1,48 @@
+import { ReactElement } from 'react';
+import { MultipleCrossCancelDefault } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+
+interface BriefIntroBannerProps {
+  onSeeMore: () => void;
+  onDismiss: () => void;
+}
+
+export function BriefIntroBanner({ onSeeMore, onDismiss }: BriefIntroBannerProps): ReactElement {
+  return (
+    <div
+      className={cn(
+        'isolate relative mb-8 overflow-hidden rounded-[16px] border border-border px-6 py-5 bg-white/5 ~bg-gradient-to-r ~from-primary/25 ~via-primary/10 ~to-primary/30',
+        'shadow-[0px_43px_26px_0px_rgba(0,0,0,0.01),0px_19px_19px_0px_rgba(0,0,0,0.02),0px_5px_10px_0px_rgba(0,0,0,0.02)]',
+        'before:pointer-events-none before:-z-10 before:absolute before:-inset-x-[12%] before:h-[550%] before:bottom-full before:translate-y-[9%] before:bg-[radial-gradient(50%_50%_at_50%_50%,hsl(var(--primary))_54%,transparent)] before:blur-2xl',
+      )}
+    >
+      <button
+        type='button'
+        aria-label='Dismiss'
+        onClick={onDismiss}
+        data-track-category='DailyBrief'
+        data-track-name='daily-brief-intro-dismiss'
+        className='absolute right-3 top-3 flex size-6 items-center justify-center rounded-[6px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+      >
+        <MultipleCrossCancelDefault size={14} />
+      </button>
+      <div className='flex flex-col items-center gap-2 text-center'>
+        <p className='font-serif text-[16px] font-bold italic leading-[20px] text-foreground'>
+          Your Morning Brief
+        </p>
+        <p className='text-[16px] font-normal leading-[20px] text-foreground/80'>
+          Everything that needs you, is overdue, waiting, and assigned to you summarized
+        </p>
+        <button
+          type='button'
+          onClick={onSeeMore}
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-intro-see-more'
+          className='mt-1 flex h-7 items-center rounded-[8px] border border-border bg-background px-2.5 text-[14px] font-semibold leading-[20px] text-foreground shadow-sm transition-colors hover:bg-accent'
+        >
+          Learn more
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefListView.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefListView.tsx
@@ -1,0 +1,73 @@
+import { ReactElement } from 'react';
+import { CalendarFilled, ChevronBigRight, File02Default } from '@xyne/icons';
+import { cn } from '../../utils/classNames';
+import type { DailyBriefHistoryItem } from '../../api/dailyBriefApi';
+
+function briefMenuLabel(date: string): string {
+  const parsed = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return `Morning Brief ${date}`;
+  const day = parsed.getDate();
+  const month = parsed.toLocaleDateString(undefined, { month: 'short' });
+  return `Morning Brief ${day} ${month}`;
+}
+
+interface BriefListViewProps {
+  history: DailyBriefHistoryItem[];
+  selectedDate: string | null;
+  onSelect: (date: string, source: 'history_menu' | 'date_picker') => void;
+  onBrowseDates: () => void;
+}
+
+export function BriefListView({
+  history,
+  selectedDate,
+  onSelect,
+  onBrowseDates,
+}: BriefListViewProps): ReactElement {
+  return (
+    <div className='flex flex-col'>
+      {history.length === 0 ? (
+        <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No past briefs.</div>
+      ) : (
+        <ul className='flex flex-col gap-px'>
+          {history.map(item => {
+            const isActive = selectedDate === item.date;
+            return (
+              <li key={item.date}>
+                <button
+                  type='button'
+                  onClick={() => onSelect(item.date, 'history_menu')}
+                  data-track-category='DailyBrief'
+                  data-track-name='daily-brief-history-item'
+                  className={cn(
+                    'flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left',
+                    'text-[14px] tracking-[-0.1px] transition-colors',
+                    isActive
+                      ? 'bg-accent font-medium text-foreground'
+                      : 'font-normal text-muted-foreground hover:bg-accent hover:text-foreground',
+                  )}
+                >
+                  <File02Default size={16} className='shrink-0 text-muted-foreground' />
+                  <span className='truncate'>{briefMenuLabel(item.date)}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <div className='mt-1 border-t border-border pt-1'>
+        <button
+          type='button'
+          onClick={onBrowseDates}
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-browse-by-date'
+          className='flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left text-[14px] font-normal tracking-[-0.1px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        >
+          <CalendarFilled size={16} className='shrink-0' />
+          <span className='flex-1 truncate'>Find a Brief</span>
+          <ChevronBigRight size={14} className='shrink-0' />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefSettingsDialog.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefSettingsDialog.tsx
@@ -184,6 +184,7 @@ export function BriefSettingsDialog({
               disabled={saving}
               data-track-category='DailyBrief'
               data-track-name='daily-brief-settings-cancel'
+              className='rounded-lg'
             >
               Cancel
             </Button>
@@ -194,6 +195,7 @@ export function BriefSettingsDialog({
               disabled={loading || saving || overLimit || busy}
               data-track-category='DailyBrief'
               data-track-name='daily-brief-settings-save-regenerate'
+              className='rounded-lg'
             >
               Save & regenerate
             </Button>
@@ -204,6 +206,7 @@ export function BriefSettingsDialog({
               loading={saving}
               data-track-category='DailyBrief'
               data-track-name='daily-brief-settings-save'
+              className='rounded-lg'
             >
               Save
             </Button>

--- a/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
@@ -1,14 +1,16 @@
 import { ReactElement, useMemo } from 'react';
 import { format } from 'date-fns';
-import { Calendar } from '../../components/ui/Calendar';
-import { ChevronBigLeft } from '@xyne/icons';
-
+import { DayPicker } from 'react-day-picker';
+import { ChevronBigLeft, ChevronBigRight } from '@xyne/icons';
 const BUCKET_FORMAT = 'yyyy-MM-dd';
 
 function parseBucket(date: string): Date | null {
   const parsed = new Date(`${date}T00:00:00`);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
+
+const NAV_BUTTON_CLASS =
+  'z-10 inline-flex size-7 items-center justify-center rounded-[8px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40 aria-disabled:pointer-events-none aria-disabled:opacity-40';
 
 interface CalendarViewProps {
   /** Every day the user has a brief for, as YYYY-MM-DD buckets. */
@@ -43,40 +45,62 @@ export function CalendarView({
   };
 
   return (
-    <div className='flex flex-col'>
-      <div className='flex items-center gap-1 pb-1 pl-0.5 pr-2.5'>
-        <button
-          type='button'
-          onClick={onBack}
-          aria-label='Back to recent briefs'
-          data-track-category='DailyBrief'
-          data-track-name='daily-brief-calendar-back'
-          className='flex size-7 shrink-0 items-center justify-center rounded-[8px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-        >
-          <ChevronBigLeft size={14} />
-        </button>
-        <span className='text-[13px] font-medium tracking-[-0.1px] text-foreground'>
-          Select a date
-        </span>
-      </div>
+    <div className='flex flex-col gap-2'>
+      <button
+        type='button'
+        onClick={onBack}
+        aria-label='Back to recent briefs'
+        data-track-category='DailyBrief'
+        data-track-name='daily-brief-calendar-back'
+        className='self-start flex items-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground pl-0.5 pr-1 py-0.5'
+      >
+        <ChevronBigLeft size={14} variant='Solid' />
+        <span className='text-xs font-medium tracking-[-0.1px] text-foreground'>List View</span>
+      </button>
       {availableDates.length === 0 ? (
         <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No briefs yet.</div>
       ) : (
-        <Calendar
+        <DayPicker
           mode='single'
+          navLayout='after'
+          showOutsideDays
+          weekStartsOn={0}
           {...(selectedObj && { selected: selectedObj })}
           onSelect={handleSelect}
           defaultMonth={defaultMonth}
           {...(bounds.earliest && { startMonth: bounds.earliest })}
           {...(bounds.latest && { endMonth: bounds.latest })}
           disabled={date => !dateSet.has(format(date, BUCKET_FORMAT))}
+          className='w-full'
           classNames={{
-            day: 'relative flex-1 p-0 text-center text-sm focus-within:relative focus-within:z-20',
+            months: 'flex w-full flex-col',
+            month: 'relative w-full',
+            month_caption: 'flex h-7 items-center px-2',
+            caption_label: 'text-lg font-medium tracking-[-0.1px] text-foreground',
+            nav: 'absolute top-0 right-0 px-1',
+            button_previous: `${NAV_BUTTON_CLASS}`,
+            button_next: `${NAV_BUTTON_CLASS}`,
+            month_grid: 'mt-1 w-full border-collapse',
+            weekdays: 'flex w-full',
+            weekday:
+              'flex h-7 flex-1 items-center justify-center text-[11px] font-normal text-muted-foreground',
+            week: 'flex w-full',
+            day: 'flex-1 p-0 text-center',
+            day_button:
+              'flex h-8 w-full items-center justify-center rounded-[8px] text-[13px] font-normal text-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none disabled:pointer-events-none disabled:text-muted-foreground/30',
             selected:
-              'bg-primary text-white hover:bg-primary hover:text-white focus:bg-primary focus:text-white rounded-md',
-            // root: 'relative',
+              '[&_button]:bg-primary [&_button]:text-white [&_button]:hover:bg-primary [&_button]:hover:text-white',
+            today: '[&_button]:font-semibold',
+            outside: '[&_button]:text-muted-foreground/40',
+            disabled: '[&_button]:text-muted-foreground/30',
+            hidden: 'invisible',
           }}
-          // navLayout='around'
+          components={{
+            Chevron: ({ orientation }) => {
+              const Icon = orientation === 'left' ? ChevronBigLeft : ChevronBigRight;
+              return <Icon size={18} />;
+            },
+          }}
           data-track-category='DailyBrief'
           data-track-name='daily-brief-calendar-day'
         />

--- a/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
@@ -1,0 +1,86 @@
+import { ReactElement, useMemo } from 'react';
+import { format } from 'date-fns';
+import { Calendar } from '../../components/ui/Calendar';
+import { ChevronBigLeft } from '@xyne/icons';
+
+const BUCKET_FORMAT = 'yyyy-MM-dd';
+
+function parseBucket(date: string): Date | null {
+  const parsed = new Date(`${date}T00:00:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+interface CalendarViewProps {
+  /** Every day the user has a brief for, as YYYY-MM-DD buckets. */
+  availableDates: string[];
+  selectedDate: string | null;
+  onSelect: (date: string, source: 'history_menu' | 'date_picker') => void;
+  onBack: () => void;
+}
+
+export function CalendarView({
+  availableDates,
+  selectedDate,
+  onSelect,
+  onBack,
+}: CalendarViewProps): ReactElement {
+  const dateSet = useMemo(() => new Set(availableDates), [availableDates]);
+
+  const bounds = useMemo(() => {
+    const parsed = availableDates
+      .map(parseBucket)
+      .filter((value): value is Date => value !== null)
+      .sort((a, b) => a.getTime() - b.getTime());
+    return { earliest: parsed[0] ?? null, latest: parsed[parsed.length - 1] ?? null };
+  }, [availableDates]);
+
+  const selectedObj = selectedDate ? parseBucket(selectedDate) : null;
+  const defaultMonth = selectedObj ?? bounds.latest ?? new Date();
+
+  const handleSelect = (date: Date | undefined): void => {
+    if (!date) return;
+    onSelect(format(date, BUCKET_FORMAT), 'date_picker');
+  };
+
+  return (
+    <div className='flex flex-col'>
+      <div className='flex items-center gap-1 pb-1 pl-0.5 pr-2.5'>
+        <button
+          type='button'
+          onClick={onBack}
+          aria-label='Back to recent briefs'
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-calendar-back'
+          className='flex size-7 shrink-0 items-center justify-center rounded-[8px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+        >
+          <ChevronBigLeft size={14} />
+        </button>
+        <span className='text-[13px] font-medium tracking-[-0.1px] text-foreground'>
+          Select a date
+        </span>
+      </div>
+      {availableDates.length === 0 ? (
+        <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No briefs yet.</div>
+      ) : (
+        <Calendar
+          mode='single'
+          {...(selectedObj && { selected: selectedObj })}
+          onSelect={handleSelect}
+          defaultMonth={defaultMonth}
+          {...(bounds.earliest && { startMonth: bounds.earliest })}
+          {...(bounds.latest && { endMonth: bounds.latest })}
+          disabled={date => !dateSet.has(format(date, BUCKET_FORMAT))}
+          classNames={{
+            day: 'relative flex-1 p-0 text-center text-sm focus-within:relative focus-within:z-20',
+            selected:
+              'bg-primary text-white hover:bg-primary hover:text-white focus:bg-primary focus:text-white rounded-md',
+            // root: 'relative',
+          }}
+          // navLayout='around'
+          data-track-category='DailyBrief'
+          data-track-name='daily-brief-calendar-day'
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
@@ -8,6 +8,7 @@ import { createMarkdownComponents } from '../../utils/markdownComponents';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
 import { useIsInPanelWebview } from '../../hooks/useIsInPanelWebview';
+import { useDailyBriefEnabled } from '../../hooks/useDailyBriefEnabled';
 import { BriefHistoryMenu, HEADER_ICON_CLASS } from './BriefHistoryMenu';
 import { BriefSettingsDialog } from './BriefSettingsDialog';
 import { BriefIntroBanner } from './BriefIntroBanner';
@@ -203,6 +204,11 @@ const DailyBriefScreen = (): ReactElement => {
   const regenerateStartedAtRef = useRef<number | null>(null);
   const isInPanelWebview = useIsInPanelWebview();
   const { introSeen, markIntroSeen } = useBriefIntroSeen();
+  const {
+    enabled: briefEnabled,
+    saving: briefEnabling,
+    setEnabled: setBriefEnabled,
+  } = useDailyBriefEnabled();
 
   const load = useCallback(async (opts?: { quiet?: boolean }) => {
     if (!mountedRef.current) return;
@@ -433,7 +439,27 @@ const DailyBriefScreen = (): ReactElement => {
       return <BriefSkeleton />;
     }
     if (!selected) {
-      return <p className={BODY_TEXT_CLASS}>No brief to show yet. Use “Generate” to create one.</p>;
+      return (
+        <div className='flex flex-col items-start gap-3'>
+          <p className={BODY_TEXT_CLASS}>
+            {briefEnabled === false
+              ? 'No brief to show yet. Turn on the morning brief to get one each day, or use “Generate” to create one now.'
+              : 'No brief to show yet. Use “Generate” to create one.'}
+          </p>
+          {briefEnabled === false && (
+            <button
+              type='button'
+              onClick={() => setBriefEnabled(true)}
+              disabled={briefEnabling}
+              data-track-category='DailyBrief'
+              data-track-name='daily-brief-empty-enable'
+              className='flex h-7 items-center rounded-[8px] bg-foreground px-2.5 text-[14px] font-semibold leading-[20px] text-background shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50'
+            >
+              {briefEnabling ? 'Turning on…' : 'Turn on morning brief'}
+            </button>
+          )}
+        </div>
+      );
     }
     if (IS_DEV && showRaw) {
       return (
@@ -577,7 +603,13 @@ const DailyBriefScreen = (): ReactElement => {
       <main className='min-h-0 flex-1 overflow-y-auto px-6 pb-16'>
         <article className='mx-auto w-full max-w-[750px]'>
           {!introSeen && !isBusy && (
-            <BriefIntroBanner onSeeMore={() => setFeaturesOpen(true)} onDismiss={markIntroSeen} />
+            <BriefIntroBanner
+              onSeeMore={() => setFeaturesOpen(true)}
+              onDismiss={markIntroSeen}
+              briefEnabled={briefEnabled ?? undefined}
+              onEnableBrief={() => setBriefEnabled(true)}
+              enabling={briefEnabling}
+            />
           )}
           {hasBrief && !isBusy && (
             <h1 className='py-10 text-center font-serif text-[40px] font-semibold italic leading-[1.2] text-foreground'>

--- a/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
@@ -3,13 +3,16 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Settings01 } from '@xyne/icons';
+import { InformationCircle, ListAiGenerated, Settings01 } from '@xyne/icons';
 import { createMarkdownComponents } from '../../utils/markdownComponents';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
 import { useIsInPanelWebview } from '../../hooks/useIsInPanelWebview';
 import { BriefHistoryMenu, HEADER_ICON_CLASS } from './BriefHistoryMenu';
 import { BriefSettingsDialog } from './BriefSettingsDialog';
+import { BriefIntroBanner } from './BriefIntroBanner';
+import { BriefFeaturesDialog } from './BriefFeaturesDialog';
+import { useBriefIntroSeen } from './useBriefIntroSeen';
 import { BriefLine, useBriefRenderContext, type BriefRenderContext } from './briefText';
 import { RawBriefView } from './RawBriefView';
 import { BriefSkeleton } from './BriefSkeleton';
@@ -22,6 +25,7 @@ import {
 import {
   trackDailyBriefRegenerateAbandoned,
   trackDailyBriefSwitched,
+  type BriefSwitchSource,
 } from '../../services/otel/dailyBriefMetrics';
 
 const REMARK_PLUGINS = [remarkGfm];
@@ -167,17 +171,25 @@ function BriefSection({
 
 const BRIEF_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const TODAY_SEGMENT = 'today';
+// Today's brief plus the previous seven. Anything older is fetched on demand
+// when the date picker routes to it.
+const HISTORY_LIMIT = 7;
 
 const DailyBriefScreen = (): ReactElement => {
   const [latest, setLatest] = useState<DailyBriefLatest | null>(null);
   const [history, setHistory] = useState<DailyBriefHistoryItem[]>([]);
+  const [availableDates, setAvailableDates] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // A brief older than the loaded window, pulled in by URL/date-picker.
+  const [fetched, setFetched] = useState<SelectedBrief | null>(null);
+  const [fetching, setFetching] = useState(false);
 
   const [regenerating, setRegenerating] = useState(false);
   const [progress, setProgress] = useState<string | null>(null);
   const [showRaw, setShowRaw] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [featuresOpen, setFeaturesOpen] = useState(false);
   const mountedRef = useRef(true);
   const navigate = useNavigate();
   const { workspaceId, briefDate } = useParams();
@@ -190,6 +202,7 @@ const DailyBriefScreen = (): ReactElement => {
   // Read on unmount, where component state is already stale.
   const regenerateStartedAtRef = useRef<number | null>(null);
   const isInPanelWebview = useIsInPanelWebview();
+  const { introSeen, markIntroSeen } = useBriefIntroSeen();
 
   const load = useCallback(async (opts?: { quiet?: boolean }) => {
     if (!mountedRef.current) return;
@@ -198,13 +211,15 @@ const DailyBriefScreen = (): ReactElement => {
       setError(null);
     }
     try {
-      const [latestRes, historyRes] = await Promise.all([
+      const [latestRes, historyRes, datesRes] = await Promise.all([
         dailyBriefApi.getLatest(),
-        dailyBriefApi.getHistory(),
+        dailyBriefApi.getHistory(HISTORY_LIMIT),
+        dailyBriefApi.getDates(),
       ]);
       if (!mountedRef.current) return;
       setLatest(latestRes);
       setHistory(historyRes);
+      setAvailableDates(datesRes.map(item => item.date));
     } catch {
       if (mountedRef.current && !opts?.quiet) setError('Failed to load daily brief.');
     } finally {
@@ -234,13 +249,46 @@ const DailyBriefScreen = (): ReactElement => {
     void navigate(todayPath, { replace: true });
   }, [briefDate, navigate, todayPath]);
 
-  // A well-formed date with no brief behind it would otherwise render the
-  // latest brief under a URL that disagrees with it.
+  const inHistory = selectedDate !== null && history.some(item => item.date === selectedDate);
+
+  // Dates outside the loaded window are legitimate — the picker can reach any
+  // day the user has a brief for, so fetch it rather than bouncing to today.
   useEffect(() => {
-    if (loading || selectedDate === null) return;
-    if (history.some(item => item.date === selectedDate)) return;
-    void navigate(todayPath, { replace: true });
-  }, [loading, selectedDate, history, navigate, todayPath]);
+    if (loading || selectedDate === null || inHistory) {
+      setFetched(null);
+      setFetching(false);
+      return undefined;
+    }
+    let cancelled = false;
+    setFetching(true);
+    void dailyBriefApi
+      .getByDate(selectedDate)
+      .then(res => {
+        if (cancelled) return;
+        if (!res || res.status === 'none') {
+          setFetched(null);
+          void navigate(todayPath, { replace: true });
+          return;
+        }
+        setFetched({
+          date: res.date ?? selectedDate,
+          status: res.status,
+          content: res.content ?? '',
+          data: res.data ?? null,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFetched(null);
+        setError('Failed to load that brief.');
+      })
+      .finally(() => {
+        if (!cancelled) setFetching(false);
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [loading, selectedDate, inHistory, navigate, todayPath]);
 
   const selected = useMemo((): SelectedBrief | null => {
     if (selectedDate) {
@@ -253,6 +301,7 @@ const DailyBriefScreen = (): ReactElement => {
           data: fromHistory.data ?? null,
         };
       }
+      return fetched?.date === selectedDate ? fetched : null;
     }
     if (latest && latest.status !== 'none') {
       return {
@@ -263,7 +312,7 @@ const DailyBriefScreen = (): ReactElement => {
       };
     }
     return null;
-  }, [selectedDate, history, latest]);
+  }, [selectedDate, history, latest, fetched]);
 
   const briefStatus = selected?.status;
   const briefGenerating = briefStatus === 'generating';
@@ -334,10 +383,14 @@ const DailyBriefScreen = (): ReactElement => {
   }, [generationInFlight, load, navigate, todayPath]);
 
   const currentDate = selected?.date ?? null;
+  const activeDate = currentDate ?? selectedDate;
   const handleSelectDate = useCallback(
-    (date: string) => {
+    (date: string, source: BriefSwitchSource) => {
       if (date !== currentDate) {
-        trackDailyBriefSwitched();
+        trackDailyBriefSwitched(source);
+        // Device-scoped `instance` cannot answer "how many users" — the server
+        // counts distinct userIds behind this beacon instead.
+        void dailyBriefApi.trackSwitch(source);
       }
       void navigate(date === todayBucket ? todayPath : `${briefPath}/${date}`);
     },
@@ -363,10 +416,13 @@ const DailyBriefScreen = (): ReactElement => {
   // A regeneration always targets today, so it only blanks the body when today
   // is what you're looking at — other briefs stay readable while it runs.
   const isBusy =
-    (loading && !selected) || (viewingToday && regenerating) || (!showRaw && briefGenerating);
+    (loading && !selected) ||
+    fetching ||
+    (viewingToday && regenerating) ||
+    (!showRaw && briefGenerating);
 
   const actionLabel = ((): string => {
-    if (loading && !selected) return 'Loading…';
+    if ((loading && !selected) || fetching) return 'Loading…';
     if (regenerating) return hasBrief ? 'Regenerating…' : 'Generating…';
     if (briefGenerating) return 'Generating…';
     return hasBrief ? 'Regenerate' : 'Generate';
@@ -476,8 +532,9 @@ const DailyBriefScreen = (): ReactElement => {
             style={APP_NO_DRAG_STYLE}
             data-track-category='DailyBrief'
             data-track-name='daily-brief-regenerate'
-            className='mr-1 rounded-[8px] border border-border px-3 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
+            className='mr-1 flex items-center gap-1.5 rounded-[8px] border border-border px-3 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
           >
+            <ListAiGenerated size={16} className='shrink-0' />
             {actionLabel}
           </button>
           <button
@@ -493,9 +550,21 @@ const DailyBriefScreen = (): ReactElement => {
           </button>
           <BriefHistoryMenu
             history={history}
-            selectedDate={currentDate}
+            availableDates={availableDates}
+            selectedDate={activeDate}
             onSelect={handleSelectDate}
           />
+          <button
+            type='button'
+            aria-label='About the daily brief'
+            onClick={() => setFeaturesOpen(true)}
+            style={APP_NO_DRAG_STYLE}
+            data-track-category='DailyBrief'
+            data-track-name='daily-brief-open-features'
+            className={cn(HEADER_ICON_CLASS, featuresOpen && 'bg-accent text-foreground')}
+          >
+            <InformationCircle size={18} />
+          </button>
         </div>
       </header>
 
@@ -507,6 +576,9 @@ const DailyBriefScreen = (): ReactElement => {
 
       <main className='min-h-0 flex-1 overflow-y-auto px-6 pb-16'>
         <article className='mx-auto w-full max-w-[750px]'>
+          {!introSeen && !isBusy && (
+            <BriefIntroBanner onSeeMore={() => setFeaturesOpen(true)} onDismiss={markIntroSeen} />
+          )}
           {hasBrief && !isBusy && (
             <h1 className='py-10 text-center font-serif text-[40px] font-semibold italic leading-[1.2] text-foreground'>
               {formatBriefTitle(selected.date)}
@@ -539,6 +611,8 @@ const DailyBriefScreen = (): ReactElement => {
           {renderBody()}
         </article>
       </main>
+
+      <BriefFeaturesDialog open={featuresOpen} onOpenChange={setFeaturesOpen} />
 
       <BriefSettingsDialog
         open={settingsOpen}

--- a/apps/dashboard/src/routes/DailyBriefScreen/briefFeatureViews.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/briefFeatureViews.tsx
@@ -1,0 +1,223 @@
+import { ReactElement, ReactNode } from 'react';
+import { format, subDays } from 'date-fns';
+import { CalendarFilled, ChevronBigRight, File02Default } from '@xyne/icons';
+import { cn } from '../../utils/classNames';
+
+/** Chrome (border/bg/shadow/radius) belongs to the animated container in
+ *  BriefFeaturesDialog — a view that drew its own would snap to size while an
+ *  invisible box animated around it. Views declare width and padding only. */
+export const CARD_CHROME =
+  'border border-border bg-background shadow-[0px_3px_6px_0px_rgba(0,0,0,0.04)]';
+const BRIEF_BODY = 'w-[380px] px-5 pb-6 pt-5';
+const LABEL = 'w-[80px] shrink-0 text-[8px] font-semibold leading-[1.5] text-foreground';
+const BODY = 'text-[8px] leading-[1.5] text-muted-foreground';
+
+const Em = ({ children }: { children: ReactNode }): ReactElement => (
+  <b className='font-semibold text-foreground'>{children}</b>
+);
+const Mention = ({ children }: { children: ReactNode }): ReactElement => (
+  <span className='text-[color:var(--mention-color)]'>{children}</span>
+);
+
+interface MiniSectionSpec {
+  label: string;
+  lines: ReactNode[];
+  dotted?: boolean;
+  /** Wrapped visual rows this section occupies — the skeleton mirrors it so the
+   *  card does not change height when the real content resolves into place. */
+  rows: number;
+}
+
+const SECTIONS: MiniSectionSpec[] = [
+  {
+    label: 'What needs you',
+    rows: 3,
+    lines: [
+      <>
+        Today is about closing the outage confirmation loop, deciding the product solution, and
+        clearing two stage-approval requests in your Tickets feed.
+      </>,
+    ],
+  },
+  {
+    label: 'Overdue',
+    dotted: true,
+    rows: 3,
+    lines: [
+      <>
+        <Em>Outage handoff, verify</Em>: approved 1:38pm, related request routed to{' '}
+        <Mention>@Maya Mehta</Mention>
+      </>,
+      <>
+        <Em>2 stage-approvals pending</Em>: check Tickets → Approvals.
+      </>,
+    ],
+  },
+  {
+    label: 'Waiting on others',
+    dotted: true,
+    rows: 2,
+    lines: [
+      <>
+        <Em>Cashfree error-description PR</Em> CC&apos;d you at 1:29pm, waiting on merge.{' '}
+        <Mention>@Maya Chen</Mention>
+      </>,
+    ],
+  },
+  {
+    label: 'Assigned to you',
+    dotted: true,
+    rows: 2,
+    lines: [
+      <>
+        <Em>Auth flow refactor</Em> HIGH priority, no update since 2 Jul, flagged stale.
+      </>,
+    ],
+  },
+];
+
+function MiniSection({ label, lines, dotted }: MiniSectionSpec): ReactElement {
+  return (
+    <div className='flex w-full items-start gap-2.5'>
+      <p className={LABEL}>{label}</p>
+      <div className='flex min-w-0 flex-1 flex-col gap-[4px]'>
+        {lines.map((line, i) => (
+          <div key={i} className='flex items-start gap-1'>
+            {dotted && (
+              <span className='mt-[4px] size-[3px] shrink-0 rounded-full bg-muted-foreground' />
+            )}
+            <p className={cn('min-w-0 flex-1', BODY)}>{line}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The dummy brief card, dated relative to today so the mock never looks stale. */
+export function MiniBriefCard({ regenerated = false }: { regenerated?: boolean }): ReactElement {
+  return (
+    <div className={BRIEF_BODY} aria-hidden>
+      <div className='mb-3 flex items-center justify-center gap-1.5'>
+        <p className='text-center font-serif text-[14px] font-bold italic text-foreground'>
+          Brief // {format(new Date(), 'MMM d')}
+        </p>
+        {regenerated && (
+          <span className='inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-[2px] text-[8px] font-semibold leading-none text-primary'>
+            <span className='size-[4px] rounded-full bg-primary' />
+            Regenerated
+          </span>
+        )}
+      </div>
+      <div className='flex flex-col gap-3'>
+        {SECTIONS.map(s => (
+          <MiniSection key={s.label} {...s} />
+        ))}
+        <div className='flex w-full items-start gap-2'>
+          <p className={LABEL}>Today&apos;s schedule</p>
+          <div className='min-w-0 flex-1 border-l-2 border-xyne-orange-500 pl-2'>
+            <p className='text-[8px] font-semibold leading-[1.5] text-foreground'>
+              Auth flow design review, 10:00 AM
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Placeholder for the regenerate demo. Row counts come from SECTIONS, so it
+ * occupies the same height as the card it resolves into — without that the
+ * crossfade also animates a height change and reads as a jump.
+ */
+export function MiniBriefSkeleton(): ReactElement {
+  return (
+    <div className={BRIEF_BODY} aria-hidden>
+      <div className='mx-auto mb-3 h-[11px] w-[88px] animate-pulse rounded-full bg-muted' />
+      <div className='flex flex-col gap-3'>
+        {[...SECTIONS.map(s => s.rows), 1].map((rows, i) => (
+          <div key={i} className='flex w-full items-start gap-2'>
+            <div className='h-[8px] w-[58px] shrink-0 animate-pulse rounded-full bg-muted' />
+            <div className='flex min-w-0 flex-1 flex-col gap-[5px]'>
+              {Array.from({ length: rows }).map((_, r) => (
+                <div
+                  key={r}
+                  className='h-[6px] animate-pulse rounded-full bg-muted'
+                  style={{ width: `${100 - r * 14}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Compact mirror of BriefSettingsDialog — the parts worth showing, nothing more. */
+export function MiniSettingsCard(): ReactElement {
+  return (
+    <div className='w-[404px] p-4' aria-hidden>
+      <p className='text-[12px] font-semibold text-foreground'>Brief settings</p>
+      <p className={cn('mt-1', BODY)}>
+        Add your own instructions to shape how the brief is written. The five sections always stay
+        the same.
+      </p>
+      <p className='mt-3 text-[9px] font-semibold text-foreground'>Your instructions</p>
+      <div className='mt-1 rounded-[6px] border border-border bg-muted/30 p-2'>
+        <p className='text-[9px] leading-[1.6] text-muted-foreground'>
+          Keep each section short and skimmable. Lead the Overdue section with the highest-risk item
+          first, and always call out who I&apos;m blocked on.
+        </p>
+      </div>
+      <div className='mt-3 flex items-center justify-between'>
+        <span className='rounded-[6px] border border-border px-3 py-1.5 text-[9px] font-semibold text-foreground'>
+          Cancel
+        </span>
+        <div className='flex items-center gap-1.5'>
+          <span className='rounded-[6px] border border-border px-3 py-1.5 text-[9px] font-semibold text-foreground'>
+            Save &amp; regenerate
+          </span>
+          <span className='rounded-[6px] bg-primary px-3 py-1.5 text-[9px] font-semibold text-primary-foreground'>
+            Save
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Mirror of BriefListView — past briefs plus the calendar entry point. */
+export function MiniHistoryCard(): ReactElement {
+  const today = new Date();
+  const rows = [1, 2, 3].map(back => format(subDays(today, back), 'd MMM'));
+  return (
+    <div className='w-[348px] p-3' aria-hidden>
+      <ul className='flex flex-col gap-px'>
+        {rows.map((label, i) => (
+          <li key={label}>
+            <div
+              className={cn(
+                'flex items-center gap-3 rounded-[10px] px-3 py-3 text-[14px] tracking-[-0.1px]',
+                i === 1
+                  ? 'bg-accent font-medium text-foreground'
+                  : 'font-normal text-muted-foreground',
+              )}
+            >
+              <File02Default size={18} className='shrink-0 text-muted-foreground' />
+              <span className='truncate'>Morning Brief {label}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className='mt-1 border-t border-border pt-1'>
+        <div className='flex items-center gap-3 rounded-[10px] px-3 py-3 text-[14px] font-normal tracking-[-0.1px] text-muted-foreground'>
+          <CalendarFilled size={18} className='shrink-0' />
+          <span className='flex-1 truncate text-left'>Find a Brief</span>
+          <ChevronBigRight size={16} className='shrink-0' />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/useBriefIntroSeen.ts
+++ b/apps/dashboard/src/routes/DailyBriefScreen/useBriefIntroSeen.ts
@@ -1,0 +1,57 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'daily-brief-intro-seen';
+
+const read = (): boolean => {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    // localStorage may be unavailable in private mode or with corrupted data
+    return false;
+  }
+};
+
+const write = (): void => {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // Ignore storage errors (private mode, quota exceeded, etc.)
+  }
+};
+
+let seen = read();
+const subscribers = new Set<() => void>();
+
+const subscribe = (listener: () => void): (() => void) => {
+  subscribers.add(listener);
+  return () => {
+    subscribers.delete(listener);
+  };
+};
+
+const getSnapshot = (): boolean => seen;
+
+export interface BriefIntroSeenResult {
+  introSeen: boolean;
+  markIntroSeen: () => void;
+}
+
+/**
+ * Whether the Daily Brief intro banner has already been shown on this device.
+ * Read through `useSyncExternalStore` so every mounted copy — the brief screen
+ * and the panel webview — flips together the moment it is dismissed.
+ */
+export const useBriefIntroSeen = (): BriefIntroSeenResult => {
+  const introSeen = useSyncExternalStore(subscribe, getSnapshot);
+
+  const markIntroSeen = useCallback(() => {
+    if (seen) return;
+    seen = true;
+    write();
+    subscribers.forEach(listener => listener());
+  }, []);
+
+  return { introSeen, markIntroSeen };
+};

--- a/apps/dashboard/src/services/otel/dailyBriefMetrics.ts
+++ b/apps/dashboard/src/services/otel/dailyBriefMetrics.ts
@@ -21,12 +21,15 @@ function getMeter(): Meter {
 
 let _dailyBriefSwitchedTotal: Counter | null = null;
 
-/** Counter: Switches to another brief from the history menu. */
+/** Which control the switch came from. Bounded to two values — never widen without checking cardinality. */
+export type BriefSwitchSource = 'history_menu' | 'date_picker';
+
+/** Counter: Switches to another brief, split by the control used. */
 const dailyBriefSwitchedTotal: Counter = new Proxy({} as Counter, {
   get(_target, prop) {
     if (!_dailyBriefSwitchedTotal) {
       _dailyBriefSwitchedTotal = getMeter().createCounter('daily_brief_switched_total', {
-        description: 'Total number of switches between briefs from the Daily Brief history menu',
+        description: 'Total number of switches between briefs, by the control used',
         unit: '1',
       });
     }
@@ -34,10 +37,11 @@ const dailyBriefSwitchedTotal: Counter = new Proxy({} as Counter, {
   },
 });
 
-/** Track a switch to another brief from the history menu. */
-export function trackDailyBriefSwitched(): void {
+/** Track a switch to another brief. Device-scoped: `instance` counts devices, not
+ *  users — the distinct-user figure comes from the server-side beacon instead. */
+export function trackDailyBriefSwitched(source: BriefSwitchSource): void {
   safeRecordMetric(() => {
-    dailyBriefSwitchedTotal.add(1);
+    dailyBriefSwitchedTotal.add(1, { source });
   });
 }
 

--- a/apps/dashboard/src/stores/dailyBriefEnabledStore.ts
+++ b/apps/dashboard/src/stores/dailyBriefEnabledStore.ts
@@ -1,0 +1,65 @@
+import { toast } from 'sonner';
+import { dailyBriefApi } from '../api/dailyBriefApi';
+
+export interface DailyBriefEnabledState {
+  /** null until the config has been fetched at least once. */
+  enabled: boolean | null;
+  saving: boolean;
+}
+
+let state: DailyBriefEnabledState = { enabled: null, saving: false };
+let inFlight: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function set(next: Partial<DailyBriefEnabledState>): void {
+  state = { ...state, ...next };
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getDailyBriefEnabledState(): DailyBriefEnabledState {
+  return state;
+}
+
+export function subscribeDailyBriefEnabled(listener: () => void): () => void {
+  listeners.add(listener);
+  return (): void => {
+    listeners.delete(listener);
+  };
+}
+
+export function loadDailyBriefEnabled(force = false): Promise<void> {
+  if (inFlight) return inFlight;
+  if (state.enabled !== null && !force) return Promise.resolve();
+  inFlight = dailyBriefApi
+    .getConfig()
+    .then(config => {
+      set({ enabled: config.enabled });
+    })
+    .catch(() => {
+      set({ enabled: false });
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
+}
+
+export function setDailyBriefEnabled(next: boolean): void {
+  const previous = state.enabled;
+  set({ enabled: next, saving: true });
+  void dailyBriefApi
+    .saveConfig({ enabled: next })
+    .then(config => {
+      set({ enabled: config.enabled });
+      toast.success(next ? 'Morning brief turned on' : 'Morning brief turned off');
+    })
+    .catch(() => {
+      set({ enabled: previous });
+      toast.error('Could not update your morning brief.');
+    })
+    .finally(() => {
+      set({ saving: false });
+    });
+}

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260820140000_daily_brief_activity/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260820140000_daily_brief_activity/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "daily_brief_activity" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "dateBucket" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "daily_brief_activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "daily_brief_activity_userId_kind_dateBucket_key" ON "daily_brief_activity"("userId", "kind", "dateBucket");
+
+-- CreateIndex
+CREATE INDEX "daily_brief_activity_orgId_idx" ON "daily_brief_activity"("orgId");
+
+-- CreateIndex
+CREATE INDEX "daily_brief_activity_kind_dateBucket_idx" ON "daily_brief_activity"("kind", "dateBucket");
+
+-- AddForeignKey
+ALTER TABLE "daily_brief_activity" ADD CONSTRAINT "daily_brief_activity_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -66,6 +66,7 @@ model User {
   /// digitalTwinEnabled opt-in pattern.
   dailyBriefEnabled   Boolean   @default(false)
   dailyBriefEnabledAt DateTime?
+  dailyBriefActivity  DailyBriefActivity[]
   /// Per-user, per-agent custom instructions (injected into every agent run for
   /// this user) + feature-generated content (first consumer: Daily Brief).
   agentInstructions   UserAgentInstruction[]
@@ -652,6 +653,33 @@ model GeneratedContent {
   @@index([userId, kind, dateBucket])
   @@index([status, kind])
   @@map("generated_content")
+}
+
+/// One row per user per day per activity kind, so a distinct-user count over any
+/// date range is an exact COUNT(DISTINCT) rather than a fixed-window sketch.
+/// Upserted, so repeat activity on the same day bumps `count` instead of adding rows.
+model DailyBriefActivity {
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  orgId  String
+
+  /// "view" | "regenerate" | "switch".
+  kind       String
+  /// Calendar bucket the activity happened on (IST), matching GeneratedContent.
+  dateBucket String
+  /// How many times this user did this on this day.
+  count      Int      @default(1)
+  /// First occurrence on this day.
+  occurredAt DateTime @default(now())
+  /// Most recent occurrence on this day.
+  lastSeenAt DateTime @default(now())
+
+  @@unique([userId, kind, dateBucket])
+  @@index([orgId])
+  @@index([kind, dateBucket])
+  @@map("daily_brief_activity")
 }
 
 model AgentChainWorkflow {

--- a/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
@@ -5,6 +5,7 @@ import { prisma } from "../db.js";
 import { redisService } from "../redis.js";
 import { createLogger } from "../logger.js";
 import { DAILY_BRIEF_KIND } from "../repositories/index.js";
+import { formatDayIST } from "../lib/ist-time.js";
 
 const log = createLogger("otel-daily-brief");
 
@@ -22,6 +23,26 @@ const REGEN_USERS_KEY = "daily_brief:regen_users";
 const DEFAULT_REJECTED_USERS_KEY = "daily_brief:default_rejected_users";
 /** Users who ever re-ran a brief they had already regenerated once. */
 const REPEAT_REGEN_USERS_KEY = "daily_brief:repeat_regen_users";
+/** Which control the user switched briefs from. Bounded — never widen without checking cardinality. */
+export type BriefSwitchSource = "history_menu" | "date_picker";
+
+/**
+ * Switching briefs is client state the server never sees on its own (the screen
+ * holds the recent window in memory), so the dashboard beacons it here. Counted
+ * by userId in Redis rather than as a metric label: one series per user would be
+ * unbounded cardinality and PII in a store with no per-series access control.
+ */
+const SWITCH_USERS_KEY = "daily_brief:switch_users";
+/** Switch events, not people — one INCR per switch, globally and per control. */
+const SWITCH_COUNT_KEY = "daily_brief:switches";
+const switchSourceCountKey = (source: BriefSwitchSource): string =>
+  `daily_brief:switches:src:${source}`;
+const switchSourceKey = (source: BriefSwitchSource): string =>
+  `daily_brief:switch_users:src:${source}`;
+/** HyperLogLog per day: a windowed distinct count without one Redis member per user per day. */
+const switchDayKey = (dateBucket: string): string => `daily_brief:switch_users:day:${dateBucket}`;
+const SWITCH_DAY_TTL_SECONDS = 35 * 24 * 60 * 60;
+
 /** Per user per day, so we know which attempt a request is. Two days is plenty. */
 const dayAttemptKey = (userId: string, dateBucket: string): string =>
   `daily_brief:regen:${userId}:${dateBucket}`;
@@ -183,6 +204,37 @@ export async function recordDailyBriefRegeneration(
   }
 }
 
+/** Record that a user switched to a different brief, from a given entry point. */
+export async function recordDailyBriefSwitch(
+  userId: string,
+  source: BriefSwitchSource,
+  dateBucket: string,
+): Promise<void> {
+  try {
+    const redis = redisService.getConnection();
+    const dayKey = switchDayKey(dateBucket);
+    await redis
+      .multi()
+      .incr(SWITCH_COUNT_KEY)
+      .incr(switchSourceCountKey(source))
+      .sadd(SWITCH_USERS_KEY, userId)
+      .sadd(switchSourceKey(source), userId)
+      .pfadd(dayKey, userId)
+      .expire(dayKey, SWITCH_DAY_TTL_SECONDS)
+      .exec();
+  } catch {
+    // metrics must never break a request
+  }
+}
+
+/** The last `days` day-bucket keys, newest first — the union PFCOUNT reads. */
+function switchDayKeysBack(days: number): string[] {
+  const now = Date.now();
+  return Array.from({ length: days }, (_, i) =>
+    switchDayKey(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
+  );
+}
+
 /**
  * Global lifetime totals, re-read on every export tick:
  *   daily_brief_users_total   — users who have at least one brief (generated_content)
@@ -216,27 +268,76 @@ export function registerDailyBriefGauges(): void {
   const repeatRegenGauge = meter.createObservableGauge("daily_brief_repeat_regen_users_total", {
     description: "Users who have re-run a brief they had already regenerated",
   });
+  const switchUsersGauge = meter.createObservableGauge("daily_brief_switch_users_total", {
+    description: "Users who have ever switched to a different brief",
+  });
+  const switchUsersWindowGauge = meter.createObservableGauge("daily_brief_switch_users_window", {
+    description: "Distinct users who switched briefs within a trailing window (HyperLogLog, ~0.81% error)",
+  });
+  const switchUsersSourceGauge = meter.createObservableGauge("daily_brief_switch_users_by_source", {
+    description: "Users who have ever switched briefs, by the control they used",
+  });
+  const switchesGauge = meter.createObservableGauge("daily_brief_switches_total", {
+    description: "Brief switches ever served globally (events, not people)",
+  });
+  const switchesSourceGauge = meter.createObservableGauge("daily_brief_switches_by_source", {
+    description: "Brief switches ever served, by the control used (events, not people)",
+  });
 
   meter.addBatchObservableCallback(
     async (result) => {
       try {
         const where = { kind: DAILY_BRIEF_KIND, generatedAt: { not: null } };
         const redis = redisService.getConnection();
-        const [briefs, users, regenerations, regenUsers, defaultRejected, repeatRegen] =
-          await Promise.all([
-            prisma.generatedContent.count({ where }),
-            prisma.generatedContent.groupBy({ by: ["userId"], where }),
-            redis.get(REGEN_COUNT_KEY).catch(() => null),
-            redis.scard(REGEN_USERS_KEY).catch(() => 0),
-            redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
-            redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
-          ]);
+        const [
+          briefs,
+          users,
+          regenerations,
+          regenUsers,
+          defaultRejected,
+          repeatRegen,
+          switchUsers,
+          switch7d,
+          switch30d,
+          switchHistoryMenu,
+          switchDatePicker,
+          switches,
+          switchesHistoryMenu,
+          switchesDatePicker,
+        ] = await Promise.all([
+          prisma.generatedContent.count({ where }),
+          prisma.generatedContent.groupBy({ by: ["userId"], where }),
+          redis.get(REGEN_COUNT_KEY).catch(() => null),
+          redis.scard(REGEN_USERS_KEY).catch(() => 0),
+          redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
+          redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
+          redis.scard(SWITCH_USERS_KEY).catch(() => 0),
+          redis.pfcount(...switchDayKeysBack(7)).catch(() => 0),
+          redis.pfcount(...switchDayKeysBack(30)).catch(() => 0),
+          redis.scard(switchSourceKey("history_menu")).catch(() => 0),
+          redis.scard(switchSourceKey("date_picker")).catch(() => 0),
+          redis.get(SWITCH_COUNT_KEY).catch(() => null),
+          redis.get(switchSourceCountKey("history_menu")).catch(() => null),
+          redis.get(switchSourceCountKey("date_picker")).catch(() => null),
+        ]);
         result.observe(usersGauge, users.length);
         result.observe(briefsGauge, briefs);
         result.observe(regenerationsGauge, Number(regenerations ?? 0));
         result.observe(regenUsersGauge, regenUsers);
         result.observe(defaultRejectedGauge, defaultRejected);
         result.observe(repeatRegenGauge, repeatRegen);
+        result.observe(switchUsersGauge, switchUsers);
+        result.observe(switchUsersWindowGauge, switch7d, { window: "7d" });
+        result.observe(switchUsersWindowGauge, switch30d, { window: "30d" });
+        result.observe(switchUsersSourceGauge, switchHistoryMenu, { source: "history_menu" });
+        result.observe(switchUsersSourceGauge, switchDatePicker, { source: "date_picker" });
+        result.observe(switchesGauge, Number(switches ?? 0));
+        result.observe(switchesSourceGauge, Number(switchesHistoryMenu ?? 0), {
+          source: "history_menu",
+        });
+        result.observe(switchesSourceGauge, Number(switchesDatePicker ?? 0), {
+          source: "date_picker",
+        });
       } catch (err) {
         // OTel swallows a rejected callback silently — log so a broken read is visible.
         log.warn(`[otel] daily-brief gauges skipped: ${err instanceof Error ? err.message : String(err)}`);
@@ -249,6 +350,11 @@ export function registerDailyBriefGauges(): void {
       regenUsersGauge,
       defaultRejectedGauge,
       repeatRegenGauge,
+      switchUsersGauge,
+      switchUsersWindowGauge,
+      switchUsersSourceGauge,
+      switchesGauge,
+      switchesSourceGauge,
     ],
   );
 }

--- a/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
@@ -41,7 +41,11 @@ const switchSourceKey = (source: BriefSwitchSource): string =>
   `daily_brief:switch_users:src:${source}`;
 /** HyperLogLog per day: a windowed distinct count without one Redis member per user per day. */
 const switchDayKey = (dateBucket: string): string => `daily_brief:switch_users:day:${dateBucket}`;
-const SWITCH_DAY_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+const DAY_HLL_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+/** Activity kinds recorded per user per day in Postgres. Bounded set. */
+export type DailyBriefActivityKind = "view" | "regenerate" | "switch";
 
 /** Per user per day, so we know which attempt a request is. Two days is plenty. */
 const dayAttemptKey = (userId: string, dateBucket: string): string =>
@@ -150,6 +154,27 @@ export function recordScheduledDeliveryDelay(dateBucket: string, generatedAt: Da
   }
 }
 
+// Daily Brief Opt-In Changes — labels: action (opted_in | opted_out)
+let _optInChanges: Counter | null = null;
+function getOptInChanges(): Counter {
+  if (!_optInChanges) {
+    _optInChanges = getMeter().createCounter("daily_brief_opt_in_changes_total", {
+      description: "Daily Brief master toggle flips, by direction",
+      unit: "1",
+    });
+  }
+  return _optInChanges;
+}
+
+/** Count one master-toggle flip. Only call when the stored value actually changed. */
+export function recordDailyBriefOptInChange(enabled: boolean): void {
+  try {
+    getOptInChanges().add(1, { action: enabled ? "opted_in" : "opted_out" });
+  } catch {
+    // metrics must never break a request
+  }
+}
+
 // Daily Brief Regeneration Attempts — labels: attempt (1 | 2 | 3 | 4+), origin
 let _regenerationAttempts: Counter | null = null;
 function getRegenerationAttempts(): Counter {
@@ -170,6 +195,7 @@ function getRegenerationAttempts(): Counter {
  */
 export async function recordDailyBriefRegeneration(
   userId: string,
+  orgId: string,
   dateBucket: string,
   existing: { status: string; generatedAt: Date | null } | null,
 ): Promise<void> {
@@ -199,14 +225,41 @@ export async function recordDailyBriefRegeneration(
     // run has attempt >= 2 without being dissatisfied with anything.
     if (origin === "replacing_own_regeneration") writes.sadd(REPEAT_REGEN_USERS_KEY, userId);
     await writes.exec();
+    await recordDailyBriefActivity(userId, orgId, "regenerate", dateBucket);
   } catch {
     // metrics must never break a brief run
+  }
+}
+
+/**
+ * Upsert one row per user per day per kind. Distinct-user counts over an arbitrary
+ * date range then come from COUNT(DISTINCT "userId") in Postgres, which is exact
+ * and unbounded in lookback — a fixed-window sketch can be neither. Repeat activity
+ * on the same day bumps `count` instead of adding a row, so the table stays bounded
+ * at one row per user per day per kind however heavy the usage.
+ */
+export async function recordDailyBriefActivity(
+  userId: string,
+  orgId: string,
+  kind: DailyBriefActivityKind,
+  dateBucket: string,
+): Promise<void> {
+  try {
+    const now = new Date();
+    await prisma.dailyBriefActivity.upsert({
+      where: { userId_kind_dateBucket: { userId, kind, dateBucket } },
+      create: { userId, orgId, kind, dateBucket, count: 1, occurredAt: now, lastSeenAt: now },
+      update: { count: { increment: 1 }, lastSeenAt: now },
+    });
+  } catch {
+    // metrics must never break a request
   }
 }
 
 /** Record that a user switched to a different brief, from a given entry point. */
 export async function recordDailyBriefSwitch(
   userId: string,
+  orgId: string,
   source: BriefSwitchSource,
   dateBucket: string,
 ): Promise<void> {
@@ -220,18 +273,28 @@ export async function recordDailyBriefSwitch(
       .sadd(SWITCH_USERS_KEY, userId)
       .sadd(switchSourceKey(source), userId)
       .pfadd(dayKey, userId)
-      .expire(dayKey, SWITCH_DAY_TTL_SECONDS)
+      .expire(dayKey, DAY_HLL_TTL_SECONDS)
       .exec();
+    await recordDailyBriefActivity(userId, orgId, "switch", dateBucket);
   } catch {
     // metrics must never break a request
   }
 }
 
+/** Record that a user opened a brief. */
+export async function recordDailyBriefViewed(
+  userId: string,
+  orgId: string,
+  dateBucket: string,
+): Promise<void> {
+  await recordDailyBriefActivity(userId, orgId, "view", dateBucket);
+}
+
 /** The last `days` day-bucket keys, newest first — the union PFCOUNT reads. */
-function switchDayKeysBack(days: number): string[] {
+function dayKeysBack(key: (dateBucket: string) => string, days: number): string[] {
   const now = Date.now();
   return Array.from({ length: days }, (_, i) =>
-    switchDayKey(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
+    key(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
   );
 }
 
@@ -283,6 +346,15 @@ export function registerDailyBriefGauges(): void {
   const switchesSourceGauge = meter.createObservableGauge("daily_brief_switches_by_source", {
     description: "Brief switches ever served, by the control used (events, not people)",
   });
+  const enabledUsersGauge = meter.createObservableGauge("daily_brief_enabled_users_total", {
+    description: "Users who currently have the Daily Brief switched on",
+  });
+  const eligibleUsersGauge = meter.createObservableGauge("daily_brief_eligible_users_total", {
+    description: "All user accounts — the fixed denominator for the opt-in rate",
+  });
+  const deliveredTodayGauge = meter.createObservableGauge("daily_brief_delivered_today", {
+    description: "Briefs ready for today's bucket — divide by opted-in users for fan-out coverage",
+  });
 
   meter.addBatchObservableCallback(
     async (result) => {
@@ -304,6 +376,9 @@ export function registerDailyBriefGauges(): void {
           switches,
           switchesHistoryMenu,
           switchesDatePicker,
+          enabledUsers,
+          eligibleUsers,
+          deliveredToday,
         ] = await Promise.all([
           prisma.generatedContent.count({ where }),
           prisma.generatedContent.groupBy({ by: ["userId"], where }),
@@ -312,13 +387,18 @@ export function registerDailyBriefGauges(): void {
           redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
           redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
           redis.scard(SWITCH_USERS_KEY).catch(() => 0),
-          redis.pfcount(...switchDayKeysBack(7)).catch(() => 0),
-          redis.pfcount(...switchDayKeysBack(30)).catch(() => 0),
+          redis.pfcount(...dayKeysBack(switchDayKey, 7)).catch(() => 0),
+          redis.pfcount(...dayKeysBack(switchDayKey, 30)).catch(() => 0),
           redis.scard(switchSourceKey("history_menu")).catch(() => 0),
           redis.scard(switchSourceKey("date_picker")).catch(() => 0),
           redis.get(SWITCH_COUNT_KEY).catch(() => null),
           redis.get(switchSourceCountKey("history_menu")).catch(() => null),
           redis.get(switchSourceCountKey("date_picker")).catch(() => null),
+          prisma.user.count({ where: { dailyBriefEnabled: true } }),
+          prisma.user.count(),
+          prisma.generatedContent.count({
+            where: { ...where, dateBucket: formatDayIST(new Date()) },
+          }),
         ]);
         result.observe(usersGauge, users.length);
         result.observe(briefsGauge, briefs);
@@ -338,6 +418,9 @@ export function registerDailyBriefGauges(): void {
         result.observe(switchesSourceGauge, Number(switchesDatePicker ?? 0), {
           source: "date_picker",
         });
+        result.observe(enabledUsersGauge, enabledUsers);
+        result.observe(eligibleUsersGauge, eligibleUsers);
+        result.observe(deliveredTodayGauge, deliveredToday);
       } catch (err) {
         // OTel swallows a rejected callback silently — log so a broken read is visible.
         log.warn(`[otel] daily-brief gauges skipped: ${err instanceof Error ? err.message : String(err)}`);
@@ -355,6 +438,9 @@ export function registerDailyBriefGauges(): void {
       switchUsersSourceGauge,
       switchesGauge,
       switchesSourceGauge,
+      enabledUsersGauge,
+      eligibleUsersGauge,
+      deliveredTodayGauge,
     ],
   );
 }

--- a/apps/xyne-claw-auth/backend/src/repositories/generatedContentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/generatedContentRepository.ts
@@ -29,6 +29,15 @@ export const generatedContentRepository = {
       take: limit,
     }),
 
+  /** Day buckets + status only (no content) — powers the brief date picker. */
+  findDateBuckets: (userId: string, kind: string, limit = 365) =>
+    prisma.generatedContent.findMany({
+      where: { userId, kind },
+      orderBy: [{ dateBucket: "desc" }],
+      take: limit,
+      select: { dateBucket: true, status: true },
+    }),
+
   /** Mark generation as started (idempotent per day) so a fetch can show "generating". */
   markGenerating: (params: {
     userId: string;

--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -141,7 +141,7 @@ router.get("/latest", async (req: Request, res: Response) => {
   try {
     const userId = getRequesterId(req);
     const orgId = getOrgId(req);
-    if (!userId || !orgId) {
+    if (!userId) {
       res.status(401).json({ success: false, error: "Unauthorized" });
       return;
     }
@@ -152,7 +152,7 @@ router.get("/latest", async (req: Request, res: Response) => {
       res.json({ success: true, data: { status: "none" } });
       return;
     }
-    void recordDailyBriefViewed(userId, orgId, today);
+    if (orgId) void recordDailyBriefViewed(userId, orgId, today);
     res.json({
       success: true,
       data: {
@@ -266,7 +266,7 @@ router.post("/switched", async (req: Request, res: Response) => {
   try {
     const userId = getRequesterId(req);
     const orgId = getOrgId(req);
-    if (!userId || !orgId) {
+    if (!userId) {
       res.status(401).json({ success: false, error: "Unauthorized" });
       return;
     }
@@ -275,7 +275,7 @@ router.post("/switched", async (req: Request, res: Response) => {
     // open the label up to arbitrary cardinality.
     const body = req.body as { source?: unknown };
     const source: BriefSwitchSource = body.source === "date_picker" ? "date_picker" : "history_menu";
-    await recordDailyBriefSwitch(userId, orgId, source, briefDateBucket());
+    if (orgId) await recordDailyBriefSwitch(userId, orgId, source, briefDateBucket());
     res.status(204).end();
   } catch (err) {
     log.error("[daily-brief] post switched", err);
@@ -291,7 +291,7 @@ router.post("/switched", async (req: Request, res: Response) => {
 router.post("/regenerate", async (req: Request, res: Response) => {
   const userId = getRequesterId(req);
   const orgId = getOrgId(req);
-  if (!userId || !orgId) {
+  if (!userId) {
     res.status(401).json({ success: false, error: "Unauthorized" });
     return;
   }
@@ -318,7 +318,7 @@ router.post("/regenerate", async (req: Request, res: Response) => {
   const existing = await generatedContentRepository
     .findForBucket(userId, DAILY_BRIEF_KIND, dateBucket)
     .catch(() => null);
-  void recordDailyBriefRegeneration(userId, orgId, dateBucket, existing);
+  if (orgId) void recordDailyBriefRegeneration(userId, orgId, dateBucket, existing);
   send("start", { date: dateBucket });
   try {
     const result = await generateDailyBrief(userId, {

--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -16,7 +16,11 @@ import {
   DAILY_BRIEF_SLUG,
   type DailyBriefPayload,
 } from "../services/dailyBrief.js";
-import { recordDailyBriefRegeneration } from "../otel/daily-brief-metrics.js";
+import {
+  recordDailyBriefRegeneration,
+  recordDailyBriefSwitch,
+  type BriefSwitchSource,
+} from "../otel/daily-brief-metrics.js";
 
 const log = createLogger("daily-brief-routes");
 const MAX_INSTRUCTIONS = 8000;
@@ -181,6 +185,90 @@ router.get("/history", async (req: Request, res: Response) => {
   } catch (err) {
     log.error("[daily-brief] get history", err);
     res.status(500).json({ success: false, error: "Failed to load daily brief history" });
+  }
+});
+
+/** GET /dates — every day the user has a brief for, newest first (date + status, no content). */
+router.get("/dates", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    const limitRaw = Number(req.query.limit);
+    const limit = Number.isFinite(limitRaw)
+      ? Math.min(Math.max(Math.trunc(limitRaw), 1), 1000)
+      : 365;
+    const rows = await generatedContentRepository.findDateBuckets(userId, DAILY_BRIEF_KIND, limit);
+    res.json({
+      success: true,
+      data: rows.map((row) => ({ date: row.dateBucket, status: row.status })),
+    });
+  } catch (err) {
+    log.error("[daily-brief] get dates", err);
+    res.status(500).json({ success: false, error: "Failed to load daily brief dates" });
+  }
+});
+
+/** GET /by-date/:date — the stored brief for one YYYY-MM-DD bucket. */
+router.get("/by-date/:date", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    const date = String(req.params.date ?? "");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      res.status(400).json({ success: false, error: "date must be YYYY-MM-DD" });
+      return;
+    }
+    const row = await generatedContentRepository.findForBucket(userId, DAILY_BRIEF_KIND, date);
+    if (!row) {
+      res.json({ success: true, data: { status: "none", date } });
+      return;
+    }
+    res.json({
+      success: true,
+      data: {
+        status: row.status,
+        date: row.dateBucket,
+        content: row.content,
+        data: row.data,
+        agentSlug: row.agentSlug,
+        generatedAt: row.generatedAt,
+        isToday: row.dateBucket === briefDateBucket(),
+      },
+    });
+  } catch (err) {
+    log.error("[daily-brief] get by date", err);
+    res.status(500).json({ success: false, error: "Failed to load daily brief" });
+  }
+});
+
+/**
+ * POST /switched — beacon for "this user switched to another brief". The screen
+ * holds the recent window in memory, so most switches never hit the server and
+ * cannot be inferred from any other route.
+ */
+router.post("/switched", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "Unauthorized" });
+      return;
+    }
+    // Coerced, not validated: `source` is client-supplied and lands on a metric
+    // label, so an unknown value must collapse into a known one rather than
+    // open the label up to arbitrary cardinality.
+    const body = req.body as { source?: unknown };
+    const source: BriefSwitchSource = body.source === "date_picker" ? "date_picker" : "history_menu";
+    await recordDailyBriefSwitch(userId, source, briefDateBucket());
+    res.status(204).end();
+  } catch (err) {
+    log.error("[daily-brief] post switched", err);
+    res.status(500).json({ success: false, error: "Failed to record brief switch" });
   }
 });
 

--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -17,8 +17,10 @@ import {
   type DailyBriefPayload,
 } from "../services/dailyBrief.js";
 import {
+  recordDailyBriefOptInChange,
   recordDailyBriefRegeneration,
   recordDailyBriefSwitch,
+  recordDailyBriefViewed,
   type BriefSwitchSource,
 } from "../otel/daily-brief-metrics.js";
 
@@ -80,6 +82,9 @@ router.put("/config", async (req: Request, res: Response) => {
         res.status(400).json({ success: false, error: "enabled must be a boolean" });
         return;
       }
+      const before = await prisma.user
+        .findUnique({ where: { id: userId }, select: { dailyBriefEnabled: true } })
+        .catch(() => null);
       await prisma.user.update({
         where: { id: userId },
         data: {
@@ -87,6 +92,9 @@ router.put("/config", async (req: Request, res: Response) => {
           ...(body.enabled ? { dailyBriefEnabledAt: new Date() } : {}),
         },
       });
+      if (before && before.dailyBriefEnabled !== body.enabled) {
+        recordDailyBriefOptInChange(body.enabled);
+      }
     }
 
     if (body.instructions !== undefined || body.instructionsEnabled !== undefined) {
@@ -132,7 +140,8 @@ router.put("/config", async (req: Request, res: Response) => {
 router.get("/latest", async (req: Request, res: Response) => {
   try {
     const userId = getRequesterId(req);
-    if (!userId) {
+    const orgId = getOrgId(req);
+    if (!userId || !orgId) {
       res.status(401).json({ success: false, error: "Unauthorized" });
       return;
     }
@@ -143,6 +152,7 @@ router.get("/latest", async (req: Request, res: Response) => {
       res.json({ success: true, data: { status: "none" } });
       return;
     }
+    void recordDailyBriefViewed(userId, orgId, today);
     res.json({
       success: true,
       data: {
@@ -255,7 +265,8 @@ router.get("/by-date/:date", async (req: Request, res: Response) => {
 router.post("/switched", async (req: Request, res: Response) => {
   try {
     const userId = getRequesterId(req);
-    if (!userId) {
+    const orgId = getOrgId(req);
+    if (!userId || !orgId) {
       res.status(401).json({ success: false, error: "Unauthorized" });
       return;
     }
@@ -264,7 +275,7 @@ router.post("/switched", async (req: Request, res: Response) => {
     // open the label up to arbitrary cardinality.
     const body = req.body as { source?: unknown };
     const source: BriefSwitchSource = body.source === "date_picker" ? "date_picker" : "history_menu";
-    await recordDailyBriefSwitch(userId, source, briefDateBucket());
+    await recordDailyBriefSwitch(userId, orgId, source, briefDateBucket());
     res.status(204).end();
   } catch (err) {
     log.error("[daily-brief] post switched", err);
@@ -279,7 +290,8 @@ router.post("/switched", async (req: Request, res: Response) => {
  */
 router.post("/regenerate", async (req: Request, res: Response) => {
   const userId = getRequesterId(req);
-  if (!userId) {
+  const orgId = getOrgId(req);
+  if (!userId || !orgId) {
     res.status(401).json({ success: false, error: "Unauthorized" });
     return;
   }
@@ -306,7 +318,7 @@ router.post("/regenerate", async (req: Request, res: Response) => {
   const existing = await generatedContentRepository
     .findForBucket(userId, DAILY_BRIEF_KIND, dateBucket)
     .catch(() => null);
-  void recordDailyBriefRegeneration(userId, dateBucket, existing);
+  void recordDailyBriefRegeneration(userId, orgId, dateBucket, existing);
   send("start", { date: dateBucket });
   try {
     const result = await generateDailyBrief(userId, {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -274,12 +274,17 @@ services:
       # VictoriaLogs datasource isn't bundled with core Grafana.
       - GF_INSTALL_PLUGINS=victoriametrics-logs-datasource
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victoriametrics-logs-datasource
+      # Read-only claw-auth DB access for the Daily Brief distinct-user panels.
+      # Same names/defaults as docker/init-db.sh.
+      - CLAW_DB_USER=${CLAW_DB_USER:-claw}
+      - CLAW_DB_PASSWORD=${CLAW_DB_PASSWORD:-claw123}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - victoriametrics
       - victorialogs-errors
+      - postgres
     # Lets webhook contact points (e.g. the Desk alert integration) reach the
     # backend running on the host, same as zero-cache's ZERO_MUTATE_URL below.
     extra_hosts:

--- a/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
+++ b/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
@@ -277,7 +277,7 @@
     {
       "type": "timeseries",
       "title": "Briefs and regenerations over time",
-      "description": "Lifetime totals plotted over the selected range \u2014 the slope is how fast briefs are being produced and regenerated.",
+      "description": "Lifetime totals plotted over the selected range — the slope is how fast briefs are being produced and regenerated.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -350,7 +350,7 @@
     {
       "type": "stat",
       "title": "Total brief switches (all time)",
-      "description": "Every brief switch ever served, counted server-side (Redis INCR). Events, not people \u2014 compare against \"Users who switched briefs\" to see switches-per-person.",
+      "description": "Every brief switch ever served, counted server-side (Redis INCR). Events, not people — compare against \"Users who switched briefs\" to see switches-per-person.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -416,7 +416,7 @@
     {
       "type": "stat",
       "title": "Users who switched briefs (last 30 days)",
-      "description": "Distinct users who switched to a different brief in the last 30 days, counted server-side by userId (Redis HyperLogLog, ~0.81% error). Replaces an earlier device-based count: the client metric carries a per-device localStorage id, so it counted browsers rather than people \u2014 one person on three devices read as three. A beacon can be blocked or lost on a fast page close, so treat this as a tight lower bound. See \"Brief switches by control\" for event volume.",
+      "description": "Distinct users who switched to a different brief in the last 30 days, counted server-side by userId (Redis HyperLogLog, ~0.81% error). Replaces an earlier device-based count: the client metric carries a per-device localStorage id, so it counted browsers rather than people — one person on three devices read as three. A beacon can be blocked or lost on a fast page close, so treat this as a tight lower bound. See \"Brief switches by control\" for event volume.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -482,7 +482,7 @@
     {
       "type": "piechart",
       "title": "Switches: list vs calendar (all time)",
-      "description": "Share of switch events by control, server-side. The calendar is the ONLY way to reach a brief older than the 8 most recent, so date_picker volume is the direct read on whether people want older briefs. Events, so one heavy user can dominate \u2014 read alongside panel \"Users reaching for older briefs\".",
+      "description": "Share of switch events by control, server-side. The calendar is the ONLY way to reach a brief older than the 8 most recent, so date_picker volume is the direct read on whether people want older briefs. Events, so one heavy user can dominate — read alongside panel \"Users reaching for older briefs\".",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -549,7 +549,7 @@
     {
       "type": "barchart",
       "title": "Users reaching for older briefs (all time)",
-      "description": "Distinct users who have used each control at least once. NOTE: these sets OVERLAP \u2014 someone who used both is counted in both, so the bars do not sum to the total user count and must not be drawn as a pie. date_picker here = how many people ever went past the recent window, which is the per-person version of the question.",
+      "description": "Distinct users who have used each control at least once. NOTE: these sets OVERLAP — someone who used both is counted in both, so the bars do not sum to the total user count and must not be drawn as a pie. date_picker here = how many people ever went past the recent window, which is the per-person version of the question.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -629,7 +629,7 @@
     {
       "type": "stat",
       "title": "Users who rejected the auto brief (all time)",
-      "description": "Users who have re-run a brief the cron produced for them \u2014 dissatisfaction with the default. Exact, lifetime.",
+      "description": "Users who have re-run a brief the cron produced for them — dissatisfaction with the default. Exact, lifetime.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -685,7 +685,7 @@
     {
       "type": "stat",
       "title": "Users who regenerated more than once (all time)",
-      "description": "Users who re-ran a brief they had already regenerated \u2014 the regeneration itself did not satisfy them. Exact, lifetime.",
+      "description": "Users who re-ran a brief they had already regenerated — the regeneration itself did not satisfy them. Exact, lifetime.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -763,7 +763,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -829,7 +829,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -873,7 +873,7 @@
     {
       "type": "barchart",
       "title": "Why briefs get regenerated",
-      "description": "replacing_scheduled_brief = rejecting the cron brief \u00b7 replacing_own_regeneration = rejecting their own re-run \u00b7 retry_after_failure = the previous run errored, not a quality signal \u00b7 first_brief_of_day = no brief existed yet.",
+      "description": "replacing_scheduled_brief = rejecting the cron brief · replacing_own_regeneration = rejecting their own re-run · retry_after_failure = the previous run errored, not a quality signal · first_brief_of_day = no brief existed yet.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -921,7 +921,7 @@
     {
       "type": "barchart",
       "title": "Regeneration outcomes",
-      "description": "How on-demand regenerations actually ended, from the server-side completion counter. Recorded when the run finishes, unlike 'Regenerations' which is counted when the request arrives \u2014 the difference between the two is runs that started and never completed. CAVEAT: 'failed' currently absorbs runs the server aborted because the HTTP connection closed (tab close, reload, network drop, proxy timeout), so it overstates genuine pipeline failures by an unknown amount; splitting an 'aborted' status out of it is a pending server-side change. This is NOT the same event as 'Regenerations abandoned' below: that histogram fires on component unmount (an in-app route change), and the dashboard passes no AbortSignal, so navigating away inside the app does not abort the run. The two count different things and do not double-count \u2014 except on a tab close, which can trigger both.",
+      "description": "How on-demand regenerations actually ended, from the server-side completion counter. Recorded when the run finishes, unlike 'Regenerations' which is counted when the request arrives — the difference between the two is runs that started and never completed. CAVEAT: 'failed' currently absorbs runs the server aborted because the HTTP connection closed (tab close, reload, network drop, proxy timeout), so it overstates genuine pipeline failures by an unknown amount; splitting an 'aborted' status out of it is a pending server-side change. This is NOT the same event as 'Regenerations abandoned' below: that histogram fires on component unmount (an in-app route change), and the dashboard passes no AbortSignal, so navigating away inside the app does not abort the run. The two count different things and do not double-count — except on a tab close, which can trigger both.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -969,7 +969,7 @@
     {
       "type": "barchart",
       "title": "How far the regeneration ladder goes",
-      "description": "SURVIVAL CURVE, NOT A DISTRIBUTION. Bar N = share of the day's regenerating users who reached at least attempt N, normalised to attempt 1. A user-day that went three deep is counted in bars 1, 2 AND 3, so bar heights do NOT mean 'N users needed N regenerations' \u2014 read 'Where people stop' for that. Bars only ever descend. CAVEAT: attempts 1\u20133 count user-days (the per-user-per-day Redis key increments once per depth), but 4+ aggregates every request at depth \u22654, so the 4+ bar is a REQUEST tally in different units and can exceed 100%. The origin filter was removed deliberately: origin is computed with 'previous run failed' taking precedence over attempt depth, so one failed or connection-dropped run relabels every later attempt that day as retry_after_failure and used to delete the entire tail of this chart. Origin belongs in 'Why briefs get regenerated'.",
+      "description": "SURVIVAL CURVE, NOT A DISTRIBUTION. Bar N = share of the day's regenerating users who reached at least attempt N, normalised to attempt 1. A user-day that went three deep is counted in bars 1, 2 AND 3, so bar heights do NOT mean 'N users needed N regenerations' — read 'Where people stop' for that. Bars only ever descend. CAVEAT: attempts 1–3 count user-days (the per-user-per-day Redis key increments once per depth), but 4+ aggregates every request at depth ≥4, so the 4+ bar is a REQUEST tally in different units and can exceed 100%. The origin filter was removed deliberately: origin is computed with 'previous run failed' taking precedence over attempt depth, so one failed or connection-dropped run relabels every later attempt that day as retry_after_failure and used to delete the entire tail of this chart. Origin belongs in 'Why briefs get regenerated'.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -1017,7 +1017,7 @@
     {
       "type": "barchart",
       "title": "Where people stop",
-      "description": "How many regenerations it actually took, derived by differencing the ladder: users who reached depth N but not N+1. This is the panel that answers 'how many regens does it take' \u2014 the ladder panel next to it cannot, because every user-day is counted at every depth it passed through. APPROXIMATE AT BUCKET 3: 'stopped at 3' subtracts the 4+ bar, which counts requests rather than user-days, so it under-reports whenever anyone is deep in the tail; all three are clamped at 0 because that subtraction can otherwise go negative (it does on the current sample data). The 4+ bar is shown separately and in different units on purpose \u2014 do not add it to the other three. A short time range can also clip a user-day's attempt 1 outside the window while its attempt 2 falls inside, which biases the first bar down. WILL CHANGE: once client-abort is split out of 'failed' server-side, fewer days will be misclassified and these buckets will shift.",
+      "description": "How many regenerations it actually took, derived by differencing the ladder: users who reached depth N but not N+1. This is the panel that answers 'how many regens does it take' — the ladder panel next to it cannot, because every user-day is counted at every depth it passed through. APPROXIMATE AT BUCKET 3: 'stopped at 3' subtracts the 4+ bar, which counts requests rather than user-days, so it under-reports whenever anyone is deep in the tail; all three are clamped at 0 because that subtraction can otherwise go negative (it does on the current sample data). The 4+ bar is shown separately and in different units on purpose — do not add it to the other three. A short time range can also clip a user-day's attempt 1 outside the window while its attempt 2 falls inside, which biases the first bar down. WILL CHANGE: once client-abort is split out of 'failed' server-side, fewer days will be misclassified and these buckets will shift.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -1118,7 +1118,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -1162,7 +1162,7 @@
     {
       "type": "stat",
       "title": "p95 generation time",
-      "description": "95th percentile of successful runs \u2014 what the slowest users actually wait.",
+      "description": "95th percentile of successful runs — what the slowest users actually wait.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -1184,7 +1184,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -1250,7 +1250,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -1388,7 +1388,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -1432,7 +1432,7 @@
     {
       "type": "stat",
       "title": "Median patience",
-      "description": "The wait at which half of the people who walked away had already gone. Put this next to p50 generation time \u2014 if it is smaller, you are losing people before the brief can possibly arrive.",
+      "description": "The wait at which half of the people who walked away had already gone. Put this next to p50 generation time — if it is smaller, you are losing people before the brief can possibly arrive.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -1454,7 +1454,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -1498,7 +1498,7 @@
     {
       "type": "stat",
       "title": "Abandonment rate",
-      "description": "Share of regenerations where the user left before it finished. Client-measured, so treat it as a lower bound \u2014 a closed tab may never report.",
+      "description": "Share of regenerations where the user left before it finished. Client-measured, so treat it as a lower bound — a closed tab may never report.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -1520,7 +1520,7 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "\u2014"
+                  "text": "—"
                 }
               },
               "type": "special"
@@ -1564,7 +1564,7 @@
     {
       "type": "barchart",
       "title": "How long people wait before giving up",
-      "description": "Share of abandonments that had already happened by each wait threshold \u2014 read it as a cumulative curve: the bar at 60s is everyone who left within 60s. Where it crosses 50% is median patience. Compare that against p50 generation time: if patience is shorter, the pipeline is losing people mid-run.",
+      "description": "Share of abandonments that had already happened by each wait threshold — read it as a cumulative curve: the bar at 60s is everyone who left within 60s. Where it crosses 50% is median patience. Compare that against p50 generation time: if patience is shorter, the pipeline is losing people mid-run.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -1610,6 +1610,2199 @@
           "instant": true,
           "expr": "sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket{le!=\"+Inf\"}[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])), 1))",
           "legendFormat": "within {{le}}s"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 105,
+      "panels": [],
+      "title": "Improved metrics",
+      "type": "row"
+    },
+    {
+      "type": "text",
+      "title": "Read this first",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 200,
+      "options": {
+        "mode": "markdown",
+        "content": "### How to read this group\n\nEvery panel here has a **denominator**, a **time window**, or both, so the value means the same thing this week as it did last week.\n\n#### Everything follows the time picker except two tiles\nDistinct-user panels run `COUNT(DISTINCT \"userId\")` against the application's own Postgres over exactly the days you select. They are **exact counts, not estimates**, with **no fixed window** and **no 35-day ceiling**. Rate and ratio panels use `$__range` against the metrics store.\n\nThe one exception says so in its title and explains why in its description:\n\n| Marker | Panel | Why |\n|---|---|---|\n| **[today]** | Fan-out coverage today | Deliberately same-day: it answers “did this morning's fan-out reach everyone”. For the range-scoped version use *Delivery completeness*. |\n\n#### Two things that will mislead you if nobody says them\n\n**1. Per-user history starts 2026-08-20.** Views, regenerations and history-browsing only began being recorded per-user-per-day when this change shipped. Panels built on that data show **“no data” rather than 0** for earlier ranges — deliberately, because a confident `0` would read as *nobody ever regenerates*, which is false: the metrics store proves regenerations happened. If a tile here is blank, the event-count panels in this group and the all-time tiles at the top of the page still have the full history.\n\nBrief **deliveries** are unaffected — they come from `generated_content` and go back to the very first brief, so *Avg brief-days per user*, *Briefs generated per reader* and *Delivery completeness* are trustworthy over any range.\n\nTwo days of regeneration history were recovered from Redis counters that had not yet expired — real user, real date, real count. Nothing else was back-filled: per-day switch history is unrecoverable (its only store was a HyperLogLog, which cannot be enumerated), and guessing that a generated brief was read would have fabricated the answer to the most important question here.\n\n**2. Per-day counts are people-per-day, not distinct people.** On *Distinct users per day*, somebody active on ten days appears on ten points. **Adding the points together does not give a distinct total** — it gives user-days and counts that person ten times. For a real distinct total, set the range and read *Distinct readers (selected range)*, which de-duplicates properly.\n\n**People vs events.** *People* / *readers* are distinct user counts. *Briefs*, *runs*, *regenerations*, *minutes* are events — one enthusiastic person can move those alone.\n\n**Every average names its denominator.** “Per regenerating user”, “per active reader” and “per subscriber” are three different questions with three different answers.\n\n**Charts on the metrics store are moving aggregates** over a window as long as the range you picked. Gaps are honest: where a window had no events to divide by, the ratio is undefined and the line breaks rather than dropping to a fake zero. Metrics export every 60s and instant queries are held back ~30s, so allow 90 seconds for a fresh number."
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Opt-in rate: subscribers / all accounts (now)",
+      "description": "THE BIG NUMBER IS RIGHT NOW. The share of all accounts that currently have Daily Brief switched on. The sparkline behind it shows how that share moved across the range you picked, so the time picker still does something without the headline lying about which moment it describes.\n\nGOOD: rising, or high and steady.\nBAD: flat while headcount grows - the feature is not spreading, it is being carried by early adopters.\nA VISIBLE STEP DOWN in the sparkline is somebody deliberately switching the feature off; the flow panels below name how many and in which direction.\n\nWHY NOT AN AVERAGE OVER THE RANGE: this tile briefly showed a time-weighted mean of the ratio, which is the wrong statistic twice over. Nobody reads 'opt-in rate' as an average over a window, and averaging a ratio weights every scrape equally regardless of how many accounts existed at that instant - so it would report something like 49% for a population that was at 50% and is now at 0%. The correct range figure is a ratio of aggregates, not an aggregate of ratios; the honest presentation is the current value plus the shape, which is what this is.\n\nBoth gauges are re-read from the database every 60s. History on this pair starts 2026-08-20 21:5x, when contaminated samples from dashboard testing were purged and the series began again clean.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 80
+      },
+      "id": 201,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "noValue": "no scrape data in this range",
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "expr": "max(daily_brief_enabled_users_total) / clamp_min(max(daily_brief_eligible_users_total), 1)",
+          "legendFormat": "opt-in rate"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Read rate: distinct readers ÷ subscribers (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Exact COUNT(DISTINCT userId) over whatever range you select — not a sketch and not a fixed window.\n\nOf the people who have Daily Brief switched on, the share who actually opened a brief in the selected range. Switching a feature on costs one click and then people forget about it, so opt-in on its own always overstates use.\n\nGOOD: high over a week or a month — most subscribers read most periods.\nBAD: low over a month — we are generating briefs for an audience that has stopped showing up, and every one of those is model spend with no reader.\n\nPick a range at least a few days long: over 3 hours almost nobody has opened anything, which is true but not informative.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so ranges reaching further back show \"no data\" rather than a misleading 0. Reads were never recorded before that date in any form, and were deliberately NOT back-filled from brief deliveries: a generated brief is not evidence of a read, and inferring one would fabricate the answer to the exact question this group exists to ask.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 80
+      },
+      "id": 202,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT CASE WHEN (SELECT min(\"dateBucket\") FROM daily_brief_activity) IS NULL OR (SELECT min(\"dateBucket\") FROM daily_brief_activity) > to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD') THEN NULL ELSE ((SELECT count(DISTINCT \"userId\") FROM daily_brief_activity WHERE kind='view' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD'))::float / NULLIF((SELECT count(*) FROM users WHERE \"dailyBriefEnabled\"),0)) END AS \"read rate\""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Regeneration reach: regenerating users ÷ users sent a brief (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Both sides are exact distinct-user counts over the selected range.\n\nOf everybody sent a brief in this range, the share who pressed Regenerate at least once.\n\nREPLACES reading “Users with a brief” and “Users who requested a regen” side by side at the top of this page: the second can never exceed the first, so the pair says nothing on its own — the ratio is where the information is.\n\nHIGH (>50%): the automatic brief routinely is not what people wanted.\nLOW (<10%): either the scheduled brief is good enough, or nobody has found the button. Use “Regenerations per 100 scheduled briefs” to tell those apart.\n\nDENOMINATOR MISMATCH WHILE HISTORY BUILDS: the denominator (deliveries) has full history, the numerator does not, so this reads LOW for ranges predating the deploy.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so a range reaching further back shows \"no data\" rather than 0 - an average over an empty set is undefined, and printing 0 would read as \"nobody regenerates\", which is false. Regenerations demonstrably happened before that date.\n\nWHERE THE HISTORY IS: the event counts survive in the metrics store and those panels have full history - see \"Brief runs and regenerations per day\", \"Regeneration mix by origin\" and \"Regenerations per 100 scheduled briefs delivered\" in this group, plus the \"Regenerations (all time)\" and \"Users who requested a regen (all time)\" tiles at the top of the page. What is NOT recoverable is which user regenerated on which day: the Redis set of regenerating users carries no dates, the per-day counters expire after 48h, and a regeneration overwrites its generated_content row in place. Two days were recovered from surviving counters before they expired; the rest is genuinely gone and was not invented.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 80
+      },
+      "id": 203,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT CASE WHEN (SELECT min(\"dateBucket\") FROM daily_brief_activity) IS NULL OR (SELECT min(\"dateBucket\") FROM daily_brief_activity) > to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD') THEN NULL ELSE (NULLIF((SELECT count(DISTINCT \"userId\") FROM daily_brief_activity WHERE kind='regenerate' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD')),0)::float / NULLIF((SELECT count(DISTINCT \"userId\") FROM generated_content WHERE kind='DAILY_BRIEF' AND \"generatedAt\" IS NOT NULL AND $__timeFilter(\"generatedAt\")),0)) END AS \"regeneration reach\""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Fan-out coverage today: briefs delivered ÷ subscribers [today]",
+      "description": "IGNORES THE TIME PICKER — by design, not by limitation.\n\nThis is a live operational tile answering one question: did THIS MORNING's fan-out reach everybody? Both sides are same-day by construction — the numerator counts today's IST date bucket, the denominator is the current subscriber count — and it resets every morning. Widening it to a range would turn it into a different metric, which already exists as “Delivery completeness” below.\n\nGOOD: 1.0 once the morning fan-out has drained — everybody who asked for a brief got one.\nBAD: still below 1.0 later in the day — briefs are failing or the queue never drained. Check “Scheduled-brief failure rate”.\n\nExpect a low reading during the cron run itself; that is the fan-out in progress, not a fault.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 80
+      },
+      "id": 204,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "max(daily_brief_delivered_today) / clamp_min(max(daily_brief_enabled_users_total), 1)"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Distinct readers (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Exact number of different people who opened a brief in the selected range — COUNT(DISTINCT userId) straight from the application's own table, so it is not a HyperLogLog estimate and has no fixed window.\n\nSet the range to 7 days for weekly actives, 30 for monthly. Unlike every “all time” tile on this page this number CAN GO DOWN, which is the point — a cumulative total keeps rising even while everybody quietly stops using the feature.\n\nGOOD: growing, or tracking the subscriber count.\nBAD: falling while opt-ins rise.\n\nCounts opening a brief in the app, so somebody who reads their brief elsewhere and never opens the screen is invisible here.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so ranges reaching further back show \"no data\" rather than a misleading 0. Reads were never recorded before that date in any form, and were deliberately NOT back-filled from brief deliveries: a generated brief is not evidence of a read, and inferring one would fabricate the answer to the exact question this group exists to ask.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 86
+      },
+      "id": 205,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT CASE WHEN (SELECT min(\"dateBucket\") FROM daily_brief_activity) IS NULL OR (SELECT min(\"dateBucket\") FROM daily_brief_activity) > to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD') THEN NULL ELSE ((SELECT count(DISTINCT \"userId\") FROM daily_brief_activity WHERE kind='view' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD'))) END AS readers"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Habit strength: share of days in range a reader was active",
+      "description": "FOLLOWS THE TIME PICKER. Replaces the old fixed 7d÷30d stickiness ratio with something that re-scopes properly and is easier to read.\n\nOf the days in the range you picked, what fraction did a typical reader actually show up for. 1.0 = the average reader opened a brief every single day in the range — a genuine daily habit, which is what a *daily* brief should produce. 0.25 = a typical reader turns up about one day in four; the daily cadence is producing briefs nobody opens three days out of four.\n\nGOOD: high and stable, or rising.\nBAD: falling while “Distinct readers” holds up — new arrivals are masking existing people quietly dropping the habit.\n\nARITHMETIC NOTE: the numerator is user-days and the denominator is (distinct readers × days in range), both computed from real rows inside one SQL statement. This is the ONLY safe way to use user-days — as the numerator of an explicit per-user average. Summed daily counts must never be used as a distinct-user total, because somebody active on ten days would be counted ten times.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so ranges reaching further back show \"no data\" rather than a misleading 0. Reads were never recorded before that date in any form, and were deliberately NOT back-filled from brief deliveries: a generated brief is not evidence of a read, and inferring one would fabricate the answer to the exact question this group exists to ask.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 86
+      },
+      "id": 206,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "WITH per_user AS (SELECT \"userId\", count(DISTINCT \"dateBucket\") AS active_days FROM daily_brief_activity WHERE kind='view' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') GROUP BY 1) SELECT (SUM(active_days)::float / NULLIF(count(*),0)) / GREATEST((to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD')::date - to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD')::date) + 1, 1) AS \"habit strength\" FROM per_user"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Subscribers with zero reads in the selected range",
+      "description": "FOLLOWS THE TIME PICKER. How many people have Daily Brief switched on but did not open a single brief in the range you selected.\n\nEvery one of them costs a full agent run every morning and nobody reads the result — this is the feature's waste bill, expressed in people. It is the number to quote when asking for an auto-pause rule.\n\nGOAL: as close to zero as possible over a 30-day range.\nBAD: growing. The fix is a product decision (nudge them, or pause the brief after N unread days), not an engineering one.\n\nSet a sensible range: over 3 hours almost every subscriber looks dormant, which is true and useless. 30 days is the number worth acting on.\n\nDELIBERATELY NOT BACKFILLED: inferring reads from the fact that a brief was generated would make this panel read zero and the read rate read 100%, fabricating the answer to the exact question it exists to ask.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so ranges reaching further back show \"no data\" rather than a misleading 0. Reads were never recorded before that date in any form, and were deliberately NOT back-filled from brief deliveries: a generated brief is not evidence of a read, and inferring one would fabricate the answer to the exact question this group exists to ask.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 86
+      },
+      "id": 207,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT CASE WHEN (SELECT min(\"dateBucket\") FROM daily_brief_activity) IS NULL OR (SELECT min(\"dateBucket\") FROM daily_brief_activity) > to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD') THEN NULL ELSE (GREATEST((SELECT count(*) FROM users WHERE \"dailyBriefEnabled\") - (SELECT count(DISTINCT \"userId\") FROM daily_brief_activity WHERE kind='view' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD')), 0)) END AS \"dormant subscribers\""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Avg brief-days per user (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Read from generated_content, which has full history back to the feature's first brief — no deploy-date floor on this one.\n\nThe average number of days in the range on which a brief-receiving person actually got a brief. Because there is exactly one brief per person per day, this reads as “how many of the selected days the typical user was served”.\n\nGOOD: close to the number of days in your range.\nBAD: much lower — people are being signed up and then not served, a churn/reliability signal hiding inside the two all-time totals at the top of this page, which both keep looking healthy.\n\nAverages hide shape: a few long-tenured users plus a crowd of one-day trials gives the same average as a uniformly middling population. Use “How many days each reader showed up” for the distribution.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 86
+      },
+      "id": 208,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 1,
+          "noValue": "no data for this range - no briefs were generated in the selected window"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT count(*)::float / NULLIF(count(DISTINCT \"userId\"),0) AS \"brief-days per user\" FROM generated_content WHERE kind='DAILY_BRIEF' AND \"generatedAt\" IS NOT NULL AND $__timeFilter(\"generatedAt\")"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Distinct users per day: readers, regenerators, history-browsers",
+      "description": "FOLLOWS THE TIME PICKER. One point per calendar day, each an exact distinct-user count for that day, over exactly the days you selected.\n\nRead the GAP between the lines. Readers is the population; the other two are what people do once they are there.\n\nGOOD: readers rising, with regenerations a small stable fraction beneath.\nBAD: readers flat or falling while regenerations climb — the same shrinking group is working harder to get a usable brief.\n\nThese are PEOPLE PER DAY, not user-days: a person active on ten days appears once on each of those ten points. Do NOT add the points together to get a distinct total — for that, set the range and read “Distinct readers (selected range)”, which de-duplicates properly.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20; earlier days have no points at all rather than points at zero. Regeneration and switch event history before that date survives only as aggregate counts - see the panels named in the tiles below.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 92
+      },
+      "id": 209,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT \"dateBucket\"::date AS time, count(DISTINCT \"userId\") FILTER (WHERE kind='view') AS \"read a brief\", count(DISTINCT \"userId\") FILTER (WHERE kind='regenerate') AS \"regenerated\", count(DISTINCT \"userId\") FILTER (WHERE kind='switch') AS \"browsed history\" FROM daily_brief_activity WHERE \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') GROUP BY 1 ORDER BY 1"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Brief runs and regenerations per day",
+      "description": "FOLLOWS THE TIME PICKER. Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend. Always a per-DAY rate, so the number means the same thing at every range.\n\nThe daily rate behind the cumulative \"Briefs and regenerations over time\" higher up the page. That panel plots running totals, which only ever slope upward — it looks like healthy growth even on a day the feature was completely dead. This one draws a flat line for a flat feature and a falling line for a dying one.\n\nGOOD: the runs line tracks the subscriber count; the regenerations line stays small and stable beside it.\nBAD: regenerations climbing faster than runs — the same population is re-rolling more often.\n\nCOUNTS RUNS, NOT BRIEF-DAYS. A regeneration is a completed run but does not create a new brief for a new day — it overwrites the existing one. So this line is deliberately higher than \"briefs generated\" and is the right measure of how much work the pipeline did. For per-day delivery coverage use \"Avg briefs delivered per subscriber per day\".\n\nBuilt on true counters rather than the lifetime gauges, because those gauges have historically stepped DOWNWARD (a database reseed took one from 19 to 0), and every rate function reads a downward step as a counter reset and silently adds the pre-dip value back — on this data that inflated the answer threefold.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 92
+      },
+      "id": 210,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(daily_brief_generated_total{status=\"ready\"}[$__range])) * 86400",
+          "legendFormat": "brief runs completed",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(daily_brief_regeneration_attempts_total[$__range])) * 86400",
+          "legendFormat": "regenerations requested",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Avg regenerations per user, per day",
+      "description": "FOLLOWS THE TIME PICKER. Each point divides that day's regenerations by that day's distinct users — numerator and denominator always from the SAME day, so growth in the user base cannot move it.\n\n“Per person who regenerated” is INTENSITY: 1.0 means the typical re-roller pressed the button once and stopped; 3 or 4 means people are fighting the brief to get something usable, which is a quality problem dressed up as engagement.\n\n“Per active reader” is FLEET-WIDE LOAD, the right number for capacity and cost.\n\nGOOD: both flat or falling.\nBAD: intensity rising while load stays flat — a small group is struggling badly, and an average across everybody would have hidden them.\n\nThe GAP between the lines is the concentration measure. Wide gap = regeneration is a minority behaviour done intensively.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so a range reaching further back shows \"no data\" rather than 0 - an average over an empty set is undefined, and printing 0 would read as \"nobody regenerates\", which is false. Regenerations demonstrably happened before that date.\n\nWHERE THE HISTORY IS: the event counts survive in the metrics store and those panels have full history - see \"Brief runs and regenerations per day\", \"Regeneration mix by origin\" and \"Regenerations per 100 scheduled briefs delivered\" in this group, plus the \"Regenerations (all time)\" and \"Users who requested a regen (all time)\" tiles at the top of the page. What is NOT recoverable is which user regenerated on which day: the Redis set of regenerating users carries no dates, the per-day counters expire after 48h, and a regeneration overwrites its generated_content row in place. Two days were recovered from surviving counters before they expired; the rest is genuinely gone and was not invented.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 100
+      },
+      "id": 211,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 2,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "WITH d AS (SELECT \"dateBucket\", SUM(count) FILTER (WHERE kind='regenerate') AS regen_events, count(DISTINCT \"userId\") FILTER (WHERE kind='regenerate') AS regen_users, count(DISTINCT \"userId\") FILTER (WHERE kind='view') AS view_users FROM daily_brief_activity WHERE \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') GROUP BY 1) SELECT \"dateBucket\"::date AS time, regen_events::float / NULLIF(regen_users,0) AS \"per person who regenerated\", regen_events::float / NULLIF(view_users,0) AS \"per active reader\" FROM d ORDER BY 1"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Regenerations per 100 scheduled briefs delivered",
+      "description": "FOLLOWS THE TIME PICKER: Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend.\n\nFor every 100 briefs the schedule delivered, how many extra generations people asked for on top. The cleanest measure of how much work the feature does BEYOND its schedule, normalised so that simply adding users cannot move it.\n\n0 = the automatic brief is accepted as-is.\n100 = one extra generation for every brief delivered — the feature costs roughly double what the schedule alone would.\nAbove 100 = people re-roll more than once per delivered brief.\n\nGOOD: low and flat. BAD: any sustained climb — but read it with “Regeneration mix by origin” beside it, because retries after an error inflate this without anybody being dissatisfied.\n\nGAPS ARE HONEST: where no scheduled brief was delivered in a bucket the ratio is undefined, so the line breaks rather than dropping to a fake zero.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 100
+      },
+      "id": 212,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "100 * sum(increase(daily_brief_regeneration_attempts_total[$__range])) / (sum(increase(daily_brief_generated_total{trigger=\"scheduled\",status=\"ready\"}[$__range])) > 0)",
+          "legendFormat": "extra generations per 100 scheduled briefs",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scheduled-brief rejection rate",
+      "description": "FOLLOWS THE TIME PICKER: Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend.\n\nShare of the briefs the cron delivered that their owner immediately threw away and re-ran. The stat tile “Rejection rate of the auto brief” higher up gives one number for the whole range; this is the same measurement as a TREND, so a model change, a prompt change or a data-source regression shows up as a visible step.\n\nGOOD: low, and stepping DOWN after a change you shipped.\nBAD: any sustained rise — the scheduled brief is getting less useful.\n\nOnly the FIRST re-run of a given day's scheduled brief counts here; further re-runs that day are classified “replacing_own_regeneration” and appear in the panel to the right. That is why this cannot exceed 100%. Buckets with no scheduled delivery draw a gap rather than a misleading zero.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 108
+      },
+      "id": 213,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(daily_brief_regeneration_attempts_total{origin=\"replacing_scheduled_brief\"}[$__range])) / (sum(increase(daily_brief_generated_total{trigger=\"scheduled\",status=\"ready\"}[$__range])) > 0)",
+          "legendFormat": "scheduled brief re-run by its owner",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Regeneration mix by origin (% of regeneration volume)",
+      "description": "FOLLOWS THE TIME PICKER: Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend.\n\nWhat the Regenerate button is actually being used for. This is the panel that stops “regenerations are up” being misreported.\n\n• replacing_scheduled_brief — the morning brief was rejected. A QUALITY problem.\n• replacing_own_regeneration — their own re-run was rejected too. A WORSE quality problem.\n• retry_after_failure — the previous run errored. A RELIABILITY problem; says nothing about quality.\n• first_brief_of_day — no brief existed yet. Not dissatisfaction, just normal use.\n\nGOOD: dominated by first_brief_of_day with a thin retry band.\nBAD: a fat retry_after_failure band. While it is wide, every raw regeneration count on this dashboard is mostly measuring outages, and the volume must NOT be reported as engagement.\n\nBands are shares and sum to 100% within each bucket; use the panel to the left for the absolute level. Buckets with no regenerations at all draw a gap.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 108
+      },
+      "id": 214,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 80,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (origin) (increase(daily_brief_regeneration_attempts_total[$__range])) / scalar(sum(increase(daily_brief_regeneration_attempts_total[$__range])) > 0)",
+          "legendFormat": "{{origin}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scheduled-brief failure rate",
+      "description": "FOLLOWS THE TIME PICKER: Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend.\n\nShare of the cron's brief runs that ended without producing a brief. Nothing else on this dashboard covers this — “Regeneration success rate” only measures the Regenerate button, the path people take when they are already looking at the screen and can see something went wrong. A SCHEDULED failure is the worst outcome the feature has: the user opens the app in the morning and there is simply nothing there, with no error to react to.\n\nGOOD: flat at 0.\nBAD: anything sustained above a few percent — each point is a morning where somebody got nothing.\n\nSpikes that line up with a deploy or a provider incident are the usual cause; cross-check “p95 generation time vs throughput” for the same period, since timeouts show up as both slow runs and failures. Buckets with no scheduled runs at all draw a gap, which is the normal state between cron fan-outs.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 116
+      },
+      "id": 215,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(daily_brief_generated_total{trigger=\"scheduled\",status=\"failed\"}[$__range])) / (sum(increase(daily_brief_generated_total{trigger=\"scheduled\"}[$__range])) > 0)",
+          "legendFormat": "scheduled runs that produced no brief",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "On-time delivery rate: scheduled briefs ready ≤ 30 min after target",
+      "description": "FOLLOWS THE TIME PICKER: Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend.\n\nOf the scheduled briefs delivered, the share ready within half an hour of the time the cron was aiming for. This is the promise the feature actually makes — “your brief is there when you start work” — as a service level you can set a target on.\n\nGOOD: close to 1.0.\nBAD: falling — the morning fan-out is queueing behind the shared model-throughput limit and the users at the back of the queue get their brief hours late.\n\n30 minutes is used because it is a real bucket edge in the underlying histogram; a threshold that is not a bucket boundary would silently return a wrong answer.\n\nCounts only runs that SUCCEEDED and whose measured delay passed the sanity check. A brief that never arrived is in the failure panel to the left, not here — read the two together, because a pipeline that fails everything and delivers one brief on time scores 100% here.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 116
+      },
+      "id": 216,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(daily_brief_scheduled_delivery_delay_milliseconds_bucket{le=\"1800000\"}[$__range])) / (sum(increase(daily_brief_scheduled_delivery_delay_milliseconds_count[$__range])) > 0)",
+          "legendFormat": "ready within 30 min of target",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "p95 generation time vs throughput (briefs/hour)",
+      "description": "FOLLOWS THE TIME PICKER. Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend. \n\nTwo lines that only mean something together: how long the slowest 5% of runs take (left axis, milliseconds) and how many runs we finish per hour (right axis). It answers the capacity question directly — can this feature take more users without getting worse for the ones it already has?\n\nBAD: p95 rises whenever throughput rises. That is contention — the pipeline is at its limit and every new subscriber makes everybody's brief later.\nGOOD: p95 flat while throughput grows — there is headroom and growth is safe.\nALSO WATCH: p95 rising while throughput is FLAT. That is a regression in the run itself (slower model, slower tools, more data per user), not a load problem, and adding capacity will not fix it.\n\nSuccessful runs only — a failed run's duration is mostly the timeout, which would drag the percentile around for reasons that have nothing to do with speed.\n\nNOTE: this uses $__range rather than $__rate_interval. On this stack $__rate_interval resolves to four times the datasource's minimum interval (1 minute) regardless of the range, which on a feature that runs once per person per day samples a one-minute window every couple of hours and reads as empty. The neighbouring pre-existing panel \"Generation time by trigger\" still has that problem.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 124
+      },
+      "id": 217,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "briefs completed per hour"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "briefs / hour"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__range])))",
+          "legendFormat": "p95 generation time",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(daily_brief_generated_total{status=\"ready\"}[$__range])) * 3600",
+          "legendFormat": "briefs completed per hour",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Generation minutes per day by trigger",
+      "description": "FOLLOWS THE TIME PICKER: Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend. Always expressed as minutes per DAY, so the number means the same thing at every range.\n\nModel time consumed per day, split by whether the schedule asked for the run or a person did. Agent runs are the expensive part of this feature, so this is the closest thing on the dashboard to a cost line.\n\nGOOD: the “scheduled” band grows in step with subscribers and the “regenerate” band stays small.\nBAD: “regenerate” approaching or passing “scheduled” — the feature then costs about twice what its schedule alone would, and the extra is spent purely because the automatic brief was not good enough first time.\n\nFAILED runs are included on purpose: a run that burned four minutes and produced nothing still cost four minutes. For a per-person figure use “Avg generation minutes per active reader per day” below.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 124
+      },
+      "id": 218,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 70,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "mappings": [],
+          "unit": "m",
+          "min": 0,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (trigger) (rate(daily_brief_generation_duration_milliseconds_sum[$__range])) * 86400 / 60000",
+          "legendFormat": "{{trigger}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "title": "Per-user averages — the denominator is the metric",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 132
+      },
+      "id": 230,
+      "options": {
+        "mode": "markdown",
+        "content": "### Per-user averages — the denominator is the metric\n\nAn average per user is only a fact once you say **which users**. The same numerator over three different denominators answers three different questions, and they can differ by 10x:\n\n| Denominator | Question it answers | Use it for |\n|---|---|---|\n| **people who did the action** | how *intensely* do the people who use this feature use it | product depth, spotting a struggling minority |\n| **active readers** | how much does the *typical Daily Brief user* generate | capacity, cost per user, fleet-wide load |\n| **subscribers** | what do we owe the people who asked for this | delivery coverage, SLO |\n\nEvery tile states its denominator, and **both sides of every ratio are counted over the same range** — so changing the time picker re-scopes the whole average, and growth in the user base cannot move it on its own.\n\n**Means hide skew.** These actions are dominated by a few heavy users, so a mean can rise while most people do nothing. Two panels exist specifically to catch that: **Participation rate** counts people rather than events, so one power user cannot move it; **How many days each reader showed up** gives the whole distribution instead of its midpoint. When an average climbs while those stay flat, a small group is doing more — not the population.\n\n**The user-days trap.** *Habit strength* uses summed user-days as a numerator over an explicit (readers × days) denominator, which is correct. Summed per-day user counts must **never** be used as a distinct-user total — a person active on ten days would count ten times. Every distinct count on this board is a real `COUNT(DISTINCT \"userId\")` computed inside one SQL statement, never a sum of daily figures."
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Avg regenerations per regenerating user (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Both sides come from the same rows over the same range, so the average is internally consistent at every setting.\n\nDENOMINATOR: distinct users who pressed Regenerate at least once in the range. Deliberately NOT all users — including people who never touch the button turns an intensity measure into a participation measure and blurs both.\n\nReads as: “someone who regenerates at all does it N times in this period.”\n\nGOOD: near 1 — people re-roll once and get what they need.\nBAD: 3, 4, 5 and climbing — people are fighting the brief. That is a quality failure which raw regeneration counts report as engagement.\n\nSKEW WARNING: a mean over a heavily skewed population. Read it beside “Participation rate” and “How many days each reader showed up” — if this rises while those stay flat, a small group is struggling badly and the fleet-wide number will not show it.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so a range reaching further back shows \"no data\" rather than 0 - an average over an empty set is undefined, and printing 0 would read as \"nobody regenerates\", which is false. Regenerations demonstrably happened before that date.\n\nWHERE THE HISTORY IS: the event counts survive in the metrics store and those panels have full history - see \"Brief runs and regenerations per day\", \"Regeneration mix by origin\" and \"Regenerations per 100 scheduled briefs delivered\" in this group, plus the \"Regenerations (all time)\" and \"Users who requested a regen (all time)\" tiles at the top of the page. What is NOT recoverable is which user regenerated on which day: the Redis set of regenerating users carries no dates, the per-day counters expire after 48h, and a regeneration overwrites its generated_content row in place. Two days were recovered from surviving counters before they expired; the rest is genuinely gone and was not invented.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 137
+      },
+      "id": 225,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 2,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT SUM(count)::float / NULLIF(count(DISTINCT \"userId\"),0) AS \"regenerations per regenerating user\" FROM daily_brief_activity WHERE kind='regenerate' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD')"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Avg regenerations per active reader (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. DENOMINATOR: every distinct person who opened a brief in the range, whether or not they ever regenerated. This is the fleet-wide load figure — the one to multiply by a user count when forecasting cost or capacity.\n\nReads as: “each Daily Brief reader costs us N extra generations in this period.”\n\nGOOD: well under 1 per week — most readers accept the scheduled brief.\nBAD: above 1 — the on-demand path, not the schedule, is the main consumer of model time.\n\nAlways lower than the tile to its left, because this denominator includes everybody who never pressed the button. The GAP between the two is the concentration: wide means regeneration is a minority behaviour done intensively.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so a range reaching further back shows \"no data\" rather than 0 - an average over an empty set is undefined, and printing 0 would read as \"nobody regenerates\", which is false. Regenerations demonstrably happened before that date.\n\nWHERE THE HISTORY IS: the event counts survive in the metrics store and those panels have full history - see \"Brief runs and regenerations per day\", \"Regeneration mix by origin\" and \"Regenerations per 100 scheduled briefs delivered\" in this group, plus the \"Regenerations (all time)\" and \"Users who requested a regen (all time)\" tiles at the top of the page. What is NOT recoverable is which user regenerated on which day: the Redis set of regenerating users carries no dates, the per-day counters expire after 48h, and a regeneration overwrites its generated_content row in place. Two days were recovered from surviving counters before they expired; the rest is genuinely gone and was not invented.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 137
+      },
+      "id": 226,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 2,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT (SELECT SUM(count) FROM daily_brief_activity WHERE kind='regenerate' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD'))::float / NULLIF((SELECT count(DISTINCT \"userId\") FROM daily_brief_activity WHERE kind='view' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD')),0) AS \"regenerations per active reader\""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Avg brief switches per switching user (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Both sides from the same rows over the same range.\n\nDENOMINATOR: distinct users who switched to a different brief at least once in the range.\n\nReads as: “someone who browses their brief history opens N of them in this period.”\n\nGOOD: comfortably above 1 — people who find the history come back to it, so it is a real tool rather than a one-time curiosity.\nBAD: pinned at ~1 — people open an old brief once and never again, which usually means they did not find what they were looking for.\n\nSKEW WARNING: a mean over a small, self-selected group. Pair it with the participation rate panel.\n\nNOTE: the pre-existing tile “Users who switched briefs (last 30 days)” higher up the page still reads a fixed 30-day Redis sketch and will not agree with this one at other ranges. This panel is the exact count.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20; before that a range shows \"no data\" rather than 0, because an average over an empty set is undefined and 0 would read as \"nobody browses history\", which is false.\n\nWHERE THE HISTORY IS: \"Total brief switches (all time)\", \"Users who switched briefs (last 30 days)\" and \"Switches: list vs calendar (all time)\" at the top of the page all have full history. Per-day switch history is genuinely UNRECOVERABLE: the only per-day structure was a HyperLogLog, whose members cannot be enumerated and which stores no event count. Nothing was inferred to fill the gap.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 137
+      },
+      "id": 227,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 2,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT SUM(count)::float / NULLIF(count(DISTINCT \"userId\"),0) AS \"switches per switching user\" FROM daily_brief_activity WHERE kind='switch' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD')"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Delivery completeness: scheduled briefs delivered ÷ perfect delivery (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Perfect delivery = every subscriber gets a brief every day, so the ideal denominator is (subscribers x days). This is the share of that ideal we actually delivered.\n\nGOOD: 100%. Everybody who asked for a brief got one, every morning in the range.\nBAD: 60% means four mornings in ten produced nothing for the average subscriber.\n\nReads generated_content, so it has FULL HISTORY back to the feature's first brief - unlike the reader panels in this group it is not limited by when durable per-user recording started.\n\nThe day count is clamped to days on which the feature actually existed, so selecting a range that reaches back before the first brief ever does not manufacture a shortfall that never happened.\n\nWHY THIS IS NOT \"Briefs generated (all time)\": that tile counts brief-days ever created and is monotonic - it rises whether the feature is healthy or half-broken, and it rises FASTER when you add users, so growth and quality are welded into one number that can only go up. This one divides by the population and by elapsed days, so adding 900 subscribers leaves it unchanged while halving delivery success halves it.\n\nCAVEAT: subscriber count is a live reading while the numerator spans the range, so a burst of recent sign-ups drags this down for a while - those people were not subscribers for the whole range. On short ranges use \"Fan-out coverage today\", where both sides are same-day.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 137
+      },
+      "id": 228,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "—"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 1,
+          "noValue": "no deliveries in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "SELECT count(*)::float / NULLIF((SELECT count(*) FROM users WHERE \"dailyBriefEnabled\") * GREATEST((to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD')::date - GREATEST(to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata','YYYY-MM-DD')::date, (SELECT min(\"dateBucket\")::date FROM generated_content WHERE kind='DAILY_BRIEF'))) + 1, 1),0) AS \"delivery completeness\" FROM generated_content WHERE kind='DAILY_BRIEF' AND \"generatedAt\" IS NOT NULL AND $__timeFilter(\"generatedAt\")"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Avg brief switches per user, per day",
+      "description": "FOLLOWS THE TIME PICKER. The switching twin of the regeneration panel beside it, on the same same-day numerator/denominator rule.\n\n“Per switching user” is DEPTH — how hard the people who use brief history lean on it. “Per active reader” is REACH — how much the average reader browses at all.\n\nREAD THE GAP: lines close together means browsing history is normal behaviour spread across the user base; a high depth line over a flat reach line means a handful of power users do all the browsing, and any mean quoted without its denominator will mislead whoever hears it.\n\nGOOD: reach rising — history is being discovered.\nBAD: depth rising while reach is flat — the same few people are hunting through old briefs, which usually means today's brief is not answering their question.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20; before that a range shows \"no data\" rather than 0, because an average over an empty set is undefined and 0 would read as \"nobody browses history\", which is false.\n\nWHERE THE HISTORY IS: \"Total brief switches (all time)\", \"Users who switched briefs (last 30 days)\" and \"Switches: list vs calendar (all time)\" at the top of the page all have full history. Per-day switch history is genuinely UNRECOVERABLE: the only per-day structure was a HyperLogLog, whose members cannot be enumerated and which stores no event count. Nothing was inferred to fill the gap.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 143
+      },
+      "id": 219,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 2,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "WITH d AS (SELECT \"dateBucket\", SUM(count) FILTER (WHERE kind='switch') AS sw_events, count(DISTINCT \"userId\") FILTER (WHERE kind='switch') AS sw_users, count(DISTINCT \"userId\") FILTER (WHERE kind='view') AS view_users FROM daily_brief_activity WHERE \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') GROUP BY 1) SELECT \"dateBucket\"::date AS time, sw_events::float / NULLIF(sw_users,0) AS \"per switching user (depth)\", sw_events::float / NULLIF(view_users,0) AS \"per active reader (reach)\" FROM d ORDER BY 1"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Participation rate: share of each day's readers who did each action",
+      "description": "FOLLOWS THE TIME PICKER. The skew-proof companion to every average on this page: it counts PEOPLE, so no amount of activity by one heavy user can move it.\n\nUse it to settle the question an average cannot: “is this behaviour spreading, or are the same few people doing more of it?” If an average rises while its line here stays flat, the answer is the second — and the right response is to look at those users, not to redesign for everybody.\n\nREGENERATED: high is ambiguous alone — either the scheduled brief misses often, or people enjoy pulling a fresh one. Split it with “Regeneration mix by origin” above.\nBROWSED HISTORY: low usually means discoverability, not disinterest — the calendar is the only way to reach a brief older than the most recent handful.\n\nCannot exceed 100%: you have to open a brief to be counted in either numerator.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20. A day with no readers yields no point rather than 0%, since a share of an empty population is undefined.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 143
+      },
+      "id": 220,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "WITH d AS (SELECT \"dateBucket\", count(DISTINCT \"userId\") FILTER (WHERE kind='regenerate') AS regen_users, count(DISTINCT \"userId\") FILTER (WHERE kind='switch') AS sw_users, count(DISTINCT \"userId\") FILTER (WHERE kind='view') AS view_users FROM daily_brief_activity WHERE \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') GROUP BY 1) SELECT \"dateBucket\"::date AS time, regen_users::float / NULLIF(view_users,0) AS \"regenerated that day\", sw_users::float / NULLIF(view_users,0) AS \"browsed history that day\" FROM d ORDER BY 1"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "How many days each reader showed up (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. The distribution behind every average on this page — bounded buckets, so no user id ever leaves the database and the panel stays readable at any scale.\n\nAn average cannot tell a population where everyone shows up sometimes from one where a handful show up constantly and the rest came once. This can.\n\nGOOD: mass in the right-hand buckets — people who find the brief keep coming back.\nBAD: a tall “1 day” bar — most readers tried it once and never returned, and every per-user average on this dashboard is being propped up by a small committed minority.\n\nBuckets count PEOPLE and sum to the total distinct readers in the range, so this one CAN be read as a share of the whole.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so ranges reaching further back show \"no data\" rather than a misleading 0. Reads were never recorded before that date in any form, and were deliberately NOT back-filled from brief deliveries: a generated brief is not evidence of a read, and inferring one would fabricate the answer to the exact question this group exists to ask.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 151
+      },
+      "id": 224,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "max": 1,
+          "decimals": 0,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "WITH per_user AS ( SELECT \"userId\", count(DISTINCT \"dateBucket\") AS days FROM daily_brief_activity WHERE kind='view' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') GROUP BY 1) SELECT CASE WHEN days = 1 THEN '1 day' WHEN days <= 3 THEN '2-3 days' WHEN days <= 7 THEN '4-7 days' WHEN days <= 20 THEN '8-20 days' ELSE '21+ days' END AS \"days active\", count(*) AS readers FROM per_user GROUP BY 1 ORDER BY min(days)"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Briefs generated per reader (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. How many briefs we produced for every person who actually read one.\n\nThis is the waste ratio in its most direct form. If we generate 30 briefs for every reader, 29 of them were produced for somebody who never opened the screen in this range.\n\nGOOD: close to the number of days in the range (one brief per reader per day, all of them read).\nBAD: far above it — the fan-out is serving an audience that is not there. Pair with “Subscribers with zero reads”, which names how many people that is.\n\nFor an absolute cost figure in model time see “Generation minutes per day by trigger”; divide that by “Distinct readers” for minutes per reader.\n\nNumerator has full history (generated_content); the denominator does not, so ranges predating the deploy read HIGH.\n\nHISTORY STARTS AT DEPLOY. This reads daily_brief_activity, which only began recording when this change shipped. A range reaching further back reads low or zero — that is MISSING HISTORY, not a fall in usage. Brief deliveries are unaffected: they come from generated_content and go back to the feature's first brief.\n\nBLANK, NOT ZERO. Durable per-user recording started 2026-08-20, so ranges reaching further back show \"no data\" rather than a misleading 0. Reads were never recorded before that date in any form, and were deliberately NOT back-filled from brief deliveries: a generated brief is not evidence of a read, and inferring one would fabricate the answer to the exact question this group exists to ask.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "claw-auth-postgres"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 151
+      },
+      "id": 223,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 1,
+          "noValue": "no data for this range - durable per-user recording started 2026-08-20"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "claw-auth-postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "editorMode": "code",
+          "rawSql": "WITH gc AS (SELECT count(*) AS briefs FROM generated_content WHERE kind='DAILY_BRIEF' AND \"generatedAt\" IS NOT NULL AND $__timeFilter(\"generatedAt\")), rd AS (SELECT count(DISTINCT \"userId\") AS readers FROM daily_brief_activity WHERE kind='view' AND \"dateBucket\" >= to_char($__timeFrom() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD') AND \"dateBucket\" <= to_char($__timeTo() AT TIME ZONE 'Asia/Kolkata', 'YYYY-MM-DD')) SELECT gc.briefs::float / NULLIF(rd.readers,0) AS \"briefs generated per reader\" FROM gc, rd"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Avg briefs delivered per subscriber per day",
+      "description": "FOLLOWS THE TIME PICKER (numerator): Each point is a moving aggregate over a window as long as the selected range, ending at that point — so the whole line re-scopes when you change the picker: a narrow range gives a responsive, spiky line, a wide range gives a smooth trend. Expressed per day. The denominator — how many people currently have the feature switched on — is a live reading and has no window of its own.\n\nGOOD: sitting at ~1.0. One brief, per subscriber, per day, which is exactly what the feature promises.\nBAD: dips below 1.0. Each dip is a morning where some subscribers got nothing, and the depth of the dip is roughly the share who missed out. Line them up against “Scheduled-brief failure rate” to see whether the runs failed or were never enqueued — a dip HERE with a clean failure rate means the fan-out never started, which is the more serious of the two.\nABOVE 1.0: should not happen for long — the cron enqueues one job per subscriber per day. A sustained reading above 1.0 means the subscriber count fell while deliveries continued, or the fan-out ran twice.\n\nCAVEAT: a wave of sign-ups pushes this below 1.0 for a day even though nothing failed — those people have not had a morning yet. For the range-scoped version with the same caveat removed, see “Delivery completeness”.\n\nCounts SCHEDULED runs that succeeded, from a true counter — not the lifetime brief-row gauge, which has historically stepped downward on a database reseed and would make every rate built on it read high.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 159
+      },
+      "id": 222,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(daily_brief_generated_total{trigger=\"scheduled\",status=\"ready\"}[$__range])) * 86400 / clamp_min(max(daily_brief_enabled_users_total), 1)",
+          "legendFormat": "briefs per subscriber per day",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Subscribers and total accounts over time",
+      "description": "FOLLOWS THE TIME PICKER. The two raw levels behind the opt-in rate: how many people have Daily Brief switched on, and how many accounts exist to switch it on.\n\nRead the GAP. Both lines rising together is healthy growth. The accounts line rising while subscribers stays flat means new joiners are not finding or not wanting the feature - a discovery problem, not a quality one.\n\nThe subscriber line is the only number on this dashboard that a user moves DELIBERATELY: it changes when somebody flips the Morning Brief toggle in Preferences, or uses the enable button on the intro banner or the empty state. A fall is a considered rejection and is worth chasing individually.\n\nThis is a LEVEL, so it shows the net position at each moment and cannot tell you how much traffic went both ways - ten people joining and ten leaving draws a flat line. The flow panel beside it separates those.\n\nThe subscriber and account gauges have been scraped since 2026-08-20 12:50, so ranges reaching further back read blank rather than zero. A two-minute window around 16:09 that day shows 4 subscribers - test accounts that were created and removed while building this dashboard. It ages out as history grows.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 167
+      },
+      "id": 229,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "noValue": "no scrape data in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_enabled_users_total)",
+          "legendFormat": "subscribers",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "max(daily_brief_eligible_users_total)",
+          "legendFormat": "all accounts",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Opt-ins and opt-outs per day",
+      "description": "FOLLOWS THE TIME PICKER. Gross flow in each direction, expressed as a per-day rate so the number means the same thing at every range.\n\nThis is what the subscriber count CANNOT show. Ten people switching on and ten switching off leaves the level perfectly flat, and reads as 'nothing is happening' when in fact the feature is churning its entire audience.\n\nGOOD: opt-ins consistently above opt-outs, with opt-outs near zero.\nBAD: the two lines tracking each other - you are acquiring and losing the same volume, so growth is a treadmill.\nWORST: an opt-out spike the day after a release; line it up against the scheduled-brief failure rate and the rejection rate to see whether quality caused it.\n\nCounts real transitions only. Saving the settings form without changing the toggle does not count, and writing the same value twice counts once - verified against the live route.\n\nOpt-in and opt-out EVENTS are counted from the moment this counter shipped (2026-08-20).\n\nWHILE THE COUNTER IS YOUNG THIS CHART WILL LOOK EMPTY AT WIDE RANGES. A per-day rate needs enough samples inside the lookback window to compute, so with only a few hours of counter history a 7-day or 90-day range returns nothing while a 3-hour range works - the opposite of what you would expect, and measured rather than assumed. It resolves on its own after a day or two of history. Until then the three tiles below give the same information as exact counts at any range. The subscriber gauge above has slightly more history than the flow counters below, so over long ranges the net flow will not fully explain the level change. They agree from here forward.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 167
+      },
+      "id": 221,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 2,
+          "min": 0,
+          "noValue": "no toggle activity in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(daily_brief_opt_in_changes_total{action=\"opted_in\"}[$__range])) * 86400",
+          "legendFormat": "opted in",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "sum(rate(daily_brief_opt_in_changes_total{action=\"opted_out\"}[$__range])) * 86400",
+          "legendFormat": "opted out",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Net subscriber change (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Opt-ins minus opt-outs across the selected range - how many net subscribers the feature gained or lost.\n\nGOOD: positive and growing.\nBAD: zero. Read it beside the two gross tiles - a net of zero from 0 in and 0 out means nobody is trying the feature, while a net of zero from 12 in and 12 out means you are losing people as fast as you win them. Those need opposite responses.\n\nNEGATIVE is the one to act on immediately: more people are switching Daily Brief off than on.\n\nOpt-in and opt-out EVENTS are counted from the moment this counter shipped (2026-08-20). The subscriber gauge above has slightly more history than the flow counters below, so over long ranges the net flow will not fully explain the level change. They agree from here forward.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 175
+      },
+      "id": 231,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "-"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "no toggle activity in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "expr": "sum(increase(daily_brief_opt_in_changes_total{action=\"opted_in\"}[$__range])) - sum(increase(daily_brief_opt_in_changes_total{action=\"opted_out\"}[$__range]))"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Opt-in rate over time",
+      "id": 234,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 181
+      },
+      "description": "FOLLOWS THE TIME PICKER. The share of accounts with Daily Brief switched on, recomputed at every point across the selected range.\n\nThis is a ratio of aggregates evaluated instant by instant - subscribers at that moment divided by accounts at that moment - which is the mathematically correct way to show a rate over time. It is NOT a running average, so every step you see is a real change in the population rather than a smoothing artefact.\n\nGOOD: a staircase climbing to the right.\nBAD: steps DOWN. Each one is a person who found the toggle and chose to turn the feature off - the clearest rejection signal the feature has. Line the date up against 'Scheduled-brief failure rate' and 'Scheduled-brief rejection rate' to see whether quality caused it.\n\nFLAT AT ZERO is a real reading, not a broken panel: it means nobody currently has the feature on.\n\nHistory starts 2026-08-20 21:5x - the point at which contaminated test samples were purged from these two gauges and the series restarted clean. Ranges reaching further back read blank.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto",
+            "lineInterpolation": "stepAfter"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "no scrape data in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "expr": "max(daily_brief_enabled_users_total) / clamp_min(max(daily_brief_eligible_users_total), 1)",
+          "legendFormat": "opt-in rate"
         }
       ]
     }

--- a/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
+++ b/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
@@ -25,11 +25,24 @@
   "timezone": "",
   "title": "Daily Brief",
   "uid": "xyne-daily-brief",
-  "version": 10,
+  "version": 15,
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Adoption & volume",
+      "type": "row"
+    },
+    {
       "type": "stat",
-      "title": "Users with a brief",
+      "title": "Users with a brief (all time)",
       "description": "Users who have at least one generated brief. Read from generated_content, so it is exact and independent of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -39,7 +52,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 1,
       "fieldConfig": {
@@ -85,7 +98,7 @@
     },
     {
       "type": "stat",
-      "title": "Users who requested a regen",
+      "title": "Users who requested a regen (all time)",
       "description": "Users who have requested at least one regeneration. Counted by user id in Redis when the request reaches claw-auth, so it is exact and independent of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -95,7 +108,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 0
+        "y": 1
       },
       "id": 2,
       "fieldConfig": {
@@ -151,73 +164,7 @@
     },
     {
       "type": "stat",
-      "title": "Users (devices) who switched briefs",
-      "description": "Distinct devices that picked a different brief from the history menu within the selected time range. Switching is a client-only action, so the only identity available is a per-browser id \u2014 the same person on web and Electron counts twice.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 0
-      },
-      "id": 3,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "count(count by (instance) (increase(daily_brief_switched_total[$__range]) > 0))"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Briefs generated",
+      "title": "Briefs generated (all time)",
       "description": "Briefs that exist globally (one per user per day; a regeneration overwrites that day's brief rather than adding one). Read from generated_content, so it is exact and independent of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -226,8 +173,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 18,
-        "y": 0
+        "x": 12,
+        "y": 1
       },
       "id": 4,
       "fieldConfig": {
@@ -273,7 +220,7 @@
     },
     {
       "type": "stat",
-      "title": "Regenerations",
+      "title": "Regenerations (all time)",
       "description": "Regeneration requests ever served, globally. Counted in Redis when the request reaches claw-auth, so it survives restarts and is exact regardless of the time range.",
       "datasource": {
         "type": "prometheus",
@@ -282,8 +229,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 0,
-        "y": 6
+        "x": 18,
+        "y": 1
       },
       "id": 5,
       "fieldConfig": {
@@ -337,9 +284,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 18,
-        "x": 6,
-        "y": 6
+        "w": 24,
+        "x": 0,
+        "y": 7
       },
       "id": 6,
       "fieldConfig": {
@@ -388,8 +335,300 @@
       ]
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Brief switching",
+      "type": "row"
+    },
+    {
       "type": "stat",
-      "title": "Users who rejected the auto brief",
+      "title": "Total brief switches (all time)",
+      "description": "Every brief switch ever served, counted server-side (Redis INCR). Events, not people \u2014 compare against \"Users who switched briefs\" to see switches-per-person.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 24,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_switches_total)",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Users who switched briefs (last 30 days)",
+      "description": "Distinct users who switched to a different brief in the last 30 days, counted server-side by userId (Redis HyperLogLog, ~0.81% error). Replaces an earlier device-based count: the client metric carries a per-device localStorage id, so it counted browsers rather than people \u2014 one person on three devices read as three. A beacon can be blocked or lost on a fast page close, so treat this as a tight lower bound. See \"Brief switches by control\" for event volume.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_switch_users_window{window=\"30d\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "piechart",
+      "title": "Switches: list vs calendar (all time)",
+      "description": "Share of switch events by control, server-side. The calendar is the ONLY way to reach a brief older than the 8 most recent, so date_picker volume is the direct read on whether people want older briefs. Events, so one heavy user can dominate \u2014 read alongside panel \"Users reaching for older briefs\".",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 25,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max by (source) (daily_brief_switches_by_source)",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "{{source}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Users reaching for older briefs (all time)",
+      "description": "Distinct users who have used each control at least once. NOTE: these sets OVERLAP \u2014 someone who used both is counted in both, so the bars do not sum to the total user count and must not be drawn as a pie. date_picker here = how many people ever went past the recent window, which is the per-person version of the question.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 26,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max by (source) (daily_brief_switch_users_by_source)",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "{{source}}"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Regeneration behaviour & outcomes",
+      "type": "row"
+    },
+    {
+      "type": "stat",
+      "title": "Users who rejected the auto brief (all time)",
       "description": "Users who have re-run a brief the cron produced for them \u2014 dissatisfaction with the default. Exact, lifetime.",
       "datasource": {
         "type": "prometheus",
@@ -399,7 +638,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 12
+        "y": 27
       },
       "id": 7,
       "fieldConfig": {
@@ -445,7 +684,7 @@
     },
     {
       "type": "stat",
-      "title": "Users who regenerated more than once",
+      "title": "Users who regenerated more than once (all time)",
       "description": "Users who re-ran a brief they had already regenerated \u2014 the regeneration itself did not satisfy them. Exact, lifetime.",
       "datasource": {
         "type": "prometheus",
@@ -455,7 +694,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 12
+        "y": 27
       },
       "id": 8,
       "fieldConfig": {
@@ -500,114 +739,18 @@
       ]
     },
     {
-      "type": "barchart",
-      "title": "Why briefs get regenerated",
-      "description": "replacing_scheduled_brief = rejecting the cron brief \u00b7 replacing_own_regeneration = rejecting their own re-run \u00b7 retry_after_failure = the previous run errored, not a quality signal \u00b7 first_brief_of_day = no brief existed yet.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 12
-      },
-      "id": 9,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (origin) (increase(daily_brief_regeneration_attempts_total[$__range]))",
-          "legendFormat": "{{origin}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "How many regenerations it takes",
-      "description": "Attempt depth within a single day per user. A tall 1 with a short 2 means one re-run usually settles it; a long tail means the brief is not converging.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 18
-      },
-      "id": 10,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "auto",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (attempt) (increase(daily_brief_regeneration_attempts_total{origin!=\"retry_after_failure\"}[$__range]))",
-          "legendFormat": "attempt {{attempt}}"
-        }
-      ]
-    },
-    {
       "type": "stat",
       "title": "Rejection rate of the auto brief",
-      "description": "Share of cron-generated briefs that the user immediately re-ran. The headline quality number for the scheduled brief.",
+      "description": "Share of cron-generated briefs that the user immediately re-ran. The headline quality number for the scheduled brief. Reads as blank rather than 0 when the cron has produced nothing in the window: clamp_min only rescues a denominator of zero, not a denominator that is an empty vector, so an empty panel here means 'no scheduled runs in range', not 'broken'.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
       },
       "gridPos": {
         "h": 6,
-        "w": 12,
+        "w": 6,
         "x": 12,
-        "y": 18
+        "y": 27
       },
       "id": 11,
       "fieldConfig": {
@@ -663,6 +806,295 @@
     },
     {
       "type": "stat",
+      "title": "Regeneration success rate",
+      "description": "Share of on-demand regeneration runs that produced a brief, within the selected range. Reliability of the Regenerate button, as distinct from the quality signals above. CAVEAT: the denominator includes runs cut short by an HTTP connection close (tab close, reload, network drop, proxy timeout), which are currently recorded as 'failed', so this reads LOWER than true pipeline reliability. Treat it as a floor until 'aborted' is split out server-side.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 27
+      },
+      "id": 22,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "\u2014"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum(increase(daily_brief_generated_total{trigger=\"regenerate\",status=\"ready\"}[$__range])) / clamp_min(sum(increase(daily_brief_generated_total{trigger=\"regenerate\"}[$__range])), 1)"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Why briefs get regenerated",
+      "description": "replacing_scheduled_brief = rejecting the cron brief \u00b7 replacing_own_regeneration = rejecting their own re-run \u00b7 retry_after_failure = the previous run errored, not a quality signal \u00b7 first_brief_of_day = no brief existed yet.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (origin) (increase(daily_brief_regeneration_attempts_total[$__range]))",
+          "legendFormat": "{{origin}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Regeneration outcomes",
+      "description": "How on-demand regenerations actually ended, from the server-side completion counter. Recorded when the run finishes, unlike 'Regenerations' which is counted when the request arrives \u2014 the difference between the two is runs that started and never completed. CAVEAT: 'failed' currently absorbs runs the server aborted because the HTTP connection closed (tab close, reload, network drop, proxy timeout), so it overstates genuine pipeline failures by an unknown amount; splitting an 'aborted' status out of it is a pending server-side change. This is NOT the same event as 'Regenerations abandoned' below: that histogram fires on component unmount (an in-app route change), and the dashboard passes no AbortSignal, so navigating away inside the app does not abort the run. The two count different things and do not double-count \u2014 except on a tab close, which can trigger both.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 21,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (status) (increase(daily_brief_generated_total{trigger=\"regenerate\"}[$__range]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "How far the regeneration ladder goes",
+      "description": "SURVIVAL CURVE, NOT A DISTRIBUTION. Bar N = share of the day's regenerating users who reached at least attempt N, normalised to attempt 1. A user-day that went three deep is counted in bars 1, 2 AND 3, so bar heights do NOT mean 'N users needed N regenerations' \u2014 read 'Where people stop' for that. Bars only ever descend. CAVEAT: attempts 1\u20133 count user-days (the per-user-per-day Redis key increments once per depth), but 4+ aggregates every request at depth \u22654, so the 4+ bar is a REQUEST tally in different units and can exceed 100%. The origin filter was removed deliberately: origin is computed with 'previous run failed' taking precedence over attempt depth, so one failed or connection-dropped run relabels every later attempt that day as retry_after_failure and used to delete the entire tail of this chart. Origin belongs in 'Why briefs get regenerated'.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (attempt) (increase(daily_brief_regeneration_attempts_total[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"1\"}[$__range])), 1))",
+          "legendFormat": "reached attempt {{attempt}}"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Where people stop",
+      "description": "How many regenerations it actually took, derived by differencing the ladder: users who reached depth N but not N+1. This is the panel that answers 'how many regens does it take' \u2014 the ladder panel next to it cannot, because every user-day is counted at every depth it passed through. APPROXIMATE AT BUCKET 3: 'stopped at 3' subtracts the 4+ bar, which counts requests rather than user-days, so it under-reports whenever anyone is deep in the tail; all three are clamped at 0 because that subtraction can otherwise go negative (it does on the current sample data). The 4+ bar is shown separately and in different units on purpose \u2014 do not add it to the other three. A short time range can also clip a user-day's attempt 1 outside the window while its attempt 2 falls inside, which biases the first bar down. WILL CHANGE: once client-abort is split out of 'failed' server-side, fewer days will be misclassified and these buckets will shift.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 20,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"1\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"2\"}[$__range])), 0)",
+          "legendFormat": "stopped at 1"
+        },
+        {
+          "refId": "B",
+          "instant": true,
+          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"2\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"3\"}[$__range])), 0)",
+          "legendFormat": "stopped at 2"
+        },
+        {
+          "refId": "C",
+          "instant": true,
+          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"3\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"4+\"}[$__range])), 0)",
+          "legendFormat": "stopped at 3 (approx)"
+        },
+        {
+          "refId": "D",
+          "instant": true,
+          "expr": "sum(increase(daily_brief_regeneration_attempts_total{attempt=\"4+\"}[$__range]))",
+          "legendFormat": "4+ (requests, not user-days)"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Generation performance",
+      "type": "row"
+    },
+    {
+      "type": "stat",
       "title": "Avg generation time",
       "description": "Mean wall-clock time of a successful brief run. sum/count is the exact mean; the quantile panel next to it is bucket-approximated.",
       "datasource": {
@@ -671,9 +1103,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
+        "w": 8,
         "x": 0,
-        "y": 24
+        "y": 46
       },
       "id": 12,
       "fieldConfig": {
@@ -737,9 +1169,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 24
+        "w": 8,
+        "x": 8,
+        "y": 46
       },
       "id": 13,
       "fieldConfig": {
@@ -803,9 +1235,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 24
+        "w": 8,
+        "x": 16,
+        "y": 46
       },
       "id": 14,
       "fieldConfig": {
@@ -860,6 +1292,78 @@
       ]
     },
     {
+      "type": "timeseries",
+      "title": "Generation time by trigger",
+      "description": "p50 and p95 of successful runs, cron versus on-demand.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 16,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto"
+          },
+          "mappings": [],
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{trigger}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{trigger}}"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Abandonment",
+      "type": "row"
+    },
+    {
       "type": "stat",
       "title": "Regenerations abandoned",
       "description": "Times someone left the screen while a regeneration was still running. Cross with the wait buckets below to see when we lose them.",
@@ -869,9 +1373,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 24
+        "w": 8,
+        "x": 0,
+        "y": 60
       },
       "id": 15,
       "fieldConfig": {
@@ -926,117 +1430,6 @@
       ]
     },
     {
-      "type": "timeseries",
-      "title": "Generation time by trigger",
-      "description": "p50 and p95 of successful runs, cron versus on-demand.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 30
-      },
-      "id": 16,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "showPoints": "auto"
-          },
-          "mappings": [],
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "histogram_quantile(0.5, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
-          "legendFormat": "p50 {{trigger}}"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
-          "legendFormat": "p95 {{trigger}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "How long people wait before giving up",
-      "description": "Share of abandonments that had already happened by each wait threshold \u2014 read it as a cumulative curve: the bar at 60s is everyone who left within 60s. Where it crosses 50% is median patience. Compare that against p50 generation time: if patience is shorter, the pipeline is losing people mid-run.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 30
-      },
-      "id": 17,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "custom": {
-            "fillOpacity": 85,
-            "lineWidth": 1,
-            "axisPlacement": "auto"
-          },
-          "mappings": [],
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0,
-        "showValue": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket{le!=\"+Inf\"}[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])), 1))",
-          "legendFormat": "within {{le}}s"
-        }
-      ]
-    },
-    {
       "type": "stat",
       "title": "Median patience",
       "description": "The wait at which half of the people who walked away had already gone. Put this next to p50 generation time \u2014 if it is smaller, you are losing people before the brief can possibly arrive.",
@@ -1046,9 +1439,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 37
+        "w": 8,
+        "x": 8,
+        "y": 60
       },
       "id": 18,
       "fieldConfig": {
@@ -1112,9 +1505,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 37
+        "w": 8,
+        "x": 16,
+        "y": 60
       },
       "id": 19,
       "fieldConfig": {
@@ -1165,6 +1558,58 @@
           "refId": "A",
           "instant": true,
           "expr": "sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])) / clamp_min(sum(increase(daily_brief_regeneration_attempts_total[$__range])), 1)"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "How long people wait before giving up",
+      "description": "Share of abandonments that had already happened by each wait threshold \u2014 read it as a cumulative curve: the bar at 60s is everyone who left within 60s. Where it crosses 50% is median patience. Compare that against p50 generation time: if patience is shorter, the pipeline is losing people mid-run.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 17,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "custom": {
+            "fillOpacity": 85,
+            "lineWidth": 1,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "expr": "sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket{le!=\"+Inf\"}[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])), 1))",
+          "legendFormat": "within {{le}}s"
         }
       ]
     }

--- a/docker/grafana/provisioning/datasources/claw-auth-postgres.yml
+++ b/docker/grafana/provisioning/datasources/claw-auth-postgres.yml
@@ -1,0 +1,32 @@
+# claw-auth's own Postgres, read-only from Grafana's point of view.
+#
+# Distinct-user counts cannot come from the metrics store: a user id in a metric
+# label is unbounded cardinality and PII, and a pre-aggregated sketch can only
+# answer the fixed windows it was exported at. Reading the app's own table lets a
+# panel run COUNT(DISTINCT "userId") over whatever range the time picker selects.
+#
+# Credentials come from the environment (same names and defaults as
+# docker/init-db.sh), so a deployment supplies its own rather than inheriting the
+# local bootstrap pair.
+
+apiVersion: 1
+
+datasources:
+  - name: ClawAuthDB
+    uid: claw-auth-postgres
+    type: grafana-postgresql-datasource
+    access: proxy
+    url: postgres:5432
+    user: $__env{CLAW_DB_USER}
+    isDefault: false
+    editable: true
+    jsonData:
+      database: claw_auth_db
+      sslmode: disable
+      postgresVersion: 1600
+      timescaledb: false
+      maxOpenConns: 5
+      maxIdleConns: 2
+      connMaxLifetime: 14400
+    secureJsonData:
+      password: $__env{CLAW_DB_PASSWORD}


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard
  - xyne-claw-auth

Release port of #873 onto `release-20260817`.

## Type of Change

- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This is #873 cherry-picked onto `release-20260817`, **plus its prerequisite #763**.

`release-20260817` was cut from `main` at `7c570c9dd` — before `7c5dec449` *"improve metrics, add feature dialog and banner (#763)"* landed on 2026-08-20. #873's three commits build directly on top of it, so they cannot stand alone here: `DailyBriefScreen.tsx` imports `BriefIntroBanner`, `BriefFeaturesDialog` and `useBriefIntroSeen`, and `fix: XYNE-55716 calendar view ui` edits `CalendarView.tsx` — none of which exist on the release branch. #763 has no other PR queued against `release-20260817`, so it is included here.

### Commits

| Commit | Origin |
|---|---|
| `improve metrics, add feature dialog and banner (#763)` | prerequisite, cherry-picked from `main` |
| `feat: XYNE-55716 add brief on/off toggle, improve metrics` | #873 |
| `fix: XYNE-55716 revert gating daily brief routes on orgId` | #873 |
| `fix: XYNE-55716 calendar view ui` | #873 |

All four applied without conflicts. Every one of the 30 files this PR touches is byte-identical to `feature/XYNE-55716-daily-brief-v2` at `d2053fce8`.

### What it contains

Two related things: a **user-facing on/off toggle for the Daily Brief**, and a **rebuild of the Daily Brief metrics** so the feature can actually be measured.

**Why the toggle matters — nobody could receive a brief.** `users.dailyBriefEnabled` defaults to `false`, and the scheduler only enqueues opted-in users. The backend has always accepted `enabled` on `PUT /daily-brief/config` and `dailyBriefApi.saveConfig` has always typed it — but no component ever sent it. The flag could only be flipped by calling the API directly, so every real user sat at `false`, the cron had nobody to enqueue, and no scheduled brief was ever delivered.

**The toggle**

| File | Change |
|---|---|
| `stores/dailyBriefEnabledStore.ts` | New. Module store (`useSyncExternalStore`, mirrors `switchOverlayStore.ts`) holding the opt-in flag. Optimistic update with rollback + toast on failure. Shared so the three surfaces below can't drift apart. |
| `hooks/useDailyBriefEnabled.ts` | New. Thin hook over the store; lazy-loads config on first mount. |
| `components/Settings/DailyBriefToggle.tsx` | New. The Preferences row. Disabled when *Open AI on launch* is off, with a note explaining why. |
| `components/Settings/Preferences/Preferences.tsx` | Nests the toggle inside the *Open AI on launch* card, since that gates the Xyne AI nav icon the brief lives under. |
| `routes/DailyBriefScreen/BriefIntroBanner.tsx` | Adds a **Turn on morning brief** button when opted out. |
| `routes/DailyBriefScreen/DailyBriefScreen.tsx` | Wires the store in; empty state gains the same button. |
| `components/AIScreen/AISidebar.tsx` | Adds `dailyBriefOnly` to the nav-item filter — Morning Brief is hidden while opted out, but stays visible while you're on `/ai/daily-brief`. |

**Metrics**

| File | Change |
|---|---|
| `otel/daily-brief-metrics.ts` | Subscriber/eligible/delivered gauges, opt-in/opt-out counter (real transitions only), per-user activity recording. Replaces the fixed-window Redis HLL sketches. |
| `routes/daily-brief.ts` | Records the opt-in transition on `PUT /config`, plus view / switch / regenerate activity. All writes best-effort; cannot fail a request. |
| `prisma/schema.prisma` + `migrations/20260820140000_daily_brief_activity/` | New `daily_brief_activity` table: one upserted row per `(userId, kind, dateBucket)`, bounded at ≤3 rows/user/day. Non-nullable `orgId` + index, matching `GeneratedContent`. Distinct-user counts become an exact `COUNT(DISTINCT)` over any range. |
| `docker/grafana/provisioning/dashboards/xyne-daily-brief.json` | Adds an **Improved metrics** row (~34 panels). Pre-existing panels unchanged. |
| `docker/grafana/provisioning/datasources/claw-auth-postgres.yml` | New read-only Postgres datasource — a user id can't go in a metric label. |
| `docker-compose.dev.yml` | Supplies that datasource's credentials to Grafana and adds the `postgres` dependency. |

## Testing

Functionality was verified on #873; this branch is a content-identical port, so testing here covers that the port is faithful and builds on the release base:

- [x] All four commits cherry-picked with zero conflicts
- [x] All 30 touched files diff-clean against `d2053fce8`
- [x] Every relative import in `DailyBriefScreen.tsx` resolves on this branch

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `feature/*`
- [x] No debug logging or commented-out code left behind

### Follow-ups (not in this PR)

- `daily_brief_api_errors_total{route,status}` — every route's 401/400/500 branches are unmeasured, so an outage currently looks like disengagement on the dashboard.
- Enqueue/worker counters — `dailyBriefCron.ts:40` logs `enqueued N/M` but emits no metric, so a fan-out that silently drops jobs is invisible.
- A Grafana datasource for the spaces DB — `workflow.user_activity_events` already holds Daily Brief UI events that no panel reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
