### PR TITLE
fix: chat-scoped filter for the platform model picker

### DIFF
--- a/apps/xyne-claw/src/routes/litellm-models.ts
+++ b/apps/xyne-claw/src/routes/litellm-models.ts
@@ -8,12 +8,13 @@
  * as entity-llm and /eval-models. Only model ids leave this process — never
  * the key.
  *
- * Reuses listJudgeModels() (the /eval-models source) rather than a raw
- * /v1/models fetch: that list is filtered to models the key can actually
- * CALL (self-hosted chat models, no budget gate), whereas /v1/models is only
- * what the key can SEE — offering budget-blocked external models in the chat
- * picker would fail at run time. The one difference from /eval-models is the
- * default: chat runs default to LITELLM.model, not the judge fastModel.
+ * Filtering: chat-scoped, deliberately broader than /eval-models'
+ * listJudgeModels (hosted_vllm only — kimi is litellm_proxy and would vanish,
+ * despite being the platform default). We keep INTERNAL providers
+ * (hosted_vllm, litellm_proxy) and drop embeddings; external paid providers
+ * (vertex_ai etc.) are budget-blocked on the proxy and would fail at run
+ * time. If /model/info is unavailable, fall back to /v1/models minus
+ * claude/gemini (the same exclusion modelSyncService applies) and embeddings.
  *
  * S2S-protected via the existing x-s2s-key middleware.
  */
@@ -21,11 +22,43 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import { validateS2SKey } from "../middleware/auth.js";
-import { listJudgeModels } from "../eval-judge.js";
 import { LITELLM } from "../config.js";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("litellm-models");
+
+const INTERNAL_PROVIDERS = new Set(["hosted_vllm", "litellm_proxy"]);
+const EXCLUDED_NAME = /^(claude|gemini)/i;
+
+async function listPlatformChatModels(): Promise<string[]> {
+  if (!LITELLM.apiKey) return [];
+  const headers = { Authorization: `Bearer ${LITELLM.apiKey}` };
+  const root = LITELLM.url.replace(/\/+$/, "");
+  try {
+    const res = await fetch(`${root}/model/info`, { headers, signal: AbortSignal.timeout(15_000) });
+    if (res.ok) {
+      const data = (await res.json()) as {
+        data?: Array<{ model_name?: unknown; litellm_params?: { custom_llm_provider?: unknown } }>;
+      };
+      const usable = new Set<string>();
+      for (const m of data.data ?? []) {
+        const name = typeof m.model_name === "string" ? m.model_name : "";
+        const prov = typeof m.litellm_params?.custom_llm_provider === "string" ? m.litellm_params.custom_llm_provider : "";
+        if (name && INTERNAL_PROVIDERS.has(prov) && !/embed/i.test(name)) usable.add(name);
+      }
+      if (usable.size > 0) return [...usable].sort();
+    }
+  } catch {
+    /* fall through to the visibility list */
+  }
+  const res = await fetch(`${root}/v1/models`, { headers, signal: AbortSignal.timeout(15_000) });
+  if (!res.ok) throw new Error(`Models endpoint ${res.status}`);
+  const data = (await res.json()) as { data?: Array<{ id?: unknown }> };
+  return (data.data ?? [])
+    .map((m) => (typeof m.id === "string" ? m.id : ""))
+    .filter((id) => id && !EXCLUDED_NAME.test(id) && !/embed/i.test(id))
+    .sort();
+}
 
 export const litellmModelsRouter = Router();
 
@@ -33,12 +66,13 @@ litellmModelsRouter.get("/internal/litellm/models", validateS2SKey, async (_req:
   try {
     // Empty when LITELLM_API_KEY is unset — the caller's "hide the picker"
     // contract, not an error.
-    const names = await listJudgeModels();
+    const names = await listPlatformChatModels();
     const models = names.map((id) => ({ id, name: id }));
     res.json({ success: true, data: models, defaultModel: LITELLM.model || null });
   } catch (err) {
+    const cause = err instanceof Error && err.cause instanceof Error ? ` (${err.cause.message})` : "";
     const message = err instanceof Error ? err.message : "Failed to fetch models";
-    log.error(`[litellm-models] platform listing failed: ${message}`);
-    res.status(500).json({ success: false, error: message });
+    log.error(`[litellm-models] platform listing failed: ${message}${cause}`);
+    res.status(500).json({ success: false, error: `${message}${cause}` });
   }
 });


### PR DESCRIPTION
## What

Follow-up to #959. The platform model picker reused `/eval-models`' `listJudgeModels()`, whose `hosted_vllm`-only filter is judge-scoped — it drops `litellm_proxy` models from the chat picker, **including kimi (`kimi-latest` / `kimi-k3`), the platform default**, and any other internally proxied model (e.g. `private-spaces-*` aliases if so labeled).

## How

`litellm-models.ts` now has its own chat-scoped filter instead of reusing the judge one:

- `/model/info` → keep models whose `custom_llm_provider` is **internal** (`hosted_vllm` or `litellm_proxy`), minus embeddings. External paid providers (`vertex_ai` etc.) stay excluded — they are budget-blocked on the proxy and fail at run time.
- `/model/info` unavailable → fall back to `/v1/models` minus `claude*`/`gemini*` (the same exclusion `modelSyncService` applies) and embeddings.

`/eval-models` and `listJudgeModels()` are untouched — judges keep their stricter list.

## Testing

- `tsc --noEmit` clean on `xyne-claw`.
- Verified against the live gateway: `/model/info` labels `kimi-latest`/`kimi-k3` as `litellm_proxy`; with this filter the endpoint returns `glm-flash-experimental, glm-latest, kimi-k3, kimi-latest, minimaxai/minimax-m2, open-fast, open-large` (previously the kimi entries were missing).

## Deployment

- xyne-claw only

## Checklist

- [x] Type checks pass (`tsc --noEmit`)
- [x] Verified locally against the live gateway
- [x] gitleaks scan on the commit — clean
- [ ] Deployed
