### PR TITLE
fix: provider ranking is the source of truth

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-provider-config.ts
@@ -381,16 +381,19 @@ export async function resolveAgentProviderConfigs(
   }
 
   // always-on: the agent's provider wins. Resolve the parent, then the order.
-  // When an order exists but nothing in it has creds, fall back to its FIRST
-  // entry (`primaryParent` maps a credential-less name like `spaces` to the
-  // platform default) — never to a key the user saved but didn't select.
-  // Mirrors agent-chat.ts. Bare-credential fallback: only when no order is set.
+  // STRICT RANKING — the order is the source of truth, top first. "spaces" is
+  // the keyless platform provider and can ALWAYS serve, so an explicit spaces
+  // entry wins over lower-ranked saved credentials; a credential only routes
+  // when its provider outranks spaces (or spaces is absent). Entries without
+  // creds are skipped. No order at all → the platform default: a credential
+  // that was saved but never selected as a provider never routes a run.
+  // (Legacy `config.provider` still counts as an explicit selection for
+  // agents predating providerOrder.) Mirrors agent-chat.ts.
   let parent: string | undefined;
   if (agentProviderOrder.length > 0) {
-    parent = agentProviderOrder.find((p) => providerConfigs[p]) ?? agentProviderOrder[0];
+    parent = agentProviderOrder.find((p) => p === "spaces" || providerConfigs[p]) ?? agentProviderOrder[0];
   }
   if (!parent && agentLevelProvider && providerConfigs[agentLevelProvider]) parent = agentLevelProvider;
-  if (!parent && agentProviderOrder.length === 0) parent = Object.keys(providerConfigs)[0];
 
   const providerOrder = agentProviderOrder.length > 0 ? agentProviderOrder : parent ? [parent] : [];
   log.info(`Provider resolution (headless): agent=${agent.id} mode=always-on parent=${parent ?? "spaces"} creds=[${Object.keys(providerConfigs).join(",")}] order=[${providerOrder.join(",")}]`);

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -873,7 +873,11 @@ router.get("/:slug/litellm-models", async (req: Request<{ slug: string }>, res: 
     const rawOrder = agentCfg["providerOrder"];
     const order = Array.isArray(rawOrder) ? rawOrder.filter((e): e is string => typeof e === "string") : [];
     const relevant = order.filter((e) => e === "spaces" || (e === "litellm" && hasCred));
-    const primary = relevant[0] ?? (hasCred ? "litellm" : "spaces");
+    // No order → the platform default serves (strict ranking: a credential
+    // that was saved but never selected as a provider never routes a run).
+    // Legacy config.provider = "litellm" still counts as an explicit selection.
+    const legacyProvider = typeof agentCfg["provider"] === "string" ? agentCfg["provider"] : undefined;
+    const primary = relevant[0] ?? (order.length === 0 && legacyProvider === "litellm" && hasCred ? "litellm" : "spaces");
 
     if (primary === "spaces" || !cred?.encryptedKey || !cred.iv || !cred.authTag) {
       const platform = await listPlatformModels();
@@ -1445,9 +1449,12 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
     // Resolution: personal user provider always wins. Otherwise providerOrder
     // (canonical) takes over, with legacy config.provider as fallback for
     // agents that haven't migrated yet.
+    // STRICT RANKING — top first. "spaces" is keyless and can always serve,
+    // so an explicit spaces entry wins over lower-ranked saved credentials
+    // (mirrors resolveAgentProviderConfigs).
     let resolvedParentProvider = personalProvider;
     if (!resolvedParentProvider && agentProviderOrder.length > 0) {
-      resolvedParentProvider = agentProviderOrder.find((p) => providerConfigs[p]) ?? agentProviderOrder[0];
+      resolvedParentProvider = agentProviderOrder.find((p) => p === "spaces" || providerConfigs[p]) ?? agentProviderOrder[0];
     }
     if (!resolvedParentProvider && agentLevelProvider) {
       resolvedParentProvider = agentLevelProvider;


### PR DESCRIPTION
## What

Makes the provider **ranking the source of truth**, exactly as the UI promises ("They're tried in order — top first"). Previously resolution picked the **first order entry with a credential**, so:

| Config | Expected | Old behavior |
|---|---|---|
| `[spaces, litellm]` + litellm cred | spaces | ❌ litellm (cred jumped the queue) |
| `[litellm, spaces]` + cred | litellm | ✅ litellm |
| no order + saved litellm cred | spaces | ❌ litellm (bare-credential fallback) |
| `[spaces]` only | spaces | ✅ spaces |

## How

- **`spaces` is keyless and can always serve** — an explicit spaces entry now wins over lower-ranked saved credentials. Applied in the chat path (`agent-chat.ts`) and the shared resolver (`agent-provider-config.ts`), which run-stream / webhook / flow-action / scheduled runs all go through.
- **No provider order at all → the platform default.** A credential that was saved but never selected as a provider never routes a run (removes the bare-credential fallback). Legacy `config.provider` still counts as an explicit selection for pre-order agents.
- **The chat model picker mirrors the same rule** (its no-order fallback is now spaces, honoring legacy `config.provider === "litellm"`), so "Recommended" and the actual run always agree — on both the claw chat and the Spaces Ask AI dashboard (which proxies this endpoint).
- Spaces remains the terminal keyless fallback when nothing else can serve (unchanged).

## Behavior change — deliberate

Two silent flips for existing agents, both restoring the documented semantics: (a) `[spaces, X]` + X credential now runs on **spaces**, not X; (b) credential saved with no provider selected now runs on the **platform**, not the credential. Agents that want their key must rank its provider above spaces.

## Testing

- `tsc --noEmit` clean; existing `agent-provider-config` vitest suite passes (4/4).
- Live matrix against local claw (test agent with a litellm credential), verified in claw's `[run] provider=` logs AND the picker response for each case:
  - `[spaces, litellm]` → run `provider=spaces`, picker Recommended = platform default, pin `spaces`
  - `[litellm, spaces]` → run `provider=litellm`, LLM call served `litellm-user` (ok=true), picker = cred model, pin `litellm`
  - no order + cred → run `provider=spaces`, picker = platform default

## Deployment

- claw-auth backend only

## Checklist

- [x] Type checks pass (`tsc --noEmit`)
- [x] Existing unit tests pass (vitest 4/4)
- [x] Live-tested all ordering cases (runtime + picker)
- [x] gitleaks scan on the commit — clean
- [ ] Deployed
