### PR TITLE
fix: persist composer formatting toolbar toggle

### DIFF
--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -211,7 +211,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       getDroppedFilesForEntity,
     } = useDraftAttachments();
     const { enterSendsMessage } = useEnterSendsMessage();
-    const { defaultFormattingToolbarOpen } = useDefaultFormattingToolbarOpen();
+    const { defaultFormattingToolbarOpen, setDefaultFormattingToolbarOpen } =
+      useDefaultFormattingToolbarOpen();
     const shareableOrigin = useShareableOrigin();
     const [isPreferencesOpen, setIsPreferencesOpen] = useState(false);
     const [selectedFile, setSelectedFile] = useState<File | UploadedFile | null>(null);
@@ -323,6 +324,15 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       setShowFormatToolbar(defaultFormattingToolbarOpen);
       setShowMobileFormattingToolbar(defaultFormattingToolbarOpen);
     }, [defaultFormattingToolbarOpen]);
+
+    const updateFormattingToolbarPreference = useCallback(
+      (value: boolean): void => {
+        setShowFormatToolbar(value);
+        setShowMobileFormattingToolbar(value);
+        setDefaultFormattingToolbarOpen(value);
+      },
+      [setDefaultFormattingToolbarOpen],
+    );
 
     const [ticketCreated, setTicketCreated] = useState(false);
 
@@ -1593,8 +1603,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                 onChannelClick={() => {
                   editor?.chain().focus().run();
                 }}
-                onShowFormattingToolbar={() => setShowMobileFormattingToolbar(true)}
-                onCloseFormattingToolbar={() => setShowMobileFormattingToolbar(false)}
+                onShowFormattingToolbar={() => updateFormattingToolbarPreference(true)}
+                onCloseFormattingToolbar={() => updateFormattingToolbarPreference(false)}
                 showEmojiPicker={features.emojiPicker}
                 onEmojiSelect={handleEmojiSelect}
                 hideSendButton={hideSendButton}
@@ -1900,7 +1910,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                     >
                       <button
                         type='button'
-                        onClick={() => setShowFormatToolbar(prev => !prev)}
+                        onClick={() => updateFormattingToolbarPreference(!showFormatToolbar)}
                         className={`p-1.5 rounded transition-all duration-200 ease-in-out ${
                           showFormatToolbar
                             ? 'bg-accent text-foreground'


### PR DESCRIPTION
1. Problem Description:
Composer formatting toolbar visibility was local component state. When a user toggled it open/closed and then moved between channels/threads, the composer remounted and reset to the stored default preference, making the toolbar appear to disappear.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported by users in Spaces thread. Verified in apps/dashboard/src/components/ui/InputBox/InputBox.tsx: the toggle only called setShowFormatToolbar / setShowMobileFormattingToolbar, while settings already persisted the default via useDefaultFormattingToolbarOpen.

3. Explain the solution implemented in the PR:
Reuse useDefaultFormattingToolbarOpen's setter from InputBox. Desktop and mobile composer toolbar toggles now update both local render state and the persisted default preference, so future composer mounts across channel/thread navigation preserve the user's last choice.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- git diff --check: passed
- pnpm --dir apps/dashboard exec prettier --check src/components/ui/InputBox/InputBox.tsx: passed
- pnpm --dir apps/dashboard exec eslint src/components/ui/InputBox/InputBox.tsx: passed with existing warnings only, 0 errors
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir apps/dashboard exec tsc --noEmit --project tsconfig.app.json --pretty false: passed
- Note: default dashboard typecheck OOMed in sandbox at Node's default heap; reran with 4GB heap and it passed.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A