### PR TITLE
fix: XYNE-56855 Add retry button for failed LLM calls

### DIFF
--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -106,6 +106,11 @@ const AUDIO_POLL_MAX_ATTEMPTS = 30;
 // recording simply has no playable audio, so we skip polling and mark it unavailable.
 const AUDIO_STITCH_GRACE_MS = AUDIO_POLL_INTERVAL_MS * AUDIO_POLL_MAX_ATTEMPTS;
 
+// A summary normally lands within minutes of the call ending. If the recording
+// ended over an hour ago and detailedSummaryReady never flipped, the in-call
+// attempt failed — stop implying progress and offer "Generate summary" instead.
+const SUMMARY_PENDING_GRACE_MS = 60 * 60 * 1000;
+
 const DEFAULT_SUMMARY_TEMPLATE_OPTION: RecordingSummaryTemplate = {
   id: 'default',
   name: 'Default summary',
@@ -770,6 +775,10 @@ export default function RecordingDetailV2Screen(): ReactElement {
     const hasTranscriptNow =
       !!transcriptText?.trim() || !!recordingRow?.transcript || !!recording?.hasTranscript;
     if (hasDetailedSummaryNow || !hasTranscriptNow) return;
+    // An hour past the end with the summary still pending, generation is not
+    // coming on its own — leave the request unset so the offer shows instead.
+    const endedAtMs = recording?.endedAt ? Date.parse(recording.endedAt) : null;
+    if (endedAtMs !== null && Date.now() - endedAtMs > SUMMARY_PENDING_GRACE_MS) return;
     if (getSummaryRequest(recordingId)) return;
     markSummaryRequested(recordingId);
   }, [recordingId, recording, recordingRow, transcriptText, awaitingSummary, summaryFailed]);
@@ -831,8 +840,16 @@ export default function RecordingDetailV2Screen(): ReactElement {
   const hasTranscript =
     !!transcriptText?.trim() || !!recordingRow?.transcript || !!recording.hasTranscript;
 
+  // Past the grace window the auto-pending shimmer would be a lie — the in-call
+  // generation isn't coming. An explicit regenerate still shimmers via
+  // `awaitingSummary`.
+  const endedAtMs = recording.endedAt ? Date.parse(recording.endedAt) : null;
+  const summaryPendingExpired =
+    !hasDetailedSummary && endedAtMs !== null && Date.now() - endedAtMs > SUMMARY_PENDING_GRACE_MS;
+
   const showSummaryShimmer =
-    awaitingSummary || (!hasDetailedSummary && hasTranscript && !summaryFailed);
+    awaitingSummary ||
+    (!hasDetailedSummary && hasTranscript && !summaryFailed && !summaryPendingExpired);
 
   const handleMarkerSelect = (item: MarkedItem): void => {
     // A moment already announces itself in the transcript with a divider, so only
@@ -859,13 +876,6 @@ export default function RecordingDetailV2Screen(): ReactElement {
       return;
     }
     openTranscriptPanel();
-  };
-
-  const handleShowSummaryShimmer = (): void => {
-    markSummaryRequested(recordingId);
-    setSummaryRunNonce(value => value + 1);
-    setSummaryFailed(false);
-    setAwaitingSummary(true);
   };
 
   const handleOpenSummaryTemplates = (): void => {
@@ -1118,7 +1128,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                 <SummaryGenerationPanel
                   isAwaiting={showSummaryShimmer}
                   canGenerate={hasTranscript}
-                  onGenerate={handleShowSummaryShimmer}
+                  onGenerate={() => void handleRegenerateSummary(selectedSummaryTemplate.id)}
                   onRetry={() => void handleRegenerateSummary(selectedSummaryTemplate.id)}
                   hasFailed={summaryFailed}
                   generationRunId={summaryRunNonce}


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
